### PR TITLE
add redirect for 'analyzing-data-flow-in-cpp-new/' to 'analyzing-data-flow-in-cpp'

### DIFF
--- a/docs/codeql/conf.py
+++ b/docs/codeql/conf.py
@@ -107,3 +107,13 @@ html_favicon = 'images/site/favicon.ico'
 
 # Exclude these paths from being built by Sphinx
 exclude_patterns = ['vale*', '_static', '_templates', 'reusables', 'images', 'support', 'ql-training', 'query-help', '_build', '*.py*', 'README.rst', 'codeql-for-visual-studio-code']
+
+# Add any redirects needed for the codeql.github.com/docs site
+
+extensions = [
+    'sphinx_reredirects'
+]
+
+redirects = {
+    "codeql-language-guides/analyzing-data-flow-in-cpp-new": "analyzing-data-flow-in-cpp.html"
+}


### PR DESCRIPTION
Follow up from:

- https://github.com/github/codeql/pull/17199

This PR is a test. We might have to either set up the workflow to install the sphinx-redirects extension (which could be useful for future article name changes) or to add the autogenerated page as a static HTML page (like the docs landing page).