### PR TITLE
C#: Extract attributes on indexers.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
@@ -51,6 +51,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 }
             }
 
+            PopulateAttributes();
             PopulateModifiers(trapFile);
             BindComments();
 

--- a/csharp/ql/lib/change-notes/2024-09-16-indexer-attributes.md
+++ b/csharp/ql/lib/change-notes/2024-09-16-indexer-attributes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C#: Add extractor support for attributes on indexers.

--- a/csharp/ql/test/library-tests/attributes/AttributeArguments.expected
+++ b/csharp/ql/test/library-tests/attributes/AttributeArguments.expected
@@ -82,32 +82,33 @@ arguments
 | attributes.cs:102:8:102:19 | [My3(...)] | 0 | attributes.cs:102:21:102:21 | 4 |
 | attributes.cs:107:6:107:17 | [My3(...)] | 0 | attributes.cs:107:19:107:19 | 5 |
 | attributes.cs:108:14:108:25 | [return: My3(...)] | 0 | attributes.cs:108:27:108:27 | 6 |
-| attributes.cs:113:10:113:21 | [My3(...)] | 0 | attributes.cs:113:23:113:23 | 7 |
-| attributes.cs:114:18:114:29 | [return: My3(...)] | 0 | attributes.cs:114:31:114:31 | 8 |
-| attributes.cs:117:18:117:29 | [My3(...)] | 0 | attributes.cs:117:31:117:31 | 9 |
-| attributes.cs:118:17:118:28 | [My3(...)] | 0 | attributes.cs:118:30:118:31 | 10 |
-| attributes.cs:125:18:125:29 | [My3(...)] | 0 | attributes.cs:125:31:125:32 | 11 |
-| attributes.cs:126:18:126:29 | [return: My3(...)] | 0 | attributes.cs:126:31:126:32 | 12 |
-| attributes.cs:129:10:129:21 | [My3(...)] | 0 | attributes.cs:129:23:129:24 | 13 |
-| attributes.cs:130:17:130:28 | [My3(...)] | 0 | attributes.cs:130:30:130:31 | 14 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 0 | attributes.cs:142:13:142:15 | "a" |
-| attributes.cs:142:6:142:11 | [Params(...)] | 1 | attributes.cs:142:18:142:20 | "b" |
-| attributes.cs:142:6:142:11 | [Params(...)] | 2 | attributes.cs:142:23:142:23 | 1 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 3 | attributes.cs:142:26:142:26 | 2 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 4 | attributes.cs:142:29:142:29 | 3 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 0 | attributes.cs:145:17:145:19 | "a" |
-| attributes.cs:145:6:145:11 | [Params(...)] | 1 | attributes.cs:145:26:145:28 | "b" |
-| attributes.cs:145:6:145:11 | [Params(...)] | 2 | attributes.cs:145:31:145:31 | 1 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 3 | attributes.cs:145:34:145:34 | 2 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 4 | attributes.cs:145:37:145:37 | 3 |
-| attributes.cs:148:6:148:11 | [Params(...)] | 0 | attributes.cs:148:35:148:37 | "a" |
-| attributes.cs:148:6:148:11 | [Params(...)] | 1 | attributes.cs:148:26:148:28 | "b" |
-| attributes.cs:148:6:148:11 | [Params(...)] | 2 | attributes.cs:148:19:148:19 | 1 |
-| attributes.cs:151:6:151:11 | [Params(...)] | 0 | attributes.cs:151:45:151:47 | "a" |
-| attributes.cs:151:6:151:11 | [Params(...)] | 1 | attributes.cs:151:36:151:38 | "b" |
-| attributes.cs:151:6:151:11 | [Params(...)] | 2 | attributes.cs:151:19:151:29 | array creation of type Int32[] |
-| attributes.cs:155:2:155:13 | [Experimental(...)] | 0 | attributes.cs:155:15:155:37 | "MyExperimentalClassId" |
-| attributes.cs:158:6:158:17 | [Experimental(...)] | 0 | attributes.cs:158:19:158:42 | "MyExperimentalMethodId" |
+| attributes.cs:114:10:114:21 | [My3(...)] | 0 | attributes.cs:114:23:114:23 | 7 |
+| attributes.cs:115:18:115:29 | [return: My3(...)] | 0 | attributes.cs:115:31:115:31 | 8 |
+| attributes.cs:118:18:118:29 | [My3(...)] | 0 | attributes.cs:118:31:118:31 | 9 |
+| attributes.cs:119:17:119:28 | [My3(...)] | 0 | attributes.cs:119:30:119:31 | 10 |
+| attributes.cs:124:6:124:17 | [My3(...)] | 0 | attributes.cs:124:19:124:20 | 16 |
+| attributes.cs:127:18:127:29 | [My3(...)] | 0 | attributes.cs:127:31:127:32 | 11 |
+| attributes.cs:128:18:128:29 | [return: My3(...)] | 0 | attributes.cs:128:31:128:32 | 12 |
+| attributes.cs:131:10:131:21 | [My3(...)] | 0 | attributes.cs:131:23:131:24 | 13 |
+| attributes.cs:132:17:132:28 | [My3(...)] | 0 | attributes.cs:132:30:132:31 | 14 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 0 | attributes.cs:144:13:144:15 | "a" |
+| attributes.cs:144:6:144:11 | [Params(...)] | 1 | attributes.cs:144:18:144:20 | "b" |
+| attributes.cs:144:6:144:11 | [Params(...)] | 2 | attributes.cs:144:23:144:23 | 1 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 3 | attributes.cs:144:26:144:26 | 2 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 4 | attributes.cs:144:29:144:29 | 3 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 0 | attributes.cs:147:17:147:19 | "a" |
+| attributes.cs:147:6:147:11 | [Params(...)] | 1 | attributes.cs:147:26:147:28 | "b" |
+| attributes.cs:147:6:147:11 | [Params(...)] | 2 | attributes.cs:147:31:147:31 | 1 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 3 | attributes.cs:147:34:147:34 | 2 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 4 | attributes.cs:147:37:147:37 | 3 |
+| attributes.cs:150:6:150:11 | [Params(...)] | 0 | attributes.cs:150:35:150:37 | "a" |
+| attributes.cs:150:6:150:11 | [Params(...)] | 1 | attributes.cs:150:26:150:28 | "b" |
+| attributes.cs:150:6:150:11 | [Params(...)] | 2 | attributes.cs:150:19:150:19 | 1 |
+| attributes.cs:153:6:153:11 | [Params(...)] | 0 | attributes.cs:153:45:153:47 | "a" |
+| attributes.cs:153:6:153:11 | [Params(...)] | 1 | attributes.cs:153:36:153:38 | "b" |
+| attributes.cs:153:6:153:11 | [Params(...)] | 2 | attributes.cs:153:19:153:29 | array creation of type Int32[] |
+| attributes.cs:157:2:157:13 | [Experimental(...)] | 0 | attributes.cs:157:15:157:37 | "MyExperimentalClassId" |
+| attributes.cs:160:6:160:17 | [Experimental(...)] | 0 | attributes.cs:160:19:160:42 | "MyExperimentalMethodId" |
 constructorArguments
 | Assembly1.dll:0:0:0:0 | [Custom(...)] | 0 | Assembly1.dll:0:0:0:0 | 1 |
 | Assembly1.dll:0:0:0:0 | [Custom(...)] | 0 | Assembly1.dll:0:0:0:0 | 3 |
