### PR TITLE
Data flow: Cache `TNodeEx`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/ProductFlow.qll
@@ -546,7 +546,7 @@ module ProductFlow {
       Flow1::PathGraph::edges(pred1, succ1, _, _) and
       exists(ReturnKindExt returnKind |
         succ1.getNode() = returnKind.getAnOutNode(call) and
-        paramReturnNode(_, pred1.asParameterReturnNode(), _, returnKind)
+        returnKind = getParamReturnPosition(_, pred1.asParameterReturnNode()).getKind()
       )
     }
 
@@ -574,7 +574,7 @@ module ProductFlow {
       Flow2::PathGraph::edges(pred2, succ2, _, _) and
       exists(ReturnKindExt returnKind |
         succ2.getNode() = returnKind.getAnOutNode(call) and
-        paramReturnNode(_, pred2.asParameterReturnNode(), _, returnKind)
+        returnKind = getParamReturnPosition(_, pred2.asParameterReturnNode()).getKind()
       )
     }
 

--- a/go/ql/test/experimental/CWE-090/LDAPInjection.expected
+++ b/go/ql/test/experimental/CWE-090/LDAPInjection.expected
@@ -25,12 +25,9 @@ edges
 | LDAPInjection.go:57:15:57:29 | call to UserAgent | LDAPInjection.go:76:24:76:32 | untrusted | provenance | Src:MaD:1  |
 | LDAPInjection.go:57:15:57:29 | call to UserAgent | LDAPInjection.go:80:22:80:30 | untrusted | provenance | Src:MaD:1  |
 | LDAPInjection.go:57:15:57:29 | call to UserAgent | LDAPInjection.go:81:25:81:33 | untrusted | provenance | Src:MaD:1  |
-| LDAPInjection.go:62:3:62:33 | slice literal [array] | LDAPInjection.go:62:3:62:33 | slice literal | provenance |  |
-| LDAPInjection.go:62:24:62:32 | untrusted | LDAPInjection.go:62:3:62:33 | slice literal [array] | provenance |  |
-| LDAPInjection.go:69:3:69:33 | slice literal [array] | LDAPInjection.go:69:3:69:33 | slice literal | provenance |  |
-| LDAPInjection.go:69:24:69:32 | untrusted | LDAPInjection.go:69:3:69:33 | slice literal [array] | provenance |  |
-| LDAPInjection.go:76:3:76:33 | slice literal [array] | LDAPInjection.go:76:3:76:33 | slice literal | provenance |  |
-| LDAPInjection.go:76:24:76:32 | untrusted | LDAPInjection.go:76:3:76:33 | slice literal [array] | provenance |  |
+| LDAPInjection.go:62:24:62:32 | untrusted | LDAPInjection.go:62:3:62:33 | slice literal | provenance |  |
+| LDAPInjection.go:69:24:69:32 | untrusted | LDAPInjection.go:69:3:69:33 | slice literal | provenance |  |
+| LDAPInjection.go:76:24:76:32 | untrusted | LDAPInjection.go:76:3:76:33 | slice literal | provenance |  |
 models
 | 1 | Source: net/http; Request; true; UserAgent; ; ; ReturnValue; remote; manual |
 nodes
@@ -38,17 +35,14 @@ nodes
 | LDAPInjection.go:59:3:59:11 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:61:3:61:51 | ...+... | semmle.label | ...+... |
 | LDAPInjection.go:62:3:62:33 | slice literal | semmle.label | slice literal |
-| LDAPInjection.go:62:3:62:33 | slice literal [array] | semmle.label | slice literal [array] |
 | LDAPInjection.go:62:24:62:32 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:66:3:66:11 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:68:3:68:51 | ...+... | semmle.label | ...+... |
 | LDAPInjection.go:69:3:69:33 | slice literal | semmle.label | slice literal |
-| LDAPInjection.go:69:3:69:33 | slice literal [array] | semmle.label | slice literal [array] |
 | LDAPInjection.go:69:24:69:32 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:73:3:73:11 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:75:3:75:51 | ...+... | semmle.label | ...+... |
 | LDAPInjection.go:76:3:76:33 | slice literal | semmle.label | slice literal |
-| LDAPInjection.go:76:3:76:33 | slice literal [array] | semmle.label | slice literal [array] |
 | LDAPInjection.go:76:24:76:32 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:80:22:80:30 | untrusted | semmle.label | untrusted |
 | LDAPInjection.go:81:25:81:33 | untrusted | semmle.label | untrusted |

--- a/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
+++ b/go/ql/test/experimental/CWE-1004/CookieWithoutHttpOnly.expected
@@ -7,6 +7,7 @@ edges
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | CookieWithoutHttpOnly.go:15:21:15:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:15:21:15:21 | c | CookieWithoutHttpOnly.go:15:20:15:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:15:21:15:21 | c | CookieWithoutHttpOnly.go:15:20:15:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:19:7:23:2 | struct literal | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:19:7:23:2 | struct literal | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
@@ -24,6 +25,8 @@ edges
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | CookieWithoutHttpOnly.go:24:21:24:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | CookieWithoutHttpOnly.go:24:21:24:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:24:21:24:21 | c | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:24:21:24:21 | c | CookieWithoutHttpOnly.go:24:20:24:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:24:21:24:21 | c | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:24:21:24:21 | c | CookieWithoutHttpOnly.go:24:20:24:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:28:7:32:2 | struct literal | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
@@ -42,6 +45,8 @@ edges
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | CookieWithoutHttpOnly.go:33:21:33:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | CookieWithoutHttpOnly.go:33:21:33:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:33:21:33:21 | c | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:33:21:33:21 | c | CookieWithoutHttpOnly.go:33:20:33:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:33:21:33:21 | c | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:33:21:33:21 | c | CookieWithoutHttpOnly.go:33:20:33:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:37:7:40:2 | struct literal | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
@@ -60,6 +65,8 @@ edges
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | CookieWithoutHttpOnly.go:42:21:42:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | CookieWithoutHttpOnly.go:42:21:42:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:42:21:42:21 | c | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:42:21:42:21 | c | CookieWithoutHttpOnly.go:42:20:42:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:42:21:42:21 | c | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:42:21:42:21 | c | CookieWithoutHttpOnly.go:42:20:42:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:46:7:49:2 | struct literal | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
@@ -78,6 +85,8 @@ edges
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | CookieWithoutHttpOnly.go:51:21:51:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | CookieWithoutHttpOnly.go:51:21:51:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:51:21:51:21 | c | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:51:21:51:21 | c | CookieWithoutHttpOnly.go:51:20:51:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:51:21:51:21 | c | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:51:21:51:21 | c | CookieWithoutHttpOnly.go:51:20:51:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:55:2:55:4 | definition of val | CookieWithoutHttpOnly.go:59:13:59:15 | val | provenance |  |
@@ -98,6 +107,8 @@ edges
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | CookieWithoutHttpOnly.go:61:21:61:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | CookieWithoutHttpOnly.go:61:21:61:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:61:21:61:21 | c | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:61:21:61:21 | c | CookieWithoutHttpOnly.go:61:20:61:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:61:21:61:21 | c | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:61:21:61:21 | c | CookieWithoutHttpOnly.go:61:20:61:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:65:2:65:4 | definition of val | CookieWithoutHttpOnly.go:69:13:69:15 | val | provenance |  |
@@ -118,6 +129,8 @@ edges
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | CookieWithoutHttpOnly.go:71:21:71:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | CookieWithoutHttpOnly.go:71:21:71:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:71:21:71:21 | c | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:71:21:71:21 | c | CookieWithoutHttpOnly.go:71:20:71:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:71:21:71:21 | c | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:71:21:71:21 | c | CookieWithoutHttpOnly.go:71:20:71:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:75:2:75:4 | definition of val | CookieWithoutHttpOnly.go:80:15:80:17 | val | provenance |  |
@@ -138,6 +151,8 @@ edges
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | CookieWithoutHttpOnly.go:81:21:81:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | CookieWithoutHttpOnly.go:81:21:81:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:81:21:81:21 | c | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:81:21:81:21 | c | CookieWithoutHttpOnly.go:81:20:81:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:81:21:81:21 | c | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:81:21:81:21 | c | CookieWithoutHttpOnly.go:81:20:81:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:85:2:85:4 | definition of val | CookieWithoutHttpOnly.go:90:15:90:17 | val | provenance |  |
@@ -158,6 +173,8 @@ edges
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | CookieWithoutHttpOnly.go:91:21:91:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | CookieWithoutHttpOnly.go:91:21:91:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:91:21:91:21 | c | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:91:21:91:21 | c | CookieWithoutHttpOnly.go:91:20:91:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:91:21:91:21 | c | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:91:21:91:21 | c | CookieWithoutHttpOnly.go:91:20:91:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:95:7:98:2 | struct literal | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
@@ -168,6 +185,7 @@ edges
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | CookieWithoutHttpOnly.go:100:21:100:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:100:21:100:21 | c | CookieWithoutHttpOnly.go:100:20:100:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:100:21:100:21 | c | CookieWithoutHttpOnly.go:100:20:100:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:104:10:104:18 | "session" | CookieWithoutHttpOnly.go:106:10:106:13 | name | provenance |  |
 | CookieWithoutHttpOnly.go:105:7:108:2 | struct literal | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
@@ -186,6 +204,8 @@ edges
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | CookieWithoutHttpOnly.go:110:21:110:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | CookieWithoutHttpOnly.go:110:21:110:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:110:21:110:21 | c | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:110:21:110:21 | c | CookieWithoutHttpOnly.go:110:20:110:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:110:21:110:21 | c | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:110:21:110:21 | c | CookieWithoutHttpOnly.go:110:20:110:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:114:13:114:24 | "login_name" | CookieWithoutHttpOnly.go:116:10:116:16 | session | provenance |  |
@@ -205,6 +225,8 @@ edges
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | CookieWithoutHttpOnly.go:120:21:120:21 | c | provenance |  |
 | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | CookieWithoutHttpOnly.go:120:21:120:21 | c | provenance |  |
+| CookieWithoutHttpOnly.go:120:21:120:21 | c | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
+| CookieWithoutHttpOnly.go:120:21:120:21 | c | CookieWithoutHttpOnly.go:120:20:120:21 | &... | provenance |  |
 | CookieWithoutHttpOnly.go:120:21:120:21 | c | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:120:21:120:21 | c | CookieWithoutHttpOnly.go:120:20:120:21 | &... [pointer] | provenance |  |
 | CookieWithoutHttpOnly.go:123:13:123:49 | call to NewCookieStore | CookieWithoutHttpOnly.go:126:16:126:20 | store | provenance |  |

--- a/go/ql/test/library-tests/semmle/go/frameworks/XNetHtml/ReflectedXss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/XNetHtml/ReflectedXss.expected
@@ -54,6 +54,7 @@ edges
 | test.go:45:22:45:31 | &... [pointer] | test.go:45:22:45:31 | &... | provenance |  |
 | test.go:45:22:45:31 | &... [pointer] | test.go:45:22:45:31 | &... | provenance |  |
 | test.go:45:22:45:31 | &... [pointer] | test.go:45:23:45:31 | cleanNode | provenance |  |
+| test.go:45:23:45:31 | cleanNode | test.go:45:22:45:31 | &... | provenance |  |
 | test.go:45:23:45:31 | cleanNode | test.go:45:22:45:31 | &... [pointer] | provenance |  |
 | test.go:47:6:47:15 | definition of cleanNode2 | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:47:6:47:15 | definition of cleanNode2 | test.go:50:22:50:32 | &... | provenance |  |
@@ -65,6 +66,7 @@ edges
 | test.go:50:22:50:32 | &... [pointer] | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:50:22:50:32 | &... [pointer] | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:50:22:50:32 | &... [pointer] | test.go:50:23:50:32 | cleanNode2 | provenance |  |
+| test.go:50:23:50:32 | cleanNode2 | test.go:50:22:50:32 | &... | provenance |  |
 | test.go:50:23:50:32 | cleanNode2 | test.go:50:22:50:32 | &... [pointer] | provenance |  |
 models
 | 1 | Summary: golang.org/x/net/html; ; false; NewTokenizer; ; ; Argument[0]; ReturnValue; taint; manual |

--- a/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -59,8 +59,7 @@ edges
 | SanitizingDoubleDash.go:13:15:13:32 | array literal [array] | SanitizingDoubleDash.go:14:23:14:30 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:13:25:13:31 | tainted | SanitizingDoubleDash.go:13:15:13:32 | array literal [array] | provenance |  |
 | SanitizingDoubleDash.go:14:23:14:30 | arrayLit [array] | SanitizingDoubleDash.go:14:23:14:33 | slice element node | provenance |  |
-| SanitizingDoubleDash.go:14:23:14:33 | slice element node | SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | provenance |  |
-| SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | SanitizingDoubleDash.go:14:23:14:33 | slice expression | provenance |  |
+| SanitizingDoubleDash.go:14:23:14:33 | slice element node | SanitizingDoubleDash.go:14:23:14:33 | slice expression | provenance |  |
 | SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | SanitizingDoubleDash.go:39:14:39:44 | call to append | provenance | MaD:3 |
 | SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | SanitizingDoubleDash.go:39:14:39:44 | call to append [array] | provenance | MaD:3 |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append | SanitizingDoubleDash.go:40:23:40:30 | arrayLit | provenance |  |
@@ -102,13 +101,11 @@ edges
 | SanitizingDoubleDash.go:95:15:95:32 | array literal [array] | SanitizingDoubleDash.go:96:24:96:31 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:95:25:95:31 | tainted | SanitizingDoubleDash.go:95:15:95:32 | array literal [array] | provenance |  |
 | SanitizingDoubleDash.go:96:24:96:31 | arrayLit [array] | SanitizingDoubleDash.go:96:24:96:34 | slice element node | provenance |  |
-| SanitizingDoubleDash.go:96:24:96:34 | slice element node | SanitizingDoubleDash.go:96:24:96:34 | slice expression [array] | provenance |  |
-| SanitizingDoubleDash.go:96:24:96:34 | slice expression [array] | SanitizingDoubleDash.go:96:24:96:34 | slice expression | provenance |  |
+| SanitizingDoubleDash.go:96:24:96:34 | slice element node | SanitizingDoubleDash.go:96:24:96:34 | slice expression | provenance |  |
 | SanitizingDoubleDash.go:100:15:100:38 | array literal [array] | SanitizingDoubleDash.go:101:24:101:31 | arrayLit [array] | provenance |  |
 | SanitizingDoubleDash.go:100:31:100:37 | tainted | SanitizingDoubleDash.go:100:15:100:38 | array literal [array] | provenance |  |
 | SanitizingDoubleDash.go:101:24:101:31 | arrayLit [array] | SanitizingDoubleDash.go:101:24:101:34 | slice element node | provenance |  |
-| SanitizingDoubleDash.go:101:24:101:34 | slice element node | SanitizingDoubleDash.go:101:24:101:34 | slice expression [array] | provenance |  |
-| SanitizingDoubleDash.go:101:24:101:34 | slice expression [array] | SanitizingDoubleDash.go:101:24:101:34 | slice expression | provenance |  |
+| SanitizingDoubleDash.go:101:24:101:34 | slice element node | SanitizingDoubleDash.go:101:24:101:34 | slice expression | provenance |  |
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | SanitizingDoubleDash.go:106:24:106:31 | arrayLit | provenance |  |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | provenance |  |
 | SanitizingDoubleDash.go:111:14:111:44 | []type{args} [array] | SanitizingDoubleDash.go:111:14:111:44 | call to append | provenance | MaD:3 |
@@ -190,7 +187,6 @@ nodes
 | SanitizingDoubleDash.go:14:23:14:30 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:14:23:14:33 | slice element node | semmle.label | slice element node |
 | SanitizingDoubleDash.go:14:23:14:33 | slice expression | semmle.label | slice expression |
-| SanitizingDoubleDash.go:14:23:14:33 | slice expression [array] | semmle.label | slice expression [array] |
 | SanitizingDoubleDash.go:39:14:39:44 | []type{args} [array] | semmle.label | []type{args} [array] |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append | semmle.label | call to append |
 | SanitizingDoubleDash.go:39:14:39:44 | call to append [array] | semmle.label | call to append [array] |
@@ -220,13 +216,11 @@ nodes
 | SanitizingDoubleDash.go:96:24:96:31 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:96:24:96:34 | slice element node | semmle.label | slice element node |
 | SanitizingDoubleDash.go:96:24:96:34 | slice expression | semmle.label | slice expression |
-| SanitizingDoubleDash.go:96:24:96:34 | slice expression [array] | semmle.label | slice expression [array] |
 | SanitizingDoubleDash.go:100:15:100:38 | array literal [array] | semmle.label | array literal [array] |
 | SanitizingDoubleDash.go:100:31:100:37 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:101:24:101:31 | arrayLit [array] | semmle.label | arrayLit [array] |
 | SanitizingDoubleDash.go:101:24:101:34 | slice element node | semmle.label | slice element node |
 | SanitizingDoubleDash.go:101:24:101:34 | slice expression | semmle.label | slice expression |
-| SanitizingDoubleDash.go:101:24:101:34 | slice expression [array] | semmle.label | slice expression [array] |
 | SanitizingDoubleDash.go:105:15:105:37 | slice literal [array] | semmle.label | slice literal [array] |
 | SanitizingDoubleDash.go:105:30:105:36 | tainted | semmle.label | tainted |
 | SanitizingDoubleDash.go:106:24:106:31 | arrayLit | semmle.label | arrayLit |

--- a/java/ql/test/experimental/query-tests/security/CWE-078/CommandInjectionRuntimeExecLocal.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-078/CommandInjectionRuntimeExecLocal.expected
@@ -14,8 +14,7 @@ edges
 | RuntimeExecTest.java:25:66:25:71 | script : String | RuntimeExecTest.java:25:42:25:72 | {...} : String[] [[]] : String | provenance |  |
 | RuntimeExecTest.java:31:17:31:29 | commandArray2 [post update] : String[] [[]] : String | RuntimeExecTest.java:32:43:32:55 | commandArray2 | provenance | Sink:MaD:1 |
 | RuntimeExecTest.java:31:36:31:41 | script : String | RuntimeExecTest.java:31:17:31:29 | commandArray2 [post update] : String[] [[]] : String | provenance |  |
-| RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:44 | toArray(...) : String[] [[]] : String | provenance | MaD:5 |
-| RuntimeExecTest.java:36:21:39:44 | toArray(...) : String[] [[]] : String | RuntimeExecTest.java:36:21:39:44 | toArray(...) | provenance | Sink:MaD:1 |
+| RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:44 | toArray(...) | provenance | MaD:5 |
 | RuntimeExecTest.java:38:25:38:59 | stream(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | provenance | MaD:4 |
 | RuntimeExecTest.java:38:39:38:58 | new String[] : String[] [[]] : String | RuntimeExecTest.java:38:25:38:59 | stream(...) : Stream [<element>] : String | provenance | MaD:3 |
 | RuntimeExecTest.java:38:39:38:58 | {...} : String[] [[]] : String | RuntimeExecTest.java:38:39:38:58 | new String[] : String[] [[]] : String | provenance |  |
@@ -39,7 +38,6 @@ nodes
 | RuntimeExecTest.java:32:43:32:55 | commandArray2 | semmle.label | commandArray2 |
 | RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | semmle.label | concat(...) : Stream [<element>] : String |
 | RuntimeExecTest.java:36:21:39:44 | toArray(...) | semmle.label | toArray(...) |
-| RuntimeExecTest.java:36:21:39:44 | toArray(...) : String[] [[]] : String | semmle.label | toArray(...) : String[] [[]] : String |
 | RuntimeExecTest.java:38:25:38:59 | stream(...) : Stream [<element>] : String | semmle.label | stream(...) : Stream [<element>] : String |
 | RuntimeExecTest.java:38:39:38:58 | new String[] : String[] [[]] : String | semmle.label | new String[] : String[] [[]] : String |
 | RuntimeExecTest.java:38:39:38:58 | {...} : String[] [[]] : String | semmle.label | {...} : String[] [[]] : String |

--- a/java/ql/test/experimental/query-tests/security/CWE-078/CommandInjectionRuntimeExecLocal.expected
+++ b/java/ql/test/experimental/query-tests/security/CWE-078/CommandInjectionRuntimeExecLocal.expected
@@ -14,7 +14,7 @@ edges
 | RuntimeExecTest.java:25:66:25:71 | script : String | RuntimeExecTest.java:25:42:25:72 | {...} : String[] [[]] : String | provenance |  |
 | RuntimeExecTest.java:31:17:31:29 | commandArray2 [post update] : String[] [[]] : String | RuntimeExecTest.java:32:43:32:55 | commandArray2 | provenance | Sink:MaD:1 |
 | RuntimeExecTest.java:31:36:31:41 | script : String | RuntimeExecTest.java:31:17:31:29 | commandArray2 [post update] : String[] [[]] : String | provenance |  |
-| RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:44 | toArray(...) | provenance | MaD:5 |
+| RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:44 | toArray(...) | provenance | MaD:5 Sink:MaD:1 |
 | RuntimeExecTest.java:38:25:38:59 | stream(...) : Stream [<element>] : String | RuntimeExecTest.java:36:21:39:21 | concat(...) : Stream [<element>] : String | provenance | MaD:4 |
 | RuntimeExecTest.java:38:39:38:58 | new String[] : String[] [[]] : String | RuntimeExecTest.java:38:25:38:59 | stream(...) : Stream [<element>] : String | provenance | MaD:3 |
 | RuntimeExecTest.java:38:39:38:58 | {...} : String[] [[]] : String | RuntimeExecTest.java:38:39:38:58 | new String[] : String[] [[]] : String | provenance |  |

--- a/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.expected
+++ b/java/ql/test/library-tests/frameworks/apache-commons-lang3/flow.expected
@@ -682,62 +682,38 @@ edges
 | ArrayUtilsTest.java:20:33:20:56 | {...} : String[] [[]] : String | ArrayUtilsTest.java:59:32:59:45 | alreadyTainted : String[] [[]] : String | provenance |  |
 | ArrayUtilsTest.java:20:33:20:56 | {...} : String[] [[]] : String | ArrayUtilsTest.java:63:29:63:42 | alreadyTainted : String[] [[]] : String | provenance |  |
 | ArrayUtilsTest.java:20:48:20:54 | taint(...) : String | ArrayUtilsTest.java:20:33:20:56 | {...} : String[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:23:12:23:44 | add(...) : String[] [[]] : String | ArrayUtilsTest.java:23:12:23:44 | add(...) | provenance |  |
-| ArrayUtilsTest.java:23:37:23:43 | taint(...) : String | ArrayUtilsTest.java:23:12:23:44 | add(...) : String[] [[]] : String | provenance | MaD:32 |
-| ArrayUtilsTest.java:24:12:24:53 | add(...) : String[] [[]] : String | ArrayUtilsTest.java:24:12:24:53 | add(...) | provenance |  |
-| ArrayUtilsTest.java:24:27:24:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:24:12:24:53 | add(...) : String[] [[]] : String | provenance | MaD:31 |
-| ArrayUtilsTest.java:26:12:26:41 | add(...) : String[] [[]] : String | ArrayUtilsTest.java:26:12:26:41 | add(...) | provenance |  |
-| ArrayUtilsTest.java:26:34:26:40 | taint(...) : String | ArrayUtilsTest.java:26:12:26:41 | add(...) : String[] [[]] : String | provenance | MaD:33 |
-| ArrayUtilsTest.java:27:12:27:50 | add(...) : String[] [[]] : String | ArrayUtilsTest.java:27:12:27:50 | add(...) | provenance |  |
-| ArrayUtilsTest.java:27:27:27:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:27:12:27:50 | add(...) : String[] [[]] : String | provenance | MaD:31 |
-| ArrayUtilsTest.java:28:12:28:53 | addAll(...) : String[] [[]] : String | ArrayUtilsTest.java:28:12:28:53 | addAll(...) | provenance |  |
-| ArrayUtilsTest.java:28:12:28:53 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:28:12:28:53 | addAll(...) : String[] [[]] : String | provenance | MaD:34 |
+| ArrayUtilsTest.java:23:37:23:43 | taint(...) : String | ArrayUtilsTest.java:23:12:23:44 | add(...) | provenance | MaD:32 |
+| ArrayUtilsTest.java:24:27:24:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:24:12:24:53 | add(...) | provenance | MaD:31 |
+| ArrayUtilsTest.java:26:34:26:40 | taint(...) : String | ArrayUtilsTest.java:26:12:26:41 | add(...) | provenance | MaD:33 |
+| ArrayUtilsTest.java:27:27:27:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:27:12:27:50 | add(...) | provenance | MaD:31 |
+| ArrayUtilsTest.java:28:12:28:53 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:28:12:28:53 | addAll(...) | provenance | MaD:34 |
 | ArrayUtilsTest.java:28:46:28:52 | taint(...) : String | ArrayUtilsTest.java:28:12:28:53 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:29:12:29:53 | addAll(...) : String[] [[]] : String | ArrayUtilsTest.java:29:12:29:53 | addAll(...) | provenance |  |
-| ArrayUtilsTest.java:29:12:29:53 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:29:12:29:53 | addAll(...) : String[] [[]] : String | provenance | MaD:34 |
+| ArrayUtilsTest.java:29:12:29:53 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:29:12:29:53 | addAll(...) | provenance | MaD:34 |
 | ArrayUtilsTest.java:29:37:29:43 | taint(...) : String | ArrayUtilsTest.java:29:12:29:53 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:30:12:30:67 | addAll(...) : String[] [[]] : String | ArrayUtilsTest.java:30:12:30:67 | addAll(...) | provenance |  |
-| ArrayUtilsTest.java:30:30:30:43 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:30:12:30:67 | addAll(...) : String[] [[]] : String | provenance | MaD:34 |
-| ArrayUtilsTest.java:31:12:31:46 | addFirst(...) : String[] [[]] : String | ArrayUtilsTest.java:31:12:31:46 | addFirst(...) | provenance |  |
-| ArrayUtilsTest.java:31:39:31:45 | taint(...) : String | ArrayUtilsTest.java:31:12:31:46 | addFirst(...) : String[] [[]] : String | provenance | MaD:36 |
-| ArrayUtilsTest.java:32:12:32:55 | addFirst(...) : String[] [[]] : String | ArrayUtilsTest.java:32:12:32:55 | addFirst(...) | provenance |  |
-| ArrayUtilsTest.java:32:32:32:45 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:32:12:32:55 | addFirst(...) : String[] [[]] : String | provenance | MaD:35 |
-| ArrayUtilsTest.java:33:12:33:43 | clone(...) : String[] [[]] : String | ArrayUtilsTest.java:33:12:33:43 | clone(...) | provenance |  |
-| ArrayUtilsTest.java:33:29:33:42 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:33:12:33:43 | clone(...) : String[] [[]] : String | provenance | MaD:37 |
+| ArrayUtilsTest.java:30:30:30:43 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:30:12:30:67 | addAll(...) | provenance | MaD:34 |
+| ArrayUtilsTest.java:31:39:31:45 | taint(...) : String | ArrayUtilsTest.java:31:12:31:46 | addFirst(...) | provenance | MaD:36 |
+| ArrayUtilsTest.java:32:32:32:45 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:32:12:32:55 | addFirst(...) | provenance | MaD:35 |
+| ArrayUtilsTest.java:33:29:33:42 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:33:12:33:43 | clone(...) | provenance | MaD:37 |
 | ArrayUtilsTest.java:34:27:34:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:34:12:34:44 | get(...) | provenance | MaD:38 |
 | ArrayUtilsTest.java:36:27:36:40 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:36:12:36:61 | get(...) | provenance | MaD:38 |
 | ArrayUtilsTest.java:38:37:38:43 | taint(...) : String | ArrayUtilsTest.java:38:12:38:44 | get(...) | provenance | MaD:39 |
-| ArrayUtilsTest.java:40:12:40:67 | insert(...) : String[] [[]] : String | ArrayUtilsTest.java:40:12:40:67 | insert(...) | provenance |  |
-| ArrayUtilsTest.java:40:33:40:46 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:40:12:40:67 | insert(...) : String[] [[]] : String | provenance | MaD:40 |
-| ArrayUtilsTest.java:41:12:41:57 | insert(...) : String[] [[]] : String | ArrayUtilsTest.java:41:12:41:57 | insert(...) | provenance |  |
-| ArrayUtilsTest.java:41:12:41:57 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:41:12:41:57 | insert(...) : String[] [[]] : String | provenance | MaD:40 |
+| ArrayUtilsTest.java:40:33:40:46 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:40:12:40:67 | insert(...) | provenance | MaD:40 |
+| ArrayUtilsTest.java:41:12:41:57 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:41:12:41:57 | insert(...) | provenance | MaD:40 |
 | ArrayUtilsTest.java:41:40:41:46 | taint(...) : String | ArrayUtilsTest.java:41:12:41:57 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:42:12:42:57 | insert(...) : String[] [[]] : String | ArrayUtilsTest.java:42:12:42:57 | insert(...) | provenance |  |
-| ArrayUtilsTest.java:42:12:42:57 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:42:12:42:57 | insert(...) : String[] [[]] : String | provenance | MaD:40 |
+| ArrayUtilsTest.java:42:12:42:57 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:42:12:42:57 | insert(...) | provenance | MaD:40 |
 | ArrayUtilsTest.java:42:50:42:56 | taint(...) : String | ArrayUtilsTest.java:42:12:42:57 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) : String[] [[]] : String | ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) | provenance |  |
