### PR TITLE
C++: Fix tests and add an actual true negative

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -13,26 +13,26 @@ edges
 | test.cpp:133:19:133:32 | *call to getenv | test.cpp:133:14:133:17 | call to atoi | provenance | TaintFunction |
 | test.cpp:148:15:148:18 | call to atol | test.cpp:152:11:152:28 | ... * ... | provenance |  |
 | test.cpp:148:20:148:33 | *call to getenv | test.cpp:148:15:148:18 | call to atol | provenance | TaintFunction |
-| test.cpp:218:8:218:23 | *get_tainted_size | test.cpp:250:9:250:24 | call to get_tainted_size | provenance |  |
-| test.cpp:220:9:220:42 | ... * ... | test.cpp:218:8:218:23 | *get_tainted_size | provenance |  |
-| test.cpp:220:14:220:27 | *call to getenv | test.cpp:220:9:220:42 | ... * ... | provenance | TaintFunction |
-| test.cpp:239:21:239:21 | s | test.cpp:240:21:240:21 | s | provenance |  |
-| test.cpp:246:19:246:52 | ... * ... | test.cpp:248:9:248:18 | local_size | provenance |  |
-| test.cpp:246:19:246:52 | ... * ... | test.cpp:254:11:254:20 | local_size | provenance |  |
-| test.cpp:246:19:246:52 | ... * ... | test.cpp:256:10:256:19 | local_size | provenance |  |
-| test.cpp:246:24:246:37 | *call to getenv | test.cpp:246:19:246:52 | ... * ... | provenance | TaintFunction |
-| test.cpp:256:10:256:19 | local_size | test.cpp:239:21:239:21 | s | provenance |  |
-| test.cpp:259:20:259:27 | *out_size | test.cpp:298:17:298:20 | get_size output argument | provenance |  |
-| test.cpp:259:20:259:27 | *out_size | test.cpp:314:18:314:21 | get_size output argument | provenance |  |
-| test.cpp:260:2:260:32 | ... = ... | test.cpp:259:20:259:27 | *out_size | provenance |  |
-| test.cpp:260:18:260:31 | *call to getenv | test.cpp:260:2:260:32 | ... = ... | provenance | TaintFunction |
-| test.cpp:268:15:268:18 | call to atoi | test.cpp:272:11:272:29 | ... * ... | provenance |  |
-| test.cpp:268:20:268:33 | *call to getenv | test.cpp:268:15:268:18 | call to atoi | provenance | TaintFunction |
-| test.cpp:298:17:298:20 | get_size output argument | test.cpp:300:11:300:28 | ... * ... | provenance |  |
-| test.cpp:314:18:314:21 | get_size output argument | test.cpp:317:10:317:27 | ... * ... | provenance |  |
-| test.cpp:362:13:362:16 | call to atoi | test.cpp:364:35:364:38 | size | provenance |  |
-| test.cpp:362:13:362:16 | call to atoi | test.cpp:365:35:365:38 | size | provenance |  |
-| test.cpp:362:18:362:31 | *call to getenv | test.cpp:362:13:362:16 | call to atoi | provenance | TaintFunction |
+| test.cpp:224:8:224:23 | *get_tainted_size | test.cpp:256:9:256:24 | call to get_tainted_size | provenance |  |
+| test.cpp:226:9:226:42 | ... * ... | test.cpp:224:8:224:23 | *get_tainted_size | provenance |  |
+| test.cpp:226:14:226:27 | *call to getenv | test.cpp:226:9:226:42 | ... * ... | provenance | TaintFunction |
+| test.cpp:245:21:245:21 | s | test.cpp:246:21:246:21 | s | provenance |  |
+| test.cpp:252:19:252:52 | ... * ... | test.cpp:254:9:254:18 | local_size | provenance |  |
+| test.cpp:252:19:252:52 | ... * ... | test.cpp:260:11:260:20 | local_size | provenance |  |
+| test.cpp:252:19:252:52 | ... * ... | test.cpp:262:10:262:19 | local_size | provenance |  |
+| test.cpp:252:24:252:37 | *call to getenv | test.cpp:252:19:252:52 | ... * ... | provenance | TaintFunction |
+| test.cpp:262:10:262:19 | local_size | test.cpp:245:21:245:21 | s | provenance |  |
+| test.cpp:265:20:265:27 | *out_size | test.cpp:304:17:304:20 | get_size output argument | provenance |  |
+| test.cpp:265:20:265:27 | *out_size | test.cpp:320:18:320:21 | get_size output argument | provenance |  |
+| test.cpp:266:2:266:32 | ... = ... | test.cpp:265:20:265:27 | *out_size | provenance |  |
+| test.cpp:266:18:266:31 | *call to getenv | test.cpp:266:2:266:32 | ... = ... | provenance | TaintFunction |
+| test.cpp:274:15:274:18 | call to atoi | test.cpp:278:11:278:29 | ... * ... | provenance |  |
+| test.cpp:274:20:274:33 | *call to getenv | test.cpp:274:15:274:18 | call to atoi | provenance | TaintFunction |
+| test.cpp:304:17:304:20 | get_size output argument | test.cpp:306:11:306:28 | ... * ... | provenance |  |
+| test.cpp:320:18:320:21 | get_size output argument | test.cpp:323:10:323:27 | ... * ... | provenance |  |
+| test.cpp:368:13:368:16 | call to atoi | test.cpp:370:35:370:38 | size | provenance |  |
+| test.cpp:368:13:368:16 | call to atoi | test.cpp:371:35:371:38 | size | provenance |  |
+| test.cpp:368:18:368:31 | *call to getenv | test.cpp:368:13:368:16 | call to atoi | provenance | TaintFunction |
 nodes
 | test.cpp:39:27:39:30 | **argv | semmle.label | **argv |
 | test.cpp:40:16:40:19 | call to atoi | semmle.label | call to atoi |