@@ -180,32 +181,33 @@ constructorArguments
 | attributes.cs:102:8:102:19 | [My3(...)] | 0 | attributes.cs:102:21:102:21 | 4 |
 | attributes.cs:107:6:107:17 | [My3(...)] | 0 | attributes.cs:107:19:107:19 | 5 |
 | attributes.cs:108:14:108:25 | [return: My3(...)] | 0 | attributes.cs:108:27:108:27 | 6 |
-| attributes.cs:113:10:113:21 | [My3(...)] | 0 | attributes.cs:113:23:113:23 | 7 |
-| attributes.cs:114:18:114:29 | [return: My3(...)] | 0 | attributes.cs:114:31:114:31 | 8 |
-| attributes.cs:117:18:117:29 | [My3(...)] | 0 | attributes.cs:117:31:117:31 | 9 |
-| attributes.cs:118:17:118:28 | [My3(...)] | 0 | attributes.cs:118:30:118:31 | 10 |
-| attributes.cs:125:18:125:29 | [My3(...)] | 0 | attributes.cs:125:31:125:32 | 11 |
-| attributes.cs:126:18:126:29 | [return: My3(...)] | 0 | attributes.cs:126:31:126:32 | 12 |
-| attributes.cs:129:10:129:21 | [My3(...)] | 0 | attributes.cs:129:23:129:24 | 13 |
-| attributes.cs:130:17:130:28 | [My3(...)] | 0 | attributes.cs:130:30:130:31 | 14 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 0 | attributes.cs:142:13:142:15 | "a" |
-| attributes.cs:142:6:142:11 | [Params(...)] | 1 | attributes.cs:142:18:142:20 | "b" |
-| attributes.cs:142:6:142:11 | [Params(...)] | 2 | attributes.cs:142:23:142:23 | 1 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 3 | attributes.cs:142:26:142:26 | 2 |
-| attributes.cs:142:6:142:11 | [Params(...)] | 4 | attributes.cs:142:29:142:29 | 3 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 0 | attributes.cs:145:17:145:19 | "a" |
-| attributes.cs:145:6:145:11 | [Params(...)] | 1 | attributes.cs:145:26:145:28 | "b" |
-| attributes.cs:145:6:145:11 | [Params(...)] | 2 | attributes.cs:145:31:145:31 | 1 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 3 | attributes.cs:145:34:145:34 | 2 |
-| attributes.cs:145:6:145:11 | [Params(...)] | 4 | attributes.cs:145:37:145:37 | 3 |
-| attributes.cs:148:6:148:11 | [Params(...)] | 0 | attributes.cs:148:35:148:37 | "a" |
-| attributes.cs:148:6:148:11 | [Params(...)] | 1 | attributes.cs:148:26:148:28 | "b" |
-| attributes.cs:148:6:148:11 | [Params(...)] | 2 | attributes.cs:148:19:148:19 | 1 |
-| attributes.cs:151:6:151:11 | [Params(...)] | 0 | attributes.cs:151:45:151:47 | "a" |
-| attributes.cs:151:6:151:11 | [Params(...)] | 1 | attributes.cs:151:36:151:38 | "b" |
-| attributes.cs:151:6:151:11 | [Params(...)] | 2 | attributes.cs:151:19:151:29 | array creation of type Int32[] |
-| attributes.cs:155:2:155:13 | [Experimental(...)] | 0 | attributes.cs:155:15:155:37 | "MyExperimentalClassId" |
-| attributes.cs:158:6:158:17 | [Experimental(...)] | 0 | attributes.cs:158:19:158:42 | "MyExperimentalMethodId" |
+| attributes.cs:114:10:114:21 | [My3(...)] | 0 | attributes.cs:114:23:114:23 | 7 |
+| attributes.cs:115:18:115:29 | [return: My3(...)] | 0 | attributes.cs:115:31:115:31 | 8 |
+| attributes.cs:118:18:118:29 | [My3(...)] | 0 | attributes.cs:118:31:118:31 | 9 |
+| attributes.cs:119:17:119:28 | [My3(...)] | 0 | attributes.cs:119:30:119:31 | 10 |
+| attributes.cs:124:6:124:17 | [My3(...)] | 0 | attributes.cs:124:19:124:20 | 16 |
+| attributes.cs:127:18:127:29 | [My3(...)] | 0 | attributes.cs:127:31:127:32 | 11 |
+| attributes.cs:128:18:128:29 | [return: My3(...)] | 0 | attributes.cs:128:31:128:32 | 12 |
+| attributes.cs:131:10:131:21 | [My3(...)] | 0 | attributes.cs:131:23:131:24 | 13 |
+| attributes.cs:132:17:132:28 | [My3(...)] | 0 | attributes.cs:132:30:132:31 | 14 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 0 | attributes.cs:144:13:144:15 | "a" |
+| attributes.cs:144:6:144:11 | [Params(...)] | 1 | attributes.cs:144:18:144:20 | "b" |
+| attributes.cs:144:6:144:11 | [Params(...)] | 2 | attributes.cs:144:23:144:23 | 1 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 3 | attributes.cs:144:26:144:26 | 2 |
+| attributes.cs:144:6:144:11 | [Params(...)] | 4 | attributes.cs:144:29:144:29 | 3 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 0 | attributes.cs:147:17:147:19 | "a" |
+| attributes.cs:147:6:147:11 | [Params(...)] | 1 | attributes.cs:147:26:147:28 | "b" |
+| attributes.cs:147:6:147:11 | [Params(...)] | 2 | attributes.cs:147:31:147:31 | 1 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 3 | attributes.cs:147:34:147:34 | 2 |
+| attributes.cs:147:6:147:11 | [Params(...)] | 4 | attributes.cs:147:37:147:37 | 3 |
+| attributes.cs:150:6:150:11 | [Params(...)] | 0 | attributes.cs:150:35:150:37 | "a" |
+| attributes.cs:150:6:150:11 | [Params(...)] | 1 | attributes.cs:150:26:150:28 | "b" |
+| attributes.cs:150:6:150:11 | [Params(...)] | 2 | attributes.cs:150:19:150:19 | 1 |
+| attributes.cs:153:6:153:11 | [Params(...)] | 0 | attributes.cs:153:45:153:47 | "a" |
+| attributes.cs:153:6:153:11 | [Params(...)] | 1 | attributes.cs:153:36:153:38 | "b" |
+| attributes.cs:153:6:153:11 | [Params(...)] | 2 | attributes.cs:153:19:153:29 | array creation of type Int32[] |
+| attributes.cs:157:2:157:13 | [Experimental(...)] | 0 | attributes.cs:157:15:157:37 | "MyExperimentalClassId" |
+| attributes.cs:160:6:160:17 | [Experimental(...)] | 0 | attributes.cs:160:19:160:42 | "MyExperimentalMethodId" |
 namedArguments
 | Assembly1.dll:0:0:0:0 | [Custom(...)] | Prop2 | Assembly1.dll:0:0:0:0 | array creation of type Object[] |
 | Assembly1.dll:0:0:0:0 | [Custom(...)] | Prop2 | Assembly1.dll:0:0:0:0 | array creation of type Object[] |