-| ArrayUtilsTest.java:43:35:43:48 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) : String[] [[]] : String | provenance | MaD:42 |
-| ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) : String[] [[]] : String | ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) | provenance |  |
-| ArrayUtilsTest.java:44:35:44:48 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) : String[] [[]] : String | provenance | MaD:41 |
-| ArrayUtilsTest.java:45:12:45:47 | remove(...) : String[] [[]] : String | ArrayUtilsTest.java:45:12:45:47 | remove(...) | provenance |  |
-| ArrayUtilsTest.java:45:30:45:43 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:45:12:45:47 | remove(...) : String[] [[]] : String | provenance | MaD:43 |
-| ArrayUtilsTest.java:47:12:47:53 | removeAll(...) : String[] [[]] : String | ArrayUtilsTest.java:47:12:47:53 | removeAll(...) | provenance |  |
-| ArrayUtilsTest.java:47:33:47:46 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:47:12:47:53 | removeAll(...) : String[] [[]] : String | provenance | MaD:44 |
-| ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) : String[] [[]] : String | ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) | provenance |  |
-| ArrayUtilsTest.java:51:43:51:56 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) : String[] [[]] : String | provenance | MaD:45 |
-| ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) : String[] [[]] : String | ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) | provenance |  |
-| ArrayUtilsTest.java:53:44:53:57 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) : String[] [[]] : String | provenance | MaD:46 |
-| ArrayUtilsTest.java:55:12:55:70 | removeElement(...) : String[] [[]] : String | ArrayUtilsTest.java:55:12:55:70 | removeElement(...) | provenance |  |
-| ArrayUtilsTest.java:55:37:55:50 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:55:12:55:70 | removeElement(...) : String[] [[]] : String | provenance | MaD:47 |
-| ArrayUtilsTest.java:56:12:56:58 | removeElements(...) : Object[] [[]] : String | ArrayUtilsTest.java:56:12:56:58 | removeElements(...) | provenance |  |
-| ArrayUtilsTest.java:56:38:56:51 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:56:12:56:58 | removeElements(...) : Object[] [[]] : String | provenance | MaD:48 |
-| ArrayUtilsTest.java:59:12:59:52 | subarray(...) : String[] [[]] : String | ArrayUtilsTest.java:59:12:59:52 | subarray(...) | provenance |  |
-| ArrayUtilsTest.java:59:32:59:45 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:59:12:59:52 | subarray(...) : String[] [[]] : String | provenance | MaD:49 |
-| ArrayUtilsTest.java:61:12:61:47 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:61:12:61:47 | toArray(...) : String[] [[]] : String | provenance | MaD:50 |
-| ArrayUtilsTest.java:61:12:61:47 | toArray(...) : String[] [[]] : String | ArrayUtilsTest.java:61:12:61:47 | toArray(...) | provenance |  |
+| ArrayUtilsTest.java:43:35:43:48 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) | provenance | MaD:42 |
+| ArrayUtilsTest.java:44:35:44:48 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) | provenance | MaD:41 |
+| ArrayUtilsTest.java:45:30:45:43 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:45:12:45:47 | remove(...) | provenance | MaD:43 |
+| ArrayUtilsTest.java:47:33:47:46 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:47:12:47:53 | removeAll(...) | provenance | MaD:44 |
+| ArrayUtilsTest.java:51:43:51:56 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) | provenance | MaD:45 |
+| ArrayUtilsTest.java:53:44:53:57 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) | provenance | MaD:46 |
+| ArrayUtilsTest.java:55:37:55:50 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:55:12:55:70 | removeElement(...) | provenance | MaD:47 |
+| ArrayUtilsTest.java:56:38:56:51 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:56:12:56:58 | removeElements(...) | provenance | MaD:48 |
+| ArrayUtilsTest.java:59:32:59:45 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:59:12:59:52 | subarray(...) | provenance | MaD:49 |
+| ArrayUtilsTest.java:61:12:61:47 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:61:12:61:47 | toArray(...) | provenance | MaD:50 |
 | ArrayUtilsTest.java:61:40:61:46 | taint(...) : String | ArrayUtilsTest.java:61:12:61:47 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
-| ArrayUtilsTest.java:62:12:62:47 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:62:12:62:47 | toArray(...) : String[] [[]] : String | provenance | MaD:50 |
-| ArrayUtilsTest.java:62:12:62:47 | toArray(...) : String[] [[]] : String | ArrayUtilsTest.java:62:12:62:47 | toArray(...) | provenance |  |
+| ArrayUtilsTest.java:62:12:62:47 | new ..[] { .. } : Object[] [[]] : String | ArrayUtilsTest.java:62:12:62:47 | toArray(...) | provenance | MaD:50 |
 | ArrayUtilsTest.java:62:31:62:37 | taint(...) : String | ArrayUtilsTest.java:62:12:62:47 | new ..[] { .. } : Object[] [[]] : String | provenance |  |
 | ArrayUtilsTest.java:63:12:63:43 | toMap(...) : Map [<map.value>] : Object | ArrayUtilsTest.java:63:12:63:54 | get(...) | provenance | MaD:15 |
 | ArrayUtilsTest.java:63:29:63:42 | alreadyTainted : String[] [[]] : String | ArrayUtilsTest.java:63:12:63:43 | toMap(...) : Map [<map.value>] : Object | provenance | MaD:51 |
@@ -747,10 +723,8 @@ edges
 | ArrayUtilsTest.java:69:36:69:67 | toObject(...) : Integer[] [[]] : Number | ArrayUtilsTest.java:70:12:70:27 | taintedBoxedInts | provenance |  |
 | ArrayUtilsTest.java:69:36:69:67 | toObject(...) : Integer[] [[]] : Number | ArrayUtilsTest.java:71:35:71:50 | taintedBoxedInts : Integer[] [[]] : Number | provenance |  |
 | ArrayUtilsTest.java:69:56:69:66 | taintedInts : int[] [[]] : Number | ArrayUtilsTest.java:69:36:69:67 | toObject(...) : Integer[] [[]] : Number | provenance | MaD:53 |
-| ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) : int[] [[]] : Number | ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) | provenance |  |
-| ArrayUtilsTest.java:71:35:71:50 | taintedBoxedInts : Integer[] [[]] : Number | ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) : int[] [[]] : Number | provenance | MaD:54 |
-| ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) : int[] [[]] : Number | ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) | provenance |  |
-| ArrayUtilsTest.java:72:53:72:69 | taint(...) : Number | ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) : int[] [[]] : Number | provenance | MaD:55 |
+| ArrayUtilsTest.java:71:35:71:50 | taintedBoxedInts : Integer[] [[]] : Number | ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) | provenance | MaD:54 |
+| ArrayUtilsTest.java:72:53:72:69 | taint(...) : Number | ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) | provenance | MaD:55 |
 | MutableTest.java:11:39:11:66 | new MutableObject<String>(...) : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | MutableTest.java:20:12:20:18 | tainted : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | provenance |  |
 | MutableTest.java:11:39:11:66 | new MutableObject<String>(...) : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | MutableTest.java:21:12:21:23 | taintedAlias : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | provenance |  |
 | MutableTest.java:11:59:11:65 | taint(...) : String | MutableTest.java:11:39:11:66 | new MutableObject<String>(...) : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | provenance | MaD:225 |
@@ -3338,36 +3312,26 @@ nodes
 | ArrayUtilsTest.java:20:33:20:56 | {...} : String[] [[]] : String | semmle.label | {...} : String[] [[]] : String |
 | ArrayUtilsTest.java:20:48:20:54 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:23:12:23:44 | add(...) | semmle.label | add(...) |
