### PR TITLE
C#/Java: Add some model generator summary debugging queries.

### DIFF
--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -1,0 +1,27 @@
+/**
+ * @name Capture Summary Models Partial Path
+ * @description Capture Summary Models Partial Path
+ * @kind path-problem
+ * @precision low
+ * @id csharp/utils/modelgenerator/summary-models-partial-path
+ * @severity info
+ * @tags modelgenerator
+ */
+
+import csharp
+import utils.modelgenerator.internal.CaptureModels
+import PartialFlow::PartialPathGraph
+
+int explorationLimit() { result = 3 }
+
+module PartialFlow = PropagateFlow::FlowExplorationFwd<explorationLimit/0>;
+
+from
+  PartialFlow::PartialPathNode source, PartialFlow::PartialPathNode sink,
+  DataFlowSummaryTargetApi api, DataFlow::ParameterNode p
+where
+  PartialFlow::partialFlow(source, sink, _) and
+  p = source.getNode() and
+  p.asParameter() = api.getParameter(0)
+select sink.getNode(), source, sink, "There is flow from a $@ to $@.", source.getNode(),
+  "parameter", sink.getNode(), "intermediate value"

--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -22,6 +22,6 @@ from
 where
   PartialFlow::partialFlow(source, sink, _) and
   p = source.getNode() and
-  p.asParameter() = api.getParameter(0)
+  p.asParameter() = api.getAParameter()
 select sink.getNode(), source, sink, "There is flow from a $@ to $@.", source.getNode(),
   "parameter", sink.getNode(), "intermediate value"

--- a/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/csharp/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Capture Summary Models Path
+ * @description Capture Summary Models Path
+ * @kind path-problem
+ * @precision low
+ * @id csharp/utils/modelgenerator/summary-models-path
+ * @severity warning
+ * @tags modelgenerator
+ */
+
+import csharp
+import utils.modelgenerator.internal.CaptureModels
+import PropagateFlow::PathGraph
+
+from
+  PropagateFlow::PathNode source, PropagateFlow::PathNode sink, DataFlowSummaryTargetApi api,
+  DataFlow::Node p, DataFlow::Node returnNodeExt
+where
+  PropagateFlow::flowPath(source, sink) and
+  p = source.getNode() and
+  returnNodeExt = sink.getNode() and
+  exists(captureThroughFlow0(api, p, returnNodeExt))
+select sink.getNode(), source, sink, "There is flow from $@ to the $@.", source.getNode(),
+  "parameter", sink.getNode(), "return value"

--- a/csharp/ql/src/utils/modelgenerator/debug/README.md
+++ b/csharp/ql/src/utils/modelgenerator/debug/README.md
@@ -1,0 +1,1 @@
+The queries in this directory are purely used for model generator debugging purposes in VS Code.

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -196,19 +196,28 @@ module PropagateFlowConfig implements DataFlow::StateConfigSig {
   }
 }
 
-private module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
+module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
 
