### PR TITLE
Go / configure-baseline: account for multiple vendor directories and the `CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS` setting

### DIFF
--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -47,6 +47,7 @@ codeql_pkg_files(
         "//go/extractor/cli/go-autobuilder",
         "//go/extractor/cli/go-bootstrap",
         "//go/extractor/cli/go-build-runner",
+        "//go/extractor/cli/go-configure-baseline",
         "//go/extractor/cli/go-extractor",
         "//go/extractor/cli/go-gen-dbscheme",
         "//go/extractor/cli/go-tokenizer",

--- a/go/codeql-tools/baseline-config-empty.json
+++ b/go/codeql-tools/baseline-config-empty.json
@@ -1,3 +1,0 @@
-{
-    "paths-ignore": []
-}

--- a/go/codeql-tools/baseline-config-vendor.json
+++ b/go/codeql-tools/baseline-config-vendor.json
@@ -1,5 +1,0 @@
-{
-    "paths-ignore": [
-        "vendor/**"
-    ]
-}

--- a/go/codeql-tools/configure-baseline.cmd
+++ b/go/codeql-tools/configure-baseline.cmd
@@ -1,7 +1,4 @@
 @echo off
-SETLOCAL EnableDelayedExpansion
 
 type NUL && "%CODEQL_EXTRACTOR_GO_ROOT%/tools/%CODEQL_PLATFORM%/go-configure-baseline.exe"
 exit /b %ERRORLEVEL%
-
-ENDLOCAL

--- a/go/codeql-tools/configure-baseline.cmd
+++ b/go/codeql-tools/configure-baseline.cmd
@@ -1,6 +1,7 @@
 @echo off
-if exist vendor\modules.txt (
-  type "%CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-vendor.json"
-) else (
-  type "%CODEQL_EXTRACTOR_GO_ROOT%\tools\baseline-config-empty.json"
-)
+SETLOCAL EnableDelayedExpansion
+
+type NUL && "%CODEQL_EXTRACTOR_GO_ROOT%/tools/%CODEQL_PLATFORM%/go-configure-baseline.exe"
+exit /b %ERRORLEVEL%
+
+ENDLOCAL

--- a/go/codeql-tools/configure-baseline.sh
+++ b/go/codeql-tools/configure-baseline.sh
@@ -1,7 +1,3 @@
 #!/bin/sh
 
-if [ -f vendor/modules.txt ]; then
-  cat "$CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-vendor.json"
-else
-  cat "$CODEQL_EXTRACTOR_GO_ROOT/tools/baseline-config-empty.json"
-fi
+"$CODEQL_EXTRACTOR_GO_ROOT/tools/$CODEQL_PLATFORM/go-configure-baseline"

--- a/go/extractor/cli/go-configure-baseline/BUILD.bazel
+++ b/go/extractor/cli/go-configure-baseline/BUILD.bazel
@@ -1,0 +1,18 @@
+# generated running `bazel run //go/gazelle`, do not edit
+
+load("@rules_go//go:def.bzl", "go_library")
+load("//go:rules.bzl", "codeql_go_binary")
+
+go_library(
+    name = "go-configure-baseline_lib",
+    srcs = ["go-configure-baseline.go"],
+    importpath = "github.com/github/codeql-go/extractor/cli/go-configure-baseline",
+    visibility = ["//visibility:private"],
+    deps = ["//go/extractor/configurebaseline"],
+)
+
+codeql_go_binary(
+    name = "go-configure-baseline",
+    embed = [":go-configure-baseline_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/go/extractor/cli/go-configure-baseline/go-configure-baseline.go
+++ b/go/extractor/cli/go-configure-baseline/go-configure-baseline.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/github/codeql-go/extractor/configurebaseline"
 )
 
@@ -9,6 +11,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	} else {
-		println(string(jsonResult))
+		fmt.Println(string(jsonResult))
 	}
 }

--- a/go/extractor/cli/go-configure-baseline/go-configure-baseline.go
+++ b/go/extractor/cli/go-configure-baseline/go-configure-baseline.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/github/codeql-go/extractor/configurebaseline"
+)
+
+func main() {
+	jsonResult, err := configurebaseline.GetConfigBaselineAsJSON(".")
+	if err != nil {
+		panic(err)
+	} else {
+		println(string(jsonResult))
+	}
+}

--- a/go/extractor/configurebaseline/BUILD.bazel
+++ b/go/extractor/configurebaseline/BUILD.bazel
@@ -1,0 +1,10 @@
+# generated running `bazel run //go/gazelle`, do not edit
+
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "configurebaseline",
+    srcs = ["configurebaseline.go"],
+    importpath = "github.com/github/codeql-go/extractor/configurebaseline",
+    visibility = ["//visibility:public"],
+)