-| ArrayUtilsTest.java:23:12:23:44 | add(...) : String[] [[]] : String | semmle.label | add(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:23:37:23:43 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:24:12:24:53 | add(...) | semmle.label | add(...) |
-| ArrayUtilsTest.java:24:12:24:53 | add(...) : String[] [[]] : String | semmle.label | add(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:24:27:24:40 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:26:12:26:41 | add(...) | semmle.label | add(...) |
-| ArrayUtilsTest.java:26:12:26:41 | add(...) : String[] [[]] : String | semmle.label | add(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:26:34:26:40 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:27:12:27:50 | add(...) | semmle.label | add(...) |
-| ArrayUtilsTest.java:27:12:27:50 | add(...) : String[] [[]] : String | semmle.label | add(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:27:27:27:40 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:28:12:28:53 | addAll(...) | semmle.label | addAll(...) |
-| ArrayUtilsTest.java:28:12:28:53 | addAll(...) : String[] [[]] : String | semmle.label | addAll(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:28:12:28:53 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:28:46:28:52 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:29:12:29:53 | addAll(...) | semmle.label | addAll(...) |
-| ArrayUtilsTest.java:29:12:29:53 | addAll(...) : String[] [[]] : String | semmle.label | addAll(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:29:12:29:53 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:29:37:29:43 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:30:12:30:67 | addAll(...) | semmle.label | addAll(...) |
-| ArrayUtilsTest.java:30:12:30:67 | addAll(...) : String[] [[]] : String | semmle.label | addAll(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:30:30:30:43 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:31:12:31:46 | addFirst(...) | semmle.label | addFirst(...) |
-| ArrayUtilsTest.java:31:12:31:46 | addFirst(...) : String[] [[]] : String | semmle.label | addFirst(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:31:39:31:45 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:32:12:32:55 | addFirst(...) | semmle.label | addFirst(...) |
-| ArrayUtilsTest.java:32:12:32:55 | addFirst(...) : String[] [[]] : String | semmle.label | addFirst(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:32:32:32:45 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:33:12:33:43 | clone(...) | semmle.label | clone(...) |
-| ArrayUtilsTest.java:33:12:33:43 | clone(...) : String[] [[]] : String | semmle.label | clone(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:33:29:33:42 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:34:12:34:44 | get(...) | semmle.label | get(...) |
 | ArrayUtilsTest.java:34:27:34:40 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
@@ -3376,50 +3340,36 @@ nodes
 | ArrayUtilsTest.java:38:12:38:44 | get(...) | semmle.label | get(...) |
 | ArrayUtilsTest.java:38:37:38:43 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:40:12:40:67 | insert(...) | semmle.label | insert(...) |
-| ArrayUtilsTest.java:40:12:40:67 | insert(...) : String[] [[]] : String | semmle.label | insert(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:40:33:40:46 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:41:12:41:57 | insert(...) | semmle.label | insert(...) |
-| ArrayUtilsTest.java:41:12:41:57 | insert(...) : String[] [[]] : String | semmle.label | insert(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:41:12:41:57 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:41:40:41:46 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:42:12:42:57 | insert(...) | semmle.label | insert(...) |
-| ArrayUtilsTest.java:42:12:42:57 | insert(...) : String[] [[]] : String | semmle.label | insert(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:42:12:42:57 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:42:50:42:56 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) | semmle.label | nullToEmpty(...) |
-| ArrayUtilsTest.java:43:12:43:49 | nullToEmpty(...) : String[] [[]] : String | semmle.label | nullToEmpty(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:43:35:43:48 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) | semmle.label | nullToEmpty(...) |
-| ArrayUtilsTest.java:44:12:44:65 | nullToEmpty(...) : String[] [[]] : String | semmle.label | nullToEmpty(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:44:35:44:48 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:45:12:45:47 | remove(...) | semmle.label | remove(...) |
-| ArrayUtilsTest.java:45:12:45:47 | remove(...) : String[] [[]] : String | semmle.label | remove(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:45:30:45:43 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:47:12:47:53 | removeAll(...) | semmle.label | removeAll(...) |
-| ArrayUtilsTest.java:47:12:47:53 | removeAll(...) : String[] [[]] : String | semmle.label | removeAll(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:47:33:47:46 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) | semmle.label | removeAllOccurences(...) |
-| ArrayUtilsTest.java:51:12:51:76 | removeAllOccurences(...) : String[] [[]] : String | semmle.label | removeAllOccurences(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:51:43:51:56 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) | semmle.label | removeAllOccurrences(...) |
-| ArrayUtilsTest.java:53:12:53:77 | removeAllOccurrences(...) : String[] [[]] : String | semmle.label | removeAllOccurrences(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:53:44:53:57 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:55:12:55:70 | removeElement(...) | semmle.label | removeElement(...) |
-| ArrayUtilsTest.java:55:12:55:70 | removeElement(...) : String[] [[]] : String | semmle.label | removeElement(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:55:37:55:50 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:56:12:56:58 | removeElements(...) | semmle.label | removeElements(...) |
-| ArrayUtilsTest.java:56:12:56:58 | removeElements(...) : Object[] [[]] : String | semmle.label | removeElements(...) : Object[] [[]] : String |
 | ArrayUtilsTest.java:56:38:56:51 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:59:12:59:52 | subarray(...) | semmle.label | subarray(...) |
-| ArrayUtilsTest.java:59:12:59:52 | subarray(...) : String[] [[]] : String | semmle.label | subarray(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:59:32:59:45 | alreadyTainted : String[] [[]] : String | semmle.label | alreadyTainted : String[] [[]] : String |
 | ArrayUtilsTest.java:61:12:61:47 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:61:12:61:47 | toArray(...) | semmle.label | toArray(...) |
-| ArrayUtilsTest.java:61:12:61:47 | toArray(...) : String[] [[]] : String | semmle.label | toArray(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:61:40:61:46 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:62:12:62:47 | new ..[] { .. } : Object[] [[]] : String | semmle.label | new ..[] { .. } : Object[] [[]] : String |
 | ArrayUtilsTest.java:62:12:62:47 | toArray(...) | semmle.label | toArray(...) |
-| ArrayUtilsTest.java:62:12:62:47 | toArray(...) : String[] [[]] : String | semmle.label | toArray(...) : String[] [[]] : String |
 | ArrayUtilsTest.java:62:31:62:37 | taint(...) : String | semmle.label | taint(...) : String |
 | ArrayUtilsTest.java:63:12:63:43 | toMap(...) : Map [<map.value>] : Object | semmle.label | toMap(...) : Map [<map.value>] : Object |
 | ArrayUtilsTest.java:63:12:63:54 | get(...) | semmle.label | get(...) |
@@ -3430,10 +3380,8 @@ nodes
 | ArrayUtilsTest.java:69:56:69:66 | taintedInts : int[] [[]] : Number | semmle.label | taintedInts : int[] [[]] : Number |
 | ArrayUtilsTest.java:70:12:70:27 | taintedBoxedInts | semmle.label | taintedBoxedInts |
 | ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) | semmle.label | toPrimitive(...) |
-| ArrayUtilsTest.java:71:12:71:51 | toPrimitive(...) : int[] [[]] : Number | semmle.label | toPrimitive(...) : int[] [[]] : Number |
 | ArrayUtilsTest.java:71:35:71:50 | taintedBoxedInts : Integer[] [[]] : Number | semmle.label | taintedBoxedInts : Integer[] [[]] : Number |
 | ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) | semmle.label | toPrimitive(...) |
-| ArrayUtilsTest.java:72:12:72:70 | toPrimitive(...) : int[] [[]] : Number | semmle.label | toPrimitive(...) : int[] [[]] : Number |
 | ArrayUtilsTest.java:72:53:72:69 | taint(...) : Number | semmle.label | taint(...) : Number |
 | MutableTest.java:11:39:11:66 | new MutableObject<String>(...) : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String | semmle.label | new MutableObject<String>(...) : MutableObject [org.apache.commons.lang3.mutable.MutableObject.value] : String |
 | MutableTest.java:11:59:11:65 | taint(...) : String | semmle.label | taint(...) : String |

--- a/java/ql/test/query-tests/security/CWE-078/ExecTainted.expected
+++ b/java/ql/test/query-tests/security/CWE-078/ExecTainted.expected
@@ -9,8 +9,7 @@ edges
 | Test.java:6:35:6:44 | arg : String | Test.java:10:61:10:73 | ... + ... : String | provenance |  |
 | Test.java:6:35:6:44 | arg : String | Test.java:16:13:16:25 | ... + ... : String | provenance |  |
 | Test.java:6:35:6:44 | arg : String | Test.java:22:15:22:27 | ... + ... : String | provenance |  |
-| Test.java:7:25:7:70 | new ..[] { .. } : String[] [[]] : String | Test.java:7:25:7:70 | new ..[] { .. } | provenance | Sink:MaD:2 |
-| Test.java:7:44:7:69 | ... + ... : String | Test.java:7:25:7:70 | new ..[] { .. } : String[] [[]] : String | provenance |  |
+| Test.java:7:44:7:69 | ... + ... : String | Test.java:7:25:7:70 | new ..[] { .. } | provenance | Sink:MaD:2 |
 | Test.java:10:29:10:74 | {...} : String[] [[]] : String | Test.java:10:29:10:74 | new String[] | provenance | Sink:MaD:2 |
 | Test.java:10:61:10:73 | ... + ... : String | Test.java:10:29:10:74 | {...} : String[] [[]] : String | provenance |  |
 | Test.java:16:5:16:7 | cmd [post update] : ArrayList [<element>] : String | Test.java:18:29:18:31 | cmd | provenance | Sink:MaD:1 |
@@ -18,8 +17,7 @@ edges
 | Test.java:22:5:22:8 | cmd1 [post update] : String[] [[]] : String | Test.java:24:29:24:32 | cmd1 | provenance | Sink:MaD:2 |
 | Test.java:22:15:22:27 | ... + ... : String | Test.java:22:5:22:8 | cmd1 [post update] : String[] [[]] : String | provenance |  |
 | Test.java:28:38:28:47 | arg : String | Test.java:29:44:29:64 | ... + ... : String | provenance |  |
-| Test.java:29:25:29:65 | new ..[] { .. } : String[] [[]] : String | Test.java:29:25:29:65 | new ..[] { .. } | provenance | Sink:MaD:2 |
-| Test.java:29:44:29:64 | ... + ... : String | Test.java:29:25:29:65 | new ..[] { .. } : String[] [[]] : String | provenance |  |
+| Test.java:29:44:29:64 | ... + ... : String | Test.java:29:25:29:65 | new ..[] { .. } | provenance | Sink:MaD:2 |
 | Test.java:57:27:57:39 | args : String[] | Test.java:60:20:60:22 | arg : String | provenance |  |
 | Test.java:57:27:57:39 | args : String[] | Test.java:61:23:61:25 | arg : String | provenance |  |
 | Test.java:60:20:60:22 | arg : String | Test.java:6:35:6:44 | arg : String | provenance |  |
@@ -31,7 +29,6 @@ models
 nodes
 | Test.java:6:35:6:44 | arg : String | semmle.label | arg : String |
 | Test.java:7:25:7:70 | new ..[] { .. } | semmle.label | new ..[] { .. } |
-| Test.java:7:25:7:70 | new ..[] { .. } : String[] [[]] : String | semmle.label | new ..[] { .. } : String[] [[]] : String |
 | Test.java:7:44:7:69 | ... + ... : String | semmle.label | ... + ... : String |
 | Test.java:10:29:10:74 | new String[] | semmle.label | new String[] |
 | Test.java:10:29:10:74 | {...} : String[] [[]] : String | semmle.label | {...} : String[] [[]] : String |
@@ -44,7 +41,6 @@ nodes
 | Test.java:24:29:24:32 | cmd1 | semmle.label | cmd1 |
 | Test.java:28:38:28:47 | arg : String | semmle.label | arg : String |
 | Test.java:29:25:29:65 | new ..[] { .. } | semmle.label | new ..[] { .. } |
-| Test.java:29:25:29:65 | new ..[] { .. } : String[] [[]] : String | semmle.label | new ..[] { .. } : String[] [[]] : String |
 | Test.java:29:44:29:64 | ... + ... : String | semmle.label | ... + ... : String |
 | Test.java:57:27:57:39 | args : String[] | semmle.label | args : String[] |
 | Test.java:60:20:60:22 | arg : String | semmle.label | arg : String |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -78,14 +78,10 @@ edges
 | semantics.rb:60:5:60:5 | a | semantics.rb:66:14:66:15 | &... | provenance |  |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a | provenance |  |
 | semantics.rb:60:9:60:18 | call to source | semantics.rb:60:5:60:5 | a | provenance |  |
-| semantics.rb:61:10:61:15 | call to s10 [element 0] | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
 | semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 | provenance |  |
-| semantics.rb:61:14:61:14 | a | semantics.rb:61:10:61:15 | call to s10 [element 0] | provenance |  |
-| semantics.rb:62:10:62:18 | call to s10 [element 1] | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
 | semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 | provenance |  |
-| semantics.rb:62:17:62:17 | a | semantics.rb:62:10:62:18 | call to s10 [element 1] | provenance |  |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 | provenance |  |
 | semantics.rb:63:19:63:19 | a | semantics.rb:63:10:63:20 | call to s10 | provenance |  |
 | semantics.rb:64:27:64:27 | a | semantics.rb:64:10:64:28 | call to s10 | provenance |  |
@@ -192,10 +188,8 @@ edges
 | semantics.rb:126:5:126:5 | b | semantics.rb:129:17:129:17 | b | provenance |  |
 | semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b | provenance |  |
 | semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b | provenance |  |
-| semantics.rb:127:10:127:18 | call to s17 [element 0] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
-| semantics.rb:127:10:127:18 | call to s17 [element 1] | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
-| semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 [element 0] | provenance |  |
-| semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 [element 1] | provenance |  |
+| semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
+| semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
 | semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
 | semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
 | semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [element 0] | provenance |  |
@@ -1191,12 +1185,10 @@ nodes
 | semantics.rb:60:9:60:18 | call to source | semmle.label | call to source |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:61:10:61:15 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:61:10:61:15 | call to s10 [element 0] | semmle.label | call to s10 [element 0] |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:61:14:61:14 | a | semmle.label | a |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
 | semantics.rb:62:10:62:18 | call to s10 | semmle.label | call to s10 |
-| semantics.rb:62:10:62:18 | call to s10 [element 1] | semmle.label | call to s10 [element 1] |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:62:17:62:17 | a | semmle.label | a |
 | semantics.rb:63:10:63:20 | call to s10 | semmle.label | call to s10 |
@@ -1322,8 +1314,6 @@ nodes
 | semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
 | semantics.rb:126:9:126:18 | call to source | semmle.label | call to source |
 | semantics.rb:127:10:127:18 | call to s17 | semmle.label | call to s17 |
-| semantics.rb:127:10:127:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
-| semantics.rb:127:10:127:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
 | semantics.rb:127:14:127:14 | a | semmle.label | a |
 | semantics.rb:127:17:127:17 | b | semmle.label | b |
 | semantics.rb:128:10:128:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -292,8 +292,8 @@ edges
 | summaries.rb:128:1:128:1 | [post] x | summaries.rb:129:6:129:6 | x | provenance |  |
 | summaries.rb:128:14:128:20 | tainted | summaries.rb:128:1:128:1 | [post] x | provenance | MaD:21 |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:131:1:131:23 | synthetic splat argument | provenance | Sink:MaD:4 |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
+| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
 nodes
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -56,28 +56,18 @@ edges
 | params_flow.rb:83:10:83:15 | call to params | params_flow.rb:83:10:83:27 | call to to_unsafe_h | provenance |  |
 | params_flow.rb:87:10:87:15 | call to params | params_flow.rb:87:10:87:30 | call to to_unsafe_hash | provenance |  |
 | params_flow.rb:91:10:91:15 | call to params | params_flow.rb:91:10:91:40 | call to transform_keys | provenance |  |
-| params_flow.rb:91:10:91:15 | call to params | params_flow.rb:91:10:91:40 | call to transform_keys [element] | provenance |  |
-| params_flow.rb:91:10:91:40 | call to transform_keys [element] | params_flow.rb:91:10:91:40 | call to transform_keys | provenance |  |
 | params_flow.rb:95:10:95:15 | call to params | params_flow.rb:95:10:95:41 | call to transform_keys! | provenance |  |
 | params_flow.rb:99:10:99:15 | call to params | params_flow.rb:99:10:99:42 | call to transform_values | provenance |  |
 | params_flow.rb:103:10:103:15 | call to params | params_flow.rb:103:10:103:43 | call to transform_values! | provenance |  |
 | params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at | provenance |  |
-| params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at [element 0] | provenance |  |
-| params_flow.rb:107:10:107:15 | call to params | params_flow.rb:107:10:107:33 | call to values_at [element 1] | provenance |  |
-| params_flow.rb:107:10:107:33 | call to values_at [element 0] | params_flow.rb:107:10:107:33 | call to values_at | provenance |  |
-| params_flow.rb:107:10:107:33 | call to values_at [element 1] | params_flow.rb:107:10:107:33 | call to values_at | provenance |  |
 | params_flow.rb:111:10:111:15 | call to params | params_flow.rb:111:10:111:29 | call to merge | provenance |  |
-| params_flow.rb:112:10:112:29 | call to merge [element 0] | params_flow.rb:112:10:112:29 | call to merge | provenance |  |
 | params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge | provenance |  |
-| params_flow.rb:112:23:112:28 | call to params | params_flow.rb:112:10:112:29 | call to merge [element 0] | provenance |  |
 | params_flow.rb:116:10:116:15 | call to params | params_flow.rb:116:10:116:37 | call to reverse_merge | provenance |  |
 | params_flow.rb:117:31:117:36 | call to params | params_flow.rb:117:10:117:37 | call to reverse_merge | provenance |  |
 | params_flow.rb:121:10:121:15 | call to params | params_flow.rb:121:10:121:43 | call to with_defaults | provenance |  |
 | params_flow.rb:122:31:122:36 | call to params | params_flow.rb:122:10:122:37 | call to with_defaults | provenance |  |
 | params_flow.rb:126:10:126:15 | call to params | params_flow.rb:126:10:126:30 | call to merge! | provenance |  |
-| params_flow.rb:127:10:127:30 | call to merge! [element 0] | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
 | params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
-| params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! [element 0] | provenance |  |
 | params_flow.rb:130:5:130:5 | [post] p | params_flow.rb:131:10:131:10 | p | provenance |  |
 | params_flow.rb:130:5:130:5 | [post] p [element 0] | params_flow.rb:131:10:131:10 | p | provenance |  |
 | params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p | provenance |  |
@@ -199,7 +189,6 @@ nodes
 | params_flow.rb:87:10:87:30 | call to to_unsafe_hash | semmle.label | call to to_unsafe_hash |
 | params_flow.rb:91:10:91:15 | call to params | semmle.label | call to params |
 | params_flow.rb:91:10:91:40 | call to transform_keys | semmle.label | call to transform_keys |
-| params_flow.rb:91:10:91:40 | call to transform_keys [element] | semmle.label | call to transform_keys [element] |
 | params_flow.rb:95:10:95:15 | call to params | semmle.label | call to params |
 | params_flow.rb:95:10:95:41 | call to transform_keys! | semmle.label | call to transform_keys! |
 | params_flow.rb:99:10:99:15 | call to params | semmle.label | call to params |
@@ -208,12 +197,9 @@ nodes
 | params_flow.rb:103:10:103:43 | call to transform_values! | semmle.label | call to transform_values! |
 | params_flow.rb:107:10:107:15 | call to params | semmle.label | call to params |
 | params_flow.rb:107:10:107:33 | call to values_at | semmle.label | call to values_at |
-| params_flow.rb:107:10:107:33 | call to values_at [element 0] | semmle.label | call to values_at [element 0] |
-| params_flow.rb:107:10:107:33 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
 | params_flow.rb:111:10:111:15 | call to params | semmle.label | call to params |
 | params_flow.rb:111:10:111:29 | call to merge | semmle.label | call to merge |
 | params_flow.rb:112:10:112:29 | call to merge | semmle.label | call to merge |
-| params_flow.rb:112:10:112:29 | call to merge [element 0] | semmle.label | call to merge [element 0] |
 | params_flow.rb:112:23:112:28 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:15 | call to params | semmle.label | call to params |
 | params_flow.rb:116:10:116:37 | call to reverse_merge | semmle.label | call to reverse_merge |
@@ -226,7 +212,6 @@ nodes
 | params_flow.rb:126:10:126:15 | call to params | semmle.label | call to params |
 | params_flow.rb:126:10:126:30 | call to merge! | semmle.label | call to merge! |
 | params_flow.rb:127:10:127:30 | call to merge! | semmle.label | call to merge! |
-| params_flow.rb:127:10:127:30 | call to merge! [element 0] | semmle.label | call to merge! [element 0] |
 | params_flow.rb:127:24:127:29 | call to params | semmle.label | call to params |
 | params_flow.rb:130:5:130:5 | [post] p | semmle.label | [post] p |
 | params_flow.rb:130:5:130:5 | [post] p [element 0] | semmle.label | [post] p [element 0] |

--- a/ruby/ql/test/query-tests/experimental/LdapInjection/Ldapinjection.expected
+++ b/ruby/ql/test/query-tests/experimental/LdapInjection/Ldapinjection.expected
@@ -6,9 +6,8 @@ edges
 | LdapInjection.rb:9:5:9:8 | name | LdapInjection.rb:33:88:33:91 | name | provenance |  |
 | LdapInjection.rb:9:12:9:17 | call to params | LdapInjection.rb:9:12:9:29 | ...[...] | provenance |  |
 | LdapInjection.rb:9:12:9:29 | ...[...] | LdapInjection.rb:9:5:9:8 | name | provenance |  |
-| LdapInjection.rb:33:87:33:92 | call to [] [element 0] | LdapInjection.rb:33:87:33:92 | call to [] | provenance |  |
+| LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:33:87:33:92 | call to [] | provenance |  |
 | LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:33:87:33:92 | call to [] | provenance | Config |
-| LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:33:87:33:92 | call to [] [element 0] | provenance |  |
 | LdapInjection.rb:33:88:33:91 | name | LdapInjection.rb:37:41:37:44 | name | provenance |  |
 | LdapInjection.rb:37:5:37:10 | filter | LdapInjection.rb:38:62:38:67 | filter | provenance |  |
 | LdapInjection.rb:37:14:37:45 | call to eq | LdapInjection.rb:37:5:37:10 | filter | provenance |  |
@@ -23,7 +22,6 @@ nodes
 | LdapInjection.rb:25:23:25:49 | "ou=people,dc=#{...},dc=com" | semmle.label | "ou=people,dc=#{...},dc=com" |
 | LdapInjection.rb:29:62:29:73 | "cn=#{...}" | semmle.label | "cn=#{...}" |
 | LdapInjection.rb:33:87:33:92 | call to [] | semmle.label | call to [] |
-| LdapInjection.rb:33:87:33:92 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | LdapInjection.rb:33:88:33:91 | name | semmle.label | name |
 | LdapInjection.rb:37:5:37:10 | filter | semmle.label | filter |
 | LdapInjection.rb:37:14:37:45 | call to eq | semmle.label | call to eq |

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -36,14 +36,12 @@ edges
 | app/controllers/foo/bars_controller.rb:36:34:36:51 | ...[...] | app/controllers/foo/bars_controller.rb:36:5:36:52 | call to t | provenance |  |
 | app/controllers/foo/bars_controller.rb:37:42:37:47 | call to params | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | app/controllers/foo/bars_controller.rb:37:5:37:60 | call to translate | provenance |  |
-| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
 | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
 | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
 | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
@@ -91,11 +89,9 @@ nodes
 | app/controllers/foo/bars_controller.rb:37:42:37:47 | call to params | semmle.label | call to params |
 | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | semmle.label | call to display_text [element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | semmle.label | ...[...] [element] |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | semmle.label | @user_website |
 | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |

--- a/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
@@ -10,14 +10,12 @@ edges
 | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | provenance |  |
 | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | provenance |  |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
 | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | provenance |  |
 | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] | provenance |  |
 | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
 | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
 | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
 | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
@@ -33,11 +31,9 @@ nodes
 | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | semmle.label | dt |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text [element] | semmle.label | call to display_text [element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] [element] | semmle.label | ...[...] [element] |
 | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
 | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -11,12 +11,10 @@ edges
 | ActiveRecordInjection.rb:50:29:50:39 | ...[...] | ActiveRecordInjection.rb:50:20:50:42 | "id = '#{...}'" | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:55:30:55:35 | call to params | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | ActiveRecordInjection.rb:55:21:55:43 | "id = '#{...}'" | provenance | AdditionalTaintStep |
-| ActiveRecordInjection.rb:59:21:59:45 | call to [] [element 0] | ActiveRecordInjection.rb:59:21:59:45 | call to [] | provenance |  |
-| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | ActiveRecordInjection.rb:59:21:59:45 | call to [] [element 0] | provenance |  |
+| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | ActiveRecordInjection.rb:59:21:59:45 | call to [] | provenance |  |
 | ActiveRecordInjection.rb:59:31:59:36 | call to params | ActiveRecordInjection.rb:59:31:59:41 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:59:31:59:41 | ...[...] | ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | provenance | AdditionalTaintStep |
-| ActiveRecordInjection.rb:64:22:64:46 | call to [] [element 0] | ActiveRecordInjection.rb:64:22:64:46 | call to [] | provenance |  |
-| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | ActiveRecordInjection.rb:64:22:64:46 | call to [] [element 0] | provenance |  |
+| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | ActiveRecordInjection.rb:64:22:64:46 | call to [] | provenance |  |
 | ActiveRecordInjection.rb:64:32:64:37 | call to params | ActiveRecordInjection.rb:64:32:64:42 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:64:32:64:42 | ...[...] | ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:69:21:69:26 | call to params | ActiveRecordInjection.rb:69:21:69:35 | ...[...] | provenance |  |
@@ -58,8 +56,7 @@ edges
 | ActiveRecordInjection.rb:136:11:136:17 | ...[...] | ActiveRecordInjection.rb:136:5:136:7 | uid | provenance |  |
 | ActiveRecordInjection.rb:137:5:137:9 | uidEq | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
 | ActiveRecordInjection.rb:137:5:137:9 | uidEq | ActiveRecordInjection.rb:141:28:141:32 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:141:20:141:32 | ... + ... [element] | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:141:28:141:32 | uidEq | ActiveRecordInjection.rb:141:20:141:32 | ... + ... [element] | provenance |  |
+| ActiveRecordInjection.rb:141:28:141:32 | uidEq | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | ActiveRecordInjection.rb:27:22:27:30 | condition | provenance |  |
@@ -117,12 +114,10 @@ nodes
 | ActiveRecordInjection.rb:55:30:55:35 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:59:21:59:45 | call to [] | semmle.label | call to [] |
-| ActiveRecordInjection.rb:59:21:59:45 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:59:31:59:36 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:59:31:59:41 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:64:22:64:46 | call to [] | semmle.label | call to [] |
-| ActiveRecordInjection.rb:64:22:64:46 | call to [] [element 0] | semmle.label | call to [] [element 0] |
 | ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
 | ActiveRecordInjection.rb:64:32:64:37 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:64:32:64:42 | ...[...] | semmle.label | ...[...] |
@@ -186,7 +181,6 @@ nodes
 | ActiveRecordInjection.rb:136:11:136:17 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:137:5:137:9 | uidEq | semmle.label | uidEq |
 | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | semmle.label | ... + ... |
-| ActiveRecordInjection.rb:141:20:141:32 | ... + ... [element] | semmle.label | ... + ... [element] |
 | ActiveRecordInjection.rb:141:28:141:32 | uidEq | semmle.label | uidEq |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -26,8 +26,7 @@ edges
 | CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
-| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... [element] | provenance |  |
-| CodeInjection.rb:86:10:86:37 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
+| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
 | CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] | provenance |  |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
 | CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
@@ -74,7 +73,6 @@ nodes
 | CodeInjection.rb:80:16:80:19 | code | semmle.label | code |
 | CodeInjection.rb:86:10:86:25 | ... + ... [element] | semmle.label | ... + ... [element] |
 | CodeInjection.rb:86:10:86:37 | ... + ... | semmle.label | ... + ... |
-| CodeInjection.rb:86:10:86:37 | ... + ... [element] | semmle.label | ... + ... [element] |
 | CodeInjection.rb:86:22:86:25 | code | semmle.label | code |
 | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | semmle.label | "prefix_#{...}_suffix" |
 | CodeInjection.rb:90:10:90:13 | code | semmle.label | code |

--- a/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
@@ -5,23 +5,19 @@ edges
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | provenance |  |
 | app/controllers/users_controller.rb:15:19:15:24 | call to params | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | provenance |  |
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | provenance |  |
-| app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | provenance |  |
-| app/controllers/users_controller.rb:17:31:17:41 | unsanitized | app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] | provenance |  |
+| app/controllers/users_controller.rb:17:31:17:41 | unsanitized | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | app/controllers/users_controller.rb:23:20:23:44 | call to sub | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | provenance |  |
 | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | provenance | heuristic-callback |
-| app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | provenance |  |
-| app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] | provenance |  |
+| app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | provenance |  |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | provenance |  |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | provenance |  |
 | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | provenance | heuristic-callback |
 | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | provenance | heuristic-callback |
-| app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | provenance |  |
-| app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] | provenance |  |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | app/controllers/users_controller.rb:49:19:49:30 | ...[...] | provenance |  |
 nodes
 | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | semmle.label | unsanitized |
@@ -29,14 +25,12 @@ nodes
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | semmle.label | ...[...] |
 | app/controllers/users_controller.rb:16:19:16:29 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:17:19:17:41 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/controllers/users_controller.rb:17:31:17:41 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | semmle.label | call to sub |
 | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | semmle.label | do ... end [captured unsanitized2] |
 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:27:16:27:39 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | semmle.label | call to cookies |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | semmle.label | ...[...] |
@@ -44,7 +38,6 @@ nodes
 | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
 | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | semmle.label | ... + ... |
-| app/controllers/users_controller.rb:35:33:35:55 | ... + ... [element] | semmle.label | ... + ... [element] |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | semmle.label | call to params |
 | app/controllers/users_controller.rb:49:19:49:30 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-1333-regexp-injection/RegExpInjection.expected
@@ -12,14 +12,12 @@ edges
 | RegExpInjection.rb:22:5:22:8 | name | RegExpInjection.rb:23:30:23:33 | name | provenance |  |
 | RegExpInjection.rb:22:12:22:17 | call to params | RegExpInjection.rb:22:12:22:24 | ...[...] | provenance |  |
 | RegExpInjection.rb:22:12:22:24 | ...[...] | RegExpInjection.rb:22:5:22:8 | name | provenance |  |
-| RegExpInjection.rb:23:24:23:33 | ... + ... [element] | RegExpInjection.rb:23:24:23:33 | ... + ... | provenance |  |
-| RegExpInjection.rb:23:30:23:33 | name | RegExpInjection.rb:23:24:23:33 | ... + ... [element] | provenance |  |
+| RegExpInjection.rb:23:30:23:33 | name | RegExpInjection.rb:23:24:23:33 | ... + ... | provenance |  |
 | RegExpInjection.rb:54:5:54:8 | name | RegExpInjection.rb:55:28:55:37 | ... + ... | provenance |  |
 | RegExpInjection.rb:54:5:54:8 | name | RegExpInjection.rb:55:34:55:37 | name | provenance |  |
 | RegExpInjection.rb:54:12:54:17 | call to params | RegExpInjection.rb:54:12:54:24 | ...[...] | provenance |  |
 | RegExpInjection.rb:54:12:54:24 | ...[...] | RegExpInjection.rb:54:5:54:8 | name | provenance |  |
-| RegExpInjection.rb:55:28:55:37 | ... + ... [element] | RegExpInjection.rb:55:28:55:37 | ... + ... | provenance |  |
-| RegExpInjection.rb:55:34:55:37 | name | RegExpInjection.rb:55:28:55:37 | ... + ... [element] | provenance |  |
+| RegExpInjection.rb:55:34:55:37 | name | RegExpInjection.rb:55:28:55:37 | ... + ... | provenance |  |
 nodes
 | RegExpInjection.rb:4:5:4:8 | name | semmle.label | name |
 | RegExpInjection.rb:4:12:4:17 | call to params | semmle.label | call to params |
@@ -37,13 +35,11 @@ nodes
 | RegExpInjection.rb:22:12:22:17 | call to params | semmle.label | call to params |
 | RegExpInjection.rb:22:12:22:24 | ...[...] | semmle.label | ...[...] |
 | RegExpInjection.rb:23:24:23:33 | ... + ... | semmle.label | ... + ... |
-| RegExpInjection.rb:23:24:23:33 | ... + ... [element] | semmle.label | ... + ... [element] |
 | RegExpInjection.rb:23:30:23:33 | name | semmle.label | name |
 | RegExpInjection.rb:54:5:54:8 | name | semmle.label | name |
 | RegExpInjection.rb:54:12:54:17 | call to params | semmle.label | call to params |
 | RegExpInjection.rb:54:12:54:24 | ...[...] | semmle.label | ...[...] |
 | RegExpInjection.rb:55:28:55:37 | ... + ... | semmle.label | ... + ... |
-| RegExpInjection.rb:55:28:55:37 | ... + ... [element] | semmle.label | ... + ... [element] |
 | RegExpInjection.rb:55:34:55:37 | name | semmle.label | name |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-134/TaintedFormatString.expected
+++ b/ruby/ql/test/query-tests/security/cwe-134/TaintedFormatString.expected
@@ -8,10 +8,8 @@ edges
 | tainted_format_string.rb:21:27:21:32 | call to params | tainted_format_string.rb:21:27:21:41 | ...[...] | provenance |  |
 | tainted_format_string.rb:22:20:22:25 | call to params | tainted_format_string.rb:22:20:22:34 | ...[...] | provenance |  |
 | tainted_format_string.rb:28:19:28:24 | call to params | tainted_format_string.rb:28:19:28:33 | ...[...] | provenance |  |
-| tainted_format_string.rb:33:12:33:46 | ... + ... [element] | tainted_format_string.rb:33:12:33:46 | ... + ... | provenance |  |
 | tainted_format_string.rb:33:32:33:37 | call to params | tainted_format_string.rb:33:32:33:46 | ...[...] | provenance |  |
 | tainted_format_string.rb:33:32:33:46 | ...[...] | tainted_format_string.rb:33:12:33:46 | ... + ... | provenance |  |
-| tainted_format_string.rb:33:32:33:46 | ...[...] | tainted_format_string.rb:33:12:33:46 | ... + ... [element] | provenance |  |
 | tainted_format_string.rb:36:30:36:35 | call to params | tainted_format_string.rb:36:30:36:44 | ...[...] | provenance |  |
 | tainted_format_string.rb:36:30:36:44 | ...[...] | tainted_format_string.rb:36:12:36:46 | "A log message: #{...}" | provenance | AdditionalTaintStep |
 | tainted_format_string.rb:39:22:39:27 | call to params | tainted_format_string.rb:39:22:39:36 | ...[...] | provenance |  |
@@ -38,7 +36,6 @@ nodes
 | tainted_format_string.rb:28:19:28:24 | call to params | semmle.label | call to params |
 | tainted_format_string.rb:28:19:28:33 | ...[...] | semmle.label | ...[...] |
 | tainted_format_string.rb:33:12:33:46 | ... + ... | semmle.label | ... + ... |
-| tainted_format_string.rb:33:12:33:46 | ... + ... [element] | semmle.label | ... + ... [element] |
 | tainted_format_string.rb:33:32:33:37 | call to params | semmle.label | call to params |
 | tainted_format_string.rb:33:32:33:46 | ...[...] | semmle.label | ...[...] |
 | tainted_format_string.rb:36:12:36:46 | "A log message: #{...}" | semmle.label | "A log message: #{...}" |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -850,6 +850,85 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   class SndLevelScopeOption = SndLevelScopeOption::Option;
 
+  final class NodeExImpl extends TNodeEx {
+    string toString() {
+      result = this.asNode().toString()
+      or
+      exists(Node n | this.isImplicitReadNode(n) | result = n.toString() + " [Ext]")
+      or
+      result = this.asParamReturnNode().toString() + " [Return]"
+    }
+
+    Node asNode() { this = TNodeNormal(result) }
+
+    /** Gets the corresponding Node if this is a normal node or its post-implicit read node. */
+    Node asNodeOrImplicitRead() { this = TNodeNormal(result) or this = TNodeImplicitRead(result) }
+
+    predicate isImplicitReadNode(Node n) { this = TNodeImplicitRead(n) }
+
+    ParameterNode asParamReturnNode() { this = TParamReturnNode(result, _) }
+
+    Node projectToNode() {
+      this = TNodeNormal(result) or
+      this = TNodeImplicitRead(result) or
+      this = TParamReturnNode(result, _)
+    }
+
+    pragma[nomagic]
+    private DataFlowCallable getEnclosingCallable0() {
+      nodeEnclosingCallable(this.projectToNode(), result)
+    }
+
+    pragma[inline]
+    DataFlowCallable getEnclosingCallable() {
+      pragma[only_bind_out](this).getEnclosingCallable0() = pragma[only_bind_into](result)
+    }
+
+    pragma[nomagic]
+    private DataFlowType getDataFlowType0() {
+      nodeDataFlowType(this.asNode(), result)
+      or
+      nodeDataFlowType(this.asParamReturnNode(), result)
+    }
+
+    pragma[inline]
+    DataFlowType getDataFlowType() {
+      pragma[only_bind_out](this).getDataFlowType0() = pragma[only_bind_into](result)
+    }
+
+    Location getLocation() { result = this.projectToNode().getLocation() }
+  }
+
+  final class ArgNodeExImpl extends NodeExImpl {
+    ArgNodeExImpl() { this.asNode() instanceof ArgNode }
+
+    DataFlowCall getCall() { this.asNode().(ArgNode).argumentOf(result, _) }
+  }
+
+  final class ParamNodeExImpl extends NodeExImpl {
+    ParamNodeExImpl() { this.asNode() instanceof ParamNode }
+
+    predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
+      this.asNode().(ParamNode).isParameterOf(c, pos)
+    }
+
+    ParameterPosition getPosition() { this.isParameterOf(_, result) }
+  }
+
+  /**
+   * A node from which flow can return to the caller. This is either a regular
+   * `ReturnNode` or a synthesized node for flow out via a parameter.
+   */
+  final class RetNodeExImpl extends NodeExImpl {
+    private ReturnPosition pos;
+
+    RetNodeExImpl() { pos = getReturnPositionEx(this) }
+
+    ReturnPosition getReturnPosition() { result = pos }
+
+    ReturnKindExt getKind() { result = pos.getKind() }
+  }
+
   cached
   private module Cached {
     /**
@@ -927,11 +1006,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       )
     }
 
-    cached
-    predicate valueReturnNode(ReturnNode n, ReturnKindExt k) { k = TValueReturn(n.getKind()) }
-
-    cached
-    predicate paramReturnNode(
+    pragma[nomagic]
+    private predicate paramReturnNode(
       PostUpdateNode n, ParamNode p, SndLevelScopeOption scope, ReturnKindExt k
     ) {
       exists(ParameterPosition pos |
@@ -1541,6 +1617,20 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     class UnreachableSetOption = UnreachableSetOption::Option;
 
+    pragma[nomagic]
+    private predicate hasValueReturnKindIn(ReturnNode ret, ReturnKindExt kind, DataFlowCallable c) {
+      c = getNodeEnclosingCallable(ret) and
+      kind = TValueReturn(ret.getKind())
+    }
+
+    pragma[nomagic]
+    private predicate hasParamReturnKindIn(
+      PostUpdateNode n, ParamNode p, ReturnKindExt kind, DataFlowCallable c
+    ) {
+      c = getNodeEnclosingCallable(n) and
+      paramReturnNode(n, p, _, kind)
+    }
+
     cached
     newtype TReturnPosition =
       TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
@@ -1548,6 +1638,22 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         or
         hasParamReturnKindIn(_, _, kind, c)
       }
+
+    cached
+    ReturnPosition getValueReturnPosition(ReturnNode ret) {
+      exists(ReturnKindExt kind, DataFlowCallable c |
+        hasValueReturnKindIn(ret, kind, c) and
+        result = TReturnPosition0(c, kind)
+      )
+    }
+
+    cached
+    ReturnPosition getParamReturnPosition(PostUpdateNode n, ParamNode p) {
+      exists(ReturnKindExt kind, DataFlowCallable c |
+        hasParamReturnKindIn(n, p, kind, c) and
+        result = TReturnPosition0(c, kind)
+      )
+    }
 
     cached
     newtype TLocalFlowCallContext =
@@ -1594,6 +1700,44 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     newtype TApproxAccessPathFrontOption =
       TApproxAccessPathFrontNone() or
       TApproxAccessPathFrontSome(ApproxAccessPathFront apf)
+
+    cached
+    newtype TNodeEx =
+      TNodeNormal(Node n) or
+      TNodeImplicitRead(Node n) or // will be restricted to nodes with actual implicit reads in `DataFlowImpl.qll`
+      TParamReturnNode(ParameterNode p, SndLevelScopeOption scope) {
+        paramReturnNode(_, p, scope, _)
+      }
+
+    /**
+     * Holds if data can flow in one local step from `node1` to `node2`.
+     */
+    cached
+    predicate localFlowStepExImpl(NodeExImpl node1, NodeExImpl node2, string model) {
+      exists(Node n1, Node n2 |
+        node1.asNode() = n1 and
+        node2.asNode() = n2 and
+        simpleLocalFlowStepExt(pragma[only_bind_into](n1), pragma[only_bind_into](n2), model)
+      )
+      or
+      exists(Node n1, Node n2, SndLevelScopeOption scope |
+        node1.asNode() = n1 and
+        node2 = TParamReturnNode(n2, scope) and
+        paramReturnNode(pragma[only_bind_into](n1), pragma[only_bind_into](n2),
+          pragma[only_bind_into](scope), _) and
+        model = ""
+      )
+    }
+
+    cached
+    ReturnPosition getReturnPositionEx(NodeExImpl ret) {
+      result = getValueReturnPosition(ret.asNode())
+      or
+      exists(ParamNode p |
+        ret = TParamReturnNode(p, _) and
+        result = getParamReturnPosition(_, p)
+      )
+    }
   }
 
   bindingset[call, tgt]
@@ -2175,36 +2319,6 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   pragma[inline]
   DataFlowType getNodeDataFlowType(Node n) {
     nodeDataFlowType(pragma[only_bind_out](n), pragma[only_bind_into](result))
-  }
-
-  pragma[nomagic]
-  private predicate hasValueReturnKindIn(ReturnNode ret, ReturnKindExt kind, DataFlowCallable c) {
-    c = getNodeEnclosingCallable(ret) and
-    valueReturnNode(ret, kind)
-  }
-
-  pragma[nomagic]
-  private predicate hasParamReturnKindIn(
-    PostUpdateNode n, ParamNode p, ReturnKindExt kind, DataFlowCallable c
-  ) {
-    c = getNodeEnclosingCallable(n) and
-    paramReturnNode(n, p, _, kind)
-  }
-
-  pragma[nomagic]
-  ReturnPosition getValueReturnPosition(ReturnNode ret) {
-    exists(ReturnKindExt kind, DataFlowCallable c |
-      hasValueReturnKindIn(ret, kind, c) and
-      result = TReturnPosition0(c, kind)
-    )
-  }
-
-  pragma[nomagic]
-  ReturnPosition getParamReturnPosition(PostUpdateNode n, ParamNode p) {
-    exists(ReturnKindExt kind, DataFlowCallable c |
-      hasParamReturnKindIn(n, p, kind, c) and
-      result = TReturnPosition0(c, kind)
-    )
   }
 
   /** An optional Boolean value. */

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -850,7 +850,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   class SndLevelScopeOption = SndLevelScopeOption::Option;
 
-  final class NodeExImpl extends TNodeEx {
+  final class NodeEx extends TNodeEx {
     string toString() {
       result = this.asNode().toString()
       or
@@ -899,14 +899,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     Location getLocation() { result = this.projectToNode().getLocation() }
   }
 
-  final class ArgNodeExImpl extends NodeExImpl {
-    ArgNodeExImpl() { this.asNode() instanceof ArgNode }
+  final class ArgNodeEx extends NodeEx {
+    ArgNodeEx() { this.asNode() instanceof ArgNode }
 
     DataFlowCall getCall() { this.asNode().(ArgNode).argumentOf(result, _) }
   }
 
-  final class ParamNodeExImpl extends NodeExImpl {
-    ParamNodeExImpl() { this.asNode() instanceof ParamNode }
+  final class ParamNodeEx extends NodeEx {
+    ParamNodeEx() { this.asNode() instanceof ParamNode }
 
     predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
       this.asNode().(ParamNode).isParameterOf(c, pos)
@@ -919,10 +919,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    * A node from which flow can return to the caller. This is either a regular
    * `ReturnNode` or a synthesized node for flow out via a parameter.
    */
-  final class RetNodeExImpl extends NodeExImpl {
+  final class RetNodeEx extends NodeEx {
     private ReturnPosition pos;
 
-    RetNodeExImpl() { pos = getReturnPositionEx(this) }
+    RetNodeEx() { pos = getReturnPositionEx(this) }
 
     ReturnPosition getReturnPosition() { result = pos }
 
@@ -1713,7 +1713,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if data can flow in one local step from `node1` to `node2`.
      */
     cached
-    predicate localFlowStepExImpl(NodeExImpl node1, NodeExImpl node2, string model) {
+    predicate localFlowStepExImpl(NodeEx node1, NodeEx node2, string model) {
       exists(Node n1, Node n2 |
         node1.asNode() = n1 and
         node2.asNode() = n2 and
@@ -1730,7 +1730,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     cached
-    ReturnPosition getReturnPositionEx(NodeExImpl ret) {
+    ReturnPosition getReturnPositionEx(NodeEx ret) {
       result = getValueReturnPosition(ret.asNode())
       or
       exists(ParamNode p |

--- a/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/FlowSummaryImpl.qll
@@ -1775,7 +1775,7 @@ module Make<
             exists(ReturnNode ret, ValueReturnKind kind |
               c = "ReturnValue" and
               ret = node.asNode() and
-              valueReturnNode(ret, kind) and
+              kind.getKind() = ret.getKind() and
               kind.getKind() = getStandardReturnValueKind() and
               mid.asCallable() = getNodeEnclosingCallable(ret)
             )

--- a/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/Taint.expected
@@ -2,9 +2,7 @@ edges
 | conversions.swift:33:16:33:26 | call to sourceInt() | conversions.swift:33:12:33:27 | call to Self.init(_:) | provenance |  |
 | conversions.swift:34:18:34:28 | call to sourceInt() | conversions.swift:34:12:34:29 | call to Self.init(_:) | provenance |  |
 | conversions.swift:35:18:35:28 | call to sourceInt() | conversions.swift:35:12:35:29 | call to Float.init(_:) | provenance |  |
-| conversions.swift:36:12:36:30 | call to String.init(_:) [Collection element] | conversions.swift:36:12:36:30 | call to String.init(_:) | provenance |  |
 | conversions.swift:36:19:36:29 | call to sourceInt() | conversions.swift:36:12:36:30 | call to String.init(_:) | provenance |  |
-| conversions.swift:36:19:36:29 | call to sourceInt() | conversions.swift:36:12:36:30 | call to String.init(_:) [Collection element] | provenance |  |
 | conversions.swift:37:12:37:30 | call to String.init(_:) | conversions.swift:37:12:37:32 | .utf8 | provenance |  |
 | conversions.swift:37:19:37:29 | call to sourceInt() | conversions.swift:37:12:37:30 | call to String.init(_:) | provenance |  |
 | conversions.swift:39:12:39:30 | [...] [Collection element] | conversions.swift:40:12:40:12 | arr | provenance |  |
@@ -13,13 +11,11 @@ edges
 | conversions.swift:39:12:39:30 | [...] [Collection element] | conversions.swift:43:20:43:20 | arr [Collection element] | provenance |  |
 | conversions.swift:39:19:39:29 | call to sourceInt() | conversions.swift:39:12:39:30 | [...] [Collection element] | provenance |  |
 | conversions.swift:41:12:41:12 | arr [Collection element] | conversions.swift:41:12:41:17 | ...[...] | provenance |  |
-| conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) [Collection element] | conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) | provenance |  |
-| conversions.swift:42:20:42:20 | arr [Collection element] | conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
+| conversions.swift:42:20:42:20 | arr [Collection element] | conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) | provenance |  |
 | conversions.swift:43:12:43:23 | call to Array<Element>.init(_:) [Collection element] | conversions.swift:43:12:43:26 | ...[...] | provenance |  |
 | conversions.swift:43:20:43:20 | arr [Collection element] | conversions.swift:43:12:43:23 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
-| conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) [Collection element] | conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) | provenance |  |
 | conversions.swift:44:20:44:33 | call to sourceString() | conversions.swift:44:20:44:35 | .utf8 | provenance |  |
-| conversions.swift:44:20:44:35 | .utf8 | conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
+| conversions.swift:44:20:44:35 | .utf8 | conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) | provenance |  |
 | conversions.swift:45:12:45:39 | call to Array<Element>.init(_:) [Collection element] | conversions.swift:45:12:45:42 | ...[...] | provenance |  |
 | conversions.swift:45:20:45:33 | call to sourceString() | conversions.swift:45:20:45:35 | .utf8 | provenance |  |
 | conversions.swift:45:20:45:35 | .utf8 | conversions.swift:45:12:45:39 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
@@ -49,19 +45,13 @@ edges
 | conversions.swift:80:12:80:22 | call to sourceInt() | conversions.swift:80:12:80:24 | .bigEndian | provenance |  |
 | conversions.swift:109:18:109:30 | call to sourceFloat() | conversions.swift:109:12:109:31 | call to Float.init(_:) | provenance |  |
 | conversions.swift:110:18:110:30 | call to sourceFloat() | conversions.swift:110:12:110:31 | call to UInt8.init(_:) | provenance |  |
-| conversions.swift:111:12:111:32 | call to String.init(_:) [Collection element] | conversions.swift:111:12:111:32 | call to String.init(_:) | provenance |  |
 | conversions.swift:111:19:111:31 | call to sourceFloat() | conversions.swift:111:12:111:32 | call to String.init(_:) | provenance |  |
-| conversions.swift:111:19:111:31 | call to sourceFloat() | conversions.swift:111:12:111:32 | call to String.init(_:) [Collection element] | provenance |  |
 | conversions.swift:112:12:112:32 | call to String.init(_:) | conversions.swift:112:12:112:34 | .utf8 | provenance |  |
 | conversions.swift:112:19:112:31 | call to sourceFloat() | conversions.swift:112:12:112:32 | call to String.init(_:) | provenance |  |
-| conversions.swift:113:12:113:34 | call to String.init(_:) [Collection element] | conversions.swift:113:12:113:34 | call to String.init(_:) | provenance |  |
 | conversions.swift:113:19:113:33 | call to sourceFloat80() | conversions.swift:113:12:113:34 | call to String.init(_:) | provenance |  |
-| conversions.swift:113:19:113:33 | call to sourceFloat80() | conversions.swift:113:12:113:34 | call to String.init(_:) [Collection element] | provenance |  |
 | conversions.swift:114:12:114:34 | call to String.init(_:) | conversions.swift:114:12:114:36 | .utf8 | provenance |  |
 | conversions.swift:114:19:114:33 | call to sourceFloat80() | conversions.swift:114:12:114:34 | call to String.init(_:) | provenance |  |
-| conversions.swift:115:12:115:33 | call to String.init(_:) [Collection element] | conversions.swift:115:12:115:33 | call to String.init(_:) | provenance |  |
 | conversions.swift:115:19:115:32 | call to sourceDouble() | conversions.swift:115:12:115:33 | call to String.init(_:) | provenance |  |
-| conversions.swift:115:19:115:32 | call to sourceDouble() | conversions.swift:115:12:115:33 | call to String.init(_:) [Collection element] | provenance |  |
 | conversions.swift:116:12:116:33 | call to String.init(_:) | conversions.swift:116:12:116:35 | .utf8 | provenance |  |
 | conversions.swift:116:19:116:32 | call to sourceDouble() | conversions.swift:116:12:116:33 | call to String.init(_:) | provenance |  |
 | conversions.swift:118:18:118:30 | call to sourceFloat() | conversions.swift:118:12:118:31 | call to Float.init(_:) | provenance |  |
@@ -76,9 +66,7 @@ edges
 | conversions.swift:129:12:129:25 | call to sourceDouble() | conversions.swift:129:12:129:27 | .significand | provenance |  |
 | conversions.swift:130:12:130:23 | call to sourceUInt() | conversions.swift:130:12:130:25 | .byteSwapped | provenance |  |
 | conversions.swift:131:12:131:25 | call to sourceUInt64() | conversions.swift:131:12:131:27 | .byteSwapped | provenance |  |
-| conversions.swift:136:12:136:33 | call to String.init(_:) [Collection element] | conversions.swift:136:12:136:33 | call to String.init(_:) | provenance |  |
 | conversions.swift:136:19:136:32 | call to sourceString() | conversions.swift:136:12:136:33 | call to String.init(_:) | provenance |  |
-| conversions.swift:136:19:136:32 | call to sourceString() | conversions.swift:136:12:136:33 | call to String.init(_:) [Collection element] | provenance |  |
 | conversions.swift:144:12:144:35 | call to MyString.init(_:) | conversions.swift:144:12:144:35 | call to MyString.init(_:) [some:0] | provenance |  |
 | conversions.swift:144:12:144:35 | call to MyString.init(_:) | conversions.swift:145:12:145:12 | ms2 | provenance |  |
 | conversions.swift:144:12:144:35 | call to MyString.init(_:) | conversions.swift:146:12:146:16 | .description | provenance |  |
@@ -251,7 +239,6 @@ nodes
 | conversions.swift:35:12:35:29 | call to Float.init(_:) | semmle.label | call to Float.init(_:) |
 | conversions.swift:35:18:35:28 | call to sourceInt() | semmle.label | call to sourceInt() |
 | conversions.swift:36:12:36:30 | call to String.init(_:) | semmle.label | call to String.init(_:) |
-| conversions.swift:36:12:36:30 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | conversions.swift:36:19:36:29 | call to sourceInt() | semmle.label | call to sourceInt() |
 | conversions.swift:37:12:37:30 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | conversions.swift:37:12:37:32 | .utf8 | semmle.label | .utf8 |
@@ -262,13 +249,11 @@ nodes
 | conversions.swift:41:12:41:12 | arr [Collection element] | semmle.label | arr [Collection element] |
 | conversions.swift:41:12:41:17 | ...[...] | semmle.label | ...[...] |
 | conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
-| conversions.swift:42:12:42:23 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
 | conversions.swift:42:20:42:20 | arr [Collection element] | semmle.label | arr [Collection element] |
 | conversions.swift:43:12:43:23 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
 | conversions.swift:43:12:43:26 | ...[...] | semmle.label | ...[...] |
 | conversions.swift:43:20:43:20 | arr [Collection element] | semmle.label | arr [Collection element] |
 | conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
-| conversions.swift:44:12:44:39 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
 | conversions.swift:44:20:44:33 | call to sourceString() | semmle.label | call to sourceString() |
 | conversions.swift:44:20:44:35 | .utf8 | semmle.label | .utf8 |
 | conversions.swift:45:12:45:39 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
@@ -321,19 +306,16 @@ nodes
 | conversions.swift:110:12:110:31 | call to UInt8.init(_:) | semmle.label | call to UInt8.init(_:) |
 | conversions.swift:110:18:110:30 | call to sourceFloat() | semmle.label | call to sourceFloat() |
 | conversions.swift:111:12:111:32 | call to String.init(_:) | semmle.label | call to String.init(_:) |
-| conversions.swift:111:12:111:32 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | conversions.swift:111:19:111:31 | call to sourceFloat() | semmle.label | call to sourceFloat() |
 | conversions.swift:112:12:112:32 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | conversions.swift:112:12:112:34 | .utf8 | semmle.label | .utf8 |
 | conversions.swift:112:19:112:31 | call to sourceFloat() | semmle.label | call to sourceFloat() |
 | conversions.swift:113:12:113:34 | call to String.init(_:) | semmle.label | call to String.init(_:) |
-| conversions.swift:113:12:113:34 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | conversions.swift:113:19:113:33 | call to sourceFloat80() | semmle.label | call to sourceFloat80() |
 | conversions.swift:114:12:114:34 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | conversions.swift:114:12:114:36 | .utf8 | semmle.label | .utf8 |
 | conversions.swift:114:19:114:33 | call to sourceFloat80() | semmle.label | call to sourceFloat80() |
 | conversions.swift:115:12:115:33 | call to String.init(_:) | semmle.label | call to String.init(_:) |
-| conversions.swift:115:12:115:33 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | conversions.swift:115:19:115:32 | call to sourceDouble() | semmle.label | call to sourceDouble() |
 | conversions.swift:116:12:116:33 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | conversions.swift:116:12:116:35 | .utf8 | semmle.label | .utf8 |
@@ -364,7 +346,6 @@ nodes
 | conversions.swift:131:12:131:27 | .byteSwapped | semmle.label | .byteSwapped |
 | conversions.swift:135:12:135:25 | call to sourceString() | semmle.label | call to sourceString() |
 | conversions.swift:136:12:136:33 | call to String.init(_:) | semmle.label | call to String.init(_:) |
-| conversions.swift:136:12:136:33 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | conversions.swift:136:19:136:32 | call to sourceString() | semmle.label | call to sourceString() |
 | conversions.swift:144:12:144:35 | call to MyString.init(_:) | semmle.label | call to MyString.init(_:) |
 | conversions.swift:144:12:144:35 | call to MyString.init(_:) [some:0] | semmle.label | call to MyString.init(_:) [some:0] |

--- a/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/swift/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -14,8 +14,7 @@ edges
 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:75:8:75:12 | let ...? [some:0] | provenance |  |
 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0, some:0] | provenance |  |
 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | provenance |  |
-| CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | CommandInjection.swift:81:2:81:2 | [post] task1 | provenance |  |
-| CommandInjection.swift:81:20:81:47 | [...] [Collection element] | CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:81:20:81:47 | [...] [Collection element] | CommandInjection.swift:81:2:81:2 | [post] task1 | provenance |  |
 | CommandInjection.swift:81:27:81:27 | userControlledString | CommandInjection.swift:81:20:81:47 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:84:5:84:9 | let ...? [some:0] | CommandInjection.swift:84:9:84:9 | validatedString | provenance |  |
 | CommandInjection.swift:84:9:84:9 | validatedString | CommandInjection.swift:87:31:87:31 | validatedString | provenance |  |
@@ -26,12 +25,10 @@ edges
 | CommandInjection.swift:84:43:84:43 | userControlledString | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | provenance |  |
 | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | CommandInjection.swift:64:22:64:33 | command [some:0] | provenance |  |
 | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | CommandInjection.swift:84:27:84:63 | call to validateCommand(_:) [some:0] | provenance |  |
-| CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | CommandInjection.swift:87:6:87:6 | [post] task2 | provenance |  |
-| CommandInjection.swift:87:24:87:46 | [...] [Collection element] | CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:87:24:87:46 | [...] [Collection element] | CommandInjection.swift:87:6:87:6 | [post] task2 | provenance |  |
 | CommandInjection.swift:87:31:87:31 | validatedString | CommandInjection.swift:87:24:87:46 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:99:20:99:40 | arguments [Collection element] | CommandInjection.swift:100:20:100:20 | arguments [Collection element] | provenance |  |
-| CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | CommandInjection.swift:100:3:100:3 | [post] self | provenance |  |
-| CommandInjection.swift:100:20:100:20 | arguments [Collection element] | CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:100:20:100:20 | arguments [Collection element] | CommandInjection.swift:100:3:100:3 | [post] self | provenance |  |
 | CommandInjection.swift:105:8:105:12 | let ...? [some:0] | CommandInjection.swift:105:12:105:12 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:120:36:120:36 | userControlledString | provenance |  |
 | CommandInjection.swift:105:12:105:12 | userControlledString | CommandInjection.swift:121:28:121:28 | userControlledString | provenance |  |
@@ -73,55 +70,42 @@ edges
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:164:33:164:33 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | CommandInjection.swift:166:57:166:57 | userControlledString | provenance |  |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) [some:0] | CommandInjection.swift:105:8:105:12 | let ...? [some:0] | provenance |  |
-| CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | CommandInjection.swift:120:2:120:2 | [post] task3 | provenance |  |
 | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:120:24:120:57 | ...! | provenance |  |
-| CommandInjection.swift:120:24:120:57 | ...! | CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | provenance |  |
+| CommandInjection.swift:120:24:120:57 | ...! | CommandInjection.swift:120:2:120:2 | [post] task3 | provenance |  |
 | CommandInjection.swift:120:36:120:36 | userControlledString | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | CommandInjection.swift:121:2:121:2 | [post] task3 | provenance |  |
-| CommandInjection.swift:121:20:121:48 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:121:20:121:48 | [...] [Collection element] | CommandInjection.swift:121:2:121:2 | [post] task3 | provenance |  |
 | CommandInjection.swift:121:28:121:28 | userControlledString | CommandInjection.swift:121:20:121:48 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | CommandInjection.swift:125:2:125:2 | [post] task4 | provenance |  |
-| CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | provenance |  |
+| CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:125:2:125:2 | [post] task4 | provenance |  |
 | CommandInjection.swift:125:45:125:45 | userControlledString | CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | CommandInjection.swift:126:2:126:2 | [post] task4 | provenance |  |
 | CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:126:24:126:57 | ...! | provenance |  |
-| CommandInjection.swift:126:24:126:57 | ...! | CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | provenance |  |
+| CommandInjection.swift:126:24:126:57 | ...! | CommandInjection.swift:126:2:126:2 | [post] task4 | provenance |  |
 | CommandInjection.swift:126:36:126:36 | userControlledString | CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | CommandInjection.swift:127:2:127:2 | [post] task4 | provenance |  |
-| CommandInjection.swift:127:20:127:56 | [...] [Collection element] | CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:127:20:127:56 | [...] [Collection element] | CommandInjection.swift:127:2:127:2 | [post] task4 | provenance |  |
 | CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | CommandInjection.swift:127:20:127:56 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | CommandInjection.swift:131:2:131:7 | [post] ...? | provenance |  |
-| CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | provenance |  |
+| CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:131:2:131:7 | [post] ...? | provenance |  |
 | CommandInjection.swift:131:46:131:46 | userControlledString | CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | CommandInjection.swift:132:2:132:7 | [post] ...? | provenance |  |
-| CommandInjection.swift:132:21:132:42 | [...] [Collection element] | CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:132:21:132:42 | [...] [Collection element] | CommandInjection.swift:132:2:132:7 | [post] ...? | provenance |  |
 | CommandInjection.swift:132:22:132:22 | userControlledString | CommandInjection.swift:132:21:132:42 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | CommandInjection.swift:136:2:136:2 | [post] task6 | provenance |  |
-| CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | provenance |  |
+| CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | CommandInjection.swift:136:2:136:2 | [post] task6 | provenance |  |
 | CommandInjection.swift:136:45:136:45 | userControlledString | CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | provenance |  |
-| CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | CommandInjection.swift:137:2:137:2 | [post] task6 | provenance |  |
 | CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | CommandInjection.swift:137:24:137:57 | ...! | provenance |  |
-| CommandInjection.swift:137:24:137:57 | ...! | CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | provenance |  |
+| CommandInjection.swift:137:24:137:57 | ...! | CommandInjection.swift:137:2:137:2 | [post] task6 | provenance |  |
 | CommandInjection.swift:137:36:137:36 | userControlledString | CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | CommandInjection.swift:138:2:138:2 | [post] task6 | provenance |  |
-| CommandInjection.swift:138:20:138:41 | [...] [Collection element] | CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:138:20:138:41 | [...] [Collection element] | CommandInjection.swift:138:2:138:2 | [post] task6 | provenance |  |
 | CommandInjection.swift:138:21:138:21 | userControlledString | CommandInjection.swift:138:20:138:41 | [...] [Collection element] | provenance |  |
 | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | CommandInjection.swift:99:20:99:40 | arguments [Collection element] | provenance |  |
 | CommandInjection.swift:139:22:139:22 | userControlledString | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:151:67:151:95 | [...] [Collection element] | CommandInjection.swift:151:67:151:95 | [...] | provenance |  |
-| CommandInjection.swift:151:75:151:75 | userControlledString | CommandInjection.swift:151:67:151:95 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:151:75:151:75 | userControlledString | CommandInjection.swift:151:67:151:95 | [...] | provenance |  |
 | CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | CommandInjection.swift:154:23:154:56 | ...! | provenance |  |
 | CommandInjection.swift:154:35:154:35 | userControlledString | CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:155:62:155:90 | [...] [Collection element] | CommandInjection.swift:155:62:155:90 | [...] | provenance |  |
-| CommandInjection.swift:155:70:155:70 | userControlledString | CommandInjection.swift:155:62:155:90 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:155:70:155:70 | userControlledString | CommandInjection.swift:155:62:155:90 | [...] | provenance |  |
 | CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | CommandInjection.swift:160:41:160:74 | ...! | provenance |  |
 | CommandInjection.swift:160:53:160:53 | userControlledString | CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | provenance |  |
 | CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:163:40:163:73 | ...! | provenance |  |
 | CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | CommandInjection.swift:163:40:163:73 | ...! | provenance |  |
 | CommandInjection.swift:163:40:163:73 | ...! | file://:0:0:0:0 | url | provenance |  |
 | CommandInjection.swift:163:52:163:52 | userControlledString | CommandInjection.swift:163:40:163:72 | call to URL.init(string:) [some:0] | provenance |  |
-| CommandInjection.swift:164:32:164:53 | [...] [Collection element] | CommandInjection.swift:164:32:164:53 | [...] | provenance |  |
-| CommandInjection.swift:164:33:164:33 | userControlledString | CommandInjection.swift:164:32:164:53 | [...] [Collection element] | provenance |  |
+| CommandInjection.swift:164:33:164:33 | userControlledString | CommandInjection.swift:164:32:164:53 | [...] | provenance |  |
 | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
 | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | CommandInjection.swift:166:45:166:78 | ...! | provenance |  |
 | CommandInjection.swift:166:45:166:78 | ...! | file://:0:0:0:0 | url | provenance |  |
@@ -129,12 +113,9 @@ edges
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:194:19:194:19 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:195:20:195:20 | newValue [Collection element] | provenance |  |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | CommandInjection.swift:196:19:196:19 | newValue [Collection element] | provenance |  |
-| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:194:19:194:19 | newValue [Collection element] | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | CommandInjection.swift:195:4:195:6 | [post] ...! | provenance |  |
-| CommandInjection.swift:195:20:195:20 | newValue [Collection element] | CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | CommandInjection.swift:196:4:196:4 | [post] ...! | provenance |  |
-| CommandInjection.swift:196:19:196:19 | newValue [Collection element] | CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:194:19:194:19 | newValue [Collection element] | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:195:20:195:20 | newValue [Collection element] | CommandInjection.swift:195:4:195:6 | [post] ...! | provenance |  |
+| CommandInjection.swift:196:19:196:19 | newValue [Collection element] | CommandInjection.swift:196:4:196:4 | [post] ...! | provenance |  |
 | CommandInjection.swift:201:9:201:13 | let ...? [some:0] | CommandInjection.swift:201:13:201:13 | userControlledString | provenance |  |
 | CommandInjection.swift:201:13:201:13 | userControlledString | CommandInjection.swift:205:19:205:19 | userControlledString | provenance |  |
 | CommandInjection.swift:201:13:201:13 | userControlledString | CommandInjection.swift:211:31:211:31 | userControlledString | provenance |  |
@@ -146,23 +127,17 @@ edges
 | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | provenance |  |
 | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | provenance |  |
 | CommandInjection.swift:205:19:205:19 | userControlledString | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! | provenance |  |
-| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! | provenance |  |
-| CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | CommandInjection.swift:208:3:208:5 | [post] ...! | provenance |  |
+| CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | CommandInjection.swift:209:3:209:3 | [post] ...! | provenance |  |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | provenance |  |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | provenance |  |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | provenance |  |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | provenance |  |
 | CommandInjection.swift:211:31:211:31 | userControlledString | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | provenance |  |
-| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | provenance |  |
-| CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | CommandInjection.swift:214:3:214:5 | [post] ...! | provenance |  |
-| CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | provenance |  |
-| CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | CommandInjection.swift:215:3:215:3 | [post] ...! | provenance |  |
-| CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | provenance |  |
+| CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | provenance |  |
+| CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | CommandInjection.swift:214:3:214:5 | [post] ...! | provenance |  |
+| CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | CommandInjection.swift:215:3:215:3 | [post] ...! | provenance |  |
 | CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | provenance |  |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url | provenance |  |
 | file://:0:0:0:0 | url | file://:0:0:0:0 | url | provenance |  |
@@ -180,7 +155,6 @@ nodes
 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0, some:0] | semmle.label | call to String.init(contentsOf:) [some:0, some:0] |
 | CommandInjection.swift:75:40:75:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:81:2:81:2 | [post] task1 | semmle.label | [post] task1 |
-| CommandInjection.swift:81:2:81:2 | [post] task1 [arguments, Collection element] | semmle.label | [post] task1 [arguments, Collection element] |
 | CommandInjection.swift:81:20:81:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:81:27:81:27 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:84:5:84:9 | let ...? [some:0] | semmle.label | let ...? [some:0] |
@@ -190,71 +164,57 @@ nodes
 | CommandInjection.swift:84:43:84:43 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:84:43:84:43 | userControlledString [some:0] | semmle.label | userControlledString [some:0] |
 | CommandInjection.swift:87:6:87:6 | [post] task2 | semmle.label | [post] task2 |
-| CommandInjection.swift:87:6:87:6 | [post] task2 [arguments, Collection element] | semmle.label | [post] task2 [arguments, Collection element] |
 | CommandInjection.swift:87:24:87:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:87:31:87:31 | validatedString | semmle.label | validatedString |
 | CommandInjection.swift:99:20:99:40 | arguments [Collection element] | semmle.label | arguments [Collection element] |
 | CommandInjection.swift:100:3:100:3 | [post] self | semmle.label | [post] self |
-| CommandInjection.swift:100:3:100:3 | [post] self [arguments, Collection element] | semmle.label | [post] self [arguments, Collection element] |
 | CommandInjection.swift:100:20:100:20 | arguments [Collection element] | semmle.label | arguments [Collection element] |
 | CommandInjection.swift:105:8:105:12 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:105:12:105:12 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) | semmle.label | call to String.init(contentsOf:) |
 | CommandInjection.swift:105:40:105:94 | call to String.init(contentsOf:) [some:0] | semmle.label | call to String.init(contentsOf:) [some:0] |
 | CommandInjection.swift:120:2:120:2 | [post] task3 | semmle.label | [post] task3 |
-| CommandInjection.swift:120:2:120:2 | [post] task3 [executableURL] | semmle.label | [post] task3 [executableURL] |
 | CommandInjection.swift:120:24:120:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:120:24:120:57 | ...! | semmle.label | ...! |
 | CommandInjection.swift:120:36:120:36 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:121:2:121:2 | [post] task3 | semmle.label | [post] task3 |
-| CommandInjection.swift:121:2:121:2 | [post] task3 [arguments, Collection element] | semmle.label | [post] task3 [arguments, Collection element] |
 | CommandInjection.swift:121:20:121:48 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:121:28:121:28 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:125:2:125:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:125:2:125:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
 | CommandInjection.swift:125:24:125:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:125:45:125:45 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:126:2:126:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:126:2:126:2 | [post] task4 [executableURL] | semmle.label | [post] task4 [executableURL] |
 | CommandInjection.swift:126:24:126:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:126:24:126:57 | ...! | semmle.label | ...! |
 | CommandInjection.swift:126:36:126:36 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:127:2:127:2 | [post] task4 | semmle.label | [post] task4 |
-| CommandInjection.swift:127:2:127:2 | [post] task4 [arguments, Collection element] | semmle.label | [post] task4 [arguments, Collection element] |
 | CommandInjection.swift:127:20:127:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:127:28:127:36 | ... .+(_:_:) ... | semmle.label | ... .+(_:_:) ... |
 | CommandInjection.swift:131:2:131:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:131:2:131:7 | [post] ...? [executableURL] | semmle.label | [post] ...? [executableURL] |
 | CommandInjection.swift:131:25:131:66 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:131:46:131:46 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:132:2:132:7 | [post] ...? | semmle.label | [post] ...? |
-| CommandInjection.swift:132:2:132:7 | [post] ...? [arguments, Collection element] | semmle.label | [post] ...? [arguments, Collection element] |
 | CommandInjection.swift:132:21:132:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:132:22:132:22 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:136:2:136:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:136:2:136:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
 | CommandInjection.swift:136:24:136:65 | call to URL.init(fileURLWithPath:) | semmle.label | call to URL.init(fileURLWithPath:) |
 | CommandInjection.swift:136:45:136:45 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:137:2:137:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:137:2:137:2 | [post] task6 [executableURL] | semmle.label | [post] task6 [executableURL] |
 | CommandInjection.swift:137:24:137:56 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:137:24:137:57 | ...! | semmle.label | ...! |
 | CommandInjection.swift:137:36:137:36 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:138:2:138:2 | [post] task6 | semmle.label | [post] task6 |
-| CommandInjection.swift:138:2:138:2 | [post] task6 [arguments, Collection element] | semmle.label | [post] task6 [arguments, Collection element] |
 | CommandInjection.swift:138:20:138:41 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:138:21:138:21 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:139:21:139:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:139:22:139:22 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:150:42:150:42 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:151:67:151:95 | [...] | semmle.label | [...] |
-| CommandInjection.swift:151:67:151:95 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:151:75:151:75 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:154:23:154:55 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:154:23:154:56 | ...! | semmle.label | ...! |
 | CommandInjection.swift:154:35:154:35 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:155:62:155:90 | [...] | semmle.label | [...] |
-| CommandInjection.swift:155:62:155:90 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:155:70:155:70 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:160:41:160:73 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:160:41:160:74 | ...! | semmle.label | ...! |
@@ -264,7 +224,6 @@ nodes
 | CommandInjection.swift:163:40:163:73 | ...! | semmle.label | ...! |
 | CommandInjection.swift:163:52:163:52 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:164:32:164:53 | [...] | semmle.label | [...] |
-| CommandInjection.swift:164:32:164:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:164:33:164:33 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:166:45:166:77 | call to URL.init(string:) [some:0] | semmle.label | call to URL.init(string:) [some:0] |
 | CommandInjection.swift:166:45:166:78 | ...! | semmle.label | ...! |
@@ -272,13 +231,10 @@ nodes
 | CommandInjection.swift:166:57:166:57 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:193:3:193:3 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:194:4:194:4 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:194:4:194:4 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:194:19:194:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:195:4:195:6 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:195:4:195:6 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:195:20:195:20 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:196:4:196:4 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:196:4:196:4 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:196:19:196:19 | newValue [Collection element] | semmle.label | newValue [Collection element] |
 | CommandInjection.swift:201:9:201:13 | let ...? [some:0] | semmle.label | let ...? [some:0] |
 | CommandInjection.swift:201:13:201:13 | userControlledString | semmle.label | userControlledString |
@@ -287,24 +243,18 @@ nodes
 | CommandInjection.swift:205:18:205:39 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:205:19:205:19 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:207:3:207:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:207:3:207:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:207:18:207:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
 | CommandInjection.swift:208:3:208:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:208:3:208:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:208:19:208:19 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
 | CommandInjection.swift:209:3:209:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:209:3:209:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:209:18:209:18 | tainted1 [Collection element] | semmle.label | tainted1 [Collection element] |
 | CommandInjection.swift:211:30:211:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | CommandInjection.swift:211:31:211:31 | userControlledString | semmle.label | userControlledString |
 | CommandInjection.swift:213:3:213:3 | [post] getter for .p1 | semmle.label | [post] getter for .p1 |
-| CommandInjection.swift:213:3:213:3 | [post] getter for .p1 [arguments, Collection element] | semmle.label | [post] getter for .p1 [arguments, Collection element] |
 | CommandInjection.swift:213:18:213:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | CommandInjection.swift:214:3:214:5 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:214:3:214:5 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:214:19:214:19 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | CommandInjection.swift:215:3:215:3 | [post] ...! | semmle.label | [post] ...! |
-| CommandInjection.swift:215:3:215:3 | [post] ...! [arguments, Collection element] | semmle.label | [post] ...! [arguments, Collection element] |
 | CommandInjection.swift:215:18:215:18 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | CommandInjection.swift:217:13:217:13 | tainted2 [Collection element] | semmle.label | tainted2 [Collection element] |
 | file://:0:0:0:0 | url | semmle.label | url |

--- a/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
+++ b/swift/ql/test/query-tests/Security/CWE-311/CleartextStorageDatabase.expected
@@ -21,35 +21,23 @@ edges
 | SQLite.swift:153:20:153:20 | mobilePhoneNumber | SQLite.swift:153:20:153:20 | [...] [Collection element] | provenance |  |
 | SQLite.swift:154:23:154:23 | [...] [Collection element] | SQLite.swift:154:23:154:23 | [...] | provenance |  |
 | SQLite.swift:154:23:154:23 | mobilePhoneNumber | SQLite.swift:154:23:154:23 | [...] [Collection element] | provenance |  |
-| SQLite.swift:158:32:158:54 | [...] [Collection element] | SQLite.swift:158:32:158:54 | [...] | provenance |  |
-| SQLite.swift:158:33:158:33 | mobilePhoneNumber | SQLite.swift:158:32:158:54 | [...] [Collection element] | provenance |  |
-| SQLite.swift:159:28:159:50 | [...] [Collection element] | SQLite.swift:159:28:159:50 | [...] | provenance |  |
-| SQLite.swift:159:29:159:29 | mobilePhoneNumber | SQLite.swift:159:28:159:50 | [...] [Collection element] | provenance |  |
-| SQLite.swift:160:31:160:53 | [...] [Collection element] | SQLite.swift:160:31:160:53 | [...] | provenance |  |
-| SQLite.swift:160:32:160:32 | mobilePhoneNumber | SQLite.swift:160:31:160:53 | [...] [Collection element] | provenance |  |
-| SQLite.swift:163:21:163:43 | [...] [Collection element] | SQLite.swift:163:21:163:43 | [...] | provenance |  |
-| SQLite.swift:163:22:163:22 | mobilePhoneNumber | SQLite.swift:163:21:163:43 | [...] [Collection element] | provenance |  |
-| SQLite.swift:164:20:164:42 | [...] [Collection element] | SQLite.swift:164:20:164:42 | [...] | provenance |  |
-| SQLite.swift:164:21:164:21 | mobilePhoneNumber | SQLite.swift:164:20:164:42 | [...] [Collection element] | provenance |  |
-| SQLite.swift:165:23:165:45 | [...] [Collection element] | SQLite.swift:165:23:165:45 | [...] | provenance |  |
-| SQLite.swift:165:24:165:24 | mobilePhoneNumber | SQLite.swift:165:23:165:45 | [...] [Collection element] | provenance |  |
-| SQLite.swift:169:32:169:70 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:169:32:169:70 | [...] | provenance |  |
-| SQLite.swift:169:43:169:53 | (...) [Tuple element at index 1] | SQLite.swift:169:32:169:70 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:158:33:158:33 | mobilePhoneNumber | SQLite.swift:158:32:158:54 | [...] | provenance |  |
+| SQLite.swift:159:29:159:29 | mobilePhoneNumber | SQLite.swift:159:28:159:50 | [...] | provenance |  |
+| SQLite.swift:160:32:160:32 | mobilePhoneNumber | SQLite.swift:160:31:160:53 | [...] | provenance |  |
+| SQLite.swift:163:22:163:22 | mobilePhoneNumber | SQLite.swift:163:21:163:43 | [...] | provenance |  |
+| SQLite.swift:164:21:164:21 | mobilePhoneNumber | SQLite.swift:164:20:164:42 | [...] | provenance |  |
+| SQLite.swift:165:24:165:24 | mobilePhoneNumber | SQLite.swift:165:23:165:45 | [...] | provenance |  |
+| SQLite.swift:169:43:169:53 | (...) [Tuple element at index 1] | SQLite.swift:169:32:169:70 | [...] | provenance |  |
 | SQLite.swift:169:53:169:53 | mobilePhoneNumber | SQLite.swift:169:43:169:53 | (...) [Tuple element at index 1] | provenance |  |
-| SQLite.swift:170:28:170:66 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:170:28:170:66 | [...] | provenance |  |
-| SQLite.swift:170:39:170:49 | (...) [Tuple element at index 1] | SQLite.swift:170:28:170:66 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:170:39:170:49 | (...) [Tuple element at index 1] | SQLite.swift:170:28:170:66 | [...] | provenance |  |
 | SQLite.swift:170:49:170:49 | mobilePhoneNumber | SQLite.swift:170:39:170:49 | (...) [Tuple element at index 1] | provenance |  |
-| SQLite.swift:171:31:171:69 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:171:31:171:69 | [...] | provenance |  |
-| SQLite.swift:171:42:171:52 | (...) [Tuple element at index 1] | SQLite.swift:171:31:171:69 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:171:42:171:52 | (...) [Tuple element at index 1] | SQLite.swift:171:31:171:69 | [...] | provenance |  |
 | SQLite.swift:171:52:171:52 | mobilePhoneNumber | SQLite.swift:171:42:171:52 | (...) [Tuple element at index 1] | provenance |  |
-| SQLite.swift:174:21:174:59 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:174:21:174:59 | [...] | provenance |  |
-| SQLite.swift:174:32:174:42 | (...) [Tuple element at index 1] | SQLite.swift:174:21:174:59 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:174:32:174:42 | (...) [Tuple element at index 1] | SQLite.swift:174:21:174:59 | [...] | provenance |  |
 | SQLite.swift:174:42:174:42 | mobilePhoneNumber | SQLite.swift:174:32:174:42 | (...) [Tuple element at index 1] | provenance |  |
-| SQLite.swift:175:20:175:58 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:175:20:175:58 | [...] | provenance |  |
-| SQLite.swift:175:31:175:41 | (...) [Tuple element at index 1] | SQLite.swift:175:20:175:58 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:175:31:175:41 | (...) [Tuple element at index 1] | SQLite.swift:175:20:175:58 | [...] | provenance |  |
 | SQLite.swift:175:41:175:41 | mobilePhoneNumber | SQLite.swift:175:31:175:41 | (...) [Tuple element at index 1] | provenance |  |
-| SQLite.swift:176:23:176:61 | [...] [Collection element, Tuple element at index 1] | SQLite.swift:176:23:176:61 | [...] | provenance |  |
-| SQLite.swift:176:34:176:44 | (...) [Tuple element at index 1] | SQLite.swift:176:23:176:61 | [...] [Collection element, Tuple element at index 1] | provenance |  |
+| SQLite.swift:176:34:176:44 | (...) [Tuple element at index 1] | SQLite.swift:176:23:176:61 | [...] | provenance |  |
 | SQLite.swift:176:44:176:44 | mobilePhoneNumber | SQLite.swift:176:34:176:44 | (...) [Tuple element at index 1] | provenance |  |
 | SQLite.swift:186:40:186:54 | ... <-(_:_:) ... | SQLite.swift:186:40:186:54 | [...] [Collection element] | provenance |  |
 | SQLite.swift:186:40:186:54 | [...] [Collection element] | SQLite.swift:186:40:186:54 | [...] | provenance |  |
@@ -87,264 +75,173 @@ edges
 | sqlite3_c_api.swift:42:69:42:69 | medicalNotes | sqlite3_c_api.swift:46:27:46:27 | insertQuery | provenance |  |
 | sqlite3_c_api.swift:43:49:43:49 | medicalNotes | sqlite3_c_api.swift:47:27:47:27 | updateQuery | provenance |  |
 | testCoreData2.swift:23:13:23:13 | value | file://:0:0:0:0 | value | provenance |  |
-| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | testCoreData2.swift:37:2:37:2 | [post] obj | provenance |  |
-| testCoreData2.swift:37:16:37:16 | bankAccountNo | testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | provenance |  |
-| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] | testCoreData2.swift:39:2:39:2 | [post] obj | provenance |  |
-| testCoreData2.swift:39:28:39:28 | bankAccountNo | testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] | provenance |  |
-| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] | testCoreData2.swift:41:2:41:2 | [post] obj | provenance |  |
-| testCoreData2.swift:41:29:41:29 | bankAccountNo | testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] | provenance |  |
-| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj | provenance |  |
+| testCoreData2.swift:37:16:37:16 | bankAccountNo | testCoreData2.swift:37:2:37:2 | [post] obj | provenance |  |
+| testCoreData2.swift:39:28:39:28 | bankAccountNo | testCoreData2.swift:39:2:39:2 | [post] obj | provenance |  |
+| testCoreData2.swift:41:29:41:29 | bankAccountNo | testCoreData2.swift:41:2:41:2 | [post] obj | provenance |  |
 | testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | provenance |  |
-| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] | provenance |  |
-| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] | testCoreData2.swift:46:2:46:10 | [post] ...? | provenance |  |
-| testCoreData2.swift:46:22:46:22 | bankAccountNo | testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] | provenance |  |
-| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] | testCoreData2.swift:48:2:48:10 | [post] ...? | provenance |  |
-| testCoreData2.swift:48:34:48:34 | bankAccountNo | testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] | provenance |  |
-| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] | testCoreData2.swift:50:2:50:10 | [post] ...? | provenance |  |
-| testCoreData2.swift:50:35:50:35 | bankAccountNo | testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] | provenance |  |
-| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:43:2:43:2 | [post] obj | provenance |  |
+| testCoreData2.swift:46:22:46:22 | bankAccountNo | testCoreData2.swift:46:2:46:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:48:34:48:34 | bankAccountNo | testCoreData2.swift:48:2:48:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:50:35:50:35 | bankAccountNo | testCoreData2.swift:50:2:50:10 | [post] ...? | provenance |  |
 | testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | provenance |  |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] | provenance |  |
-| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] | testCoreData2.swift:57:3:57:3 | [post] obj | provenance |  |
-| testCoreData2.swift:57:29:57:29 | bankAccountNo | testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] | provenance |  |
-| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] | testCoreData2.swift:60:4:60:4 | [post] obj | provenance |  |
-| testCoreData2.swift:60:30:60:30 | bankAccountNo | testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] | provenance |  |
-| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] | testCoreData2.swift:62:4:62:4 | [post] obj | provenance |  |
-| testCoreData2.swift:62:30:62:30 | bankAccountNo | testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] | provenance |  |
-| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | testCoreData2.swift:65:3:65:3 | [post] obj | provenance |  |
-| testCoreData2.swift:65:29:65:29 | bankAccountNo | testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | provenance |  |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:52:2:52:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:57:29:57:29 | bankAccountNo | testCoreData2.swift:57:3:57:3 | [post] obj | provenance |  |
+| testCoreData2.swift:60:30:60:30 | bankAccountNo | testCoreData2.swift:60:4:60:4 | [post] obj | provenance |  |
+| testCoreData2.swift:62:30:62:30 | bankAccountNo | testCoreData2.swift:62:4:62:4 | [post] obj | provenance |  |
+| testCoreData2.swift:65:29:65:29 | bankAccountNo | testCoreData2.swift:65:3:65:3 | [post] obj | provenance |  |
 | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | self | provenance |  |
 | testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | self [value] | provenance |  |
 | testCoreData2.swift:70:9:70:9 | value | file://:0:0:0:0 | value | provenance |  |
 | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | self | provenance |  |
-| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] | testCoreData2.swift:79:2:79:2 | [post] dbObj | provenance |  |
-| testCoreData2.swift:79:18:79:28 | .bankAccountNo | testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] | provenance |  |
-| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] | testCoreData2.swift:80:2:80:2 | [post] dbObj | provenance |  |
-| testCoreData2.swift:80:18:80:28 | ...! | testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:79:18:79:28 | .bankAccountNo | testCoreData2.swift:79:2:79:2 | [post] dbObj | provenance |  |
+| testCoreData2.swift:80:18:80:28 | ...! | testCoreData2.swift:80:2:80:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | testCoreData2.swift:80:18:80:28 | ...! | provenance |  |
-| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] | testCoreData2.swift:82:2:82:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:82:18:82:32 | .value | provenance | Config |
-| testCoreData2.swift:82:18:82:32 | .value | testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] | provenance |  |
-| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] | testCoreData2.swift:83:2:83:2 | [post] dbObj | provenance |  |
+| testCoreData2.swift:82:18:82:32 | .value | testCoreData2.swift:82:2:82:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:71:9:71:9 | self | provenance |  |
 | testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:83:18:83:32 | .value2 | provenance | Config |
-| testCoreData2.swift:83:18:83:32 | ...! | testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:83:18:83:32 | ...! | testCoreData2.swift:83:2:83:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:83:18:83:32 | .value2 | testCoreData2.swift:83:18:83:32 | ...! | provenance |  |
-| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] | testCoreData2.swift:84:2:84:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:84:18:84:33 | .value | provenance | Config |
 | testCoreData2.swift:84:18:84:18 | bankAccountNo2 | testCoreData2.swift:84:18:84:18 | ...! | provenance |  |
