### PR TITLE
Update CookieInjection.ql to remove period from @name

### DIFF
--- a/python/ql/src/Security/CWE-020/CookieInjection.ql
+++ b/python/ql/src/Security/CWE-020/CookieInjection.ql
@@ -1,5 +1,5 @@
 /**
- * @name Construction of a cookie using user-supplied input.
+ * @name Construction of a cookie using user-supplied input
  * @description Constructing cookies from user input may allow an attacker to perform a Cookie Poisoning attack.
  * @kind path-problem
  * @problem.severity warning


### PR DESCRIPTION
The `@name` attribute for queries should not end with a period, see [Query metadata style guide](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md#query-name-name).

This PR removes the period from the name. As far as I can tell, this is the only place where the update needs to be made.

Ideally this would be picked up by a linter or reviewer before it generates a linter error in the Docs repository, but it doesn't happen very often 🙂 

👋🏻 One process consideration. When a team promotes an experimental query into the default packs, it would make sense to ask for a review by the Docs team since we don't review the user-facing content for experimental queries when they are added to the repository.