--- a/go/extractor/configurebaseline/BUILD.bazel
+++ b/go/extractor/configurebaseline/BUILD.bazel
@@ -7,4 +7,5 @@ go_library(
     srcs = ["configurebaseline.go"],
     importpath = "github.com/github/codeql-go/extractor/configurebaseline",
     visibility = ["//visibility:public"],
+    deps = ["//go/extractor/util"],
 )

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -18,7 +18,7 @@ func fileExists(path string) bool {
 // Decides if `dirPath` is a vendor directory by testing whether it is called `vendor`
 // and contains a `modules.txt` file.
 func isGolangVendorDirectory(dirPath string) bool {
-	return path.Base(dirPath) == "vendor" && fileExists(path.Join(dirPath, "modules.txt"))
+	return filepath.Base(dirPath) == "vendor" && fileExists(filepath.Join(dirPath, "modules.txt"))
 }
 
 type BaselineConfig struct {
@@ -38,7 +38,8 @@ func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
 				return nil
 			}
 			if isGolangVendorDirectory(dirPath) {
-				vendorDirs = append(vendorDirs, path.Join(dirPath, "**"))
+				// Note that CodeQL expects a forward-slash-separated path, even on Windows.
+				vendorDirs = append(vendorDirs, path.Join(filepath.ToSlash(dirPath), "**"))
 				return filepath.SkipDir
 			} else {
 				return nil

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -19,7 +19,7 @@ func isGolangVendorDirectory(dirPath string) bool {
 	return path.Base(dirPath) == "vendor" && fileExists(path.Join(dirPath, "modules.txt"))
 }
 
-type PathsIgnoreStruct struct {
+type BaselineConfig struct {
 	PathsIgnore []string `json:"paths-ignore"`
 }
 
@@ -43,6 +43,6 @@ func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
 		})
 	}
 
