### PR TITLE
Kotlin: Restrict some TrapWriter types to DiagnosticTrapWriter

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
@@ -220,26 +220,26 @@ open class LoggerBase(val logCounter: LogCounter) {
         logStream.write(logMessage.toJsonLine())
     }
 
-    fun trace(tw: TrapWriter, msg: String) {
+    fun trace(dtw: DiagnosticTrapWriter, msg: String) {
         if (verbosity >= 4) {
             val logMessage = LogMessage("TRACE", msg)
-            tw.writeComment(logMessage.toText())
+            dtw.writeComment(logMessage.toText())
             logStream.write(logMessage.toJsonLine())
         }
     }
 
-    fun debug(tw: TrapWriter, msg: String) {
+    fun debug(dtw: DiagnosticTrapWriter, msg: String) {
         if (verbosity >= 4) {
             val logMessage = LogMessage("DEBUG", msg)
-            tw.writeComment(logMessage.toText())
+            dtw.writeComment(logMessage.toText())
             logStream.write(logMessage.toJsonLine())
         }
     }
 
-    fun info(tw: TrapWriter, msg: String) {
+    fun info(dtw: DiagnosticTrapWriter, msg: String) {
         if (verbosity >= 3) {
             val logMessage = LogMessage("INFO", msg)
-            tw.writeComment(logMessage.toText())
+            dtw.writeComment(logMessage.toText())
             logStream.write(logMessage.toJsonLine())
         }
     }


### PR DESCRIPTION
We never use the greater generality, so this makes it easier to see what's happening.