### PR TITLE
Rust: Add query suites

### DIFF
--- a/rust/ql/src/codeql-suites/rust-code-scanning.qls
+++ b/rust/ql/src/codeql-suites/rust-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for Rust
+- queries: .
+- apply: code-scanning-selectors.yml
+  from: codeql/suite-helpers

--- a/rust/ql/src/codeql-suites/rust-security-and-quality.qls
+++ b/rust/ql/src/codeql-suites/rust-security-and-quality.qls
@@ -1,0 +1,4 @@
+- description: Security-and-quality queries for Rust
+- queries: .
+- apply: security-and-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/rust/ql/src/codeql-suites/rust-security-experimental.qls
+++ b/rust/ql/src/codeql-suites/rust-security-experimental.qls
@@ -1,0 +1,4 @@
+- description: Extended and experimental security queries for Rust
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers

--- a/rust/ql/src/codeql-suites/rust-security-extended.qls
+++ b/rust/ql/src/codeql-suites/rust-security-extended.qls
@@ -1,0 +1,4 @@
+- description: Security-extended queries for Rust
+- queries: .
+- apply: security-extended-selectors.yml
+  from: codeql/suite-helpers


### PR DESCRIPTION
Add the core query suite `.qls` files for Rust.