### PR TITLE
C++: Tweak the `bounded` barrier

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
+++ b/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll
@@ -1,6 +1,6 @@
 /**
- * This file provides the `bounded` predicate that is used in both `cpp/uncontrolled-arithmetic`
- * and `cpp/tainted-arithmetic`.
+ * This file provides the `bounded` predicate that is used in `cpp/uncontrolled-arithmetic`,
+ * `cpp/tainted-arithmetic` and `cpp/uncontrolled-allocation-size`.
  */
 
 private import cpp
@@ -8,20 +8,18 @@ private import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 private import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 
 /**
- * An operand `e` of a bitwise and expression `andExpr` (i.e., `andExpr` is either an `BitwiseAndExpr`
- * or an `AssignAndExpr`) with operands `operand1` and `operand2` is the operand that is not `e` is upper
- * bounded by some number that is less than the maximum integer allowed by the result type of `andExpr`.
+ * An operand `operand` of a bitwise and expression `andExpr` (i.e., `andExpr` is either a
+ * `BitwiseAndExpr` or an `AssignAndExpr`) is upper bounded by some number that is less than the
+ * maximum integer allowed by the result type of `andExpr`.
  */
 pragma[inline]
-private predicate boundedBitwiseAnd(Expr e, Expr andExpr, Expr operand1, Expr operand2) {
-  operand1 != operand2 and
-  e = operand1 and
-  upperBound(operand2.getFullyConverted()) < exprMaxVal(andExpr.getFullyConverted())
+private predicate boundedBitwiseAnd(Expr operand, Expr andExpr) {
+  upperBound(operand.getFullyConverted()) < exprMaxVal(andExpr.getFullyConverted())
 }
 
 /**
- * Holds if `e` is an arithmetic expression that cannot overflow, or if `e` is an operand of an
- * operation that may greatly reduce the range of possible values.
+ * Holds if `e` is an arithmetic expression that cannot overflow, or if `e` is an operation that
+ * may greatly reduce the range of possible values.
  */
 predicate bounded(Expr e) {
   // There can be two separate reasons for `convertedExprMightOverflow` not holding:
@@ -35,25 +33,25 @@ predicate bounded(Expr e) {
   ) and
   not convertedExprMightOverflow(e)
   or
-  // Optimistically assume that a remainder expression always yields a much smaller value.
-  e = any(RemExpr rem).getLeftOperand()
+  // Optimistically assume that the following operations always yields a much smaller value.
+  e instanceof RemExpr
   or
-  e = any(AssignRemExpr rem).getLValue()
+  e instanceof DivExpr
+  or
+  e instanceof RShiftExpr
   or
   exists(BitwiseAndExpr andExpr |
-    boundedBitwiseAnd(e, andExpr, andExpr.getAnOperand(), andExpr.getAnOperand())
+    e = andExpr and boundedBitwiseAnd(andExpr.getAnOperand(), andExpr)
   )
   or
-  exists(AssignAndExpr andExpr |
-    boundedBitwiseAnd(e, andExpr, andExpr.getAnOperand(), andExpr.getAnOperand())
-  )
-  or
-  // Optimistically assume that a division always yields a much smaller value.
-  e = any(DivExpr div).getLeftOperand()
+  // For the assignment variant of the operations we place the barrier on the assigned lvalue.
+  e = any(AssignRemExpr rem).getLValue()
   or
   e = any(AssignDivExpr div).getLValue()
   or
-  e = any(RShiftExpr shift).getLeftOperand()
-  or
   e = any(AssignRShiftExpr div).getLValue()
+  or
+  exists(AssignAndExpr andExpr |
+    e = andExpr.getLValue() and boundedBitwiseAnd(andExpr.getRValue(), andExpr)
+  )
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/ArithmeticUncontrolled.expected
@@ -32,6 +32,8 @@ edges
 | test.cpp:24:11:24:18 | call to get_rand | test.cpp:25:7:25:7 | r | provenance |  |
 | test.cpp:30:13:30:14 | get_rand2 output argument | test.cpp:31:7:31:7 | r | provenance |  |
 | test.cpp:36:13:36:13 | get_rand3 output argument | test.cpp:37:7:37:7 | r | provenance |  |
+| test.cpp:62:19:62:24 | call to rand | test.cpp:62:19:62:24 | call to rand | provenance |  |
+| test.cpp:62:19:62:24 | call to rand | test.cpp:65:9:65:9 | x | provenance |  |
 | test.cpp:86:10:86:13 | call to rand | test.cpp:86:10:86:13 | call to rand | provenance |  |
 | test.cpp:86:10:86:13 | call to rand | test.cpp:90:10:90:10 | x | provenance |  |
 | test.cpp:98:10:98:13 | call to rand | test.cpp:98:10:98:13 | call to rand | provenance |  |
@@ -105,6 +107,9 @@ nodes
 | test.cpp:31:7:31:7 | r | semmle.label | r |
 | test.cpp:36:13:36:13 | get_rand3 output argument | semmle.label | get_rand3 output argument |
 | test.cpp:37:7:37:7 | r | semmle.label | r |
+| test.cpp:62:19:62:24 | call to rand | semmle.label | call to rand |
+| test.cpp:62:19:62:24 | call to rand | semmle.label | call to rand |
+| test.cpp:65:9:65:9 | x | semmle.label | x |
 | test.cpp:86:10:86:13 | call to rand | semmle.label | call to rand |
 | test.cpp:86:10:86:13 | call to rand | semmle.label | call to rand |
 | test.cpp:90:10:90:10 | x | semmle.label | x |
@@ -156,6 +161,7 @@ subpaths
 | test.cpp:25:7:25:7 | r | test.cpp:8:9:8:12 | call to rand | test.cpp:25:7:25:7 | r | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:8:9:8:12 | call to rand | uncontrolled value |
 | test.cpp:31:7:31:7 | r | test.cpp:13:10:13:13 | call to rand | test.cpp:31:7:31:7 | r | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:13:10:13:13 | call to rand | uncontrolled value |
 | test.cpp:37:7:37:7 | r | test.cpp:18:9:18:12 | call to rand | test.cpp:37:7:37:7 | r | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:18:9:18:12 | call to rand | uncontrolled value |
+| test.cpp:65:9:65:9 | x | test.cpp:62:19:62:24 | call to rand | test.cpp:65:9:65:9 | x | This arithmetic expression depends on an $@, potentially causing an underflow. | test.cpp:62:19:62:22 | call to rand | uncontrolled value |
 | test.cpp:90:10:90:10 | x | test.cpp:86:10:86:13 | call to rand | test.cpp:90:10:90:10 | x | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:86:10:86:13 | call to rand | uncontrolled value |
 | test.cpp:102:10:102:10 | x | test.cpp:98:10:98:13 | call to rand | test.cpp:102:10:102:10 | x | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:98:10:98:13 | call to rand | uncontrolled value |
 | test.cpp:146:9:146:9 | y | test.cpp:137:10:137:13 | call to rand | test.cpp:146:9:146:9 | y | This arithmetic expression depends on an $@, potentially causing an overflow. | test.cpp:137:10:137:13 | call to rand | uncontrolled value |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/ArithmeticUncontrolled/test.cpp
@@ -62,7 +62,7 @@ unsigned int test_remainder_subtract_unsigned()
 	unsigned int x = rand();
 	unsigned int y = x % 100; // y <= x
 
-	return x - y; // GOOD (as y <= x)
+	return x - y; // GOOD (as y <= x) [FALSE POSITIVE]
 }
 
 typedef unsigned long size_t;

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/TaintedAllocationSize.expected
@@ -13,26 +13,30 @@ edges
 | test.cpp:133:19:133:32 | *call to getenv | test.cpp:133:14:133:17 | call to atoi | provenance | TaintFunction |
 | test.cpp:148:15:148:18 | call to atol | test.cpp:152:11:152:28 | ... * ... | provenance |  |
 | test.cpp:148:20:148:33 | *call to getenv | test.cpp:148:15:148:18 | call to atol | provenance | TaintFunction |
-| test.cpp:224:8:224:23 | *get_tainted_size | test.cpp:256:9:256:24 | call to get_tainted_size | provenance |  |
-| test.cpp:226:9:226:42 | ... * ... | test.cpp:224:8:224:23 | *get_tainted_size | provenance |  |
-| test.cpp:226:14:226:27 | *call to getenv | test.cpp:226:9:226:42 | ... * ... | provenance | TaintFunction |
-| test.cpp:245:21:245:21 | s | test.cpp:246:21:246:21 | s | provenance |  |
-| test.cpp:252:19:252:52 | ... * ... | test.cpp:254:9:254:18 | local_size | provenance |  |
-| test.cpp:252:19:252:52 | ... * ... | test.cpp:260:11:260:20 | local_size | provenance |  |
-| test.cpp:252:19:252:52 | ... * ... | test.cpp:262:10:262:19 | local_size | provenance |  |
-| test.cpp:252:24:252:37 | *call to getenv | test.cpp:252:19:252:52 | ... * ... | provenance | TaintFunction |
-| test.cpp:262:10:262:19 | local_size | test.cpp:245:21:245:21 | s | provenance |  |
-| test.cpp:265:20:265:27 | *out_size | test.cpp:304:17:304:20 | get_size output argument | provenance |  |
-| test.cpp:265:20:265:27 | *out_size | test.cpp:320:18:320:21 | get_size output argument | provenance |  |
-| test.cpp:266:2:266:32 | ... = ... | test.cpp:265:20:265:27 | *out_size | provenance |  |
-| test.cpp:266:18:266:31 | *call to getenv | test.cpp:266:2:266:32 | ... = ... | provenance | TaintFunction |
-| test.cpp:274:15:274:18 | call to atoi | test.cpp:278:11:278:29 | ... * ... | provenance |  |
-| test.cpp:274:20:274:33 | *call to getenv | test.cpp:274:15:274:18 | call to atoi | provenance | TaintFunction |
-| test.cpp:304:17:304:20 | get_size output argument | test.cpp:306:11:306:28 | ... * ... | provenance |  |
-| test.cpp:320:18:320:21 | get_size output argument | test.cpp:323:10:323:27 | ... * ... | provenance |  |
-| test.cpp:368:13:368:16 | call to atoi | test.cpp:370:35:370:38 | size | provenance |  |
-| test.cpp:368:13:368:16 | call to atoi | test.cpp:371:35:371:38 | size | provenance |  |
-| test.cpp:368:18:368:31 | *call to getenv | test.cpp:368:13:368:16 | call to atoi | provenance | TaintFunction |
+| test.cpp:190:14:190:17 | call to atoi | test.cpp:194:11:194:28 | ... * ... | provenance |  |
+| test.cpp:190:19:190:32 | *call to getenv | test.cpp:190:14:190:17 | call to atoi | provenance | TaintFunction |
+| test.cpp:205:14:205:17 | call to atoi | test.cpp:209:11:209:28 | ... * ... | provenance |  |
+| test.cpp:205:19:205:32 | *call to getenv | test.cpp:205:14:205:17 | call to atoi | provenance | TaintFunction |
+| test.cpp:239:8:239:23 | *get_tainted_size | test.cpp:271:9:271:24 | call to get_tainted_size | provenance |  |
+| test.cpp:241:9:241:42 | ... * ... | test.cpp:239:8:239:23 | *get_tainted_size | provenance |  |
+| test.cpp:241:14:241:27 | *call to getenv | test.cpp:241:9:241:42 | ... * ... | provenance | TaintFunction |
+| test.cpp:260:21:260:21 | s | test.cpp:261:21:261:21 | s | provenance |  |
+| test.cpp:267:19:267:52 | ... * ... | test.cpp:269:9:269:18 | local_size | provenance |  |
+| test.cpp:267:19:267:52 | ... * ... | test.cpp:275:11:275:20 | local_size | provenance |  |
+| test.cpp:267:19:267:52 | ... * ... | test.cpp:277:10:277:19 | local_size | provenance |  |
+| test.cpp:267:24:267:37 | *call to getenv | test.cpp:267:19:267:52 | ... * ... | provenance | TaintFunction |
+| test.cpp:277:10:277:19 | local_size | test.cpp:260:21:260:21 | s | provenance |  |
+| test.cpp:280:20:280:27 | *out_size | test.cpp:319:17:319:20 | get_size output argument | provenance |  |
+| test.cpp:280:20:280:27 | *out_size | test.cpp:335:18:335:21 | get_size output argument | provenance |  |
+| test.cpp:281:2:281:32 | ... = ... | test.cpp:280:20:280:27 | *out_size | provenance |  |
+| test.cpp:281:18:281:31 | *call to getenv | test.cpp:281:2:281:32 | ... = ... | provenance | TaintFunction |
+| test.cpp:289:15:289:18 | call to atoi | test.cpp:293:11:293:29 | ... * ... | provenance |  |
+| test.cpp:289:20:289:33 | *call to getenv | test.cpp:289:15:289:18 | call to atoi | provenance | TaintFunction |
+| test.cpp:319:17:319:20 | get_size output argument | test.cpp:321:11:321:28 | ... * ... | provenance |  |
+| test.cpp:335:18:335:21 | get_size output argument | test.cpp:338:10:338:27 | ... * ... | provenance |  |
+| test.cpp:383:13:383:16 | call to atoi | test.cpp:385:35:385:38 | size | provenance |  |
+| test.cpp:383:13:383:16 | call to atoi | test.cpp:386:35:386:38 | size | provenance |  |
+| test.cpp:383:18:383:31 | *call to getenv | test.cpp:383:13:383:16 | call to atoi | provenance | TaintFunction |
 nodes
 | test.cpp:39:27:39:30 | **argv | semmle.label | **argv |
 | test.cpp:40:16:40:19 | call to atoi | semmle.label | call to atoi |
@@ -52,31 +56,37 @@ nodes
 | test.cpp:148:15:148:18 | call to atol | semmle.label | call to atol |
 | test.cpp:148:20:148:33 | *call to getenv | semmle.label | *call to getenv |
 | test.cpp:152:11:152:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:224:8:224:23 | *get_tainted_size | semmle.label | *get_tainted_size |
-| test.cpp:226:9:226:42 | ... * ... | semmle.label | ... * ... |
-| test.cpp:226:14:226:27 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:245:21:245:21 | s | semmle.label | s |
-| test.cpp:246:21:246:21 | s | semmle.label | s |
-| test.cpp:252:19:252:52 | ... * ... | semmle.label | ... * ... |
-| test.cpp:252:24:252:37 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:254:9:254:18 | local_size | semmle.label | local_size |
-| test.cpp:256:9:256:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
-| test.cpp:260:11:260:20 | local_size | semmle.label | local_size |
-| test.cpp:262:10:262:19 | local_size | semmle.label | local_size |
-| test.cpp:265:20:265:27 | *out_size | semmle.label | *out_size |
-| test.cpp:266:2:266:32 | ... = ... | semmle.label | ... = ... |
-| test.cpp:266:18:266:31 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:274:15:274:18 | call to atoi | semmle.label | call to atoi |
-| test.cpp:274:20:274:33 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:278:11:278:29 | ... * ... | semmle.label | ... * ... |
-| test.cpp:304:17:304:20 | get_size output argument | semmle.label | get_size output argument |
-| test.cpp:306:11:306:28 | ... * ... | semmle.label | ... * ... |
-| test.cpp:320:18:320:21 | get_size output argument | semmle.label | get_size output argument |
-| test.cpp:323:10:323:27 | ... * ... | semmle.label | ... * ... |
-| test.cpp:368:13:368:16 | call to atoi | semmle.label | call to atoi |
-| test.cpp:368:18:368:31 | *call to getenv | semmle.label | *call to getenv |
-| test.cpp:370:35:370:38 | size | semmle.label | size |
-| test.cpp:371:35:371:38 | size | semmle.label | size |
+| test.cpp:190:14:190:17 | call to atoi | semmle.label | call to atoi |
+| test.cpp:190:19:190:32 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:194:11:194:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:205:14:205:17 | call to atoi | semmle.label | call to atoi |
+| test.cpp:205:19:205:32 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:209:11:209:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:239:8:239:23 | *get_tainted_size | semmle.label | *get_tainted_size |
+| test.cpp:241:9:241:42 | ... * ... | semmle.label | ... * ... |
+| test.cpp:241:14:241:27 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:260:21:260:21 | s | semmle.label | s |
+| test.cpp:261:21:261:21 | s | semmle.label | s |
+| test.cpp:267:19:267:52 | ... * ... | semmle.label | ... * ... |
+| test.cpp:267:24:267:37 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:269:9:269:18 | local_size | semmle.label | local_size |
+| test.cpp:271:9:271:24 | call to get_tainted_size | semmle.label | call to get_tainted_size |
+| test.cpp:275:11:275:20 | local_size | semmle.label | local_size |
+| test.cpp:277:10:277:19 | local_size | semmle.label | local_size |
+| test.cpp:280:20:280:27 | *out_size | semmle.label | *out_size |
+| test.cpp:281:2:281:32 | ... = ... | semmle.label | ... = ... |
+| test.cpp:281:18:281:31 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:289:15:289:18 | call to atoi | semmle.label | call to atoi |
+| test.cpp:289:20:289:33 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:293:11:293:29 | ... * ... | semmle.label | ... * ... |
+| test.cpp:319:17:319:20 | get_size output argument | semmle.label | get_size output argument |
+| test.cpp:321:11:321:28 | ... * ... | semmle.label | ... * ... |
+| test.cpp:335:18:335:21 | get_size output argument | semmle.label | get_size output argument |
+| test.cpp:338:10:338:27 | ... * ... | semmle.label | ... * ... |
+| test.cpp:383:13:383:16 | call to atoi | semmle.label | call to atoi |
+| test.cpp:383:18:383:31 | *call to getenv | semmle.label | *call to getenv |
+| test.cpp:385:35:385:38 | size | semmle.label | size |
+| test.cpp:386:35:386:38 | size | semmle.label | size |
 subpaths
 #select
 | test.cpp:43:31:43:36 | call to malloc | test.cpp:39:27:39:30 | **argv | test.cpp:43:38:43:44 | tainted | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:39:27:39:30 | **argv | user input (a command-line argument) |
@@ -88,12 +98,14 @@ subpaths
 | test.cpp:128:17:128:22 | call to malloc | test.cpp:124:18:124:31 | *call to getenv | test.cpp:128:24:128:41 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:124:18:124:31 | *call to getenv | user input (an environment variable) |
 | test.cpp:135:3:135:8 | call to malloc | test.cpp:133:19:133:32 | *call to getenv | test.cpp:135:10:135:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:133:19:133:32 | *call to getenv | user input (an environment variable) |
 | test.cpp:152:4:152:9 | call to malloc | test.cpp:148:20:148:33 | *call to getenv | test.cpp:152:11:152:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:148:20:148:33 | *call to getenv | user input (an environment variable) |
-| test.cpp:246:14:246:19 | call to malloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:246:21:246:21 | s | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:254:2:254:7 | call to malloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:254:9:254:18 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:256:2:256:7 | call to malloc | test.cpp:226:14:226:27 | *call to getenv | test.cpp:256:9:256:24 | call to get_tainted_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:226:14:226:27 | *call to getenv | user input (an environment variable) |
-| test.cpp:260:2:260:9 | call to my_alloc | test.cpp:252:24:252:37 | *call to getenv | test.cpp:260:11:260:20 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:252:24:252:37 | *call to getenv | user input (an environment variable) |
-| test.cpp:278:4:278:9 | call to malloc | test.cpp:274:20:274:33 | *call to getenv | test.cpp:278:11:278:29 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:274:20:274:33 | *call to getenv | user input (an environment variable) |
-| test.cpp:306:4:306:9 | call to malloc | test.cpp:266:18:266:31 | *call to getenv | test.cpp:306:11:306:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:266:18:266:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:323:3:323:8 | call to malloc | test.cpp:266:18:266:31 | *call to getenv | test.cpp:323:10:323:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:266:18:266:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:370:25:370:33 | call to MyMalloc1 | test.cpp:368:18:368:31 | *call to getenv | test.cpp:370:35:370:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:368:18:368:31 | *call to getenv | user input (an environment variable) |
-| test.cpp:371:25:371:33 | call to MyMalloc2 | test.cpp:368:18:368:31 | *call to getenv | test.cpp:371:35:371:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:368:18:368:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:194:4:194:9 | call to malloc | test.cpp:190:19:190:32 | *call to getenv | test.cpp:194:11:194:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:190:19:190:32 | *call to getenv | user input (an environment variable) |
+| test.cpp:209:4:209:9 | call to malloc | test.cpp:205:19:205:32 | *call to getenv | test.cpp:209:11:209:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:205:19:205:32 | *call to getenv | user input (an environment variable) |
+| test.cpp:261:14:261:19 | call to malloc | test.cpp:267:24:267:37 | *call to getenv | test.cpp:261:21:261:21 | s | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:267:24:267:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:269:2:269:7 | call to malloc | test.cpp:267:24:267:37 | *call to getenv | test.cpp:269:9:269:18 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:267:24:267:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:271:2:271:7 | call to malloc | test.cpp:241:14:241:27 | *call to getenv | test.cpp:271:9:271:24 | call to get_tainted_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:241:14:241:27 | *call to getenv | user input (an environment variable) |
+| test.cpp:275:2:275:9 | call to my_alloc | test.cpp:267:24:267:37 | *call to getenv | test.cpp:275:11:275:20 | local_size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:267:24:267:37 | *call to getenv | user input (an environment variable) |
+| test.cpp:293:4:293:9 | call to malloc | test.cpp:289:20:289:33 | *call to getenv | test.cpp:293:11:293:29 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:289:20:289:33 | *call to getenv | user input (an environment variable) |
+| test.cpp:321:4:321:9 | call to malloc | test.cpp:281:18:281:31 | *call to getenv | test.cpp:321:11:321:28 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:281:18:281:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:338:3:338:8 | call to malloc | test.cpp:281:18:281:31 | *call to getenv | test.cpp:338:10:338:27 | ... * ... | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:281:18:281:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:385:25:385:33 | call to MyMalloc1 | test.cpp:383:18:383:31 | *call to getenv | test.cpp:385:35:385:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:383:18:383:31 | *call to getenv | user input (an environment variable) |
+| test.cpp:386:25:386:33 | call to MyMalloc2 | test.cpp:383:18:383:31 | *call to getenv | test.cpp:386:35:386:38 | size | This allocation size is derived from $@ and could allocate arbitrary amounts of memory. | test.cpp:383:18:383:31 | *call to getenv | user input (an environment variable) |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp
@@ -191,7 +191,22 @@ void more_bounded_tests() {
 
 		if (size % 100)
 		{
-			malloc(size * sizeof(int)); // BAD [NOT DETECTED]
+			malloc(size * sizeof(int)); // BAD
+		}
+	}
+
+	{
+		int size = atoi(getenv("USER"));
+		int size2 = size & 7; // Pick the first three bits of size
+		malloc(size2 * sizeof(int)); // GOOD
+	}
+
+	{
+		int size = atoi(getenv("USER"));
+
+		if (size & 7)
+		{
+			malloc(size * sizeof(int)); // BAD
 		}
 	}
 


### PR DESCRIPTION
The `cpp/uncontrolled-allocation-size` query has some false negatives, such as [this one](https://github.com/paldepind/codeql/blob/d9dbcdba3481016956f20f7f99c7d88a87dfb832/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/TaintedAllocationSize/test.cpp#L194).

To improve this, @geoffw0 suggested a change to how [`bounded`](https://github.com/paldepind/codeql/blob/d9dbcdba3481016956f20f7f99c7d88a87dfb832/cpp/ql/src/Security/CWE/CWE-190/Bounded.qll#L26) (which servers as a barrier for this query) works. In an expression like `a % 10` the barrier should be put on the whole expression and not on `a` as is done now. This fixes aforementioned false negative (and potentially others as well).

Note that since `bounded` is also used in two other queries well have to see to what extend this change impacts them. I'm running MRVA on `cpp/uncontrolled-arithmetic` and for the top 600 repos I'm seeing 5 results. I don't know what the diff is yet as MRVA is still running.