### PR TITLE
Bazel/Go: Bump `rules_go` to 0.50.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 # see https://registry.bazel.build/ for a list of available packages
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_go", version = "0.49.0")
+bazel_dep(name = "rules_go", version = "0.50.0")
 bazel_dep(name = "rules_pkg", version = "0.10.1")
 bazel_dep(name = "rules_nodejs", version = "6.2.0-codeql.1")
 bazel_dep(name = "rules_python", version = "0.32.2")


### PR DESCRIPTION
As noted by @criemen in #17058, `rules_go` version 0.50.0 is out which contains a bug fix for Windows that is needed for Go 1.23. I have teased this out into its own PR since it should be fine to merge independently of the Go 1.23 work and we can then remove the code owners hit on `codeql-ci-reviewers` for those PRs.