### PR TITLE
Go: Run CI when shared libraries change

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - "go/**"
+      - "shared/**"
       - .github/workflows/go-tests.yml
       - .github/actions/**
       - codeql-workspace.yml
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - "go/**"
+      - "shared/**"
       - .github/workflows/go-tests.yml
       - .github/actions/**
       - codeql-workspace.yml


### PR DESCRIPTION
Go CI should have run for https://github.com/github/codeql/pull/17504. Hopefully this change will fix it.

I did consider whether to restrict to the shared libraries that are actually used by Go, but I think we will forget to update it.