### PR TITLE
Rust: make ql tests extract files together

### DIFF
--- a/rust/ql/test/.gitignore
+++ b/rust/ql/test/.gitignore
@@ -1,3 +1,4 @@
 Cargo.toml
 Cargo.lock
+lib.rs
 target/

--- a/rust/ql/test/extractor-tests/generated/File/File.expected
+++ b/rust/ql/test/extractor-tests/generated/File/File.expected
@@ -1,1 +1,2 @@
+| lib.rs:0:0:0:0 | lib.rs | DbFile | getName: | lib.rs |
 | test.rs:0:0:0:0 | test.rs | DbFile | getName: | test.rs |

--- a/rust/tools/qltest.sh
+++ b/rust/tools/qltest.sh
@@ -7,26 +7,20 @@ export RUST_BACKTRACE=full
 QLTEST_LOG="$CODEQL_EXTRACTOR_RUST_LOG_DIR"/qltest.log
 
 EXTRACTOR="$CODEQL_EXTRACTOR_RUST_ROOT/tools/$CODEQL_PLATFORM/extractor"
+echo > lib.rs
 for src in *.rs; do
-  echo -e "[workspace]\n\n[package]\nname = \"test\"\nversion=\"0.0.1\"\n[lib]\npath=\"$src\"\n" > Cargo.toml
-  env=()
-  opts=("$src")
-  opts+=($(sed -n '1 s=//codeql-extractor-options:==p' $src))
-  expected_status=$(sed -n 's=//codeql-extractor-expected-status:[[:space:]]*==p' $src)
-  expected_status=${expected_status:-0}
-  env+=($(sed -n '1 s=//codeql-extractor-env:==p' $src))
-  echo >> $QLTEST_LOG
-  echo "env ${env[@]} $EXTRACTOR ${opts[@]}" >> "$QLTEST_LOG"
-  env "${env[@]}" "$EXTRACTOR" "${opts[@]}" >> $QLTEST_LOG 2>&1
-  actual_status=$?
-  if [[ $actual_status != $expected_status ]]; then
-    FAILED=1
-  fi
+  echo "mod ${src%.rs};" >> lib.rs
 done
-
-rm -rf Cargo.*
-
-if [ -n "$FAILED" ]; then
+cat > Cargo.toml << EOF
+[workspace]
+[package]
+name = "test"
+version="0.0.1"
+[lib]
+path="lib.rs"
+EOF
+"$EXTRACTOR" *.rs >> "$QLTEST_LOG"
+if [[ "$?" != 0 ]]; then
   cat "$QLTEST_LOG" # Show compiler errors on extraction failure
   exit 1
 fi

--- a/rust/tools/qltest.sh
+++ b/rust/tools/qltest.sh
@@ -16,6 +16,7 @@ cat > Cargo.toml << EOF
 [package]
 name = "test"
 version="0.0.1"
+edition="2021"
 [lib]
 path="lib.rs"
 EOF


### PR DESCRIPTION
For the moment this removes the possibility to set custom flags or env variables for the extractor via comments, but that can be added back easily if needed with a different mechanism (like an `env` file).