-/**
- * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
- */
-string captureThroughFlow(DataFlowSummaryTargetApi api) {
-  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt, string input, string output |
-    PropagateFlow::flow(p, returnNodeExt) and
+string captureThroughFlow0(
+  DataFlowSummaryTargetApi api, DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt
+) {
+  exists(string input, string output |
+    p.getEnclosingCallable() = api and
     returnNodeExt.(DataFlow::Node).getEnclosingCallable() = api and
     input = parameterNodeAsInput(p) and
     output = returnNodeExt.getOutput() and
     input != output and
     result = Printing::asTaintModel(api, input, output)
+  )
+}
+
+/**
+ * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
+ */
+string captureThroughFlow(DataFlowSummaryTargetApi api) {
+  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
+    PropagateFlow::flow(p, returnNodeExt) and
+    result = captureThroughFlow0(api, p, returnNodeExt)
   )
 }
 

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -1,0 +1,28 @@
+/**
+ * @name Capture Summary Models Partial Path
+ * @description Capture Summary Models Partial Path
+ * @kind path-problem
+ * @precision low
+ * @id java/utils/modelgenerator/summary-models-partial-path
+ * @severity info
+ * @tags modelgenerator
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import utils.modelgenerator.internal.CaptureModels
+import PartialFlow::PartialPathGraph
+
+int explorationLimit() { result = 3 }
+
+module PartialFlow = PropagateFlow::FlowExplorationFwd<explorationLimit/0>;
+
+from
+  PartialFlow::PartialPathNode source, PartialFlow::PartialPathNode sink,
+  DataFlowSummaryTargetApi api, DataFlow::ParameterNode p
+where
+  PartialFlow::partialFlow(source, sink, _) and
+  p = source.getNode() and
+  p.asParameter() = api.getParameter(0)
+select sink.getNode(), source, sink, "There is flow from a $@ to $@.", source.getNode(),
+  "parameter", sink.getNode(), "intermediate value"

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPartialPath.ql
@@ -23,6 +23,6 @@ from
 where
   PartialFlow::partialFlow(source, sink, _) and
   p = source.getNode() and
-  p.asParameter() = api.getParameter(0)
+  p.asParameter() = api.getAParameter()
 select sink.getNode(), source, sink, "There is flow from a $@ to $@.", source.getNode(),
   "parameter", sink.getNode(), "intermediate value"

--- a/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
+++ b/java/ql/src/utils/modelgenerator/debug/CaptureSummaryModelsPath.ql
@@ -1,0 +1,25 @@
+/**
+ * @name Capture Summary Models Path
+ * @description Capture Summary Models Path
+ * @kind path-problem
+ * @precision low
+ * @id java/utils/modelgenerator/summary-models-path
+ * @severity warning
+ * @tags modelgenerator
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import utils.modelgenerator.internal.CaptureModels
+import PropagateFlow::PathGraph
+
+from
+  PropagateFlow::PathNode source, PropagateFlow::PathNode sink, DataFlowSummaryTargetApi api,
+  DataFlow::Node p, DataFlow::Node returnNodeExt
+where
+  PropagateFlow::flowPath(source, sink) and
+  p = source.getNode() and
+  returnNodeExt = sink.getNode() and
+  exists(captureThroughFlow0(api, p, returnNodeExt))
+select sink.getNode(), source, sink, "There is flow from $@ to the $@.", source.getNode(),
+  "parameter", sink.getNode(), "return value"

--- a/java/ql/src/utils/modelgenerator/debug/README.md
+++ b/java/ql/src/utils/modelgenerator/debug/README.md
@@ -1,0 +1,1 @@
+The queries in this directory are purely used for model generator debugging purposes in VS Code.

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -196,19 +196,28 @@ module PropagateFlowConfig implements DataFlow::StateConfigSig {
   }
 }
 
-private module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
+module PropagateFlow = TaintTracking::GlobalWithState<PropagateFlowConfig>;
 
-/**
- * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
- */
-string captureThroughFlow(DataFlowSummaryTargetApi api) {
-  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt, string input, string output |
-    PropagateFlow::flow(p, returnNodeExt) and
+string captureThroughFlow0(
+  DataFlowSummaryTargetApi api, DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt
+) {
+  exists(string input, string output |
+    p.getEnclosingCallable() = api and
     returnNodeExt.(DataFlow::Node).getEnclosingCallable() = api and
     input = parameterNodeAsInput(p) and
     output = returnNodeExt.getOutput() and
     input != output and
     result = Printing::asTaintModel(api, input, output)
+  )
+}
+
+/**
+ * Gets the summary model(s) of `api`, if there is flow from parameters to return value or parameter.
+ */
+string captureThroughFlow(DataFlowSummaryTargetApi api) {
+  exists(DataFlow::ParameterNode p, ReturnNodeExt returnNodeExt |
+    PropagateFlow::flow(p, returnNodeExt) and
+    result = captureThroughFlow0(api, p, returnNodeExt)
   )
 }
 


### PR DESCRIPTION
In this PR we add a couple of debugging queries related to model generation for C# and Java.
- A query for returning flow paths (if we need to figure out why the model generator generates a certain model).
- A query for partial flow (if we need to figure out why the model generator doesn't generate a certain model).