### PR TITLE
C#/Go: Fix test expectations including double space

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest1.expected
@@ -10,7 +10,7 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
 nodes

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest2.expected
@@ -11,10 +11,10 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
-| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:5  |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest3.expected
@@ -13,14 +13,14 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
-| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:5  |
-| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:43:29:43:50 | call to method ReadEnv : String | Test.cs:43:20:43:25 | access to local variable result : String | provenance | Src:MaD:6  |
-| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:62:29:62:48 | call to method GetCliArg : String | Test.cs:62:20:62:25 | access to local variable result : String | provenance | Src:MaD:7  |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest4.expected
@@ -14,16 +14,16 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
-| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:5  |
-| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:43:29:43:50 | call to method ReadEnv : String | Test.cs:43:20:43:25 | access to local variable result : String | provenance | Src:MaD:6  |
-| Test.cs:53:20:53:25 | access to local variable result : String | Test.cs:56:42:56:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:53:20:53:25 | access to local variable result : String | Test.cs:56:42:56:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:53:29:53:52 | call to method GetCustom : String | Test.cs:53:20:53:25 | access to local variable result : String | provenance | Src:MaD:7  |
-| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:62:29:62:48 | call to method GetCliArg : String | Test.cs:62:20:62:25 | access to local variable result : String | provenance | Src:MaD:8  |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest5.expected
@@ -12,12 +12,12 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
-| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:43:20:43:25 | access to local variable result : String | Test.cs:46:42:46:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:43:29:43:50 | call to method ReadEnv : String | Test.cs:43:20:43:25 | access to local variable result : String | provenance | Src:MaD:5  |
-| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:62:29:62:48 | call to method GetCliArg : String | Test.cs:62:20:62:25 | access to local variable result : String | provenance | Src:MaD:6  |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |

--- a/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
+++ b/csharp/ql/test/library-tests/dataflow/threat-models/threat-models-flowtest6.expected
@@ -12,12 +12,12 @@ edges
 | Test.cs:23:42:23:59 | call to method GetStream : NetworkStream | Test.cs:23:33:23:38 | access to local variable stream : NetworkStream | provenance | Src:MaD:3  |
 | Test.cs:25:29:25:34 | access to local variable stream : NetworkStream | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | provenance | MaD:2 |
 | Test.cs:25:41:25:46 | [post] access to local variable buffer : Byte[] [element] : Object | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | provenance |  |
-| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:28:85:28:105 | call to method BytesToString : String | Test.cs:28:42:28:111 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | provenance |  |
 | Test.cs:28:99:28:104 | access to local variable buffer : Byte[] [element] : Object | Test.cs:28:85:28:105 | call to method BytesToString : String | provenance | MaD:4 |
-| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:34:20:34:25 | access to local variable result : String | Test.cs:37:42:37:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:34:29:34:69 | call to method ExecuteQuery : String | Test.cs:34:20:34:25 | access to local variable result : String | provenance | Src:MaD:5  |
-| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance |  Sink:MaD:1 |
+| Test.cs:62:20:62:25 | access to local variable result : String | Test.cs:65:42:65:96 | ... + ... | provenance | Sink:MaD:1 |
 | Test.cs:62:29:62:48 | call to method GetCliArg : String | Test.cs:62:20:62:25 | access to local variable result : String | provenance | Src:MaD:6  |
 nodes
 | Test.cs:12:45:12:49 | bytes : Byte[] [element] : Object | semmle.label | bytes : Byte[] [element] : Object |

--- a/csharp/ql/test/query-tests/Security Features/CWE-020/UntrustedDataToExternalAPI.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-020/UntrustedDataToExternalAPI.expected
@@ -2,7 +2,7 @@
 | UntrustedData.cs:9:20:9:30 | access to property Request | UntrustedData.cs:9:20:9:30 | access to property Request | UntrustedData.cs:9:20:9:30 | access to property Request | Call to System.Web.HttpRequest.get_QueryString with untrusted data from $@. | UntrustedData.cs:9:20:9:30 | access to property Request | access to property Request |
 | UntrustedData.cs:13:28:13:31 | access to local variable name | UntrustedData.cs:9:20:9:42 | access to property QueryString : NameValueCollection | UntrustedData.cs:13:28:13:31 | access to local variable name | Call to System.Web.HttpResponse.Write with untrusted data from $@. | UntrustedData.cs:9:20:9:42 | access to property QueryString : NameValueCollection | access to property QueryString : NameValueCollection |
 edges
-| UntrustedData.cs:9:13:9:16 | access to local variable name : String | UntrustedData.cs:13:28:13:31 | access to local variable name | provenance |  Sink:MaD:1 |
+| UntrustedData.cs:9:13:9:16 | access to local variable name : String | UntrustedData.cs:13:28:13:31 | access to local variable name | provenance | Sink:MaD:1 |
 | UntrustedData.cs:9:20:9:42 | access to property QueryString : NameValueCollection | UntrustedData.cs:9:13:9:16 | access to local variable name : String | provenance |  |
 | UntrustedData.cs:9:20:9:42 | access to property QueryString : NameValueCollection | UntrustedData.cs:9:20:9:50 | access to indexer : String | provenance | MaD:2 |
 | UntrustedData.cs:9:20:9:50 | access to indexer : String | UntrustedData.cs:9:13:9:16 | access to local variable name : String | provenance |  |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/StoredXSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/StoredXSS/StoredXSS.expected
@@ -4,7 +4,7 @@ edges
 | StoredXSS.cs:17:31:17:44 | access to local variable customerReader : SqlDataReader | StoredXSS.cs:22:60:22:73 | access to local variable customerReader : SqlDataReader | provenance |  |
 | StoredXSS.cs:17:48:17:78 | call to method ExecuteReader : SqlDataReader | StoredXSS.cs:17:31:17:44 | access to local variable customerReader : SqlDataReader | provenance |  |
 | StoredXSS.cs:22:60:22:73 | access to local variable customerReader : SqlDataReader | StoredXSS.cs:22:60:22:86 | call to method GetString : String | provenance | MaD:1 |
-| StoredXSS.cs:22:60:22:86 | call to method GetString : String | StoredXSS.cs:22:44:22:86 | ... + ... | provenance |  Sink:MaD:2 |
+| StoredXSS.cs:22:60:22:86 | call to method GetString : String | StoredXSS.cs:22:44:22:86 | ... + ... | provenance | Sink:MaD:2 |
 models
 | 1 | Summary: System.Data; IDataRecord; true; GetString; (System.Int32); ; Argument[this]; ReturnValue; taint; manual |
 | 2 | Sink: System.Web; HttpResponse; false; Write; ; ; Argument[0]; html-injection; manual |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
@@ -22,7 +22,7 @@ edges
 | XSS.cs:26:32:26:40 | access to local variable userInput : StringBuilder | XSS.cs:26:32:26:51 | call to method ToString | provenance | MaD:3 |
 | XSS.cs:27:29:27:37 | access to local variable userInput : StringBuilder | XSS.cs:27:29:27:48 | call to method ToString | provenance | MaD:3 |
 | XSS.cs:28:26:28:34 | access to local variable userInput : StringBuilder | XSS.cs:28:26:28:45 | call to method ToString | provenance | MaD:3 |
-| XSS.cs:37:20:37:23 | access to local variable name : String | XSS.cs:38:36:38:39 | access to local variable name | provenance |  Sink:MaD:5 |
+| XSS.cs:37:20:37:23 | access to local variable name : String | XSS.cs:38:36:38:39 | access to local variable name | provenance | Sink:MaD:5 |
 | XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | XSS.cs:37:20:37:23 | access to local variable name : String | provenance |  |
 | XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | XSS.cs:37:27:37:61 | access to indexer : String | provenance | MaD:6 |
 | XSS.cs:37:27:37:61 | access to indexer : String | XSS.cs:37:20:37:23 | access to local variable name : String | provenance |  |
@@ -41,7 +41,7 @@ edges
 | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:85:20:85:23 | access to local variable name : String | provenance |  |
 | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:85:27:85:61 | access to indexer : String | provenance | MaD:6 |
 | XSS.cs:85:27:85:61 | access to indexer : String | XSS.cs:85:20:85:23 | access to local variable name : String | provenance |  |
-| XSS.cs:94:20:94:23 | access to local variable name : String | XSS.cs:95:31:95:34 | access to local variable name | provenance |  Sink:MaD:1 |
+| XSS.cs:94:20:94:23 | access to local variable name : String | XSS.cs:95:31:95:34 | access to local variable name | provenance | Sink:MaD:1 |
 | XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | XSS.cs:94:20:94:23 | access to local variable name : String | provenance |  |
 | XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | XSS.cs:94:27:94:61 | access to indexer : String | provenance | MaD:6 |
 | XSS.cs:94:27:94:61 | access to indexer : String | XSS.cs:94:20:94:23 | access to local variable name : String | provenance |  |

--- a/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-089/SqlInjection.expected
@@ -28,7 +28,7 @@ edges
 | SecondOrderSqlInjection.cs:20:31:20:44 | access to local variable customerReader : SqlDataReader | SecondOrderSqlInjection.cs:25:119:25:132 | access to local variable customerReader : SqlDataReader | provenance |  |
 | SecondOrderSqlInjection.cs:20:48:20:78 | call to method ExecuteReader : SqlDataReader | SecondOrderSqlInjection.cs:20:31:20:44 | access to local variable customerReader : SqlDataReader | provenance |  |
 | SecondOrderSqlInjection.cs:25:119:25:132 | access to local variable customerReader : SqlDataReader | SecondOrderSqlInjection.cs:25:119:25:145 | call to method GetString : String | provenance | MaD:20 |
-| SecondOrderSqlInjection.cs:25:119:25:145 | call to method GetString : String | SecondOrderSqlInjection.cs:25:71:25:145 | ... + ... | provenance |  Sink:MaD:16 |
+| SecondOrderSqlInjection.cs:25:119:25:145 | call to method GetString : String | SecondOrderSqlInjection.cs:25:71:25:145 | ... + ... | provenance | Sink:MaD:16 |
 | SecondOrderSqlInjection.cs:33:31:33:32 | access to local variable fs : FileStream | SecondOrderSqlInjection.cs:35:59:35:60 | access to local variable fs : FileStream | provenance |  |
 | SecondOrderSqlInjection.cs:33:36:33:78 | object creation of type FileStream : FileStream | SecondOrderSqlInjection.cs:33:31:33:32 | access to local variable fs : FileStream | provenance | Src:MaD:21  |
 | SecondOrderSqlInjection.cs:33:36:33:78 | object creation of type FileStream : FileStream | SecondOrderSqlInjection.cs:33:31:33:32 | access to local variable fs : FileStream | provenance | Src:MaD:22  |