-| testCoreData2.swift:84:18:84:33 | .value | testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] | provenance |  |
-| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] | testCoreData2.swift:85:2:85:2 | [post] dbObj | provenance |  |
+| testCoreData2.swift:84:18:84:33 | .value | testCoreData2.swift:84:2:84:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:85:18:85:18 | ...! | testCoreData2.swift:71:9:71:9 | self | provenance |  |
 | testCoreData2.swift:85:18:85:18 | ...! | testCoreData2.swift:85:18:85:33 | .value2 | provenance | Config |
 | testCoreData2.swift:85:18:85:18 | bankAccountNo2 | testCoreData2.swift:85:18:85:18 | ...! | provenance |  |
-| testCoreData2.swift:85:18:85:33 | ...! | testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:85:18:85:33 | ...! | testCoreData2.swift:85:2:85:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:85:18:85:33 | .value2 | testCoreData2.swift:85:18:85:33 | ...! | provenance |  |
-| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] | testCoreData2.swift:87:2:87:10 | [post] ...? | provenance |  |
-| testCoreData2.swift:87:22:87:32 | .bankAccountNo | testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] | provenance |  |
-| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] | testCoreData2.swift:88:2:88:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:87:22:87:32 | .bankAccountNo | testCoreData2.swift:87:2:87:10 | [post] ...? | provenance |  |
 | testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:88:22:88:22 | bankAccountNo | testCoreData2.swift:88:22:88:36 | .value | provenance | Config |
