### PR TITLE
Java: add change notes for three recent buildless fixes

### DIFF
--- a/java/ql/lib/change-notes/2024-08-09-buildless-executable-war.md
+++ b/java/ql/lib/change-notes/2024-08-09-buildless-executable-war.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an issue where Java analysis in `build-mode: none` would fail to resolve dependencies using the `executable-war` Maven artifact type.

--- a/java/ql/lib/change-notes/2024-08-09-buildless-gradle-classifiers.md
+++ b/java/ql/lib/change-notes/2024-08-09-buildless-gradle-classifiers.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an issue where analysis in `build-mode: none` may fail to resolve dependencies of Gradle projects where the dependency uses a non-empty artifact classifier -- for example, `someproject-1.2.3-tests.jar`, which has the classifier `tests`.

--- a/java/ql/lib/change-notes/2024-08-14-buildless-coder-malfunction.md
+++ b/java/ql/lib/change-notes/2024-08-14-buildless-coder-malfunction.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed an issue where analysis in `build-mode: none` may very occasionally throw a `CoderMalfunctionError` while resolving dependencies provided by a build system (Maven or Gradle), which could cause some dependency resolution and consequently alerts to vary unpredictably from one run to another.


### PR DESCRIPTION
These were all missing a change note when originally merged.