### PR TITLE
C++: Do not inline `InvalidPointerToDerefConfig::isSink`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
+++ b/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll
@@ -173,7 +173,6 @@ private module InvalidPointerToDerefConfig implements DataFlow::StateConfigSig {
     invalidPointerToDerefSource(_, pai, source)
   }
 
-  pragma[inline]
   predicate isSink(DataFlow::Node sink) { isInvalidPointerDerefSink(sink, _, _, _, _) }
 
   predicate isSink(DataFlow::Node sink, FlowState pai) { none() }


### PR DESCRIPTION
https://github.com/github/codeql/pull/17262 follow-up.