### PR TITLE
C++: Add test for cpp/uninitialized-local and va_copy

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/UninitializedLocal.expected
@@ -2,28 +2,28 @@ edges
 nodes
 | test.cpp:11:6:11:8 | definition of foo | semmle.label | definition of foo |
 | test.cpp:111:6:111:8 | definition of foo | semmle.label | definition of foo |
-| test.cpp:218:7:218:7 | definition of x | semmle.label | definition of x |
-| test.cpp:241:6:241:6 | definition of i | semmle.label | definition of i |
-| test.cpp:333:7:333:7 | definition of a | semmle.label | definition of a |
-| test.cpp:358:7:358:7 | definition of a | semmle.label | definition of a |
-| test.cpp:359:6:359:8 | definition of val | semmle.label | definition of val |
-| test.cpp:414:9:414:9 | definition of j | semmle.label | definition of j |
-| test.cpp:431:9:431:9 | definition of j | semmle.label | definition of j |
-| test.cpp:452:6:452:6 | definition of x | semmle.label | definition of x |
-| test.cpp:458:6:458:6 | definition of x | semmle.label | definition of x |
-| test.cpp:464:6:464:6 | definition of x | semmle.label | definition of x |
-| test.cpp:471:6:471:6 | definition of x | semmle.label | definition of x |
+| test.cpp:226:7:226:7 | definition of x | semmle.label | definition of x |
+| test.cpp:249:6:249:6 | definition of i | semmle.label | definition of i |
+| test.cpp:341:7:341:7 | definition of a | semmle.label | definition of a |
+| test.cpp:366:7:366:7 | definition of a | semmle.label | definition of a |
+| test.cpp:367:6:367:8 | definition of val | semmle.label | definition of val |
+| test.cpp:422:9:422:9 | definition of j | semmle.label | definition of j |
+| test.cpp:439:9:439:9 | definition of j | semmle.label | definition of j |
+| test.cpp:460:6:460:6 | definition of x | semmle.label | definition of x |
+| test.cpp:466:6:466:6 | definition of x | semmle.label | definition of x |
+| test.cpp:472:6:472:6 | definition of x | semmle.label | definition of x |
+| test.cpp:479:6:479:6 | definition of x | semmle.label | definition of x |
 #select
 | test.cpp:12:6:12:8 | foo | test.cpp:11:6:11:8 | definition of foo | test.cpp:11:6:11:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:11:6:11:8 | foo | foo |
 | test.cpp:113:6:113:8 | foo | test.cpp:111:6:111:8 | definition of foo | test.cpp:111:6:111:8 | definition of foo | The variable $@ may not be initialized at this access. | test.cpp:111:6:111:8 | foo | foo |