@@ -52,31 +52,31 @@ nodes
 | test.cpp:148:15:148:18 | call to atol | semmle.label | call to atol |
 | test.cpp:148:20:148:33 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:218:8:218:23 | *get_tainted_size | semmle.label | *get_tainted_size |
-| test.cpp:220:9:220:42 | ... * ... | semmle.label | ... * ... |
-| test.cpp:220:14:220:27 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:239:21:239:21 | s | semmle.label | s |
-| test.cpp:240:21:240:21 | s | semmle.label | s |
-| test.cpp:246:19:246:52 | ... * ... | semmle.label | ... * ... |
-| test.cpp:246:24:246:37 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:248:9:248:18 | local_size | semmle.label | local_size |
-| test.cpp:250:9:250:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:254:11:254:20 | local_size | semmle.label | local_size |
-| test.cpp:256:10:256:19 | local_size | semmle.label | local_size |
-| test.cpp:259:20:259:27 | *out_size | semmle.label | *out_size |
-| test.cpp:260:2:260:32 | ... = ... | semmle.label | ... = ... |
-| test.cpp:260:18:260:31 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:268:15:268:18 | call to atoi | semmle.label | call to atoi |
-| test.cpp:268:20:268:33 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:272:11:272:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:298:17:298:20 | get_size output argument | semmle.label | get_size output argument |
-| test.cpp:300:11:300:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:314:18:314:21 | get_size output argument | semmle.label | get_size output argument |
-| test.cpp:317:10:317:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:362:13:362:16 | call to atoi | semmle.label | call to atoi |
-| test.cpp:362:18:362:31 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:364:35:364:38 | size | semmle.label | size |
-| test.cpp:365:35:365:38 | size | semmle.label | size |
+| test.cpp:224:8:224:23 | *get_tainted_size | semmle.label | *get_tainted_size |
+| test.cpp:226:9:226:42 | ... * ... | semmle.label | ... * ... |
+| test.cpp:226:14:226:27 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:245:21:245:21 | s | semmle.label | s |
+| test.cpp:246:21:246:21 | s | semmle.label | s |
+| test.cpp:252:19:252:52 | ... * ... | semmle.label | ... * ... |
+| test.cpp:252:24:252:37 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:254:9:254:18 | local_size | semmle.label | local_size |
+| test.cpp:256:9:256:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:260:11:260:20 | local_size | semmle.label | local_size |
+| test.cpp:262:10:262:19 | local_size | semmle.label | local_size |
+| test.cpp:265:20:265:27 | *out_size | semmle.label | *out_size |
+| test.cpp:266:2:266:32 | ... = ... | semmle.label | ... = ... |
+| test.cpp:266:18:266:31 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:274:15:274:18 | call to atoi | semmle.label | call to atoi |
+| test.cpp:274:20:274:33 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:278:11:278:29 | ... * ... | semmle.label | ... * ... |
+| test.cpp:304:17:304:20 | get_size output argument | semmle.label | get_size output argument |
+| test.cpp:306:11:306:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:320:18:320:21 | get_size output argument | semmle.label | get_size output argument |
+| test.cpp:323:10:323:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:368:13:368:16 | call to atoi | semmle.label | call to atoi |
+| test.cpp:368:18:368:31 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:370:35:370:38 | size | semmle.label | size |
+| test.cpp:371:35:371:38 | size | semmle.label | size |
 subpaths
 #select
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
@@ -88,12 +88,12 @@ subpaths
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | *call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:124:18:124:31 | *call to getenv | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | *call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:133:19:133:32 | *call to getenv | user input (an environment variable) |
 | test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | *call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:148:20:148:33 | *call to getenv | user input (an environment variable) |