@@ -38,48 +38,48 @@ edges
 | SecondOrderSqlInjection.cs:38:29:38:31 | access to local variable sql : String | SecondOrderSqlInjection.cs:40:31:40:33 | access to local variable sql : String | provenance |  |
 | SecondOrderSqlInjection.cs:38:35:38:36 | access to local variable sr : StreamReader | SecondOrderSqlInjection.cs:38:35:38:47 | call to method ReadLine : String | provenance | MaD:25 |
 | SecondOrderSqlInjection.cs:38:35:38:47 | call to method ReadLine : String | SecondOrderSqlInjection.cs:38:29:38:31 | access to local variable sql : String | provenance |  |
-| SecondOrderSqlInjection.cs:40:25:40:27 | access to local variable sql : String | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | provenance |  Sink:MaD:10 |
+| SecondOrderSqlInjection.cs:40:25:40:27 | access to local variable sql : String | SecondOrderSqlInjection.cs:45:57:45:59 | access to local variable sql | provenance | Sink:MaD:10 |
 | SecondOrderSqlInjection.cs:40:31:40:33 | access to local variable sql : String | SecondOrderSqlInjection.cs:40:31:40:40 | call to method Trim : String | provenance | MaD:28 |
 | SecondOrderSqlInjection.cs:40:31:40:40 | call to method Trim : String | SecondOrderSqlInjection.cs:40:25:40:27 | access to local variable sql : String | provenance |  |
-| SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | SqlInjection.cs:39:50:39:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
+| SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | SqlInjection.cs:39:50:39:55 | access to local variable query1 | provenance | Sink:MaD:18 |
 | SqlInjection.cs:38:21:38:35 | access to field categoryTextBox : TextBox | SqlInjection.cs:38:21:38:40 | access to property Text : String | provenance | MaD:26 |
 | SqlInjection.cs:38:21:38:40 | access to property Text : String | SqlInjection.cs:37:21:37:26 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:74:56:74:61 | access to local variable query1 | provenance |  Sink:MaD:7 |
-| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:75:55:75:60 | access to local variable query1 | provenance |  Sink:MaD:8 |
+| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:74:56:74:61 | access to local variable query1 | provenance | Sink:MaD:7 |
+| SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | SqlInjection.cs:75:55:75:60 | access to local variable query1 | provenance | Sink:MaD:8 |
 | SqlInjection.cs:73:33:73:47 | access to field categoryTextBox : TextBox | SqlInjection.cs:73:33:73:52 | access to property Text : String | provenance | MaD:26 |
 | SqlInjection.cs:73:33:73:52 | access to property Text : String | SqlInjection.cs:72:25:72:30 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | SqlInjection.cs:88:50:88:55 | access to local variable query1 | provenance |  Sink:MaD:18 |
+| SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | SqlInjection.cs:88:50:88:55 | access to local variable query1 | provenance | Sink:MaD:18 |
 | SqlInjection.cs:87:21:87:29 | access to property Text : String | SqlInjection.cs:86:21:86:26 | access to local variable query1 : String | provenance |  |
-| SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
+| SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString | provenance | Sink:MaD:15 |
 | SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | SqlInjection.cs:98:42:98:52 | access to local variable queryString : String | provenance |  |
 | SqlInjection.cs:97:21:97:29 | access to property Text : String | SqlInjection.cs:96:21:96:31 | access to local variable queryString : String | provenance |  |
-| SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:99:50:99:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
+| SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:99:50:99:52 | access to local variable cmd | provenance | Sink:MaD:17 |
 | SqlInjection.cs:98:27:98:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:98:21:98:23 | access to local variable cmd : SqlCommand | provenance |  |
 | SqlInjection.cs:98:42:98:52 | access to local variable queryString : String | SqlInjection.cs:98:27:98:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
-| SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString | provenance |  Sink:MaD:15 |
+| SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString | provenance | Sink:MaD:15 |
 | SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | provenance |  |
 | SqlInjection.cs:108:21:108:38 | call to method ReadLine : String | SqlInjection.cs:107:21:107:31 | access to local variable queryString : String | provenance | Src:MaD:27  |
-| SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:110:50:110:52 | access to local variable cmd | provenance |  Sink:MaD:17 |
+| SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | SqlInjection.cs:110:50:110:52 | access to local variable cmd | provenance | Sink:MaD:17 |
 | SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | SqlInjection.cs:109:21:109:23 | access to local variable cmd : SqlCommand | provenance |  |
 | SqlInjection.cs:109:42:109:52 | access to local variable queryString : String | SqlInjection.cs:109:27:109:53 | object creation of type SqlCommand : SqlCommand | provenance | MaD:19 |
 | SqlInjection.cs:122:73:122:78 | userId : String | SqlInjection.cs:125:20:125:24 | access to local variable query : String | provenance |  |
-| SqlInjection.cs:125:20:125:24 | access to local variable query : String | SqlInjection.cs:129:53:129:57 | access to local variable query | provenance |  Sink:MaD:16 |
-| SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | provenance |  Sink:MaD:4 |
+| SqlInjection.cs:125:20:125:24 | access to local variable query : String | SqlInjection.cs:129:53:129:57 | access to local variable query | provenance | Sink:MaD:16 |
+| SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | SqlInjectionDapper.cs:21:55:21:59 | access to local variable query | provenance | Sink:MaD:4 |
 | SqlInjectionDapper.cs:20:86:20:94 | access to property Text : String | SqlInjectionDapper.cs:20:21:20:25 | access to local variable query : String | provenance |  |
-| SqlInjectionDapper.cs:29:21:29:25 | access to local variable query : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | provenance |  Sink:MaD:5 |
+| SqlInjectionDapper.cs:29:21:29:25 | access to local variable query : String | SqlInjectionDapper.cs:30:66:30:70 | access to local variable query | provenance | Sink:MaD:5 |
 | SqlInjectionDapper.cs:29:86:29:94 | access to property Text : String | SqlInjectionDapper.cs:29:21:29:25 | access to local variable query : String | provenance |  |
-| SqlInjectionDapper.cs:38:21:38:25 | access to local variable query : String | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | provenance |  Sink:MaD:6 |
+| SqlInjectionDapper.cs:38:21:38:25 | access to local variable query : String | SqlInjectionDapper.cs:39:63:39:67 | access to local variable query | provenance | Sink:MaD:6 |
 | SqlInjectionDapper.cs:38:86:38:94 | access to property Text : String | SqlInjectionDapper.cs:38:21:38:25 | access to local variable query : String | provenance |  |
-| SqlInjectionDapper.cs:47:21:47:25 | access to local variable query : String | SqlInjectionDapper.cs:49:47:49:51 | access to local variable query | provenance |  Sink:MaD:1 |
+| SqlInjectionDapper.cs:47:21:47:25 | access to local variable query : String | SqlInjectionDapper.cs:49:47:49:51 | access to local variable query | provenance | Sink:MaD:1 |
 | SqlInjectionDapper.cs:47:86:47:94 | access to property Text : String | SqlInjectionDapper.cs:47:21:47:25 | access to local variable query : String | provenance |  |
-| SqlInjectionDapper.cs:57:21:57:25 | access to local variable query : String | SqlInjectionDapper.cs:58:42:58:46 | access to local variable query | provenance |  Sink:MaD:3 |
+| SqlInjectionDapper.cs:57:21:57:25 | access to local variable query : String | SqlInjectionDapper.cs:58:42:58:46 | access to local variable query | provenance | Sink:MaD:3 |
 | SqlInjectionDapper.cs:57:86:57:94 | access to property Text : String | SqlInjectionDapper.cs:57:21:57:25 | access to local variable query : String | provenance |  |
-| SqlInjectionDapper.cs:66:21:66:25 | access to local variable query : String | SqlInjectionDapper.cs:67:42:67:46 | access to local variable query | provenance |  Sink:MaD:2 |
+| SqlInjectionDapper.cs:66:21:66:25 | access to local variable query : String | SqlInjectionDapper.cs:67:42:67:46 | access to local variable query | provenance | Sink:MaD:2 |
 | SqlInjectionDapper.cs:66:86:66:94 | access to property Text : String | SqlInjectionDapper.cs:66:21:66:25 | access to local variable query : String | provenance |  |
 | SqlInjectionDapper.cs:75:21:75:25 | access to local variable query : String | SqlInjectionDapper.cs:77:52:77:56 | access to local variable query | provenance |  |
 | SqlInjectionDapper.cs:75:86:75:94 | access to property Text : String | SqlInjectionDapper.cs:75:21:75:25 | access to local variable query : String | provenance |  |
 | SqlInjectionSqlite.cs:19:51:19:63 | access to field untrustedData : TextBox | SqlInjectionSqlite.cs:19:51:19:68 | access to property Text | provenance | MaD:26 Sink:MaD:9 |
-| SqlInjectionSqlite.cs:24:17:24:19 | access to local variable cmd : SQLiteCommand | SqlInjectionSqlite.cs:44:45:44:47 | access to local variable cmd | provenance |  Sink:MaD:11 |
+| SqlInjectionSqlite.cs:24:17:24:19 | access to local variable cmd : SQLiteCommand | SqlInjectionSqlite.cs:44:45:44:47 | access to local variable cmd | provenance | Sink:MaD:11 |
 | SqlInjectionSqlite.cs:24:23:24:71 | object creation of type SQLiteCommand : SQLiteCommand | SqlInjectionSqlite.cs:24:17:24:19 | access to local variable cmd : SQLiteCommand | provenance |  |
 | SqlInjectionSqlite.cs:24:41:24:53 | access to field untrustedData : TextBox | SqlInjectionSqlite.cs:24:41:24:58 | access to property Text | provenance | MaD:26 Sink:MaD:10 |
 | SqlInjectionSqlite.cs:24:41:24:53 | access to field untrustedData : TextBox | SqlInjectionSqlite.cs:24:41:24:58 | access to property Text : String | provenance | MaD:26 |
