### PR TITLE
Bazel: stub internal repo parts needed for building rust binaries

### DIFF
--- a/misc/bazel/rust.bzl
+++ b/misc/bazel/rust.bzl
@@ -8,7 +8,7 @@ def codeql_rust_binary(
         visibility = None,
         symbols_test = True,
         **kwargs):
-    rust_label_name = name + "_single_arch"
+    rust_label_name = "single_arch/" + name
     universal_binary(
         name = name,
         dep = ":" + rust_label_name,

--- a/misc/bazel/semmle_code_stub/buildutils-internal/glibc_symbols_check.bzl
+++ b/misc/bazel/semmle_code_stub/buildutils-internal/glibc_symbols_check.bzl
@@ -1,0 +1,4 @@
+# This check only makes sense when building from the internal repository
+
+def glibc_symbols_check(**kwargs):
+    pass

--- a/misc/bazel/semmle_code_stub/buildutils-internal/lipo.bzl
+++ b/misc/bazel/semmle_code_stub/buildutils-internal/lipo.bzl
@@ -1,0 +1,5 @@
+# we only need to build universal binaries when building releases from the internal repo
+# when building from the codeql repo, we can stub this rule with an alias
+
+def universal_binary(*, name, dep, **kwargs):
+    native.alias(name = name, actual = dep, **kwargs)


### PR DESCRIPTION
This is another shot at https://github.com/github/codeql/pull/17382, using a different and more lightweight approach.

This allows building the ruby and python (and in the future also rust) packs from within the codeql repository. This will:
* skip defining the glibc symbols checking, which only makes sense when building the release from the internal repository
* stub out our `universal_binary` rule, which we only need when building the release.