### PR TITLE
Go: Fix bad join order using late inlined predicate

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -409,7 +409,7 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
  * subexpression of `ret`, and when `ret` has value `outcome` then property `p`
  * holds of `g`.
  */
-bindingset[g, outp, p, fd, ret, outcome]
+bindingset[g]
 pragma[inline_late]
 private predicate guardingFunctionHelper(
   Node g, FunctionOutput outp, DataFlow::Property p, FuncDecl fd, Node ret, boolean outcome

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -391,8 +391,9 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
           c = f2.getACall() and
           arg = inp2.getNode(c) and
           (
-            // See comment above ("This method's contract...") for rationale re: the inversion of
-            // `p` and `outpProp` here:
+            // See comment in `guardingFunctionHelper` ("This predicate's
+            // contract...") for the rationale behind the inversion of `p` and
+            // `outpProp` here:
             outpProp.checkOn(ret, p.asBoolean(), outp2.getNode(c))
             or
             // The particular case where p is non-boolean (i.e., nil or non-nil), and we directly return `c`:

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -419,7 +419,7 @@ private predicate guardingFunctionHelper(
   // (and we have (this has outcome ==> arg is checked))
   // but p.checkOn(ret, outcome, this) gives us (ret has outcome ==> p holds of this),
   // so we need to swap outcome and (specifically boolean) p:
-  DataFlow::booleanProperty(pragma[only_bind_into](outcome)).checkOn(ret, p.asBoolean(), g)
+  DataFlow::booleanProperty(outcome).checkOn(ret, p.asBoolean(), g)
 }
 
 DataFlow::Node getUniqueOutputNode(FuncDecl fd, FunctionOutput outp) {


### PR DESCRIPTION
Currently it's evaluating DataFlow::booleanProperty(outcome).checkOn(ret, p.asBoolean(), g) first, which is massive, then joining ret = getUniqueOutputNode(fd, outp) , which makes it a bit smaller, then guardChecks(g, arg.asExpr(), outcome), which makes it empty. So basically, we are looking for code that looks like returns someFunction(arg) and only then checking if someFunction is a function that we care about. I think it would probably fix the problem to force it to evaluate guardChecks(g, arg.asExpr(), outcome) first, because it will generally be small. I tried putting either only_bind pragma on either of the places that outcome was used, but it made no difference. I then tried pulling out the two lines that aren't guardChecks(g, arg.asExpr(), outcome) and putting them in an inline late predicate. I wasn't sure what to use as the bindingset so I used all the variables. That fixed the join problem.

Before:
```
Evaluated recursive predicate DataFlowUtil::BarrierGuard<TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard>::guardingFunction/5#f413785b@124c4xve in 1ms on iteration 1 (delta size: 0).
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard>::guardingFunction/5#f413785b@124c4xve on iteration 1 running pipeline base with tuple counts:
        175394   ~1%    {4} r1 = JOIN `_Properties::Property.checkOn/3#dispred#43ad13f2_num#Properties::IsBoolean#d0c3641f#shared` WITH num#Properties::IsBoolean#d0c3641f ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Rhs.1
          2385   ~0%    {6}    | JOIN WITH `DataFlowUtil::getUniqueOutputNode/2#05007054_201#join_rhs` ON FIRST 1 OUTPUT Rhs.2, Rhs.1, Lhs.0, Lhs.1, Lhs.2, Lhs.3
          2385   ~0%    {5}    | JOIN WITH `FunctionInputsAndOutputs::FunctionOutput.getEntryNode/1#dispred#e470844c` ON FIRST 3 OUTPUT Lhs.1, Lhs.3, Lhs.4, Lhs.5, Lhs.0
          2385   ~5%    {6}    | JOIN WITH `Scopes::DeclaredFunction.getFuncDecl/0#dispred#657c96f0_10#join_rhs` ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.0, Lhs.4, Rhs.1
             0   ~0%    {6}    | JOIN WITH `TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard/3#e445654a_021#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                    
             0   ~0%    {6} r2 = JOIN r1 WITH DataFlowUtil::ExprNode#9f54f090_20#join_rhs ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Lhs.4, Lhs.5
                    
             0   ~0%    {6} r3 = JOIN r1 WITH DataFlowUtil::ExprNode#9f54f090_20#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
             0   ~0%    {6}    | JOIN WITH `#DataFlowUtil::localFlowStep/2#edbc0f9aPlus#swapped` ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.1, Lhs.2, Lhs.4, Lhs.5
                    
             0   ~0%    {6} r4 = r2 UNION r3
             0   ~0%    {5}    | JOIN WITH `FunctionInputsAndOutputs::FunctionInput.getExitNode/1#dispred#f3d2cd98_120#join_rhs` ON FIRST 2 OUTPUT Lhs.2, Lhs.5, Rhs.2, Lhs.4, Lhs.3
                        return r4
```
After:
```
Evaluated recursive predicate DataFlowUtil::BarrierGuard<TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard>::guardingFunction/5#f413785b@41fc6xau in 0ms on iteration 1 (delta size: 0).
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard>::guardingFunction/5#f413785b@41fc6xau on iteration 1 running pipeline base with tuple counts:
          60  ~0%    {6} r1 = JOIN `_#DataFlowUtil::localFlowStep/2#edbc0f9aPlus_DataFlowUtil::ExprNode#9f54f090_FunctionInputsAndOutput__#shared` WITH `TaintTrackingUtil::listOfConstantsComparisonSanitizerGuard/3#e445654a_102#join_rhs` ON FIRST 1 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.4, Rhs.1, Rhs.2
        1132  ~4%    {8}    | JOIN WITH `FunctionInputsAndOutputs::FunctionOutput.getEntryNode/1#dispred#e470844c_102#join_rhs` ON FIRST 1 OUTPUT Lhs.0, Rhs.1, Rhs.2, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
           0  ~0%    {7}    | JOIN WITH `DataFlowUtil::getUniqueOutputNode/2#05007054` ON FIRST 3 OUTPUT Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.1, Lhs.2
           0  ~0%    {8}    | JOIN WITH num#Properties::IsBoolean#d0c3641f_10#join_rhs ON FIRST 1 OUTPUT Lhs.6, Rhs.1, Lhs.3, Lhs.0, Lhs.1, Lhs.2, Lhs.4, Lhs.5
           0  ~0%    {7}    | JOIN WITH `Properties::Property.checkOn/3#dispred#43ad13f2_1230#join_rhs` ON FIRST 3 OUTPUT Lhs.6, Rhs.3, Lhs.3, Lhs.4, Lhs.5, Lhs.2, Lhs.7
           0  ~0%    {5}    | JOIN WITH num#Properties::IsBoolean#d0c3641f ON FIRST 2 OUTPUT Lhs.5, Lhs.3, Lhs.4, Lhs.6, Lhs.2
                     return r1
```