@@ -97,7 +97,7 @@ edges
 | SqlInjectionSqlite.cs:54:29:54:31 | access to local variable sql : String | SqlInjectionSqlite.cs:56:31:56:33 | access to local variable sql : String | provenance |  |
 | SqlInjectionSqlite.cs:54:35:54:36 | access to local variable sr : StreamReader | SqlInjectionSqlite.cs:54:35:54:47 | call to method ReadLine : String | provenance | MaD:25 |
 | SqlInjectionSqlite.cs:54:35:54:47 | call to method ReadLine : String | SqlInjectionSqlite.cs:54:29:54:31 | access to local variable sql : String | provenance |  |
-| SqlInjectionSqlite.cs:56:25:56:27 | access to local variable sql : String | SqlInjectionSqlite.cs:61:53:61:55 | access to local variable sql | provenance |  Sink:MaD:10 |
+| SqlInjectionSqlite.cs:56:25:56:27 | access to local variable sql : String | SqlInjectionSqlite.cs:61:53:61:55 | access to local variable sql | provenance | Sink:MaD:10 |
 | SqlInjectionSqlite.cs:56:31:56:33 | access to local variable sql : String | SqlInjectionSqlite.cs:56:31:56:40 | call to method Trim : String | provenance | MaD:28 |
 | SqlInjectionSqlite.cs:56:31:56:40 | call to method Trim : String | SqlInjectionSqlite.cs:56:25:56:27 | access to local variable sql : String | provenance |  |
 models

--- a/csharp/ql/test/query-tests/Security Features/CWE-201/ExposureInTransmittedData/ExposureInTransmittedData.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-201/ExposureInTransmittedData/ExposureInTransmittedData.expected
@@ -9,8 +9,8 @@
 | ExposureInTransmittedData.cs:32:24:32:52 | ... + ... | ExposureInTransmittedData.cs:30:17:30:36 | call to method GetField : String | ExposureInTransmittedData.cs:32:24:32:52 | ... + ... | This data transmitted to the user depends on $@. | ExposureInTransmittedData.cs:30:17:30:36 | call to method GetField | sensitive information |
 | ExposureInTransmittedData.cs:33:27:33:27 | access to local variable p | ExposureInTransmittedData.cs:30:17:30:36 | call to method GetField : String | ExposureInTransmittedData.cs:33:27:33:27 | access to local variable p | This data transmitted to the user depends on $@. | ExposureInTransmittedData.cs:30:17:30:36 | call to method GetField | sensitive information |
 edges
-| ExposureInTransmittedData.cs:24:32:24:38 | access to property Data : IDictionary | ExposureInTransmittedData.cs:24:32:24:50 | access to indexer | provenance |  Sink:MaD:2 |
 | ExposureInTransmittedData.cs:24:32:24:38 | access to property Data : IDictionary | ExposureInTransmittedData.cs:24:32:24:50 | access to indexer | provenance | MaD:1 Sink:MaD:2 |
+| ExposureInTransmittedData.cs:24:32:24:38 | access to property Data : IDictionary | ExposureInTransmittedData.cs:24:32:24:50 | access to indexer | provenance | Sink:MaD:2 |
 | ExposureInTransmittedData.cs:30:13:30:13 | access to local variable p : String | ExposureInTransmittedData.cs:31:53:31:53 | access to local variable p | provenance |  |
 | ExposureInTransmittedData.cs:30:13:30:13 | access to local variable p : String | ExposureInTransmittedData.cs:31:56:31:56 | access to local variable p | provenance |  |
 | ExposureInTransmittedData.cs:30:13:30:13 | access to local variable p : String | ExposureInTransmittedData.cs:32:24:32:52 | ... + ... | provenance |  |

--- a/csharp/ql/test/query-tests/Security Features/CWE-321/HardcodedSymmetricEncryptionKey/HardcodedSymmetricEncryptionKey.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-321/HardcodedSymmetricEncryptionKey/HardcodedSymmetricEncryptionKey.expected
@@ -11,7 +11,7 @@ edges
 | HardcodedSymmetricEncryptionKey.cs:25:17:25:17 | access to local variable c : Byte[] | HardcodedSymmetricEncryptionKey.cs:41:50:41:50 | access to local variable c : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:25:17:25:17 | access to local variable c : Byte[] | HardcodedSymmetricEncryptionKey.cs:50:35:50:35 | access to local variable c : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:25:21:25:97 | array creation of type Byte[] : Byte[] | HardcodedSymmetricEncryptionKey.cs:25:17:25:17 | access to local variable c : Byte[] | provenance |  |
-| HardcodedSymmetricEncryptionKey.cs:26:17:26:17 | access to local variable d : Byte[] | HardcodedSymmetricEncryptionKey.cs:31:21:31:21 | access to local variable d | provenance |  Sink:MaD:3 |
+| HardcodedSymmetricEncryptionKey.cs:26:17:26:17 | access to local variable d : Byte[] | HardcodedSymmetricEncryptionKey.cs:31:21:31:21 | access to local variable d | provenance | Sink:MaD:3 |
 | HardcodedSymmetricEncryptionKey.cs:26:17:26:17 | access to local variable d : Byte[] | HardcodedSymmetricEncryptionKey.cs:36:37:36:37 | access to local variable d : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:28:17:28:35 | access to local variable byteArrayFromString : Byte[] | HardcodedSymmetricEncryptionKey.cs:44:51:44:69 | access to local variable byteArrayFromString : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:28:39:28:116 | call to method GetBytes : Byte[] | HardcodedSymmetricEncryptionKey.cs:28:17:28:35 | access to local variable byteArrayFromString : Byte[] | provenance |  |
@@ -20,9 +20,9 @@ edges
 | HardcodedSymmetricEncryptionKey.cs:41:50:41:50 | access to local variable c : Byte[] | HardcodedSymmetricEncryptionKey.cs:112:63:112:65 | key : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:44:51:44:69 | access to local variable byteArrayFromString : Byte[] | HardcodedSymmetricEncryptionKey.cs:112:63:112:65 | key : Byte[] | provenance |  |
 | HardcodedSymmetricEncryptionKey.cs:50:35:50:35 | access to local variable c : Byte[] | HardcodedSymmetricEncryptionKey.cs:59:64:59:71 | password : Byte[] | provenance |  |
-| HardcodedSymmetricEncryptionKey.cs:59:64:59:71 | password : Byte[] | HardcodedSymmetricEncryptionKey.cs:68:87:68:94 | access to parameter password | provenance |  Sink:MaD:1 |
-| HardcodedSymmetricEncryptionKey.cs:103:57:103:59 | key : Byte[] | HardcodedSymmetricEncryptionKey.cs:108:23:108:25 | access to parameter key | provenance |  Sink:MaD:3 |
-| HardcodedSymmetricEncryptionKey.cs:112:63:112:65 | key : Byte[] | HardcodedSymmetricEncryptionKey.cs:121:87:121:89 | access to parameter key | provenance |  Sink:MaD:2 |
+| HardcodedSymmetricEncryptionKey.cs:59:64:59:71 | password : Byte[] | HardcodedSymmetricEncryptionKey.cs:68:87:68:94 | access to parameter password | provenance | Sink:MaD:1 |
+| HardcodedSymmetricEncryptionKey.cs:103:57:103:59 | key : Byte[] | HardcodedSymmetricEncryptionKey.cs:108:23:108:25 | access to parameter key | provenance | Sink:MaD:3 |
+| HardcodedSymmetricEncryptionKey.cs:112:63:112:65 | key : Byte[] | HardcodedSymmetricEncryptionKey.cs:121:87:121:89 | access to parameter key | provenance | Sink:MaD:2 |
 models
 | 1 | Sink: System.Security.Cryptography; SymmetricAlgorithm; true; CreateDecryptor; (System.Byte[],System.Byte[]); ; Argument[0]; encryption-decryptor; manual |
 | 2 | Sink: System.Security.Cryptography; SymmetricAlgorithm; true; CreateEncryptor; (System.Byte[],System.Byte[]); ; Argument[0]; encryption-encryptor; manual |

--- a/csharp/ql/test/query-tests/Security Features/CWE-838/InappropriateEncoding.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-838/InappropriateEncoding.expected
@@ -12,10 +12,10 @@
 | SqlEncode.cs:15:46:15:50 | access to local variable query | SqlEncode.cs:14:62:14:87 | call to method Replace : String | SqlEncode.cs:15:46:15:50 | access to local variable query | This SQL expression may include data from a $@. | SqlEncode.cs:14:62:14:87 | call to method Replace | possibly inappropriately encoded value |
 | UrlEncode.cs:10:31:10:69 | ... + ... | UrlEncode.cs:10:43:10:69 | call to method HtmlEncode : String | UrlEncode.cs:10:31:10:69 | ... + ... | This URL expression may include data from a $@. | UrlEncode.cs:10:43:10:69 | call to method HtmlEncode | possibly inappropriately encoded value |
 edges
-| HtmlEncode.cs:10:40:10:65 | call to method UrlEncode : String | HtmlEncode.cs:10:28:10:65 | ... + ... | provenance |  Sink:MaD:2 |
+| HtmlEncode.cs:10:40:10:65 | call to method UrlEncode : String | HtmlEncode.cs:10:28:10:65 | ... + ... | provenance | Sink:MaD:2 |
 | InappropriateEncoding.cs:13:13:13:24 | access to local variable encodedValue : String | InappropriateEncoding.cs:16:17:16:22 | access to local variable query1 : String | provenance |  |
 | InappropriateEncoding.cs:13:28:13:40 | call to method Encode : String | InappropriateEncoding.cs:13:13:13:24 | access to local variable encodedValue : String | provenance |  |
