### PR TITLE
Backport "Bazel/Go: Bump rules_go to 0.50.0" to `rc/3.15`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ local_path_override(
 # see https://registry.bazel.build/ for a list of available packages
 
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_go", version = "0.49.0")
+bazel_dep(name = "rules_go", version = "0.50.0")
 bazel_dep(name = "rules_pkg", version = "0.10.1")
 bazel_dep(name = "rules_nodejs", version = "6.2.0-codeql.1")
 bazel_dep(name = "rules_python", version = "0.32.2")


### PR DESCRIPTION
We need this for the Go 1.23 work, which we are aiming to get into `rc/3.15`, but we merged it into `main` yesterday in #17359. This PR backports it to `rc/3.15`. 