### PR TITLE
Python: replace `src_archive` exclusion patterns with `*.testproj` ones

### DIFF
--- a/python/ql/test/2/extractor-tests/hidden/options
+++ b/python/ql/test/2/extractor-tests/hidden/options
@@ -1,2 +1,1 @@
-semmle-extractor-options: -R . -p . --filter exclude:**/src_archive/**
-
+semmle-extractor-options: -R . -p . --filter exclude:**/*.testproj/**

--- a/python/ql/test/extractor-tests/exo_path/options
+++ b/python/ql/test/extractor-tests/exo_path/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: --path path1 -p path2 -R . --filter exclude:**/src_archive/**
+semmle-extractor-options: --path path1 -p path2 -R . --filter exclude:**/*.testproj/**

--- a/python/ql/test/extractor-tests/filter-option/options
+++ b/python/ql/test/extractor-tests/filter-option/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -v --filter include:**/*.py --filter exclude:**/*test.py -R .  --filter exclude:**/foo/exclude_this.py   --filter include:**/include*.py --filter exclude:**/src_archive/**
+semmle-extractor-options: -v --filter include:**/*.py --filter exclude:**/*test.py -R .  --filter exclude:**/foo/exclude_this.py   --filter include:**/include*.py --filter exclude:**/*.testproj/**

--- a/python/ql/test/extractor-tests/flags/options
+++ b/python/ql/test/extractor-tests/flags/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . --path no-such-path --filter exclude:**/src_archive/** --respect-init=False --max-context-cost=11 --dont-split-graph
+semmle-extractor-options: -R . --path no-such-path --filter exclude:**/*.testproj/** --respect-init=False --max-context-cost=11 --dont-split-graph

--- a/python/ql/test/extractor-tests/identical_contents/options
+++ b/python/ql/test/extractor-tests/identical_contents/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . --path no-such-path --filter exclude:**/src_archive/**
+semmle-extractor-options: -R . --path no-such-path --filter exclude:**/*.testproj/**

--- a/python/ql/test/extractor-tests/paths/options
+++ b/python/ql/test/extractor-tests/paths/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . -p non-such --filter exclude:**/src_archive/**
+semmle-extractor-options: -R . -p non-such --filter exclude:**/*.testproj/**

--- a/python/ql/test/extractor-tests/thrift/options
+++ b/python/ql/test/extractor-tests/thrift/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . --filter=include:**/*.thrift --filter exclude:**/src_archive/**
+semmle-extractor-options: -R . --filter=include:**/*.thrift --filter exclude:**/*.testproj/**

--- a/python/ql/test/library-tests/modules/spurious_init/options
+++ b/python/ql/test/library-tests/modules/spurious_init/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . --filter exclude:**/src_archive/**
+semmle-extractor-options: -R . --filter exclude:**/*.testproj/**

--- a/python/ql/test/library-tests/thrift/options
+++ b/python/ql/test/library-tests/thrift/options
@@ -1,1 +1,1 @@
-semmle-extractor-options: -R . --filter=include:**/*.thrift --filter exclude:**/src_archive/**
+semmle-extractor-options: -R . --filter=include:**/*.thrift --filter exclude:**/*.testproj/**


### PR DESCRIPTION
The `**/src_archive/**` exclusion patterns seem to have to do with trying to exclude archived source files from being picked up for the extractor while running the test itself. However it seems that directory is not being used any more by `codeql` (which uses a `src` directory instead).

A `*.testproj` exclusion pattern will work in a more robust way, by excluding any file inside the database being built.
