### PR TITLE
Java: Reveal false negative in test

### DIFF
--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
@@ -1,2 +1,3 @@
 failures
 testFailures
+| ImplicitPendingIntentsTest.java:35:60:35:87 | // $hasImplicitPendingIntent | Missing result:hasImplicitPendingIntent= |

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
@@ -1,3 +1,3 @@
-failures
 testFailures
 | ImplicitPendingIntentsTest.java:35:60:35:87 | // $hasImplicitPendingIntent | Missing result:hasImplicitPendingIntent= |
+failures

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
@@ -1,3 +1,2 @@
 testFailures
-| ImplicitPendingIntentsTest.java:35:60:35:87 | // $hasImplicitPendingIntent | Missing result:hasImplicitPendingIntent= |
 failures

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
@@ -32,7 +32,7 @@ public class ImplicitPendingIntentsTest {
             PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, 0);
             Intent fwdIntent = new Intent();
             fwdIntent.putExtra("fwdIntent", pi);
-            ctx.startActivities(new Intent[] {fwdIntent}); // $hasImplicitPendingIntent
+            ctx.startActivities(new Intent[] {fwdIntent}); // $ MISSING: hasImplicitPendingIntent
             ctx.startActivity(fwdIntent); // $hasImplicitPendingIntent
             ctx.startService(fwdIntent); // Safe
             ctx.sendBroadcast(fwdIntent); // $hasImplicitPendingIntent

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.java
@@ -32,8 +32,8 @@ public class ImplicitPendingIntentsTest {
             PendingIntent pi = PendingIntent.getActivity(ctx, 0, baseIntent, 0);
             Intent fwdIntent = new Intent();
             fwdIntent.putExtra("fwdIntent", pi);
-            ctx.startActivity(fwdIntent); // $hasImplicitPendingIntent
             ctx.startActivities(new Intent[] {fwdIntent}); // $hasImplicitPendingIntent
+            ctx.startActivity(fwdIntent); // $hasImplicitPendingIntent
             ctx.startService(fwdIntent); // Safe
             ctx.sendBroadcast(fwdIntent); // $hasImplicitPendingIntent
 


### PR DESCRIPTION
One of the sinks in `ImplicitPendingIntents` was flagged for the wrong reason in the test case.

The flow into the `startActivities` sink isn't working properly, but this was not revealed by the test since an alternate, spurious path exists. The spurious path goes through the implicit read at the prior sink and takes a use-use step to the `startActivities` sink. Swapping the order of the two sinks reveals the false negative.

I noticed this while attempting to fix the above-mentioned issue where a use-use step is taken after an implicit read, which caused this test to fail. But for now, just updating the test to reveal the missed flow.