-| InappropriateEncoding.cs:16:17:16:22 | access to local variable query1 : String | InappropriateEncoding.cs:18:46:18:51 | access to local variable query1 | provenance |  Sink:MaD:1 |
+| InappropriateEncoding.cs:16:17:16:22 | access to local variable query1 : String | InappropriateEncoding.cs:18:46:18:51 | access to local variable query1 | provenance | Sink:MaD:1 |
 | InappropriateEncoding.cs:34:13:34:24 | access to local variable encodedValue : String | InappropriateEncoding.cs:35:32:35:43 | access to local variable encodedValue | provenance |  |
 | InappropriateEncoding.cs:34:13:34:24 | access to local variable encodedValue : String | InappropriateEncoding.cs:36:22:36:59 | ... + ... | provenance |  |
 | InappropriateEncoding.cs:34:13:34:24 | access to local variable encodedValue : String | InappropriateEncoding.cs:37:59:37:70 | access to local variable encodedValue : String | provenance |  |
@@ -24,7 +24,7 @@ edges
 | InappropriateEncoding.cs:55:13:55:24 | access to local variable encodedValue : String | InappropriateEncoding.cs:56:31:56:42 | access to local variable encodedValue | provenance |  |
 | InappropriateEncoding.cs:55:28:55:56 | call to method HtmlEncode : String | InappropriateEncoding.cs:55:13:55:24 | access to local variable encodedValue : String | provenance |  |
 | InappropriateEncoding.cs:66:16:66:42 | call to method Replace : String | InappropriateEncoding.cs:13:28:13:40 | call to method Encode : String | provenance |  |
-| SqlEncode.cs:14:17:14:21 | access to local variable query : String | SqlEncode.cs:15:46:15:50 | access to local variable query | provenance |  Sink:MaD:1 |
+| SqlEncode.cs:14:17:14:21 | access to local variable query : String | SqlEncode.cs:15:46:15:50 | access to local variable query | provenance | Sink:MaD:1 |
 | SqlEncode.cs:14:62:14:87 | call to method Replace : String | SqlEncode.cs:14:17:14:21 | access to local variable query : String | provenance |  |
 | UrlEncode.cs:10:43:10:69 | call to method HtmlEncode : String | UrlEncode.cs:10:31:10:69 | ... + ... | provenance |  |
 models

--- a/go/ql/test/library-tests/semmle/go/frameworks/Beego/TaintedPath.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Beego/TaintedPath.expected
@@ -7,14 +7,14 @@
 | test.go:342:53:342:61 | untrusted | test.go:340:15:340:26 | call to Data | test.go:342:53:342:61 | untrusted | This path depends on a $@. | test.go:340:15:340:26 | call to Data | user-provided value |
 | test.go:344:23:344:31 | untrusted | test.go:340:15:340:26 | call to Data | test.go:344:23:344:31 | untrusted | This path depends on a $@. | test.go:340:15:340:26 | call to Data | user-provided value |
 edges
-| test.go:215:15:215:26 | call to Data | test.go:216:18:216:26 | untrusted | provenance | Src:MaD:3  Sink:MaD:5 |
-| test.go:215:15:215:26 | call to Data | test.go:217:10:217:18 | untrusted | provenance | Src:MaD:3  Sink:MaD:8 |
-| test.go:215:15:215:26 | call to Data | test.go:218:35:218:43 | untrusted | provenance | Src:MaD:3  Sink:MaD:6 |
+| test.go:215:15:215:26 | call to Data | test.go:216:18:216:26 | untrusted | provenance | Src:MaD:3 Sink:MaD:5 |
+| test.go:215:15:215:26 | call to Data | test.go:217:10:217:18 | untrusted | provenance | Src:MaD:3 Sink:MaD:8 |
+| test.go:215:15:215:26 | call to Data | test.go:218:35:218:43 | untrusted | provenance | Src:MaD:3 Sink:MaD:6 |
 | test.go:324:17:324:37 | selection of RequestBody | test.go:324:40:324:43 | &... | provenance | Src:MaD:4 MaD:1 |
-| test.go:324:40:324:43 | &... | test.go:326:35:326:43 | untrusted | provenance |  Sink:MaD:6 |
-| test.go:332:15:332:26 | call to Data | test.go:334:23:334:31 | untrusted | provenance | Src:MaD:3  Sink:MaD:2 |
-| test.go:340:15:340:26 | call to Data | test.go:342:53:342:61 | untrusted | provenance | Src:MaD:3  Sink:MaD:7 |
-| test.go:340:15:340:26 | call to Data | test.go:344:23:344:31 | untrusted | provenance | Src:MaD:3  Sink:MaD:2 |
+| test.go:324:40:324:43 | &... | test.go:326:35:326:43 | untrusted | provenance | Sink:MaD:6 |
+| test.go:332:15:332:26 | call to Data | test.go:334:23:334:31 | untrusted | provenance | Src:MaD:3 Sink:MaD:2 |
+| test.go:340:15:340:26 | call to Data | test.go:342:53:342:61 | untrusted | provenance | Src:MaD:3 Sink:MaD:7 |
+| test.go:340:15:340:26 | call to Data | test.go:344:23:344:31 | untrusted | provenance | Src:MaD:3 Sink:MaD:2 |
 models
 | 1 | Summary: encoding/json; ; false; Unmarshal; ; ; Argument[0]; Argument[1]; taint; manual |
 | 2 | Sink: group:beego-context; BeegoOutput; false; Download; ; ; Argument[0]; path-injection; manual |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Echo/OpenRedirect.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Echo/OpenRedirect.expected
@@ -2,7 +2,7 @@
 | test.go:173:20:173:24 | param | test.go:172:11:172:32 | call to Param | test.go:173:20:173:24 | param | This path to an untrusted URL redirection depends on a $@. | test.go:172:11:172:32 | call to Param | user-provided value |
 | test.go:182:20:182:28 | ...+... | test.go:178:11:178:32 | call to Param | test.go:182:20:182:28 | ...+... | This path to an untrusted URL redirection depends on a $@. | test.go:178:11:178:32 | call to Param | user-provided value |
 edges
-| test.go:172:11:172:32 | call to Param | test.go:173:20:173:24 | param | provenance | Src:MaD:2  Sink:MaD:1 |
+| test.go:172:11:172:32 | call to Param | test.go:173:20:173:24 | param | provenance | Src:MaD:2 Sink:MaD:1 |
 | test.go:178:11:178:32 | call to Param | test.go:182:24:182:28 | param | provenance | Src:MaD:2  |
 | test.go:182:24:182:28 | param | test.go:182:20:182:28 | ...+... | provenance | Config Sink:MaD:1 |
 | test.go:190:9:190:26 | star expression | test.go:190:10:190:26 | selection of URL | provenance | Config |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Echo/TaintedPath.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Echo/TaintedPath.expected
@@ -2,8 +2,8 @@
 | test.go:222:17:222:24 | filepath | test.go:221:15:221:38 | call to QueryParam | test.go:222:17:222:24 | filepath | This path depends on a $@. | test.go:221:15:221:38 | call to QueryParam | user-provided value |
 | test.go:226:23:226:30 | filepath | test.go:225:15:225:38 | call to QueryParam | test.go:226:23:226:30 | filepath | This path depends on a $@. | test.go:225:15:225:38 | call to QueryParam | user-provided value |
 edges
-| test.go:221:15:221:38 | call to QueryParam | test.go:222:17:222:24 | filepath | provenance | Src:MaD:3  Sink:MaD:2 |
-| test.go:225:15:225:38 | call to QueryParam | test.go:226:23:226:30 | filepath | provenance | Src:MaD:3  Sink:MaD:1 |
+| test.go:221:15:221:38 | call to QueryParam | test.go:222:17:222:24 | filepath | provenance | Src:MaD:3 Sink:MaD:2 |
+| test.go:225:15:225:38 | call to QueryParam | test.go:226:23:226:30 | filepath | provenance | Src:MaD:3 Sink:MaD:1 |
 models
 | 1 | Sink: github.com/labstack/echo; Context; false; Attachment; ; ; Argument[0]; path-injection; manual |
 | 2 | Sink: github.com/labstack/echo; Context; false; File; ; ; Argument[0]; path-injection; manual |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Encoding/jsoniter.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Encoding/jsoniter.expected
@@ -10,13 +10,13 @@ edges
 | jsoniter.go:24:21:24:40 | call to getUntrustedString | jsoniter.go:35:27:35:41 | untrustedString | provenance |  |
 | jsoniter.go:24:21:24:40 | call to getUntrustedString | jsoniter.go:39:31:39:45 | untrustedString | provenance |  |
 | jsoniter.go:27:17:27:30 | untrustedInput | jsoniter.go:27:33:27:37 | &... | provenance | MaD:3 |
-| jsoniter.go:27:33:27:37 | &... | jsoniter.go:28:15:28:24 | selection of field | provenance |  Sink:MaD:5 |
+| jsoniter.go:27:33:27:37 | &... | jsoniter.go:28:15:28:24 | selection of field | provenance | Sink:MaD:5 |
 | jsoniter.go:31:21:31:34 | untrustedInput | jsoniter.go:31:37:31:42 | &... | provenance | MaD:1 |
-| jsoniter.go:31:37:31:42 | &... | jsoniter.go:32:15:32:25 | selection of field | provenance |  Sink:MaD:5 |
+| jsoniter.go:31:37:31:42 | &... | jsoniter.go:32:15:32:25 | selection of field | provenance | Sink:MaD:5 |
 | jsoniter.go:35:27:35:41 | untrustedString | jsoniter.go:35:44:35:49 | &... | provenance | MaD:4 |
-| jsoniter.go:35:44:35:49 | &... | jsoniter.go:36:15:36:25 | selection of field | provenance |  Sink:MaD:5 |
+| jsoniter.go:35:44:35:49 | &... | jsoniter.go:36:15:36:25 | selection of field | provenance | Sink:MaD:5 |
 | jsoniter.go:39:31:39:45 | untrustedString | jsoniter.go:39:48:39:53 | &... | provenance | MaD:2 |
-| jsoniter.go:39:48:39:53 | &... | jsoniter.go:40:15:40:25 | selection of field | provenance |  Sink:MaD:5 |
+| jsoniter.go:39:48:39:53 | &... | jsoniter.go:40:15:40:25 | selection of field | provenance | Sink:MaD:5 |
 nodes
 | jsoniter.go:23:20:23:38 | call to getUntrustedBytes | semmle.label | call to getUntrustedBytes |
 | jsoniter.go:24:21:24:40 | call to getUntrustedString | semmle.label | call to getUntrustedString |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Gin/TaintedPath.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Gin/TaintedPath.expected