-| test.cpp:240:14:240:19 | call to malloc | test.cpp:246:24:246:37 | *call to getenv | test.cpp:240:21:240:21 | s | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:246:24:246:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:248:2:248:7 | call to malloc | test.cpp:246:24:246:37 | *call to getenv | test.cpp:248:9:248:18 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:246:24:246:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:250:2:250:7 | call to malloc | test.cpp:220:14:220:27 | *call to getenv | test.cpp:250:9:250:24 | call to get_tainted_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:220:14:220:27 | *call to getenv | user input (an environment variable) |
-| test.cpp:254:2:254:9 | call to my_alloc | test.cpp:246:24:246:37 | *call to getenv | test.cpp:254:11:254:20 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:246:24:246:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:272:4:272:9 | call to malloc | test.cpp:268:20:268:33 | *call to getenv | test.cpp:272:11:272:29 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:268:20:268:33 | *call to getenv | user input (an environment variable) |
-| test.cpp:300:4:300:9 | call to malloc | test.cpp:260:18:260:31 | *call to getenv | test.cpp:300:11:300:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:260:18:260:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:317:3:317:8 | call to malloc | test.cpp:260:18:260:31 | *call to getenv | test.cpp:317:10:317:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:260:18:260:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:364:25:364:33 | call to MyMalloc1 | test.cpp:362:18:362:31 | *call to getenv | test.cpp:364:35:364:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:362:18:362:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:365:25:365:33 | call to MyMalloc2 | test.cpp:362:18:362:31 | *call to getenv | test.cpp:365:35:365:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:362:18:362:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:246:14:246:19 | call to malloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:246:21:246:21 | s | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:254:2:254:7 | call to malloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:254:9:254:18 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:256:2:256:7 | call to malloc | test.cpp:226:14:226:27 | *call to getenv | test.cpp:256:9:256:24 | call to get_tainted_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:226:14:226:27 | *call to getenv | user input (an environment variable) |
+| test.cpp:260:2:260:9 | call to my_alloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:260:11:260:20 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:278:4:278:9 | call to malloc | test.cpp:274:20:274:33 | *call to getenv | test.cpp:278:11:278:29 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:274:20:274:33 | *call to getenv | user input (an environment variable) |
+| test.cpp:306:4:306:9 | call to malloc | test.cpp:266:18:266:31 | *call to getenv | test.cpp:306:11:306:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:266:18:266:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:323:3:323:8 | call to malloc | test.cpp:266:18:266:31 | *call to getenv | test.cpp:323:10:323:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:266:18:266:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:370:25:370:33 | call to MyMalloc1 | test.cpp:368:18:368:31 | *call to getenv | test.cpp:370:35:370:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:368:18:368:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:371:25:371:33 | call to MyMalloc2 | test.cpp:368:18:368:31 | *call to getenv | test.cpp:371:35:371:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:368:18:368:31 | *call to getenv | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -182,10 +182,16 @@ void more_bounded_tests() {
 
 	{
 		int size = atoi(getenv("USER"));
+		int size2 = size % 100;
+		malloc(size2 * sizeof(int)); // GOOD
+	}
+
+	{
+		int size = atoi(getenv("USER"));
 
 		if (size % 100)
 		{
-			malloc(size * sizeof(int)); // GOOD
+			malloc(size * sizeof(int)); // BAD [NOT DETECTED]
 		}
 	}
 


### PR DESCRIPTION
As pointed out by @intrigus-lgtm the test that I added in #17220 was not a true negative but a false negative. This PR fixes that by adding an actual true negative and marking the false negative as such.