--- a/csharp/ql/test/library-tests/attributes/AttributeArguments.expected
+++ b/csharp/ql/test/library-tests/attributes/AttributeArguments.expected
@@ -82,6 +82,7 @@ arguments
 | attributes.cs:102:8:102:19 | [My3(...)] | 0 | attributes.cs:102:21:102:21 | 4 |
 | attributes.cs:107:6:107:17 | [My3(...)] | 0 | attributes.cs:107:19:107:19 | 5 |
 | attributes.cs:108:14:108:25 | [return: My3(...)] | 0 | attributes.cs:108:27:108:27 | 6 |
+| attributes.cs:111:6:111:17 | [My3(...)] | 0 | attributes.cs:111:19:111:20 | 15 |
 | attributes.cs:114:10:114:21 | [My3(...)] | 0 | attributes.cs:114:23:114:23 | 7 |
 | attributes.cs:115:18:115:29 | [return: My3(...)] | 0 | attributes.cs:115:31:115:31 | 8 |
 | attributes.cs:118:18:118:29 | [My3(...)] | 0 | attributes.cs:118:31:118:31 | 9 |
@@ -181,6 +182,7 @@ constructorArguments
 | attributes.cs:102:8:102:19 | [My3(...)] | 0 | attributes.cs:102:21:102:21 | 4 |
 | attributes.cs:107:6:107:17 | [My3(...)] | 0 | attributes.cs:107:19:107:19 | 5 |
 | attributes.cs:108:14:108:25 | [return: My3(...)] | 0 | attributes.cs:108:27:108:27 | 6 |