@@ -4,10 +4,10 @@
 | Gin.go:27:20:27:27 | filepath | Gin.go:24:15:24:33 | call to Query | Gin.go:27:20:27:27 | filepath | This path depends on a $@. | Gin.go:24:15:24:33 | call to Query | user-provided value |
 | Gin.go:29:32:29:39 | filepath | Gin.go:24:15:24:33 | call to Query | Gin.go:29:32:29:39 | filepath | This path depends on a $@. | Gin.go:24:15:24:33 | call to Query | user-provided value |
 edges
-| Gin.go:24:15:24:33 | call to Query | Gin.go:25:10:25:17 | filepath | provenance | Src:MaD:4  Sink:MaD:1 |
-| Gin.go:24:15:24:33 | call to Query | Gin.go:26:39:26:46 | filepath | provenance | Src:MaD:4  Sink:MaD:5 |
-| Gin.go:24:15:24:33 | call to Query | Gin.go:27:20:27:27 | filepath | provenance | Src:MaD:4  Sink:MaD:2 |
-| Gin.go:24:15:24:33 | call to Query | Gin.go:29:32:29:39 | filepath | provenance | Src:MaD:4  Sink:MaD:3 |
+| Gin.go:24:15:24:33 | call to Query | Gin.go:25:10:25:17 | filepath | provenance | Src:MaD:4 Sink:MaD:1 |
+| Gin.go:24:15:24:33 | call to Query | Gin.go:26:39:26:46 | filepath | provenance | Src:MaD:4 Sink:MaD:5 |
+| Gin.go:24:15:24:33 | call to Query | Gin.go:27:20:27:27 | filepath | provenance | Src:MaD:4 Sink:MaD:2 |
+| Gin.go:24:15:24:33 | call to Query | Gin.go:29:32:29:39 | filepath | provenance | Src:MaD:4 Sink:MaD:3 |
 models
 | 1 | Sink: github.com/gin-gonic/gin; Context; false; File; ; ; Argument[0]; path-injection; manual |
 | 2 | Sink: github.com/gin-gonic/gin; Context; false; FileAttachment; ; ; Argument[0]; path-injection; manual |

--- a/go/ql/test/library-tests/semmle/go/frameworks/Gorestful/gorestful.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Gorestful/gorestful.expected
@@ -5,14 +5,14 @@ models
 | 4 | Source: github.com/emicklei/go-restful; Request; true; ReadEntity; ; ; Argument[0]; remote; manual |
 | 5 | Sink: os/exec; ; false; Command; ; ; Argument[0]; command-injection; manual |
 edges
-| gorestful.go:15:15:15:44 | call to QueryParameters | gorestful.go:15:15:15:47 | index expression | provenance | Src:MaD:1  Sink:MaD:5 |
-| gorestful.go:17:2:17:39 | ... := ...[0] | gorestful.go:18:15:18:17 | val | provenance | Src:MaD:2  Sink:MaD:5 |
-| gorestful.go:21:15:21:38 | call to PathParameters | gorestful.go:21:15:21:45 | index expression | provenance | Src:MaD:3  Sink:MaD:5 |
-| gorestful.go:23:21:23:24 | &... | gorestful.go:24:15:24:21 | selection of cmd | provenance | Src:MaD:4  Sink:MaD:5 |
-| gorestful_v2.go:15:15:15:44 | call to QueryParameters | gorestful_v2.go:15:15:15:47 | index expression | provenance | Src:MaD:1  Sink:MaD:5 |
-| gorestful_v2.go:17:2:17:39 | ... := ...[0] | gorestful_v2.go:18:15:18:17 | val | provenance | Src:MaD:2  Sink:MaD:5 |
-| gorestful_v2.go:21:15:21:38 | call to PathParameters | gorestful_v2.go:21:15:21:45 | index expression | provenance | Src:MaD:3  Sink:MaD:5 |
-| gorestful_v2.go:23:21:23:24 | &... | gorestful_v2.go:24:15:24:21 | selection of cmd | provenance | Src:MaD:4  Sink:MaD:5 |
+| gorestful.go:15:15:15:44 | call to QueryParameters | gorestful.go:15:15:15:47 | index expression | provenance | Src:MaD:1 Sink:MaD:5 |
+| gorestful.go:17:2:17:39 | ... := ...[0] | gorestful.go:18:15:18:17 | val | provenance | Src:MaD:2 Sink:MaD:5 |
+| gorestful.go:21:15:21:38 | call to PathParameters | gorestful.go:21:15:21:45 | index expression | provenance | Src:MaD:3 Sink:MaD:5 |
+| gorestful.go:23:21:23:24 | &... | gorestful.go:24:15:24:21 | selection of cmd | provenance | Src:MaD:4 Sink:MaD:5 |
+| gorestful_v2.go:15:15:15:44 | call to QueryParameters | gorestful_v2.go:15:15:15:47 | index expression | provenance | Src:MaD:1 Sink:MaD:5 |
+| gorestful_v2.go:17:2:17:39 | ... := ...[0] | gorestful_v2.go:18:15:18:17 | val | provenance | Src:MaD:2 Sink:MaD:5 |
+| gorestful_v2.go:21:15:21:38 | call to PathParameters | gorestful_v2.go:21:15:21:45 | index expression | provenance | Src:MaD:3 Sink:MaD:5 |
+| gorestful_v2.go:23:21:23:24 | &... | gorestful_v2.go:24:15:24:21 | selection of cmd | provenance | Src:MaD:4 Sink:MaD:5 |
 nodes
 | gorestful.go:15:15:15:44 | call to QueryParameters | semmle.label | call to QueryParameters |
 | gorestful.go:15:15:15:47 | index expression | semmle.label | index expression |

--- a/go/ql/test/query-tests/Security/CWE-020/IncompleteHostnameRegexp/IncompleteHostnameRegexp.expected
+++ b/go/ql/test/query-tests/Security/CWE-020/IncompleteHostnameRegexp/IncompleteHostnameRegexp.expected
@@ -6,9 +6,9 @@
 | main.go:56:15:56:34 | ...+... | main.go:56:15:56:34 | ...+... | main.go:56:15:56:34 | ...+... | This regular expression has an unescaped dot before 'example.com', so it might match more hosts than expected when $@. | main.go:56:15:56:34 | ...+... | the regular expression is used |
 | main.go:58:15:58:42 | ...+... | main.go:58:15:58:42 | ...+... | main.go:58:15:58:42 | ...+... | This regular expression has an unescaped dot before 'example.com', so it might match more hosts than expected when $@. | main.go:58:15:58:42 | ...+... | the regular expression is used |
 edges
-| IncompleteHostnameRegexp.go:11:8:11:36 | "^((www\|beta).)?example.com/" | IncompleteHostnameRegexp.go:12:38:12:39 | re | provenance |  Sink:MaD:2 |
+| IncompleteHostnameRegexp.go:11:8:11:36 | "^((www\|beta).)?example.com/" | IncompleteHostnameRegexp.go:12:38:12:39 | re | provenance | Sink:MaD:2 |
 | main.go:49:21:49:45 | `https://www.example.com` | main.go:62:15:62:25 | sourceConst | provenance |  |
-| main.go:62:15:62:25 | sourceConst | main.go:65:15:65:23 | localVar3 | provenance |  Sink:MaD:1 |
+| main.go:62:15:62:25 | sourceConst | main.go:65:15:65:23 | localVar3 | provenance | Sink:MaD:1 |
 models
 | 1 | Sink: regexp; ; true; Match; ; ; Argument[0]; regex-use[1]; manual |
 | 2 | Sink: regexp; ; true; MatchString; ; ; Argument[0]; regex-use[1]; manual |

--- a/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/TaintedPath.expected
@@ -4,7 +4,7 @@
 | TaintedPath.go:68:28:68:57 | call to Clean | TaintedPath.go:14:18:14:22 | selection of URL | TaintedPath.go:68:28:68:57 | call to Clean | This path depends on a $@. | TaintedPath.go:14:18:14:22 | selection of URL | user-provided value |
 edges
 | TaintedPath.go:14:18:14:22 | selection of URL | TaintedPath.go:14:18:14:30 | call to Query | provenance | Src:MaD:2 MaD:3 |
-| TaintedPath.go:14:18:14:30 | call to Query | TaintedPath.go:17:29:17:40 | tainted_path | provenance |  Sink:MaD:1 |
+| TaintedPath.go:14:18:14:30 | call to Query | TaintedPath.go:17:29:17:40 | tainted_path | provenance | Sink:MaD:1 |
 | TaintedPath.go:14:18:14:30 | call to Query | TaintedPath.go:21:57:21:68 | tainted_path | provenance |  |
 | TaintedPath.go:14:18:14:30 | call to Query | TaintedPath.go:68:39:68:56 | ...+... | provenance |  |
 | TaintedPath.go:21:57:21:68 | tainted_path | TaintedPath.go:21:28:21:69 | call to Join | provenance | FunctionModel Sink:MaD:1 |

--- a/go/ql/test/query-tests/Security/CWE-022/UnsafeUnzipSymlink.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/UnsafeUnzipSymlink.expected
@@ -5,8 +5,8 @@
 | UnsafeUnzipSymlink.go:126:17:126:31 | selection of Linkname | UnsafeUnzipSymlink.go:126:17:126:31 | selection of Linkname | UnsafeUnzipSymlink.go:112:13:112:20 | linkName | Unresolved path from an archive header, which may point outside the archive root, is used in $@. | UnsafeUnzipSymlink.go:112:13:112:20 | linkName | symlink creation |
 | UnsafeUnzipSymlink.go:126:34:126:44 | selection of Name | UnsafeUnzipSymlink.go:126:34:126:44 | selection of Name | UnsafeUnzipSymlink.go:112:23:112:30 | fileName | Unresolved path from an archive header, which may point outside the archive root, is used in $@. | UnsafeUnzipSymlink.go:112:23:112:30 | fileName | symlink creation |
 edges
