### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,12 +2,12 @@
 
 #### All query authors
 
-- [ ] Add a change note if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
+- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
 - [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
 - [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
 - [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.
 
 #### Internal query authors only
 
-- [ ] If this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files, make sure that autofixes generated based on these changes are valid. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
-- [ ] Test your changes [at scale](https://github.com/github/codeql-dca/) (internal access required).
+- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
+- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,13 @@
 ### Pull Request checklist
 
-- [ ] Add a change note if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md).
+#### All query authors
+
+- [ ] Add a change note if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
+- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/mainπ /docs/query-help-style-guide.md) in this repository.
+- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
+- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.
+
+#### Internal query authors only
+
 - [ ] If this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files, make sure that autofixes generated based on these changes are valid. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
-- [ ] All new queries has appropriate `.qhelp`.
-- [ ] QL tests are added if necessary.
-- [ ] Test your changes in [DCA](https://github.com/github/codeql-dca/) (internal access required).
+- [ ] Test your changes [at scale](https://github.com/github/codeql-dca/) (internal access required).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### Pull Request checklist
+
+- [ ] Add a change note if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md).
+- [ ] If this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files, make sure that autofixes generated based on these changes are valid. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
+- [ ] All new queries has appropriate `.qhelp`.
+- [ ] QL tests are added if necessary.
+- [ ] Test your changes in [DCA](https://github.com/github/codeql-dca/) (internal access required).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 #### All query authors
 
 - [ ] Add a change note if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
-- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/mainπ /docs/query-help-style-guide.md) in this repository.
+- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
 - [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
 - [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.
 


### PR DESCRIPTION
This PR adds a pull request template. It is sparse right now. The main goal is to remind query authors to check for autofix changes when they add new queries or update existing ones.