### PR TITLE
C#: Fix trivial upgrade.properties errors

### DIFF
--- a/csharp/downgrades/ab09ac8287516082b7a7367f8fda1862b1be47c5/upgrade.properties
+++ b/csharp/downgrades/ab09ac8287516082b7a7367f8fda1862b1be47c5/upgrade.properties
@@ -1,3 +1,3 @@
 description: Remove 'kind' from 'attributes'.
-compatability: full
+compatibility: full
 attributes.rel: reorder attributes.rel (@attribute id, int kind, @type_or_ref type_id, @attributable target) id type_id target

--- a/csharp/ql/lib/upgrades/ba2201248071b2bf0bb52909b35014091d2e18a6/upgrade.properties
+++ b/csharp/ql/lib/upgrades/ba2201248071b2bf0bb52909b35014091d2e18a6/upgrade.properties
@@ -1,3 +1,3 @@
 description: Add 'kind' to 'attributes'.
-compatability: backwards
+compatibility: backwards
 attributes.rel: run attribute_kind.ql

--- a/csharp/ql/lib/upgrades/dd813977f70fcbf737b0bbe9dc8297edff713168/upgrade.properties
+++ b/csharp/ql/lib/upgrades/dd813977f70fcbf737b0bbe9dc8297edff713168/upgrade.properties
@@ -1,4 +1,4 @@
-description: Added '@cil_function_pointer_type' and related relations ('cil_function_pointer_return_type',
-'cil_function_pointer_calling_conventions'). Introduced 'cil_type_annotation' and '@cil_has_type_annotation'
+description: Added '@cil_function_pointer_type' and related relations ('cil_function_pointer_return_type', \
+'cil_function_pointer_calling_conventions'). Introduced 'cil_type_annotation' and '@cil_has_type_annotation' \
 to store by-reference type annotation. Added '@cil_parameterizable' to represent methods and type parameters.
 compatibility: backwards

--- a/csharp/ql/lib/upgrades/efcd69e086a26dd33395f2ddb3113b2849399040/upgrade.properties
+++ b/csharp/ql/lib/upgrades/efcd69e086a26dd33395f2ddb3113b2849399040/upgrade.properties
@@ -1,5 +1,5 @@
-description: Add '@preprocessor_directive' to store preprocessor directives. Add
-'locations_mapped' relation to store location that take into account '#line'
-directives. Finally, the '@define_symbol_expr' expression was added to represent
+description: Add '@preprocessor_directive' to store preprocessor directives. Add \
+'locations_mapped' relation to store location that take into account '#line' \
+directives. Finally, the '@define_symbol_expr' expression was added to represent \
 symbols inside conditions of '#if' and '#elif' directives.
 compatibility: backwards


### PR DESCRIPTION
This PR fixes trivial errors in a few upgrade.properties files.