-| UnsafeUnzipSymlink.go:111:19:111:26 | definition of linkName | UnsafeUnzipSymlink.go:112:13:112:20 | linkName | provenance |  Sink:MaD:1 |
-| UnsafeUnzipSymlink.go:111:29:111:36 | definition of fileName | UnsafeUnzipSymlink.go:112:23:112:30 | fileName | provenance |  Sink:MaD:1 |
+| UnsafeUnzipSymlink.go:111:19:111:26 | definition of linkName | UnsafeUnzipSymlink.go:112:13:112:20 | linkName | provenance | Sink:MaD:1 |
+| UnsafeUnzipSymlink.go:111:29:111:36 | definition of fileName | UnsafeUnzipSymlink.go:112:23:112:30 | fileName | provenance | Sink:MaD:1 |
 | UnsafeUnzipSymlink.go:126:17:126:31 | selection of Linkname | UnsafeUnzipSymlink.go:111:19:111:26 | definition of linkName | provenance |  |
 | UnsafeUnzipSymlink.go:126:34:126:44 | selection of Name | UnsafeUnzipSymlink.go:111:29:111:36 | definition of fileName | provenance |  |
 models

--- a/go/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
+++ b/go/ql/test/query-tests/Security/CWE-022/ZipSlip.expected
@@ -11,11 +11,11 @@ edges
 | UnsafeUnzipSymlinkGood.go:76:24:76:38 | selection of Linkname | UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate | provenance |  |
 | UnsafeUnzipSymlinkGood.go:76:70:76:80 | selection of Name | UnsafeUnzipSymlinkGood.go:52:24:52:32 | definition of candidate | provenance |  |
 | ZipSlip.go:11:2:15:2 | range statement[1] | ZipSlip.go:12:24:12:29 | selection of Name | provenance |  |
-| ZipSlip.go:12:3:12:30 | ... := ...[0] | ZipSlip.go:14:20:14:20 | p | provenance |  Sink:MaD:1 |
+| ZipSlip.go:12:3:12:30 | ... := ...[0] | ZipSlip.go:14:20:14:20 | p | provenance | Sink:MaD:1 |
 | ZipSlip.go:12:24:12:29 | selection of Name | ZipSlip.go:12:3:12:30 | ... := ...[0] | provenance | MaD:4 |
 | tarslip.go:15:2:15:30 | ... := ...[0] | tarslip.go:16:23:16:33 | selection of Name | provenance |  |
 | tarslip.go:16:23:16:33 | selection of Name | tarslip.go:16:14:16:34 | call to Dir | provenance | MaD:5 Sink:MaD:2 |
-| tst.go:23:2:43:2 | range statement[1] | tst.go:29:20:29:23 | path | provenance |  Sink:MaD:1 |
+| tst.go:23:2:43:2 | range statement[1] | tst.go:29:20:29:23 | path | provenance | Sink:MaD:1 |
 models
 | 1 | Sink: io/ioutil; ; false; WriteFile; ; ; Argument[0]; path-injection; manual |
 | 2 | Sink: os; ; false; MkdirAll; ; ; Argument[0]; path-injection; manual |

--- a/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -39,7 +39,7 @@ edges
 | CommandInjection2.go:44:67:44:75 | imageName | CommandInjection2.go:44:34:44:88 | []type{args} [array] | provenance |  |
 | CommandInjection2.go:44:67:44:75 | imageName | CommandInjection2.go:44:34:44:88 | call to Sprintf | provenance | FunctionModel |
 | CommandInjection.go:9:13:9:19 | selection of URL | CommandInjection.go:9:13:9:27 | call to Query | provenance | Src:MaD:5 MaD:6 |
-| CommandInjection.go:9:13:9:27 | call to Query | CommandInjection.go:10:22:10:28 | cmdName | provenance |  Sink:MaD:7 |
+| CommandInjection.go:9:13:9:27 | call to Query | CommandInjection.go:10:22:10:28 | cmdName | provenance | Sink:MaD:7 |
 | GitSubcommands.go:11:13:11:19 | selection of URL | GitSubcommands.go:11:13:11:27 | call to Query | provenance | Src:MaD:5 MaD:6 |
 | GitSubcommands.go:11:13:11:27 | call to Query | GitSubcommands.go:13:31:13:37 | tainted | provenance |  |
 | GitSubcommands.go:11:13:11:27 | call to Query | GitSubcommands.go:14:31:14:37 | tainted | provenance |  |

--- a/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
+++ b/go/ql/test/query-tests/Security/CWE-078/StoredCommand.expected
@@ -3,7 +3,7 @@
 edges
 | StoredCommand.go:11:2:11:27 | ... := ...[0] | StoredCommand.go:13:2:13:5 | rows | provenance |  |
 | StoredCommand.go:13:2:13:5 | rows | StoredCommand.go:13:12:13:19 | &... | provenance | FunctionModel |
-| StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:14:22:14:28 | cmdName | provenance |  Sink:MaD:1 |
+| StoredCommand.go:13:12:13:19 | &... | StoredCommand.go:14:22:14:28 | cmdName | provenance | Sink:MaD:1 |
 models
 | 1 | Sink: os/exec; ; false; Command; ; ; Argument[0]; command-injection; manual |
 nodes

--- a/go/ql/test/query-tests/Security/CWE-347/MissingJwtSignatureCheck.expected
+++ b/go/ql/test/query-tests/Security/CWE-347/MissingJwtSignatureCheck.expected
@@ -7,13 +7,13 @@ edges
 | go-jose.v3.go:25:16:25:47 | call to Get | go-jose.v3.go:26:15:26:25 | signedToken | provenance |  |
 | go-jose.v3.go:26:15:26:25 | signedToken | go-jose.v3.go:29:19:29:29 | definition of signedToken | provenance |  |
 | go-jose.v3.go:29:19:29:29 | definition of signedToken | go-jose.v3.go:31:37:31:47 | signedToken | provenance |  |
-| go-jose.v3.go:31:2:31:48 | ... := ...[0] | go-jose.v3.go:33:12:33:23 | DecodedToken | provenance |  Sink:MaD:1 |
+| go-jose.v3.go:31:2:31:48 | ... := ...[0] | go-jose.v3.go:33:12:33:23 | DecodedToken | provenance | Sink:MaD:1 |
 | go-jose.v3.go:31:37:31:47 | signedToken | go-jose.v3.go:31:2:31:48 | ... := ...[0] | provenance | MaD:2 |
 | golang-jwt-v5.go:28:16:28:20 | selection of URL | golang-jwt-v5.go:28:16:28:28 | call to Query | provenance | Src:MaD:4 MaD:5 |
 | golang-jwt-v5.go:28:16:28:28 | call to Query | golang-jwt-v5.go:28:16:28:47 | call to Get | provenance | MaD:6 |
 | golang-jwt-v5.go:28:16:28:47 | call to Get | golang-jwt-v5.go:29:25:29:35 | signedToken | provenance |  |
 | golang-jwt-v5.go:29:25:29:35 | signedToken | golang-jwt-v5.go:32:29:32:39 | definition of signedToken | provenance |  |
-| golang-jwt-v5.go:32:29:32:39 | definition of signedToken | golang-jwt-v5.go:34:58:34:68 | signedToken | provenance |  Sink:MaD:3 |
+| golang-jwt-v5.go:32:29:32:39 | definition of signedToken | golang-jwt-v5.go:34:58:34:68 | signedToken | provenance | Sink:MaD:3 |
 models
 | 1 | Sink: group:go-jose/jwt; JSONWebToken; true; UnsafeClaimsWithoutVerification; ; ; Argument[receiver]; jwt; manual |
 | 2 | Summary: group:go-jose/jwt; ; true; ParseSigned; ; ; Argument[0]; ReturnValue[0]; taint; manual |

--- a/go/ql/test/query-tests/Security/CWE-601/BadRedirectCheck/BadRedirectCheck.expected
+++ b/go/ql/test/query-tests/Security/CWE-601/BadRedirectCheck/BadRedirectCheck.expected
@@ -11,23 +11,23 @@
 edges
 | BadRedirectCheck.go:3:18:3:22 | argument corresponding to redir | BadRedirectCheck.go:5:10:5:14 | redir | provenance |  |
 | BadRedirectCheck.go:3:18:3:22 | definition of redir | BadRedirectCheck.go:5:10:5:14 | redir | provenance |  |
-| BadRedirectCheck.go:5:10:5:14 | redir | main.go:11:25:11:45 | call to sanitizeUrl | provenance |  Sink:MaD:1 |
-| cves.go:14:23:14:25 | argument corresponding to url | cves.go:16:26:16:28 | url | provenance |  Sink:MaD:1 |
-| cves.go:33:14:33:34 | call to Get | cves.go:37:25:37:32 | redirect | provenance |  Sink:MaD:1 |
-| cves.go:41:14:41:34 | call to Get | cves.go:45:25:45:32 | redirect | provenance |  Sink:MaD:1 |
+| BadRedirectCheck.go:5:10:5:14 | redir | main.go:11:25:11:45 | call to sanitizeUrl | provenance | Sink:MaD:1 |
+| cves.go:14:23:14:25 | argument corresponding to url | cves.go:16:26:16:28 | url | provenance | Sink:MaD:1 |
+| cves.go:33:14:33:34 | call to Get | cves.go:37:25:37:32 | redirect | provenance | Sink:MaD:1 |
+| cves.go:41:14:41:34 | call to Get | cves.go:45:25:45:32 | redirect | provenance | Sink:MaD:1 |
 | main.go:10:18:10:25 | argument corresponding to redirect | main.go:11:37:11:44 | redirect | provenance |  |
 | main.go:11:37:11:44 | redirect | BadRedirectCheck.go:3:18:3:22 | definition of redir | provenance |  |
-| main.go:11:37:11:44 | redirect | main.go:11:25:11:45 | call to sanitizeUrl | provenance |  Sink:MaD:1 |
-| main.go:32:24:32:26 | argument corresponding to url | main.go:34:26:34:28 | url | provenance |  Sink:MaD:1 |
+| main.go:11:37:11:44 | redirect | main.go:11:25:11:45 | call to sanitizeUrl | provenance | Sink:MaD:1 |
+| main.go:32:24:32:26 | argument corresponding to url | main.go:34:26:34:28 | url | provenance | Sink:MaD:1 |
 | main.go:68:17:68:24 | argument corresponding to redirect | main.go:73:20:73:27 | redirect | provenance |  |
 | main.go:68:17:68:24 | definition of redirect | main.go:73:20:73:27 | redirect | provenance |  |
