### PR TITLE
Data flow: Move `toNormalSinkNodeEx` into `PathNodeMid`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -246,16 +246,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       ReturnKindExt getKind() { result = pos.getKind() }
     }
 
-    /** If `node` corresponds to a sink, gets the normal node for that sink. */
-    pragma[nomagic]
-    private NodeEx toNormalSinkNodeEx(NodeEx node) {
-      exists(Node n |
-        node.asNodeOrImplicitRead() = n and
-        (Config::isSink(n) or Config::isSink(n, _)) and
-        result.asNode() = n
-      )
-    }
-
     private predicate inBarrier(NodeEx node) {
       exists(Node n |
         node.asNode() = n and
@@ -2607,7 +2597,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             TPathNodeSink(NodeEx node, FlowState state) {
               exists(PathNodeMid sink |
                 sink.isAtSink() and
-                node = toNormalSinkNodeEx(sink.getNodeEx()) and
+                node = sink.toNormalSinkNodeEx() and
                 state = sink.getState()
               )
             } or
@@ -2734,6 +2724,16 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
               )
             }
 
+            /** If this node corresponds to a sink, gets the normal node for that sink. */
+            pragma[nomagic]
+            NodeEx toNormalSinkNodeEx() {
+              exists(Node n |
+                node.asNodeOrImplicitRead() = n and
+                (Config::isSink(n) or Config::isSink(n, _)) and
+                result.asNode() = n
+              )
+            }
+
             override PathNodeImpl getASuccessorImpl(string label) {
               // an intermediate step to another intermediate node
               exists(string l2 | result = this.getSuccMid(l2) |
@@ -2825,7 +2825,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             PathNodeSink projectToSink(string model) {
               this.isAtSink() and
               sinkModel(node, model) and
-              result.getNodeEx() = toNormalSinkNodeEx(node) and
+              result.getNodeEx() = this.toNormalSinkNodeEx() and
               result.getState() = state
             }
           }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2728,7 +2728,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             pragma[nomagic]
             NodeEx toNormalSinkNodeEx() {
               exists(Node n |
-                node.asNodeOrImplicitRead() = n and
+                pragma[only_bind_out](node.asNodeOrImplicitRead()) = n and
                 (Config::isSink(n) or Config::isSink(n, _)) and
                 result.asNode() = n
               )


### PR DESCRIPTION
https://github.com/github/codeql/pull/17262 follow-up.

The C++ query [`InvalidPointerDeref.ql`](https://github.com/github/codeql/blob/main/cpp/ql/src/Security/CWE/CWE-193/InvalidPointerDeref.ql) makes use of an [inlined `isSink` predicate](https://github.com/github/codeql/blob/main/cpp/ql/lib/semmle/code/cpp/security/InvalidPointerDereference/InvalidPointerToDereference.qll#L177), presumably in order to only calculate the predicate based on what is forwards reachable in the initial pruning stage.

It is perhaps questionable to rely on the data flow library being able to support this, but this PR at least restores that functionality.