### PR TITLE
C++: Reveal false negative in test case 

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -450,7 +450,7 @@ void test_qualifiers()
 	b.member = source();
 	sink(b); // $ ir MISSING: ast
 	sink(b.member); // $ ast,ir
-	sink(b.getMember()); // $ ir MISSING: ast
+	sink(b.getMember()); // $  MISSING: ir ast
 
 	c = new MyClass2(0);
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -4,7 +4,4 @@ WARNING: module 'DataFlow' has been deprecated and may be removed in future (tai
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (taint.ql:68,25-33)
 WARNING: module 'TaintTracking' has been deprecated and may be removed in future (taint.ql:73,20-33)
 testFailures
-| taint.cpp:453:23:453:42 | // $ ir MISSING: ast | Missing result:ir= |
-| vector.cpp:118:12:118:30 | // $ ir MISSING:ast | Missing result:ir= |
-| vector.cpp:119:12:119:30 | // $ ir MISSING:ast | Missing result:ir= |
 failures

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/vector.cpp
@@ -115,8 +115,8 @@ void test_vector_swap() {
 	v3.swap(v4);
 
 	sink(v1);
-	sink(v2); // $ ir MISSING:ast
-	sink(v3); // $ ir MISSING:ast
+	sink(v2); // $ MISSING:ir ast
+	sink(v3); // $ MISSING:ir ast
 	sink(v4);
 }
 


### PR DESCRIPTION
Some of the sinks in this test were flagged for the wrong reason.

The flow into these sinks isn't working properly, but this was not revealed by the test since an alternate, spurious path exists for each of them. The spurious path goes through the implicit read at one of the prior sinks and takes a use-use step.

In one case the false negative can be revealed by swapping the order of the sinks, but in the other case I had to remove some of the sinks to avoid the interference.

This came up while trying to [fix the issue](https://github.com/github/codeql/pull/17262) with use-use flow after an implicit read, and this test started failing because the fix removes the spurious paths that the test was relying on.