-	outputStruct := PathsIgnoreStruct{PathsIgnore: vendorDirs}
+	outputStruct := BaselineConfig{PathsIgnore: vendorDirs}
 	return json.Marshal(outputStruct)
 }

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -1,0 +1,48 @@
+package configurebaseline
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+func fileExists(path string) bool {
+	stat, err := os.Stat(path)
+	return err == nil && stat.Mode().IsRegular()
+}
+
+func isGolangVendorDirectory(dirPath string) bool {
+	// Call a directory a Golang vendor directory if it contains a modules.txt file.
+	return path.Base(dirPath) == "vendor" && fileExists(path.Join(dirPath, "modules.txt"))
+}
+
+type PathsIgnoreStruct struct {
+	PathsIgnore []string `json:"paths-ignore"`
+}
+
+func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
+	vendorDirs := make([]string, 0)
+
+	// If CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS is "true":
+	if os.Getenv("CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS") == "true" {
+		// The user wants vendor directories scanned; emit an empty report.
+	} else {
+		filepath.WalkDir(rootDir, func(dirPath string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// Mask any unreadable paths.
+				return nil
+			}
+			if isGolangVendorDirectory(dirPath) {
+				vendorDirs = append(vendorDirs, path.Join(dirPath, "**"))
+				return filepath.SkipDir
+			} else {
+				return nil
+			}
+		})
+	}
+
+	outputStruct := PathsIgnoreStruct{PathsIgnore: vendorDirs}
+	return json.Marshal(outputStruct)
+}

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/github/codeql-go/extractor/util"
 )
 
 func fileExists(path string) bool {
@@ -26,7 +28,7 @@ type BaselineConfig struct {
 func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
 	vendorDirs := make([]string, 0)
 
-	if os.Getenv("CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS") == "true" {
+	if util.IsVendorDirExtractionEnabled() {
 		// The user wants vendor directories scanned; emit an empty report.
 	} else {
 		filepath.WalkDir(rootDir, func(dirPath string, d fs.DirEntry, err error) error {

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -13,8 +13,9 @@ func fileExists(path string) bool {
 	return err == nil && stat.Mode().IsRegular()
 }
 
+// Decides if `dirPath` is a vendor directory by testing whether it is called `vendor`
+// and contains a `modules.txt` file.
 func isGolangVendorDirectory(dirPath string) bool {
-	// Call a directory a Golang vendor directory if it contains a modules.txt file.
 	return path.Base(dirPath) == "vendor" && fileExists(path.Join(dirPath, "modules.txt"))
 }
 
@@ -25,7 +26,6 @@ type PathsIgnoreStruct struct {
 func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
 	vendorDirs := make([]string, 0)
 
-	// If CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS is "true":
 	if os.Getenv("CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS") == "true" {
 		// The user wants vendor directories scanned; emit an empty report.
 	} else {

--- a/go/extractor/configurebaseline/configurebaseline.go
+++ b/go/extractor/configurebaseline/configurebaseline.go
@@ -33,7 +33,8 @@ func GetConfigBaselineAsJSON(rootDir string) ([]byte, error) {
 	} else {
 		filepath.WalkDir(rootDir, func(dirPath string, d fs.DirEntry, err error) error {
 			if err != nil {
-				// Mask any unreadable paths.
+				// Ignore any unreadable paths -- if this script can't see it, very likely
+				// it will not be extracted either.
 				return nil
 			}
 			if isGolangVendorDirectory(dirPath) {

--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -199,7 +199,7 @@ func ExtractWithFlags(buildFlags []string, patterns []string) error {
 
 	// If CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS is "true", we extract `vendor` directories;
 	// otherwise (the default) is to exclude them from extraction
-	includeVendor := os.Getenv("CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS") == "true"
+	includeVendor := util.IsVendorDirExtractionEnabled()
 	if !includeVendor {
 		excludedDirs = append(excludedDirs, "vendor")
 	}

--- a/go/extractor/util/BUILD.bazel
+++ b/go/extractor/util/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "util",
     srcs = [
+        "extractvendordirs.go",
         "semver.go",
         "util.go",
     ],

--- a/go/extractor/util/extractvendordirs.go
+++ b/go/extractor/util/extractvendordirs.go
@@ -1,0 +1,9 @@
+package util
+
+import (
+	"os"
+)
+
+func IsVendorDirExtractionEnabled() bool {
+	return os.Getenv("CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS") == "true"
+}

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/src/a/vendor/avendor.go
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/src/a/vendor/avendor.go
@@ -1,0 +1,1 @@
+package abc

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/src/b/vendor/bvendor.go
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/src/b/vendor/bvendor.go
@@ -1,0 +1,1 @@
+package abc

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/src/c/vendor/cvendor.go
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/src/c/vendor/cvendor.go
@@ -1,0 +1,1 @@
+package abc

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/src/root.go
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/src/root.go
@@ -1,0 +1,1 @@
+package abc

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
@@ -1,0 +1,9 @@
+import os.path
+import json
+
+def test(codeql, go):
+    codeql.database.init(source_root="src")
+    baseline_info_path = os.path.join("test-db", "baseline-info.json")
+    with open(baseline_info_path, "r") as f:
+        baseline_info = json.load(f)
+    assert set(baseline_info["languages"]["go"]["files"]) == set(["root.go", os.path.join("c", "vendor", "cvendor.go")]), "Expected root.go and cvendor.go in baseline"

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
@@ -6,4 +6,4 @@ def test(codeql, go):
     baseline_info_path = os.path.join("test-db", "baseline-info.json")
     with open(baseline_info_path, "r") as f:
         baseline_info = json.load(f)
-    assert set(baseline_info["languages"]["go"]["files"]) == set(["root.go", "c/vendor/cvendor.go")]), "Expected root.go and cvendor.go in baseline"
+    assert set(baseline_info["languages"]["go"]["files"]) == set(["root.go", "c/vendor/cvendor.go"]), "Expected root.go and cvendor.go in baseline"

--- a/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
+++ b/go/ql/integration-tests/all-platforms/go/configure-baseline/test.py
@@ -6,4 +6,4 @@ def test(codeql, go):
     baseline_info_path = os.path.join("test-db", "baseline-info.json")
     with open(baseline_info_path, "r") as f:
         baseline_info = json.load(f)
-    assert set(baseline_info["languages"]["go"]["files"]) == set(["root.go", os.path.join("c", "vendor", "cvendor.go")]), "Expected root.go and cvendor.go in baseline"
+    assert set(baseline_info["languages"]["go"]["files"]) == set(["root.go", "c/vendor/cvendor.go")]), "Expected root.go and cvendor.go in baseline"

--- a/go/ql/lib/change-notes/2024-08-20-vendor-dirs-baseline.md
+++ b/go/ql/lib/change-notes/2024-08-20-vendor-dirs-baseline.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Golang vendor directories not at the root of a repository are now correctly excluded from the baseline Go file count. This means code coverage information will be more accurate.


### PR DESCRIPTION
Our existing configure-baseline scripts would give the wrong result if a `vendor` directory wasn't at the root of the repository, or if the `CODEQL_EXTRACTOR_GO_EXTRACT_VENDOR_DIRS` variable was set to `true` indicating the user wants their vendored code scanned.

Here I replace the shell scripts that implemented the very simplest behaviour with a small Go program.