### PR TITLE
Rust: Add more summary stats.

### DIFF
--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -11,13 +11,13 @@ import Stats
 
 from string key, string value
 where
-  key = "Extracted files" and value = count(File f | exists(f.getRelativePath())).toString()
+  key = "Files extracted" and value = count(File f | exists(f.getRelativePath())).toString()
   or
-  key = "Extracted elements" and value = count(Element e | not e instanceof Unextracted).toString()
+  key = "Elements extracted" and value = count(Element e | not e instanceof Unextracted).toString()
   or
-  key = "Unextracted elements" and value = count(Unextracted e).toString()
+  key = "Elements unextracted" and value = count(Unextracted e).toString()
   or
-  key = "Lines of code" and value = getLinesOfCode().toString()
+  key = "Lines of code extracted" and value = getLinesOfCode().toString()
   or
-  key = "Lines of user code" and value = getLinesOfUserCode().toString()
+  key = "Lines of user code extracted" and value = getLinesOfUserCode().toString()
 select key, value

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -13,6 +13,10 @@ from string key, string value
 where
   key = "Extracted files" and value = count(File f | exists(f.getRelativePath())).toString()
   or
+  key = "Extracted elements" and value = count(Element e | not e instanceof Unextracted).toString()
+  or
+  key = "Unextracted elements" and value = count(Unextracted e).toString()
+  or
   key = "Lines of code" and value = getLinesOfCode().toString()
   or
   key = "Lines of user code" and value = getLinesOfUserCode().toString()

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -11,6 +11,8 @@ import Stats
 
 from string key, string value
 where
+  key = "Extracted files" and value = count(File f | exists(f.getRelativePath())).toString()
+  or
   key = "Lines of code" and value = getLinesOfCode().toString()
   or
   key = "Lines of user code" and value = getLinesOfUserCode().toString()

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -1,2 +1,3 @@
+| Extracted files | 6 |
 | Lines of code | 24 |
 | Lines of user code | 24 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -1,3 +1,5 @@
+| Extracted elements | 61 |
 | Extracted files | 6 |
 | Lines of code | 24 |
 | Lines of user code | 24 |
+| Unextracted elements | 26 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -1,5 +1,5 @@
-| Extracted elements | 61 |
-| Extracted files | 6 |
-| Lines of code | 24 |
-| Lines of user code | 24 |
-| Unextracted elements | 26 |
+| Elements extracted | 61 |
+| Elements unextracted | 26 |
+| Files extracted | 6 |
+| Lines of code extracted | 24 |
+| Lines of user code extracted | 24 |


### PR DESCRIPTION
Add a bit more data to `rust/summary/summary-statistics` (this query is intended for manual use on a project when you want to get a first impression of a database).