+| attributes.cs:111:6:111:17 | [My3(...)] | 0 | attributes.cs:111:19:111:20 | 15 |
 | attributes.cs:114:10:114:21 | [My3(...)] | 0 | attributes.cs:114:23:114:23 | 7 |
 | attributes.cs:115:18:115:29 | [return: My3(...)] | 0 | attributes.cs:115:31:115:31 | 8 |
 | attributes.cs:118:18:118:29 | [My3(...)] | 0 | attributes.cs:118:31:118:31 | 9 |

--- a/csharp/ql/test/library-tests/attributes/AttributeElements.expected
+++ b/csharp/ql/test/library-tests/attributes/AttributeElements.expected
@@ -24,6 +24,7 @@
 | attributes.cs:103:17:103:27 | My2Delegate | attributes.cs:102:8:102:19 | [My3(...)] | My3Attribute |
 | attributes.cs:109:32:109:32 | + | attributes.cs:107:6:107:17 | [My3(...)] | My3Attribute |
 | attributes.cs:109:32:109:32 | + | attributes.cs:108:14:108:25 | [return: My3(...)] | My3Attribute |
+| attributes.cs:112:16:112:19 | Item | attributes.cs:111:6:111:17 | [My3(...)] | My3Attribute |
 | attributes.cs:116:9:116:11 | get_Item | attributes.cs:114:10:114:21 | [My3(...)] | My3Attribute |
 | attributes.cs:116:9:116:11 | get_Item | attributes.cs:115:18:115:29 | [return: My3(...)] | My3Attribute |
 | attributes.cs:120:9:120:11 | set_Item | attributes.cs:118:18:118:29 | [My3(...)] | My3Attribute |

--- a/csharp/ql/test/library-tests/attributes/AttributeElements.expected
+++ b/csharp/ql/test/library-tests/attributes/AttributeElements.expected
@@ -24,20 +24,21 @@
 | attributes.cs:103:17:103:27 | My2Delegate | attributes.cs:102:8:102:19 | [My3(...)] | My3Attribute |
 | attributes.cs:109:32:109:32 | + | attributes.cs:107:6:107:17 | [My3(...)] | My3Attribute |
 | attributes.cs:109:32:109:32 | + | attributes.cs:108:14:108:25 | [return: My3(...)] | My3Attribute |