-| main.go:73:9:73:28 | call to Clean | main.go:77:25:77:39 | call to getTarget1 | provenance |  Sink:MaD:1 |
+| main.go:73:9:73:28 | call to Clean | main.go:77:25:77:39 | call to getTarget1 | provenance | Sink:MaD:1 |
 | main.go:73:20:73:27 | redirect | main.go:73:9:73:28 | call to Clean | provenance | MaD:2 |
 | main.go:73:20:73:27 | redirect | main.go:73:9:73:28 | call to Clean | provenance | MaD:2 |
 | main.go:76:19:76:21 | argument corresponding to url | main.go:77:36:77:38 | url | provenance |  |
 | main.go:77:36:77:38 | url | main.go:68:17:68:24 | definition of redirect | provenance |  |
 | main.go:77:36:77:38 | url | main.go:77:25:77:39 | call to getTarget1 | provenance | MaD:2 Sink:MaD:1 |
-| main.go:87:9:87:14 | selection of Path | main.go:91:25:91:39 | call to getTarget2 | provenance |  Sink:MaD:1 |
+| main.go:87:9:87:14 | selection of Path | main.go:91:25:91:39 | call to getTarget2 | provenance | Sink:MaD:1 |
 models
 | 1 | Sink: net/http; ; true; Redirect; ; ; Argument[2]; url-redirection[0]; manual |
 | 2 | Summary: path; ; false; Clean; ; ; Argument[0]; ReturnValue; taint; manual |

--- a/go/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
+++ b/go/ql/test/query-tests/Security/CWE-601/OpenUrlRedirect/OpenUrlRedirect.expected
@@ -20,7 +20,7 @@ edges
 | stdlib.go:31:13:31:32 | call to Get | stdlib.go:35:34:35:39 | target | provenance |  |
 | stdlib.go:35:34:35:39 | target | stdlib.go:35:30:35:39 | ...+... | provenance | Config |
 | stdlib.go:44:13:44:18 | selection of Form | stdlib.go:44:13:44:32 | call to Get | provenance | Src:MaD:3 Config |
-| stdlib.go:44:13:44:32 | call to Get | stdlib.go:46:23:46:28 | target | provenance |  Sink:MaD:1 |
+| stdlib.go:44:13:44:32 | call to Get | stdlib.go:46:23:46:28 | target | provenance | Sink:MaD:1 |
 | stdlib.go:64:13:64:18 | selection of Form | stdlib.go:64:13:64:32 | call to Get | provenance | Src:MaD:3 Config |
 | stdlib.go:64:13:64:32 | call to Get | stdlib.go:67:23:67:28 | target | provenance |  |
 | stdlib.go:67:23:67:28 | target | stdlib.go:67:23:67:37 | ...+... | provenance | Config |
@@ -28,7 +28,7 @@ edges
 | stdlib.go:89:13:89:18 | selection of Form | stdlib.go:89:13:89:32 | call to Get | provenance | Src:MaD:3 Config |
 | stdlib.go:89:13:89:32 | call to Get | stdlib.go:90:3:90:8 | target | provenance |  |
 | stdlib.go:90:3:90:8 | target | stdlib.go:90:3:90:25 | ... += ... | provenance | Config |
-| stdlib.go:90:3:90:25 | ... += ... | stdlib.go:92:23:92:28 | target | provenance |  Sink:MaD:1 |
+| stdlib.go:90:3:90:25 | ... += ... | stdlib.go:92:23:92:28 | target | provenance | Sink:MaD:1 |
 | stdlib.go:107:54:107:54 | definition of r [pointer, URL, pointer] | stdlib.go:112:4:112:4 | r [pointer, URL, pointer] | provenance |  |
 | stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:112:4:112:4 | r [pointer, URL] | provenance |  |
 | stdlib.go:107:54:107:54 | definition of r [pointer, URL] | stdlib.go:113:24:113:24 | r [pointer, URL] | provenance |  |
@@ -48,14 +48,14 @@ edges
 | stdlib.go:113:24:113:24 | r [pointer, URL] | stdlib.go:113:24:113:24 | implicit dereference [URL] | provenance |  |
 | stdlib.go:113:24:113:28 | selection of URL | stdlib.go:113:24:113:37 | call to String | provenance | Src:MaD:4 Config Sink:MaD:1 |
 | stdlib.go:146:13:146:18 | selection of Form | stdlib.go:146:13:146:32 | call to Get | provenance | Src:MaD:3 Config |
-| stdlib.go:146:13:146:32 | call to Get | stdlib.go:152:23:152:28 | target | provenance |  Sink:MaD:1 |
+| stdlib.go:146:13:146:32 | call to Get | stdlib.go:152:23:152:28 | target | provenance | Sink:MaD:1 |
 | stdlib.go:159:10:159:15 | star expression | stdlib.go:159:11:159:15 | selection of URL | provenance | Config |
 | stdlib.go:159:10:159:15 | star expression | stdlib.go:162:24:162:26 | url | provenance |  |
 | stdlib.go:159:11:159:15 | selection of URL | stdlib.go:159:10:159:15 | star expression | provenance | Src:MaD:4 Config |
 | stdlib.go:162:24:162:26 | url | stdlib.go:162:24:162:35 | call to String | provenance | Config Sink:MaD:1 |
 | stdlib.go:173:35:173:39 | selection of URL | stdlib.go:173:35:173:52 | call to RequestURI | provenance | Src:MaD:4 Config |
 | stdlib.go:173:35:173:52 | call to RequestURI | stdlib.go:173:24:173:52 | ...+... | provenance | Config Sink:MaD:1 |
-| stdlib.go:182:13:182:33 | call to FormValue | stdlib.go:184:23:184:28 | target | provenance | Src:MaD:2  Sink:MaD:1 |
+| stdlib.go:182:13:182:33 | call to FormValue | stdlib.go:184:23:184:28 | target | provenance | Src:MaD:2 Sink:MaD:1 |
 | stdlib.go:190:3:190:8 | definition of target | stdlib.go:192:23:192:28 | target | provenance |  |
 | stdlib.go:190:3:190:8 | definition of target | stdlib.go:194:23:194:28 | target | provenance |  |
 | stdlib.go:190:3:190:57 | ... := ...[0] | stdlib.go:190:3:190:8 | definition of target | provenance |  |

--- a/go/ql/test/query-tests/Security/CWE-643/XPathInjection.expected
+++ b/go/ql/test/query-tests/Security/CWE-643/XPathInjection.expected
@@ -44,61 +44,61 @@
 | tst.go:146:23:146:85 | ...+... | tst.go:139:14:139:19 | selection of Form | tst.go:146:23:146:85 | ...+... | XPath expression depends on a $@. | tst.go:139:14:139:19 | selection of Form | user-provided value |
 edges
 | XPathInjection.go:13:14:13:19 | selection of Form | XPathInjection.go:13:14:13:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| XPathInjection.go:13:14:13:35 | call to Get | XPathInjection.go:16:29:16:91 | ...+... | provenance |  Sink:MaD:21 |
+| XPathInjection.go:13:14:13:35 | call to Get | XPathInjection.go:16:29:16:91 | ...+... | provenance | Sink:MaD:21 |
 | tst.go:35:14:35:19 | selection of Form | tst.go:35:14:35:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:35:14:35:35 | call to Get | tst.go:38:23:38:85 | ...+... | provenance |  Sink:MaD:17 |
-| tst.go:35:14:35:35 | call to Get | tst.go:39:29:39:87 | ...+... | provenance |  Sink:MaD:18 |
-| tst.go:35:14:35:35 | call to Get | tst.go:40:24:40:86 | ...+... | provenance |  Sink:MaD:19 |
-| tst.go:35:14:35:35 | call to Get | tst.go:41:24:41:82 | ...+... | provenance |  Sink:MaD:20 |
+| tst.go:35:14:35:35 | call to Get | tst.go:38:23:38:85 | ...+... | provenance | Sink:MaD:17 |
+| tst.go:35:14:35:35 | call to Get | tst.go:39:29:39:87 | ...+... | provenance | Sink:MaD:18 |
+| tst.go:35:14:35:35 | call to Get | tst.go:40:24:40:86 | ...+... | provenance | Sink:MaD:19 |
+| tst.go:35:14:35:35 | call to Get | tst.go:41:24:41:82 | ...+... | provenance | Sink:MaD:20 |
 | tst.go:46:14:46:19 | selection of Form | tst.go:46:14:46:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:46:14:46:35 | call to Get | tst.go:49:26:49:84 | ...+... | provenance |  Sink:MaD:1 |
-| tst.go:46:14:46:35 | call to Get | tst.go:50:29:50:87 | ...+... | provenance |  Sink:MaD:2 |
-| tst.go:46:14:46:35 | call to Get | tst.go:51:30:51:88 | ...+... | provenance |  Sink:MaD:3 |
-| tst.go:46:14:46:35 | call to Get | tst.go:52:33:52:91 | ...+... | provenance |  Sink:MaD:4 |
+| tst.go:46:14:46:35 | call to Get | tst.go:49:26:49:84 | ...+... | provenance | Sink:MaD:1 |
+| tst.go:46:14:46:35 | call to Get | tst.go:50:29:50:87 | ...+... | provenance | Sink:MaD:2 |
+| tst.go:46:14:46:35 | call to Get | tst.go:51:30:51:88 | ...+... | provenance | Sink:MaD:3 |
+| tst.go:46:14:46:35 | call to Get | tst.go:52:33:52:91 | ...+... | provenance | Sink:MaD:4 |
 | tst.go:57:14:57:19 | selection of Form | tst.go:57:14:57:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:57:14:57:35 | call to Get | tst.go:60:25:60:83 | ...+... | provenance |  Sink:MaD:9 |
