### PR TITLE
Go: Remove change note from 1.15.md

### DIFF
--- a/go/ql/lib/change-notes/released/1.1.5.md
+++ b/go/ql/lib/change-notes/released/1.1.5.md
@@ -1,17 +1,5 @@
 ## 1.1.5
 
-### Minor Analysis Improvements
-
-* Local source models for reading and parsing environment variables have been added for the following libraries:
-  - os
-  - syscall
-  - github.com/caarlos0/env
-  - github.com/gobuffalo/envy
-  - github.com/hashicorp/go-envparse
-  - github.com/joho/godotenv
-  - github.com/kelseyhightower/envconfig
-* Local source models have been added for the APIs which open files in the `io/fs`, `io/ioutil` and `os` packages in the Go standard library. You can optionally include threat models as appropriate when using the CodeQL CLI and in GitHub code scanning. For more information, see [Analyzing your code with CodeQL queries](https://docs.github.com/code-security/codeql-cli/getting-started-with-the-codeql-cli/analyzing-your-code-with-codeql-queries#including-model-packs-to-add-potential-sources-of-tainted-data>) and [Customizing your advanced setup for code scanning](https://docs.github.com/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#extending-codeql-coverage-with-threat-models).
-
 ### Bug Fixes
 
 * Fixed an issue where `io/ioutil.WriteFile`'s non-path arguments incorrectly generated `go/path-injection` alerts when untrusted data was written to a file, or controlled the file's mode.


### PR DESCRIPTION
We will include this change note when there is documentation about how to use the functionality.