-| testCoreData2.swift:88:22:88:36 | .value | testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] | provenance |  |
-| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] | testCoreData2.swift:89:2:89:10 | [post] ...? | provenance |  |
+| testCoreData2.swift:88:22:88:36 | .value | testCoreData2.swift:88:2:88:10 | [post] ...? | provenance |  |
 | testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:71:9:71:9 | self | provenance |  |
 | testCoreData2.swift:89:22:89:22 | ...! | testCoreData2.swift:89:22:89:37 | .value2 | provenance | Config |
 | testCoreData2.swift:89:22:89:22 | bankAccountNo2 | testCoreData2.swift:89:22:89:22 | ...! | provenance |  |
-| testCoreData2.swift:89:22:89:37 | ...! | testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] | provenance |  |
+| testCoreData2.swift:89:22:89:37 | ...! | testCoreData2.swift:89:2:89:10 | [post] ...? | provenance |  |
 | testCoreData2.swift:89:22:89:37 | .value2 | testCoreData2.swift:89:22:89:37 | ...! | provenance |  |
 | testCoreData2.swift:91:10:91:10 | bankAccountNo | testCoreData2.swift:92:10:92:10 | a | provenance |  |
 | testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:92:10:92:10 | a | testCoreData2.swift:92:10:92:12 | .value | provenance | Config |
 | testCoreData2.swift:92:10:92:12 | .value | testCoreData2.swift:93:18:93:18 | b | provenance |  |
-| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] | testCoreData2.swift:93:2:93:2 | [post] dbObj | provenance |  |
-| testCoreData2.swift:93:18:93:18 | b | testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:93:18:93:18 | b | testCoreData2.swift:93:2:93:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:95:10:95:10 | bankAccountNo | testCoreData2.swift:97:12:97:12 | c | provenance |  |
 | testCoreData2.swift:97:2:97:2 | [post] d [value] | testCoreData2.swift:98:18:98:18 | d [value] | provenance |  |
 | testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:97:12:97:12 | c | testCoreData2.swift:97:12:97:14 | .value | provenance | Config |
 | testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:70:9:70:9 | value | provenance |  |
 | testCoreData2.swift:97:12:97:14 | .value | testCoreData2.swift:97:2:97:2 | [post] d [value] | provenance |  |
-| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | testCoreData2.swift:98:2:98:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] | provenance |  |
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:98:18:98:20 | .value | provenance |  |
-| testCoreData2.swift:98:18:98:20 | .value | testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:98:18:98:20 | .value | testCoreData2.swift:98:2:98:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:101:10:101:10 | bankAccountNo | testCoreData2.swift:103:13:103:13 | e | provenance |  |
 | testCoreData2.swift:103:13:103:13 | e | testCoreData2.swift:104:18:104:18 | e | provenance |  |
-| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | testCoreData2.swift:104:2:104:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | provenance |  |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:104:18:104:20 | .value | provenance | Config |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:105:18:105:18 | e | provenance |  |
-| testCoreData2.swift:104:18:104:20 | .value | testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | provenance |  |
-| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] | testCoreData2.swift:105:2:105:2 | [post] dbObj | provenance |  |
+| testCoreData2.swift:104:18:104:20 | .value | testCoreData2.swift:104:2:104:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self | provenance |  |
 | testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:105:18:105:20 | .value2 | provenance | Config |
-| testCoreData2.swift:105:18:105:20 | ...! | testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] | provenance |  |
+| testCoreData2.swift:105:18:105:20 | ...! | testCoreData2.swift:105:2:105:2 | [post] dbObj | provenance |  |
 | testCoreData2.swift:105:18:105:20 | .value2 | testCoreData2.swift:105:18:105:20 | ...! | provenance |  |
 | testCoreData.swift:18:19:18:26 | value | testCoreData.swift:19:12:19:12 | value | provenance |  |
 | testCoreData.swift:31:3:31:3 | newValue | testCoreData.swift:32:13:32:13 | newValue | provenance |  |
 | testCoreData.swift:61:25:61:25 | password | testCoreData.swift:18:19:18:26 | value | provenance |  |
-| testCoreData.swift:64:2:64:2 | [post] obj [myValue] | testCoreData.swift:64:2:64:2 | [post] obj | provenance |  |
 | testCoreData.swift:64:16:64:16 | password | testCoreData.swift:31:3:31:3 | newValue | provenance |  |
-| testCoreData.swift:64:16:64:16 | password | testCoreData.swift:64:2:64:2 | [post] obj [myValue] | provenance |  |
+| testCoreData.swift:64:16:64:16 | password | testCoreData.swift:64:2:64:2 | [post] obj | provenance |  |
 | testCoreData.swift:77:24:77:24 | x | testCoreData.swift:78:15:78:15 | x | provenance |  |
 | testCoreData.swift:80:10:80:22 | call to getPassword() | testCoreData.swift:81:15:81:15 | y | provenance |  |
 | testCoreData.swift:91:10:91:10 | passwd | testCoreData.swift:95:15:95:15 | x | provenance |  |
 | testCoreData.swift:92:10:92:10 | passwd | testCoreData.swift:96:15:96:15 | y | provenance |  |
 | testCoreData.swift:93:10:93:10 | passwd | testCoreData.swift:97:15:97:15 | z | provenance |  |
-| testGRDB.swift:73:56:73:65 | [...] [Collection element] | testGRDB.swift:73:56:73:65 | [...] | provenance |  |
-| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:76:42:76:51 | [...] [Collection element] | testGRDB.swift:76:42:76:51 | [...] | provenance |  |
-| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:81:44:81:53 | [...] [Collection element] | testGRDB.swift:81:44:81:53 | [...] | provenance |  |
-| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:83:44:83:53 | [...] [Collection element] | testGRDB.swift:83:44:83:53 | [...] | provenance |  |
-| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:85:44:85:53 | [...] [Collection element] | testGRDB.swift:85:44:85:53 | [...] | provenance |  |
-| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:87:44:87:53 | [...] [Collection element] | testGRDB.swift:87:44:87:53 | [...] | provenance |  |
-| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:92:37:92:46 | [...] [Collection element] | testGRDB.swift:92:37:92:46 | [...] | provenance |  |
-| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:95:36:95:45 | [...] [Collection element] | testGRDB.swift:95:36:95:45 | [...] | provenance |  |
-| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:100:72:100:81 | [...] [Collection element] | testGRDB.swift:100:72:100:81 | [...] | provenance |  |
-| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:101:72:101:81 | [...] [Collection element] | testGRDB.swift:101:72:101:81 | [...] | provenance |  |
-| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:107:52:107:61 | [...] [Collection element] | testGRDB.swift:107:52:107:61 | [...] | provenance |  |
-| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:109:52:109:61 | [...] [Collection element] | testGRDB.swift:109:52:109:61 | [...] | provenance |  |
-| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:111:51:111:60 | [...] [Collection element] | testGRDB.swift:111:51:111:60 | [...] | provenance |  |
-| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:116:47:116:56 | [...] [Collection element] | testGRDB.swift:116:47:116:56 | [...] | provenance |  |
-| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:118:47:118:56 | [...] [Collection element] | testGRDB.swift:118:47:118:56 | [...] | provenance |  |
-| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:121:44:121:53 | [...] [Collection element] | testGRDB.swift:121:44:121:53 | [...] | provenance |  |
-| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:123:44:123:53 | [...] [Collection element] | testGRDB.swift:123:44:123:53 | [...] | provenance |  |
-| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:126:44:126:53 | [...] [Collection element] | testGRDB.swift:126:44:126:53 | [...] | provenance |  |
-| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:128:44:128:53 | [...] [Collection element] | testGRDB.swift:128:44:128:53 | [...] | provenance |  |
-| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:131:44:131:53 | [...] [Collection element] | testGRDB.swift:131:44:131:53 | [...] | provenance |  |
-| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:133:44:133:53 | [...] [Collection element] | testGRDB.swift:133:44:133:53 | [...] | provenance |  |
-| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:138:68:138:77 | [...] [Collection element] | testGRDB.swift:138:68:138:77 | [...] | provenance |  |
-| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:140:68:140:77 | [...] [Collection element] | testGRDB.swift:140:68:140:77 | [...] | provenance |  |
-| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:143:65:143:74 | [...] [Collection element] | testGRDB.swift:143:65:143:74 | [...] | provenance |  |
-| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:145:65:145:74 | [...] [Collection element] | testGRDB.swift:145:65:145:74 | [...] | provenance |  |
-| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:148:65:148:74 | [...] [Collection element] | testGRDB.swift:148:65:148:74 | [...] | provenance |  |
-| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:150:65:150:74 | [...] [Collection element] | testGRDB.swift:150:65:150:74 | [...] | provenance |  |
-| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:153:65:153:74 | [...] [Collection element] | testGRDB.swift:153:65:153:74 | [...] | provenance |  |
-| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:155:65:155:74 | [...] [Collection element] | testGRDB.swift:155:65:155:74 | [...] | provenance |  |
-| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:160:59:160:68 | [...] [Collection element] | testGRDB.swift:160:59:160:68 | [...] | provenance |  |
-| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:161:50:161:59 | [...] [Collection element] | testGRDB.swift:161:50:161:59 | [...] | provenance |  |
-| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:164:59:164:68 | [...] [Collection element] | testGRDB.swift:164:59:164:68 | [...] | provenance |  |
-| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:165:50:165:59 | [...] [Collection element] | testGRDB.swift:165:50:165:59 | [...] | provenance |  |
-| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:169:56:169:65 | [...] [Collection element] | testGRDB.swift:169:56:169:65 | [...] | provenance |  |
-| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:170:47:170:56 | [...] [Collection element] | testGRDB.swift:170:47:170:56 | [...] | provenance |  |
-| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:173:56:173:65 | [...] [Collection element] | testGRDB.swift:173:56:173:65 | [...] | provenance |  |
-| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:174:47:174:56 | [...] [Collection element] | testGRDB.swift:174:47:174:56 | [...] | provenance |  |
-| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:178:56:178:65 | [...] [Collection element] | testGRDB.swift:178:56:178:65 | [...] | provenance |  |
-| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:179:47:179:56 | [...] [Collection element] | testGRDB.swift:179:47:179:56 | [...] | provenance |  |
-| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:182:56:182:65 | [...] [Collection element] | testGRDB.swift:182:56:182:65 | [...] | provenance |  |
-| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:183:47:183:56 | [...] [Collection element] | testGRDB.swift:183:47:183:56 | [...] | provenance |  |
-| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:187:56:187:65 | [...] [Collection element] | testGRDB.swift:187:56:187:65 | [...] | provenance |  |
-| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:188:47:188:56 | [...] [Collection element] | testGRDB.swift:188:47:188:56 | [...] | provenance |  |
-| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:191:56:191:65 | [...] [Collection element] | testGRDB.swift:191:56:191:65 | [...] | provenance |  |
-| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:192:47:192:56 | [...] [Collection element] | testGRDB.swift:192:47:192:56 | [...] | provenance |  |
-| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:198:29:198:38 | [...] [Collection element] | testGRDB.swift:198:29:198:38 | [...] | provenance |  |
-| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:201:23:201:32 | [...] [Collection element] | testGRDB.swift:201:23:201:32 | [...] | provenance |  |
-| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:206:66:206:75 | [...] [Collection element] | testGRDB.swift:206:66:206:75 | [...] | provenance |  |
-| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:208:80:208:89 | [...] [Collection element] | testGRDB.swift:208:80:208:89 | [...] | provenance |  |
-| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:210:84:210:93 | [...] [Collection element] | testGRDB.swift:210:84:210:93 | [...] | provenance |  |
-| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] [Collection element] | provenance |  |
-| testGRDB.swift:212:98:212:107 | [...] [Collection element] | testGRDB.swift:212:98:212:107 | [...] | provenance |  |
-| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] [Collection element] | provenance |  |
+| testGRDB.swift:73:57:73:57 | password | testGRDB.swift:73:56:73:65 | [...] | provenance |  |
+| testGRDB.swift:76:43:76:43 | password | testGRDB.swift:76:42:76:51 | [...] | provenance |  |
+| testGRDB.swift:81:45:81:45 | password | testGRDB.swift:81:44:81:53 | [...] | provenance |  |
+| testGRDB.swift:83:45:83:45 | password | testGRDB.swift:83:44:83:53 | [...] | provenance |  |
+| testGRDB.swift:85:45:85:45 | password | testGRDB.swift:85:44:85:53 | [...] | provenance |  |
+| testGRDB.swift:87:45:87:45 | password | testGRDB.swift:87:44:87:53 | [...] | provenance |  |
+| testGRDB.swift:92:38:92:38 | password | testGRDB.swift:92:37:92:46 | [...] | provenance |  |
+| testGRDB.swift:95:37:95:37 | password | testGRDB.swift:95:36:95:45 | [...] | provenance |  |
+| testGRDB.swift:100:73:100:73 | password | testGRDB.swift:100:72:100:81 | [...] | provenance |  |
+| testGRDB.swift:101:73:101:73 | password | testGRDB.swift:101:72:101:81 | [...] | provenance |  |
+| testGRDB.swift:107:53:107:53 | password | testGRDB.swift:107:52:107:61 | [...] | provenance |  |
+| testGRDB.swift:109:53:109:53 | password | testGRDB.swift:109:52:109:61 | [...] | provenance |  |
+| testGRDB.swift:111:52:111:52 | password | testGRDB.swift:111:51:111:60 | [...] | provenance |  |
+| testGRDB.swift:116:48:116:48 | password | testGRDB.swift:116:47:116:56 | [...] | provenance |  |
+| testGRDB.swift:118:48:118:48 | password | testGRDB.swift:118:47:118:56 | [...] | provenance |  |
+| testGRDB.swift:121:45:121:45 | password | testGRDB.swift:121:44:121:53 | [...] | provenance |  |
+| testGRDB.swift:123:45:123:45 | password | testGRDB.swift:123:44:123:53 | [...] | provenance |  |
+| testGRDB.swift:126:45:126:45 | password | testGRDB.swift:126:44:126:53 | [...] | provenance |  |
+| testGRDB.swift:128:45:128:45 | password | testGRDB.swift:128:44:128:53 | [...] | provenance |  |
+| testGRDB.swift:131:45:131:45 | password | testGRDB.swift:131:44:131:53 | [...] | provenance |  |
+| testGRDB.swift:133:45:133:45 | password | testGRDB.swift:133:44:133:53 | [...] | provenance |  |
+| testGRDB.swift:138:69:138:69 | password | testGRDB.swift:138:68:138:77 | [...] | provenance |  |
+| testGRDB.swift:140:69:140:69 | password | testGRDB.swift:140:68:140:77 | [...] | provenance |  |
+| testGRDB.swift:143:66:143:66 | password | testGRDB.swift:143:65:143:74 | [...] | provenance |  |
+| testGRDB.swift:145:66:145:66 | password | testGRDB.swift:145:65:145:74 | [...] | provenance |  |
+| testGRDB.swift:148:66:148:66 | password | testGRDB.swift:148:65:148:74 | [...] | provenance |  |
+| testGRDB.swift:150:66:150:66 | password | testGRDB.swift:150:65:150:74 | [...] | provenance |  |
+| testGRDB.swift:153:66:153:66 | password | testGRDB.swift:153:65:153:74 | [...] | provenance |  |
+| testGRDB.swift:155:66:155:66 | password | testGRDB.swift:155:65:155:74 | [...] | provenance |  |
+| testGRDB.swift:160:60:160:60 | password | testGRDB.swift:160:59:160:68 | [...] | provenance |  |
+| testGRDB.swift:161:51:161:51 | password | testGRDB.swift:161:50:161:59 | [...] | provenance |  |
+| testGRDB.swift:164:60:164:60 | password | testGRDB.swift:164:59:164:68 | [...] | provenance |  |
+| testGRDB.swift:165:51:165:51 | password | testGRDB.swift:165:50:165:59 | [...] | provenance |  |
+| testGRDB.swift:169:57:169:57 | password | testGRDB.swift:169:56:169:65 | [...] | provenance |  |
+| testGRDB.swift:170:48:170:48 | password | testGRDB.swift:170:47:170:56 | [...] | provenance |  |
+| testGRDB.swift:173:57:173:57 | password | testGRDB.swift:173:56:173:65 | [...] | provenance |  |
+| testGRDB.swift:174:48:174:48 | password | testGRDB.swift:174:47:174:56 | [...] | provenance |  |
+| testGRDB.swift:178:57:178:57 | password | testGRDB.swift:178:56:178:65 | [...] | provenance |  |
+| testGRDB.swift:179:48:179:48 | password | testGRDB.swift:179:47:179:56 | [...] | provenance |  |
+| testGRDB.swift:182:57:182:57 | password | testGRDB.swift:182:56:182:65 | [...] | provenance |  |
+| testGRDB.swift:183:48:183:48 | password | testGRDB.swift:183:47:183:56 | [...] | provenance |  |
+| testGRDB.swift:187:57:187:57 | password | testGRDB.swift:187:56:187:65 | [...] | provenance |  |
+| testGRDB.swift:188:48:188:48 | password | testGRDB.swift:188:47:188:56 | [...] | provenance |  |
+| testGRDB.swift:191:57:191:57 | password | testGRDB.swift:191:56:191:65 | [...] | provenance |  |
+| testGRDB.swift:192:48:192:48 | password | testGRDB.swift:192:47:192:56 | [...] | provenance |  |
+| testGRDB.swift:198:30:198:30 | password | testGRDB.swift:198:29:198:38 | [...] | provenance |  |
+| testGRDB.swift:201:24:201:24 | password | testGRDB.swift:201:23:201:32 | [...] | provenance |  |
+| testGRDB.swift:206:67:206:67 | password | testGRDB.swift:206:66:206:75 | [...] | provenance |  |
+| testGRDB.swift:208:81:208:81 | password | testGRDB.swift:208:80:208:89 | [...] | provenance |  |
+| testGRDB.swift:210:85:210:85 | password | testGRDB.swift:210:84:210:93 | [...] | provenance |  |
+| testGRDB.swift:212:99:212:99 | password | testGRDB.swift:212:98:212:107 | [...] | provenance |  |
 | testRealm2.swift:13:6:13:6 | value | file://:0:0:0:0 | value | provenance |  |
 | testRealm2.swift:13:6:13:6 | value [Collection element] | file://:0:0:0:0 | value [Collection element] | provenance |  |
-| testRealm2.swift:18:2:18:2 | [post] o [data] | testRealm2.swift:18:2:18:2 | [post] o | provenance |  |
 | testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:18:2:18:2 | [post] o [data] | provenance |  |