-| tst.go:57:14:57:35 | call to Get | tst.go:61:28:61:86 | ...+... | provenance |  Sink:MaD:10 |
-| tst.go:57:14:57:35 | call to Get | tst.go:62:25:62:83 | ...+... | provenance |  Sink:MaD:11 |
-| tst.go:57:14:57:35 | call to Get | tst.go:63:34:63:92 | ...+... | provenance |  Sink:MaD:12 |
-| tst.go:57:14:57:35 | call to Get | tst.go:64:29:64:87 | ...+... | provenance |  Sink:MaD:13 |
-| tst.go:57:14:57:35 | call to Get | tst.go:65:32:65:90 | ...+... | provenance |  Sink:MaD:14 |
-| tst.go:57:14:57:35 | call to Get | tst.go:66:23:66:85 | ...+... | provenance |  Sink:MaD:16 |
-| tst.go:57:14:57:35 | call to Get | tst.go:67:22:67:84 | ...+... | provenance |  Sink:MaD:15 |
+| tst.go:57:14:57:35 | call to Get | tst.go:60:25:60:83 | ...+... | provenance | Sink:MaD:9 |
+| tst.go:57:14:57:35 | call to Get | tst.go:61:28:61:86 | ...+... | provenance | Sink:MaD:10 |
+| tst.go:57:14:57:35 | call to Get | tst.go:62:25:62:83 | ...+... | provenance | Sink:MaD:11 |
+| tst.go:57:14:57:35 | call to Get | tst.go:63:34:63:92 | ...+... | provenance | Sink:MaD:12 |
+| tst.go:57:14:57:35 | call to Get | tst.go:64:29:64:87 | ...+... | provenance | Sink:MaD:13 |
+| tst.go:57:14:57:35 | call to Get | tst.go:65:32:65:90 | ...+... | provenance | Sink:MaD:14 |
+| tst.go:57:14:57:35 | call to Get | tst.go:66:23:66:85 | ...+... | provenance | Sink:MaD:16 |
+| tst.go:57:14:57:35 | call to Get | tst.go:67:22:67:84 | ...+... | provenance | Sink:MaD:15 |
 | tst.go:72:14:72:19 | selection of Form | tst.go:72:14:72:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:72:14:72:35 | call to Get | tst.go:75:26:75:84 | ...+... | provenance |  Sink:MaD:5 |
-| tst.go:72:14:72:35 | call to Get | tst.go:76:29:76:87 | ...+... | provenance |  Sink:MaD:6 |
-| tst.go:72:14:72:35 | call to Get | tst.go:77:30:77:88 | ...+... | provenance |  Sink:MaD:7 |
-| tst.go:72:14:72:35 | call to Get | tst.go:78:33:78:91 | ...+... | provenance |  Sink:MaD:8 |
+| tst.go:72:14:72:35 | call to Get | tst.go:75:26:75:84 | ...+... | provenance | Sink:MaD:5 |
+| tst.go:72:14:72:35 | call to Get | tst.go:76:29:76:87 | ...+... | provenance | Sink:MaD:6 |
+| tst.go:72:14:72:35 | call to Get | tst.go:77:30:77:88 | ...+... | provenance | Sink:MaD:7 |
+| tst.go:72:14:72:35 | call to Get | tst.go:78:33:78:91 | ...+... | provenance | Sink:MaD:8 |
 | tst.go:83:14:83:19 | selection of Form | tst.go:83:14:83:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:83:14:83:35 | call to Get | tst.go:86:25:86:87 | ...+... | provenance |  Sink:MaD:24 |
-| tst.go:83:14:83:35 | call to Get | tst.go:87:26:87:88 | ...+... | provenance |  Sink:MaD:25 |
+| tst.go:83:14:83:35 | call to Get | tst.go:86:25:86:87 | ...+... | provenance | Sink:MaD:24 |
+| tst.go:83:14:83:35 | call to Get | tst.go:87:26:87:88 | ...+... | provenance | Sink:MaD:25 |
 | tst.go:92:14:92:19 | selection of Form | tst.go:92:14:92:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:92:14:92:35 | call to Get | tst.go:96:23:96:126 | ...+... | provenance |  Sink:MaD:22 |
-| tst.go:92:14:92:35 | call to Get | tst.go:97:24:97:127 | ...+... | provenance |  Sink:MaD:21 |
-| tst.go:92:14:92:35 | call to Get | tst.go:98:27:98:122 | ...+... | provenance |  Sink:MaD:23 |
+| tst.go:92:14:92:35 | call to Get | tst.go:96:23:96:126 | ...+... | provenance | Sink:MaD:22 |
+| tst.go:92:14:92:35 | call to Get | tst.go:97:24:97:127 | ...+... | provenance | Sink:MaD:21 |
+| tst.go:92:14:92:35 | call to Get | tst.go:98:27:98:122 | ...+... | provenance | Sink:MaD:23 |
 | tst.go:93:14:93:19 | selection of Form | tst.go:93:14:93:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:93:14:93:35 | call to Get | tst.go:96:23:96:126 | ...+... | provenance |  Sink:MaD:22 |
-| tst.go:93:14:93:35 | call to Get | tst.go:97:24:97:127 | ...+... | provenance |  Sink:MaD:21 |
-| tst.go:93:14:93:35 | call to Get | tst.go:98:27:98:122 | ...+... | provenance |  Sink:MaD:23 |
+| tst.go:93:14:93:35 | call to Get | tst.go:96:23:96:126 | ...+... | provenance | Sink:MaD:22 |
+| tst.go:93:14:93:35 | call to Get | tst.go:97:24:97:127 | ...+... | provenance | Sink:MaD:21 |
+| tst.go:93:14:93:35 | call to Get | tst.go:98:27:98:122 | ...+... | provenance | Sink:MaD:23 |
 | tst.go:106:14:106:19 | selection of Form | tst.go:106:14:106:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:106:14:106:35 | call to Get | tst.go:109:27:109:89 | ...+... | provenance |  Sink:MaD:34 |
-| tst.go:106:14:106:35 | call to Get | tst.go:110:28:110:90 | ...+... | provenance |  Sink:MaD:35 |
+| tst.go:106:14:106:35 | call to Get | tst.go:109:27:109:89 | ...+... | provenance | Sink:MaD:34 |
+| tst.go:106:14:106:35 | call to Get | tst.go:110:28:110:90 | ...+... | provenance | Sink:MaD:35 |
 | tst.go:115:14:115:19 | selection of Form | tst.go:115:14:115:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:115:14:115:35 | call to Get | tst.go:119:33:119:136 | ...+... | provenance |  Sink:MaD:33 |
-| tst.go:115:14:115:35 | call to Get | tst.go:120:18:120:121 | ...+... | provenance |  Sink:MaD:29 |
-| tst.go:115:14:115:35 | call to Get | tst.go:121:31:121:126 | ...+... | provenance |  Sink:MaD:30 |
-| tst.go:115:14:115:35 | call to Get | tst.go:122:21:122:116 | ...+... | provenance |  Sink:MaD:31 |
-| tst.go:115:14:115:35 | call to Get | tst.go:123:27:123:122 | ...+... | provenance |  Sink:MaD:32 |
+| tst.go:115:14:115:35 | call to Get | tst.go:119:33:119:136 | ...+... | provenance | Sink:MaD:33 |
+| tst.go:115:14:115:35 | call to Get | tst.go:120:18:120:121 | ...+... | provenance | Sink:MaD:29 |
+| tst.go:115:14:115:35 | call to Get | tst.go:121:31:121:126 | ...+... | provenance | Sink:MaD:30 |
+| tst.go:115:14:115:35 | call to Get | tst.go:122:21:122:116 | ...+... | provenance | Sink:MaD:31 |
+| tst.go:115:14:115:35 | call to Get | tst.go:123:27:123:122 | ...+... | provenance | Sink:MaD:32 |
 | tst.go:116:14:116:19 | selection of Form | tst.go:116:14:116:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:116:14:116:35 | call to Get | tst.go:119:33:119:136 | ...+... | provenance |  Sink:MaD:33 |
-| tst.go:116:14:116:35 | call to Get | tst.go:120:18:120:121 | ...+... | provenance |  Sink:MaD:29 |
-| tst.go:116:14:116:35 | call to Get | tst.go:121:31:121:126 | ...+... | provenance |  Sink:MaD:30 |
-| tst.go:116:14:116:35 | call to Get | tst.go:122:21:122:116 | ...+... | provenance |  Sink:MaD:31 |
-| tst.go:116:14:116:35 | call to Get | tst.go:123:27:123:122 | ...+... | provenance |  Sink:MaD:32 |
+| tst.go:116:14:116:35 | call to Get | tst.go:119:33:119:136 | ...+... | provenance | Sink:MaD:33 |
+| tst.go:116:14:116:35 | call to Get | tst.go:120:18:120:121 | ...+... | provenance | Sink:MaD:29 |
+| tst.go:116:14:116:35 | call to Get | tst.go:121:31:121:126 | ...+... | provenance | Sink:MaD:30 |
+| tst.go:116:14:116:35 | call to Get | tst.go:122:21:122:116 | ...+... | provenance | Sink:MaD:31 |
+| tst.go:116:14:116:35 | call to Get | tst.go:123:27:123:122 | ...+... | provenance | Sink:MaD:32 |
 | tst.go:139:14:139:19 | selection of Form | tst.go:139:14:139:35 | call to Get | provenance | Src:MaD:36 MaD:37 |
-| tst.go:139:14:139:35 | call to Get | tst.go:144:17:144:87 | type conversion | provenance |  Sink:MaD:26 |
+| tst.go:139:14:139:35 | call to Get | tst.go:144:17:144:87 | type conversion | provenance | Sink:MaD:26 |
 | tst.go:139:14:139:35 | call to Get | tst.go:145:41:145:103 | ...+... | provenance |  |
-| tst.go:139:14:139:35 | call to Get | tst.go:146:23:146:85 | ...+... | provenance |  Sink:MaD:28 |
+| tst.go:139:14:139:35 | call to Get | tst.go:146:23:146:85 | ...+... | provenance | Sink:MaD:28 |
 | tst.go:145:41:145:103 | ...+... | tst.go:145:23:145:104 | call to NewReader | provenance | MaD:38 Sink:MaD:27 |
 models
 | 1 | Sink: github.com/antchfx/htmlquery; ; true; Find; ; ; Argument[1]; xpath-injection; manual |


### PR DESCRIPTION
https://github.com/github/codeql/pull/17504 didn't update the test expectations for all the affected languages.