-| attributes.cs:115:9:115:11 | get_Item | attributes.cs:113:10:113:21 | [My3(...)] | My3Attribute |
-| attributes.cs:115:9:115:11 | get_Item | attributes.cs:114:18:114:29 | [return: My3(...)] | My3Attribute |
-| attributes.cs:119:9:119:11 | set_Item | attributes.cs:117:18:117:29 | [My3(...)] | My3Attribute |
-| attributes.cs:119:9:119:11 | value | attributes.cs:118:17:118:28 | [My3(...)] | My3Attribute |
-| attributes.cs:127:9:127:11 | get_Prop1 | attributes.cs:125:18:125:29 | [My3(...)] | My3Attribute |
-| attributes.cs:127:9:127:11 | get_Prop1 | attributes.cs:126:18:126:29 | [return: My3(...)] | My3Attribute |
-| attributes.cs:131:9:131:11 | set_Prop1 | attributes.cs:129:10:129:21 | [My3(...)] | My3Attribute |
-| attributes.cs:131:9:131:11 | value | attributes.cs:130:17:130:28 | [My3(...)] | My3Attribute |
-| attributes.cs:143:17:143:18 | M1 | attributes.cs:142:6:142:11 | [Params(...)] | Class1+ParamsAttribute |
-| attributes.cs:146:17:146:18 | M2 | attributes.cs:145:6:145:11 | [Params(...)] | Class1+ParamsAttribute |
-| attributes.cs:149:17:149:18 | M3 | attributes.cs:148:6:148:11 | [Params(...)] | Class1+ParamsAttribute |
-| attributes.cs:152:17:152:18 | M4 | attributes.cs:151:6:151:11 | [Params(...)] | Class1+ParamsAttribute |
-| attributes.cs:156:14:156:32 | MyExperimentalClass | attributes.cs:155:2:155:13 | [Experimental(...)] | System.Diagnostics.CodeAnalysis.ExperimentalAttribute |
-| attributes.cs:159:17:159:36 | MyExperimentalMethod | attributes.cs:158:6:158:17 | [Experimental(...)] | System.Diagnostics.CodeAnalysis.ExperimentalAttribute |
+| attributes.cs:116:9:116:11 | get_Item | attributes.cs:114:10:114:21 | [My3(...)] | My3Attribute |
+| attributes.cs:116:9:116:11 | get_Item | attributes.cs:115:18:115:29 | [return: My3(...)] | My3Attribute |
+| attributes.cs:120:9:120:11 | set_Item | attributes.cs:118:18:118:29 | [My3(...)] | My3Attribute |
+| attributes.cs:120:9:120:11 | value | attributes.cs:119:17:119:28 | [My3(...)] | My3Attribute |
+| attributes.cs:125:16:125:20 | Prop1 | attributes.cs:124:6:124:17 | [My3(...)] | My3Attribute |
+| attributes.cs:129:9:129:11 | get_Prop1 | attributes.cs:127:18:127:29 | [My3(...)] | My3Attribute |
+| attributes.cs:129:9:129:11 | get_Prop1 | attributes.cs:128:18:128:29 | [return: My3(...)] | My3Attribute |
+| attributes.cs:133:9:133:11 | set_Prop1 | attributes.cs:131:10:131:21 | [My3(...)] | My3Attribute |
+| attributes.cs:133:9:133:11 | value | attributes.cs:132:17:132:28 | [My3(...)] | My3Attribute |
+| attributes.cs:145:17:145:18 | M1 | attributes.cs:144:6:144:11 | [Params(...)] | Class1+ParamsAttribute |
+| attributes.cs:148:17:148:18 | M2 | attributes.cs:147:6:147:11 | [Params(...)] | Class1+ParamsAttribute |
+| attributes.cs:151:17:151:18 | M3 | attributes.cs:150:6:150:11 | [Params(...)] | Class1+ParamsAttribute |
+| attributes.cs:154:17:154:18 | M4 | attributes.cs:153:6:153:11 | [Params(...)] | Class1+ParamsAttribute |
+| attributes.cs:158:14:158:32 | MyExperimentalClass | attributes.cs:157:2:157:13 | [Experimental(...)] | System.Diagnostics.CodeAnalysis.ExperimentalAttribute |
+| attributes.cs:161:17:161:36 | MyExperimentalMethod | attributes.cs:160:6:160:17 | [Experimental(...)] | System.Diagnostics.CodeAnalysis.ExperimentalAttribute |
 | attributes.dll:0:0:0:0 | attributes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | attributes.cs:11:12:11:24 | [assembly: AssemblyTitle(...)] | System.Reflection.AssemblyTitleAttribute |
 | attributes.dll:0:0:0:0 | attributes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | attributes.cs:12:12:12:30 | [assembly: AssemblyDescription(...)] | System.Reflection.AssemblyDescriptionAttribute |
 | attributes.dll:0:0:0:0 | attributes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null | attributes.cs:13:12:13:32 | [assembly: AssemblyConfiguration(...)] | System.Reflection.AssemblyConfigurationAttribute |

--- a/csharp/ql/test/library-tests/attributes/ExperimentalAttributes.expected
+++ b/csharp/ql/test/library-tests/attributes/ExperimentalAttributes.expected
@@ -1,2 +1,2 @@
-| attributes.cs:156:14:156:32 | MyExperimentalClass | attributes.cs:155:2:155:13 | [Experimental(...)] | MyExperimentalClassId |
-| attributes.cs:159:17:159:36 | MyExperimentalMethod | attributes.cs:158:6:158:17 | [Experimental(...)] | MyExperimentalMethodId |
+| attributes.cs:158:14:158:32 | MyExperimentalClass | attributes.cs:157:2:157:13 | [Experimental(...)] | MyExperimentalClassId |
+| attributes.cs:161:17:161:36 | MyExperimentalMethod | attributes.cs:160:6:160:17 | [Experimental(...)] | MyExperimentalMethodId |