-| test.cpp:219:3:219:3 | x | test.cpp:218:7:218:7 | definition of x | test.cpp:218:7:218:7 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:218:7:218:7 | x | x |
-| test.cpp:243:13:243:13 | i | test.cpp:241:6:241:6 | definition of i | test.cpp:241:6:241:6 | definition of i | The variable $@ may not be initialized at this access. | test.cpp:241:6:241:6 | i | i |
-| test.cpp:336:10:336:10 | a | test.cpp:333:7:333:7 | definition of a | test.cpp:333:7:333:7 | definition of a | The variable $@ may not be initialized at this access. | test.cpp:333:7:333:7 | a | a |
-| test.cpp:369:10:369:10 | a | test.cpp:358:7:358:7 | definition of a | test.cpp:358:7:358:7 | definition of a | The variable $@ may not be initialized at this access. | test.cpp:358:7:358:7 | a | a |
-| test.cpp:378:9:378:11 | val | test.cpp:359:6:359:8 | definition of val | test.cpp:359:6:359:8 | definition of val | The variable $@ may not be initialized at this access. | test.cpp:359:6:359:8 | val | val |
-| test.cpp:417:10:417:10 | j | test.cpp:414:9:414:9 | definition of j | test.cpp:414:9:414:9 | definition of j | The variable $@ may not be initialized at this access. | test.cpp:414:9:414:9 | j | j |
-| test.cpp:436:9:436:9 | j | test.cpp:431:9:431:9 | definition of j | test.cpp:431:9:431:9 | definition of j | The variable $@ may not be initialized at this access. | test.cpp:431:9:431:9 | j | j |
-| test.cpp:454:2:454:2 | x | test.cpp:452:6:452:6 | definition of x | test.cpp:452:6:452:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:452:6:452:6 | x | x |
-| test.cpp:460:7:460:7 | x | test.cpp:458:6:458:6 | definition of x | test.cpp:458:6:458:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:458:6:458:6 | x | x |
-| test.cpp:467:2:467:2 | x | test.cpp:464:6:464:6 | definition of x | test.cpp:464:6:464:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:464:6:464:6 | x | x |
-| test.cpp:474:7:474:7 | x | test.cpp:471:6:471:6 | definition of x | test.cpp:471:6:471:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:471:6:471:6 | x | x |
+| test.cpp:227:3:227:3 | x | test.cpp:226:7:226:7 | definition of x | test.cpp:226:7:226:7 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:226:7:226:7 | x | x |
+| test.cpp:251:13:251:13 | i | test.cpp:249:6:249:6 | definition of i | test.cpp:249:6:249:6 | definition of i | The variable $@ may not be initialized at this access. | test.cpp:249:6:249:6 | i | i |
+| test.cpp:344:10:344:10 | a | test.cpp:341:7:341:7 | definition of a | test.cpp:341:7:341:7 | definition of a | The variable $@ may not be initialized at this access. | test.cpp:341:7:341:7 | a | a |
+| test.cpp:377:10:377:10 | a | test.cpp:366:7:366:7 | definition of a | test.cpp:366:7:366:7 | definition of a | The variable $@ may not be initialized at this access. | test.cpp:366:7:366:7 | a | a |
+| test.cpp:386:9:386:11 | val | test.cpp:367:6:367:8 | definition of val | test.cpp:367:6:367:8 | definition of val | The variable $@ may not be initialized at this access. | test.cpp:367:6:367:8 | val | val |
+| test.cpp:425:10:425:10 | j | test.cpp:422:9:422:9 | definition of j | test.cpp:422:9:422:9 | definition of j | The variable $@ may not be initialized at this access. | test.cpp:422:9:422:9 | j | j |
+| test.cpp:444:9:444:9 | j | test.cpp:439:9:439:9 | definition of j | test.cpp:439:9:439:9 | definition of j | The variable $@ may not be initialized at this access. | test.cpp:439:9:439:9 | j | j |
+| test.cpp:462:2:462:2 | x | test.cpp:460:6:460:6 | definition of x | test.cpp:460:6:460:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:460:6:460:6 | x | x |
+| test.cpp:468:7:468:7 | x | test.cpp:466:6:466:6 | definition of x | test.cpp:466:6:466:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:466:6:466:6 | x | x |
+| test.cpp:475:2:475:2 | x | test.cpp:472:6:472:6 | definition of x | test.cpp:472:6:472:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:472:6:472:6 | x | x |
+| test.cpp:482:7:482:7 | x | test.cpp:479:6:479:6 | definition of x | test.cpp:479:6:479:6 | definition of x | The variable $@ may not be initialized at this access. | test.cpp:479:6:479:6 | x | x |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-457/semmle/tests/test.cpp
@@ -156,11 +156,12 @@ int absCorrect2(int i) {
 	return j; // correct: j always initialized before use
 }
 
+typedef __builtin_va_list va_list;
+#define va_start(v, l)	__builtin_va_start(v,l)
+#define va_end(v)	__builtin_va_end(v)
+#define va_arg(v, l)	__builtin_va_arg(v,l)
+#define va_copy(d, s)	__builtin_va_copy(d,s)
 
-typedef void *va_list;
-#define va_start(ap, parmN)
-#define va_end(ap)
-#define va_arg(ap, type) ((type)0)
 #define NULL 0
 
 // Variadic initialisation
@@ -176,7 +177,7 @@ void init(int val, ...) {
 void test15() {
   int foo;
   init(42, &foo, NULL);
-  use(foo); //GOOD -- initialised by `init`
+  use(foo); // GOOD -- initialised by `init`
 }
 
 // Variadic non-initialisation
@@ -190,6 +191,13 @@ void test16() {
   int foo;
   nonInit(42, &foo, NULL);
   use(foo); // BAD (NOT REPORTED)
+}
+
+void test_va_copy(va_list va) {
+  va_list va2;
+  va_copy(va2, va); // GOOD -- this is an initialization
+  use(va2);
+  va_end(va2);
 }
 
 bool test17(bool b) {


### PR DESCRIPTION
Adds a test to confirm and ensure that `cpp/uninitialized-local` doesn't produce false positives for `va_copy` when `va_copy` is extracted as what we would expect.