### PR TITLE
Go: Expose whether functions are variadic in their pp() output

### DIFF
--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -921,9 +921,12 @@ class SignatureType extends @signaturetype, CompositeType {
 
   language[monotonicAggregates]
   override string pp() {
-    result =
-      "func(" + concat(int i, Type tp | tp = this.getParameterType(i) | tp.pp(), ", " order by i) +
-        ") " + concat(int i, Type tp | tp = this.getResultType(i) | tp.pp(), ", " order by i)
+    exists(string suffix | (if this.isVariadic() then suffix = "[variadic]" else suffix = "") |
+      result =
+        "func(" + concat(int i, Type tp | tp = this.getParameterType(i) | tp.pp(), ", " order by i) +
+          ") " + concat(int i, Type tp | tp = this.getResultType(i) | tp.pp(), ", " order by i) +
+          " " + suffix
+    )
   }
 
   override string toString() { result = "signature type" }

--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -921,11 +921,11 @@ class SignatureType extends @signaturetype, CompositeType {
 
   language[monotonicAggregates]
   override string pp() {
-    exists(string suffix | (if this.isVariadic() then suffix = "[variadic]" else suffix = "") |
+    exists(string suffix | (if this.isVariadic() then suffix = " [variadic]" else suffix = "") |
       result =
         "func(" + concat(int i, Type tp | tp = this.getParameterType(i) | tp.pp(), ", " order by i) +
           ") " + concat(int i, Type tp | tp = this.getResultType(i) | tp.pp(), ", " order by i) +
-          " " + suffix
+          suffix
     )
   }
 

--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -921,12 +921,20 @@ class SignatureType extends @signaturetype, CompositeType {
 
   language[monotonicAggregates]
   override string pp() {
-    exists(string suffix | (if this.isVariadic() then suffix = " [variadic]" else suffix = "") |
-      result =
-        "func(" + concat(int i, Type tp | tp = this.getParameterType(i) | tp.pp(), ", " order by i) +
-          ") " + concat(int i, Type tp | tp = this.getResultType(i) | tp.pp(), ", " order by i) +
-          suffix
-    )
+    result =
+      "func(" +
+        concat(int i, Type tp, string prefix |
+          if i = this.getNumParameter() - 1 and this.isVariadic()
+          then
+            tp = this.getParameterType(i).(SliceType).getElementType() and
+            prefix = "..."
+          else (
+            tp = this.getParameterType(i) and
+            prefix = ""
+          )
+        |
+          prefix + tp.pp(), ", " order by i
+        ) + ") " + concat(int i, Type tp | tp = this.getResultType(i) | tp.pp(), ", " order by i)
   }
 
   override string toString() { result = "signature type" }

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -53,10 +53,10 @@ input.go:
 #   20|         0: [CallExpr] call to Println
 #   20|             Type = (int, error)
 #   20|           0: [FunctionName, SelectorExpr] selection of Println
-#   20|               Type = func([]interface { }) int, error [variadic]
+#   20|               Type = func(...interface { }) int, error
 #   20|             0: [Ident, PackageName] fmt
 #   20|             1: [FunctionName, Ident] Println
-#   20|                 Type = func([]interface { }) int, error [variadic]
+#   20|                 Type = func(...interface { }) int, error
 #   20|           1: [StringLit] "Hi"
 #   20|               Type = string
 #   20|               Value = [StringLit] Hi
@@ -203,10 +203,10 @@ input.go:
 #   52|               0: [CallExpr] call to Println
 #   52|                   Type = (int, error)
 #   52|                 0: [FunctionName, SelectorExpr] selection of Println
-#   52|                     Type = func([]interface { }) int, error [variadic]
+#   52|                     Type = func(...interface { }) int, error
 #   52|                   0: [Ident, PackageName] fmt
 #   52|                   1: [FunctionName, Ident] Println
-#   52|                       Type = func([]interface { }) int, error [variadic]
+#   52|                       Type = func(...interface { }) int, error
 #   52|                 1: [StringLit] "Heard from ch1"
 #   52|                     Type = string
 #   52|                     Value = [StringLit] Heard from ch1
@@ -229,20 +229,20 @@ input.go:
 #   54|               0: [CallExpr] call to Println
 #   54|                   Type = (int, error)
 #   54|                 0: [FunctionName, SelectorExpr] selection of Println
-#   54|                     Type = func([]interface { }) int, error [variadic]
+#   54|                     Type = func(...interface { }) int, error
 #   54|                   0: [Ident, PackageName] fmt
 #   54|                   1: [FunctionName, Ident] Println
-#   54|                       Type = func([]interface { }) int, error [variadic]
+#   54|                       Type = func(...interface { }) int, error
 #   54|                 1: [Ident, VariableName] a
 #   54|                     Type = [1]float32
 #   55|             2: [ExprStmt] expression statement
 #   55|               0: [CallExpr] call to Println
 #   55|                   Type = (int, error)
 #   55|                 0: [FunctionName, SelectorExpr] selection of Println
-#   55|                     Type = func([]interface { }) int, error [variadic]
+#   55|                     Type = func(...interface { }) int, error
 #   55|                   0: [Ident, PackageName] fmt
 #   55|                   1: [FunctionName, Ident] Println
-#   55|                       Type = func([]interface { }) int, error [variadic]
+#   55|                       Type = func(...interface { }) int, error
 #   55|                 1: [Ident, VariableName] w
 #   55|                     Type = bool
 #   56|           2: [CommClause] comm clause
@@ -250,10 +250,10 @@ input.go:
 #   57|               0: [CallExpr] call to Println
 #   57|                   Type = (int, error)
 #   57|                 0: [FunctionName, SelectorExpr] selection of Println
-#   57|                     Type = func([]interface { }) int, error [variadic]
+#   57|                     Type = func(...interface { }) int, error
 #   57|                   0: [Ident, PackageName] fmt
 #   57|                   1: [FunctionName, Ident] Println
-#   57|                       Type = func([]interface { }) int, error [variadic]
+#   57|                       Type = func(...interface { }) int, error
 #   58|           3: [CommClause] comm clause
 #   58|             0: [SendStmt] send statement
 #   58|               0: [Ident, VariableName] ch1
@@ -297,10 +297,10 @@ input.go:
 #   67|                     0: [CallExpr] call to Println
 #   67|                         Type = (int, error)
 #   67|                       0: [FunctionName, SelectorExpr] selection of Println
-#   67|                           Type = func([]interface { }) int, error [variadic]
+#   67|                           Type = func(...interface { }) int, error
 #   67|                         0: [Ident, PackageName] fmt
 #   67|                         1: [FunctionName, Ident] Println
-#   67|                             Type = func([]interface { }) int, error [variadic]
+#   67|                             Type = func(...interface { }) int, error
 #   67|                       1: [Ident, VariableName] x
 #   67|                           Type = int
 #   68|         2: [BlockStmt] block statement
@@ -316,10 +316,10 @@ input.go:
 #   69|                     0: [CallExpr] call to Println
 #   69|                         Type = (int, error)
 #   69|                       0: [FunctionName, SelectorExpr] selection of Println
-#   69|                           Type = func([]interface { }) int, error [variadic]
+#   69|                           Type = func(...interface { }) int, error
 #   69|                         0: [Ident, PackageName] fmt
 #   69|                         1: [FunctionName, Ident] Println
-#   69|                             Type = func([]interface { }) int, error [variadic]
+#   69|                             Type = func(...interface { }) int, error
 #   69|                       1: [MinusExpr] -...
 #   69|                           Type = int
 #   69|                         0: [Ident, VariableName] x
@@ -474,10 +474,10 @@ input.go:
 #  115|               0: [CallExpr] call to Println
 #  115|                   Type = (int, error)
 #  115|                 0: [FunctionName, SelectorExpr] selection of Println
-#  115|                     Type = func([]interface { }) int, error [variadic]
+#  115|                     Type = func(...interface { }) int, error
 #  115|                   0: [Ident, PackageName] fmt
 #  115|                   1: [FunctionName, Ident] Println
-#  115|                       Type = func([]interface { }) int, error [variadic]
+#  115|                       Type = func(...interface { }) int, error
 #  115|                 1: [Ident, VariableName] y
 #  115|                     Type = interface { }
 #  116|           1: [CaseClause] case clause
@@ -566,10 +566,10 @@ input.go:
 #  138|             0: [CallExpr] call to Print
 #  138|                 Type = (int, error)
 #  138|               0: [FunctionName, SelectorExpr] selection of Print
-#  138|                   Type = func([]interface { }) int, error [variadic]
+#  138|                   Type = func(...interface { }) int, error
 #  138|                 0: [Ident, PackageName] fmt
 #  138|                 1: [FunctionName, Ident] Print
-#  138|                     Type = func([]interface { }) int, error [variadic]
+#  138|                     Type = func(...interface { }) int, error
 #  138|               1: [Ident, VariableName] x
 #  138|                   Type = int
 #  141|       1: [RangeStmt] range statement
@@ -584,10 +584,10 @@ input.go:
 #  142|             0: [CallExpr] call to Print
 #  142|                 Type = (int, error)
 #  142|               0: [FunctionName, SelectorExpr] selection of Print
-#  142|                   Type = func([]interface { }) int, error [variadic]
+#  142|                   Type = func(...interface { }) int, error
 #  142|                 0: [Ident, PackageName] fmt
 #  142|                 1: [FunctionName, Ident] Print
-#  142|                     Type = func([]interface { }) int, error [variadic]
+#  142|                     Type = func(...interface { }) int, error
 #  142|               1: [Ident, VariableName] i
 #  142|                   Type = int
 #  142|               2: [Ident, VariableName] v

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -53,10 +53,10 @@ input.go:
 #   20|         0: [CallExpr] call to Println
 #   20|             Type = (int, error)
 #   20|           0: [FunctionName, SelectorExpr] selection of Println
-#   20|               Type = func([]interface { }) int, error
+#   20|               Type = func([]interface { }) int, error [variadic]
 #   20|             0: [Ident, PackageName] fmt
 #   20|             1: [FunctionName, Ident] Println
-#   20|                 Type = func([]interface { }) int, error
+#   20|                 Type = func([]interface { }) int, error [variadic]
 #   20|           1: [StringLit] "Hi"
 #   20|               Type = string
 #   20|               Value = [StringLit] Hi
@@ -203,10 +203,10 @@ input.go:
 #   52|               0: [CallExpr] call to Println
 #   52|                   Type = (int, error)
 #   52|                 0: [FunctionName, SelectorExpr] selection of Println
-#   52|                     Type = func([]interface { }) int, error
+#   52|                     Type = func([]interface { }) int, error [variadic]
 #   52|                   0: [Ident, PackageName] fmt
 #   52|                   1: [FunctionName, Ident] Println
-#   52|                       Type = func([]interface { }) int, error
+#   52|                       Type = func([]interface { }) int, error [variadic]
 #   52|                 1: [StringLit] "Heard from ch1"
 #   52|                     Type = string
 #   52|                     Value = [StringLit] Heard from ch1
@@ -229,20 +229,20 @@ input.go:
 #   54|               0: [CallExpr] call to Println
 #   54|                   Type = (int, error)
 #   54|                 0: [FunctionName, SelectorExpr] selection of Println
-#   54|                     Type = func([]interface { }) int, error
+#   54|                     Type = func([]interface { }) int, error [variadic]
 #   54|                   0: [Ident, PackageName] fmt
 #   54|                   1: [FunctionName, Ident] Println
-#   54|                       Type = func([]interface { }) int, error
+#   54|                       Type = func([]interface { }) int, error [variadic]
 #   54|                 1: [Ident, VariableName] a
 #   54|                     Type = [1]float32
 #   55|             2: [ExprStmt] expression statement
 #   55|               0: [CallExpr] call to Println
 #   55|                   Type = (int, error)
 #   55|                 0: [FunctionName, SelectorExpr] selection of Println
-#   55|                     Type = func([]interface { }) int, error
+#   55|                     Type = func([]interface { }) int, error [variadic]
 #   55|                   0: [Ident, PackageName] fmt
 #   55|                   1: [FunctionName, Ident] Println
-#   55|                       Type = func([]interface { }) int, error
+#   55|                       Type = func([]interface { }) int, error [variadic]
 #   55|                 1: [Ident, VariableName] w
 #   55|                     Type = bool
 #   56|           2: [CommClause] comm clause
@@ -250,10 +250,10 @@ input.go:
 #   57|               0: [CallExpr] call to Println
 #   57|                   Type = (int, error)
 #   57|                 0: [FunctionName, SelectorExpr] selection of Println
-#   57|                     Type = func([]interface { }) int, error
+#   57|                     Type = func([]interface { }) int, error [variadic]
 #   57|                   0: [Ident, PackageName] fmt
 #   57|                   1: [FunctionName, Ident] Println
-#   57|                       Type = func([]interface { }) int, error
+#   57|                       Type = func([]interface { }) int, error [variadic]
 #   58|           3: [CommClause] comm clause
 #   58|             0: [SendStmt] send statement
 #   58|               0: [Ident, VariableName] ch1
@@ -297,10 +297,10 @@ input.go:
 #   67|                     0: [CallExpr] call to Println
 #   67|                         Type = (int, error)
 #   67|                       0: [FunctionName, SelectorExpr] selection of Println
-#   67|                           Type = func([]interface { }) int, error
+#   67|                           Type = func([]interface { }) int, error [variadic]
 #   67|                         0: [Ident, PackageName] fmt
 #   67|                         1: [FunctionName, Ident] Println
-#   67|                             Type = func([]interface { }) int, error
+#   67|                             Type = func([]interface { }) int, error [variadic]
 #   67|                       1: [Ident, VariableName] x
 #   67|                           Type = int
 #   68|         2: [BlockStmt] block statement
@@ -316,10 +316,10 @@ input.go:
 #   69|                     0: [CallExpr] call to Println
 #   69|                         Type = (int, error)
 #   69|                       0: [FunctionName, SelectorExpr] selection of Println
-#   69|                           Type = func([]interface { }) int, error
+#   69|                           Type = func([]interface { }) int, error [variadic]
 #   69|                         0: [Ident, PackageName] fmt
 #   69|                         1: [FunctionName, Ident] Println
-#   69|                             Type = func([]interface { }) int, error
+#   69|                             Type = func([]interface { }) int, error [variadic]
 #   69|                       1: [MinusExpr] -...
 #   69|                           Type = int
 #   69|                         0: [Ident, VariableName] x
@@ -474,10 +474,10 @@ input.go:
 #  115|               0: [CallExpr] call to Println
 #  115|                   Type = (int, error)
 #  115|                 0: [FunctionName, SelectorExpr] selection of Println
-#  115|                     Type = func([]interface { }) int, error
+#  115|                     Type = func([]interface { }) int, error [variadic]
 #  115|                   0: [Ident, PackageName] fmt
 #  115|                   1: [FunctionName, Ident] Println
-#  115|                       Type = func([]interface { }) int, error
+#  115|                       Type = func([]interface { }) int, error [variadic]
 #  115|                 1: [Ident, VariableName] y
 #  115|                     Type = interface { }
 #  116|           1: [CaseClause] case clause
@@ -566,10 +566,10 @@ input.go:
 #  138|             0: [CallExpr] call to Print
 #  138|                 Type = (int, error)
 #  138|               0: [FunctionName, SelectorExpr] selection of Print
-#  138|                   Type = func([]interface { }) int, error
+#  138|                   Type = func([]interface { }) int, error [variadic]
 #  138|                 0: [Ident, PackageName] fmt
 #  138|                 1: [FunctionName, Ident] Print
-#  138|                     Type = func([]interface { }) int, error
+#  138|                     Type = func([]interface { }) int, error [variadic]
 #  138|               1: [Ident, VariableName] x
 #  138|                   Type = int
 #  141|       1: [RangeStmt] range statement
@@ -584,10 +584,10 @@ input.go:
 #  142|             0: [CallExpr] call to Print
 #  142|                 Type = (int, error)
 #  142|               0: [FunctionName, SelectorExpr] selection of Print
-#  142|                   Type = func([]interface { }) int, error
+#  142|                   Type = func([]interface { }) int, error [variadic]
 #  142|                 0: [Ident, PackageName] fmt
 #  142|                 1: [FunctionName, Ident] Print
-#  142|                     Type = func([]interface { }) int, error
+#  142|                     Type = func([]interface { }) int, error [variadic]
 #  142|               1: [Ident, VariableName] i
 #  142|                   Type = int
 #  142|               2: [Ident, VariableName] v

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -33,10 +33,10 @@ input.go:
 #   20|         0: [CallExpr] call to Println
 #   20|             Type = (int, error)
 #   20|           0: [FunctionName, SelectorExpr] selection of Println
-#   20|               Type = func([]interface { }) int, error
+#   20|               Type = func([]interface { }) int, error [variadic]
 #   20|             0: [Ident, PackageName] fmt
 #   20|             1: [FunctionName, Ident] Println
-#   20|                 Type = func([]interface { }) int, error
+#   20|                 Type = func([]interface { }) int, error [variadic]
 #   20|           1: [StringLit] "Hi"
 #   20|               Type = string
 #   20|               Value = [StringLit] Hi
@@ -183,10 +183,10 @@ input.go:
 #   52|               0: [CallExpr] call to Println
 #   52|                   Type = (int, error)
 #   52|                 0: [FunctionName, SelectorExpr] selection of Println
-#   52|                     Type = func([]interface { }) int, error
+#   52|                     Type = func([]interface { }) int, error [variadic]
 #   52|                   0: [Ident, PackageName] fmt
 #   52|                   1: [FunctionName, Ident] Println
-#   52|                       Type = func([]interface { }) int, error
+#   52|                       Type = func([]interface { }) int, error [variadic]
 #   52|                 1: [StringLit] "Heard from ch1"
 #   52|                     Type = string
 #   52|                     Value = [StringLit] Heard from ch1
@@ -209,20 +209,20 @@ input.go:
 #   54|               0: [CallExpr] call to Println
 #   54|                   Type = (int, error)
 #   54|                 0: [FunctionName, SelectorExpr] selection of Println
-#   54|                     Type = func([]interface { }) int, error
+#   54|                     Type = func([]interface { }) int, error [variadic]
 #   54|                   0: [Ident, PackageName] fmt
 #   54|                   1: [FunctionName, Ident] Println
-#   54|                       Type = func([]interface { }) int, error
+#   54|                       Type = func([]interface { }) int, error [variadic]
 #   54|                 1: [Ident, VariableName] a
 #   54|                     Type = [1]float32
 #   55|             2: [ExprStmt] expression statement
 #   55|               0: [CallExpr] call to Println
 #   55|                   Type = (int, error)
 #   55|                 0: [FunctionName, SelectorExpr] selection of Println
-#   55|                     Type = func([]interface { }) int, error
+#   55|                     Type = func([]interface { }) int, error [variadic]
 #   55|                   0: [Ident, PackageName] fmt
 #   55|                   1: [FunctionName, Ident] Println
-#   55|                       Type = func([]interface { }) int, error
+#   55|                       Type = func([]interface { }) int, error [variadic]
 #   55|                 1: [Ident, VariableName] w
 #   55|                     Type = bool
 #   56|           2: [CommClause] comm clause
@@ -230,10 +230,10 @@ input.go:
 #   57|               0: [CallExpr] call to Println
 #   57|                   Type = (int, error)
 #   57|                 0: [FunctionName, SelectorExpr] selection of Println
-#   57|                     Type = func([]interface { }) int, error
+#   57|                     Type = func([]interface { }) int, error [variadic]
 #   57|                   0: [Ident, PackageName] fmt
 #   57|                   1: [FunctionName, Ident] Println
-#   57|                       Type = func([]interface { }) int, error
+#   57|                       Type = func([]interface { }) int, error [variadic]
 #   58|           3: [CommClause] comm clause
 #   58|             0: [SendStmt] send statement
 #   58|               0: [Ident, VariableName] ch1
@@ -277,10 +277,10 @@ input.go:
 #   67|                     0: [CallExpr] call to Println
 #   67|                         Type = (int, error)
 #   67|                       0: [FunctionName, SelectorExpr] selection of Println
-#   67|                           Type = func([]interface { }) int, error
+#   67|                           Type = func([]interface { }) int, error [variadic]
 #   67|                         0: [Ident, PackageName] fmt
 #   67|                         1: [FunctionName, Ident] Println
-#   67|                             Type = func([]interface { }) int, error
+#   67|                             Type = func([]interface { }) int, error [variadic]
 #   67|                       1: [Ident, VariableName] x
 #   67|                           Type = int
 #   68|         2: [BlockStmt] block statement
@@ -296,10 +296,10 @@ input.go:
 #   69|                     0: [CallExpr] call to Println
 #   69|                         Type = (int, error)
 #   69|                       0: [FunctionName, SelectorExpr] selection of Println
-#   69|                           Type = func([]interface { }) int, error
+#   69|                           Type = func([]interface { }) int, error [variadic]
 #   69|                         0: [Ident, PackageName] fmt
 #   69|                         1: [FunctionName, Ident] Println
-#   69|                             Type = func([]interface { }) int, error
+#   69|                             Type = func([]interface { }) int, error [variadic]
 #   69|                       1: [MinusExpr] -...
 #   69|                           Type = int
 #   69|                         0: [Ident, VariableName] x
@@ -454,10 +454,10 @@ input.go:
 #  115|               0: [CallExpr] call to Println
 #  115|                   Type = (int, error)
 #  115|                 0: [FunctionName, SelectorExpr] selection of Println
-#  115|                     Type = func([]interface { }) int, error
+#  115|                     Type = func([]interface { }) int, error [variadic]
 #  115|                   0: [Ident, PackageName] fmt
 #  115|                   1: [FunctionName, Ident] Println
-#  115|                       Type = func([]interface { }) int, error
+#  115|                       Type = func([]interface { }) int, error [variadic]
 #  115|                 1: [Ident, VariableName] y
 #  115|                     Type = interface { }
 #  116|           1: [CaseClause] case clause
@@ -546,10 +546,10 @@ input.go:
 #  138|             0: [CallExpr] call to Print
 #  138|                 Type = (int, error)
 #  138|               0: [FunctionName, SelectorExpr] selection of Print
-#  138|                   Type = func([]interface { }) int, error
+#  138|                   Type = func([]interface { }) int, error [variadic]
 #  138|                 0: [Ident, PackageName] fmt
 #  138|                 1: [FunctionName, Ident] Print
-#  138|                     Type = func([]interface { }) int, error
+#  138|                     Type = func([]interface { }) int, error [variadic]
 #  138|               1: [Ident, VariableName] x
 #  138|                   Type = int
 #  141|       1: [RangeStmt] range statement
@@ -564,10 +564,10 @@ input.go:
 #  142|             0: [CallExpr] call to Print
 #  142|                 Type = (int, error)
 #  142|               0: [FunctionName, SelectorExpr] selection of Print
-#  142|                   Type = func([]interface { }) int, error
+#  142|                   Type = func([]interface { }) int, error [variadic]
 #  142|                 0: [Ident, PackageName] fmt
 #  142|                 1: [FunctionName, Ident] Print
-#  142|                     Type = func([]interface { }) int, error
+#  142|                     Type = func([]interface { }) int, error [variadic]
 #  142|               1: [Ident, VariableName] i
 #  142|                   Type = int
 #  142|               2: [Ident, VariableName] v

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -33,10 +33,10 @@ input.go:
 #   20|         0: [CallExpr] call to Println
 #   20|             Type = (int, error)
 #   20|           0: [FunctionName, SelectorExpr] selection of Println
-#   20|               Type = func([]interface { }) int, error [variadic]
+#   20|               Type = func(...interface { }) int, error
 #   20|             0: [Ident, PackageName] fmt
 #   20|             1: [FunctionName, Ident] Println
-#   20|                 Type = func([]interface { }) int, error [variadic]
+#   20|                 Type = func(...interface { }) int, error
 #   20|           1: [StringLit] "Hi"
 #   20|               Type = string
 #   20|               Value = [StringLit] Hi
@@ -183,10 +183,10 @@ input.go:
 #   52|               0: [CallExpr] call to Println
 #   52|                   Type = (int, error)
 #   52|                 0: [FunctionName, SelectorExpr] selection of Println
-#   52|                     Type = func([]interface { }) int, error [variadic]
+#   52|                     Type = func(...interface { }) int, error
 #   52|                   0: [Ident, PackageName] fmt
 #   52|                   1: [FunctionName, Ident] Println
-#   52|                       Type = func([]interface { }) int, error [variadic]
+#   52|                       Type = func(...interface { }) int, error
 #   52|                 1: [StringLit] "Heard from ch1"
 #   52|                     Type = string
 #   52|                     Value = [StringLit] Heard from ch1
@@ -209,20 +209,20 @@ input.go:
 #   54|               0: [CallExpr] call to Println
 #   54|                   Type = (int, error)
 #   54|                 0: [FunctionName, SelectorExpr] selection of Println
-#   54|                     Type = func([]interface { }) int, error [variadic]
+#   54|                     Type = func(...interface { }) int, error
 #   54|                   0: [Ident, PackageName] fmt
 #   54|                   1: [FunctionName, Ident] Println
-#   54|                       Type = func([]interface { }) int, error [variadic]
+#   54|                       Type = func(...interface { }) int, error
 #   54|                 1: [Ident, VariableName] a
 #   54|                     Type = [1]float32
 #   55|             2: [ExprStmt] expression statement
 #   55|               0: [CallExpr] call to Println
 #   55|                   Type = (int, error)
 #   55|                 0: [FunctionName, SelectorExpr] selection of Println
-#   55|                     Type = func([]interface { }) int, error [variadic]
+#   55|                     Type = func(...interface { }) int, error
 #   55|                   0: [Ident, PackageName] fmt
 #   55|                   1: [FunctionName, Ident] Println
-#   55|                       Type = func([]interface { }) int, error [variadic]
+#   55|                       Type = func(...interface { }) int, error
 #   55|                 1: [Ident, VariableName] w
 #   55|                     Type = bool
 #   56|           2: [CommClause] comm clause
@@ -230,10 +230,10 @@ input.go:
 #   57|               0: [CallExpr] call to Println
 #   57|                   Type = (int, error)
 #   57|                 0: [FunctionName, SelectorExpr] selection of Println
-#   57|                     Type = func([]interface { }) int, error [variadic]
+#   57|                     Type = func(...interface { }) int, error
 #   57|                   0: [Ident, PackageName] fmt
 #   57|                   1: [FunctionName, Ident] Println
-#   57|                       Type = func([]interface { }) int, error [variadic]
+#   57|                       Type = func(...interface { }) int, error
 #   58|           3: [CommClause] comm clause
 #   58|             0: [SendStmt] send statement
 #   58|               0: [Ident, VariableName] ch1
@@ -277,10 +277,10 @@ input.go:
 #   67|                     0: [CallExpr] call to Println
 #   67|                         Type = (int, error)
 #   67|                       0: [FunctionName, SelectorExpr] selection of Println
-#   67|                           Type = func([]interface { }) int, error [variadic]
+#   67|                           Type = func(...interface { }) int, error
 #   67|                         0: [Ident, PackageName] fmt
 #   67|                         1: [FunctionName, Ident] Println
-#   67|                             Type = func([]interface { }) int, error [variadic]
+#   67|                             Type = func(...interface { }) int, error
 #   67|                       1: [Ident, VariableName] x
 #   67|                           Type = int
 #   68|         2: [BlockStmt] block statement
@@ -296,10 +296,10 @@ input.go:
 #   69|                     0: [CallExpr] call to Println
 #   69|                         Type = (int, error)
 #   69|                       0: [FunctionName, SelectorExpr] selection of Println
-#   69|                           Type = func([]interface { }) int, error [variadic]
+#   69|                           Type = func(...interface { }) int, error
 #   69|                         0: [Ident, PackageName] fmt
 #   69|                         1: [FunctionName, Ident] Println
-#   69|                             Type = func([]interface { }) int, error [variadic]
+#   69|                             Type = func(...interface { }) int, error
 #   69|                       1: [MinusExpr] -...
 #   69|                           Type = int
 #   69|                         0: [Ident, VariableName] x
@@ -454,10 +454,10 @@ input.go:
 #  115|               0: [CallExpr] call to Println
 #  115|                   Type = (int, error)
 #  115|                 0: [FunctionName, SelectorExpr] selection of Println
-#  115|                     Type = func([]interface { }) int, error [variadic]
+#  115|                     Type = func(...interface { }) int, error
 #  115|                   0: [Ident, PackageName] fmt
 #  115|                   1: [FunctionName, Ident] Println
-#  115|                       Type = func([]interface { }) int, error [variadic]
+#  115|                       Type = func(...interface { }) int, error
 #  115|                 1: [Ident, VariableName] y
 #  115|                     Type = interface { }
 #  116|           1: [CaseClause] case clause
@@ -546,10 +546,10 @@ input.go:
 #  138|             0: [CallExpr] call to Print
 #  138|                 Type = (int, error)
 #  138|               0: [FunctionName, SelectorExpr] selection of Print
-#  138|                   Type = func([]interface { }) int, error [variadic]
+#  138|                   Type = func(...interface { }) int, error
 #  138|                 0: [Ident, PackageName] fmt
 #  138|                 1: [FunctionName, Ident] Print
-#  138|                     Type = func([]interface { }) int, error [variadic]
+#  138|                     Type = func(...interface { }) int, error
 #  138|               1: [Ident, VariableName] x
 #  138|                   Type = int
 #  141|       1: [RangeStmt] range statement
@@ -564,10 +564,10 @@ input.go:
 #  142|             0: [CallExpr] call to Print
 #  142|                 Type = (int, error)
 #  142|               0: [FunctionName, SelectorExpr] selection of Print
-#  142|                   Type = func([]interface { }) int, error [variadic]
+#  142|                   Type = func(...interface { }) int, error
 #  142|                 0: [Ident, PackageName] fmt
 #  142|                 1: [FunctionName, Ident] Print
-#  142|                     Type = func([]interface { }) int, error [variadic]
+#  142|                     Type = func(...interface { }) int, error
 #  142|               1: [Ident, VariableName] i
 #  142|                   Type = int
 #  142|               2: [Ident, VariableName] v


### PR DESCRIPTION
This avoids our having types that are distinct both in the database and are distinguishable in QL, but which pretty-print identically.