### PR TITLE
C#: ASP.NET Controller is allowed to be abstract.

### DIFF
--- a/csharp/ql/lib/change-notes/2024-08-21-abstract-asp-controller.md
+++ b/csharp/ql/lib/change-notes/2024-08-21-abstract-asp-controller.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Parameters of public methods in abstract controller-like classes are now considered remote flow sources.

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/AspNetCore.qll
@@ -205,7 +205,6 @@ class MicrosoftAspNetCoreMvcController extends Class {
       )
     ) and
     this.isPublic() and
-    (not this.isAbstract() or this instanceof MicrosoftAspNetCoreMvcControllerBaseClass) and
     not this instanceof Generic and
     (
       this.getABaseType*() instanceof MicrosoftAspNetCoreMvcControllerBaseClass

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/AspRemoteFlowSource.cs
@@ -58,4 +58,9 @@ namespace Testing
             app.Run();
         }
     }
+
+    public abstract class AbstractTestController : Controller
+    {
+        public void MyActionMethod(string param) { }
+    }
 }

--- a/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/dataflow/flowsources/aspremote/aspRemoteFlowSource.expected
@@ -12,3 +12,4 @@ remoteFlowSources
 | AspRemoteFlowSource.cs:53:63:53:73 | mapPutParam |
 | AspRemoteFlowSource.cs:54:69:54:82 | mapDeleteParam |
 | AspRemoteFlowSource.cs:56:41:56:44 | item |
+| AspRemoteFlowSource.cs:64:43:64:47 | param |

--- a/csharp/ql/test/library-tests/frameworks/microsoft/AspNetCore.cs
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/AspNetCore.cs
@@ -56,6 +56,15 @@ public class HomeController5 : HomeController4
     }
 }
 
+// is abstract
+public abstract class HomeController6 : Controller
+{
+    public string Index()
+    {
+        return "This is Home Controller";
+    }
+}
+
 // is not public
 internal class NotHomeController : Controller
 {
@@ -65,17 +74,8 @@ internal class NotHomeController : Controller
     }
 }
 
-// is abstract
-public abstract class NotHomeController2 : Controller
-{
-    public string Index()
-    {
-        return "This is Home Controller";
-    }
-}
-
 // contains generic parameters