-| testRealm2.swift:24:2:24:2 | [post] o [data] | testRealm2.swift:24:2:24:2 | [post] o | provenance |  |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:18:2:18:2 | [post] o | provenance |  |
 | testRealm2.swift:24:11:24:11 | socialSecurityNumber | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:24:11:24:11 | socialSecurityNumber | testRealm2.swift:24:2:24:2 | [post] o [data] | provenance |  |
-| testRealm2.swift:25:2:25:2 | [post] o [data] | testRealm2.swift:25:2:25:2 | [post] o | provenance |  |
+| testRealm2.swift:24:11:24:11 | socialSecurityNumber | testRealm2.swift:24:2:24:2 | [post] o | provenance |  |
 | testRealm2.swift:25:11:25:11 | ssn | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:25:11:25:11 | ssn | testRealm2.swift:25:2:25:2 | [post] o [data] | provenance |  |
-| testRealm2.swift:26:2:26:2 | [post] o [data, Collection element] | testRealm2.swift:26:2:26:2 | [post] o | provenance |  |
-| testRealm2.swift:26:2:26:2 | [post] o [data] | testRealm2.swift:26:2:26:2 | [post] o | provenance |  |
+| testRealm2.swift:25:11:25:11 | ssn | testRealm2.swift:25:2:25:2 | [post] o | provenance |  |
 | testRealm2.swift:26:11:26:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:26:11:26:25 | call to String.init(_:) | testRealm2.swift:26:2:26:2 | [post] o [data] | provenance |  |
+| testRealm2.swift:26:11:26:25 | call to String.init(_:) | testRealm2.swift:26:2:26:2 | [post] o | provenance |  |
 | testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | provenance |  |
-| testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | testRealm2.swift:26:2:26:2 | [post] o [data, Collection element] | provenance |  |
+| testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | testRealm2.swift:26:2:26:2 | [post] o | provenance |  |
 | testRealm2.swift:26:18:26:18 | ssn_int | testRealm2.swift:26:11:26:25 | call to String.init(_:) | provenance |  |
 | testRealm2.swift:26:18:26:18 | ssn_int | testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | provenance |  |
-| testRealm2.swift:32:2:32:2 | [post] o [data] | testRealm2.swift:32:2:32:2 | [post] o | provenance |  |
 | testRealm2.swift:32:11:32:11 | creditCardNumber | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:32:11:32:11 | creditCardNumber | testRealm2.swift:32:2:32:2 | [post] o [data] | provenance |  |
-| testRealm2.swift:33:2:33:2 | [post] o [data] | testRealm2.swift:33:2:33:2 | [post] o | provenance |  |
+| testRealm2.swift:32:11:32:11 | creditCardNumber | testRealm2.swift:32:2:32:2 | [post] o | provenance |  |
 | testRealm2.swift:33:11:33:11 | CCN | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:33:11:33:11 | CCN | testRealm2.swift:33:2:33:2 | [post] o [data] | provenance |  |
-| testRealm2.swift:34:2:34:2 | [post] o [data, Collection element] | testRealm2.swift:34:2:34:2 | [post] o | provenance |  |
-| testRealm2.swift:34:2:34:2 | [post] o [data] | testRealm2.swift:34:2:34:2 | [post] o | provenance |  |
+| testRealm2.swift:33:11:33:11 | CCN | testRealm2.swift:33:2:33:2 | [post] o | provenance |  |
 | testRealm2.swift:34:11:34:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | provenance |  |
-| testRealm2.swift:34:11:34:25 | call to String.init(_:) | testRealm2.swift:34:2:34:2 | [post] o [data] | provenance |  |
+| testRealm2.swift:34:11:34:25 | call to String.init(_:) | testRealm2.swift:34:2:34:2 | [post] o | provenance |  |
 | testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | provenance |  |
-| testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | testRealm2.swift:34:2:34:2 | [post] o [data, Collection element] | provenance |  |
+| testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | testRealm2.swift:34:2:34:2 | [post] o | provenance |  |
 | testRealm2.swift:34:18:34:18 | int_ccn | testRealm2.swift:34:11:34:25 | call to String.init(_:) | provenance |  |
 | testRealm2.swift:34:18:34:18 | int_ccn | testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | provenance |  |
 | testRealm.swift:27:6:27:6 | value | file://:0:0:0:0 | value | provenance |  |
 | testRealm.swift:34:6:34:6 | value | file://:0:0:0:0 | value | provenance |  |
-| testRealm.swift:41:2:41:2 | [post] a [data] | testRealm.swift:41:2:41:2 | [post] a | provenance |  |
 | testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | provenance |  |
-| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:41:2:41:2 | [post] a [data] | provenance |  |
-| testRealm.swift:49:2:49:2 | [post] c [data] | testRealm.swift:49:2:49:2 | [post] c | provenance |  |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:41:2:41:2 | [post] a | provenance |  |
 | testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | provenance |  |
-| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:49:2:49:2 | [post] c [data] | provenance |  |
-| testRealm.swift:59:2:59:3 | [post] ...! [data] | testRealm.swift:59:2:59:3 | [post] ...! | provenance |  |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:49:2:49:2 | [post] c | provenance |  |
 | testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | provenance |  |
-| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:59:2:59:3 | [post] ...! [data] | provenance |  |
-| testRealm.swift:66:2:66:2 | [post] g [data] | testRealm.swift:66:2:66:2 | [post] g | provenance |  |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:59:2:59:3 | [post] ...! | provenance |  |
 | testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | provenance |  |
-| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:66:2:66:2 | [post] g [data] | provenance |  |
-| testRealm.swift:73:2:73:2 | [post] h [password] | testRealm.swift:73:2:73:2 | [post] h | provenance |  |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:66:2:66:2 | [post] g | provenance |  |
 | testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | provenance |  |
-| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:73:2:73:2 | [post] h [password] | provenance |  |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:73:2:73:2 | [post] h | provenance |  |
 nodes
 | SQLite.swift:119:70:119:70 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:120:50:120:50 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
@@ -377,45 +274,33 @@ nodes
 | SQLite.swift:154:23:154:23 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:154:23:154:23 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:158:32:158:54 | [...] | semmle.label | [...] |
-| SQLite.swift:158:32:158:54 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:158:33:158:33 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:159:28:159:50 | [...] | semmle.label | [...] |
-| SQLite.swift:159:28:159:50 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:159:29:159:29 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:160:31:160:53 | [...] | semmle.label | [...] |
-| SQLite.swift:160:31:160:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:160:32:160:32 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:163:21:163:43 | [...] | semmle.label | [...] |
-| SQLite.swift:163:21:163:43 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:163:22:163:22 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:164:20:164:42 | [...] | semmle.label | [...] |
-| SQLite.swift:164:20:164:42 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:164:21:164:21 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:165:23:165:45 | [...] | semmle.label | [...] |
-| SQLite.swift:165:23:165:45 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | SQLite.swift:165:24:165:24 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:169:32:169:70 | [...] | semmle.label | [...] |
-| SQLite.swift:169:32:169:70 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:169:43:169:53 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:169:53:169:53 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:170:28:170:66 | [...] | semmle.label | [...] |
-| SQLite.swift:170:28:170:66 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:170:39:170:49 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:170:49:170:49 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:171:31:171:69 | [...] | semmle.label | [...] |
-| SQLite.swift:171:31:171:69 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:171:42:171:52 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:171:52:171:52 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:174:21:174:59 | [...] | semmle.label | [...] |
-| SQLite.swift:174:21:174:59 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:174:32:174:42 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:174:42:174:42 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:175:20:175:58 | [...] | semmle.label | [...] |
-| SQLite.swift:175:20:175:58 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:175:31:175:41 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:175:41:175:41 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:176:23:176:61 | [...] | semmle.label | [...] |
-| SQLite.swift:176:23:176:61 | [...] [Collection element, Tuple element at index 1] | semmle.label | [...] [Collection element, Tuple element at index 1] |
 | SQLite.swift:176:34:176:44 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
 | SQLite.swift:176:44:176:44 | mobilePhoneNumber | semmle.label | mobilePhoneNumber |
 | SQLite.swift:186:40:186:54 | ... <-(_:_:) ... | semmle.label | ... <-(_:_:) ... |
@@ -467,40 +352,28 @@ nodes
 | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | semmle.label | self [Return] [notStoredBankAccountNumber] |
 | testCoreData2.swift:23:13:23:13 | value | semmle.label | value |
 | testCoreData2.swift:37:2:37:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:37:2:37:2 | [post] obj [myValue] | semmle.label | [post] obj [myValue] |
 | testCoreData2.swift:37:16:37:16 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:39:2:39:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:39:2:39:2 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:39:28:39:28 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:41:2:41:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:41:2:41:2 | [post] obj [myBankAccountNumber2] | semmle.label | [post] obj [myBankAccountNumber2] |
 | testCoreData2.swift:41:29:41:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:43:2:43:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] | semmle.label | [post] obj [notStoredBankAccountNumber] |
 | testCoreData2.swift:43:35:43:35 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:46:2:46:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:46:2:46:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
 | testCoreData2.swift:46:22:46:22 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:48:2:48:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:48:2:48:10 | [post] ...? [myBankAccountNumber] | semmle.label | [post] ...? [myBankAccountNumber] |
 | testCoreData2.swift:48:34:48:34 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:50:2:50:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:50:2:50:10 | [post] ...? [myBankAccountNumber2] | semmle.label | [post] ...? [myBankAccountNumber2] |
 | testCoreData2.swift:50:35:50:35 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:52:2:52:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] | semmle.label | [post] ...? [notStoredBankAccountNumber] |
 | testCoreData2.swift:52:41:52:41 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:57:3:57:3 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:57:3:57:3 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:57:29:57:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:60:4:60:4 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:60:4:60:4 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:60:30:60:30 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:62:4:62:4 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:62:4:62:4 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:62:30:62:30 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:65:3:65:3 | [post] obj | semmle.label | [post] obj |
-| testCoreData2.swift:65:3:65:3 | [post] obj [myBankAccountNumber] | semmle.label | [post] obj [myBankAccountNumber] |
 | testCoreData2.swift:65:29:65:29 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:70:9:70:9 | self | semmle.label | self |
 | testCoreData2.swift:70:9:70:9 | self [Return] [value] | semmle.label | self [Return] [value] |
@@ -508,41 +381,32 @@ nodes
 | testCoreData2.swift:70:9:70:9 | value | semmle.label | value |
 | testCoreData2.swift:71:9:71:9 | self | semmle.label | self |
 | testCoreData2.swift:79:2:79:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:79:2:79:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:79:18:79:28 | .bankAccountNo | semmle.label | .bankAccountNo |
 | testCoreData2.swift:80:2:80:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:80:2:80:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:80:18:80:28 | ...! | semmle.label | ...! |
 | testCoreData2.swift:80:18:80:28 | .bankAccountNo2 | semmle.label | .bankAccountNo2 |
 | testCoreData2.swift:82:2:82:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:82:2:82:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:82:18:82:18 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:82:18:82:32 | .value | semmle.label | .value |
 | testCoreData2.swift:83:2:83:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:83:2:83:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:83:18:83:18 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:83:18:83:32 | ...! | semmle.label | ...! |
 | testCoreData2.swift:83:18:83:32 | .value2 | semmle.label | .value2 |
 | testCoreData2.swift:84:2:84:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:84:2:84:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:84:18:84:18 | ...! | semmle.label | ...! |
 | testCoreData2.swift:84:18:84:18 | bankAccountNo2 | semmle.label | bankAccountNo2 |
 | testCoreData2.swift:84:18:84:33 | .value | semmle.label | .value |
 | testCoreData2.swift:85:2:85:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:85:2:85:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:85:18:85:18 | ...! | semmle.label | ...! |
 | testCoreData2.swift:85:18:85:18 | bankAccountNo2 | semmle.label | bankAccountNo2 |
 | testCoreData2.swift:85:18:85:33 | ...! | semmle.label | ...! |
 | testCoreData2.swift:85:18:85:33 | .value2 | semmle.label | .value2 |
 | testCoreData2.swift:87:2:87:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:87:2:87:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
 | testCoreData2.swift:87:22:87:32 | .bankAccountNo | semmle.label | .bankAccountNo |
 | testCoreData2.swift:88:2:88:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:88:2:88:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
 | testCoreData2.swift:88:22:88:22 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:88:22:88:36 | .value | semmle.label | .value |
 | testCoreData2.swift:89:2:89:10 | [post] ...? | semmle.label | [post] ...? |
-| testCoreData2.swift:89:2:89:10 | [post] ...? [myValue] | semmle.label | [post] ...? [myValue] |
 | testCoreData2.swift:89:22:89:22 | ...! | semmle.label | ...! |
 | testCoreData2.swift:89:22:89:22 | bankAccountNo2 | semmle.label | bankAccountNo2 |
 | testCoreData2.swift:89:22:89:37 | ...! | semmle.label | ...! |
@@ -551,24 +415,20 @@ nodes
 | testCoreData2.swift:92:10:92:10 | a | semmle.label | a |
 | testCoreData2.swift:92:10:92:12 | .value | semmle.label | .value |
 | testCoreData2.swift:93:2:93:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:93:2:93:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:93:18:93:18 | b | semmle.label | b |
 | testCoreData2.swift:95:10:95:10 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:97:2:97:2 | [post] d [value] | semmle.label | [post] d [value] |
 | testCoreData2.swift:97:12:97:12 | c | semmle.label | c |
 | testCoreData2.swift:97:12:97:14 | .value | semmle.label | .value |
 | testCoreData2.swift:98:2:98:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:98:2:98:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:98:18:98:18 | d [value] | semmle.label | d [value] |
 | testCoreData2.swift:98:18:98:20 | .value | semmle.label | .value |
 | testCoreData2.swift:101:10:101:10 | bankAccountNo | semmle.label | bankAccountNo |
 | testCoreData2.swift:103:13:103:13 | e | semmle.label | e |
 | testCoreData2.swift:104:2:104:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:104:2:104:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:104:18:104:18 | e | semmle.label | e |
 | testCoreData2.swift:104:18:104:20 | .value | semmle.label | .value |
 | testCoreData2.swift:105:2:105:2 | [post] dbObj | semmle.label | [post] dbObj |
-| testCoreData2.swift:105:2:105:2 | [post] dbObj [myValue] | semmle.label | [post] dbObj [myValue] |
 | testCoreData2.swift:105:18:105:18 | e | semmle.label | e |
 | testCoreData2.swift:105:18:105:20 | ...! | semmle.label | ...! |
 | testCoreData2.swift:105:18:105:20 | .value2 | semmle.label | .value2 |
@@ -581,7 +441,6 @@ nodes
 | testCoreData.swift:58:15:58:15 | password | semmle.label | password |
 | testCoreData.swift:61:25:61:25 | password | semmle.label | password |
 | testCoreData.swift:64:2:64:2 | [post] obj | semmle.label | [post] obj |
-| testCoreData.swift:64:2:64:2 | [post] obj [myValue] | semmle.label | [post] obj [myValue] |
 | testCoreData.swift:64:16:64:16 | password | semmle.label | password |
 | testCoreData.swift:77:24:77:24 | x | semmle.label | x |
 | testCoreData.swift:78:15:78:15 | x | semmle.label | x |
@@ -597,186 +456,126 @@ nodes
 | testCoreData.swift:128:15:128:33 | call to generateSecretKey() | semmle.label | call to generateSecretKey() |
 | testCoreData.swift:129:15:129:30 | call to getCertificate() | semmle.label | call to getCertificate() |
 | testGRDB.swift:73:56:73:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:73:56:73:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:73:57:73:57 | password | semmle.label | password |
 | testGRDB.swift:76:42:76:51 | [...] | semmle.label | [...] |
-| testGRDB.swift:76:42:76:51 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:76:43:76:43 | password | semmle.label | password |
 | testGRDB.swift:81:44:81:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:81:44:81:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:81:45:81:45 | password | semmle.label | password |
 | testGRDB.swift:83:44:83:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:83:44:83:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:83:45:83:45 | password | semmle.label | password |
 | testGRDB.swift:85:44:85:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:85:44:85:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:85:45:85:45 | password | semmle.label | password |
 | testGRDB.swift:87:44:87:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:87:44:87:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:87:45:87:45 | password | semmle.label | password |
 | testGRDB.swift:92:37:92:46 | [...] | semmle.label | [...] |
-| testGRDB.swift:92:37:92:46 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:92:38:92:38 | password | semmle.label | password |
 | testGRDB.swift:95:36:95:45 | [...] | semmle.label | [...] |
-| testGRDB.swift:95:36:95:45 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:95:37:95:37 | password | semmle.label | password |
 | testGRDB.swift:100:72:100:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:100:72:100:81 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:100:73:100:73 | password | semmle.label | password |
 | testGRDB.swift:101:72:101:81 | [...] | semmle.label | [...] |
-| testGRDB.swift:101:72:101:81 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:101:73:101:73 | password | semmle.label | password |
 | testGRDB.swift:107:52:107:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:107:52:107:61 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:107:53:107:53 | password | semmle.label | password |
 | testGRDB.swift:109:52:109:61 | [...] | semmle.label | [...] |
-| testGRDB.swift:109:52:109:61 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:109:53:109:53 | password | semmle.label | password |
 | testGRDB.swift:111:51:111:60 | [...] | semmle.label | [...] |
-| testGRDB.swift:111:51:111:60 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:111:52:111:52 | password | semmle.label | password |
 | testGRDB.swift:116:47:116:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:116:47:116:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:116:48:116:48 | password | semmle.label | password |
 | testGRDB.swift:118:47:118:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:118:47:118:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:118:48:118:48 | password | semmle.label | password |
 | testGRDB.swift:121:44:121:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:121:44:121:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:121:45:121:45 | password | semmle.label | password |
 | testGRDB.swift:123:44:123:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:123:44:123:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:123:45:123:45 | password | semmle.label | password |
 | testGRDB.swift:126:44:126:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:126:44:126:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:126:45:126:45 | password | semmle.label | password |
 | testGRDB.swift:128:44:128:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:128:44:128:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:128:45:128:45 | password | semmle.label | password |
 | testGRDB.swift:131:44:131:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:131:44:131:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:131:45:131:45 | password | semmle.label | password |
 | testGRDB.swift:133:44:133:53 | [...] | semmle.label | [...] |
-| testGRDB.swift:133:44:133:53 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:133:45:133:45 | password | semmle.label | password |
 | testGRDB.swift:138:68:138:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:138:68:138:77 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:138:69:138:69 | password | semmle.label | password |
 | testGRDB.swift:140:68:140:77 | [...] | semmle.label | [...] |
-| testGRDB.swift:140:68:140:77 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:140:69:140:69 | password | semmle.label | password |
 | testGRDB.swift:143:65:143:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:143:65:143:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:143:66:143:66 | password | semmle.label | password |
 | testGRDB.swift:145:65:145:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:145:65:145:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:145:66:145:66 | password | semmle.label | password |
 | testGRDB.swift:148:65:148:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:148:65:148:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:148:66:148:66 | password | semmle.label | password |
 | testGRDB.swift:150:65:150:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:150:65:150:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:150:66:150:66 | password | semmle.label | password |
 | testGRDB.swift:153:65:153:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:153:65:153:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:153:66:153:66 | password | semmle.label | password |
 | testGRDB.swift:155:65:155:74 | [...] | semmle.label | [...] |
-| testGRDB.swift:155:65:155:74 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:155:66:155:66 | password | semmle.label | password |
 | testGRDB.swift:160:59:160:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:160:59:160:68 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:160:60:160:60 | password | semmle.label | password |
 | testGRDB.swift:161:50:161:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:161:50:161:59 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:161:51:161:51 | password | semmle.label | password |
 | testGRDB.swift:164:59:164:68 | [...] | semmle.label | [...] |
-| testGRDB.swift:164:59:164:68 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:164:60:164:60 | password | semmle.label | password |
 | testGRDB.swift:165:50:165:59 | [...] | semmle.label | [...] |
-| testGRDB.swift:165:50:165:59 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:165:51:165:51 | password | semmle.label | password |
 | testGRDB.swift:169:56:169:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:169:56:169:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:169:57:169:57 | password | semmle.label | password |
 | testGRDB.swift:170:47:170:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:170:47:170:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:170:48:170:48 | password | semmle.label | password |
 | testGRDB.swift:173:56:173:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:173:56:173:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:173:57:173:57 | password | semmle.label | password |
 | testGRDB.swift:174:47:174:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:174:47:174:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:174:48:174:48 | password | semmle.label | password |
 | testGRDB.swift:178:56:178:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:178:56:178:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:178:57:178:57 | password | semmle.label | password |
 | testGRDB.swift:179:47:179:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:179:47:179:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:179:48:179:48 | password | semmle.label | password |
 | testGRDB.swift:182:56:182:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:182:56:182:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:182:57:182:57 | password | semmle.label | password |
 | testGRDB.swift:183:47:183:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:183:47:183:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:183:48:183:48 | password | semmle.label | password |
 | testGRDB.swift:187:56:187:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:187:56:187:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:187:57:187:57 | password | semmle.label | password |
 | testGRDB.swift:188:47:188:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:188:47:188:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:188:48:188:48 | password | semmle.label | password |
 | testGRDB.swift:191:56:191:65 | [...] | semmle.label | [...] |
-| testGRDB.swift:191:56:191:65 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:191:57:191:57 | password | semmle.label | password |
 | testGRDB.swift:192:47:192:56 | [...] | semmle.label | [...] |
-| testGRDB.swift:192:47:192:56 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:192:48:192:48 | password | semmle.label | password |
 | testGRDB.swift:198:29:198:38 | [...] | semmle.label | [...] |
-| testGRDB.swift:198:29:198:38 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:198:30:198:30 | password | semmle.label | password |
 | testGRDB.swift:201:23:201:32 | [...] | semmle.label | [...] |
-| testGRDB.swift:201:23:201:32 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:201:24:201:24 | password | semmle.label | password |
 | testGRDB.swift:206:66:206:75 | [...] | semmle.label | [...] |
-| testGRDB.swift:206:66:206:75 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:206:67:206:67 | password | semmle.label | password |
 | testGRDB.swift:208:80:208:89 | [...] | semmle.label | [...] |
-| testGRDB.swift:208:80:208:89 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:208:81:208:81 | password | semmle.label | password |
 | testGRDB.swift:210:84:210:93 | [...] | semmle.label | [...] |
-| testGRDB.swift:210:84:210:93 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:210:85:210:85 | password | semmle.label | password |
 | testGRDB.swift:212:98:212:107 | [...] | semmle.label | [...] |
-| testGRDB.swift:212:98:212:107 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | testGRDB.swift:212:99:212:99 | password | semmle.label | password |
 | testRealm2.swift:13:6:13:6 | self [Return] [data, Collection element] | semmle.label | self [Return] [data, Collection element] |
 | testRealm2.swift:13:6:13:6 | self [Return] [data] | semmle.label | self [Return] [data] |
 | testRealm2.swift:13:6:13:6 | value | semmle.label | value |
 | testRealm2.swift:13:6:13:6 | value [Collection element] | semmle.label | value [Collection element] |
 | testRealm2.swift:18:2:18:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:18:2:18:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:18:11:18:11 | myPassword | semmle.label | myPassword |
 | testRealm2.swift:24:2:24:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:24:2:24:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:24:11:24:11 | socialSecurityNumber | semmle.label | socialSecurityNumber |
 | testRealm2.swift:25:2:25:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:25:2:25:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:25:11:25:11 | ssn | semmle.label | ssn |
 | testRealm2.swift:26:2:26:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:26:2:26:2 | [post] o [data, Collection element] | semmle.label | [post] o [data, Collection element] |
-| testRealm2.swift:26:2:26:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:26:11:26:25 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | testRealm2.swift:26:18:26:18 | ssn_int | semmle.label | ssn_int |
 | testRealm2.swift:32:2:32:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:32:2:32:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:32:11:32:11 | creditCardNumber | semmle.label | creditCardNumber |
 | testRealm2.swift:33:2:33:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:33:2:33:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:33:11:33:11 | CCN | semmle.label | CCN |
 | testRealm2.swift:34:2:34:2 | [post] o | semmle.label | [post] o |
-| testRealm2.swift:34:2:34:2 | [post] o [data, Collection element] | semmle.label | [post] o [data, Collection element] |
-| testRealm2.swift:34:2:34:2 | [post] o [data] | semmle.label | [post] o [data] |
 | testRealm2.swift:34:11:34:25 | call to String.init(_:) | semmle.label | call to String.init(_:) |
 | testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | semmle.label | call to String.init(_:) [Collection element] |
 | testRealm2.swift:34:18:34:18 | int_ccn | semmle.label | int_ccn |