--- a/csharp/ql/test/library-tests/attributes/PrintAst.expected
+++ b/csharp/ql/test/library-tests/attributes/PrintAst.expected
@@ -338,136 +338,140 @@ attributes.cs:
 #  109|       1: [Parameter] b
 #  109|         -1: [TypeMention] MyAttributeUsage
 #  109|     4: [IntLiteral] 0
-#  111|   6: [Indexer] Item
-#  111|     -1: [TypeMention] int
+#  112|   6: [Indexer] Item
+#  112|     -1: [TypeMention] int
 #-----|     1: (Parameters)
-#  111|       0: [Parameter] x
-#  111|         -1: [TypeMention] int
-#  115|     3: [Getter] get_Item
+#  112|       0: [Parameter] x
+#  112|         -1: [TypeMention] int
+#  116|     3: [Getter] get_Item
 #-----|       0: (Attributes)
-#  113|         1: [DefaultAttribute] [My3(...)]
-#  113|           -1: [TypeMention] My3Attribute
-#  113|           0: [IntLiteral] 7
-#  114|         2: [ReturnAttribute] [return: My3(...)]
+#  114|         1: [DefaultAttribute] [My3(...)]
 #  114|           -1: [TypeMention] My3Attribute
-#  114|           0: [IntLiteral] 8
+#  114|           0: [IntLiteral] 7
+#  115|         2: [ReturnAttribute] [return: My3(...)]
+#  115|           -1: [TypeMention] My3Attribute
+#  115|           0: [IntLiteral] 8
 #-----|       2: (Parameters)
-#  111|         0: [Parameter] x
-#  115|       4: [BlockStmt] {...}
-#  115|         0: [ReturnStmt] return ...;
-#  115|           0: [AddExpr] ... + ...
-#  115|             0: [ParameterAccess] access to parameter x
-#  115|             1: [IntLiteral] 1
-#  119|     4: [Setter] set_Item
+#  112|         0: [Parameter] x
+#  116|       4: [BlockStmt] {...}
+#  116|         0: [ReturnStmt] return ...;
+#  116|           0: [AddExpr] ... + ...
+#  116|             0: [ParameterAccess] access to parameter x
+#  116|             1: [IntLiteral] 1
+#  120|     4: [Setter] set_Item
 #-----|       0: (Attributes)
-#  117|         1: [DefaultAttribute] [My3(...)]
-#  117|           -1: [TypeMention] My3Attribute
-#  117|           0: [IntLiteral] 9
+#  118|         1: [DefaultAttribute] [My3(...)]
+#  118|           -1: [TypeMention] My3Attribute
+#  118|           0: [IntLiteral] 9
 #-----|       2: (Parameters)
-#  111|         0: [Parameter] x
-#  119|         1: [Parameter] value
+#  112|         0: [Parameter] x
+#  120|         1: [Parameter] value
 #-----|           0: (Attributes)
-#  118|             1: [DefaultAttribute] [My3(...)]
-#  118|               -1: [TypeMention] My3Attribute
-#  118|               0: [IntLiteral] 10
-#  119|       4: [BlockStmt] {...}
-#  119|         0: [ReturnStmt] return ...;
-#  122|   7: [Field] p
-#  122|     -1: [TypeMention] int
-#  123|   8: [Property] Prop1
+#  119|             1: [DefaultAttribute] [My3(...)]
+#  119|               -1: [TypeMention] My3Attribute
+#  119|               0: [IntLiteral] 10
+#  120|       4: [BlockStmt] {...}
+#  120|         0: [ReturnStmt] return ...;
+#  123|   7: [Field] p
 #  123|     -1: [TypeMention] int
-#  127|     3: [Getter] get_Prop1
+#  125|   8: [Property] Prop1
+#  125|     -1: [TypeMention] int
+#-----|     0: (Attributes)
+#  124|       1: [DefaultAttribute] [My3(...)]
+#  124|         -1: [TypeMention] My3Attribute
+#  124|         0: [IntLiteral] 16
+#  129|     3: [Getter] get_Prop1
 #-----|       0: (Attributes)
-#  125|         1: [DefaultAttribute] [My3(...)]
-#  125|           -1: [TypeMention] My3Attribute
-#  125|           0: [IntLiteral] 11
-#  126|         2: [ReturnAttribute] [return: My3(...)]
-#  126|           -1: [TypeMention] My3Attribute
-#  126|           0: [IntLiteral] 12
-#  127|       4: [BlockStmt] {...}
-#  127|         0: [ReturnStmt] return ...;
-#  127|           0: [FieldAccess] access to field p
-#  131|     4: [Setter] set_Prop1
+#  127|         1: [DefaultAttribute] [My3(...)]
+#  127|           -1: [TypeMention] My3Attribute
+#  127|           0: [IntLiteral] 11
+#  128|         2: [ReturnAttribute] [return: My3(...)]
+#  128|           -1: [TypeMention] My3Attribute
+#  128|           0: [IntLiteral] 12
+#  129|       4: [BlockStmt] {...}
+#  129|         0: [ReturnStmt] return ...;
+#  129|           0: [FieldAccess] access to field p
+#  133|     4: [Setter] set_Prop1
 #-----|       0: (Attributes)