-public class NotHomeController3<T> : Controller
+public class NotHomeController2<T> : Controller
 {
     public string Index()
     {
@@ -85,7 +85,7 @@ public class NotHomeController3<T> : Controller
 
 // has [NonController] attribute
 [NonController]
-public class NotHomeController4 : Controller
+public class NotHomeController3 : Controller
 {
     public string Index()
     {
@@ -94,7 +94,7 @@ public class NotHomeController4 : Controller
 }
 
 // derived from a class that has [NonController] attribute
-public class NotController : NotHomeController4
+public class NotController : NotHomeController3
 {
     public string Index()
     {

--- a/csharp/ql/test/library-tests/frameworks/microsoft/AspNetCore.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/AspNetCore.expected
@@ -4,3 +4,4 @@
 | AspNetCore.cs:32:14:32:28 | HomeController3 |
 | AspNetCore.cs:42:14:42:28 | HomeController4 |
 | AspNetCore.cs:51:14:51:28 | HomeController5 |
+| AspNetCore.cs:60:23:60:37 | HomeController6 |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -1,14 +1,14 @@
 #select
 | SecondOrderSqlInjection.cs:25:71:25:145 | ... + ... | SecondOrderSqlInjection.cs:20:48:20:78 | call to method ExecuteReader : SqlDataReader | SecondOrderSqlInjection.cs:25:71:25:145 | ... + ... | This query depends on $@. | SecondOrderSqlInjection.cs:20:48:20:78 | call to method ExecuteReader : SqlDataReader | this database input |
 | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | SecondOrderSqlInjection.cs:33:36:33:78 | object creation of type FileStream : FileStream | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | This query depends on $@. | SecondOrderSqlInjection.cs:33:36:33:78 | object creation of type FileStream : FileStream | this file stream |
-| SqlInjection.cs:34:50:34:55 | access to local variable query1 | SqlInjection.cs:33:21:33:35 | access to field categoryTextBox : TextBox | SqlInjection.cs:34:50:34:55 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:33:21:33:35 | access to field categoryTextBox : TextBox | this ASP.NET user input |
-| SqlInjection.cs:69:56:69:61 | access to local variable query1 | SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:69:56:69:61 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | this ASP.NET user input |
-| SqlInjection.cs:70:55:70:60 | access to local variable query1 | SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:70:55:70:60 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | this ASP.NET user input |
-| SqlInjection.cs:83:50:83:55 | access to local variable query1 | SqlInjection.cs:82:21:82:29 | access to property Text : String | SqlInjection.cs:83:50:83:55 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:82:21:82:29 | access to property Text : String | this TextBox text |
-| SqlInjection.cs:93:42:93:52 | access to local variable queryString | SqlInjection.cs:92:21:92:29 | access to property Text : String | SqlInjection.cs:93:42:93:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:92:21:92:29 | access to property Text : String | this TextBox text |
-| SqlInjection.cs:94:50:94:52 | access to local variable cmd | SqlInjection.cs:92:21:92:29 | access to property Text : String | SqlInjection.cs:94:50:94:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:92:21:92:29 | access to property Text : String | this TextBox text |
-| SqlInjection.cs:104:42:104:52 | access to local variable queryString | SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | SqlInjection.cs:104:42:104:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | this read from stdin |
-| SqlInjection.cs:105:50:105:52 | access to local variable cmd | SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | SqlInjection.cs:105:50:105:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | this read from stdin |
+| SqlInjection.cs:39:50:39:55 | access to local variable query1 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox : TextBox | SqlInjection.cs:39:50:39:55 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox : TextBox | this ASP.NET user input |
+| SqlInjection.cs:74:56:74:61 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:74:56:74:61 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | this ASP.NET user input |
+| SqlInjection.cs:75:55:75:60 | access to local variable query1 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:75:55:75:60 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | this ASP.NET user input |
+| SqlInjection.cs:88:50:88:55 | access to local variable query1 | SqlInjection.cs:87:21:87:29 | access to property Text : String | SqlInjection.cs:88:50:88:55 | access to local variable query1 | This query depends on $@. | SqlInjection.cs:87:21:87:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:98:42:98:52 | access to local variable queryString | SqlInjection.cs:97:21:97:29 | access to property Text : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:97:21:97:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:99:50:99:52 | access to local variable cmd | SqlInjection.cs:97:21:97:29 | access to property Text : String | SqlInjection.cs:99:50:99:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:97:21:97:29 | access to property Text : String | this TextBox text |
+| SqlInjection.cs:109:42:109:52 | access to local variable queryString | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | this read from stdin |
+| SqlInjection.cs:110:50:110:52 | access to local variable cmd | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:110:50:110:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | this read from stdin |
 | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | this TextBox text |
 | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | SqlInjectionDapper.cs:29:86:29:94 | access to property Text : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:29:86:29:94 | access to property Text : String | this TextBox text |
 | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | SqlInjectionDapper.cs:38:86:38:94 | access to property Text : String | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:38:86:38:94 | access to property Text : String | this TextBox text |
@@ -40,27 +40,27 @@ edges
 | SecondOrderSqlInjection.cs:40:25:40:27 | access to local variable sql : String | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | provenance |  Sink:MaD:10 |
 | SecondOrderSqlInjection.cs:40:31:40:33 | access to local variable sql : String | SecondOrderSqlInjection.cs:40:31:40:40 | call to method Trim : String | provenance | MaD:28 |
 | SecondOrderSqlInjection.cs:40:31:40:40 | call to method Trim : String | SecondOrderSqlInjection.cs:40:25:40:27 | access to local variable sql : String | provenance |  |
-| SqlInjection.cs:32:21:32:26 | access to local variable query1 : String | SqlInjection.cs:34:50:34:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
-| SqlInjection.cs:33:21:33:35 | access to field categoryTextBox : TextBox | SqlInjection.cs:33:21:33:40 | access to property Text : String | provenance | MaD:26 |
-| SqlInjection.cs:33:21:33:40 | access to property Text : String | SqlInjection.cs:32:21:32:26 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:67:25:67:30 | access to local variable query1 : String | SqlInjection.cs:69:56:69:61 | access to local variable query1 | provenance |  Sink:MaD:7 |
-| SqlInjection.cs:67:25:67:30 | access to local variable query1 : String | SqlInjection.cs:70:55:70:60 | access to local variable query1 | provenance |  Sink:MaD:8 |
-| SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:68:33:68:52 | access to property Text : String | provenance | MaD:26 |
-| SqlInjection.cs:68:33:68:52 | access to property Text : String | SqlInjection.cs:67:25:67:30 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:81:21:81:26 | access to local variable query1 : String | SqlInjection.cs:83:50:83:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
-| SqlInjection.cs:82:21:82:29 | access to property Text : String | SqlInjection.cs:81:21:81:26 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:91:21:91:31 | access to local variable queryString : String | SqlInjection.cs:93:42:93:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
-| SqlInjection.cs:91:21:91:31 | access to local variable queryString : String | SqlInjection.cs:93:42:93:52 | access to local variable queryString : String | provenance |  |
-| SqlInjection.cs:92:21:92:29 | access to property Text : String | SqlInjection.cs:91:21:91:31 | access to local variable queryString : String | provenance |  |
-| SqlInjection.cs:93:21:93:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:94:50:94:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
-| SqlInjection.cs:93:27:93:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:93:21:93:23 | access to local variable cmd : SqlCommand | provenance |  |
-| SqlInjection.cs:93:42:93:52 | access to local variable queryString : String | SqlInjection.cs:93:27:93:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
-| SqlInjection.cs:102:21:102:31 | access to local variable queryString : String | SqlInjection.cs:104:42:104:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
-| SqlInjection.cs:102:21:102:31 | access to local variable queryString : String | SqlInjection.cs:104:42:104:52 | access to local variable queryString : String | provenance |  |
-| SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | SqlInjection.cs:102:21:102:31 | access to local variable queryString : String | provenance | Src:MaD:27  |
-| SqlInjection.cs:104:21:104:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:105:50:105:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
-| SqlInjection.cs:104:27:104:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:104:21:104:23 | access to local variable cmd : SqlCommand | provenance |  |
-| SqlInjection.cs:104:42:104:52 | access to local variable queryString : String | SqlInjection.cs:104:27:104:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
+| SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | SqlInjection.cs:39:50:39:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
+| SqlInjection.cs:38:21:38:35 | access to field categoryTextBox : TextBox | SqlInjection.cs:38:21:38:40 | access to property Text : String | provenance | MaD:26 |
+| SqlInjection.cs:38:21:38:40 | access to property Text : String | SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | provenance |  |
+| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:74:56:74:61 | access to local variable query1 | provenance |  Sink:MaD:7 |
+| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:75:55:75:60 | access to local variable query1 | provenance |  Sink:MaD:8 |
+| SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:73:33:73:52 | access to property Text : String | provenance | MaD:26 |
+| SqlInjection.cs:73:33:73:52 | access to property Text : String | SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | provenance |  |
+| SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | SqlInjection.cs:88:50:88:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
+| SqlInjection.cs:87:21:87:29 | access to property Text : String | SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | provenance |  |
+| SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
+| SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:97:21:97:29 | access to property Text : String | SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:99:50:99:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
+| SqlInjection.cs:98:27:98:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | provenance |  |
+| SqlInjection.cs:98:42:98:52 | access to local variable queryString : String | SqlInjection.cs:98:27:98:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
+| SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
+| SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | provenance |  |
+| SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | provenance | Src:MaD:27  |
+| SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:110:50:110:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
+| SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | provenance |  |
+| SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
 | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | provenance |  Sink:MaD:4 |
 | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | provenance |  |
 | SqlInjectionDapper.cs:29:21:29:25 | access to local variable query : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | provenance |  Sink:MaD:5 |
@@ -144,32 +144,32 @@ nodes
 | SecondOrderSqlInjection.cs:40:31:40:33 | access to local variable sql : String | semmle.label | access to local variable sql : String |
 | SecondOrderSqlInjection.cs:40:31:40:40 | call to method Trim : String | semmle.label | call to method Trim : String |
 | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | semmle.label | access to local variable sql |
-| SqlInjection.cs:32:21:32:26 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
-| SqlInjection.cs:33:21:33:35 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
-| SqlInjection.cs:33:21:33:40 | access to property Text : String | semmle.label | access to property Text : String |
-| SqlInjection.cs:34:50:34:55 | access to local variable query1 | semmle.label | access to local variable query1 |
-| SqlInjection.cs:67:25:67:30 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
-| SqlInjection.cs:68:33:68:47 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
-| SqlInjection.cs:68:33:68:52 | access to property Text : String | semmle.label | access to property Text : String |
-| SqlInjection.cs:69:56:69:61 | access to local variable query1 | semmle.label | access to local variable query1 |
-| SqlInjection.cs:70:55:70:60 | access to local variable query1 | semmle.label | access to local variable query1 |
-| SqlInjection.cs:81:21:81:26 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
-| SqlInjection.cs:82:21:82:29 | access to property Text : String | semmle.label | access to property Text : String |
-| SqlInjection.cs:83:50:83:55 | access to local variable query1 | semmle.label | access to local variable query1 |
-| SqlInjection.cs:91:21:91:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:92:21:92:29 | access to property Text : String | semmle.label | access to property Text : String |
-| SqlInjection.cs:93:21:93:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
-| SqlInjection.cs:93:27:93:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
-| SqlInjection.cs:93:42:93:52 | access to local variable queryString | semmle.label | access to local variable queryString |
-| SqlInjection.cs:93:42:93:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:94:50:94:52 | access to local variable cmd | semmle.label | access to local variable cmd |
-| SqlInjection.cs:102:21:102:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:103:21:103:38 | call to method ReadLine : String | semmle.label | call to method ReadLine : String |
-| SqlInjection.cs:104:21:104:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
-| SqlInjection.cs:104:27:104:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
-| SqlInjection.cs:104:42:104:52 | access to local variable queryString | semmle.label | access to local variable queryString |
-| SqlInjection.cs:104:42:104:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
-| SqlInjection.cs:105:50:105:52 | access to local variable cmd | semmle.label | access to local variable cmd |
+| SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
+| SqlInjection.cs:38:21:38:35 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
+| SqlInjection.cs:38:21:38:40 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:39:50:39:55 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
+| SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
+| SqlInjection.cs:73:33:73:52 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:74:56:74:61 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:75:55:75:60 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | semmle.label | access to local variable query1 : String |
+| SqlInjection.cs:87:21:87:29 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:88:50:88:55 | access to local variable query1 | semmle.label | access to local variable query1 |
+| SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:97:21:97:29 | access to property Text : String | semmle.label | access to property Text : String |
+| SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
+| SqlInjection.cs:98:27:98:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
+| SqlInjection.cs:98:42:98:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+| SqlInjection.cs:98:42:98:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:99:50:99:52 | access to local variable cmd | semmle.label | access to local variable cmd |
+| SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | semmle.label | call to method ReadLine : String |
+| SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | semmle.label | access to local variable cmd : SqlCommand |
+| SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | semmle.label | object creation of type SqlCommand : SqlCommand |
+| SqlInjection.cs:109:42:109:52 | access to local variable queryString | semmle.label | access to local variable queryString |
+| SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
+| SqlInjection.cs:110:50:110:52 | access to local variable cmd | semmle.label | access to local variable cmd |
 | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | semmle.label | access to local variable query : String |
 | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | semmle.label | access to property Text : String |
 | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | semmle.label | access to local variable query |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -9,6 +9,7 @@
 | SqlInjection.cs:99:50:99:52 | access to local variable cmd | SqlInjection.cs:97:21:97:29 | access to property Text : String | SqlInjection.cs:99:50:99:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:97:21:97:29 | access to property Text : String | this TextBox text |
 | SqlInjection.cs:109:42:109:52 | access to local variable queryString | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString | This query depends on $@. | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | this read from stdin |
 | SqlInjection.cs:110:50:110:52 | access to local variable cmd | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:110:50:110:52 | access to local variable cmd | This query depends on $@. | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | this read from stdin |
+| SqlInjection.cs:129:53:129:57 | access to local variable query | SqlInjection.cs:122:73:122:78 | userId : String | SqlInjection.cs:129:53:129:57 | access to local variable query | This query depends on $@. | SqlInjection.cs:122:73:122:78 | userId : String | this ASP.NET Core MVC action method parameter |
 | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | this TextBox text |
 | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | SqlInjectionDapper.cs:29:86:29:94 | access to property Text : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:29:86:29:94 | access to property Text : String | this TextBox text |
 | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | SqlInjectionDapper.cs:38:86:38:94 | access to property Text : String | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | This query depends on $@. | SqlInjectionDapper.cs:38:86:38:94 | access to property Text : String | this TextBox text |
@@ -61,6 +62,8 @@ edges
 | SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:110:50:110:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
 | SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | provenance |  |
 | SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
+| SqlInjection.cs:122:73:122:78 | userId : String | SqlInjection.cs:125:20:125:24 | access to local variable query : String | provenance |  |
+| SqlInjection.cs:125:20:125:24 | access to local variable query : String | SqlInjection.cs:129:53:129:57 | access to local variable query | provenance |  Sink:MaD:16 |
 | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | provenance |  Sink:MaD:4 |
 | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | provenance |  |
 | SqlInjectionDapper.cs:29:21:29:25 | access to local variable query : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | provenance |  Sink:MaD:5 |
@@ -170,6 +173,9 @@ nodes
 | SqlInjection.cs:109:42:109:52 | access to local variable queryString | semmle.label | access to local variable queryString |
 | SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | semmle.label | access to local variable queryString : String |
 | SqlInjection.cs:110:50:110:52 | access to local variable cmd | semmle.label | access to local variable cmd |
+| SqlInjection.cs:122:73:122:78 | userId : String | semmle.label | userId : String |
+| SqlInjection.cs:125:20:125:24 | access to local variable query : String | semmle.label | access to local variable query : String |
+| SqlInjection.cs:129:53:129:57 | access to local variable query | semmle.label | access to local variable query |
 | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | semmle.label | access to local variable query : String |
 | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | semmle.label | access to property Text : String |
 | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | semmle.label | access to local variable query |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/options
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/options
@@ -3,3 +3,4 @@ semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resour
 semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/System.Data.SqlClient/4.8.5/System.Data.SqlClient.csproj
 semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/System.Data.SQLite/1.0.118/System.Data.SQLite.csproj
 semmle-extractor-options: ${testdir}/../../../resources/stubs/System.Windows.cs
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.AspNetCore.App/Microsoft.AspNetCore.App.csproj


### PR DESCRIPTION
In this PR we remove the restriction that a controller should be *instantiable* (this was introduced as a part of https://github.com/github/codeql/pull/9406).
Even though the documentation states that controllers should be *instantiable* then from an analysis perspective it makes sense to include abstract controllers as we are mostly interested in parameters (as remote sources) and methods (action methods) on controllers, which can easily be exposed to a user as the following example shows
```csharp
public abstract class AbstractController : Controller {
    public void ActionMethod(string userInput) { sink(userInput); }
}

public class ConcreteController : AbstractController { }
```