### PR TITLE
Include hidden files when uploading Ruby pack

### DIFF
--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -140,6 +140,7 @@ jobs:
           path: |
             ${{ runner.temp }}/query-packs/*
           retention-days: 1
+          include-hidden-files: true
 
   package:
     runs-on: ubuntu-latest
@@ -176,6 +177,7 @@ jobs:
           name: codeql-ruby-pack
           path: ruby/codeql-ruby.zip
           retention-days: 1
+          include-hidden-files: true
       - uses: actions/download-artifact@v3
         with:
           name: codeql-ruby-queries
@@ -193,6 +195,7 @@ jobs:
           name: codeql-ruby-bundle
           path: ruby/codeql-ruby-bundle.zip
           retention-days: 1
+          include-hidden-files: true
 
   test:
     defaults:


### PR DESCRIPTION
A recent update to the `upload-artifact` action stopped uploading "hidden" files (paths that begin with `.`) by default. This was announced widely last week, but I misinterpreted "hidden" as meaning the "hidden" file attribute on Windows, rather than the `.`-prefix convention.

I've fixed the problematic uses in the ruby-build workflow, and I'll work with IDX to see if there are any other workflows that need updating.
