### PR TITLE
Shared: Fix bad join in content flow.

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
@@ -456,26 +456,41 @@ module MakeImplContentDataFlow<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
+    private predicate nodeAndState(Flow::PathNode n, Node node, State state) {
+      n.getNode() = node and n.getState() = state
+    }
+
+    pragma[nomagic]
+    private predicate succNodeAndState(
+      Flow::PathNode pre, Node preNode, State preState, Flow::PathNode succ, Node succNode,
+      State succState
+    ) {
+      nodeAndState(pre, preNode, preState) and
+      nodeAndState(succ, succNode, succState) and
+      pre.getASuccessor() = succ
+    }
+
+    pragma[nomagic]
     private predicate nodeReachesStore(
-      Flow::PathNode source, AccessPath scReads, AccessPath scStores, Flow::PathNode node,
+      Flow::PathNode source, AccessPath scReads, AccessPath scStores, Flow::PathNode target,
       ContentSet c, AccessPath reads, AccessPath stores
     ) {
-      exists(Flow::PathNode mid |
+      exists(Flow::PathNode mid, State midState, Node midNode, State targetState, Node targetNode |
         nodeReaches(source, scReads, scStores, mid, reads, stores) and
-        storeStep(mid.getNode(), mid.getState(), c, node.getNode(), node.getState()) and
-        mid.getASuccessor() = node
+        succNodeAndState(mid, midNode, midState, target, targetNode, targetState) and
+        storeStep(midNode, midState, c, targetNode, targetState)
       )
     }
 
     pragma[nomagic]
     private predicate nodeReachesRead(
-      Flow::PathNode source, AccessPath scReads, AccessPath scStores, Flow::PathNode node,
+      Flow::PathNode source, AccessPath scReads, AccessPath scStores, Flow::PathNode target,
       ContentSet c, AccessPath reads, AccessPath stores
     ) {
-      exists(Flow::PathNode mid |
+      exists(Flow::PathNode mid, State midState, Node midNode, State targetState, Node targetNode |
         nodeReaches(source, scReads, scStores, mid, reads, stores) and
-        readStep(mid.getNode(), mid.getState(), c, node.getNode(), node.getState()) and
-        mid.getASuccessor() = node
+        succNodeAndState(mid, midNode, midState, target, targetNode, targetState) and
+        readStep(midNode, midState, c, targetNode, targetState)
       )
     }
 

--- a/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
@@ -456,17 +456,14 @@ module MakeImplContentDataFlow<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private predicate nodeAndState(Flow::PathNode n, Node node, State state) {
-      n.getNode() = node and n.getState() = state
-    }
-
-    pragma[nomagic]
     private predicate succNodeAndState(
       Flow::PathNode pre, Node preNode, State preState, Flow::PathNode succ, Node succNode,
       State succState
     ) {
-      nodeAndState(pre, preNode, preState) and
-      nodeAndState(succ, succNode, succState) and
+      pre.getNode() = preNode and
+      pre.getState() = preState and
+      succ.getNode() = succNode and
+      succ.getState() = succState and
       pre.getASuccessor() = succ
     }
 


### PR DESCRIPTION
```
17950      ~0%     {7} r1 = JOIN `_CaptureModels::PropagateContentFlow::nodeReaches/6#a1f43490#prev_delta_DataFlowImpl::Impl<CaptureMo__#shared` WITH `CaptureModels::PropagateContentFlow::readStep/5#34c0c273#cpe#25` ON FIRST 1 OUTPUT Lhs.4, Lhs.1 'source', Lhs.2 'scReads', Lhs.3 'scStores', Lhs.5 'reads', Lhs.6 'stores', Rhs.1
17950      ~1%     {8}    | JOIN WITH `DataFlowImpl::Impl<CaptureModels::PropagateContentFlow::Flow::C>::S6::PathNode.getNode/0#dispred#c4a4b697` ON FIRST 1 OUTPUT Lhs.6, Lhs.1 'source', Lhs.2 'scReads', Lhs.3 'scStores', Lhs.0, Lhs.4 'reads', Lhs.5 'stores', Rhs.1
1149877000 ~0%     {8}    | JOIN WITH `DataFlowImpl::Impl<CaptureModels::PropagateContentFlow::Flow::C>::S6::PathNode.getState/0#dispred#06e3fe70_10#join_rhs` ON FIRST 1 OUTPUT Lhs.4, Rhs.1 'node', Lhs.1 'source', Lhs.2 'scReads', Lhs.3 'scStores', Lhs.5 'reads', Lhs.6 'stores', Lhs.7
6088       ~2%     {7}    | JOIN WITH `DataFlowImpl::Impl<CaptureModels::PropagateContentFlow::Flow::C>::S6::PathNode.getASuccessor/0#dispred#3b7dd794` ON FIRST 2 OUTPUT Lhs.1 'node', Lhs.2 'source', Lhs.3 'scReads', Lhs.4 'scStores', Lhs.5 'reads', Lhs.6 'stores', Lhs.7
6088       ~2%     {8}    | JOIN WITH `DataFlowImpl::Impl<CaptureModels::PropagateContentFlow::Flow::C>::S6::PathNode.getNode/0#dispred#c4a4b697` ON FIRST 1 OUTPUT Lhs.6, Rhs.1, Lhs.1 'source', Lhs.2 'scReads', Lhs.3 'scStores', Lhs.4 'reads', Lhs.5 'stores', Lhs.0 'node'
4704       ~0%     {7}    | JOIN WITH `CaptureModels::PropagateContentFlow::readStep/5#34c0c273#cpe#134_021#join_rhs` ON FIRST 2 OUTPUT Rhs.2 'c', Lhs.5 'reads', Lhs.2 'source', Lhs.3 'scReads', Lhs.4 'scStores', Lhs.7 'node', Lhs.6 'stores'
4704       ~0%     {7}    | AND NOT `CaptureModels::PropagateContentFlow::nodeReachesRead/7#063d6ac5#reorder_4_5_0_1_2_3_6#prev`(FIRST 7)
                                         return r1
```

This is a pre-requisite for further field based model generation for java.

With this performance improvement a quick and dirty field based model generation for the java sdk yielded
<img width="789" alt="image" src="https://github.com/user-attachments/assets/49f7d0e9-d8a1-47f9-a0f2-2ea950332e8d">