-#  129|         1: [DefaultAttribute] [My3(...)]
-#  129|           -1: [TypeMention] My3Attribute
-#  129|           0: [IntLiteral] 13
+#  131|         1: [DefaultAttribute] [My3(...)]
+#  131|           -1: [TypeMention] My3Attribute
+#  131|           0: [IntLiteral] 13
 #-----|       2: (Parameters)
-#  131|         0: [Parameter] value
+#  133|         0: [Parameter] value
 #-----|           0: (Attributes)
-#  130|             1: [DefaultAttribute] [My3(...)]
-#  130|               -1: [TypeMention] My3Attribute
-#  130|               0: [IntLiteral] 14
-#  131|       4: [BlockStmt] {...}
-#  131|         0: [ExprStmt] ...;
-#  131|           0: [AssignExpr] ... = ...
-#  131|             0: [FieldAccess] access to field p
-#  131|             1: [ParameterAccess] access to parameter value
-#  135| [Class] Class1
-#  137|   5: [Class] ParamsAttribute
+#  132|             1: [DefaultAttribute] [My3(...)]
+#  132|               -1: [TypeMention] My3Attribute
+#  132|               0: [IntLiteral] 14
+#  133|       4: [BlockStmt] {...}
+#  133|         0: [ExprStmt] ...;
+#  133|           0: [AssignExpr] ... = ...
+#  133|             0: [FieldAccess] access to field p
+#  133|             1: [ParameterAccess] access to parameter value
+#  137| [Class] Class1
+#  139|   5: [Class] ParamsAttribute
 #-----|     3: (Base types)
-#  137|       0: [TypeMention] Attribute
-#  139|     4: [InstanceConstructor] ParamsAttribute
+#  139|       0: [TypeMention] Attribute
+#  141|     4: [InstanceConstructor] ParamsAttribute
 #-----|       2: (Parameters)
-#  139|         0: [Parameter] s1
-#  139|           -1: [TypeMention] string
-#  139|         1: [Parameter] s2
-#  139|           -1: [TypeMention] string
-#  139|         2: [Parameter] args
-#  139|           -1: [TypeMention] Int32[]
-#  139|             1: [TypeMention] int
-#  139|       4: [BlockStmt] {...}
-#  143|   6: [Method] M1
-#  143|     -1: [TypeMention] Void
+#  141|         0: [Parameter] s1
+#  141|           -1: [TypeMention] string
+#  141|         1: [Parameter] s2
+#  141|           -1: [TypeMention] string
+#  141|         2: [Parameter] args
+#  141|           -1: [TypeMention] Int32[]
+#  141|             1: [TypeMention] int
+#  141|       4: [BlockStmt] {...}
+#  145|   6: [Method] M1
+#  145|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#  142|       1: [DefaultAttribute] [Params(...)]
-#  142|         -1: [TypeMention] ParamsAttribute
-#  142|         0: [StringLiteralUtf16] "a"
-#  142|         1: [StringLiteralUtf16] "b"
-#  142|         2: [IntLiteral] 1
-#  142|         3: [IntLiteral] 2
-#  142|         4: [IntLiteral] 3
-#  143|     4: [BlockStmt] {...}
-#  146|   7: [Method] M2
-#  146|     -1: [TypeMention] Void
+#  144|       1: [DefaultAttribute] [Params(...)]
+#  144|         -1: [TypeMention] ParamsAttribute
+#  144|         0: [StringLiteralUtf16] "a"
+#  144|         1: [StringLiteralUtf16] "b"
+#  144|         2: [IntLiteral] 1
+#  144|         3: [IntLiteral] 2
+#  144|         4: [IntLiteral] 3
+#  145|     4: [BlockStmt] {...}
+#  148|   7: [Method] M2
+#  148|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#  145|       1: [DefaultAttribute] [Params(...)]
-#  145|         -1: [TypeMention] ParamsAttribute
-#  145|         0: [StringLiteralUtf16] "a"
-#  145|         1: [StringLiteralUtf16] "b"
-#  145|         2: [IntLiteral] 1
-#  145|         3: [IntLiteral] 2
-#  145|         4: [IntLiteral] 3
-#  146|     4: [BlockStmt] {...}
-#  149|   8: [Method] M3
-#  149|     -1: [TypeMention] Void
+#  147|       1: [DefaultAttribute] [Params(...)]
+#  147|         -1: [TypeMention] ParamsAttribute
+#  147|         0: [StringLiteralUtf16] "a"
+#  147|         1: [StringLiteralUtf16] "b"
+#  147|         2: [IntLiteral] 1
+#  147|         3: [IntLiteral] 2
+#  147|         4: [IntLiteral] 3
+#  148|     4: [BlockStmt] {...}
+#  151|   8: [Method] M3
+#  151|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#  148|       1: [DefaultAttribute] [Params(...)]
-#  148|         -1: [TypeMention] ParamsAttribute
-#  148|         0: [StringLiteralUtf16] "a"
-#  148|         1: [StringLiteralUtf16] "b"
-#  148|         2: [IntLiteral] 1
-#  149|     4: [BlockStmt] {...}
-#  152|   9: [Method] M4
-#  152|     -1: [TypeMention] Void
+#  150|       1: [DefaultAttribute] [Params(...)]
+#  150|         -1: [TypeMention] ParamsAttribute
+#  150|         0: [StringLiteralUtf16] "a"
+#  150|         1: [StringLiteralUtf16] "b"
+#  150|         2: [IntLiteral] 1
+#  151|     4: [BlockStmt] {...}
+#  154|   9: [Method] M4
+#  154|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#  151|       1: [DefaultAttribute] [Params(...)]
-#  151|         -1: [TypeMention] ParamsAttribute
-#  151|         0: [StringLiteralUtf16] "a"
-#  151|         1: [StringLiteralUtf16] "b"
-#  151|         2: [ArrayCreation] array creation of type Int32[]
-#  151|           -1: [ArrayInitializer] { ..., ... }
-#  151|             0: [IntLiteral] 1
-#  152|     4: [BlockStmt] {...}
-#  156| [Class] MyExperimentalClass
+#  153|       1: [DefaultAttribute] [Params(...)]
+#  153|         -1: [TypeMention] ParamsAttribute
+#  153|         0: [StringLiteralUtf16] "a"
+#  153|         1: [StringLiteralUtf16] "b"
+#  153|         2: [ArrayCreation] array creation of type Int32[]
+#  153|           -1: [ArrayInitializer] { ..., ... }
+#  153|             0: [IntLiteral] 1
+#  154|     4: [BlockStmt] {...}
+#  158| [Class] MyExperimentalClass
 #-----|   0: (Attributes)
