### PR TITLE
Rust: Add a README.md

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -21,7 +21,7 @@ You now need to create a [per-user CodeQL configuration file](https://docs.githu
 ```
 --search-path Users/YOURUSERNAME/semmle-code/ql
 ```
-(or wherever the `ql` directory is on your system)
+(or wherever the `codeql` checkout is on your system)
 
 You can now use the Rust extractor e.g. to run Rust tests from the command line or in VSCode.
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,42 @@
+# Rust on CodeQL
+
+## Development
+
+### Dependencies
+
+At present you need to be in the `rust-experiment` branch (or a branch on top of that) in both the `semmle-code` and `codeql` repos.
+
+TODO: are there any dependencies that aren't already CodeQL dependencies?  bazel and rustc?
+
+### Building the Rust Extractor
+
+This approach uses a released `codeql` version and is simpler to use for QL development. From your `semmle-code` directory run:
+```bash
+bazel run @codeql//rust:rust-installer
+```
+You now need to create a [per-user CodeQL configuration file](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/specifying-command-options-in-a-codeql-configuration-file#using-a-codeql-configuration-file) and specify the option:
+```
+--search-path Users/YOURUSERNAME/semmle-code/ql
+```
+(or wherever the `ql` directory is on your system)
+
+You can now use the Rust extractor e.g. to run Rust tests from the command line or in VSCode.
+
+### Building the Rust Extractor (as a sembuild target)
+
+This approach allows you to build a Rust extractor with a CLI built from source. From your `semmle-code` directory run:
+```bash
+./build target/intree/codeql-rust
+```
+You can now invoke it directly, for example to run some tests:
+```bash
+./target/intree/codeql-rust/codeql test run ql/rust/ql/test/PATH/TO/TEST/
+```
+
+### Building a Database
+
+TODO
+
+### Code Generation
+
+TODO

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,8 +7,6 @@
 
 ### Dependencies
 
-At present you need to be in the `rust-experiment` branch (or a branch on top of that) in both the `semmle-code` and `codeql` repos.
-
 If you don't have the `semmle-code` repo you may need to install Bazel manually, e.g. from https://github.com/bazelbuild/bazelisk.
 
 ### Building the Rust Extractor

--- a/rust/README.md
+++ b/rust/README.md
@@ -17,9 +17,9 @@ bazel run @codeql//rust:rust-installer
 ```
 You now need to create a [per-user CodeQL configuration file](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/specifying-command-options-in-a-codeql-configuration-file#using-a-codeql-configuration-file) and specify the option:
 ```
---search-path Users/YOURUSERNAME/semmle-code/ql
+--search-path PATH/TO/semmle-code/ql
 ```
-(or wherever the `codeql` checkout is on your system)
+(wherever the `codeql` checkout is on your system)
 
 You can now use the Rust extractor e.g. to run Rust tests from the command line or in VSCode.
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,12 +1,15 @@
 # Rust on CodeQL
 
+> [!WARNING]
+> Rust support for CodeQL is experimental. No support is offered. QL and database interfaces will change and break without notice or deprecation periods.
+
 ## Development
 
 ### Dependencies
 
 At present you need to be in the `rust-experiment` branch (or a branch on top of that) in both the `semmle-code` and `codeql` repos.
 
-TODO: are there any dependencies that aren't already CodeQL dependencies?  bazel and rustc?
+If you don't have the `semmle-code` repo you may need to install Bazel manually, e.g. from https://github.com/bazelbuild/bazelisk.
 
 ### Building the Rust Extractor
 


### PR DESCRIPTION
Add a `README.md` for Rust, explaining how developers can get started.

I'm happy to take suggestions for the `TODO`s I've left in the doc; alternatively we can merge this as-is and come back to them later.