### PR TITLE
Update JS helmet model structure

### DIFF
--- a/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.Required.Setting.model.yml
+++ b/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.Required.Setting.model.yml
@@ -1,6 +1,6 @@
 extensions:
   - addsTo:
-      pack: codeql/javascript-queries
+      pack: codeql/javascript-all
       extensible: requiredHelmetSecuritySetting
     data:
       - ["frameguard"]

--- a/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
@@ -4,6 +4,9 @@
 
 import javascript
 
+/**
+ * A write to a property of a route handler from the "helmet" module.
+ */
 class HelmetProperty extends DataFlow::Node instanceof DataFlow::PropWrite {
   ExpressLibraries::HelmetRouteHandler helmet;
 
@@ -11,17 +14,28 @@ class HelmetProperty extends DataFlow::Node instanceof DataFlow::PropWrite {
     this = helmet.(DataFlow::CallNode).getAnArgument().getALocalSource().getAPropertyWrite()
   }
 
+  /**
+   * Gets the route handler associated to this property.
+   */
   ExpressLibraries::HelmetRouteHandler getHelmet() { result = helmet }
 
+  /**
+   * Gets the boolean value of this property, if it may evaluate to a `Boolean`.
+   */
   predicate isFalse() { DataFlow::PropWrite.super.getRhs().mayHaveBooleanValue(false) }
 
+  /**
+   * Gets the name of the `HelmetProperty`.
+   */
   string getName() { result = DataFlow::PropWrite.super.getPropertyName() }
 
-  predicate isImportantSecuritySetting() {
-    // read from data extensions to allow enforcing custom settings
-    // defaults are located in javascript/ql/lib/semmle/frameworks/helmet/Helmet.Required.Setting.model.yml
-    requiredHelmetSecuritySetting(this.getName())
-  }
+  /**
+   * read from data extensions to allow enforcing custom settings
+   */
+  predicate isImportantSecuritySetting() { requiredHelmetSecuritySetting(this.getName()) }
 }
 
+/**
+ * defaults are located in `javascript/ql/lib/semmle/frameworks/helmet/Helmet.Required.Setting.model.yml`
+ */
 extensible predicate requiredHelmetSecuritySetting(string name);

--- a/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
@@ -2,7 +2,7 @@
  * Provides classes for working with Helmet
  */
 
-import javascript
+private import javascript
 
 /**
  * A write to a property of a route handler from the "helmet" module.

--- a/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/helmet/Helmet.qll
@@ -1,0 +1,27 @@
+/**
+ * Provides classes for working with Helmet
+ */
+
+import javascript
+
+class HelmetProperty extends DataFlow::Node instanceof DataFlow::PropWrite {
+  ExpressLibraries::HelmetRouteHandler helmet;
+
+  HelmetProperty() {
+    this = helmet.(DataFlow::CallNode).getAnArgument().getALocalSource().getAPropertyWrite()
+  }
+
+  ExpressLibraries::HelmetRouteHandler getHelmet() { result = helmet }
+
+  predicate isFalse() { DataFlow::PropWrite.super.getRhs().mayHaveBooleanValue(false) }
+
+  string getName() { result = DataFlow::PropWrite.super.getPropertyName() }
+
+  predicate isImportantSecuritySetting() {
+    // read from data extensions to allow enforcing custom settings
+    // defaults are located in javascript/ql/lib/semmle/frameworks/helmet/Helmet.Required.Setting.model.yml
+    requiredHelmetSecuritySetting(this.getName())
+  }
+}
+
+extensible predicate requiredHelmetSecuritySetting(string name);

--- a/javascript/ql/src/Security/CWE-693/CUSTOMIZING.md
+++ b/javascript/ql/src/Security/CWE-693/CUSTOMIZING.md
@@ -24,7 +24,7 @@ A suitable [model pack](https://docs.github.com/en/code-security/codeql-cli/usin
 name: my-org/javascript-helmet-insecure-config-model-pack
 version: 1.0.0
 extensionTargets:
-  codeql/java-all: '*'
+  codeql/javascript-all: '*'
 dataExtensions:
   - models/**/*.yml
 ```

--- a/javascript/ql/src/Security/CWE-693/InsecureHelmet.ql
+++ b/javascript/ql/src/Security/CWE-693/InsecureHelmet.ql
@@ -12,30 +12,8 @@
  */
 
 import javascript
-import DataFlow
 import semmle.javascript.frameworks.ExpressModules
-
-class HelmetProperty extends DataFlow::Node instanceof DataFlow::PropWrite {
-  ExpressLibraries::HelmetRouteHandler helmet;
-
-  HelmetProperty() {
-    this = helmet.(DataFlow::CallNode).getAnArgument().getALocalSource().getAPropertyWrite()
-  }
-
-  ExpressLibraries::HelmetRouteHandler getHelmet() { result = helmet }
-
-  predicate isFalse() { DataFlow::PropWrite.super.getRhs().mayHaveBooleanValue(false) }
-
-  string getName() { result = DataFlow::PropWrite.super.getPropertyName() }
-
-  predicate isImportantSecuritySetting() {
-    // read from data extensions to allow enforcing custom settings
-    // defaults are located in javascript/ql/lib/semmle/frameworks/helmet/Helmet.Required.Setting.model.yml
-    requiredHelmetSecuritySetting(this.getName())
-  }
-}
-
-extensible predicate requiredHelmetSecuritySetting(string name);
+import semmle.javascript.frameworks.helmet.Helmet
 
 from HelmetProperty helmetProperty, ExpressLibraries::HelmetRouteHandler helmet
 where


### PR DESCRIPTION
previously was getting the below warning due to pack structure:
```
WARNING: In extension for codeql/javascript-queries:requiredHelmetSecuritySetting, addsTo.pack 'codeql/javascript-queries' is not one of the transitive dependencies of 'codeql/javascript-all'. This warning will become an error in future versions of CodeQL. (.../codeql/packages/codeql/javascript-all/1.1.1/semmle/javascript/frameworks/helmet/Helmet.Required.Setting.model.yml:1,1-1
```