### PR TITLE
DataFlow: Bugfix in content flow state for value preservation.

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/ContentDataFlowImpl.qll
@@ -51,11 +51,6 @@ module MakeImplContentDataFlow<LocationSig Location, InputSig<Location> Lang> {
      */
     default predicate isAdditionalFlowStep(Node node1, Node node2) { none() }
 
-    /**
-     * Holds if taint may propagate from `node1` to `node2` in addition to the normal data-flow steps.
-     */
-    default predicate isAdditionalTaintStep(Node node1, Node node2) { none() }
-
     /** Holds if data flow into `node` is prohibited. */
     default predicate isBarrier(Node node) { none() }
 
@@ -106,10 +101,8 @@ module MakeImplContentDataFlow<LocationSig Location, InputSig<Location> Lang> {
       predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
         storeStep(node1, state1, _, node2, state2) or
         readStep(node1, state1, _, node2, state2) or
-        additionalTaintStep(node1, state1, node2, state2)
+        additionalStep(node1, state1, node2, state2)
       }
-
-      predicate isAdditionalFlowStep = ContentConfig::isAdditionalFlowStep/2;
 
       predicate isBarrier = ContentConfig::isBarrier/1;
 
@@ -234,8 +227,8 @@ module MakeImplContentDataFlow<LocationSig Location, InputSig<Location> Lang> {
       )
     }
 
-    private predicate additionalTaintStep(Node node1, State state1, Node node2, State state2) {
-      ContentConfig::isAdditionalTaintStep(node1, node2) and
+    private predicate additionalStep(Node node1, State state1, Node node2, State state2) {
+      ContentConfig::isAdditionalFlowStep(node1, node2) and
       (
         state1 instanceof InitState and
         state2.(InitState).decode(false)


### PR DESCRIPTION
This PR fixes a problem with the flow state in the content flow implementation. The flow state is used to track the number of reads and stores and whether the value is preserved.

The snippet of code seen below was from the original implementation.
Note that `ContentConfig::isAdditionalFlowStep/2` was also used within the `additionalStep` predicate. 
```
predicate isAdditionalFlowStep(Node node1, FlowState state1, Node node2, FlowState state2) {
    storeStep(node1, state1, _, node2, state2) or
    readStep(node1, state1, _, node2, state2) or
    additionalStep(node1, state1, node2, state2)
}

predicate isAdditionalFlowStep = ContentConfig::isAdditionalFlowStep/2;
```
This meant that the steps provided by `ContentConfig::isAdditionalFlowStep/2` could be taken with and without altering the flow state (there is a built in assumption in `additionalStep` that the step taken via `ContentConfig::isAdditionalFlowStep/2` is a non-value preserving step).

Besides the flow state fix, there is also a minor update to the `excludeSteps` predicate where we re-use a materialised relation from a previous PR (that was introduced to avoid a bad join).
