### PR TITLE
Python: Exclude certificate classification fo sensitive data queries

### DIFF
--- a/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -41,8 +41,9 @@ module CleartextLogging {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() in
-        [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
+      not SensitiveDataSource.super.getClassification() in [
+          SensitiveDataClassification::id(), SensitiveDataClassification::certificate()
+        ]
     }
 
     override SensitiveDataClassification getClassification() {

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -41,7 +41,8 @@ module CleartextLogging {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() = SensitiveDataClassification::id()
+      not SensitiveDataSource.super.getClassification() =
+        [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
     }
 
     override SensitiveDataClassification getClassification() {

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextLoggingCustomizations.qll
@@ -41,7 +41,7 @@ module CleartextLogging {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() =
+      not SensitiveDataSource.super.getClassification() in
         [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
     }
 

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -40,7 +40,8 @@ module CleartextStorage {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() = SensitiveDataClassification::id()
+      not SensitiveDataSource.super.getClassification() =
+        [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
     }
 
     override SensitiveDataClassification getClassification() {

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -40,8 +40,9 @@ module CleartextStorage {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() in
-        [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
+      not SensitiveDataSource.super.getClassification() in [
+          SensitiveDataClassification::id(), SensitiveDataClassification::certificate()
+        ]
     }
 
     override SensitiveDataClassification getClassification() {

--- a/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
+++ b/python/ql/lib/semmle/python/security/dataflow/CleartextStorageCustomizations.qll
@@ -40,7 +40,7 @@ module CleartextStorage {
    */
   class SensitiveDataSourceAsSource extends Source, SensitiveDataSource {
     SensitiveDataSourceAsSource() {
-      not SensitiveDataSource.super.getClassification() =
+      not SensitiveDataSource.super.getClassification() in
         [SensitiveDataClassification::id(), SensitiveDataClassification::certificate()]
     }
 

--- a/python/ql/src/change-notes/2024-08-27-sensitive-certificate.md
+++ b/python/ql/src/change-notes/2024-08-27-sensitive-certificate.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data` queries have been updated to exclude the `certificate` classification of of sensitive sources, which often do not actually contain sensitive data.
+* The `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data` queries have been updated to exclude the `certificate` classification of sensitive sources, which often do not contain sensitive data.

--- a/python/ql/src/change-notes/2024-08-27-sensitive-certificate.md
+++ b/python/ql/src/change-notes/2024-08-27-sensitive-certificate.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `py/clear-text-logging-sensitive-data` and `py/clear-text-storage-sensitive-data` queries have been updated to exclude the `certificate` classification of of sensitive sources, which often do not actually contain sensitive data.

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/CleartextLogging.expected
@@ -30,7 +30,6 @@ nodes
 | test.py:23:58:23:65 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
 | test.py:27:40:27:47 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
 | test.py:30:58:30:65 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
-| test.py:34:30:34:39 | ControlFlowNode for get_cert() | semmle.label | ControlFlowNode for get_cert() |
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
@@ -73,7 +72,6 @@ subpaths
 | test.py:23:58:23:65 | ControlFlowNode for password | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:23:58:23:65 | ControlFlowNode for password | This expression logs $@ as clear text. | test.py:19:16:19:29 | ControlFlowNode for get_password() | sensitive data (password) |
 | test.py:27:40:27:47 | ControlFlowNode for password | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:27:40:27:47 | ControlFlowNode for password | This expression logs $@ as clear text. | test.py:19:16:19:29 | ControlFlowNode for get_password() | sensitive data (password) |
 | test.py:30:58:30:65 | ControlFlowNode for password | test.py:19:16:19:29 | ControlFlowNode for get_password() | test.py:30:58:30:65 | ControlFlowNode for password | This expression logs $@ as clear text. | test.py:19:16:19:29 | ControlFlowNode for get_password() | sensitive data (password) |
-| test.py:34:30:34:39 | ControlFlowNode for get_cert() | test.py:34:30:34:39 | ControlFlowNode for get_cert() | test.py:34:30:34:39 | ControlFlowNode for get_cert() | This expression logs $@ as clear text. | test.py:34:30:34:39 | ControlFlowNode for get_cert() | sensitive data (certificate) |
 | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | test.py:37:11:37:24 | ControlFlowNode for get_password() | This expression logs $@ as clear text. | test.py:37:11:37:24 | ControlFlowNode for get_password() | sensitive data (password) |
 | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | test.py:39:22:39:35 | ControlFlowNode for get_password() | This expression logs $@ as clear text. | test.py:39:22:39:35 | ControlFlowNode for get_password() | sensitive data (password) |
 | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | test.py:40:22:40:35 | ControlFlowNode for get_password() | This expression logs $@ as clear text. | test.py:40:22:40:35 | ControlFlowNode for get_password() | sensitive data (password) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextLogging/test.py
@@ -31,7 +31,7 @@ def log_password():
 
 
 def log_cert():
-    logging.debug("Cert=%s", get_cert()) # NOT OK
+    logging.debug("Cert=%s", get_cert()) # OK
 
 def print_password():
     print(get_password()) # NOT OK
@@ -52,8 +52,8 @@ def log_private():
         print(passportNo) # NOT OK
 
     def log2(post_code, zipCode, home_address):
-        print(post_code) # NOT OK, but NOT FOUND - "code" is treated as enxrypted and thus not sensitive
-        print(zipCode) # NOT OK, but NOT FOUND - "code" is treated as enxrypted and thus not sensitive
+        print(post_code) # NOT OK, but NOT FOUND - "code" is treated as encrypted and thus not sensitive
+        print(zipCode) # NOT OK, but NOT FOUND - "code" is treated as encrypted and thus not sensitive
         print(home_address) # NOT OK
 
     def log3(user_latitude, user_longitude):

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage-py3/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage-py3/CleartextStorage.expected
@@ -1,16 +1,16 @@
 edges
-| test.py:9:5:9:8 | ControlFlowNode for cert | test.py:12:21:12:24 | ControlFlowNode for cert | provenance |  |
-| test.py:9:5:9:8 | ControlFlowNode for cert | test.py:13:22:13:41 | ControlFlowNode for Attribute() | provenance |  |
-| test.py:9:5:9:8 | ControlFlowNode for cert | test.py:15:26:15:29 | ControlFlowNode for cert | provenance |  |
-| test.py:9:12:9:21 | ControlFlowNode for get_cert() | test.py:9:5:9:8 | ControlFlowNode for cert | provenance |  |
+| test.py:9:5:9:12 | ControlFlowNode for password | test.py:12:21:12:28 | ControlFlowNode for password | provenance |  |
+| test.py:9:5:9:12 | ControlFlowNode for password | test.py:13:22:13:45 | ControlFlowNode for Attribute() | provenance |  |
+| test.py:9:5:9:12 | ControlFlowNode for password | test.py:15:26:15:33 | ControlFlowNode for password | provenance |  |
+| test.py:9:16:9:29 | ControlFlowNode for get_password() | test.py:9:5:9:12 | ControlFlowNode for password | provenance |  |
 nodes
-| test.py:9:5:9:8 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
-| test.py:9:12:9:21 | ControlFlowNode for get_cert() | semmle.label | ControlFlowNode for get_cert() |
-| test.py:12:21:12:24 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
-| test.py:13:22:13:41 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
-| test.py:15:26:15:29 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
+| test.py:9:5:9:12 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
+| test.py:9:16:9:29 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
+| test.py:12:21:12:28 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
+| test.py:13:22:13:45 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
+| test.py:15:26:15:33 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
 subpaths
 #select
-| test.py:12:21:12:24 | ControlFlowNode for cert | test.py:9:12:9:21 | ControlFlowNode for get_cert() | test.py:12:21:12:24 | ControlFlowNode for cert | This expression stores $@ as clear text. | test.py:9:12:9:21 | ControlFlowNode for get_cert() | sensitive data (certificate) |
-| test.py:13:22:13:41 | ControlFlowNode for Attribute() | test.py:9:12:9:21 | ControlFlowNode for get_cert() | test.py:13:22:13:41 | ControlFlowNode for Attribute() | This expression stores $@ as clear text. | test.py:9:12:9:21 | ControlFlowNode for get_cert() | sensitive data (certificate) |
-| test.py:15:26:15:29 | ControlFlowNode for cert | test.py:9:12:9:21 | ControlFlowNode for get_cert() | test.py:15:26:15:29 | ControlFlowNode for cert | This expression stores $@ as clear text. | test.py:9:12:9:21 | ControlFlowNode for get_cert() | sensitive data (certificate) |
+| test.py:12:21:12:28 | ControlFlowNode for password | test.py:9:16:9:29 | ControlFlowNode for get_password() | test.py:12:21:12:28 | ControlFlowNode for password | This expression stores $@ as clear text. | test.py:9:16:9:29 | ControlFlowNode for get_password() | sensitive data (password) |
+| test.py:13:22:13:45 | ControlFlowNode for Attribute() | test.py:9:16:9:29 | ControlFlowNode for get_password() | test.py:13:22:13:45 | ControlFlowNode for Attribute() | This expression stores $@ as clear text. | test.py:9:16:9:29 | ControlFlowNode for get_password() | sensitive data (password) |
+| test.py:15:26:15:33 | ControlFlowNode for password | test.py:9:16:9:29 | ControlFlowNode for get_password() | test.py:15:26:15:33 | ControlFlowNode for password | This expression stores $@ as clear text. | test.py:9:16:9:29 | ControlFlowNode for get_password() | sensitive data (password) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage-py3/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage-py3/test.py
@@ -1,15 +1,15 @@
 import pathlib
 
 
-def get_cert():
-    return "<CERT>"
+def get_password():
+    return "password"
 
 
 def write_password(filename):
-    cert = get_cert()
+    password = get_password()
 
     path = pathlib.Path(filename)
-    path.write_text(cert) # NOT OK
-    path.write_bytes(cert.encode("utf-8")) # NOT OK
+    path.write_text(password) # NOT OK
+    path.write_bytes(password.encode("utf-8")) # NOT OK
 
-    path.open("w").write(cert) # NOT OK
+    path.open("w").write(password) # NOT OK

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/CleartextStorage.expected
@@ -3,10 +3,10 @@ edges
 | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | password_in_cookie.py:7:5:7:12 | ControlFlowNode for password | provenance |  |
 | password_in_cookie.py:14:5:14:12 | ControlFlowNode for password | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | provenance |  |
 | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | password_in_cookie.py:14:5:14:12 | ControlFlowNode for password | provenance |  |
-| test.py:6:5:6:8 | ControlFlowNode for cert | test.py:8:20:8:23 | ControlFlowNode for cert | provenance |  |
-| test.py:6:5:6:8 | ControlFlowNode for cert | test.py:9:9:9:13 | ControlFlowNode for lines | provenance |  |
-| test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:6:5:6:8 | ControlFlowNode for cert | provenance |  |
-| test.py:9:9:9:13 | ControlFlowNode for lines | test.py:10:25:10:29 | ControlFlowNode for lines | provenance |  |
+| test.py:15:5:15:12 | ControlFlowNode for password | test.py:17:20:17:27 | ControlFlowNode for password | provenance |  |
+| test.py:15:5:15:12 | ControlFlowNode for password | test.py:18:9:18:13 | ControlFlowNode for lines | provenance |  |
+| test.py:15:16:15:29 | ControlFlowNode for get_password() | test.py:15:5:15:12 | ControlFlowNode for password | provenance |  |
+| test.py:18:9:18:13 | ControlFlowNode for lines | test.py:19:25:19:29 | ControlFlowNode for lines | provenance |  |
 nodes
 | password_in_cookie.py:7:5:7:12 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
 | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
@@ -14,14 +14,14 @@ nodes
 | password_in_cookie.py:14:5:14:12 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
 | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | semmle.label | ControlFlowNode for Attribute() |
 | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
-| test.py:6:5:6:8 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
-| test.py:6:12:6:21 | ControlFlowNode for get_cert() | semmle.label | ControlFlowNode for get_cert() |
-| test.py:8:20:8:23 | ControlFlowNode for cert | semmle.label | ControlFlowNode for cert |
-| test.py:9:9:9:13 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
-| test.py:10:25:10:29 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
+| test.py:15:5:15:12 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
+| test.py:15:16:15:29 | ControlFlowNode for get_password() | semmle.label | ControlFlowNode for get_password() |
+| test.py:17:20:17:27 | ControlFlowNode for password | semmle.label | ControlFlowNode for password |
+| test.py:18:9:18:13 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
+| test.py:19:25:19:29 | ControlFlowNode for lines | semmle.label | ControlFlowNode for lines |
 subpaths
 #select
 | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | password_in_cookie.py:9:33:9:40 | ControlFlowNode for password | This expression stores $@ as clear text. | password_in_cookie.py:7:16:7:43 | ControlFlowNode for Attribute() | sensitive data (password) |
 | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | password_in_cookie.py:16:33:16:40 | ControlFlowNode for password | This expression stores $@ as clear text. | password_in_cookie.py:14:16:14:43 | ControlFlowNode for Attribute() | sensitive data (password) |
-| test.py:8:20:8:23 | ControlFlowNode for cert | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:8:20:8:23 | ControlFlowNode for cert | This expression stores $@ as clear text. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | sensitive data (certificate) |
-| test.py:10:25:10:29 | ControlFlowNode for lines | test.py:6:12:6:21 | ControlFlowNode for get_cert() | test.py:10:25:10:29 | ControlFlowNode for lines | This expression stores $@ as clear text. | test.py:6:12:6:21 | ControlFlowNode for get_cert() | sensitive data (certificate) |
+| test.py:17:20:17:27 | ControlFlowNode for password | test.py:15:16:15:29 | ControlFlowNode for get_password() | test.py:17:20:17:27 | ControlFlowNode for password | This expression stores $@ as clear text. | test.py:15:16:15:29 | ControlFlowNode for get_password() | sensitive data (password) |
+| test.py:19:25:19:29 | ControlFlowNode for lines | test.py:15:16:15:29 | ControlFlowNode for get_password() | test.py:19:25:19:29 | ControlFlowNode for lines | This expression stores $@ as clear text. | test.py:15:16:15:29 | ControlFlowNode for get_password() | sensitive data (password) |

--- a/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/test.py
+++ b/python/ql/test/query-tests/Security/CWE-312-CleartextStorage/test.py
@@ -1,12 +1,21 @@
 def get_cert():
     return "<CERT>"
 
+def get_password():
+    return "password"
 
 def write_cert(filename):
     cert = get_cert()
     with open(filename, "w") as file:
-        file.write(cert) # NOT OK
+        file.write(cert) # OK
         lines = [cert + "\n"]
+        file.writelines(lines) # OK
+
+def write_password(filename):
+    password = get_password()
+    with open(filename, "w") as file:
+        file.write(password) # NOT OK
+        lines = [password + "\n"]
         file.writelines(lines) # NOT OK
 
 def FPs():


### PR DESCRIPTION
A certificate, such as an SSL certificate or x509 certificate, often does not contain sensitive data, so the cleartext storage and cleartext logging queries result in false positive alerts when considering them. This PR excludes certificates as sources for these queries. 