@@ -785,23 +584,18 @@ nodes
 | testRealm.swift:34:6:34:6 | self [Return] [password] | semmle.label | self [Return] [password] |
 | testRealm.swift:34:6:34:6 | value | semmle.label | value |
 | testRealm.swift:41:2:41:2 | [post] a | semmle.label | [post] a |
-| testRealm.swift:41:2:41:2 | [post] a [data] | semmle.label | [post] a [data] |
 | testRealm.swift:41:11:41:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:49:2:49:2 | [post] c | semmle.label | [post] c |
-| testRealm.swift:49:2:49:2 | [post] c [data] | semmle.label | [post] c [data] |
 | testRealm.swift:49:11:49:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:59:2:59:3 | [post] ...! | semmle.label | [post] ...! |
-| testRealm.swift:59:2:59:3 | [post] ...! [data] | semmle.label | [post] ...! [data] |
 | testRealm.swift:59:12:59:12 | myPassword | semmle.label | myPassword |
 | testRealm.swift:66:2:66:2 | [post] g | semmle.label | [post] g |
-| testRealm.swift:66:2:66:2 | [post] g [data] | semmle.label | [post] g [data] |
 | testRealm.swift:66:11:66:11 | myPassword | semmle.label | myPassword |
 | testRealm.swift:73:2:73:2 | [post] h | semmle.label | [post] h |
-| testRealm.swift:73:2:73:2 | [post] h [password] | semmle.label | [post] h [password] |
 | testRealm.swift:73:15:73:15 | myPassword | semmle.label | myPassword |
 subpaths
-| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj [notStoredBankAccountNumber] |
-| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? [notStoredBankAccountNumber] |
+| testCoreData2.swift:43:35:43:35 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:43:2:43:2 | [post] obj |
+| testCoreData2.swift:52:41:52:41 | bankAccountNo | testCoreData2.swift:23:13:23:13 | value | testCoreData2.swift:23:13:23:13 | self [Return] [notStoredBankAccountNumber] | testCoreData2.swift:52:2:52:10 | [post] ...? |
 | testCoreData2.swift:82:18:82:18 | bankAccountNo | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:82:18:82:32 | .value |
 | testCoreData2.swift:83:18:83:18 | bankAccountNo | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:83:18:83:32 | .value2 |
 | testCoreData2.swift:84:18:84:18 | ...! | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:84:18:84:33 | .value |
@@ -814,20 +608,20 @@ subpaths
 | testCoreData2.swift:98:18:98:18 | d [value] | testCoreData2.swift:70:9:70:9 | self [value] | file://:0:0:0:0 | .value | testCoreData2.swift:98:18:98:20 | .value |
 | testCoreData2.swift:104:18:104:18 | e | testCoreData2.swift:70:9:70:9 | self | file://:0:0:0:0 | .value | testCoreData2.swift:104:18:104:20 | .value |
 | testCoreData2.swift:105:18:105:18 | e | testCoreData2.swift:71:9:71:9 | self | file://:0:0:0:0 | .value2 | testCoreData2.swift:105:18:105:20 | .value2 |
-| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:18:2:18:2 | [post] o [data] |
-| testRealm2.swift:24:11:24:11 | socialSecurityNumber | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:24:2:24:2 | [post] o [data] |
-| testRealm2.swift:25:11:25:11 | ssn | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:25:2:25:2 | [post] o [data] |
-| testRealm2.swift:26:11:26:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:26:2:26:2 | [post] o [data] |
-| testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | testRealm2.swift:13:6:13:6 | self [Return] [data, Collection element] | testRealm2.swift:26:2:26:2 | [post] o [data, Collection element] |
-| testRealm2.swift:32:11:32:11 | creditCardNumber | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:32:2:32:2 | [post] o [data] |
-| testRealm2.swift:33:11:33:11 | CCN | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:33:2:33:2 | [post] o [data] |
-| testRealm2.swift:34:11:34:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:34:2:34:2 | [post] o [data] |
-| testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | testRealm2.swift:13:6:13:6 | self [Return] [data, Collection element] | testRealm2.swift:34:2:34:2 | [post] o [data, Collection element] |
-| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:41:2:41:2 | [post] a [data] |
-| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:49:2:49:2 | [post] c [data] |
-| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:59:2:59:3 | [post] ...! [data] |
-| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:66:2:66:2 | [post] g [data] |
-| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | testRealm.swift:34:6:34:6 | self [Return] [password] | testRealm.swift:73:2:73:2 | [post] h [password] |
+| testRealm2.swift:18:11:18:11 | myPassword | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:18:2:18:2 | [post] o |
+| testRealm2.swift:24:11:24:11 | socialSecurityNumber | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:24:2:24:2 | [post] o |
+| testRealm2.swift:25:11:25:11 | ssn | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:25:2:25:2 | [post] o |
+| testRealm2.swift:26:11:26:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:26:2:26:2 | [post] o |
+| testRealm2.swift:26:11:26:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | testRealm2.swift:13:6:13:6 | self [Return] [data, Collection element] | testRealm2.swift:26:2:26:2 | [post] o |
+| testRealm2.swift:32:11:32:11 | creditCardNumber | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:32:2:32:2 | [post] o |
+| testRealm2.swift:33:11:33:11 | CCN | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:33:2:33:2 | [post] o |
+| testRealm2.swift:34:11:34:25 | call to String.init(_:) | testRealm2.swift:13:6:13:6 | value | testRealm2.swift:13:6:13:6 | self [Return] [data] | testRealm2.swift:34:2:34:2 | [post] o |
+| testRealm2.swift:34:11:34:25 | call to String.init(_:) [Collection element] | testRealm2.swift:13:6:13:6 | value [Collection element] | testRealm2.swift:13:6:13:6 | self [Return] [data, Collection element] | testRealm2.swift:34:2:34:2 | [post] o |
+| testRealm.swift:41:11:41:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:41:2:41:2 | [post] a |
+| testRealm.swift:49:11:49:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:49:2:49:2 | [post] c |
+| testRealm.swift:59:12:59:12 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:59:2:59:3 | [post] ...! |
+| testRealm.swift:66:11:66:11 | myPassword | testRealm.swift:27:6:27:6 | value | testRealm.swift:27:6:27:6 | self [Return] [data] | testRealm.swift:66:2:66:2 | [post] g |
+| testRealm.swift:73:15:73:15 | myPassword | testRealm.swift:34:6:34:6 | value | testRealm.swift:34:6:34:6 | self [Return] [password] | testRealm.swift:73:2:73:2 | [post] h |
 #select
 | SQLite.swift:123:17:123:17 | insertQuery | SQLite.swift:119:70:119:70 | mobilePhoneNumber | SQLite.swift:123:17:123:17 | insertQuery | This operation stores 'insertQuery' in a database. It may contain unencrypted sensitive data from $@. | SQLite.swift:119:70:119:70 | mobilePhoneNumber | mobilePhoneNumber |
 | SQLite.swift:124:17:124:17 | updateQuery | SQLite.swift:120:50:120:50 | mobilePhoneNumber | SQLite.swift:124:17:124:17 | updateQuery | This operation stores 'updateQuery' in a database. It may contain unencrypted sensitive data from $@. | SQLite.swift:120:50:120:50 | mobilePhoneNumber | mobilePhoneNumber |

--- a/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
+++ b/swift/ql/test/query-tests/Security/CWE-321/HardcodedEncryptionKey.expected
@@ -26,8 +26,8 @@ edges
 | cryptoswift.swift:94:18:94:36 | call to getConstantString() | cryptoswift.swift:155:26:155:26 | keyString | provenance |  |
 | cryptoswift.swift:94:18:94:36 | call to getConstantString() | cryptoswift.swift:164:24:164:24 | keyString | provenance |  |
 | cryptoswift.swift:94:18:94:36 | call to getConstantString() | cryptoswift.swift:166:24:166:24 | keyString | provenance |  |
-| file://:0:0:0:0 | [post] self [encryptionKey] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [encryptionKey] | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | provenance |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [encryptionKey] | provenance |  |
 | grdb.swift:21:20:21:20 | abc123 | grdb.swift:27:23:27:23 | constString | provenance |  |
 | grdb.swift:21:20:21:20 | abc123 | grdb.swift:31:26:31:26 | constString | provenance |  |
@@ -40,18 +40,14 @@ edges
 | misc.swift:57:19:57:38 | call to Data.init(_:) | misc.swift:66:25:66:25 | myConstKey | provenance |  |
 | misc.swift:57:19:57:38 | call to Data.init(_:) | misc.swift:70:41:70:41 | myConstKey | provenance |  |
 | misc.swift:57:24:57:24 | abcdef123456 | misc.swift:57:19:57:38 | call to Data.init(_:) | provenance |  |
-| misc.swift:66:2:66:2 | [post] config [encryptionKey] | misc.swift:66:2:66:2 | [post] config | provenance |  |
 | misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
-| misc.swift:66:25:66:25 | myConstKey | misc.swift:66:2:66:2 | [post] config [encryptionKey] | provenance |  |
-| misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | misc.swift:70:2:70:18 | [post] getter for .config | provenance |  |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:66:2:66:2 | [post] config | provenance |  |
 | misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | provenance |  |
-| misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | provenance |  |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:70:2:70:18 | [post] getter for .config | provenance |  |
 | misc.swift:73:14:73:20 | k1 | misc.swift:76:26:76:29 | .utf8 | provenance |  |
 | misc.swift:73:28:73:34 | k2 | misc.swift:77:26:77:29 | .utf8 | provenance |  |
-| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | provenance |  |
-| misc.swift:76:26:76:29 | .utf8 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
-| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | provenance |  |
-| misc.swift:77:26:77:29 | .utf8 | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | provenance |  |
+| misc.swift:76:26:76:29 | .utf8 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | provenance |  |
+| misc.swift:77:26:77:29 | .utf8 | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | provenance |  |
 | misc.swift:82:10:82:10 | abc123 | misc.swift:73:14:73:20 | k1 | provenance |  |
 | misc.swift:83:10:83:10 | abc123 | misc.swift:73:14:73:20 | k1 | provenance |  |
 | misc.swift:83:20:83:20 | abc123 | misc.swift:73:28:73:34 | k2 | provenance |  |
@@ -128,18 +124,14 @@ nodes
 | misc.swift:57:24:57:24 | abcdef123456 | semmle.label | abcdef123456 |
 | misc.swift:62:41:62:41 | myConstKey | semmle.label | myConstKey |
 | misc.swift:66:2:66:2 | [post] config | semmle.label | [post] config |
-| misc.swift:66:2:66:2 | [post] config [encryptionKey] | semmle.label | [post] config [encryptionKey] |
 | misc.swift:66:25:66:25 | myConstKey | semmle.label | myConstKey |
 | misc.swift:70:2:70:18 | [post] getter for .config | semmle.label | [post] getter for .config |
-| misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] | semmle.label | [post] getter for .config [encryptionKey] |
 | misc.swift:70:41:70:41 | myConstKey | semmle.label | myConstKey |
 | misc.swift:73:14:73:20 | k1 | semmle.label | k1 |
 | misc.swift:73:28:73:34 | k2 | semmle.label | k2 |
 | misc.swift:76:20:76:33 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
-| misc.swift:76:20:76:33 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
 | misc.swift:76:26:76:29 | .utf8 | semmle.label | .utf8 |
 | misc.swift:77:20:77:33 | call to Array<Element>.init(_:) | semmle.label | call to Array<Element>.init(_:) |
-| misc.swift:77:20:77:33 | call to Array<Element>.init(_:) [Collection element] | semmle.label | call to Array<Element>.init(_:) [Collection element] |
 | misc.swift:77:26:77:29 | .utf8 | semmle.label | .utf8 |
 | misc.swift:82:10:82:10 | abc123 | semmle.label | abc123 |
 | misc.swift:83:10:83:10 | abc123 | semmle.label | abc123 |
@@ -168,8 +160,8 @@ nodes
 | sqlite3_c_api.swift:49:36:49:36 | buffer | semmle.label | buffer |
 | sqlite3_c_api.swift:50:38:50:38 | buffer | semmle.label | buffer |
 subpaths
-| misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:66:2:66:2 | [post] config [encryptionKey] |
-| misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:70:2:70:18 | [post] getter for .config [encryptionKey] |
+| misc.swift:66:25:66:25 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:66:2:66:2 | [post] config |
+| misc.swift:70:41:70:41 | myConstKey | misc.swift:30:7:30:7 | value | misc.swift:30:7:30:7 | self [Return] [encryptionKey] | misc.swift:70:2:70:18 | [post] getter for .config |
 #select
 | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | SQLite.swift:43:13:43:13 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:43:13:43:13 | hardcoded_key | hardcoded_key |
 | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | SQLite.swift:45:23:45:23 | hardcoded_key | The key 'hardcoded_key' has been initialized with hard-coded values from $@. | SQLite.swift:45:23:45:23 | hardcoded_key | hardcoded_key |

--- a/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
+++ b/swift/ql/test/query-tests/Security/CWE-757/InsecureTLS.expected
@@ -3,62 +3,51 @@ edges
 | InsecureTLS.swift:20:7:20:7 | value | file://:0:0:0:0 | value | provenance |  |
 | InsecureTLS.swift:22:7:22:7 | value | file://:0:0:0:0 | value | provenance |  |
 | InsecureTLS.swift:23:7:23:7 | value | file://:0:0:0:0 | value | provenance |  |
-| InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:40:3:40:3 | [post] config | provenance |  |
 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
-| InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:45:3:45:3 | [post] config | provenance |  |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:3:40:3 | [post] config | provenance |  |
 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
-| InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:57:3:57:3 | [post] config | provenance |  |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:45:3:45:3 | [post] config | provenance |  |
 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | provenance |  |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] | provenance |  |
-| InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] | InsecureTLS.swift:64:3:64:3 | [post] config | provenance |  |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:57:3:57:3 | [post] config | provenance |  |
 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | provenance |  |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] | provenance |  |
-| InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] | InsecureTLS.swift:76:3:76:3 | [post] config | provenance |  |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:64:3:64:3 | [post] config | provenance |  |
 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | provenance |  |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] | provenance |  |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:76:3:76:3 | [post] config | provenance |  |
 | InsecureTLS.swift:102:10:102:33 | .TLSv10 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | provenance |  |
-| InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:111:3:111:3 | [post] config | provenance |  |
 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:111:3:111:3 | [post] config | provenance |  |
 | InsecureTLS.swift:121:55:121:66 | version | InsecureTLS.swift:122:47:122:47 | version | provenance |  |
-| InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:122:3:122:3 | [post] config | provenance |  |
 | InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:122:3:122:3 | [post] config | provenance |  |
 | InsecureTLS.swift:127:25:127:48 | .TLSv11 | InsecureTLS.swift:121:55:121:66 | version | provenance |  |
 | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | self [TLSVersion] | provenance |  |
 | InsecureTLS.swift:158:7:158:7 | value | file://:0:0:0:0 | value | provenance |  |
 | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | provenance |  |
 | InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value | provenance |  |
 | InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | provenance |  |
-| InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:165:3:165:3 | [post] config | provenance |  |
 | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | provenance |  |
 | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:165:47:165:51 | .TLSVersion | provenance |  |
 | InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
-| InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config | provenance |  |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:165:3:165:3 | [post] config | provenance |  |
 | InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | provenance |  |
-| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] | provenance |  |
+| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:181:3:181:9 | [post] getter for .config | provenance |  |
 | InsecureTLS.swift:185:20:185:36 | withMinVersion | InsecureTLS.swift:187:42:187:42 | withMinVersion | provenance |  |
-| InsecureTLS.swift:187:5:187:5 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:187:5:187:5 | [post] self | provenance |  |
-| InsecureTLS.swift:187:42:187:42 | withMinVersion | InsecureTLS.swift:187:5:187:5 | [post] self [tlsMinimumSupportedProtocolVersion] | provenance |  |
+| InsecureTLS.swift:187:42:187:42 | withMinVersion | InsecureTLS.swift:187:5:187:5 | [post] self | provenance |  |
 | InsecureTLS.swift:193:51:193:74 | .TLSv10 | InsecureTLS.swift:185:20:185:36 | withMinVersion | provenance |  |
 | InsecureTLS.swift:196:56:196:63 | value | InsecureTLS.swift:196:1:198:1 | version[return] | provenance |  |
-| InsecureTLS.swift:202:24:202:24 | [post] config [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:202:24:202:24 | [post] config | provenance |  |
-| InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | InsecureTLS.swift:202:24:202:24 | [post] config [tlsMinimumSupportedProtocolVersion] | provenance |  |
+| InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | InsecureTLS.swift:202:24:202:24 | [post] config | provenance |  |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:196:56:196:63 | value | provenance |  |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | provenance |  |
 | file://:0:0:0:0 | [post] self [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | provenance |  |
-| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | provenance |  |
-| file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | provenance |  |
-| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocolVersion] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | provenance |  |
-| file://:0:0:0:0 | [post] self [tlsMinimumSupportedProtocol] | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | provenance |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self | provenance |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [TLSVersion] | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocolVersion] | provenance |  |
 | file://:0:0:0:0 | value | file://:0:0:0:0 | [post] self [tlsMaximumSupportedProtocol] | provenance |  |
@@ -74,27 +63,20 @@ nodes
 | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | semmle.label | self [Return] [tlsMaximumSupportedProtocol] |
 | InsecureTLS.swift:23:7:23:7 | value | semmle.label | value |
 | InsecureTLS.swift:40:3:40:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:40:47:40:70 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:45:3:45:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:45:47:45:70 | .TLSv11 | semmle.label | .TLSv11 |
 | InsecureTLS.swift:57:3:57:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] | semmle.label | [post] config [tlsMaximumSupportedProtocolVersion] |
 | InsecureTLS.swift:57:47:57:70 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:64:3:64:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] | semmle.label | [post] config [tlsMinimumSupportedProtocol] |
 | InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
 | InsecureTLS.swift:76:3:76:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] | semmle.label | [post] config [tlsMaximumSupportedProtocol] |
 | InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | semmle.label | .tlsProtocol10 |
 | InsecureTLS.swift:102:10:102:33 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:111:3:111:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | semmle.label | call to getBadTLSVersion() |
 | InsecureTLS.swift:121:55:121:66 | version | semmle.label | version |
 | InsecureTLS.swift:122:3:122:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:122:47:122:47 | version | semmle.label | version |
 | InsecureTLS.swift:127:25:127:48 | .TLSv11 | semmle.label | .TLSv11 |
 | InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | semmle.label | self [Return] [TLSVersion] |
@@ -103,21 +85,17 @@ nodes
 | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] | semmle.label | [post] def [TLSVersion] |
 | InsecureTLS.swift:163:20:163:43 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:165:3:165:3 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | semmle.label | def [TLSVersion] |
 | InsecureTLS.swift:165:47:165:51 | .TLSVersion | semmle.label | .TLSVersion |
 | InsecureTLS.swift:181:3:181:9 | [post] getter for .config | semmle.label | [post] getter for .config |
-| InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] getter for .config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:181:53:181:76 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:185:20:185:36 | withMinVersion | semmle.label | withMinVersion |
 | InsecureTLS.swift:187:5:187:5 | [post] self | semmle.label | [post] self |
-| InsecureTLS.swift:187:5:187:5 | [post] self [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] self [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:187:42:187:42 | withMinVersion | semmle.label | withMinVersion |
 | InsecureTLS.swift:193:51:193:74 | .TLSv10 | semmle.label | .TLSv10 |
 | InsecureTLS.swift:196:1:198:1 | version[return] | semmle.label | version[return] |
 | InsecureTLS.swift:196:56:196:63 | value | semmle.label | value |
 | InsecureTLS.swift:202:24:202:24 | [post] config | semmle.label | [post] config |
-| InsecureTLS.swift:202:24:202:24 | [post] config [tlsMinimumSupportedProtocolVersion] | semmle.label | [post] config [tlsMinimumSupportedProtocolVersion] |
 | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion | semmle.label | [post] getter for .tlsMinimumSupportedProtocolVersion |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | semmle.label | .TLSv10 |
 | file://:0:0:0:0 | .TLSVersion | semmle.label | .TLSVersion |
@@ -137,17 +115,17 @@ nodes
 | file://:0:0:0:0 | value | semmle.label | value |
 | file://:0:0:0:0 | value | semmle.label | value |
 subpaths
-| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:40:3:40:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:45:3:45:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:57:3:57:3 | [post] config [tlsMaximumSupportedProtocolVersion] |
-| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | InsecureTLS.swift:64:3:64:3 | [post] config [tlsMinimumSupportedProtocol] |
-| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | InsecureTLS.swift:76:3:76:3 | [post] config [tlsMaximumSupportedProtocol] |
-| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:111:3:111:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:122:3:122:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:40:3:40:3 | [post] config |
+| InsecureTLS.swift:45:47:45:70 | .TLSv11 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:45:3:45:3 | [post] config |
+| InsecureTLS.swift:57:47:57:70 | .TLSv10 | InsecureTLS.swift:20:7:20:7 | value | InsecureTLS.swift:20:7:20:7 | self [Return] [tlsMaximumSupportedProtocolVersion] | InsecureTLS.swift:57:3:57:3 | [post] config |
+| InsecureTLS.swift:64:40:64:52 | .tlsProtocol10 | InsecureTLS.swift:22:7:22:7 | value | InsecureTLS.swift:22:7:22:7 | self [Return] [tlsMinimumSupportedProtocol] | InsecureTLS.swift:64:3:64:3 | [post] config |
+| InsecureTLS.swift:76:40:76:52 | .tlsProtocol10 | InsecureTLS.swift:23:7:23:7 | value | InsecureTLS.swift:23:7:23:7 | self [Return] [tlsMaximumSupportedProtocol] | InsecureTLS.swift:76:3:76:3 | [post] config |
+| InsecureTLS.swift:111:47:111:64 | call to getBadTLSVersion() | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:111:3:111:3 | [post] config |
+| InsecureTLS.swift:122:47:122:47 | version | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:122:3:122:3 | [post] config |
 | InsecureTLS.swift:163:20:163:43 | .TLSv10 | InsecureTLS.swift:158:7:158:7 | value | InsecureTLS.swift:158:7:158:7 | self [Return] [TLSVersion] | InsecureTLS.swift:163:3:163:3 | [post] def [TLSVersion] |
 | InsecureTLS.swift:165:47:165:47 | def [TLSVersion] | InsecureTLS.swift:158:7:158:7 | self [TLSVersion] | file://:0:0:0:0 | .TLSVersion | InsecureTLS.swift:165:47:165:51 | .TLSVersion |
-| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:165:3:165:3 | [post] config [tlsMinimumSupportedProtocolVersion] |
-| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config [tlsMinimumSupportedProtocolVersion] |
+| InsecureTLS.swift:165:47:165:51 | .TLSVersion | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:165:3:165:3 | [post] config |
+| InsecureTLS.swift:181:53:181:76 | .TLSv10 | InsecureTLS.swift:19:7:19:7 | value | InsecureTLS.swift:19:7:19:7 | self [Return] [tlsMinimumSupportedProtocolVersion] | InsecureTLS.swift:181:3:181:9 | [post] getter for .config |
 | InsecureTLS.swift:202:74:202:97 | .TLSv10 | InsecureTLS.swift:196:56:196:63 | value | InsecureTLS.swift:196:1:198:1 | version[return] | InsecureTLS.swift:202:24:202:31 | [post] getter for .tlsMinimumSupportedProtocolVersion |
 #select
 | InsecureTLS.swift:40:3:40:3 | [post] config | InsecureTLS.swift:40:47:40:70 | .TLSv10 | InsecureTLS.swift:40:3:40:3 | [post] config | This TLS configuration is insecure. |


### PR DESCRIPTION
This PR moves the `TNodeEx` `newtype` from `DataFlowImpl.qll` into `DataFlowImplCommon.qll` (and makes it `cached`). The purpose of doing this is to avoid an additional `newtype` creation for all instantiations of the data flow library, and as witnessed by the DCA runs it has a very positive impact on memory/cache usage (and in general also a modest impact on timing).

Before moving the `newtype`, the first commit removes the Boolean `hasRead` column from `TNodeImplicitRead`, in order to the size of the `newtype` when later caching it. This commit then also adjusts the generated `edges` relation by never revealing the implicit reads that happen at sinks.

Commit-by-commit review is suggested.