### PR TITLE
C#: Restrict dataflow node creation to source and source-referenced entities

### DIFF
--- a/csharp/ql/lib/change-notes/2024-09-19-reduced-dataflow-nodes.md
+++ b/csharp/ql/lib/change-notes/2024-09-19-reduced-dataflow-nodes.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* `DataFlow::Node` instances are no longer created for library methods and fields that are not callable (either statically or dynamically) or otherwise referred to from source code. This may affect third-party queries that use these nodes to identify library methods or fields that are present in DLL files where those methods or fields are unreferenced. If this presents a problem, consider using `Callable` and other non-dataflow classes to identify such library entities.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1003,7 +1003,15 @@ private class CallableUsedInSource extends Callable {
   CallableUsedInSource() {
     this.fromSource()
     or
-    this.getACall().fromSource()
+    // Note that getARuntimeTarget cannot be used here, because the
+    // DelegateLikeCall case depends on lambda-flow, which in turn
+    // uses the dataflow library; hence this would introduce recursion
+    // into the definition of data-flow nodes.
+    exists(Call c, DispatchCall dc | c.fromSource() and c = dc.getCall() |
+      this = dc.getADynamicTarget()
+    )
+    or
+    this = any(CallableAccess ca | ca.fromSource()).getTarget()
   }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -995,6 +995,30 @@ private class InstanceCallable extends Callable {
   Location getARelevantLocation() { result = l }
 }
 
+/**
+ * A callable which is either itself defined in source or which is the target
+ * of some call in source, and therefore ought to have dataflow nodes created.
+ */
+private class CallableUsedInSource extends Callable {
+  CallableUsedInSource() {
+    this.fromSource()
+    or
+    this.getACall().fromSource()
+  }
+}
+
+/**
+ * A field or property which is either itself defined in source or which is the target
+ * of some access in source, and therefore ought to have dataflow nodes created.
+ */
+private class FieldOrPropertyUsedInSource extends FieldOrProperty {
+  FieldOrPropertyUsedInSource() {
+    this.fromSource()
+    or
+    this.getAnAccess().fromSource()
+  }
+}
+
 /** A collection of cached types and predicates to be evaluated in the same stage. */
 cached
 private module Cached {
@@ -1018,8 +1042,13 @@ private module Cached {
     TAssignableDefinitionNode(AssignableDefinition def, ControlFlow::Node cfn) {
       cfn = def.getExpr().getAControlFlowNode()
     } or
-    TExplicitParameterNode(Parameter p, DataFlowCallable c) { p = c.asCallable(_).getAParameter() } or
-    TInstanceParameterNode(InstanceCallable c, Location l) { l = c.getARelevantLocation() } or
+    TExplicitParameterNode(Parameter p, DataFlowCallable c) {
+      p = c.asCallable(_).(CallableUsedInSource).getAParameter()
+    } or
+    TInstanceParameterNode(InstanceCallable c, Location l) {
+      c instanceof CallableUsedInSource and
+      l = c.getARelevantLocation()
+    } or
     TDelegateSelfReferenceNode(Callable c) { lambdaCreationExpr(_, c) } or
     TLocalFunctionCreationNode(ControlFlow::Nodes::ElementNode cfn, Boolean isPostUpdate) {
       cfn.getAstNode() instanceof LocalFunctionStmt
@@ -1055,11 +1084,13 @@ private module Cached {
       or
       lambdaCallExpr(_, cfn)
     } or
-    TFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn) or
+    TFlowSummaryNode(FlowSummaryImpl::Private::SummaryNode sn) {
+      sn.getSummarizedCallable() instanceof CallableUsedInSource
+    } or
     TParamsArgumentNode(ControlFlow::Node callCfn) {
       callCfn = any(Call c | isParamsArg(c, _, _)).getAControlFlowNode()
     } or
-    TFlowInsensitiveFieldNode(FieldOrProperty f) { f.isFieldLike() } or
+    TFlowInsensitiveFieldNode(FieldOrPropertyUsedInSource f) { f.isFieldLike() } or
     TFlowInsensitiveCapturedVariableNode(LocalScopeVariable v) { v.isCaptured() } or
     TInstanceParameterAccessNode(ControlFlow::Node cfn, Boolean isPostUpdate) {
       cfn = getAPrimaryConstructorParameterCfn(_)

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1011,7 +1011,7 @@ private class CallableUsedInSource extends Callable {
     this.hasBody()
     or
     exists(Callable target |
-      exists(Call c | c.fromSource() |
+      exists(Call c |
         // Note that getADynamicTarget does not always include getTarget.
         target = c.getTarget()
         or
@@ -1022,7 +1022,7 @@ private class CallableUsedInSource extends Callable {
         exists(DispatchCall dc | c = dc.getCall() | target = dc.getADynamicTarget())
       )
       or
-      target = any(CallableAccess ca | ca.fromSource()).getTarget()
+      target = any(CallableAccess ca).getTarget()
     |
       this = target.getUnboundDeclaration()
     )


### PR DESCRIPTION
This addresses a problem observed when libraries define a very large number of types with large class hierarchies, for example as part of generated code. Since user code is very unlikely to refer to all or even most of them, by excluding such code from dataflow node generation and therefore from the C# dataflow hooks' idea of a "relevant" type, we can make many of the type predicates defined in DataFlowPrivate.qll very much cheaper.

See discarded variant https://github.com/github/codeql/pull/17482 for some discussion.