### PR TITLE
C++: Add basic modeling of functions that don't throw

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/Models.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/Models.qll
@@ -42,6 +42,7 @@ private import implementations.Accept
 private import implementations.Poll
 private import implementations.Select
 private import implementations.MySql
+private import implementations.NoexceptFunction
 private import implementations.ODBC
 private import implementations.SqLite3
 private import implementations.PostgreSql

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Memcpy.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Memcpy.qll
@@ -9,13 +9,14 @@ import semmle.code.cpp.models.interfaces.DataFlow
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
 import semmle.code.cpp.models.interfaces.Taint
+import semmle.code.cpp.models.interfaces.NonThrowing
 
 /**
  * The standard functions `memcpy`, `memmove` and `bcopy`; and the gcc variant
  * `__builtin___memcpy_chk`.
  */
 private class MemcpyFunction extends ArrayFunction, DataFlowFunction, SideEffectFunction,
-  AliasFunction
+  AliasFunction, NonThrowingFunction
 {
   MemcpyFunction() {
     // memcpy(dest, src, num)

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Memset.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Memset.qll
@@ -8,9 +8,10 @@ import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.DataFlow
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
+import semmle.code.cpp.models.interfaces.NonThrowing
 
 private class MemsetFunctionModel extends ArrayFunction, DataFlowFunction, AliasFunction,
-  SideEffectFunction
+  SideEffectFunction, NonThrowingFunction
 {
   MemsetFunctionModel() {
     this.hasGlobalOrStdOrBslName("memset")

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/NoexceptFunction.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/NoexceptFunction.qll
@@ -1,0 +1,11 @@
+import semmle.code.cpp.models.interfaces.NonThrowing
+
+/**
+ * A function that is annotated with a `noexcept` specifier (or the equivalent
+ * `throw()` specifier) guaranteeing that the function can not throw exceptions.
+ *
+ * Note: The `throw` specifier was deprecated in C++11 and removed in C++17.
+ */
+class NoexceptFunction extends NonThrowingFunction {
+  NoexceptFunction() { this.isNoExcept() or this.isNoThrow() }
+}

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
@@ -173,7 +173,7 @@ private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction, 
  *      and
  *      https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms860435(v=msdn.10)
  */
-private class StringCchPrintf extends FormattingFunction, NonThrowingFunction {
+private class StringCchPrintf extends FormattingFunction {
   StringCchPrintf() {
     this instanceof TopLevelFunction and
     exists(string baseName |

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Printf.qll
@@ -8,11 +8,12 @@
 import semmle.code.cpp.models.interfaces.FormattingFunction
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
+import semmle.code.cpp.models.interfaces.NonThrowing
 
 /**
  * The standard functions `printf`, `wprintf` and their glib variants.
  */
-private class Printf extends FormattingFunction, AliasFunction {
+private class Printf extends FormattingFunction, AliasFunction, NonThrowingFunction {
   Printf() {
     this instanceof TopLevelFunction and
     (
@@ -36,7 +37,7 @@ private class Printf extends FormattingFunction, AliasFunction {
 /**
  * The standard functions `fprintf`, `fwprintf` and their glib variants.
  */
-private class Fprintf extends FormattingFunction {
+private class Fprintf extends FormattingFunction, NonThrowingFunction {
   Fprintf() {
     this instanceof TopLevelFunction and
     (
@@ -54,7 +55,7 @@ private class Fprintf extends FormattingFunction {
 /**
  * The standard function `sprintf` and its Microsoft and glib variants.
  */
-private class Sprintf extends FormattingFunction {
+private class Sprintf extends FormattingFunction, NonThrowingFunction {
   Sprintf() {
     this instanceof TopLevelFunction and
     (
@@ -97,7 +98,7 @@ private class Sprintf extends FormattingFunction {
 /**
  * Implements `Snprintf`.
  */
-private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction {
+private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction, NonThrowingFunction {
   SnprintfImpl() {
     this instanceof TopLevelFunction and
     (
@@ -172,7 +173,7 @@ private class SnprintfImpl extends Snprintf, AliasFunction, SideEffectFunction {
  *      and
  *      https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms860435(v=msdn.10)
  */
-private class StringCchPrintf extends FormattingFunction {
+private class StringCchPrintf extends FormattingFunction, NonThrowingFunction {
   StringCchPrintf() {
     this instanceof TopLevelFunction and
     exists(string baseName |
@@ -204,7 +205,7 @@ private class StringCchPrintf extends FormattingFunction {
 /**
  * The standard function `syslog`.
  */
-private class Syslog extends FormattingFunction {
+private class Syslog extends FormattingFunction, NonThrowingFunction {
   Syslog() {
     this instanceof TopLevelFunction and
     this.hasGlobalName("syslog") and

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcat.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcat.qll
@@ -7,13 +7,16 @@ import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.DataFlow
 import semmle.code.cpp.models.interfaces.Taint
 import semmle.code.cpp.models.interfaces.SideEffect
+import semmle.code.cpp.models.interfaces.NonThrowing
 
 /**
  * The standard function `strcat` and its wide, sized, and Microsoft variants.
  *
  * Does not include `strlcat`, which is covered by `StrlcatFunction`
  */
-class StrcatFunction extends TaintFunction, DataFlowFunction, ArrayFunction, SideEffectFunction {
+class StrcatFunction extends TaintFunction, DataFlowFunction, ArrayFunction, SideEffectFunction,
+  NonThrowingFunction
+{
   StrcatFunction() {
     this.hasGlobalOrStdOrBslName([
         "strcat", // strcat(dst, src)

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Strcpy.qll
@@ -7,11 +7,14 @@ import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.DataFlow
 import semmle.code.cpp.models.interfaces.Taint
 import semmle.code.cpp.models.interfaces.SideEffect
+import semmle.code.cpp.models.interfaces.NonThrowing
 
 /**
  * The standard function `strcpy` and its wide, sized, and Microsoft variants.
  */
-class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, SideEffectFunction {
+class StrcpyFunction extends ArrayFunction, DataFlowFunction, TaintFunction, SideEffectFunction,
+  NonThrowingFunction
+{
   StrcpyFunction() {
     this.hasGlobalOrStdOrBslName([
         "strcpy", // strcpy(dst, src)

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/NonThrowing.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/NonThrowing.qll
@@ -1,7 +1,5 @@
 /**
- * Provides an abstract class for modeling functions that never throws.
- *
- * See also `ThrowingFunction` for modeling functions that do throw.
+ * Provides an abstract class for modeling functions that never throw.
  */
 
 import semmle.code.cpp.Function

--- a/cpp/ql/lib/semmle/code/cpp/models/interfaces/NonThrowing.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/interfaces/NonThrowing.qll
@@ -1,0 +1,13 @@
+/**
+ * Provides an abstract class for modeling functions that never throws.
+ *
+ * See also `ThrowingFunction` for modeling functions that do throw.
+ */
+
+import semmle.code.cpp.Function
+import semmle.code.cpp.models.Models
+
+/**
+ * A function that is guaranteed to never throw.
+ */
+abstract class NonThrowingFunction extends Function { }

--- a/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
@@ -16,6 +16,8 @@
 import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.controlflow.Guards
+import semmle.code.cpp.models.interfaces.NonThrowing
+import semmle.code.cpp.models.implementations.NoexceptFunction
 
 /** Gets the `Constructor` invoked when `newExpr` allocates memory. */
 Constructor getConstructorForAllocation(NewOrNewArrayExpr newExpr) {
@@ -44,9 +46,8 @@ predicate deleteMayThrow(DeleteOrDeleteArrayExpr deleteExpr) {
  * like it might throw an exception, and the function does not have a `noexcept` or `throw()` specifier.
  */
 predicate functionMayThrow(Function f) {
-  (not exists(f.getBlock()) or stmtMayThrow(f.getBlock())) and
-  not f.isNoExcept() and
-  not f.isNoThrow()
+  not f instanceof NonThrowingFunction and
+  (not exists(f.getBlock()) or stmtMayThrow(f.getBlock()))
 }
 
 /** Holds if the evaluation of `stmt` may throw an exception. */
@@ -172,8 +173,7 @@ class ThrowingAllocator extends Function {
       not exists(Parameter p | p = this.getAParameter() |
         p.getUnspecifiedType().stripType() instanceof NoThrowType
       ) and
-      not this.isNoExcept() and
-      not this.isNoThrow()
+      not this instanceof NoexceptFunction
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
+++ b/cpp/ql/src/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.ql
@@ -16,7 +16,6 @@
 import cpp
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.controlflow.Guards
-import semmle.code.cpp.models.interfaces.NonThrowing
 import semmle.code.cpp.models.implementations.NoexceptFunction
 
 /** Gets the `Constructor` invoked when `newExpr` allocates memory. */

--- a/cpp/ql/src/change-notes/2024-08-26-non-throwing-functions.md
+++ b/cpp/ql/src/change-notes/2024-08-26-non-throwing-functions.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Add modeling of C functions that don't throw, thereby increasing the precision of the `cpp/incorrect-allocation-error-handling` ("Incorrect allocation-error handling") query. The query now produces additional true positives.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/IncorrectAllocationErrorHandling.expected
@@ -17,3 +17,4 @@
 | test.cpp:229:15:229:35 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:231:16:231:19 | { ... } | This catch block |
 | test.cpp:242:14:242:34 | new | This allocation cannot throw. $@ is unnecessary. | test.cpp:243:34:243:36 | { ... } | This catch block |
 | test.cpp:276:17:276:31 | new[] | This allocation cannot return null. $@ is unnecessary. | test.cpp:277:8:277:12 | ! ... | This check |
+| test.cpp:288:19:288:47 | new[] | This allocation cannot throw. $@ is unnecessary. | test.cpp:291:30:293:5 | { ... } | This catch block |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-570/test.cpp
@@ -282,7 +282,7 @@ namespace qhelp {
   }
 
   // BAD: the allocation won't throw an exception, but
-  // instead return a null pointer. [NOT DETECTED]
+  // instead return a null pointer.
   void bad2(std::size_t length) noexcept {
     try {
       int* dest = new(std::nothrow) int[length];


### PR DESCRIPTION
Add basic modeling of functions that don't throw.

For now I've just let the classes for the two C functions mentioned in the issue, `memset` and `memcpy`, extend the new class.