-#  155|     1: [DefaultAttribute] [Experimental(...)]
-#  155|       -1: [TypeMention] ExperimentalAttribute
-#  155|       0: [StringLiteralUtf16] "MyExperimentalClassId"
-#  159|   5: [Method] MyExperimentalMethod
-#  159|     -1: [TypeMention] Void
+#  157|     1: [DefaultAttribute] [Experimental(...)]
+#  157|       -1: [TypeMention] ExperimentalAttribute
+#  157|       0: [StringLiteralUtf16] "MyExperimentalClassId"
+#  161|   5: [Method] MyExperimentalMethod
+#  161|     -1: [TypeMention] Void
 #-----|     0: (Attributes)
-#  158|       1: [DefaultAttribute] [Experimental(...)]
-#  158|         -1: [TypeMention] ExperimentalAttribute
-#  158|         0: [StringLiteralUtf16] "MyExperimentalMethodId"
-#  159|     4: [BlockStmt] {...}
+#  160|       1: [DefaultAttribute] [Experimental(...)]
+#  160|         -1: [TypeMention] ExperimentalAttribute
+#  160|         0: [StringLiteralUtf16] "MyExperimentalMethodId"
+#  161|     4: [BlockStmt] {...}

--- a/csharp/ql/test/library-tests/attributes/PrintAst.expected
+++ b/csharp/ql/test/library-tests/attributes/PrintAst.expected
@@ -340,6 +340,10 @@ attributes.cs:
 #  109|     4: [IntLiteral] 0
 #  112|   6: [Indexer] Item
 #  112|     -1: [TypeMention] int
+#-----|     0: (Attributes)
+#  111|       1: [DefaultAttribute] [My3(...)]
+#  111|         -1: [TypeMention] My3Attribute
+#  111|         0: [IntLiteral] 15
 #-----|     1: (Parameters)
 #  112|       0: [Parameter] x
 #  112|         -1: [TypeMention] int

--- a/csharp/ql/test/library-tests/attributes/attributes.cs
+++ b/csharp/ql/test/library-tests/attributes/attributes.cs
@@ -108,6 +108,7 @@ public class MyAttributeUsage
     [return: My3Attribute(6)]
     public static int operator +(MyAttributeUsage a, MyAttributeUsage b) => 0;
 
+    [My3Attribute(15)]
     public int this[int x]
     {
         [My3Attribute(7)]
@@ -120,6 +121,7 @@ public class MyAttributeUsage
     }
 
     private int p;
+    [My3Attribute(16)]
     public int Prop1
     {
         [method: My3Attribute(11)]


### PR DESCRIPTION
In this PR we add extractor support for attributes on indexers.
With this change we now extract the attribute usage on the example below
```csharp
[Attribute]
public object this[int i] => return null;
```