### PR TITLE
Make ripunzip installer accessible from outside this repo.

### DIFF
--- a/.github/workflows/buildifier.yml
+++ b/.github/workflows/buildifier.yml
@@ -24,5 +24,5 @@ jobs:
           extra_args: >
             buildifier --all-files 2>&1 ||
             (
-              echo -e "In order to format all bazel files, please run:\n  bazel run //misc/bazel:buildifier"; exit 1
+              echo -e "In order to format all bazel files, please run:\n  bazel run //misc/bazel/buildifier"; exit 1
             )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
         name: Format bazel files
         files: \.(bazel|bzl)
         language: system
-        entry: bazel run //misc/bazel:buildifier
+        entry: bazel run //misc/bazel/buildifier
         pass_filenames: false
 
 #      DISABLED: can be enabled by copying this config and installing `pre-commit` with `--config` on the copy

--- a/misc/bazel/BUILD.bazel
+++ b/misc/bazel/BUILD.bazel
@@ -1,13 +1,3 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
-
-buildifier(
-    name = "buildifier",
-    exclude_patterns = [
-        "./.git/*",
-    ],
-    lint_mode = "fix",
-)
-
 sh_library(
     name = "sh_runfiles",
     srcs = ["runfiles.sh"],

--- a/misc/bazel/buildifier/BUILD.bazel
+++ b/misc/bazel/buildifier/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "fix",
+)

--- a/misc/ripunzip/BUILD.bazel
+++ b/misc/ripunzip/BUILD.bazel
@@ -9,5 +9,5 @@ sh_binary(
     srcs = ["install.sh"],
     args = ["$(rlocationpath :ripunzip)"],
     data = [":ripunzip"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = ["//misc/bazel:sh_runfiles"],
 )

--- a/misc/ripunzip/BUILD.bazel
+++ b/misc/ripunzip/BUILD.bazel
@@ -9,5 +9,5 @@ sh_binary(
     srcs = ["install.sh"],
     args = ["$(rlocationpath :ripunzip)"],
     data = [":ripunzip"],
-    deps = ["//misc/bazel:sh_runfiles"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/misc/ripunzip/install.sh
+++ b/misc/ripunzip/install.sh
@@ -2,7 +2,16 @@
 
 set -eu
 
-. misc/bazel/runfiles.sh
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
 
 dest="${2:-$HOME/.local/bin}"
 

--- a/misc/ripunzip/install.sh
+++ b/misc/ripunzip/install.sh
@@ -2,16 +2,7 @@
 
 set -eu
 
-# --- begin runfiles.bash initialization v3 ---
-# Copy-pasted from the Bazel Bash runfiles library v3.
-set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
-source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$0.runfiles/$f" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
-  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
-# --- end runfiles.bash initialization v3 ---
+source misc/bazel/runfiles.sh 2>/dev/null || source external/ql~/misc/bazel/runfiles.sh
 
 dest="${2:-$HOME/.local/bin}"
 


### PR DESCRIPTION
* The relative path to misc doesn't work when running from another repo
* The buildifier dependency is not available from other repos, therefore we can't pull in //misc/bazel without further refactoring.

Therefore, inline the runfiles snippet here.