### PR TITLE
C++: Update expected test results after extractor changes

### DIFF
--- a/cpp/ql/test/header-variant-tests/multi-target-includes/includes.expected
+++ b/cpp/ql/test/header-variant-tests/multi-target-includes/includes.expected
@@ -5,6 +5,5 @@
 | main1.cpp:7:1:7:26 | #include "defines_issue.h" | Include | defines_issue.h | 1 |
 | main2.cpp:3:1:3:19 | #include "common.h" | Include | common.h | 1 |
 | main2.cpp:7:1:7:26 | #include "defines_issue.h" | Include | defines_issue.h | 1 |
-| nameclash.h:3:1:3:27 | #include_next "nameclash.h" | IncludeNext | nameclash.h | 1 |
 | nameclash.h:3:1:3:27 | #include_next "nameclash.h" | IncludeNext | subdir1/nameclash.h | 1 |
 | nameclash.h:3:1:3:27 | #include_next "nameclash.h" | IncludeNext | subdir2/nameclash.h | 1 |

--- a/cpp/ql/test/library-tests/includes/include_next/includes.expected
+++ b/cpp/ql/test/library-tests/includes/include_next/includes.expected
@@ -1,4 +1,3 @@
-| a/test.h:2:1:2:22 | #include_next <test.h> | a/test.h:0:0:0:0 | a/test.h |
 | a/test.h:2:1:2:22 | #include_next <test.h> | b/test.h:0:0:0:0 | b/test.h |
 | b/loop.h:2:1:2:22 | #include_next <test.h> | a/test.h:0:0:0:0 | a/test.h |
 | b/test.h:4:1:4:17 | #include "loop.h" | b/loop.h:0:0:0:0 | b/loop.h |


### PR DESCRIPTION
The updated test results look more correct, as the documentation of `#include_next` [1] that it should start looking in the next directory in the search path. Before this update, the frontend was actually looking in the current directory first, which is incorrect.

[1] https://gcc.gnu.org/onlinedocs/cpp/Wrapper-Headers.html