### PR TITLE
Shared: Do not use `@kind graph` for CFG test output

### DIFF
--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1,14634 +1,4949 @@
-AccessorCalls.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter AccessorCalls
-#-----|  -> call to constructor Object
-
-#    1| exit AccessorCalls
-
-#    1| exit AccessorCalls (normal)
-#-----|  -> exit AccessorCalls
-
-#    1| {...}
-#-----|  -> exit AccessorCalls (normal)
-
-#    5| enter get_Item
-#-----|  -> access to parameter i
-
-#    5| exit get_Item
-
-#    5| exit get_Item (normal)
-#-----|  -> exit get_Item
-
-#    5| access to parameter i
-#-----|  -> exit get_Item (normal)
-
-#    5| enter set_Item
-#-----|  -> {...}
-
-#    5| exit set_Item
-
-#    5| exit set_Item (normal)
-#-----|  -> exit set_Item
-
-#    5| {...}
-#-----|  -> exit set_Item (normal)
-
-#    7| enter add_Event
-#-----|  -> {...}
-
-#    7| exit add_Event
-
-#    7| exit add_Event (normal)
-#-----|  -> exit add_Event
-
-#    7| {...}
-#-----|  -> exit add_Event (normal)
-
-#    7| enter remove_Event
-#-----|  -> {...}
-
-#    7| exit remove_Event
-
-#    7| exit remove_Event (normal)
-#-----|  -> exit remove_Event
-
-#    7| {...}
-#-----|  -> exit remove_Event (normal)
-
-#   10| enter M1
-#-----|  -> {...}
-
-#   10| exit M1
-
-#   10| exit M1 (normal)
-#-----|  -> exit M1
-
-#   11| {...}
-#-----|  -> ...;
-
-#   12| this access
-#-----|  -> this access
-
-#   12| ... = ...
-#-----|  -> ...;
-
-#   12| ...;
-#-----|  -> this access
-
-#   12| this access
-#-----|  -> access to field Field
-
-#   12| access to field Field
-#-----|  -> ... = ...
-
-#   13| this access
-#-----|  -> this access
-
-#   13| access to property Prop
-#-----|  -> ... = ...
-
-#   13| ... = ...
-#-----|  -> ...;
-
-#   13| ...;
-#-----|  -> this access
-
-#   13| this access
-#-----|  -> access to property Prop
-
-#   13| access to property Prop
-#-----|  -> access to property Prop
-
-#   14| this access
-#-----|  -> 0
-
-#   14| access to indexer
-#-----|  -> ... = ...
-
-#   14| ... = ...
-#-----|  -> ...;
-
-#   14| ...;
-#-----|  -> this access
-
-#   14| 0
-#-----|  -> this access
-
-#   14| this access
-#-----|  -> 1
-
-#   14| access to indexer
-#-----|  -> access to indexer
-
-#   14| 1
-#-----|  -> access to indexer
-
-#   15| this access
-#-----|  -> access to parameter e
-
-#   15| access to event Event
-#-----|  -> ... += ...
-
-#   15| ... += ...
-#-----|  -> ...;
-
-#   15| ...;
-#-----|  -> this access
-
-#   15| access to parameter e
-#-----|  -> access to event Event
-
-#   16| this access
-#-----|  -> access to parameter e
-
-#   16| access to event Event
-#-----|  -> ... -= ...
-
-#   16| ... -= ...
-#-----|  -> exit M1 (normal)
-
-#   16| ...;
-#-----|  -> this access
-
-#   16| access to parameter e
-#-----|  -> access to event Event
-
-#   19| enter M2
-#-----|  -> {...}
-
-#   19| exit M2
-
-#   19| exit M2 (normal)
-#-----|  -> exit M2
-
-#   20| {...}
-#-----|  -> ...;
-
-#   21| this access
-#-----|  -> access to field x
-
-#   21| access to field x
-#-----|  -> this access
-
-#   21| ... = ...
-#-----|  -> ...;
-
-#   21| ...;
-#-----|  -> this access
-
-#   21| this access
-#-----|  -> access to field x
-
-#   21| access to field x
-#-----|  -> access to field Field
-
-#   21| access to field Field
-#-----|  -> ... = ...
-
-#   22| this access
-#-----|  -> access to field x
-
-#   22| access to field x
-#-----|  -> this access
-
-#   22| access to property Prop
-#-----|  -> ... = ...
-
-#   22| ... = ...
-#-----|  -> ...;
-
-#   22| ...;
-#-----|  -> this access
-
-#   22| this access
-#-----|  -> access to field x
-
-#   22| access to field x
-#-----|  -> access to property Prop
-
-#   22| access to property Prop
-#-----|  -> access to property Prop
-
-#   23| this access
-#-----|  -> access to field x
-
-#   23| access to field x
-#-----|  -> 0
-
-#   23| access to indexer
-#-----|  -> ... = ...
-
-#   23| ... = ...
-#-----|  -> ...;
-
-#   23| ...;
-#-----|  -> this access
-
-#   23| 0
-#-----|  -> this access
-
-#   23| this access
-#-----|  -> access to field x
-
-#   23| access to field x
-#-----|  -> 1
-
-#   23| access to indexer
-#-----|  -> access to indexer
-
-#   23| 1
-#-----|  -> access to indexer
-
-#   24| this access
-#-----|  -> access to field x
-
-#   24| access to field x
-#-----|  -> access to parameter e
-
-#   24| access to event Event
-#-----|  -> ... += ...
-
-#   24| ... += ...
-#-----|  -> ...;
-
-#   24| ...;
-#-----|  -> this access
-
-#   24| access to parameter e
-#-----|  -> access to event Event
-
-#   25| this access
-#-----|  -> access to field x
-
-#   25| access to field x
-#-----|  -> access to parameter e
-
-#   25| access to event Event
-#-----|  -> ... -= ...
-
-#   25| ... -= ...
-#-----|  -> exit M2 (normal)
-
-#   25| ...;
-#-----|  -> this access
-
-#   25| access to parameter e
-#-----|  -> access to event Event
-
-#   28| enter M3
-#-----|  -> {...}
-
-#   28| exit M3
-
-#   28| exit M3 (normal)
-#-----|  -> exit M3
-
-#   29| {...}
-#-----|  -> ...;
-
-#   30| this access
-#-----|  -> access to field Field
-
-#   30| access to field Field
-#-----|  -> ...++
-
-#   30| ...++
-#-----|  -> ...;
-
-#   30| ...;
-#-----|  -> this access
-
-#   31| this access
-#-----|  -> access to property Prop
-
-#   31| access to property Prop
-#-----|  -> ...++
-
-#   31| ...++
-#-----|  -> ...;
-
-#   31| ...;
-#-----|  -> this access
-
-#   32| this access
-#-----|  -> 0
-
-#   32| access to indexer
-#-----|  -> ...++
-
-#   32| ...++
-#-----|  -> exit M3 (normal)
-
-#   32| ...;
-#-----|  -> this access
-
-#   32| 0
-#-----|  -> access to indexer
-
-#   35| enter M4
-#-----|  -> {...}
-
-#   35| exit M4
-
-#   35| exit M4 (normal)
-#-----|  -> exit M4
-
-#   36| {...}
-#-----|  -> ...;
-
-#   37| this access
-#-----|  -> access to field x
-
-#   37| access to field x
-#-----|  -> access to field Field
-
-#   37| access to field Field
-#-----|  -> ...++
-
-#   37| ...++
-#-----|  -> ...;
-
-#   37| ...;
-#-----|  -> this access
-
-#   38| this access
-#-----|  -> access to field x
-
-#   38| access to field x
-#-----|  -> access to property Prop
-
-#   38| access to property Prop
-#-----|  -> ...++
-
-#   38| ...++
-#-----|  -> ...;
-
-#   38| ...;
-#-----|  -> this access
-
-#   39| this access
-#-----|  -> access to field x
-
-#   39| access to field x
-#-----|  -> 0
-
-#   39| access to indexer
-#-----|  -> ...++
-
-#   39| ...++
-#-----|  -> exit M4 (normal)
-
-#   39| ...;
-#-----|  -> this access
-
-#   39| 0
-#-----|  -> access to indexer
-
-#   42| enter M5
-#-----|  -> {...}
-
-#   42| exit M5
-
-#   42| exit M5 (normal)
-#-----|  -> exit M5
-
-#   43| {...}
-#-----|  -> ...;
-
-#   44| this access
-#-----|  -> this access
-
-#   44| this access
-#-----|  -> access to field Field
-
-#   44| access to field Field
-#-----|  -> this access
-
-#   44| ... + ...
-#-----|  -> ... = ...
-
-#   44| ... = ...
-#-----|  -> ...;
-
-#   44| ...;
-#-----|  -> this access
-
-#   44| this access
-#-----|  -> access to field Field
-
-#   44| access to field Field
-#-----|  -> ... + ...
-
-#   45| this access
-#-----|  -> this access
-
-#   45| this access
-#-----|  -> access to property Prop
-
-#   45| access to property Prop
-#-----|  -> ... = ...
-
-#   45| access to property Prop
-#-----|  -> this access
-
-#   45| ... + ...
-#-----|  -> access to property Prop
-
-#   45| ... = ...
-#-----|  -> ...;
-
-#   45| ...;
-#-----|  -> this access
-
-#   45| this access
-#-----|  -> access to property Prop
-
-#   45| access to property Prop
-#-----|  -> ... + ...
-
-#   46| this access
-#-----|  -> 0
-
-#   46| this access
-#-----|  -> 0
-
-#   46| access to indexer
-#-----|  -> ... = ...
-
-#   46| access to indexer
-#-----|  -> this access
-
-#   46| ... + ...
-#-----|  -> access to indexer
-
-#   46| ... = ...
-#-----|  -> exit M5 (normal)
-
-#   46| ...;
-#-----|  -> this access
-
-#   46| 0
-#-----|  -> this access
-
-#   46| 0
-#-----|  -> access to indexer
-
-#   46| this access
-#-----|  -> 0
-
-#   46| access to indexer
-#-----|  -> ... + ...
-
-#   46| 0
-#-----|  -> access to indexer
-
-#   49| enter M6
-#-----|  -> {...}
-
-#   49| exit M6
-
-#   49| exit M6 (normal)
-#-----|  -> exit M6
-
-#   50| {...}
-#-----|  -> ...;
-
-#   51| this access
-#-----|  -> access to field x
-
-#   51| this access
-#-----|  -> access to field x
-
-#   51| access to field x
-#-----|  -> this access
-
-#   51| access to field x
-#-----|  -> access to field Field
-
-#   51| access to field Field
-#-----|  -> this access
-
-#   51| ... + ...
-#-----|  -> ... = ...
-
-#   51| ... = ...
-#-----|  -> ...;
-
-#   51| ...;
-#-----|  -> this access
-
-#   51| this access
-#-----|  -> access to field x
-
-#   51| access to field x
-#-----|  -> access to field Field
-
-#   51| access to field Field
-#-----|  -> ... + ...
-
-#   52| this access
-#-----|  -> access to field x
-
-#   52| this access
-#-----|  -> access to field x
-
-#   52| access to field x
-#-----|  -> this access
-
-#   52| access to field x
-#-----|  -> access to property Prop
-
-#   52| access to property Prop
-#-----|  -> ... = ...
-
-#   52| access to property Prop
-#-----|  -> this access
-
-#   52| ... + ...
-#-----|  -> access to property Prop
-
-#   52| ... = ...
-#-----|  -> ...;
-
-#   52| ...;
-#-----|  -> this access
-
-#   52| this access
-#-----|  -> access to field x
-
-#   52| access to field x
-#-----|  -> access to property Prop
-
-#   52| access to property Prop
-#-----|  -> ... + ...
-
-#   53| this access
-#-----|  -> access to field x
-
-#   53| this access
-#-----|  -> access to field x
-
-#   53| access to field x
-#-----|  -> 0
-
-#   53| access to field x
-#-----|  -> 0
-
-#   53| access to indexer
-#-----|  -> ... = ...
-
-#   53| access to indexer
-#-----|  -> this access
-
-#   53| ... + ...
-#-----|  -> access to indexer
-
-#   53| ... = ...
-#-----|  -> exit M6 (normal)
-
-#   53| ...;
-#-----|  -> this access
-
-#   53| 0
-#-----|  -> this access
-
-#   53| 0
-#-----|  -> access to indexer
-
-#   53| this access
-#-----|  -> access to field x
-
-#   53| access to field x
-#-----|  -> 0
-
-#   53| access to indexer
-#-----|  -> ... + ...
-
-#   53| 0
-#-----|  -> access to indexer
-
-#   56| enter M7
-#-----|  -> {...}
-
-#   56| exit M7
-
-#   56| exit M7 (normal)
-#-----|  -> exit M7
-
-#   57| {...}
-#-----|  -> ...;
-
-#   58| (..., ...)
-#-----|  -> this access
-
-#   58| ... = ...
-#-----|  -> exit M7 (normal)
-
-#   58| ...;
-#-----|  -> this access
-
-#   58| this access
-#-----|  -> this access
-
-#   58| this access
-#-----|  -> this access
-
-#   58| access to property Prop
-#-----|  -> access to indexer
-
-#   58| (..., ...)
-#-----|  -> (..., ...)
-
-#   58| this access
-#-----|  -> 0
-
-#   58| access to indexer
-#-----|  -> ... = ...
-
-#   58| 0
-#-----|  -> (..., ...)
-
-#   58| (..., ...)
-#-----|  -> access to property Prop
-
-#   58| this access
-#-----|  -> access to field Field
-
-#   58| access to field Field
-#-----|  -> this access
-
-#   58| this access
-#-----|  -> access to property Prop
-
-#   58| access to property Prop
-#-----|  -> 0
-
-#   58| (..., ...)
-#-----|  -> (..., ...)
-
-#   58| 0
-#-----|  -> this access
-
-#   58| this access
-#-----|  -> 1
-
-#   58| access to indexer
-#-----|  -> (..., ...)
-
-#   58| 1
-#-----|  -> access to indexer
-
-#   61| enter M8
-#-----|  -> {...}
-
-#   61| exit M8
-
-#   61| exit M8 (normal)
-#-----|  -> exit M8
-
-#   62| {...}
-#-----|  -> ...;
-
-#   63| (..., ...)
-#-----|  -> this access
-
-#   63| ... = ...
-#-----|  -> exit M8 (normal)
-
-#   63| ...;
-#-----|  -> this access
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> this access
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> this access
-
-#   63| access to property Prop
-#-----|  -> access to indexer
-
-#   63| (..., ...)
-#-----|  -> (..., ...)
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> 0
-
-#   63| access to indexer
-#-----|  -> ... = ...
-
-#   63| 0
-#-----|  -> (..., ...)
-
-#   63| (..., ...)
-#-----|  -> access to property Prop
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> access to field Field
-
-#   63| access to field Field
-#-----|  -> this access
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> access to property Prop
-
-#   63| access to property Prop
-#-----|  -> 0
-
-#   63| (..., ...)
-#-----|  -> (..., ...)
-
-#   63| 0
-#-----|  -> this access
-
-#   63| this access
-#-----|  -> access to field x
-
-#   63| access to field x
-#-----|  -> 1
-
-#   63| access to indexer
-#-----|  -> (..., ...)
-
-#   63| 1
-#-----|  -> access to indexer
-
-#   66| enter M9
-#-----|  -> {...}
-
-#   66| exit M9
-
-#   66| exit M9 (normal)
-#-----|  -> exit M9
-
-#   67| {...}
-#-----|  -> ... ...;
-
-#   68| ... ...;
-#-----|  -> access to parameter o
-
-#   68| dynamic d = ...
-#-----|  -> ...;
-
-#   68| access to parameter o
-#-----|  -> dynamic d = ...
-
-#   69| access to local variable d
-#-----|  -> access to local variable d
-
-#   69| dynamic access to member MaybeProp1
-#-----|  -> ... = ...
-
-#   69| ... = ...
-#-----|  -> ...;
-
-#   69| ...;
-#-----|  -> access to local variable d
-
-#   69| access to local variable d
-#-----|  -> dynamic access to member MaybeProp2
-
-#   69| dynamic access to member MaybeProp2
-#-----|  -> dynamic access to member MaybeProp1
-
-#   70| access to local variable d
-#-----|  -> dynamic access to member MaybeProp
-
-#   70| dynamic access to member MaybeProp
-#-----|  -> dynamic call to operator ++
-
-#   70| dynamic call to operator ++
-#-----|  -> ...;
-
-#   70| ...;
-#-----|  -> access to local variable d
-
-#   71| access to local variable d
-#-----|  -> access to local variable d
-
-#   71| access to local variable d
-#-----|  -> dynamic access to member MaybeEvent
-
-#   71| dynamic access to member MaybeEvent
-#-----|  -> ... = ...
-
-#   71| dynamic access to member MaybeEvent
-#-----|  -> access to parameter e
-
-#   71| ... = ...
-#-----|  -> ...;
-
-#   71| dynamic call to operator +
-#-----|  -> dynamic access to member MaybeEvent
-
-#   71| ...;
-#-----|  -> access to local variable d
-
-#   71| access to parameter e
-#-----|  -> dynamic call to operator +
-
-#   72| access to local variable d
-#-----|  -> 0
-
-#   72| access to local variable d
-#-----|  -> 0
-
-#   72| dynamic access to element
-#-----|  -> ... = ...
-
-#   72| dynamic access to element
-#-----|  -> access to local variable d
-
-#   72| ... = ...
-#-----|  -> ...;
-
-#   72| dynamic call to operator +
-#-----|  -> dynamic access to element
-
-#   72| ...;
-#-----|  -> access to local variable d
-
-#   72| 0
-#-----|  -> access to local variable d
-
-#   72| 0
-#-----|  -> dynamic access to element
-
-#   72| access to local variable d
-#-----|  -> 1
-
-#   72| dynamic access to element
-#-----|  -> dynamic call to operator +
-
-#   72| 1
-#-----|  -> dynamic access to element
-
-#   73| (..., ...)
-#-----|  -> access to local variable d
-
-#   73| ... = ...
-#-----|  -> exit M9 (normal)
-
-#   73| ...;
-#-----|  -> access to local variable d
-
-#   73| access to local variable d
-#-----|  -> this access
-
-#   73| dynamic access to member MaybeProp1
-#-----|  -> access to property Prop
-
-#   73| this access
-#-----|  -> access to local variable d
-
-#   73| access to property Prop
-#-----|  -> dynamic access to element
-
-#   73| (..., ...)
-#-----|  -> (..., ...)
-
-#   73| access to local variable d
-#-----|  -> 0
-
-#   73| dynamic access to element
-#-----|  -> ... = ...
-
-#   73| 0
-#-----|  -> (..., ...)
-
-#   73| (..., ...)
-#-----|  -> dynamic access to member MaybeProp1
-
-#   73| access to local variable d
-#-----|  -> dynamic access to member MaybeProp1
-
-#   73| dynamic access to member MaybeProp1
-#-----|  -> this access
-
-#   73| this access
-#-----|  -> access to property Prop
-
-#   73| access to property Prop
-#-----|  -> 0
-
-#   73| (..., ...)
-#-----|  -> (..., ...)
-
-#   73| 0
-#-----|  -> access to local variable d
-
-#   73| access to local variable d
-#-----|  -> 1
-
-#   73| dynamic access to element
-#-----|  -> (..., ...)
-
-#   73| 1
-#-----|  -> dynamic access to element
-
-ArrayCreation.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter ArrayCreation
-#-----|  -> call to constructor Object
-
-#    1| exit ArrayCreation
-
-#    1| exit ArrayCreation (normal)
-#-----|  -> exit ArrayCreation
-
-#    1| {...}
-#-----|  -> exit ArrayCreation (normal)
-
-#    3| enter M1
-#-----|  -> 0
-
-#    3| exit M1
-
-#    3| exit M1 (normal)
-#-----|  -> exit M1
-
-#    3| array creation of type Int32[]
-#-----|  -> exit M1 (normal)
-
-#    3| 0
-#-----|  -> array creation of type Int32[]
-
-#    5| enter M2
-#-----|  -> 0
-
-#    5| exit M2
-
-#    5| exit M2 (normal)
-#-----|  -> exit M2
-
-#    5| array creation of type Int32[,]
-#-----|  -> exit M2 (normal)
-
-#    5| 0
-#-----|  -> 1
-
-#    5| 1
-#-----|  -> array creation of type Int32[,]
-
-#    7| enter M3
-#-----|  -> 2
-
-#    7| exit M3
-
-#    7| exit M3 (normal)
-#-----|  -> exit M3
-
-#    7| 2
-#-----|  -> array creation of type Int32[]
-
-#    7| array creation of type Int32[]
-#-----|  -> 0
-
-#    7| { ..., ... }
-#-----|  -> exit M3 (normal)
-
-#    7| 0
-#-----|  -> 1
-
-#    7| 1
-#-----|  -> { ..., ... }
-
-#    9| enter M4
-#-----|  -> 2
-
-#    9| exit M4
-
-#    9| exit M4 (normal)
-#-----|  -> exit M4
-
-#    9| 2
-#-----|  -> 2
-
-#    9| 2
-#-----|  -> array creation of type Int32[,]
-
-#    9| array creation of type Int32[,]
-#-----|  -> 0
-
-#    9| { ..., ... }
-#-----|  -> exit M4 (normal)
-
-#    9| { ..., ... }
-#-----|  -> 2
-
-#    9| 0
-#-----|  -> 1
-
-#    9| 1
-#-----|  -> { ..., ... }
-
-#    9| { ..., ... }
-#-----|  -> { ..., ... }
-
-#    9| 2
-#-----|  -> 3
-
-#    9| 3
-#-----|  -> { ..., ... }
-
-Assert.cs:
-#    5| call to constructor Object
-#-----|  -> {...}
-
-#    5| enter AssertTests
-#-----|  -> call to constructor Object
-
-#    5| exit AssertTests
-
-#    5| exit AssertTests (normal)
-#-----|  -> exit AssertTests
-
-#    5| {...}
-#-----|  -> exit AssertTests (normal)
-
-#    7| enter M1
-#-----|  -> {...}
-
-#    7| exit M1
-
-#    7| exit M1 (abnormal)
-#-----|  -> exit M1
-
-#    7| exit M1 (normal)
-#-----|  -> exit M1
-
-#    8| {...}
-#-----|  -> ... ...;
-
-#    9| ... ...;
-#-----|  -> access to parameter b
-
-#    9| String s = ...
-#-----|  -> ...;
-
-#    9| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#    9| ... ? ... : ...
-#-----|  -> String s = ...
-
-#    9| null
-#-----|  -> ... ? ... : ...
-
-#    9| ""
-#-----|  -> ... ? ... : ...
-
-#   10| [assertion failure] call to method Assert
-#-----| exit -> exit M1 (abnormal)
-
-#   10| [assertion success] call to method Assert
-#-----|  -> ...;
-
-#   10| ...;
-#-----|  -> access to local variable s
-
-#   10| access to local variable s
-#-----|  -> null
-
-#   10| ... != ...
-#-----| false -> [assertion failure] call to method Assert
-#-----| true -> [assertion success] call to method Assert
-
-#   10| null
-#-----|  -> ... != ...
-
-#   11| call to method WriteLine
-#-----|  -> exit M1 (normal)
-
-#   11| ...;
-#-----|  -> access to local variable s
-
-#   11| access to local variable s
-#-----|  -> access to property Length
-
-#   11| access to property Length
-#-----|  -> call to method WriteLine
-
-#   14| enter M2
-#-----|  -> {...}
-
-#   14| exit M2
-
-#   14| exit M2 (abnormal)
-#-----|  -> exit M2
-
-#   14| exit M2 (normal)
-#-----|  -> exit M2
-
-#   15| {...}
-#-----|  -> ... ...;
-
-#   16| ... ...;
-#-----|  -> access to parameter b
-
-#   16| String s = ...
-#-----|  -> ...;
-
-#   16| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   16| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   16| null
-#-----|  -> ... ? ... : ...
-
-#   16| ""
-#-----|  -> ... ? ... : ...
-
-#   17| [assertion failure] call to method IsNull
-#-----| exception(AssertFailedException) -> exit M2 (abnormal)
-
-#   17| [assertion success] call to method IsNull
-#-----|  -> ...;
-
-#   17| ...;
-#-----|  -> access to local variable s
-
-#   17| access to local variable s
-#-----| non-null -> [assertion failure] call to method IsNull
-#-----| null -> [assertion success] call to method IsNull
-
-#   18| call to method WriteLine
-#-----|  -> exit M2 (normal)
-
-#   18| ...;
-#-----|  -> access to local variable s
-
-#   18| access to local variable s
-#-----|  -> access to property Length
-
-#   18| access to property Length
-#-----|  -> call to method WriteLine
-
-#   21| enter M3
-#-----|  -> {...}
-
-#   21| exit M3
-
-#   21| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   21| exit M3 (normal)
-#-----|  -> exit M3
-
-#   22| {...}
-#-----|  -> ... ...;
-
-#   23| ... ...;
-#-----|  -> access to parameter b
-
-#   23| String s = ...
-#-----|  -> ...;
-
-#   23| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   23| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   23| null
-#-----|  -> ... ? ... : ...
-
-#   23| ""
-#-----|  -> ... ? ... : ...
-
-#   24| [assertion failure] call to method IsNotNull
-#-----| exception(AssertFailedException) -> exit M3 (abnormal)
-
-#   24| [assertion success] call to method IsNotNull
-#-----|  -> ...;
-
-#   24| ...;
-#-----|  -> access to local variable s
-
-#   24| access to local variable s
-#-----| non-null -> [assertion success] call to method IsNotNull
-#-----| null -> [assertion failure] call to method IsNotNull
-
-#   25| call to method WriteLine
-#-----|  -> exit M3 (normal)
-
-#   25| ...;
-#-----|  -> access to local variable s
-
-#   25| access to local variable s
-#-----|  -> access to property Length
-
-#   25| access to property Length
-#-----|  -> call to method WriteLine
-
-#   28| enter M4
-#-----|  -> {...}
-
-#   28| exit M4
-
-#   28| exit M4 (abnormal)
-#-----|  -> exit M4
-
-#   28| exit M4 (normal)
-#-----|  -> exit M4
-
-#   29| {...}
-#-----|  -> ... ...;
-
-#   30| ... ...;
-#-----|  -> access to parameter b
-
-#   30| String s = ...
-#-----|  -> ...;
-
-#   30| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   30| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   30| null
-#-----|  -> ... ? ... : ...
-
-#   30| ""
-#-----|  -> ... ? ... : ...
-
-#   31| [assertion failure] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M4 (abnormal)
-
-#   31| [assertion success] call to method IsTrue
-#-----|  -> ...;
-
-#   31| ...;
-#-----|  -> access to local variable s
-
-#   31| access to local variable s
-#-----|  -> null
-
-#   31| ... == ...
-#-----| false -> [assertion failure] call to method IsTrue
-#-----| true -> [assertion success] call to method IsTrue
-
-#   31| null
-#-----|  -> ... == ...
-
-#   32| call to method WriteLine
-#-----|  -> exit M4 (normal)
-
-#   32| ...;
-#-----|  -> access to local variable s
-
-#   32| access to local variable s
-#-----|  -> access to property Length
-
-#   32| access to property Length
-#-----|  -> call to method WriteLine
-
-#   35| enter M5
-#-----|  -> {...}
-
-#   35| exit M5
-
-#   35| exit M5 (abnormal)
-#-----|  -> exit M5
-
-#   35| exit M5 (normal)
-#-----|  -> exit M5
-
-#   36| {...}
-#-----|  -> ... ...;
-
-#   37| ... ...;
-#-----|  -> access to parameter b
-
-#   37| String s = ...
-#-----|  -> ...;
-
-#   37| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   37| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   37| null
-#-----|  -> ... ? ... : ...
-
-#   37| ""
-#-----|  -> ... ? ... : ...
-
-#   38| [assertion failure] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M5 (abnormal)
-
-#   38| [assertion success] call to method IsTrue
-#-----|  -> ...;
-
-#   38| ...;
-#-----|  -> access to local variable s
-
-#   38| access to local variable s
-#-----|  -> null
-
-#   38| ... != ...
-#-----| false -> [assertion failure] call to method IsTrue
-#-----| true -> [assertion success] call to method IsTrue
-
-#   38| null
-#-----|  -> ... != ...
-
-#   39| call to method WriteLine
-#-----|  -> exit M5 (normal)
-
-#   39| ...;
-#-----|  -> access to local variable s
-
-#   39| access to local variable s
-#-----|  -> access to property Length
-
-#   39| access to property Length
-#-----|  -> call to method WriteLine
-
-#   42| enter M6
-#-----|  -> {...}
-
-#   42| exit M6
-
-#   42| exit M6 (abnormal)
-#-----|  -> exit M6
-
-#   42| exit M6 (normal)
-#-----|  -> exit M6
-
-#   43| {...}
-#-----|  -> ... ...;
-
-#   44| ... ...;
-#-----|  -> access to parameter b
-
-#   44| String s = ...
-#-----|  -> ...;
-
-#   44| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   44| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   44| null
-#-----|  -> ... ? ... : ...
-
-#   44| ""
-#-----|  -> ... ? ... : ...
-
-#   45| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M6 (abnormal)
-
-#   45| [assertion success] call to method IsFalse
-#-----|  -> ...;
-
-#   45| ...;
-#-----|  -> access to local variable s
-
-#   45| access to local variable s
-#-----|  -> null
-
-#   45| ... != ...
-#-----| false -> [assertion success] call to method IsFalse
-#-----| true -> [assertion failure] call to method IsFalse
-
-#   45| null
-#-----|  -> ... != ...
-
-#   46| call to method WriteLine
-#-----|  -> exit M6 (normal)
-
-#   46| ...;
-#-----|  -> access to local variable s
-
-#   46| access to local variable s
-#-----|  -> access to property Length
-
-#   46| access to property Length
-#-----|  -> call to method WriteLine
-
-#   49| enter M7
-#-----|  -> {...}
-
-#   49| exit M7
-
-#   49| exit M7 (abnormal)
-#-----|  -> exit M7
-
-#   49| exit M7 (normal)
-#-----|  -> exit M7
-
-#   50| {...}
-#-----|  -> ... ...;
-
-#   51| ... ...;
-#-----|  -> access to parameter b
-
-#   51| String s = ...
-#-----|  -> ...;
-
-#   51| access to parameter b
-#-----| true -> null
-#-----| false -> ""
-
-#   51| ... ? ... : ...
-#-----|  -> String s = ...
-
-#   51| null
-#-----|  -> ... ? ... : ...
-
-#   51| ""
-#-----|  -> ... ? ... : ...
-
-#   52| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M7 (abnormal)
-
-#   52| [assertion success] call to method IsFalse
-#-----|  -> ...;
-
-#   52| ...;
-#-----|  -> access to local variable s
-
-#   52| access to local variable s
-#-----|  -> null
-
-#   52| ... == ...
-#-----| false -> [assertion success] call to method IsFalse
-#-----| true -> [assertion failure] call to method IsFalse
-
-#   52| null
-#-----|  -> ... == ...
-
-#   53| call to method WriteLine
-#-----|  -> exit M7 (normal)
-
-#   53| ...;
-#-----|  -> access to local variable s
-
-#   53| access to local variable s
-#-----|  -> access to property Length
-
-#   53| access to property Length
-#-----|  -> call to method WriteLine
-
-#   56| enter M8
-#-----|  -> {...}
-
-#   56| exit M8
-
-#   56| exit M8 (abnormal)
-#-----|  -> exit M8
-
-#   56| exit M8 (normal)
-#-----|  -> exit M8
-
-#   57| {...}
-#-----|  -> ... ...;
-
-#   58| ... ...;
-#-----|  -> access to parameter b
-
-#   58| [b (line 56): false] String s = ...
-#-----|  -> [b (line 56): false] ...;
-
-#   58| [b (line 56): true] String s = ...
-#-----|  -> [b (line 56): true] ...;
-
-#   58| access to parameter b
-#-----| true -> [b (line 56): true] null
-#-----| false -> [b (line 56): false] ""
-
-#   58| [b (line 56): false] ... ? ... : ...
-#-----|  -> [b (line 56): false] String s = ...
-
-#   58| [b (line 56): true] ... ? ... : ...
-#-----|  -> [b (line 56): true] String s = ...
-
-#   58| [b (line 56): true] null
-#-----|  -> [b (line 56): true] ... ? ... : ...
-
-#   58| [b (line 56): false] ""
-#-----|  -> [b (line 56): false] ... ? ... : ...
-
-#   59| [assertion failure] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M8 (abnormal)
-
-#   59| [assertion success] call to method IsTrue
-#-----|  -> ...;
-
-#   59| [b (line 56): false] ...;
-#-----|  -> [b (line 56): false] access to local variable s
-
-#   59| [b (line 56): true] ...;
-#-----|  -> [b (line 56): true] access to local variable s
-
-#   59| [b (line 56): false] access to local variable s
-#-----|  -> [b (line 56): false] null
-
-#   59| [b (line 56): true] access to local variable s
-#-----|  -> [b (line 56): true] null
-
-#   59| [b (line 56): false] ... != ...
-#-----| false -> [false] ... && ...
-#-----| true -> [b (line 56): false] access to parameter b
-
-#   59| [b (line 56): true] ... != ...
-#-----| false -> [false] ... && ...
-#-----| true -> [b (line 56): true] access to parameter b
-
-#   59| [false] ... && ...
-#-----| false -> [assertion failure] call to method IsTrue
-
-#   59| [true] ... && ...
-#-----| true -> [assertion success] call to method IsTrue
-
-#   59| [b (line 56): false] null
-#-----|  -> [b (line 56): false] ... != ...
-
-#   59| [b (line 56): true] null
-#-----|  -> [b (line 56): true] ... != ...
-
-#   59| [b (line 56): false] access to parameter b
-#-----| false -> [false] ... && ...
-
-#   59| [b (line 56): true] access to parameter b
-#-----| true -> [true] ... && ...
-
-#   60| call to method WriteLine
-#-----|  -> exit M8 (normal)
-
-#   60| ...;
-#-----|  -> access to local variable s
-
-#   60| access to local variable s
-#-----|  -> access to property Length
-
-#   60| access to property Length
-#-----|  -> call to method WriteLine
-
-#   63| enter M9
-#-----|  -> {...}
-
-#   63| exit M9
-
-#   63| exit M9 (abnormal)
-#-----|  -> exit M9
-
-#   63| exit M9 (normal)
-#-----|  -> exit M9
-
-#   64| {...}
-#-----|  -> ... ...;
-
-#   65| ... ...;
-#-----|  -> access to parameter b
-
-#   65| [b (line 63): false] String s = ...
-#-----|  -> [b (line 63): false] ...;
-
-#   65| [b (line 63): true] String s = ...
-#-----|  -> [b (line 63): true] ...;
-
-#   65| access to parameter b
-#-----| true -> [b (line 63): true] null
-#-----| false -> [b (line 63): false] ""
-
-#   65| [b (line 63): false] ... ? ... : ...
-#-----|  -> [b (line 63): false] String s = ...
-
-#   65| [b (line 63): true] ... ? ... : ...
-#-----|  -> [b (line 63): true] String s = ...
-
-#   65| [b (line 63): true] null
-#-----|  -> [b (line 63): true] ... ? ... : ...
-
-#   65| [b (line 63): false] ""
-#-----|  -> [b (line 63): false] ... ? ... : ...
-
-#   66| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M9 (abnormal)
-
-#   66| [assertion success] call to method IsFalse
-#-----|  -> ...;
-
-#   66| [b (line 63): false] ...;
-#-----|  -> [b (line 63): false] access to local variable s
-
-#   66| [b (line 63): true] ...;
-#-----|  -> [b (line 63): true] access to local variable s
-
-#   66| [b (line 63): false] access to local variable s
-#-----|  -> [b (line 63): false] null
-
-#   66| [b (line 63): true] access to local variable s
-#-----|  -> [b (line 63): true] null
-
-#   66| [b (line 63): false] ... == ...
-#-----| true -> [true] ... || ...
-#-----| false -> [b (line 63): false] access to parameter b
-
-#   66| [b (line 63): true] ... == ...
-#-----| true -> [true] ... || ...
-#-----| false -> [b (line 63): true] access to parameter b
-
-#   66| [false] ... || ...
-#-----| false -> [assertion success] call to method IsFalse
-
-#   66| [true] ... || ...
-#-----| true -> [assertion failure] call to method IsFalse
-
-#   66| [b (line 63): false] null
-#-----|  -> [b (line 63): false] ... == ...
-
-#   66| [b (line 63): true] null
-#-----|  -> [b (line 63): true] ... == ...
-
-#   66| [b (line 63): false] access to parameter b
-#-----| false -> [false] ... || ...
-
-#   66| [b (line 63): true] access to parameter b
-#-----| true -> [true] ... || ...
-
-#   67| call to method WriteLine
-#-----|  -> exit M9 (normal)
-
-#   67| ...;
-#-----|  -> access to local variable s
-
-#   67| access to local variable s
-#-----|  -> access to property Length
-
-#   67| access to property Length
-#-----|  -> call to method WriteLine
-
-#   70| enter M10
-#-----|  -> {...}
-
-#   70| exit M10
-
-#   70| exit M10 (abnormal)
-#-----|  -> exit M10
-
-#   70| exit M10 (normal)
-#-----|  -> exit M10
-
-#   71| {...}
-#-----|  -> ... ...;
-
-#   72| ... ...;
-#-----|  -> access to parameter b
-
-#   72| [b (line 70): false] String s = ...
-#-----|  -> [b (line 70): false] ...;
-
-#   72| [b (line 70): true] String s = ...
-#-----|  -> [b (line 70): true] ...;
-
-#   72| access to parameter b
-#-----| true -> [b (line 70): true] null
-#-----| false -> [b (line 70): false] ""
-
-#   72| [b (line 70): false] ... ? ... : ...
-#-----|  -> [b (line 70): false] String s = ...
-
-#   72| [b (line 70): true] ... ? ... : ...
-#-----|  -> [b (line 70): true] String s = ...
-
-#   72| [b (line 70): true] null
-#-----|  -> [b (line 70): true] ... ? ... : ...
-
-#   72| [b (line 70): false] ""
-#-----|  -> [b (line 70): false] ... ? ... : ...
-
-#   73| [assertion failure] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M10 (abnormal)
-
-#   73| [assertion success] call to method IsTrue
-#-----|  -> ...;
-
-#   73| [b (line 70): false] ...;
-#-----|  -> [b (line 70): false] access to local variable s
-
-#   73| [b (line 70): true] ...;
-#-----|  -> [b (line 70): true] access to local variable s
-
-#   73| [b (line 70): false] access to local variable s
-#-----|  -> [b (line 70): false] null
-
-#   73| [b (line 70): true] access to local variable s
-#-----|  -> [b (line 70): true] null
-
-#   73| [b (line 70): false] ... == ...
-#-----| false -> [false] ... && ...
-#-----| true -> [b (line 70): false] access to parameter b
-
-#   73| [b (line 70): true] ... == ...
-#-----| false -> [false] ... && ...
-#-----| true -> [b (line 70): true] access to parameter b
-
-#   73| [false] ... && ...
-#-----| false -> [assertion failure] call to method IsTrue
-
-#   73| [true] ... && ...
-#-----| true -> [assertion success] call to method IsTrue
-
-#   73| [b (line 70): false] null
-#-----|  -> [b (line 70): false] ... == ...
-
-#   73| [b (line 70): true] null
-#-----|  -> [b (line 70): true] ... == ...
-
-#   73| [b (line 70): false] access to parameter b
-#-----| false -> [false] ... && ...
-
-#   73| [b (line 70): true] access to parameter b
-#-----| true -> [true] ... && ...
-
-#   74| call to method WriteLine
-#-----|  -> exit M10 (normal)
-
-#   74| ...;
-#-----|  -> access to local variable s
-
-#   74| access to local variable s
-#-----|  -> access to property Length
-
-#   74| access to property Length
-#-----|  -> call to method WriteLine
-
-#   77| enter M11
-#-----|  -> {...}
-
-#   77| exit M11
-
-#   77| exit M11 (abnormal)
-#-----|  -> exit M11
-
-#   77| exit M11 (normal)
-#-----|  -> exit M11
-
-#   78| {...}
-#-----|  -> ... ...;
-
-#   79| ... ...;
-#-----|  -> access to parameter b
-
-#   79| [b (line 77): false] String s = ...
-#-----|  -> [b (line 77): false] ...;
-
-#   79| [b (line 77): true] String s = ...
-#-----|  -> [b (line 77): true] ...;
-
-#   79| access to parameter b
-#-----| true -> [b (line 77): true] null
-#-----| false -> [b (line 77): false] ""
-
-#   79| [b (line 77): false] ... ? ... : ...
-#-----|  -> [b (line 77): false] String s = ...
-
-#   79| [b (line 77): true] ... ? ... : ...
-#-----|  -> [b (line 77): true] String s = ...
-
-#   79| [b (line 77): true] null
-#-----|  -> [b (line 77): true] ... ? ... : ...
-
-#   79| [b (line 77): false] ""
-#-----|  -> [b (line 77): false] ... ? ... : ...
-
-#   80| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M11 (abnormal)
-
-#   80| [assertion success] call to method IsFalse
-#-----|  -> ...;
-
-#   80| [b (line 77): false] ...;
-#-----|  -> [b (line 77): false] access to local variable s
-
-#   80| [b (line 77): true] ...;
-#-----|  -> [b (line 77): true] access to local variable s
-
-#   80| [b (line 77): false] access to local variable s
-#-----|  -> [b (line 77): false] null
-
-#   80| [b (line 77): true] access to local variable s
-#-----|  -> [b (line 77): true] null
-
-#   80| [b (line 77): false] ... != ...
-#-----| true -> [true] ... || ...
-#-----| false -> [b (line 77): false] access to parameter b
-
-#   80| [b (line 77): true] ... != ...
-#-----| true -> [true] ... || ...
-#-----| false -> [b (line 77): true] access to parameter b
-
-#   80| [false] ... || ...
-#-----| false -> [assertion success] call to method IsFalse
-
-#   80| [true] ... || ...
-#-----| true -> [assertion failure] call to method IsFalse
-
-#   80| [b (line 77): false] null
-#-----|  -> [b (line 77): false] ... != ...
-
-#   80| [b (line 77): true] null
-#-----|  -> [b (line 77): true] ... != ...
-
-#   80| [b (line 77): false] access to parameter b
-#-----| false -> [false] ... || ...
-
-#   80| [b (line 77): true] access to parameter b
-#-----| true -> [true] ... || ...
-
-#   81| call to method WriteLine
-#-----|  -> exit M11 (normal)
-
-#   81| ...;
-#-----|  -> access to local variable s
-
-#   81| access to local variable s
-#-----|  -> access to property Length
-
-#   81| access to property Length
-#-----|  -> call to method WriteLine
-
-#   84| enter M12
-#-----|  -> {...}
-
-#   84| exit M12
-
-#   84| exit M12 (abnormal)
-#-----|  -> exit M12
-
-#   84| exit M12 (normal)
-#-----|  -> exit M12
-
-#   85| {...}
-#-----|  -> ... ...;
-
-#   86| ... ...;
-#-----|  -> access to parameter b
-
-#   86| [b (line 84): false] String s = ...
-#-----|  -> [b (line 84): false] ...;
-
-#   86| [b (line 84): true] String s = ...
-#-----|  -> [b (line 84): true] ...;
-
-#   86| access to parameter b
-#-----| true -> [b (line 84): true] null
-#-----| false -> [b (line 84): false] ""
-
-#   86| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] String s = ...
-
-#   86| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] String s = ...
-
-#   86| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#   86| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#   87| [assertion failure, b (line 84): false] call to method Assert
-#-----| exit -> exit M12 (abnormal)
-
-#   87| [assertion failure, b (line 84): true] call to method Assert
-#-----| exit -> exit M12 (abnormal)
-
-#   87| [assertion success, b (line 84): false] call to method Assert
-#-----|  -> [b (line 84): false] ...;
-
-#   87| [assertion success, b (line 84): true] call to method Assert
-#-----|  -> [b (line 84): true] ...;
-
-#   87| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   87| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   87| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#   87| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#   87| [b (line 84): false] ... != ...
-#-----| false -> [assertion failure, b (line 84): false] call to method Assert
-#-----| true -> [assertion success, b (line 84): false] call to method Assert
-
-#   87| [b (line 84): true] ... != ...
-#-----| false -> [assertion failure, b (line 84): true] call to method Assert
-#-----| true -> [assertion success, b (line 84): true] call to method Assert
-
-#   87| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... != ...
-
-#   87| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... != ...
-
-#   88| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#   88| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#   88| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   88| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   88| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#   88| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#   88| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#   88| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#   90| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#   90| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#   90| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#   90| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#   90| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#   90| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#   90| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#   90| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#   90| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#   90| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#   91| [assertion failure, b (line 84): false] call to method IsNull
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   91| [assertion failure, b (line 84): true] call to method IsNull
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   91| [assertion success, b (line 84): false] call to method IsNull
-#-----|  -> [b (line 84): false] ...;
-
-#   91| [assertion success, b (line 84): true] call to method IsNull
-#-----|  -> [b (line 84): true] ...;
-
-#   91| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   91| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   91| [b (line 84): false] access to local variable s
-#-----| non-null -> [assertion failure, b (line 84): false] call to method IsNull
-#-----| null -> [assertion success, b (line 84): false] call to method IsNull
-
-#   91| [b (line 84): true] access to local variable s
-#-----| non-null -> [assertion failure, b (line 84): true] call to method IsNull
-#-----| null -> [assertion success, b (line 84): true] call to method IsNull
-
-#   92| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#   92| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#   92| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   92| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   92| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#   92| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#   92| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#   92| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#   94| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#   94| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#   94| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#   94| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#   94| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#   94| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#   94| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#   94| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#   94| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#   94| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#   95| [assertion failure, b (line 84): false] call to method IsNotNull
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   95| [assertion failure, b (line 84): true] call to method IsNotNull
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   95| [assertion success, b (line 84): false] call to method IsNotNull
-#-----|  -> [b (line 84): false] ...;
-
-#   95| [assertion success, b (line 84): true] call to method IsNotNull
-#-----|  -> [b (line 84): true] ...;
-
-#   95| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   95| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   95| [b (line 84): false] access to local variable s
-#-----| non-null -> [assertion success, b (line 84): false] call to method IsNotNull
-#-----| null -> [assertion failure, b (line 84): false] call to method IsNotNull
-
-#   95| [b (line 84): true] access to local variable s
-#-----| non-null -> [assertion success, b (line 84): true] call to method IsNotNull
-#-----| null -> [assertion failure, b (line 84): true] call to method IsNotNull
-
-#   96| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#   96| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#   96| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   96| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   96| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#   96| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#   96| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#   96| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#   98| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#   98| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#   98| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#   98| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#   98| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#   98| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#   98| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#   98| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#   98| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#   98| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#   99| [assertion failure, b (line 84): false] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   99| [assertion failure, b (line 84): true] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#   99| [assertion success, b (line 84): false] call to method IsTrue
-#-----|  -> [b (line 84): false] ...;
-
-#   99| [assertion success, b (line 84): true] call to method IsTrue
-#-----|  -> [b (line 84): true] ...;
-
-#   99| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#   99| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#   99| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#   99| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#   99| [b (line 84): false] ... == ...
-#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
-#-----| true -> [assertion success, b (line 84): false] call to method IsTrue
-
-#   99| [b (line 84): true] ... == ...
-#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
-#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
-
-#   99| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... == ...
-
-#   99| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... == ...
-
-#  100| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#  100| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  100| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  100| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  100| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#  100| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  100| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#  100| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  102| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#  102| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  102| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#  102| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  102| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#  102| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  102| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#  102| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  102| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  102| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#  103| [assertion failure, b (line 84): false] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  103| [assertion failure, b (line 84): true] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  103| [assertion success, b (line 84): false] call to method IsTrue
-#-----|  -> [b (line 84): false] ...;
-
-#  103| [assertion success, b (line 84): true] call to method IsTrue
-#-----|  -> [b (line 84): true] ...;
-
-#  103| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  103| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  103| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#  103| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  103| [b (line 84): false] ... != ...
-#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
-#-----| true -> [assertion success, b (line 84): false] call to method IsTrue
-
-#  103| [b (line 84): true] ... != ...
-#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
-#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
-
-#  103| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... != ...
-
-#  103| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... != ...
-
-#  104| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#  104| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  104| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  104| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  104| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#  104| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  104| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#  104| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  106| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#  106| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  106| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#  106| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  106| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#  106| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  106| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#  106| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  106| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  106| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#  107| [assertion failure, b (line 84): false] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  107| [assertion failure, b (line 84): true] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  107| [assertion success, b (line 84): false] call to method IsFalse
-#-----|  -> [b (line 84): false] ...;
-
-#  107| [assertion success, b (line 84): true] call to method IsFalse
-#-----|  -> [b (line 84): true] ...;
-
-#  107| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  107| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  107| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#  107| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  107| [b (line 84): false] ... != ...
-#-----| false -> [assertion success, b (line 84): false] call to method IsFalse
-#-----| true -> [assertion failure, b (line 84): false] call to method IsFalse
-
-#  107| [b (line 84): true] ... != ...
-#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
-#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
-
-#  107| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... != ...
-
-#  107| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... != ...
-
-#  108| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#  108| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  108| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  108| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  108| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#  108| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  108| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#  108| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  110| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#  110| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  110| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#  110| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  110| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#  110| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  110| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#  110| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  110| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  110| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#  111| [assertion failure, b (line 84): false] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  111| [assertion failure, b (line 84): true] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  111| [assertion success, b (line 84): false] call to method IsFalse
-#-----|  -> [b (line 84): false] ...;
-
-#  111| [assertion success, b (line 84): true] call to method IsFalse
-#-----|  -> [b (line 84): true] ...;
-
-#  111| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  111| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  111| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#  111| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  111| [b (line 84): false] ... == ...
-#-----| false -> [assertion success, b (line 84): false] call to method IsFalse
-#-----| true -> [assertion failure, b (line 84): false] call to method IsFalse
-
-#  111| [b (line 84): true] ... == ...
-#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
-#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
-
-#  111| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... == ...
-
-#  111| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... == ...
-
-#  112| [b (line 84): false] call to method WriteLine
-#-----|  -> [b (line 84): false] ...;
-
-#  112| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  112| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  112| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  112| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] access to property Length
-
-#  112| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  112| [b (line 84): false] access to property Length
-#-----|  -> [b (line 84): false] call to method WriteLine
-
-#  112| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  114| [b (line 84): false] ... = ...
-#-----|  -> [b (line 84): false] ...;
-
-#  114| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  114| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to parameter b
-
-#  114| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  114| [b (line 84): false] access to parameter b
-#-----| false -> [b (line 84): false] ""
-
-#  114| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  114| [b (line 84): false] ... ? ... : ...
-#-----|  -> [b (line 84): false] ... = ...
-
-#  114| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  114| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  114| [b (line 84): false] ""
-#-----|  -> [b (line 84): false] ... ? ... : ...
-
-#  115| [assertion failure, b (line 84): false] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  115| [assertion failure, b (line 84): true] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  115| [assertion success, b (line 84): true] call to method IsTrue
-#-----|  -> [b (line 84): true] ...;
-
-#  115| [b (line 84): false] ...;
-#-----|  -> [b (line 84): false] access to local variable s
-
-#  115| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  115| [b (line 84): false] access to local variable s
-#-----|  -> [b (line 84): false] null
-
-#  115| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  115| [b (line 84): false] ... != ...
-#-----| false -> [false, b (line 84): false] ... && ...
-#-----| true -> [b (line 84): false] access to parameter b
-
-#  115| [b (line 84): true] ... != ...
-#-----| false -> [false, b (line 84): true] ... && ...
-#-----| true -> [b (line 84): true] access to parameter b
-
-#  115| [false, b (line 84): false] ... && ...
-#-----| false -> [assertion failure, b (line 84): false] call to method IsTrue
-
-#  115| [false, b (line 84): true] ... && ...
-#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
-
-#  115| [true, b (line 84): true] ... && ...
-#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
-
-#  115| [b (line 84): false] null
-#-----|  -> [b (line 84): false] ... != ...
-
-#  115| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... != ...
-
-#  115| [b (line 84): false] access to parameter b
-#-----| false -> [false, b (line 84): false] ... && ...
-
-#  115| [b (line 84): true] access to parameter b
-#-----| true -> [true, b (line 84): true] ... && ...
-
-#  116| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  116| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  116| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  116| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  118| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  118| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  118| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  118| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  118| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  119| [assertion failure, b (line 84): true] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  119| [assertion success, b (line 84): true] call to method IsFalse
-#-----|  -> [b (line 84): true] ...;
-
-#  119| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  119| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  119| [b (line 84): true] ... == ...
-#-----| true -> [true, b (line 84): true] ... || ...
-#-----| false -> [b (line 84): true] access to parameter b
-
-#  119| [false, b (line 84): true] ... || ...
-#-----| false -> [assertion success, b (line 84): true] call to method IsFalse
-
-#  119| [true, b (line 84): true] ... || ...
-#-----| true -> [assertion failure, b (line 84): true] call to method IsFalse
-
-#  119| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... == ...
-
-#  119| [false, b (line 84): true] !...
-#-----| false -> [false, b (line 84): true] ... || ...
-
-#  119| [b (line 84): true] access to parameter b
-#-----| true -> [false, b (line 84): true] !...
-
-#  120| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  120| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  120| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  120| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  122| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  122| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  122| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  122| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  122| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  123| [assertion failure, b (line 84): true] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  123| [assertion success, b (line 84): true] call to method IsTrue
-#-----|  -> [b (line 84): true] ...;
-
-#  123| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  123| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  123| [b (line 84): true] ... == ...
-#-----| false -> [false, b (line 84): true] ... && ...
-#-----| true -> [b (line 84): true] access to parameter b
-
-#  123| [false, b (line 84): true] ... && ...
-#-----| false -> [assertion failure, b (line 84): true] call to method IsTrue
-
-#  123| [true, b (line 84): true] ... && ...
-#-----| true -> [assertion success, b (line 84): true] call to method IsTrue
-
-#  123| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... == ...
-
-#  123| [b (line 84): true] access to parameter b
-#-----| true -> [true, b (line 84): true] ... && ...
-
-#  124| [b (line 84): true] call to method WriteLine
-#-----|  -> [b (line 84): true] ...;
-
-#  124| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  124| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] access to property Length
-
-#  124| [b (line 84): true] access to property Length
-#-----|  -> [b (line 84): true] call to method WriteLine
-
-#  126| [b (line 84): true] ... = ...
-#-----|  -> [b (line 84): true] ...;
-
-#  126| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to parameter b
-
-#  126| [b (line 84): true] access to parameter b
-#-----| true -> [b (line 84): true] null
-
-#  126| [b (line 84): true] ... ? ... : ...
-#-----|  -> [b (line 84): true] ... = ...
-
-#  126| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... ? ... : ...
-
-#  127| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit M12 (abnormal)
-
-#  127| [assertion success] call to method IsFalse
-#-----|  -> ...;
-
-#  127| [b (line 84): true] ...;
-#-----|  -> [b (line 84): true] access to local variable s
-
-#  127| [b (line 84): true] access to local variable s
-#-----|  -> [b (line 84): true] null
-
-#  127| [b (line 84): true] ... != ...
-#-----| true -> [true] ... || ...
-#-----| false -> [b (line 84): true] access to parameter b
-
-#  127| [false] ... || ...
-#-----| false -> [assertion success] call to method IsFalse
-
-#  127| [true] ... || ...
-#-----| true -> [assertion failure] call to method IsFalse
-
-#  127| [b (line 84): true] null
-#-----|  -> [b (line 84): true] ... != ...
-
-#  127| [false] !...
-#-----| false -> [false] ... || ...
-
-#  127| [b (line 84): true] access to parameter b
-#-----| true -> [false] !...
-
-#  128| call to method WriteLine
-#-----|  -> exit M12 (normal)
-
-#  128| ...;
-#-----|  -> access to local variable s
-
-#  128| access to local variable s
-#-----|  -> access to property Length
-
-#  128| access to property Length
-#-----|  -> call to method WriteLine
-
-#  131| enter AssertTrueFalse
-#-----|  -> {...}
-
-#  131| exit AssertTrueFalse
-
-#  131| exit AssertTrueFalse (normal)
-#-----|  -> exit AssertTrueFalse
-
-#  135| {...}
-#-----|  -> exit AssertTrueFalse (normal)
-
-#  138| enter M13
-#-----|  -> {...}
-
-#  138| exit M13
-
-#  138| exit M13 (abnormal)
-#-----|  -> exit M13
-
-#  138| exit M13 (normal)
-#-----|  -> exit M13
-
-#  139| {...}
-#-----|  -> ...;
-
-#  140| [assertion failure] call to method AssertTrueFalse
-#-----| exception(Exception) -> exit M13 (abnormal)
-
-#  140| [assertion failure] call to method AssertTrueFalse
-#-----| exception(Exception) -> exit M13 (abnormal)
-
-#  140| [assertion success] call to method AssertTrueFalse
-#-----|  -> return ...;
-
-#  140| this access
-#-----|  -> access to parameter b1
-
-#  140| ...;
-#-----|  -> this access
-
-#  140| access to parameter b1
-#-----| false -> [assertion failure] access to parameter b2
-#-----| true -> access to parameter b2
-
-#  140| [assertion failure] access to parameter b2
-#-----| false, true -> [assertion failure] access to parameter b3
-
-#  140| access to parameter b2
-#-----| false -> [assertion success] access to parameter b3
-#-----| true -> [assertion failure] access to parameter b3
-
-#  140| [assertion failure] access to parameter b3
-#-----|  -> [assertion failure] call to method AssertTrueFalse
-
-#  140| [assertion failure] access to parameter b3
-#-----|  -> [assertion failure] call to method AssertTrueFalse
-
-#  140| [assertion success] access to parameter b3
-#-----|  -> [assertion success] call to method AssertTrueFalse
-
-#  141| return ...;
-#-----| return -> exit M13 (normal)
-
-Assignments.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter Assignments
-#-----|  -> call to constructor Object
-
-#    1| exit Assignments
-
-#    1| exit Assignments (normal)
-#-----|  -> exit Assignments
-
-#    1| {...}
-#-----|  -> exit Assignments (normal)
-
-#    3| enter M
-#-----|  -> {...}
-
-#    3| exit M
-
-#    3| exit M (normal)
-#-----|  -> exit M
-
-#    4| {...}
-#-----|  -> ... ...;
-
-#    5| ... ...;
-#-----|  -> 0
-
-#    5| Int32 x = ...
-#-----|  -> ...;
-
-#    5| 0
-#-----|  -> Int32 x = ...
-
-#    6| access to local variable x
-#-----|  -> 1
-
-#    6| ... + ...
-#-----|  -> ... = ...
-
-#    6| ... = ...
-#-----|  -> ... ...;
-
-#    6| ...;
-#-----|  -> access to local variable x
-
-#    6| 1
-#-----|  -> ... + ...
-
-#    8| ... ...;
-#-----|  -> 0
-
-#    8| dynamic d = ...
-#-----|  -> ...;
-
-#    8| (...) ...
-#-----|  -> dynamic d = ...
-
-#    8| 0
-#-----|  -> (...) ...
-
-#    9| access to local variable d
-#-----|  -> 2
-
-#    9| ... = ...
-#-----|  -> ... ...;
-
-#    9| dynamic call to operator -
-#-----|  -> ... = ...
-
-#    9| ...;
-#-----|  -> access to local variable d
-
-#    9| 2
-#-----|  -> dynamic call to operator -
-
-#   11| ... ...;
-#-----|  -> object creation of type Assignments
-
-#   11| Assignments a = ...
-#-----|  -> ...;
-
-#   11| object creation of type Assignments
-#-----|  -> Assignments a = ...
-
-#   12| access to local variable a
-#-----|  -> this access
-
-#   12| ... = ...
-#-----|  -> ...;
-
-#   12| call to operator +
-#-----|  -> ... = ...
-
-#   12| ...;
-#-----|  -> access to local variable a
-
-#   12| this access
-#-----|  -> call to operator +
-
-#   14| access to event Event
-#-----|  -> ... += ...
-
-#   14| this access
-#-----|  -> (...) => ...
-
-#   14| ... += ...
-#-----|  -> exit M (normal)
-
-#   14| ...;
-#-----|  -> this access
-
-#   14| (...) => ...
-#-----|  -> access to event Event
-
-#   14| enter (...) => ...
-#-----|  -> {...}
-
-#   14| exit (...) => ...
-
-#   14| exit (...) => ... (normal)
-#-----|  -> exit (...) => ...
-
-#   14| {...}
-#-----|  -> exit (...) => ... (normal)
-
-#   17| enter +
-#-----|  -> {...}
-
-#   17| exit +
-
-#   17| exit + (normal)
-#-----|  -> exit +
-
-#   18| {...}
-#-----|  -> access to parameter x
-
-#   19| return ...;
-#-----| return -> exit + (normal)
-
-#   19| access to parameter x
-#-----|  -> return ...;
-
-BreakInTry.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter BreakInTry
-#-----|  -> call to constructor Object
-
-#    1| exit BreakInTry
-
-#    1| exit BreakInTry (normal)
-#-----|  -> exit BreakInTry
-
-#    1| {...}
-#-----|  -> exit BreakInTry (normal)
-
-#    3| enter M1
-#-----|  -> {...}
-
-#    3| exit M1
-
-#    3| exit M1 (normal)
-#-----|  -> exit M1
-
-#    4| {...}
-#-----|  -> try {...} ...
-
-#    5| try {...} ...
-#-----|  -> {...}
-
-#    6| {...}
-#-----|  -> access to parameter args
-
-#    7| foreach (... ... in ...) ...
-#-----| non-empty -> String arg
-#-----| empty -> {...}
-
-#    7| String arg
-#-----|  -> {...}
-
-#    7| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#    8| {...}
-#-----|  -> if (...) ...
-
-#    9| if (...) ...
-#-----|  -> access to local variable arg
-
-#    9| access to local variable arg
-#-----|  -> null
-
-#    9| ... == ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> break;
-
-#    9| null
-#-----|  -> ... == ...
-
-#   10| break;
-#-----| break -> {...}
-
-#   14| {...}
-#-----|  -> if (...) ...
-
-#   15| if (...) ...
-#-----|  -> access to parameter args
-
-#   15| access to parameter args
-#-----|  -> null
-
-#   15| ... == ...
-#-----| false -> exit M1 (normal)
-#-----| true -> ;
-
-#   15| null
-#-----|  -> ... == ...
-
-#   16| ;
-#-----|  -> exit M1 (normal)
-
-#   20| enter M2
-#-----|  -> {...}
-
-#   20| exit M2
-
-#   20| exit M2 (normal)
-#-----|  -> exit M2
-
-#   21| {...}
-#-----|  -> access to parameter args
-
-#   22| foreach (... ... in ...) ...
-#-----| non-empty -> String arg
-#-----| empty -> ;
-
-#   22| String arg
-#-----|  -> {...}
-
-#   22| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   23| {...}
-#-----|  -> try {...} ...
-
-#   24| try {...} ...
-#-----|  -> {...}
-
-#   25| {...}
-#-----|  -> if (...) ...
-
-#   26| if (...) ...
-#-----|  -> access to local variable arg
-
-#   26| access to local variable arg
-#-----|  -> null
-
-#   26| ... == ...
-#-----| true -> break;
-#-----| false -> {...}
-
-#   26| null
-#-----|  -> ... == ...
-
-#   27| break;
-#-----| break -> [finally: break] {...}
-
-#   30| [finally: break] {...}
-#-----|  -> [finally: break] if (...) ...
-
-#   30| {...}
-#-----|  -> if (...) ...
-
-#   31| [finally: break] if (...) ...
-#-----|  -> [finally: break] access to parameter args
-
-#   31| if (...) ...
-#-----|  -> access to parameter args
-
-#   31| [finally: break] access to parameter args
-#-----|  -> [finally: break] null
-
-#   31| access to parameter args
-#-----|  -> null
-
-#   31| ... == ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> ;
-
-#   31| [finally: break] ... == ...
-#-----| true -> [finally: break] ;
-#-----| false -> ;
-
-#   31| [finally: break] null
-#-----|  -> [finally: break] ... == ...
-
-#   31| null
-#-----|  -> ... == ...
-
-#   32| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   32| [finally: break] ;
-#-----| break -> ;
-
-#   35| ;
-#-----|  -> exit M2 (normal)
-
-#   38| enter M3
-#-----|  -> {...}
-
-#   38| exit M3
-
-#   38| exit M3 (normal)
-#-----|  -> exit M3
-
-#   39| {...}
-#-----|  -> try {...} ...
-
-#   40| try {...} ...
-#-----|  -> {...}
-
-#   41| {...}
-#-----|  -> if (...) ...
-
-#   42| if (...) ...
-#-----|  -> access to parameter args
-
-#   42| access to parameter args
-#-----|  -> null
-
-#   42| ... == ...
-#-----| true -> return ...;
-#-----| false -> {...}
-
-#   42| null
-#-----|  -> ... == ...
-
-#   43| return ...;
-#-----| return -> [finally: return] {...}
-
-#   46| [finally: return] {...}
-#-----|  -> [finally: return] access to parameter args
-
-#   46| {...}
-#-----|  -> access to parameter args
-
-#   47| [finally: return] foreach (... ... in ...) ...
-#-----| return -> exit M3 (normal)
-#-----| non-empty -> [finally: return] String arg
-
-#   47| foreach (... ... in ...) ...
-#-----| non-empty -> String arg
-#-----| empty -> ;
-
-#   47| String arg
-#-----|  -> {...}
-
-#   47| [finally: return] String arg
-#-----|  -> [finally: return] {...}
-
-#   47| [finally: return] access to parameter args
-#-----|  -> [finally: return] foreach (... ... in ...) ...
-
-#   47| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   48| [finally: return] {...}
-#-----|  -> [finally: return] if (...) ...
-
-#   48| {...}
-#-----|  -> if (...) ...
-
-#   49| [finally: return] if (...) ...
-#-----|  -> [finally: return] access to local variable arg
-
-#   49| if (...) ...
-#-----|  -> access to local variable arg
-
-#   49| [finally: return] access to local variable arg
-#-----|  -> [finally: return] null
-
-#   49| access to local variable arg
-#-----|  -> null
-
-#   49| ... == ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> break;
-
-#   49| [finally: return] ... == ...
-#-----| false -> [finally: return] foreach (... ... in ...) ...
-#-----| true -> [finally: return] break;
-
-#   49| [finally: return] null
-#-----|  -> [finally: return] ... == ...
-
-#   49| null
-#-----|  -> ... == ...
-
-#   50| [finally: return] break;
-#-----| return -> exit M3 (normal)
-
-#   50| break;
-#-----| break -> ;
-
-#   53| ;
-#-----|  -> exit M3 (normal)
-
-#   56| enter M4
-#-----|  -> {...}
-
-#   56| exit M4
-
-#   56| exit M4 (normal)
-#-----|  -> exit M4
-
-#   57| {...}
-#-----|  -> try {...} ...
-
-#   58| try {...} ...
-#-----|  -> {...}
-
-#   59| {...}
-#-----|  -> if (...) ...
-
-#   60| if (...) ...
-#-----|  -> access to parameter args
-
-#   60| access to parameter args
-#-----|  -> null
-
-#   60| ... == ...
-#-----| true -> return ...;
-#-----| false -> {...}
-
-#   60| null
-#-----|  -> ... == ...
-
-#   61| return ...;
-#-----| return -> [finally: return] {...}
-
-#   64| [finally: return] {...}
-#-----|  -> [finally: return] access to parameter args
-
-#   64| {...}
-#-----|  -> access to parameter args
-
-#   65| [finally: return] foreach (... ... in ...) ...
-#-----| return -> exit M4 (normal)
-#-----| non-empty -> [finally: return] String arg
-
-#   65| foreach (... ... in ...) ...
-#-----| empty -> exit M4 (normal)
-#-----| non-empty -> String arg
-
-#   65| String arg
-#-----|  -> {...}
-
-#   65| [finally: return] String arg
-#-----|  -> [finally: return] {...}
-
-#   65| [finally: return] access to parameter args
-#-----|  -> [finally: return] foreach (... ... in ...) ...
-
-#   65| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   66| [finally: return] {...}
-#-----|  -> [finally: return] if (...) ...
-
-#   66| {...}
-#-----|  -> if (...) ...
-
-#   67| [finally: return] if (...) ...
-#-----|  -> [finally: return] access to local variable arg
-
-#   67| if (...) ...
-#-----|  -> access to local variable arg
-
-#   67| [finally: return] access to local variable arg
-#-----|  -> [finally: return] null
-
-#   67| access to local variable arg
-#-----|  -> null
-
-#   67| ... == ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> break;
-
-#   67| [finally: return] ... == ...
-#-----| false -> [finally: return] foreach (... ... in ...) ...
-#-----| true -> [finally: return] break;
-
-#   67| [finally: return] null
-#-----|  -> [finally: return] ... == ...
-
-#   67| null
-#-----|  -> ... == ...
-
-#   68| [finally: return] break;
-#-----| return -> exit M4 (normal)
-
-#   68| break;
-#-----| break -> exit M4 (normal)
-
-CompileTimeOperators.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter CompileTimeOperators
-#-----|  -> call to constructor Object
-
-#    3| exit CompileTimeOperators
-
-#    3| exit CompileTimeOperators (normal)
-#-----|  -> exit CompileTimeOperators
-
-#    3| {...}
-#-----|  -> exit CompileTimeOperators (normal)
-
-#    5| enter Default
-#-----|  -> {...}
-
-#    5| exit Default
-
-#    5| exit Default (normal)
-#-----|  -> exit Default
-
-#    6| {...}
-#-----|  -> default(...)
-
-#    7| return ...;
-#-----| return -> exit Default (normal)
-
-#    7| default(...)
-#-----|  -> return ...;
-
-#   10| enter Sizeof
-#-----|  -> {...}
-
-#   10| exit Sizeof
-
-#   10| exit Sizeof (normal)
-#-----|  -> exit Sizeof
-
-#   11| {...}
-#-----|  -> sizeof(..)
-
-#   12| return ...;
-#-----| return -> exit Sizeof (normal)
-
-#   12| sizeof(..)
-#-----|  -> return ...;
-
-#   15| enter Typeof
-#-----|  -> {...}
-
-#   15| exit Typeof
-
-#   15| exit Typeof (normal)
-#-----|  -> exit Typeof
-
-#   16| {...}
-#-----|  -> typeof(...)
-
-#   17| return ...;
-#-----| return -> exit Typeof (normal)
-
-#   17| typeof(...)
-#-----|  -> return ...;
-
-#   20| enter Nameof
-#-----|  -> {...}
-
-#   20| exit Nameof
-
-#   20| exit Nameof (normal)
-#-----|  -> exit Nameof
-
-#   21| {...}
-#-----|  -> nameof(...)
-
-#   22| return ...;
-#-----| return -> exit Nameof (normal)
-
-#   22| nameof(...)
-#-----|  -> return ...;
-
-#   26| call to constructor Object
-#-----|  -> {...}
-
-#   26| enter GotoInTryFinally
-#-----|  -> call to constructor Object
-
-#   26| exit GotoInTryFinally
-
-#   26| exit GotoInTryFinally (normal)
-#-----|  -> exit GotoInTryFinally
-
-#   26| {...}
-#-----|  -> exit GotoInTryFinally (normal)
-
-#   28| enter M
-#-----|  -> {...}
-
-#   28| exit M
-
-#   28| exit M (normal)
-#-----|  -> exit M
-
-#   29| {...}
-#-----|  -> try {...} ...
-
-#   30| try {...} ...
-#-----|  -> {...}
-
-#   31| {...}
-#-----|  -> goto ...;
-
-#   32| goto ...;
-#-----| goto(End) -> [finally: goto(End)] {...}
-
-#   36| [finally: goto(End)] {...}
-#-----|  -> [finally: goto(End)] ...;
-
-#   37| [finally: goto(End)] call to method WriteLine
-#-----| goto(End) -> End:
-
-#   37| [finally: goto(End)] ...;
-#-----|  -> [finally: goto(End)] "Finally"
-
-#   37| [finally: goto(End)] "Finally"
-#-----|  -> [finally: goto(End)] call to method WriteLine
-
-#   40| End:
-#-----|  -> ...;
-
-#   40| call to method WriteLine
-#-----|  -> exit M (normal)
-
-#   40| ...;
-#-----|  -> "End"
-
-#   40| "End"
-#-----|  -> call to method WriteLine
-
-ConditionalAccess.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter ConditionalAccess
-#-----|  -> call to constructor Object
-
-#    1| exit ConditionalAccess
-
-#    1| exit ConditionalAccess (normal)
-#-----|  -> exit ConditionalAccess
-
-#    1| {...}
-#-----|  -> exit ConditionalAccess (normal)
-
-#    3| enter M1
-#-----|  -> access to parameter i
-
-#    3| exit M1
-
-#    3| exit M1 (normal)
-#-----|  -> exit M1
-
-#    3| access to parameter i
-#-----| null -> exit M1 (normal)
-#-----| non-null -> call to method ToString
-
-#    3| call to method ToString
-#-----| null -> exit M1 (normal)
-#-----| non-null -> call to method ToLower
-
-#    3| call to method ToLower
-#-----|  -> exit M1 (normal)
-
-#    5| enter M2
-#-----|  -> access to parameter s
-
-#    5| exit M2
-
-#    5| exit M2 (normal)
-#-----|  -> exit M2
-
-#    5| access to parameter s
-#-----| null -> exit M2 (normal)
-#-----| non-null -> access to property Length
-
-#    5| access to property Length
-#-----|  -> exit M2 (normal)
-
-#    7| enter M3
-#-----|  -> access to parameter s1
-
-#    7| exit M3
-
-#    7| exit M3 (normal)
-#-----|  -> exit M3
-
-#    7| access to property Length
-#-----|  -> exit M3 (normal)
-
-#    7| access to parameter s1
-#-----| non-null -> ... ?? ...
-#-----| null -> access to parameter s2
-
-#    7| ... ?? ...
-#-----| null -> exit M3 (normal)
-#-----| non-null -> access to property Length
-
-#    7| [non-null] ... ?? ...
-#-----| non-null -> access to property Length
-
-#    7| [null] ... ?? ...
-#-----| null -> exit M3 (normal)
-
-#    7| access to parameter s2
-#-----| non-null -> [non-null] ... ?? ...
-#-----| null -> [null] ... ?? ...
-
-#    9| enter M4
-#-----|  -> access to parameter s
-
-#    9| exit M4
-
-#    9| exit M4 (normal)
-#-----|  -> exit M4
-
-#    9| access to parameter s
-#-----| non-null -> access to property Length
-#-----| null -> 0
-
-#    9| access to property Length
-#-----| non-null -> ... ?? ...
-#-----| null -> 0
-
-#    9| ... ?? ...
-#-----|  -> exit M4 (normal)
-
-#    9| 0
-#-----|  -> ... ?? ...
-
-#   11| enter M5
-#-----|  -> {...}
-
-#   11| exit M5
-
-#   11| exit M5 (normal)
-#-----|  -> exit M5
-
-#   12| {...}
-#-----|  -> if (...) ...
-
-#   13| if (...) ...
-#-----|  -> access to parameter s
-
-#   13| access to parameter s
-#-----| non-null -> access to property Length
-#-----| null -> 0
-
-#   13| access to property Length
-#-----|  -> 0
-
-#   13| ... > ...
-#-----| true -> 0
-#-----| false -> 1
-
-#   13| (...) ...
-#-----|  -> ... > ...
-
-#   13| 0
-#-----|  -> (...) ...
-
-#   14| return ...;
-#-----| return -> exit M5 (normal)
-
-#   14| 0
-#-----|  -> return ...;
-
-#   16| return ...;
-#-----| return -> exit M5 (normal)
-
-#   16| 1
-#-----|  -> return ...;
-
-#   19| enter M6
-#-----|  -> access to parameter s1
-
-#   19| exit M6
-
-#   19| exit M6 (normal)
-#-----|  -> exit M6
-
-#   19| access to parameter s1
-#-----| null -> exit M6 (normal)
-#-----| non-null -> access to parameter s2
-
-#   19| call to method CommaJoinWith
-#-----|  -> exit M6 (normal)
-
-#   19| access to parameter s2
-#-----|  -> call to method CommaJoinWith
-
-#   21| enter M7
-#-----|  -> {...}
-
-#   21| exit M7
-
-#   21| exit M7 (normal)
-#-----|  -> exit M7
-
-#   22| {...}
-#-----|  -> ... ...;
-
-#   23| ... ...;
-#-----|  -> null
-
-#   23| Nullable<Int32> j = ...
-#-----|  -> ... ...;
-
-#   23| (...) ...
-#-----| null -> Nullable<Int32> j = ...
-
-#   23| null
-#-----|  -> (...) ...
-
-#   24| ... ...;
-#-----|  -> access to parameter i
-
-#   24| String s = ...
-#-----|  -> ...;
-
-#   24| call to method ToString
-#-----|  -> String s = ...
-
-#   24| (...) ...
-#-----| non-null -> call to method ToString
-
-#   24| access to parameter i
-#-----|  -> (...) ...
-
-#   25| ... = ...
-#-----|  -> exit M7 (normal)
-
-#   25| ...;
-#-----|  -> ""
-
-#   25| ""
-#-----| non-null -> access to local variable s
-
-#   25| call to method CommaJoinWith
-#-----|  -> ... = ...
-
-#   25| access to local variable s
-#-----|  -> call to method CommaJoinWith
-
-#   30| enter Out
-#-----|  -> 0
-
-#   30| exit Out
-
-#   30| exit Out (normal)
-#-----|  -> exit Out
-
-#   30| ... = ...
-#-----|  -> exit Out (normal)
-
-#   30| 0
-#-----|  -> ... = ...
-
-#   32| enter M8
-#-----|  -> {...}
-
-#   32| exit M8
-
-#   32| exit M8 (normal)
-#-----|  -> exit M8
-
-#   33| {...}
-#-----|  -> ...;
-
-#   34| ... = ...
-#-----|  -> ...;
-
-#   34| ...;
-#-----|  -> 0
-
-#   34| 0
-#-----|  -> ... = ...
-
-#   35| access to property Prop
-#-----| null -> exit M8 (normal)
-#-----| non-null -> call to method Out
-
-#   35| this access
-#-----|  -> access to property Prop
-
-#   35| call to method Out
-#-----|  -> exit M8 (normal)
-
-#   35| ...;
-#-----|  -> this access
-
-#   41| enter CommaJoinWith
-#-----|  -> access to parameter s1
-
-#   41| exit CommaJoinWith
-
-#   41| exit CommaJoinWith (normal)
-#-----|  -> exit CommaJoinWith
-
-#   41| access to parameter s1
-#-----|  -> ", "
-
-#   41| ... + ...
-#-----|  -> access to parameter s2
-
-#   41| ... + ...
-#-----|  -> exit CommaJoinWith (normal)
-
-#   41| ", "
-#-----|  -> ... + ...
-
-#   41| access to parameter s2
-#-----|  -> ... + ...
-
-Conditions.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter Conditions
-#-----|  -> call to constructor Object
-
-#    1| exit Conditions
-
-#    1| exit Conditions (normal)
-#-----|  -> exit Conditions
-
-#    1| {...}
-#-----|  -> exit Conditions (normal)
-
-#    3| enter IncrOrDecr
-#-----|  -> {...}
-
-#    3| exit IncrOrDecr
-
-#    3| exit IncrOrDecr (normal)
-#-----|  -> exit IncrOrDecr
-
-#    4| {...}
-#-----|  -> if (...) ...
-
-#    5| if (...) ...
-#-----|  -> access to parameter inc
-
-#    5| access to parameter inc
-#-----| true -> [inc (line 3): true] ...;
-#-----| false -> [inc (line 3): false] if (...) ...
-
-#    6| [inc (line 3): true] access to parameter x
-#-----|  -> [inc (line 3): true] ...++
-
-#    6| [inc (line 3): true] ...++
-#-----|  -> [inc (line 3): true] if (...) ...
-
-#    6| [inc (line 3): true] ...;
-#-----|  -> [inc (line 3): true] access to parameter x
-
-#    7| [inc (line 3): false] if (...) ...
-#-----|  -> [inc (line 3): false] access to parameter inc
-
-#    7| [inc (line 3): true] if (...) ...
-#-----|  -> [inc (line 3): true] access to parameter inc
-
-#    7| [false] !...
-#-----| false -> exit IncrOrDecr (normal)
-
-#    7| [true] !...
-#-----| true -> ...;
-
-#    7| [inc (line 3): false] access to parameter inc
-#-----| false -> [true] !...
-
-#    7| [inc (line 3): true] access to parameter inc
-#-----| true -> [false] !...
-
-#    8| access to parameter x
-#-----|  -> ...--
-
-#    8| ...--
-#-----|  -> exit IncrOrDecr (normal)
-
-#    8| ...;
-#-----|  -> access to parameter x
-
-#   11| enter M1
-#-----|  -> {...}
-
-#   11| exit M1
-
-#   11| exit M1 (normal)
-#-----|  -> exit M1
-
-#   12| {...}
-#-----|  -> ... ...;
-
-#   13| ... ...;
-#-----|  -> 0
-
-#   13| Int32 x = ...
-#-----|  -> if (...) ...
-
-#   13| 0
-#-----|  -> Int32 x = ...
-
-#   14| if (...) ...
-#-----|  -> access to parameter b
-
-#   14| access to parameter b
-#-----| true -> [b (line 11): true] ...;
-#-----| false -> [b (line 11): false] if (...) ...
-
-#   15| [b (line 11): true] access to local variable x
-#-----|  -> [b (line 11): true] ...++
-
-#   15| [b (line 11): true] ...++
-#-----|  -> [b (line 11): true] if (...) ...
-
-#   15| [b (line 11): true] ...;
-#-----|  -> [b (line 11): true] access to local variable x
-
-#   16| [b (line 11): false] if (...) ...
-#-----|  -> [b (line 11): false] access to local variable x
-
-#   16| [b (line 11): true] if (...) ...
-#-----|  -> [b (line 11): true] access to local variable x
-
-#   16| [b (line 11): false] access to local variable x
-#-----|  -> [b (line 11): false] 0
-
-#   16| [b (line 11): true] access to local variable x
-#-----|  -> [b (line 11): true] 0
-
-#   16| [b (line 11): false] ... > ...
-#-----| true -> [b (line 11): false] if (...) ...
-#-----| false -> access to local variable x
-
-#   16| [b (line 11): true] ... > ...
-#-----| true -> [b (line 11): true] if (...) ...
-#-----| false -> access to local variable x
-
-#   16| [b (line 11): false] 0
-#-----|  -> [b (line 11): false] ... > ...
-
-#   16| [b (line 11): true] 0
-#-----|  -> [b (line 11): true] ... > ...
-
-#   17| [b (line 11): false] if (...) ...
-#-----|  -> [b (line 11): false] access to parameter b
-
-#   17| [b (line 11): true] if (...) ...
-#-----|  -> [b (line 11): true] access to parameter b
-
-#   17| [false] !...
-#-----| false -> access to local variable x
-
-#   17| [true] !...
-#-----| true -> ...;
-
-#   17| [b (line 11): false] access to parameter b
-#-----| false -> [true] !...
-
-#   17| [b (line 11): true] access to parameter b
-#-----| true -> [false] !...
-
-#   18| access to local variable x
-#-----|  -> ...--
-
-#   18| ...--
-#-----|  -> access to local variable x
-
-#   18| ...;
-#-----|  -> access to local variable x
-
-#   19| return ...;
-#-----| return -> exit M1 (normal)
-
-#   19| access to local variable x
-#-----|  -> return ...;
-
-#   22| enter M2
-#-----|  -> {...}
-
-#   22| exit M2
-
-#   22| exit M2 (normal)
-#-----|  -> exit M2
-
-#   23| {...}
-#-----|  -> ... ...;
-
-#   24| ... ...;
-#-----|  -> 0
-
-#   24| Int32 x = ...
-#-----|  -> if (...) ...
-
-#   24| 0
-#-----|  -> Int32 x = ...
-
-#   25| if (...) ...
-#-----|  -> access to parameter b1
-
-#   25| access to parameter b1
-#-----| true -> if (...) ...
-#-----| false -> if (...) ...
-
-#   26| if (...) ...
-#-----|  -> access to parameter b2
-
-#   26| access to parameter b2
-#-----| true -> [b2 (line 22): true] ...;
-#-----| false -> [b2 (line 22): false] if (...) ...
-
-#   27| [b2 (line 22): true] access to local variable x
-#-----|  -> [b2 (line 22): true] ...++
-
-#   27| [b2 (line 22): true] ...++
-#-----|  -> [b2 (line 22): true] if (...) ...
-
-#   27| [b2 (line 22): true] ...;
-#-----|  -> [b2 (line 22): true] access to local variable x
-
-#   28| [b2 (line 22): false] if (...) ...
-#-----|  -> [b2 (line 22): false] access to parameter b2
-
-#   28| [b2 (line 22): true] if (...) ...
-#-----|  -> [b2 (line 22): true] access to parameter b2
-
-#   28| if (...) ...
-#-----|  -> access to parameter b2
-
-#   28| [b2 (line 22): false] access to parameter b2
-#-----| false -> access to local variable x
-
-#   28| [b2 (line 22): true] access to parameter b2
-#-----| true -> ...;
-
-#   28| access to parameter b2
-#-----| true -> ...;
-#-----| false -> access to local variable x
-
-#   29| access to local variable x
-#-----|  -> ...++
-
-#   29| ...++
-#-----|  -> access to local variable x
-
-#   29| ...;
-#-----|  -> access to local variable x
-
-#   30| return ...;
-#-----| return -> exit M2 (normal)
-
-#   30| access to local variable x
-#-----|  -> return ...;
-
-#   33| enter M3
-#-----|  -> {...}
-
-#   33| exit M3
-
-#   33| exit M3 (normal)
-#-----|  -> exit M3
-
-#   34| {...}
-#-----|  -> ... ...;
-
-#   35| ... ...;
-#-----|  -> 0
-
-#   35| Int32 x = ...
-#-----|  -> ... ...;
-
-#   35| 0
-#-----|  -> Int32 x = ...
-
-#   36| ... ...;
-#-----|  -> false
-
-#   36| Boolean b2 = ...
-#-----|  -> if (...) ...
-
-#   36| false
-#-----|  -> Boolean b2 = ...
-
-#   37| if (...) ...
-#-----|  -> access to parameter b1
-
-#   37| access to parameter b1
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   38| ... = ...
-#-----|  -> if (...) ...
-
-#   38| ...;
-#-----|  -> access to parameter b1
-
-#   38| access to parameter b1
-#-----|  -> ... = ...
-
-#   39| if (...) ...
-#-----|  -> access to local variable b2
-
-#   39| access to local variable b2
-#-----| true -> [b2 (line 39): true] ...;
-#-----| false -> [b2 (line 39): false] if (...) ...
-
-#   40| [b2 (line 39): true] access to local variable x
-#-----|  -> [b2 (line 39): true] ...++
-
-#   40| [b2 (line 39): true] ...++
-#-----|  -> [b2 (line 39): true] if (...) ...
-
-#   40| [b2 (line 39): true] ...;
-#-----|  -> [b2 (line 39): true] access to local variable x
-
-#   41| [b2 (line 39): false] if (...) ...
-#-----|  -> [b2 (line 39): false] access to local variable b2
-
-#   41| [b2 (line 39): true] if (...) ...
-#-----|  -> [b2 (line 39): true] access to local variable b2
-
-#   41| [b2 (line 39): false] access to local variable b2
-#-----| false -> access to local variable x
-
-#   41| [b2 (line 39): true] access to local variable b2
-#-----| true -> ...;
-
-#   42| access to local variable x
-#-----|  -> ...++
-
-#   42| ...++
-#-----|  -> access to local variable x
-
-#   42| ...;
-#-----|  -> access to local variable x
-
-#   43| return ...;
-#-----| return -> exit M3 (normal)
-
-#   43| access to local variable x
-#-----|  -> return ...;
-
-#   46| enter M4
-#-----|  -> {...}
-
-#   46| exit M4
-
-#   46| exit M4 (normal)
-#-----|  -> exit M4
-
-#   47| {...}
-#-----|  -> ... ...;
-
-#   48| ... ...;
-#-----|  -> 0
-
-#   48| Int32 y = ...
-#-----|  -> while (...) ...
-
-#   48| 0
-#-----|  -> Int32 y = ...
-
-#   49| while (...) ...
-#-----|  -> access to parameter x
-
-#   49| [b (line 46): false] access to parameter x
-#-----|  -> [b (line 46): false] ...--
-
-#   49| [b (line 46): true] access to parameter x
-#-----|  -> [b (line 46): true] ...--
-
-#   49| access to parameter x
-#-----|  -> ...--
-
-#   49| ...--
-#-----|  -> 0
-
-#   49| [b (line 46): false] ...--
-#-----|  -> [b (line 46): false] 0
-
-#   49| [b (line 46): true] ...--
-#-----|  -> [b (line 46): true] 0
-
-#   49| ... > ...
-#-----| true -> {...}
-#-----| false -> access to local variable y
-
-#   49| [b (line 46): false] ... > ...
-#-----| true -> [b (line 46): false] {...}
-#-----| false -> access to local variable y
-
-#   49| [b (line 46): true] ... > ...
-#-----| true -> [b (line 46): true] {...}
-#-----| false -> access to local variable y
-
-#   49| 0
-#-----|  -> ... > ...
-
-#   49| [b (line 46): false] 0
-#-----|  -> [b (line 46): false] ... > ...
-
-#   49| [b (line 46): true] 0
-#-----|  -> [b (line 46): true] ... > ...
-
-#   50| [b (line 46): false] {...}
-#-----|  -> [b (line 46): false] if (...) ...
-
-#   50| [b (line 46): true] {...}
-#-----|  -> [b (line 46): true] if (...) ...
-
-#   50| {...}
-#-----|  -> if (...) ...
-
-#   51| [b (line 46): false] if (...) ...
-#-----|  -> [b (line 46): false] access to parameter b
-
-#   51| [b (line 46): true] if (...) ...
-#-----|  -> [b (line 46): true] access to parameter b
-
-#   51| if (...) ...
-#-----|  -> access to parameter b
-
-#   51| [b (line 46): false] access to parameter b
-#-----| false -> [b (line 46): false] access to parameter x
-
-#   51| [b (line 46): true] access to parameter b
-#-----| true -> [b (line 46): true] ...;
-
-#   51| access to parameter b
-#-----| false -> [b (line 46): false] access to parameter x
-#-----| true -> [b (line 46): true] ...;
-
-#   52| [b (line 46): true] access to local variable y
-#-----|  -> [b (line 46): true] ...++
-
-#   52| [b (line 46): true] ...++
-#-----|  -> [b (line 46): true] access to parameter x
-
-#   52| [b (line 46): true] ...;
-#-----|  -> [b (line 46): true] access to local variable y
-
-#   54| return ...;
-#-----| return -> exit M4 (normal)
-
-#   54| access to local variable y
-#-----|  -> return ...;
-
-#   57| enter M5
-#-----|  -> {...}
-
-#   57| exit M5
-
-#   57| exit M5 (normal)
-#-----|  -> exit M5
-
-#   58| {...}
-#-----|  -> ... ...;
-
-#   59| ... ...;
-#-----|  -> 0
-
-#   59| Int32 y = ...
-#-----|  -> while (...) ...
-
-#   59| 0
-#-----|  -> Int32 y = ...
-
-#   60| while (...) ...
-#-----|  -> access to parameter x
-
-#   60| [b (line 57): false] access to parameter x
-#-----|  -> [b (line 57): false] ...--
-
-#   60| [b (line 57): true] access to parameter x
-#-----|  -> [b (line 57): true] ...--
-
-#   60| access to parameter x
-#-----|  -> ...--
-
-#   60| ...--
-#-----|  -> 0
-
-#   60| [b (line 57): false] ...--
-#-----|  -> [b (line 57): false] 0
-
-#   60| [b (line 57): true] ...--
-#-----|  -> [b (line 57): true] 0
-
-#   60| ... > ...
-#-----| true -> {...}
-#-----| false -> if (...) ...
-
-#   60| [b (line 57): false] ... > ...
-#-----| true -> [b (line 57): false] {...}
-#-----| false -> [b (line 57): false] if (...) ...
-
-#   60| [b (line 57): true] ... > ...
-#-----| true -> [b (line 57): true] {...}
-#-----| false -> [b (line 57): true] if (...) ...
-
-#   60| 0
-#-----|  -> ... > ...
-
-#   60| [b (line 57): false] 0
-#-----|  -> [b (line 57): false] ... > ...
-
-#   60| [b (line 57): true] 0
-#-----|  -> [b (line 57): true] ... > ...
-
-#   61| [b (line 57): false] {...}
-#-----|  -> [b (line 57): false] if (...) ...
-
-#   61| [b (line 57): true] {...}
-#-----|  -> [b (line 57): true] if (...) ...
-
-#   61| {...}
-#-----|  -> if (...) ...
-
-#   62| [b (line 57): false] if (...) ...
-#-----|  -> [b (line 57): false] access to parameter b
-
-#   62| [b (line 57): true] if (...) ...
-#-----|  -> [b (line 57): true] access to parameter b
-
-#   62| if (...) ...
-#-----|  -> access to parameter b
-
-#   62| [b (line 57): false] access to parameter b
-#-----| false -> [b (line 57): false] access to parameter x
-
-#   62| [b (line 57): true] access to parameter b
-#-----| true -> [b (line 57): true] ...;
-
-#   62| access to parameter b
-#-----| false -> [b (line 57): false] access to parameter x
-#-----| true -> [b (line 57): true] ...;
-
-#   63| [b (line 57): true] access to local variable y
-#-----|  -> [b (line 57): true] ...++
-
-#   63| [b (line 57): true] ...++
-#-----|  -> [b (line 57): true] access to parameter x
-
-#   63| [b (line 57): true] ...;
-#-----|  -> [b (line 57): true] access to local variable y
-
-#   65| [b (line 57): false] if (...) ...
-#-----|  -> [b (line 57): false] access to parameter b
-
-#   65| [b (line 57): true] if (...) ...
-#-----|  -> [b (line 57): true] access to parameter b
-
-#   65| if (...) ...
-#-----|  -> access to parameter b
-
-#   65| [b (line 57): false] access to parameter b
-#-----| false -> access to local variable y
-
-#   65| [b (line 57): true] access to parameter b
-#-----| true -> ...;
-
-#   65| access to parameter b
-#-----| true -> ...;
-#-----| false -> access to local variable y
-
-#   66| access to local variable y
-#-----|  -> ...++
-
-#   66| ...++
-#-----|  -> access to local variable y
-
-#   66| ...;
-#-----|  -> access to local variable y
-
-#   67| return ...;
-#-----| return -> exit M5 (normal)
-
-#   67| access to local variable y
-#-----|  -> return ...;
-
-#   70| enter M6
-#-----|  -> {...}
-
-#   70| exit M6
-
-#   70| exit M6 (normal)
-#-----|  -> exit M6
-
-#   71| {...}
-#-----|  -> ... ...;
-
-#   72| ... ...;
-#-----|  -> access to parameter ss
-
-#   72| Boolean b = ...
-#-----|  -> ... ...;
-
-#   72| access to parameter ss
-#-----|  -> access to property Length
-
-#   72| access to property Length
-#-----|  -> 0
-
-#   72| ... > ...
-#-----|  -> Boolean b = ...
-
-#   72| 0
-#-----|  -> ... > ...
-
-#   73| ... ...;
-#-----|  -> 0
-
-#   73| Int32 x = ...
-#-----|  -> access to parameter ss
-
-#   73| 0
-#-----|  -> Int32 x = ...
-
-#   74| foreach (... ... in ...) ...
-#-----| non-empty -> String _
-#-----| empty -> if (...) ...
-
-#   74| String _
-#-----|  -> {...}
-
-#   74| access to parameter ss
-#-----|  -> foreach (... ... in ...) ...
-
-#   75| {...}
-#-----|  -> if (...) ...
-
-#   76| if (...) ...
-#-----|  -> access to local variable b
-
-#   76| access to local variable b
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   77| access to local variable x
-#-----|  -> ...++
-
-#   77| ...++
-#-----|  -> if (...) ...
-
-#   77| ...;
-#-----|  -> access to local variable x
-
-#   78| if (...) ...
-#-----|  -> access to local variable x
-
-#   78| access to local variable x
-#-----|  -> 0
-
-#   78| ... > ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> ...;
-
-#   78| 0
-#-----|  -> ... > ...
-
-#   79| ... = ...
-#-----|  -> foreach (... ... in ...) ...
-
-#   79| ...;
-#-----|  -> false
-
-#   79| false
-#-----|  -> ... = ...
-
-#   81| if (...) ...
-#-----|  -> access to local variable b
-
-#   81| access to local variable b
-#-----| true -> ...;
-#-----| false -> access to local variable x
-
-#   82| access to local variable x
-#-----|  -> ...++
-
-#   82| ...++
-#-----|  -> access to local variable x
-
-#   82| ...;
-#-----|  -> access to local variable x
-
-#   83| return ...;
-#-----| return -> exit M6 (normal)
-
-#   83| access to local variable x
-#-----|  -> return ...;
-
-#   86| enter M7
-#-----|  -> {...}
-
-#   86| exit M7
-
-#   86| exit M7 (normal)
-#-----|  -> exit M7
-
-#   87| {...}
-#-----|  -> ... ...;
-
-#   88| ... ...;
-#-----|  -> access to parameter ss
-
-#   88| Boolean b = ...
-#-----|  -> ... ...;
-
-#   88| access to parameter ss
-#-----|  -> access to property Length
-
-#   88| access to property Length
-#-----|  -> 0
-
-#   88| ... > ...
-#-----|  -> Boolean b = ...
-
-#   88| 0
-#-----|  -> ... > ...
-
-#   89| ... ...;
-#-----|  -> 0
-
-#   89| Int32 x = ...
-#-----|  -> access to parameter ss
-
-#   89| 0
-#-----|  -> Int32 x = ...
-
-#   90| foreach (... ... in ...) ...
-#-----| non-empty -> String _
-#-----| empty -> access to local variable x
-
-#   90| String _
-#-----|  -> {...}
-
-#   90| access to parameter ss
-#-----|  -> foreach (... ... in ...) ...
-
-#   91| {...}
-#-----|  -> if (...) ...
-
-#   92| if (...) ...
-#-----|  -> access to local variable b
-
-#   92| access to local variable b
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   93| access to local variable x
-#-----|  -> ...++
-
-#   93| ...++
-#-----|  -> if (...) ...
-
-#   93| ...;
-#-----|  -> access to local variable x
-
-#   94| if (...) ...
-#-----|  -> access to local variable x
-
-#   94| access to local variable x
-#-----|  -> 0
-
-#   94| ... > ...
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   94| 0
-#-----|  -> ... > ...
-
-#   95| ... = ...
-#-----|  -> if (...) ...
-
-#   95| ...;
-#-----|  -> false
-
-#   95| false
-#-----|  -> ... = ...
-
-#   96| if (...) ...
-#-----|  -> access to local variable b
-
-#   96| access to local variable b
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> ...;
-
-#   97| access to local variable x
-#-----|  -> ...++
-
-#   97| ...++
-#-----|  -> foreach (... ... in ...) ...
-
-#   97| ...;
-#-----|  -> access to local variable x
-
-#   99| return ...;
-#-----| return -> exit M7 (normal)
-
-#   99| access to local variable x
-#-----|  -> return ...;
-
-#  102| enter M8
-#-----|  -> {...}
-
-#  102| exit M8
-
-#  102| exit M8 (normal)
-#-----|  -> exit M8
-
-#  103| {...}
-#-----|  -> ... ...;
-
-#  104| ... ...;
-#-----|  -> access to parameter b
-
-#  104| String x = ...
-#-----|  -> if (...) ...
-
-#  104| access to parameter b
-#-----|  -> call to method ToString
-
-#  104| call to method ToString
-#-----|  -> String x = ...
-
-#  105| if (...) ...
-#-----|  -> access to parameter b
-
-#  105| access to parameter b
-#-----| true -> [b (line 102): true] ...;
-#-----| false -> [b (line 102): false] if (...) ...
-
-#  106| [b (line 102): true] access to local variable x
-#-----|  -> [b (line 102): true] ""
-
-#  106| [b (line 102): true] ... + ...
-#-----|  -> [b (line 102): true] ... = ...
-
-#  106| [b (line 102): true] ... = ...
-#-----|  -> [b (line 102): true] if (...) ...
-
-#  106| [b (line 102): true] ...;
-#-----|  -> [b (line 102): true] access to local variable x
-
-#  106| [b (line 102): true] ""
-#-----|  -> [b (line 102): true] ... + ...
-
-#  107| [b (line 102): false] if (...) ...
-#-----|  -> [b (line 102): false] access to local variable x
-
-#  107| [b (line 102): true] if (...) ...
-#-----|  -> [b (line 102): true] access to local variable x
-
-#  107| [b (line 102): false] access to local variable x
-#-----|  -> [b (line 102): false] access to property Length
-
-#  107| [b (line 102): true] access to local variable x
-#-----|  -> [b (line 102): true] access to property Length
-
-#  107| [b (line 102): false] access to property Length
-#-----|  -> [b (line 102): false] 0
-
-#  107| [b (line 102): true] access to property Length
-#-----|  -> [b (line 102): true] 0
-
-#  107| [b (line 102): false] ... > ...
-#-----| true -> [b (line 102): false] if (...) ...
-#-----| false -> access to local variable x
-
-#  107| [b (line 102): true] ... > ...
-#-----| true -> [b (line 102): true] if (...) ...
-#-----| false -> access to local variable x
-
-#  107| [b (line 102): false] 0
-#-----|  -> [b (line 102): false] ... > ...
-
-#  107| [b (line 102): true] 0
-#-----|  -> [b (line 102): true] ... > ...
-
-#  108| [b (line 102): false] if (...) ...
-#-----|  -> [b (line 102): false] access to parameter b
-
-#  108| [b (line 102): true] if (...) ...
-#-----|  -> [b (line 102): true] access to parameter b
-
-#  108| [false] !...
-#-----| false -> access to local variable x
-
-#  108| [true] !...
-#-----| true -> ...;
-
-#  108| [b (line 102): false] access to parameter b
-#-----| false -> [true] !...
-
-#  108| [b (line 102): true] access to parameter b
-#-----| true -> [false] !...
-
-#  109| access to local variable x
-#-----|  -> ""
-
-#  109| ... + ...
-#-----|  -> ... = ...
-
-#  109| ... = ...
-#-----|  -> access to local variable x
-
-#  109| ...;
-#-----|  -> access to local variable x
-
-#  109| ""
-#-----|  -> ... + ...
-
-#  110| return ...;
-#-----| return -> exit M8 (normal)
-
-#  110| access to local variable x
-#-----|  -> return ...;
-
-#  113| enter M9
-#-----|  -> {...}
-
-#  113| exit M9
-
-#  113| exit M9 (normal)
-#-----|  -> exit M9
-
-#  114| {...}
-#-----|  -> ... ...;
-
-#  115| ... ...;
-#-----|  -> null
-
-#  115| String s = ...
-#-----|  -> for (...;...;...) ...
-
-#  115| null
-#-----|  -> String s = ...
-
-#  116| for (...;...;...) ...
-#-----|  -> 0
-
-#  116| Int32 i = ...
-#-----|  -> access to local variable i
-
-#  116| 0
-#-----|  -> Int32 i = ...
-
-#  116| access to local variable i
-#-----|  -> access to parameter args
-
-#  116| ... < ...
-#-----| false -> exit M9 (normal)
-#-----| true -> {...}
-
-#  116| access to parameter args
-#-----|  -> access to property Length
-
-#  116| access to property Length
-#-----|  -> ... < ...
-
-#  116| access to local variable i
-#-----|  -> ...++
-
-#  116| ...++
-#-----|  -> access to local variable i
-
-#  117| {...}
-#-----|  -> ... ...;
-
-#  118| ... ...;
-#-----|  -> access to local variable i
-
-#  118| Boolean last = ...
-#-----|  -> if (...) ...
-
-#  118| access to local variable i
-#-----|  -> access to parameter args
-
-#  118| ... == ...
-#-----|  -> Boolean last = ...
-
-#  118| access to parameter args
-#-----|  -> access to property Length
-
-#  118| access to property Length
-#-----|  -> 1
-
-#  118| ... - ...
-#-----|  -> ... == ...
-
-#  118| 1
-#-----|  -> ... - ...
-
-#  119| if (...) ...
-#-----|  -> access to local variable last
-
-#  119| [false, last (line 118): true] !...
-#-----| false -> [last (line 118): true] if (...) ...
-
-#  119| [true, last (line 118): false] !...
-#-----| true -> [last (line 118): false] ...;
-
-#  119| access to local variable last
-#-----| false -> [true, last (line 118): false] !...
-#-----| true -> [false, last (line 118): true] !...
-
-#  120| [last (line 118): false] ... = ...
-#-----|  -> [last (line 118): false] if (...) ...
-
-#  120| [last (line 118): false] ...;
-#-----|  -> [last (line 118): false] ""
-
-#  120| [last (line 118): false] ""
-#-----|  -> [last (line 118): false] ... = ...
-
-#  121| [last (line 118): false] if (...) ...
-#-----|  -> [last (line 118): false] access to local variable last
-
-#  121| [last (line 118): true] if (...) ...
-#-----|  -> [last (line 118): true] access to local variable last
-
-#  121| [last (line 118): false] access to local variable last
-#-----| false -> access to local variable i
-
-#  121| [last (line 118): true] access to local variable last
-#-----| true -> ...;
-
-#  122| ... = ...
-#-----|  -> access to local variable i
-
-#  122| ...;
-#-----|  -> null
-
-#  122| null
-#-----|  -> ... = ...
-
-#  129| enter M10
-#-----|  -> {...}
-
-#  130| {...}
-#-----|  -> while (...) ...
-
-#  131| while (...) ...
-#-----|  -> true
-
-#  131| [Field1 (line 129): false] true
-#-----| true -> [Field1 (line 129): false] {...}
-
-#  131| [Field1 (line 129): true, Field2 (line 129): false] true
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): false] {...}
-
-#  131| [Field1 (line 129): true, Field2 (line 129): true] true
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
-
-#  131| true
-#-----| true -> {...}
-
-#  132| [Field1 (line 129): false] {...}
-#-----|  -> [Field1 (line 129): false] if (...) ...
-
-#  132| [Field1 (line 129): true, Field2 (line 129): false] {...}
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
-
-#  132| [Field1 (line 129): true, Field2 (line 129): true] {...}
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
-
-#  132| {...}
-#-----|  -> if (...) ...
-
-#  133| [Field1 (line 129): false] if (...) ...
-#-----|  -> [Field1 (line 129): false] this access
-
-#  133| [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] this access
-
-#  133| [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
-
-#  133| if (...) ...
-#-----|  -> this access
-
-#  133| [Field1 (line 129): false] access to field Field1
-#-----| false -> [Field1 (line 129): false] true
-
-#  133| [Field1 (line 129): false] this access
-#-----|  -> [Field1 (line 129): false] access to field Field1
-
-#  133| [Field1 (line 129): true, Field2 (line 129): false] access to field Field1
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): false] {...}
-
-#  133| [Field1 (line 129): true, Field2 (line 129): false] this access
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] access to field Field1
-
-#  133| [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
-
-#  133| [Field1 (line 129): true, Field2 (line 129): true] this access
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
-
-#  133| access to field Field1
-#-----| false -> [Field1 (line 129): false] true
-#-----| true -> [Field1 (line 129): true] {...}
-
-#  133| this access
-#-----|  -> access to field Field1
-
-#  134| [Field1 (line 129): true, Field2 (line 129): false] {...}
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
-
-#  134| [Field1 (line 129): true, Field2 (line 129): true] {...}
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
-
-#  134| [Field1 (line 129): true] {...}
-#-----|  -> [Field1 (line 129): true] if (...) ...
-
-#  135| [Field1 (line 129): true, Field2 (line 129): false] if (...) ...
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] this access
-
-#  135| [Field1 (line 129): true, Field2 (line 129): true] if (...) ...
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
-
-#  135| [Field1 (line 129): true] if (...) ...
-#-----|  -> [Field1 (line 129): true] this access
-
-#  135| [Field1 (line 129): true, Field2 (line 129): false] access to field Field2
-#-----| false -> [Field1 (line 129): true, Field2 (line 129): false] true
-
-#  135| [Field1 (line 129): true, Field2 (line 129): false] this access
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): false] access to field Field2
-
-#  135| [Field1 (line 129): true, Field2 (line 129): true] access to field Field2
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
-
-#  135| [Field1 (line 129): true, Field2 (line 129): true] this access
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field2
-
-#  135| [Field1 (line 129): true] access to field Field2
-#-----| false -> [Field1 (line 129): true, Field2 (line 129): false] true
-#-----| true -> [Field1 (line 129): true, Field2 (line 129): true] {...}
-
-#  135| [Field1 (line 129): true] this access
-#-----|  -> [Field1 (line 129): true] access to field Field2
-
-#  136| [Field1 (line 129): true, Field2 (line 129): true] {...}
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] ...;
-
-#  137| [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] call to method ToString
-
-#  137| [Field1 (line 129): true, Field2 (line 129): true] this access
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] access to field Field1
-
-#  137| [Field1 (line 129): true, Field2 (line 129): true] call to method ToString
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] true
-
-#  137| [Field1 (line 129): true, Field2 (line 129): true] ...;
-#-----|  -> [Field1 (line 129): true, Field2 (line 129): true] this access
-
-#  143| enter M11
-#-----|  -> {...}
-
-#  143| exit M11
-
-#  143| exit M11 (normal)
-#-----|  -> exit M11
-
-#  144| {...}
-#-----|  -> ... ...;
-
-#  145| ... ...;
-#-----|  -> access to parameter b
-
-#  145| [b (line 143): false] String s = ...
-#-----|  -> [b (line 143): false] if (...) ...
-
-#  145| [b (line 143): true] String s = ...
-#-----|  -> [b (line 143): true] if (...) ...
-
-#  145| access to parameter b
-#-----| true -> [b (line 143): true] "a"
-#-----| false -> [b (line 143): false] "b"
-
-#  145| [b (line 143): false] ... ? ... : ...
-#-----|  -> [b (line 143): false] String s = ...
-
-#  145| [b (line 143): true] ... ? ... : ...
-#-----|  -> [b (line 143): true] String s = ...
-
-#  145| [b (line 143): true] "a"
-#-----|  -> [b (line 143): true] ... ? ... : ...
-
-#  145| [b (line 143): false] "b"
-#-----|  -> [b (line 143): false] ... ? ... : ...
-
-#  146| [b (line 143): false] if (...) ...
-#-----|  -> [b (line 143): false] access to parameter b
-
-#  146| [b (line 143): true] if (...) ...
-#-----|  -> [b (line 143): true] access to parameter b
-
-#  146| [b (line 143): false] access to parameter b
-#-----| false -> ...;
-
-#  146| [b (line 143): true] access to parameter b
-#-----| true -> ...;
-
-#  147| call to method WriteLine
-#-----|  -> exit M11 (normal)
-
-#  147| ...;
-#-----|  -> "a = "
-
-#  147| $"..."
-#-----|  -> call to method WriteLine
-
-#  147| "a = "
-#-----|  -> access to local variable s
-
-#  147| access to local variable s
-#-----|  -> $"..."
-
-#  149| call to method WriteLine
-#-----|  -> exit M11 (normal)
-
-#  149| ...;
-#-----|  -> "b = "
-
-#  149| $"..."
-#-----|  -> call to method WriteLine
-
-#  149| "b = "
-#-----|  -> access to local variable s
-
-#  149| access to local variable s
-#-----|  -> $"..."
-
-ExitMethods.cs:
-#    6| call to constructor Object
-#-----|  -> {...}
-
-#    6| enter ExitMethods
-#-----|  -> call to constructor Object
-
-#    6| exit ExitMethods
-
-#    6| exit ExitMethods (normal)
-#-----|  -> exit ExitMethods
-
-#    6| {...}
-#-----|  -> exit ExitMethods (normal)
-
-#    8| enter M1
-#-----|  -> {...}
-
-#    8| exit M1
-
-#    8| exit M1 (normal)
-#-----|  -> exit M1
-
-#    9| {...}
-#-----|  -> ...;
-
-#   10| call to method ErrorMaybe
-#-----|  -> return ...;
-
-#   10| ...;
-#-----|  -> true
-
-#   10| true
-#-----|  -> call to method ErrorMaybe
-
-#   11| return ...;
-#-----| return -> exit M1 (normal)
-
-#   14| enter M2
-#-----|  -> {...}
-
-#   14| exit M2
-
-#   14| exit M2 (normal)
-#-----|  -> exit M2
-
-#   15| {...}
-#-----|  -> ...;
-
-#   16| call to method ErrorMaybe
-#-----|  -> return ...;
-
-#   16| ...;
-#-----|  -> false
-
-#   16| false
-#-----|  -> call to method ErrorMaybe
-
-#   17| return ...;
-#-----| return -> exit M2 (normal)
-
-#   20| enter M3
-#-----|  -> {...}
-
-#   20| exit M3
-
-#   20| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   21| {...}
-#-----|  -> ...;
-
-#   22| call to method ErrorAlways
-#-----| exception(ArgumentException), exception(Exception) -> exit M3 (abnormal)
-
-#   22| ...;
-#-----|  -> true
-
-#   22| true
-#-----|  -> call to method ErrorAlways
-
-#   26| enter M4
-#-----|  -> {...}
-
-#   26| exit M4
-
-#   26| exit M4 (abnormal)
-#-----|  -> exit M4
-
-#   27| {...}
-#-----|  -> ...;
-
-#   28| call to method Exit
-#-----| exit -> exit M4 (abnormal)
-
-#   28| this access
-#-----|  -> call to method Exit
-
-#   28| ...;
-#-----|  -> this access
-
-#   32| enter M5
-#-----|  -> {...}
-
-#   32| exit M5
-
-#   32| exit M5 (abnormal)
-#-----|  -> exit M5
-
-#   33| {...}
-#-----|  -> ...;
-
-#   34| call to method ApplicationExit
-#-----| exit -> exit M5 (abnormal)
-
-#   34| this access
-#-----|  -> call to method ApplicationExit
-
-#   34| ...;
-#-----|  -> this access
-
-#   38| enter M6
-#-----|  -> {...}
-
-#   38| exit M6
-
-#   38| exit M6 (normal)
-#-----|  -> exit M6
-
-#   39| {...}
-#-----|  -> try {...} ...
-
-#   40| try {...} ...
-#-----|  -> {...}
-
-#   41| {...}
-#-----|  -> ...;
-
-#   42| call to method ErrorAlways
-#-----| exception(ArgumentException) -> [exception: ArgumentException] catch (...) {...}
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-
-#   42| ...;
-#-----|  -> false
-
-#   42| false
-#-----|  -> call to method ErrorAlways
-
-#   44| [exception: ArgumentException] catch (...) {...}
-#-----| match -> {...}
-
-#   44| [exception: Exception] catch (...) {...}
-#-----| match -> {...}
-#-----| no-match -> [exception: Exception] catch (...) {...}
-
-#   45| {...}
-#-----|  -> return ...;
-
-#   46| return ...;
-#-----| return -> exit M6 (normal)
-
-#   48| [exception: Exception] catch (...) {...}
-#-----| match -> {...}
-
-#   49| {...}
-#-----|  -> return ...;
-
-#   50| return ...;
-#-----| return -> exit M6 (normal)
-
-#   54| enter M7
-#-----|  -> {...}
-
-#   54| exit M7
-
-#   54| exit M7 (abnormal)
-#-----|  -> exit M7
-
-#   55| {...}
-#-----|  -> ...;
-
-#   56| call to method ErrorAlways2
-#-----| exception(Exception) -> exit M7 (abnormal)
-
-#   56| ...;
-#-----|  -> call to method ErrorAlways2
-
-#   60| enter M8
-#-----|  -> {...}
-
-#   60| exit M8
-
-#   60| exit M8 (abnormal)
-#-----|  -> exit M8
-
-#   61| {...}
-#-----|  -> ...;
-
-#   62| call to method ErrorAlways3
-#-----| exception(Exception) -> exit M8 (abnormal)
-
-#   62| ...;
-#-----|  -> call to method ErrorAlways3
-
-#   66| enter ErrorMaybe
-#-----|  -> {...}
-
-#   66| exit ErrorMaybe
-
-#   66| exit ErrorMaybe (abnormal)
-#-----|  -> exit ErrorMaybe
-
-#   66| exit ErrorMaybe (normal)
-#-----|  -> exit ErrorMaybe
-
-#   67| {...}
-#-----|  -> if (...) ...
-
-#   68| if (...) ...
-#-----|  -> access to parameter b
-
-#   68| access to parameter b
-#-----| false -> exit ErrorMaybe (normal)
-#-----| true -> object creation of type Exception
-
-#   69| throw ...;
-#-----| exception(Exception) -> exit ErrorMaybe (abnormal)
-
-#   69| object creation of type Exception
-#-----|  -> throw ...;
-
-#   72| enter ErrorAlways
-#-----|  -> {...}
-
-#   72| exit ErrorAlways
-
-#   72| exit ErrorAlways (abnormal)
-#-----|  -> exit ErrorAlways
-
-#   73| {...}
-#-----|  -> if (...) ...
-
-#   74| if (...) ...
-#-----|  -> access to parameter b
-
-#   74| access to parameter b
-#-----| true -> object creation of type Exception
-#-----| false -> "b"
-
-#   75| throw ...;
-#-----| exception(Exception) -> exit ErrorAlways (abnormal)
-
-#   75| object creation of type Exception
-#-----|  -> throw ...;
-
-#   77| throw ...;
-#-----| exception(ArgumentException) -> exit ErrorAlways (abnormal)
-
-#   77| object creation of type ArgumentException
-#-----|  -> throw ...;
-
-#   77| "b"
-#-----|  -> object creation of type ArgumentException
-
-#   80| enter ErrorAlways2
-#-----|  -> {...}
-
-#   80| exit ErrorAlways2
-
-#   80| exit ErrorAlways2 (abnormal)
-#-----|  -> exit ErrorAlways2
-
-#   81| {...}
-#-----|  -> object creation of type Exception
-
-#   82| throw ...;
-#-----| exception(Exception) -> exit ErrorAlways2 (abnormal)
-
-#   82| object creation of type Exception
-#-----|  -> throw ...;
-
-#   85| enter ErrorAlways3
-#-----|  -> object creation of type Exception
-
-#   85| exit ErrorAlways3
-
-#   85| exit ErrorAlways3 (abnormal)
-#-----|  -> exit ErrorAlways3
-
-#   85| throw ...
-#-----| exception(Exception) -> exit ErrorAlways3 (abnormal)
-
-#   85| object creation of type Exception
-#-----|  -> throw ...
-
-#   87| enter Exit
-#-----|  -> {...}
-
-#   87| exit Exit
-
-#   87| exit Exit (abnormal)
-#-----|  -> exit Exit
-
-#   88| {...}
-#-----|  -> ...;
-
-#   89| call to method Exit
-#-----| exit -> exit Exit (abnormal)
-
-#   89| ...;
-#-----|  -> 0
-
-#   89| 0
-#-----|  -> call to method Exit
-
-#   92| enter ExitInTry
-#-----|  -> {...}
-
-#   92| exit ExitInTry
-
-#   92| exit ExitInTry (abnormal)
-#-----|  -> exit ExitInTry
-
-#   93| {...}
-#-----|  -> try {...} ...
-
-#   94| try {...} ...
-#-----|  -> {...}
-
-#   95| {...}
-#-----|  -> ...;
-
-#   96| call to method Exit
-#-----| exit -> exit ExitInTry (abnormal)
-
-#   96| this access
-#-----|  -> call to method Exit
-
-#   96| ...;
-#-----|  -> this access
-
-#  105| enter ApplicationExit
-#-----|  -> {...}
-
-#  105| exit ApplicationExit
-
-#  105| exit ApplicationExit (abnormal)
-#-----|  -> exit ApplicationExit
-
-#  106| {...}
-#-----|  -> ...;
-
-#  107| call to method Exit
-#-----| exit -> exit ApplicationExit (abnormal)
-
-#  107| ...;
-#-----|  -> call to method Exit
-
-#  110| enter ThrowExpr
-#-----|  -> {...}
-
-#  110| exit ThrowExpr
-
-#  110| exit ThrowExpr (abnormal)
-#-----|  -> exit ThrowExpr
-
-#  110| exit ThrowExpr (normal)
-#-----|  -> exit ThrowExpr
-
-#  111| {...}
-#-----|  -> access to parameter input
-
-#  112| return ...;
-#-----| return -> exit ThrowExpr (normal)
-
-#  112| access to parameter input
-#-----|  -> 0
-
-#  112| ... != ...
-#-----| true -> 1
-#-----| false -> "input"
-
-#  112| ... ? ... : ...
-#-----|  -> return ...;
-
-#  112| (...) ...
-#-----|  -> ... != ...
-
-#  112| 0
-#-----|  -> (...) ...
-
-#  112| (...) ...
-#-----|  -> access to parameter input
-
-#  112| 1
-#-----|  -> (...) ...
-
-#  112| ... / ...
-#-----|  -> ... ? ... : ...
-
-#  112| access to parameter input
-#-----|  -> ... / ...
-
-#  112| throw ...
-#-----| exception(ArgumentException) -> exit ThrowExpr (abnormal)
-
-#  112| object creation of type ArgumentException
-#-----|  -> throw ...
-
-#  112| "input"
-#-----|  -> object creation of type ArgumentException
-
-#  115| enter ExtensionMethodCall
-#-----|  -> {...}
-
-#  115| exit ExtensionMethodCall
-
-#  115| exit ExtensionMethodCall (normal)
-#-----|  -> exit ExtensionMethodCall
-
-#  116| {...}
-#-----|  -> access to parameter s
-
-#  117| return ...;
-#-----| return -> exit ExtensionMethodCall (normal)
-
-#  117| access to parameter s
-#-----|  -> -
-
-#  117| call to method Contains
-#-----| true -> 0
-#-----| false -> 1
-
-#  117| ... ? ... : ...
-#-----|  -> return ...;
-
-#  117| -
-#-----|  -> call to method Contains
-
-#  117| 0
-#-----|  -> ... ? ... : ...
-
-#  117| 1
-#-----|  -> ... ? ... : ...
-
-#  120| enter FailingAssertion
-#-----|  -> {...}
-
-#  120| exit FailingAssertion
-
-#  120| exit FailingAssertion (abnormal)
-#-----|  -> exit FailingAssertion
-
-#  121| {...}
-#-----|  -> ...;
-
-#  122| [assertion failure] call to method IsTrue
-#-----| exception(AssertFailedException) -> exit FailingAssertion (abnormal)
-
-#  122| ...;
-#-----|  -> false
-
-#  122| false
-#-----| false -> [assertion failure] call to method IsTrue
-
-#  126| enter FailingAssertion2
-#-----|  -> {...}
-
-#  126| exit FailingAssertion2
-
-#  126| exit FailingAssertion2 (abnormal)
-#-----|  -> exit FailingAssertion2
-
-#  127| {...}
-#-----|  -> ...;
-
-#  128| call to method FailingAssertion
-#-----| exception(AssertFailedException) -> exit FailingAssertion2 (abnormal)
-
-#  128| this access
-#-----|  -> call to method FailingAssertion
-
-#  128| ...;
-#-----|  -> this access
-
-#  132| enter AssertFalse
-#-----|  -> access to parameter b
-
-#  132| exit AssertFalse
-
-#  132| exit AssertFalse (abnormal)
-#-----|  -> exit AssertFalse
-
-#  132| exit AssertFalse (normal)
-#-----|  -> exit AssertFalse
-
-#  132| [assertion failure] call to method IsFalse
-#-----| exception(AssertFailedException) -> exit AssertFalse (abnormal)
-
-#  132| [assertion success] call to method IsFalse
-#-----|  -> exit AssertFalse (normal)
-
-#  132| access to parameter b
-#-----| false -> [assertion success] call to method IsFalse
-#-----| true -> [assertion failure] call to method IsFalse
-
-#  134| enter FailingAssertion3
-#-----|  -> {...}
-
-#  134| exit FailingAssertion3
-
-#  134| exit FailingAssertion3 (abnormal)
-#-----|  -> exit FailingAssertion3
-
-#  135| {...}
-#-----|  -> ...;
-
-#  136| [assertion failure] call to method AssertFalse
-#-----| exception(AssertFailedException) -> exit FailingAssertion3 (abnormal)
-
-#  136| this access
-#-----|  -> true
-
-#  136| ...;
-#-----|  -> this access
-
-#  136| true
-#-----| true -> [assertion failure] call to method AssertFalse
-
-#  140| enter ExceptionDispatchInfoThrow
-#-----|  -> {...}
-
-#  140| exit ExceptionDispatchInfoThrow
-
-#  140| exit ExceptionDispatchInfoThrow (abnormal)
-#-----|  -> exit ExceptionDispatchInfoThrow
-
-#  141| {...}
-#-----|  -> if (...) ...
-
-#  142| if (...) ...
-#-----|  -> access to parameter b
-
-#  142| access to parameter b
-#-----| true -> ...;
-#-----| false -> ...;
-
-#  143| call to method Throw
-#-----| exception(ArgumentException) -> exit ExceptionDispatchInfoThrow (abnormal)
-
-#  143| ...;
-#-----|  -> access to parameter e
-
-#  143| access to parameter e
-#-----|  -> call to method Throw
-
-#  145| call to method Capture
-#-----|  -> call to method Throw
-
-#  145| call to method Throw
-#-----| exception(Exception) -> exit ExceptionDispatchInfoThrow (abnormal)
-
-#  145| ...;
-#-----|  -> access to parameter e
-
-#  145| access to parameter e
-#-----|  -> call to method Capture
-
-Extensions.cs:
-#    5| enter ToInt32
-#-----|  -> {...}
-
-#    5| exit ToInt32
-
-#    5| exit ToInt32 (normal)
-#-----|  -> exit ToInt32
-
-#    6| {...}
-#-----|  -> access to parameter s
-
-#    7| return ...;
-#-----| return -> exit ToInt32 (normal)
-
-#    7| call to method Parse
-#-----|  -> return ...;
-
-#    7| access to parameter s
-#-----|  -> call to method Parse
-
-#   10| enter ToBool
-#-----|  -> {...}
-
-#   10| exit ToBool
-
-#   10| exit ToBool (normal)
-#-----|  -> exit ToBool
-
-#   11| {...}
-#-----|  -> access to parameter f
-
-#   12| return ...;
-#-----| return -> exit ToBool (normal)
-
-#   12| access to parameter f
-#-----|  -> access to parameter s
-
-#   12| delegate call
-#-----|  -> return ...;
-
-#   12| access to parameter s
-#-----|  -> delegate call
-
-#   15| enter CallToInt32
-#-----|  -> "0"
-
-#   15| exit CallToInt32
-
-#   15| exit CallToInt32 (normal)
-#-----|  -> exit CallToInt32
-
-#   15| call to method ToInt32
-#-----|  -> exit CallToInt32 (normal)
-
-#   15| "0"
-#-----|  -> call to method ToInt32
-
-#   20| enter Main
-#-----|  -> {...}
-
-#   20| exit Main
-
-#   20| exit Main (normal)
-#-----|  -> exit Main
-
-#   21| {...}
-#-----|  -> ...;
-
-#   22| access to parameter s
-#-----|  -> call to method ToInt32
-
-#   22| call to method ToInt32
-#-----|  -> ...;
-
-#   22| ...;
-#-----|  -> access to parameter s
-
-#   23| call to method ToInt32
-#-----|  -> ...;
-
-#   23| ...;
-#-----|  -> ""
-
-#   23| ""
-#-----|  -> call to method ToInt32
-
-#   24| call to method ToBool
-#-----|  -> ...;
-
-#   24| ...;
-#-----|  -> "true"
-
-#   24| "true"
-#-----|  -> access to method Parse
-
-#   24| access to method Parse
-#-----|  -> delegate creation of type Func<String,Boolean>
-
-#   24| delegate creation of type Func<String,Boolean>
-#-----|  -> call to method ToBool
-
-#   25| "true"
-#-----|  -> access to method Parse
-
-#   25| call to method ToBool
-#-----|  -> exit Main (normal)
-
-#   25| ...;
-#-----|  -> "true"
-
-#   25| access to method Parse
-#-----|  -> delegate creation of type Func<String,Boolean>
-
-#   25| delegate creation of type Func<String,Boolean>
-#-----|  -> call to method ToBool
-
-Finally.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter Finally
-#-----|  -> call to constructor Object
-
-#    3| exit Finally
-
-#    3| exit Finally (normal)
-#-----|  -> exit Finally
-
-#    3| {...}
-#-----|  -> exit Finally (normal)
-
-#    7| enter M1
-#-----|  -> {...}
-
-#    7| exit M1
-
-#    7| exit M1 (abnormal)
-#-----|  -> exit M1
-
-#    7| exit M1 (normal)
-#-----|  -> exit M1
-
-#    8| {...}
-#-----|  -> try {...} ...
-
-#    9| try {...} ...
-#-----|  -> {...}
-
-#   10| {...}
-#-----|  -> ...;
-
-#   11| call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----|  -> {...}
-
-#   11| ...;
-#-----|  -> "Try1"
-
-#   11| "Try1"
-#-----|  -> call to method WriteLine
-
-#   14| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#   14| {...}
-#-----|  -> ...;
-
-#   15| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M1 (abnormal)
-
-#   15| call to method WriteLine
-#-----|  -> exit M1 (normal)
-
-#   15| ...;
-#-----|  -> "Finally"
-
-#   15| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "Finally"
-
-#   15| "Finally"
-#-----|  -> call to method WriteLine
-
-#   15| [finally: exception(Exception)] "Finally"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#   19| enter M2
-#-----|  -> {...}
-
-#   19| exit M2
-
-#   19| exit M2 (abnormal)
-#-----|  -> exit M2
-
-#   19| exit M2 (normal)
-#-----|  -> exit M2
-
-#   20| {...}
-#-----|  -> try {...} ...
-
-#   21| try {...} ...
-#-----|  -> {...}
-
-#   22| {...}
-#-----|  -> ...;
-
-#   23| call to method WriteLine
-#-----|  -> return ...;
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-
-#   23| ...;
-#-----|  -> "Try2"
-
-#   23| "Try2"
-#-----|  -> call to method WriteLine
-
-#   24| return ...;
-#-----| return -> [finally: return] {...}
-
-#   26| [exception: Exception] catch (...) {...}
-#-----| match -> [exception: Exception] IOException ex
-#-----| no-match -> [exception: Exception] catch (...) {...}
-
-#   26| [exception: Exception] IOException ex
-#-----|  -> [exception: Exception] true
-
-#   26| [exception: Exception] true
-#-----| true -> {...}
-
-#   27| {...}
-#-----|  -> throw ...;
-
-#   28| throw ...;
-#-----| exception(IOException) -> [finally: exception(IOException)] {...}
-
-#   30| [exception: Exception] catch (...) {...}
-#-----| match -> [exception: Exception] ArgumentException ex
-#-----| no-match -> [exception: Exception] catch (...) {...}
-
-#   30| [exception: Exception] ArgumentException ex
-#-----|  -> {...}
-
-#   31| {...}
-#-----|  -> try {...} ...
-
-#   32| try {...} ...
-#-----|  -> {...}
-
-#   33| {...}
-#-----|  -> if (...) ...
-
-#   34| if (...) ...
-#-----|  -> true
-
-#   34| true
-#-----| true -> throw ...;
-
-#   34| throw ...;
-#-----| exception(ArgumentException) -> [finally: exception(ArgumentException)] {...}
-
-#   37| [finally: exception(ArgumentException)] {...}
-#-----|  -> [finally: exception(ArgumentException)] "Boo!"
-
-#   38| [finally: exception(ArgumentException)] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#   38| [finally: exception(ArgumentException)] object creation of type Exception
-#-----|  -> [finally: exception(ArgumentException)] throw ...;
-
-#   38| [finally: exception(ArgumentException)] "Boo!"
-#-----|  -> [finally: exception(ArgumentException)] object creation of type Exception
-
-#   41| [exception: Exception] catch (...) {...}
-#-----| match -> {...}
-
-#   42| {...}
-#-----|  -> {...}
-
-#   49| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#   49| [finally: exception(IOException)] {...}
-#-----|  -> [finally: exception(IOException)] ...;
-
-#   49| [finally: return] {...}
-#-----|  -> [finally: return] ...;
-
-#   49| {...}
-#-----|  -> ...;
-
-#   50| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M2 (abnormal)
-
-#   50| [finally: exception(IOException)] call to method WriteLine
-#-----| exception(IOException) -> exit M2 (abnormal)
-
-#   50| [finally: return] call to method WriteLine
-#-----| return -> exit M2 (normal)
-
-#   50| call to method WriteLine
-#-----|  -> exit M2 (normal)
-
-#   50| ...;
-#-----|  -> "Finally"
-
-#   50| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "Finally"
-
-#   50| [finally: exception(IOException)] ...;
-#-----|  -> [finally: exception(IOException)] "Finally"
-
-#   50| [finally: return] ...;
-#-----|  -> [finally: return] "Finally"
-
-#   50| "Finally"
-#-----|  -> call to method WriteLine
-
-#   50| [finally: exception(Exception)] "Finally"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#   50| [finally: exception(IOException)] "Finally"
-#-----|  -> [finally: exception(IOException)] call to method WriteLine
-
-#   50| [finally: return] "Finally"
-#-----|  -> [finally: return] call to method WriteLine
-
-#   54| enter M3
-#-----|  -> {...}
-
-#   54| exit M3
-
-#   54| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   54| exit M3 (normal)
-#-----|  -> exit M3
-
-#   55| {...}
-#-----|  -> try {...} ...
-
-#   56| try {...} ...
-#-----|  -> {...}
-
-#   57| {...}
-#-----|  -> ...;
-
-#   58| call to method WriteLine
-#-----|  -> return ...;
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-
-#   58| ...;
-#-----|  -> "Try3"
-
-#   58| "Try3"
-#-----|  -> call to method WriteLine
-
-#   59| return ...;
-#-----| return -> [finally: return] {...}
-
-#   61| [exception: Exception] catch (...) {...}
-#-----| match -> [exception: Exception] IOException ex
-#-----| no-match -> [exception: Exception] catch (...) {...}
-
-#   61| [exception: Exception] IOException ex
-#-----|  -> [exception: Exception] true
-
-#   61| [exception: Exception] true
-#-----| true -> {...}
-
-#   62| {...}
-#-----|  -> throw ...;
-
-#   63| throw ...;
-#-----| exception(IOException) -> [finally: exception(IOException)] {...}
-
-#   65| [exception: Exception] catch (...) {...}
-#-----| match -> [exception: Exception] Exception e
-
-#   65| [exception: Exception] Exception e
-#-----|  -> [exception: Exception] access to local variable e
-
-#   65| [exception: Exception] access to local variable e
-#-----|  -> [exception: Exception] access to property Message
-
-#   65| [exception: Exception] access to property Message
-#-----|  -> [exception: Exception] null
-
-#   65| [exception: Exception] ... != ...
-#-----| true -> {...}
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#   65| [exception: Exception] null
-#-----|  -> [exception: Exception] ... != ...
-
-#   66| {...}
-#-----|  -> {...}
-
-#   69| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#   69| [finally: exception(IOException)] {...}
-#-----|  -> [finally: exception(IOException)] ...;
-
-#   69| [finally: return] {...}
-#-----|  -> [finally: return] ...;
-
-#   69| {...}
-#-----|  -> ...;
-
-#   70| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M3 (abnormal)
-
-#   70| [finally: exception(IOException)] call to method WriteLine
-#-----| exception(IOException) -> exit M3 (abnormal)
-
-#   70| [finally: return] call to method WriteLine
-#-----| return -> exit M3 (normal)
-
-#   70| call to method WriteLine
-#-----|  -> exit M3 (normal)
-
-#   70| ...;
-#-----|  -> "Finally"
-
-#   70| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "Finally"
-
-#   70| [finally: exception(IOException)] ...;
-#-----|  -> [finally: exception(IOException)] "Finally"
-
-#   70| [finally: return] ...;
-#-----|  -> [finally: return] "Finally"
-
-#   70| "Finally"
-#-----|  -> call to method WriteLine
-
-#   70| [finally: exception(Exception)] "Finally"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#   70| [finally: exception(IOException)] "Finally"
-#-----|  -> [finally: exception(IOException)] call to method WriteLine
-
-#   70| [finally: return] "Finally"
-#-----|  -> [finally: return] call to method WriteLine
-
-#   74| enter M4
-#-----|  -> {...}
-
-#   74| exit M4
-
-#   74| exit M4 (abnormal)
-#-----|  -> exit M4
-
-#   74| exit M4 (normal)
-#-----|  -> exit M4
-
-#   75| {...}
-#-----|  -> ... ...;
-
-#   76| ... ...;
-#-----|  -> 10
-
-#   76| Int32 i = ...
-#-----|  -> while (...) ...
-
-#   76| 10
-#-----|  -> Int32 i = ...
-
-#   77| while (...) ...
-#-----|  -> access to local variable i
-
-#   77| access to local variable i
-#-----|  -> 0
-
-#   77| ... > ...
-#-----| false -> exit M4 (normal)
-#-----| true -> {...}
-
-#   77| 0
-#-----|  -> ... > ...
-
-#   78| {...}
-#-----|  -> try {...} ...
-
-#   79| try {...} ...
-#-----|  -> {...}
-
-#   80| {...}
-#-----|  -> if (...) ...
-
-#   81| if (...) ...
-#-----|  -> access to local variable i
-
-#   81| access to local variable i
-#-----|  -> 0
-
-#   81| ... == ...
-#-----| true -> return ...;
-#-----| false -> if (...) ...
-
-#   81| 0
-#-----|  -> ... == ...
-
-#   82| return ...;
-#-----| return -> [finally: return] {...}
-
-#   83| if (...) ...
-#-----|  -> access to local variable i
-
-#   83| access to local variable i
-#-----|  -> 1
-
-#   83| ... == ...
-#-----| true -> continue;
-#-----| false -> if (...) ...
-
-#   83| 1
-#-----|  -> ... == ...
-
-#   84| continue;
-#-----| continue -> [finally: continue] {...}
-
-#   85| if (...) ...
-#-----|  -> access to local variable i
-
-#   85| access to local variable i
-#-----|  -> 2
-
-#   85| ... == ...
-#-----| true -> break;
-#-----| false -> {...}
-
-#   85| 2
-#-----|  -> ... == ...
-
-#   86| break;
-#-----| break -> [finally: break] {...}
-
-#   89| [finally: break] {...}
-#-----|  -> [finally: break] try {...} ...
-
-#   89| [finally: continue] {...}
-#-----|  -> [finally: continue] try {...} ...
-
-#   89| [finally: return] {...}
-#-----|  -> [finally: return] try {...} ...
-
-#   89| {...}
-#-----|  -> try {...} ...
-
-#   90| [finally: break] try {...} ...
-#-----|  -> [finally: break] {...}
-
-#   90| [finally: continue] try {...} ...
-#-----|  -> [finally: continue] {...}
-
-#   90| [finally: return] try {...} ...
-#-----|  -> [finally: return] {...}
-
-#   90| try {...} ...
-#-----|  -> {...}
-
-#   91| [finally: break] {...}
-#-----|  -> [finally: break] if (...) ...
-
-#   91| [finally: continue] {...}
-#-----|  -> [finally: continue] if (...) ...
-
-#   91| [finally: return] {...}
-#-----|  -> [finally: return] if (...) ...
-
-#   91| {...}
-#-----|  -> if (...) ...
-
-#   92| [finally: break] if (...) ...
-#-----|  -> [finally: break] access to local variable i
-
-#   92| [finally: continue] if (...) ...
-#-----|  -> [finally: continue] access to local variable i
-
-#   92| [finally: return] if (...) ...
-#-----|  -> [finally: return] access to local variable i
-
-#   92| if (...) ...
-#-----|  -> access to local variable i
-
-#   92| [finally: break] access to local variable i
-#-----|  -> [finally: break] 3
-
-#   92| [finally: continue] access to local variable i
-#-----|  -> [finally: continue] 3
-
-#   92| [finally: return] access to local variable i
-#-----|  -> [finally: return] 3
-
-#   92| access to local variable i
-#-----|  -> 3
-
-#   92| ... == ...
-#-----| true -> object creation of type Exception
-#-----| false -> {...}
-
-#   92| [finally: break] ... == ...
-#-----| true -> [finally: break] object creation of type Exception
-#-----| false -> [finally: break] {...}
-
-#   92| [finally: continue] ... == ...
-#-----| true -> [finally: continue] object creation of type Exception
-#-----| false -> [finally: continue] {...}
-
-#   92| [finally: return] ... == ...
-#-----| true -> [finally: return] object creation of type Exception
-#-----| false -> [finally: return] {...}
-
-#   92| 3
-#-----|  -> ... == ...
-
-#   92| [finally: break] 3
-#-----|  -> [finally: break] ... == ...
-
-#   92| [finally: continue] 3
-#-----|  -> [finally: continue] ... == ...
-
-#   92| [finally: return] 3
-#-----|  -> [finally: return] ... == ...
-
-#   93| [finally: break] throw ...;
-#-----| exception(Exception) -> [finally: break, finally(1): exception(Exception)] {...}
-
-#   93| [finally: continue] throw ...;
-#-----| exception(Exception) -> [finally: continue, finally(1): exception(Exception)] {...}
-
-#   93| [finally: return] throw ...;
-#-----| exception(Exception) -> [finally: return, finally(1): exception(Exception)] {...}
-
-#   93| throw ...;
-#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
-
-#   93| [finally: break] object creation of type Exception
-#-----|  -> [finally: break] throw ...;
-#-----| exception(Exception) -> [finally: break, finally(1): exception(Exception)] {...}
-
-#   93| [finally: continue] object creation of type Exception
-#-----|  -> [finally: continue] throw ...;
-#-----| exception(Exception) -> [finally: continue, finally(1): exception(Exception)] {...}
-
-#   93| [finally: return] object creation of type Exception
-#-----|  -> [finally: return] throw ...;
-#-----| exception(Exception) -> [finally: return, finally(1): exception(Exception)] {...}
-
-#   93| object creation of type Exception
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
-
-#   96| [finally(1): exception(Exception)] {...}
-#-----|  -> [finally(1): exception(Exception)] ...;
-
-#   96| [finally: break, finally(1): exception(Exception)] {...}
-#-----|  -> [finally: break, finally(1): exception(Exception)] ...;
-
-#   96| [finally: break] {...}
-#-----|  -> [finally: break] ...;
-
-#   96| [finally: continue, finally(1): exception(Exception)] {...}
-#-----|  -> [finally: continue, finally(1): exception(Exception)] ...;
-
-#   96| [finally: continue] {...}
-#-----|  -> [finally: continue] ...;
-
-#   96| [finally: return, finally(1): exception(Exception)] {...}
-#-----|  -> [finally: return, finally(1): exception(Exception)] ...;
-
-#   96| [finally: return] {...}
-#-----|  -> [finally: return] ...;
-
-#   96| {...}
-#-----|  -> ...;
-
-#   97| [finally(1): exception(Exception)] access to local variable i
-#-----|  -> [finally(1): exception(Exception)] ...--
-
-#   97| [finally: break, finally(1): exception(Exception)] access to local variable i
-#-----|  -> [finally: break, finally(1): exception(Exception)] ...--
-
-#   97| [finally: break] access to local variable i
-#-----|  -> [finally: break] ...--
-
-#   97| [finally: continue, finally(1): exception(Exception)] access to local variable i
-#-----|  -> [finally: continue, finally(1): exception(Exception)] ...--
-
-#   97| [finally: continue] access to local variable i
-#-----|  -> [finally: continue] ...--
-
-#   97| [finally: return, finally(1): exception(Exception)] access to local variable i
-#-----|  -> [finally: return, finally(1): exception(Exception)] ...--
-
-#   97| [finally: return] access to local variable i
-#-----|  -> [finally: return] ...--
-
-#   97| access to local variable i
-#-----|  -> ...--
-
-#   97| ...--
-#-----|  -> access to local variable i
-
-#   97| [finally(1): exception(Exception)] ...--
-#-----| exception(Exception) -> exit M4 (abnormal)
-
-#   97| [finally: break, finally(1): exception(Exception)] ...--
-#-----| exception(Exception) -> exit M4 (abnormal)
-
-#   97| [finally: break] ...--
-#-----| break -> exit M4 (normal)
-
-#   97| [finally: continue, finally(1): exception(Exception)] ...--
-#-----| exception(Exception) -> exit M4 (abnormal)
-
-#   97| [finally: continue] ...--
-#-----| continue -> access to local variable i
-
-#   97| [finally: return, finally(1): exception(Exception)] ...--
-#-----| exception(Exception) -> exit M4 (abnormal)
-
-#   97| [finally: return] ...--
-#-----| return -> exit M4 (normal)
-
-#   97| ...;
-#-----|  -> access to local variable i
-
-#   97| [finally(1): exception(Exception)] ...;
-#-----|  -> [finally(1): exception(Exception)] access to local variable i
-
-#   97| [finally: break, finally(1): exception(Exception)] ...;
-#-----|  -> [finally: break, finally(1): exception(Exception)] access to local variable i
-
-#   97| [finally: break] ...;
-#-----|  -> [finally: break] access to local variable i
-
-#   97| [finally: continue, finally(1): exception(Exception)] ...;
-#-----|  -> [finally: continue, finally(1): exception(Exception)] access to local variable i
-
-#   97| [finally: continue] ...;
-#-----|  -> [finally: continue] access to local variable i
-
-#   97| [finally: return, finally(1): exception(Exception)] ...;
-#-----|  -> [finally: return, finally(1): exception(Exception)] access to local variable i
-
-#   97| [finally: return] ...;
-#-----|  -> [finally: return] access to local variable i
-
-#  103| enter M5
-#-----|  -> {...}
-
-#  103| exit M5
-
-#  103| exit M5 (abnormal)
-#-----|  -> exit M5
-
-#  103| exit M5 (normal)
-#-----|  -> exit M5
-
-#  104| {...}
-#-----|  -> try {...} ...
-
-#  105| try {...} ...
-#-----|  -> {...}
-
-#  106| {...}
-#-----|  -> if (...) ...
-
-#  107| if (...) ...
-#-----|  -> this access
-
-#  107| access to field Field
-#-----|  -> access to property Length
-#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
-
-#  107| this access
-#-----|  -> access to field Field
-
-#  107| access to property Length
-#-----|  -> 0
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
-
-#  107| ... == ...
-#-----| true -> return ...;
-#-----| false -> if (...) ...
-
-#  107| 0
-#-----|  -> ... == ...
-
-#  108| return ...;
-#-----| return -> [finally: return] {...}
-
-#  109| if (...) ...
-#-----|  -> this access
-
-#  109| access to field Field
-#-----|  -> access to property Length
-#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
-
-#  109| this access
-#-----|  -> access to field Field
-
-#  109| access to property Length
-#-----|  -> 1
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----| exception(NullReferenceException) -> [finally: exception(NullReferenceException)] {...}
-
-#  109| ... == ...
-#-----| true -> object creation of type OutOfMemoryException
-#-----| false -> {...}
-
-#  109| 1
-#-----|  -> ... == ...
-
-#  110| throw ...;
-#-----| exception(OutOfMemoryException) -> [finally: exception(OutOfMemoryException)] {...}
-
-#  110| object creation of type OutOfMemoryException
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  113| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  113| [finally: exception(NullReferenceException)] {...}
-#-----|  -> [finally: exception(NullReferenceException)] if (...) ...
-
-#  113| [finally: exception(OutOfMemoryException)] {...}
-#-----|  -> [finally: exception(OutOfMemoryException)] if (...) ...
-
-#  113| [finally: return] {...}
-#-----|  -> [finally: return] if (...) ...
-
-#  113| {...}
-#-----|  -> if (...) ...
-
-#  114| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] this access
-
-#  114| [finally: exception(NullReferenceException)] if (...) ...
-#-----|  -> [finally: exception(NullReferenceException)] this access
-
-#  114| [finally: exception(OutOfMemoryException)] if (...) ...
-#-----|  -> [finally: exception(OutOfMemoryException)] this access
-
-#  114| [finally: return] if (...) ...
-#-----|  -> [finally: return] this access
-
-#  114| if (...) ...
-#-----|  -> this access
-
-#  114| [false, finally: exception(Exception)] !...
-#-----| false -> [finally: exception(Exception)] if (...) ...
-
-#  114| [false, finally: exception(NullReferenceException)] !...
-#-----| false -> [finally: exception(NullReferenceException)] if (...) ...
-
-#  114| [false, finally: exception(OutOfMemoryException)] !...
-#-----| false -> [finally: exception(OutOfMemoryException)] if (...) ...
-
-#  114| [false, finally: return] !...
-#-----| false -> [finally: return] if (...) ...
-
-#  114| [false] !...
-#-----| false -> if (...) ...
-
-#  114| [true, finally: exception(Exception)] !...
-#-----| true -> [finally: exception(Exception)] ...;
-
-#  114| [true, finally: exception(NullReferenceException)] !...
-#-----| true -> [finally: exception(NullReferenceException)] ...;
-
-#  114| [true, finally: exception(OutOfMemoryException)] !...
-#-----| true -> [finally: exception(OutOfMemoryException)] ...;
-
-#  114| [true, finally: return] !...
-#-----| true -> [finally: return] ...;
-
-#  114| [true] !...
-#-----| true -> ...;
-
-#  114| [finally: exception(Exception)] access to field Field
-#-----|  -> [finally: exception(Exception)] access to property Length
-
-#  114| [finally: exception(Exception)] this access
-#-----|  -> [finally: exception(Exception)] access to field Field
-
-#  114| [finally: exception(NullReferenceException)] access to field Field
-#-----|  -> [finally: exception(NullReferenceException)] access to property Length
-
-#  114| [finally: exception(NullReferenceException)] this access
-#-----|  -> [finally: exception(NullReferenceException)] access to field Field
-
-#  114| [finally: exception(OutOfMemoryException)] access to field Field
-#-----|  -> [finally: exception(OutOfMemoryException)] access to property Length
-
-#  114| [finally: exception(OutOfMemoryException)] this access
-#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
-
-#  114| [finally: return] access to field Field
-#-----|  -> [finally: return] access to property Length
-
-#  114| [finally: return] this access
-#-----|  -> [finally: return] access to field Field
-
-#  114| access to field Field
-#-----|  -> access to property Length
-
-#  114| this access
-#-----|  -> access to field Field
-
-#  114| [finally: exception(Exception)] access to property Length
-#-----|  -> [finally: exception(Exception)] 0
-
-#  114| [finally: exception(NullReferenceException)] access to property Length
-#-----|  -> [finally: exception(NullReferenceException)] 0
-
-#  114| [finally: exception(OutOfMemoryException)] access to property Length
-#-----|  -> [finally: exception(OutOfMemoryException)] 0
-
-#  114| [finally: return] access to property Length
-#-----|  -> [finally: return] 0
-
-#  114| access to property Length
-#-----|  -> 0
-
-#  114| ... == ...
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#  114| [finally: exception(Exception)] ... == ...
-#-----| false -> [true, finally: exception(Exception)] !...
-#-----| true -> [false, finally: exception(Exception)] !...
-
-#  114| [finally: exception(NullReferenceException)] ... == ...
-#-----| false -> [true, finally: exception(NullReferenceException)] !...
-#-----| true -> [false, finally: exception(NullReferenceException)] !...
-
-#  114| [finally: exception(OutOfMemoryException)] ... == ...
-#-----| false -> [true, finally: exception(OutOfMemoryException)] !...
-#-----| true -> [false, finally: exception(OutOfMemoryException)] !...
-
-#  114| [finally: return] ... == ...
-#-----| false -> [true, finally: return] !...
-#-----| true -> [false, finally: return] !...
-
-#  114| 0
-#-----|  -> ... == ...
-
-#  114| [finally: exception(Exception)] 0
-#-----|  -> [finally: exception(Exception)] ... == ...
-
-#  114| [finally: exception(NullReferenceException)] 0
-#-----|  -> [finally: exception(NullReferenceException)] ... == ...
-
-#  114| [finally: exception(OutOfMemoryException)] 0
-#-----|  -> [finally: exception(OutOfMemoryException)] ... == ...
-
-#  114| [finally: return] 0
-#-----|  -> [finally: return] ... == ...
-
-#  115| [finally: exception(Exception)] call to method WriteLine
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  115| [finally: exception(NullReferenceException)] call to method WriteLine
-#-----|  -> [finally: exception(NullReferenceException)] if (...) ...
-
-#  115| [finally: exception(OutOfMemoryException)] call to method WriteLine
-#-----|  -> [finally: exception(OutOfMemoryException)] if (...) ...
-
-#  115| [finally: return] call to method WriteLine
-#-----|  -> [finally: return] if (...) ...
-
-#  115| call to method WriteLine
-#-----|  -> if (...) ...
-
-#  115| ...;
-#-----|  -> this access
-
-#  115| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] this access
-
-#  115| [finally: exception(NullReferenceException)] ...;
-#-----|  -> [finally: exception(NullReferenceException)] this access
-
-#  115| [finally: exception(OutOfMemoryException)] ...;
-#-----|  -> [finally: exception(OutOfMemoryException)] this access
-
-#  115| [finally: return] ...;
-#-----|  -> [finally: return] this access
-
-#  115| [finally: exception(Exception)] access to field Field
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  115| [finally: exception(Exception)] this access
-#-----|  -> [finally: exception(Exception)] access to field Field
-
-#  115| [finally: exception(NullReferenceException)] access to field Field
-#-----|  -> [finally: exception(NullReferenceException)] call to method WriteLine
-
-#  115| [finally: exception(NullReferenceException)] this access
-#-----|  -> [finally: exception(NullReferenceException)] access to field Field
-
-#  115| [finally: exception(OutOfMemoryException)] access to field Field
-#-----|  -> [finally: exception(OutOfMemoryException)] call to method WriteLine
-
-#  115| [finally: exception(OutOfMemoryException)] this access
-#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
-
-#  115| [finally: return] access to field Field
-#-----|  -> [finally: return] call to method WriteLine
-
-#  115| [finally: return] this access
-#-----|  -> [finally: return] access to field Field
-
-#  115| access to field Field
-#-----|  -> call to method WriteLine
-
-#  115| this access
-#-----|  -> access to field Field
-
-#  116| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] this access
-
-#  116| [finally: exception(NullReferenceException)] if (...) ...
-#-----|  -> [finally: exception(NullReferenceException)] this access
-
-#  116| [finally: exception(OutOfMemoryException)] if (...) ...
-#-----|  -> [finally: exception(OutOfMemoryException)] this access
-
-#  116| [finally: return] if (...) ...
-#-----|  -> [finally: return] this access
-
-#  116| if (...) ...
-#-----|  -> this access
-
-#  116| [finally: exception(Exception)] access to field Field
-#-----|  -> [finally: exception(Exception)] access to property Length
-
-#  116| [finally: exception(Exception)] this access
-#-----|  -> [finally: exception(Exception)] access to field Field
-
-#  116| [finally: exception(NullReferenceException)] access to field Field
-#-----|  -> [finally: exception(NullReferenceException)] access to property Length
-
-#  116| [finally: exception(NullReferenceException)] this access
-#-----|  -> [finally: exception(NullReferenceException)] access to field Field
-
-#  116| [finally: exception(OutOfMemoryException)] access to field Field
-#-----|  -> [finally: exception(OutOfMemoryException)] access to property Length
-
-#  116| [finally: exception(OutOfMemoryException)] this access
-#-----|  -> [finally: exception(OutOfMemoryException)] access to field Field
-
-#  116| [finally: return] access to field Field
-#-----|  -> [finally: return] access to property Length
-
-#  116| [finally: return] this access
-#-----|  -> [finally: return] access to field Field
-
-#  116| access to field Field
-#-----|  -> access to property Length
-
-#  116| this access
-#-----|  -> access to field Field
-
-#  116| [finally: exception(Exception)] access to property Length
-#-----|  -> [finally: exception(Exception)] 0
-
-#  116| [finally: exception(NullReferenceException)] access to property Length
-#-----|  -> [finally: exception(NullReferenceException)] 0
-
-#  116| [finally: exception(OutOfMemoryException)] access to property Length
-#-----|  -> [finally: exception(OutOfMemoryException)] 0
-
-#  116| [finally: return] access to property Length
-#-----|  -> [finally: return] 0
-
-#  116| access to property Length
-#-----|  -> 0
-
-#  116| ... > ...
-#-----| false -> exit M5 (normal)
-#-----| true -> ...;
-
-#  116| [finally: exception(Exception)] ... > ...
-#-----| exception(Exception) -> exit M5 (abnormal)
-#-----| true -> [finally: exception(Exception)] ...;
-
-#  116| [finally: exception(NullReferenceException)] ... > ...
-#-----| exception(NullReferenceException) -> exit M5 (abnormal)
-#-----| true -> [finally: exception(NullReferenceException)] ...;
-
-#  116| [finally: exception(OutOfMemoryException)] ... > ...
-#-----| exception(OutOfMemoryException) -> exit M5 (abnormal)
-#-----| true -> [finally: exception(OutOfMemoryException)] ...;
-
-#  116| [finally: return] ... > ...
-#-----| return -> exit M5 (normal)
-#-----| true -> [finally: return] ...;
-
-#  116| 0
-#-----|  -> ... > ...
-
-#  116| [finally: exception(Exception)] 0
-#-----|  -> [finally: exception(Exception)] ... > ...
-
-#  116| [finally: exception(NullReferenceException)] 0
-#-----|  -> [finally: exception(NullReferenceException)] ... > ...
-
-#  116| [finally: exception(OutOfMemoryException)] 0
-#-----|  -> [finally: exception(OutOfMemoryException)] ... > ...
-
-#  116| [finally: return] 0
-#-----|  -> [finally: return] ... > ...
-
-#  117| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M5 (abnormal)
-
-#  117| [finally: exception(NullReferenceException)] call to method WriteLine
-#-----| exception(NullReferenceException) -> exit M5 (abnormal)
-
-#  117| [finally: exception(OutOfMemoryException)] call to method WriteLine
-#-----| exception(OutOfMemoryException) -> exit M5 (abnormal)
-
-#  117| [finally: return] call to method WriteLine
-#-----| return -> exit M5 (normal)
-
-#  117| call to method WriteLine
-#-----|  -> exit M5 (normal)
-
-#  117| ...;
-#-----|  -> 1
-
-#  117| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] 1
-
-#  117| [finally: exception(NullReferenceException)] ...;
-#-----|  -> [finally: exception(NullReferenceException)] 1
-
-#  117| [finally: exception(OutOfMemoryException)] ...;
-#-----|  -> [finally: exception(OutOfMemoryException)] 1
-
-#  117| [finally: return] ...;
-#-----|  -> [finally: return] 1
-
-#  117| 1
-#-----|  -> call to method WriteLine
-
-#  117| [finally: exception(Exception)] 1
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  117| [finally: exception(NullReferenceException)] 1
-#-----|  -> [finally: exception(NullReferenceException)] call to method WriteLine
-
-#  117| [finally: exception(OutOfMemoryException)] 1
-#-----|  -> [finally: exception(OutOfMemoryException)] call to method WriteLine
-
-#  117| [finally: return] 1
-#-----|  -> [finally: return] call to method WriteLine
-
-#  121| enter M6
-#-----|  -> {...}
-
-#  121| exit M6
-
-#  121| exit M6 (normal)
-#-----|  -> exit M6
-
-#  122| {...}
-#-----|  -> try {...} ...
-
-#  123| try {...} ...
-#-----|  -> {...}
-
-#  124| {...}
-#-----|  -> ... ...;
-
-#  125| ... ...;
-#-----|  -> 0
-
-#  125| Double temp = ...
-#-----|  -> exit M6 (normal)
-
-#  125| (...) ...
-#-----|  -> access to constant E
-
-#  125| 0
-#-----|  -> (...) ...
-
-#  125| ... / ...
-#-----|  -> Double temp = ...
-
-#  125| access to constant E
-#-----|  -> ... / ...
-
-#  133| enter M7
-#-----|  -> {...}
-
-#  133| exit M7
-
-#  133| exit M7 (abnormal)
-#-----|  -> exit M7
-
-#  134| {...}
-#-----|  -> try {...} ...
-
-#  135| try {...} ...
-#-----|  -> {...}
-
-#  136| {...}
-#-----|  -> ...;
-
-#  137| call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----|  -> {...}
-
-#  137| ...;
-#-----|  -> "Try"
-
-#  137| "Try"
-#-----|  -> call to method WriteLine
-
-#  140| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ""
-
-#  140| {...}
-#-----|  -> ""
-
-#  141| [finally: exception(Exception)] throw ...;
-#-----| exception(ArgumentException) -> exit M7 (abnormal)
-
-#  141| throw ...;
-#-----| exception(ArgumentException) -> exit M7 (abnormal)
-
-#  141| [finally: exception(Exception)] object creation of type ArgumentException
-#-----|  -> [finally: exception(Exception)] throw ...;
-
-#  141| object creation of type ArgumentException
-#-----|  -> throw ...;
-
-#  141| ""
-#-----|  -> object creation of type ArgumentException
-
-#  141| [finally: exception(Exception)] ""
-#-----|  -> [finally: exception(Exception)] object creation of type ArgumentException
-
-#  147| enter M8
-#-----|  -> {...}
-
-#  147| exit M8
-
-#  147| exit M8 (abnormal)
-#-----|  -> exit M8
-
-#  147| exit M8 (normal)
-#-----|  -> exit M8
-
-#  148| {...}
-#-----|  -> try {...} ...
-
-#  149| try {...} ...
-#-----|  -> {...}
-
-#  150| {...}
-#-----|  -> if (...) ...
-
-#  151| if (...) ...
-#-----|  -> access to parameter args
-
-#  151| access to parameter args
-#-----|  -> null
-
-#  151| ... == ...
-#-----| true -> object creation of type ArgumentNullException
-#-----| false -> {...}
-
-#  151| null
-#-----|  -> ... == ...
-
-#  152| throw ...;
-#-----| exception(ArgumentNullException) -> [finally: exception(ArgumentNullException)] {...}
-
-#  152| object creation of type ArgumentNullException
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  155| [finally: exception(ArgumentNullException)] {...}
-#-----|  -> [finally: exception(ArgumentNullException)] try {...} ...
-
-#  155| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] try {...} ...
-
-#  155| {...}
-#-----|  -> try {...} ...
-
-#  156| [finally: exception(ArgumentNullException)] try {...} ...
-#-----|  -> [finally: exception(ArgumentNullException)] {...}
-
-#  156| [finally: exception(Exception)] try {...} ...
-#-----|  -> [finally: exception(Exception)] {...}
-
-#  156| try {...} ...
-#-----|  -> {...}
-
-#  157| [finally: exception(ArgumentNullException)] {...}
-#-----|  -> [finally: exception(ArgumentNullException)] if (...) ...
-
-#  157| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  157| {...}
-#-----|  -> if (...) ...
-
-#  158| [finally: exception(ArgumentNullException)] if (...) ...
-#-----|  -> [finally: exception(ArgumentNullException)] access to parameter args
-
-#  158| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] access to parameter args
-
-#  158| if (...) ...
-#-----|  -> access to parameter args
-
-#  158| [finally: exception(ArgumentNullException)] access to parameter args
-#-----|  -> [finally: exception(ArgumentNullException)] access to property Length
-
-#  158| [finally: exception(Exception)] access to parameter args
-#-----|  -> [finally: exception(Exception)] access to property Length
-
-#  158| access to parameter args
-#-----|  -> access to property Length
-
-#  158| [finally: exception(ArgumentNullException)] access to property Length
-#-----|  -> [finally: exception(ArgumentNullException)] 1
-#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
-#-----| exception(NullReferenceException) -> [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...}
-
-#  158| [finally: exception(Exception)] access to property Length
-#-----|  -> [finally: exception(Exception)] 1
-#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
-#-----| exception(NullReferenceException) -> [finally: exception(Exception), exception: NullReferenceException] catch (...) {...}
-
-#  158| access to property Length
-#-----|  -> 1
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-#-----| exception(NullReferenceException) -> [exception: NullReferenceException] catch (...) {...}
-
-#  158| ... == ...
-#-----| false -> exit M8 (normal)
-#-----| true -> "1"
-
-#  158| [finally: exception(ArgumentNullException)] ... == ...
-#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
-#-----| true -> [finally: exception(ArgumentNullException)] "1"
-
-#  158| [finally: exception(Exception)] ... == ...
-#-----| exception(Exception) -> exit M8 (abnormal)
-#-----| true -> [finally: exception(Exception)] "1"
-
-#  158| 1
-#-----|  -> ... == ...
-
-#  158| [finally: exception(ArgumentNullException)] 1
-#-----|  -> [finally: exception(ArgumentNullException)] ... == ...
-
-#  158| [finally: exception(Exception)] 1
-#-----|  -> [finally: exception(Exception)] ... == ...
-
-#  159| [finally: exception(ArgumentNullException)] throw ...;
-#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
-
-#  159| [finally: exception(Exception)] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
-
-#  159| throw ...;
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-
-#  159| [finally: exception(ArgumentNullException)] object creation of type Exception
-#-----|  -> [finally: exception(ArgumentNullException)] throw ...;
-#-----| exception(Exception) -> [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
-
-#  159| [finally: exception(Exception)] object creation of type Exception
-#-----|  -> [finally: exception(Exception)] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception] catch (...) {...}
-
-#  159| object creation of type Exception
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [exception: Exception] catch (...) {...}
-
-#  159| "1"
-#-----|  -> object creation of type Exception
-
-#  159| [finally: exception(ArgumentNullException)] "1"
-#-----|  -> [finally: exception(ArgumentNullException)] object creation of type Exception
-
-#  159| [finally: exception(Exception)] "1"
-#-----|  -> [finally: exception(Exception)] object creation of type Exception
-
-#  161| [exception: Exception] catch (...) {...}
-#-----| match -> [exception: Exception] Exception e
-
-#  161| [exception: NullReferenceException] catch (...) {...}
-#-----| match -> [exception: NullReferenceException] Exception e
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...}
-#-----| match -> [finally: exception(ArgumentNullException), exception: Exception] Exception e
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...}
-#-----| match -> [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e
-
-#  161| [finally: exception(Exception), exception: Exception] catch (...) {...}
-#-----| match -> [finally: exception(Exception), exception: Exception] Exception e
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] catch (...) {...}
-#-----| match -> [finally: exception(Exception), exception: NullReferenceException] Exception e
-
-#  161| [exception: Exception] Exception e
-#-----|  -> [exception: Exception] access to local variable e
-
-#  161| [exception: NullReferenceException] Exception e
-#-----|  -> [exception: NullReferenceException] access to local variable e
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] Exception e
-#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] access to local variable e
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e
-#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e
-
-#  161| [finally: exception(Exception), exception: Exception] Exception e
-#-----|  -> [finally: exception(Exception), exception: Exception] access to local variable e
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] Exception e
-#-----|  -> [finally: exception(Exception), exception: NullReferenceException] access to local variable e
-
-#  161| [exception: Exception] access to local variable e
-#-----|  -> [exception: Exception] access to property Message
-
-#  161| [exception: NullReferenceException] access to local variable e
-#-----|  -> [exception: NullReferenceException] access to property Message
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] access to local variable e
-#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] access to property Message
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e
-#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message
-
-#  161| [finally: exception(Exception), exception: Exception] access to local variable e
-#-----|  -> [finally: exception(Exception), exception: Exception] access to property Message
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] access to local variable e
-#-----|  -> [finally: exception(Exception), exception: NullReferenceException] access to property Message
-
-#  161| [exception: Exception] access to property Message
-#-----|  -> [exception: Exception] "1"
-
-#  161| [exception: NullReferenceException] access to property Message
-#-----|  -> [exception: NullReferenceException] "1"
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] access to property Message
-#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] "1"
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message
-#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] "1"
-
-#  161| [finally: exception(Exception), exception: Exception] access to property Message
-#-----|  -> [finally: exception(Exception), exception: Exception] "1"
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] access to property Message
-#-----|  -> [finally: exception(Exception), exception: NullReferenceException] "1"
-
-#  161| [exception: Exception] ... == ...
-#-----| true -> {...}
-#-----| false -> catch {...}
-
-#  161| [exception: NullReferenceException] ... == ...
-#-----| true -> {...}
-#-----| false -> catch {...}
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] ... == ...
-#-----| true -> [finally: exception(ArgumentNullException)] {...}
-#-----| false -> [finally: exception(ArgumentNullException)] catch {...}
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ...
-#-----| true -> [finally: exception(ArgumentNullException)] {...}
-#-----| false -> [finally: exception(ArgumentNullException)] catch {...}
-
-#  161| [finally: exception(Exception), exception: Exception] ... == ...
-#-----| true -> [finally: exception(Exception)] {...}
-#-----| false -> [finally: exception(Exception)] catch {...}
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] ... == ...
-#-----| true -> [finally: exception(Exception)] {...}
-#-----| false -> [finally: exception(Exception)] catch {...}
-
-#  161| [exception: Exception] "1"
-#-----|  -> [exception: Exception] ... == ...
-
-#  161| [exception: NullReferenceException] "1"
-#-----|  -> [exception: NullReferenceException] ... == ...
-
-#  161| [finally: exception(ArgumentNullException), exception: Exception] "1"
-#-----|  -> [finally: exception(ArgumentNullException), exception: Exception] ... == ...
-
-#  161| [finally: exception(ArgumentNullException), exception: NullReferenceException] "1"
-#-----|  -> [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ...
-
-#  161| [finally: exception(Exception), exception: Exception] "1"
-#-----|  -> [finally: exception(Exception), exception: Exception] ... == ...
-
-#  161| [finally: exception(Exception), exception: NullReferenceException] "1"
-#-----|  -> [finally: exception(Exception), exception: NullReferenceException] ... == ...
-
-#  162| [finally: exception(ArgumentNullException)] {...}
-#-----|  -> [finally: exception(ArgumentNullException)] ...;
-
-#  162| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  162| {...}
-#-----|  -> ...;
-
-#  163| [finally: exception(ArgumentNullException)] call to method WriteLine
-#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
-
-#  163| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M8 (abnormal)
-
-#  163| call to method WriteLine
-#-----|  -> exit M8 (normal)
-
-#  163| ...;
-#-----|  -> access to parameter args
-
-#  163| [finally: exception(ArgumentNullException)] ...;
-#-----|  -> [finally: exception(ArgumentNullException)] access to parameter args
-
-#  163| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] access to parameter args
-
-#  163| [finally: exception(ArgumentNullException)] access to parameter args
-#-----|  -> [finally: exception(ArgumentNullException)] 0
-
-#  163| [finally: exception(Exception)] access to parameter args
-#-----|  -> [finally: exception(Exception)] 0
-
-#  163| access to parameter args
-#-----|  -> 0
-
-#  163| [finally: exception(ArgumentNullException)] access to array element
-#-----|  -> [finally: exception(ArgumentNullException)] call to method WriteLine
-
-#  163| [finally: exception(Exception)] access to array element
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  163| access to array element
-#-----|  -> call to method WriteLine
-
-#  163| 0
-#-----|  -> access to array element
-
-#  163| [finally: exception(ArgumentNullException)] 0
-#-----|  -> [finally: exception(ArgumentNullException)] access to array element
-
-#  163| [finally: exception(Exception)] 0
-#-----|  -> [finally: exception(Exception)] access to array element
-
-#  165| [finally: exception(ArgumentNullException)] catch {...}
-#-----|  -> [finally: exception(ArgumentNullException)] {...}
-
-#  165| [finally: exception(Exception)] catch {...}
-#-----|  -> [finally: exception(Exception)] {...}
-
-#  165| catch {...}
-#-----|  -> {...}
-
-#  166| [finally: exception(ArgumentNullException)] {...}
-#-----|  -> [finally: exception(ArgumentNullException)] ...;
-
-#  166| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  166| {...}
-#-----|  -> ...;
-
-#  167| [finally: exception(ArgumentNullException)] call to method WriteLine
-#-----| exception(ArgumentNullException) -> exit M8 (abnormal)
-
-#  167| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M8 (abnormal)
-
-#  167| call to method WriteLine
-#-----|  -> exit M8 (normal)
-
-#  167| ...;
-#-----|  -> ""
-
-#  167| [finally: exception(ArgumentNullException)] ...;
-#-----|  -> [finally: exception(ArgumentNullException)] ""
-
-#  167| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] ""
-
-#  167| ""
-#-----|  -> call to method WriteLine
-
-#  167| [finally: exception(ArgumentNullException)] ""
-#-----|  -> [finally: exception(ArgumentNullException)] call to method WriteLine
-
-#  167| [finally: exception(Exception)] ""
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  172| call to constructor Exception
-#-----|  -> {...}
-
-#  172| enter ExceptionA
-#-----|  -> call to constructor Exception
-
-#  172| exit ExceptionA
-
-#  172| exit ExceptionA (normal)
-#-----|  -> exit ExceptionA
-
-#  172| {...}
-#-----|  -> exit ExceptionA (normal)
-
-#  173| call to constructor Exception
-#-----|  -> {...}
-
-#  173| enter ExceptionB
-#-----|  -> call to constructor Exception
-
-#  173| exit ExceptionB
-
-#  173| exit ExceptionB (normal)
-#-----|  -> exit ExceptionB
-
-#  173| {...}
-#-----|  -> exit ExceptionB (normal)
-
-#  174| call to constructor Exception
-#-----|  -> {...}
-
-#  174| enter ExceptionC
-#-----|  -> call to constructor Exception
-
-#  174| exit ExceptionC
-
-#  174| exit ExceptionC (normal)
-#-----|  -> exit ExceptionC
-
-#  174| {...}
-#-----|  -> exit ExceptionC (normal)
-
-#  176| enter M9
-#-----|  -> {...}
-
-#  176| exit M9
-
-#  176| exit M9 (abnormal)
-#-----|  -> exit M9
-
-#  176| exit M9 (normal)
-#-----|  -> exit M9
-
-#  177| {...}
-#-----|  -> try {...} ...
-
-#  178| try {...} ...
-#-----|  -> {...}
-
-#  179| {...}
-#-----|  -> if (...) ...
-
-#  180| if (...) ...
-#-----|  -> access to parameter b1
-
-#  180| access to parameter b1
-#-----| true -> [b1 (line 176): true] object creation of type ExceptionA
-#-----| false -> [b1 (line 176): false] {...}
-
-#  180| [b1 (line 176): true] throw ...;
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
-
-#  180| [b1 (line 176): true] object creation of type ExceptionA
-#-----|  -> [b1 (line 176): true] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), b1 (line 176): true] {...}
-
-#  183| [b1 (line 176): false] {...}
-#-----|  -> [b1 (line 176): false] try {...} ...
-
-#  183| [finally: exception(Exception), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] try {...} ...
-
-#  183| [finally: exception(ExceptionA), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] try {...} ...
-
-#  184| [b1 (line 176): false] try {...} ...
-#-----|  -> [b1 (line 176): false] {...}
-
-#  184| [finally: exception(Exception), b1 (line 176): true] try {...} ...
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] {...}
-
-#  184| [finally: exception(ExceptionA), b1 (line 176): true] try {...} ...
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
-
-#  185| [b1 (line 176): false] {...}
-#-----|  -> [b1 (line 176): false] if (...) ...
-
-#  185| [finally: exception(Exception), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] if (...) ...
-
-#  185| [finally: exception(ExceptionA), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
-
-#  186| [b1 (line 176): false] if (...) ...
-#-----|  -> [b1 (line 176): false] access to parameter b2
-
-#  186| [finally: exception(Exception), b1 (line 176): true] if (...) ...
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] access to parameter b2
-
-#  186| [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2
-
-#  186| [b1 (line 176): false] access to parameter b2
-#-----| false -> exit M9 (normal)
-#-----| true -> [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB
-
-#  186| [finally: exception(Exception), b1 (line 176): true] access to parameter b2
-#-----| exception(Exception) -> exit M9 (abnormal)
-#-----| true -> [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
-
-#  186| [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2
-#-----| exception(ExceptionA) -> exit M9 (abnormal)
-#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
-
-#  186| [b1 (line 176): false, b2 (line 176): true] throw ...;
-#-----| exception(ExceptionB) -> [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
-
-#  186| [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...;
-#-----| exception(ExceptionB) -> [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-
-#  186| [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...;
-#-----| exception(ExceptionB) -> [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-
-#  186| [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB
-#-----|  -> [b1 (line 176): false, b2 (line 176): true] throw ...;
-#-----| exception(Exception) -> [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
-
-#  186| [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
-#-----|  -> [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-
-#  186| [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...;
-#-----| exception(Exception) -> [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-
-#  188| [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
-#-----| exception(Exception) -> exit M9 (abnormal)
-#-----| match -> [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2
-
-#  188| [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...}
-#-----| match -> [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2
-
-#  188| [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-#-----| exception(Exception) -> exit M9 (abnormal)
-#-----| match -> [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-
-#  188| [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-#-----| match -> [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-
-#  188| [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-#-----| exception(Exception) -> exit M9 (abnormal)
-#-----| match -> [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-
-#  188| [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...}
-#-----| match -> [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-
-#  188| [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2
-#-----| true -> [b1 (line 176): false] {...}
-
-#  188| [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2
-#-----| true -> [b1 (line 176): false] {...}
-
-#  188| [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-#-----| true -> [finally: exception(Exception), b1 (line 176): true] {...}
-
-#  188| [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-#-----| true -> [finally: exception(Exception), b1 (line 176): true] {...}
-
-#  188| [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
-
-#  188| [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2
-#-----| true -> [finally: exception(ExceptionA), b1 (line 176): true] {...}
-
-#  189| [b1 (line 176): false] {...}
-#-----|  -> [b1 (line 176): false] if (...) ...
-
-#  189| [finally: exception(Exception), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] if (...) ...
-
-#  189| [finally: exception(ExceptionA), b1 (line 176): true] {...}
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
-
-#  190| [b1 (line 176): false] if (...) ...
-#-----|  -> [b1 (line 176): false] access to parameter b1
-
-#  190| [finally: exception(Exception), b1 (line 176): true] if (...) ...
-#-----|  -> [finally: exception(Exception), b1 (line 176): true] access to parameter b1
-
-#  190| [finally: exception(ExceptionA), b1 (line 176): true] if (...) ...
-#-----|  -> [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1
-
-#  190| [b1 (line 176): false] access to parameter b1
-#-----| false -> exit M9 (normal)
-
-#  190| [finally: exception(Exception), b1 (line 176): true] access to parameter b1
-#-----| true -> [finally: exception(Exception)] object creation of type ExceptionC
-
-#  190| [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1
-#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionC
-
-#  190| [finally: exception(Exception)] throw ...;
-#-----| exception(ExceptionC) -> exit M9 (abnormal)
-
-#  190| [finally: exception(ExceptionA)] throw ...;
-#-----| exception(ExceptionC) -> exit M9 (abnormal)
-
-#  190| [finally: exception(Exception)] object creation of type ExceptionC
-#-----|  -> [finally: exception(Exception)] throw ...;
-
-#  190| [finally: exception(ExceptionA)] object creation of type ExceptionC
-#-----|  -> [finally: exception(ExceptionA)] throw ...;
-
-#  195| enter M10
-#-----|  -> {...}
-
-#  195| exit M10
-
-#  195| exit M10 (abnormal)
-#-----|  -> exit M10
-
-#  195| exit M10 (normal)
-#-----|  -> exit M10
-
-#  196| {...}
-#-----|  -> try {...} ...
-
-#  197| try {...} ...
-#-----|  -> {...}
-
-#  198| {...}
-#-----|  -> if (...) ...
-
-#  199| if (...) ...
-#-----|  -> access to parameter b1
-
-#  199| access to parameter b1
-#-----| true -> object creation of type ExceptionA
-#-----| false -> {...}
-
-#  199| throw ...;
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  199| object creation of type ExceptionA
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  202| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] try {...} ...
-
-#  202| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] try {...} ...
-
-#  202| {...}
-#-----|  -> try {...} ...
-
-#  203| [finally: exception(Exception)] try {...} ...
-#-----|  -> [finally: exception(Exception)] {...}
-
-#  203| [finally: exception(ExceptionA)] try {...} ...
-#-----|  -> [finally: exception(ExceptionA)] {...}
-
-#  203| try {...} ...
-#-----|  -> {...}
-
-#  204| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  204| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] if (...) ...
-
-#  204| {...}
-#-----|  -> if (...) ...
-
-#  205| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] access to parameter b2
-
-#  205| [finally: exception(ExceptionA)] if (...) ...
-#-----|  -> [finally: exception(ExceptionA)] access to parameter b2
-
-#  205| if (...) ...
-#-----|  -> access to parameter b2
-
-#  205| [finally: exception(Exception)] access to parameter b2
-#-----| true -> [finally: exception(Exception)] object creation of type ExceptionB
-#-----| false -> [finally: exception(Exception)] {...}
-
-#  205| [finally: exception(ExceptionA)] access to parameter b2
-#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionB
-#-----| false -> [finally: exception(ExceptionA)] {...}
-
-#  205| access to parameter b2
-#-----| true -> object creation of type ExceptionB
-#-----| false -> {...}
-
-#  205| [finally: exception(Exception)] throw ...;
-#-----| exception(ExceptionB) -> [finally: exception(Exception), finally(1): exception(ExceptionB)] {...}
-
-#  205| [finally: exception(ExceptionA)] throw ...;
-#-----| exception(ExceptionB) -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...}
-
-#  205| throw ...;
-#-----| exception(ExceptionB) -> [finally(1): exception(ExceptionB)] {...}
-
-#  205| [finally: exception(Exception)] object creation of type ExceptionB
-#-----|  -> [finally: exception(Exception)] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), finally(1): exception(Exception)] {...}
-
-#  205| [finally: exception(ExceptionA)] object creation of type ExceptionB
-#-----|  -> [finally: exception(ExceptionA)] throw ...;
-#-----| exception(Exception) -> [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
-
-#  205| object creation of type ExceptionB
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
-
-#  208| [finally(1): exception(Exception)] {...}
-#-----|  -> [finally(1): exception(Exception)] if (...) ...
-
-#  208| [finally(1): exception(ExceptionB)] {...}
-#-----|  -> [finally(1): exception(ExceptionB)] if (...) ...
-
-#  208| [finally: exception(Exception), finally(1): exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] if (...) ...
-
-#  208| [finally: exception(Exception), finally(1): exception(ExceptionB)] {...}
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ...
-
-#  208| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  208| [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ...
-
-#  208| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...}
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ...
-
-#  208| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] if (...) ...
-
-#  208| {...}
-#-----|  -> if (...) ...
-
-#  209| [finally(1): exception(Exception)] if (...) ...
-#-----|  -> [finally(1): exception(Exception)] access to parameter b3
-
-#  209| [finally(1): exception(ExceptionB)] if (...) ...
-#-----|  -> [finally(1): exception(ExceptionB)] access to parameter b3
-
-#  209| [finally: exception(Exception), finally(1): exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3
-
-#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ...
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3
-
-#  209| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] access to parameter b3
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ...
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3
-
-#  209| [finally: exception(ExceptionA)] if (...) ...
-#-----|  -> [finally: exception(ExceptionA)] access to parameter b3
-
-#  209| if (...) ...
-#-----|  -> access to parameter b3
-
-#  209| [finally(1): exception(Exception)] access to parameter b3
-#-----| exception(Exception) -> exit M10 (abnormal)
-#-----| true -> [finally(1): exception(Exception)] object creation of type ExceptionC
-
-#  209| [finally(1): exception(ExceptionB)] access to parameter b3
-#-----| exception(ExceptionB) -> exit M10 (abnormal)
-#-----| true -> [finally(1): exception(ExceptionB)] object creation of type ExceptionC
-
-#  209| [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3
-#-----| exception(Exception) -> exit M10 (abnormal)
-#-----| true -> [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC
-
-#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3
-#-----| exception(ExceptionB) -> exit M10 (abnormal)
-#-----| true -> [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC
-
-#  209| [finally: exception(Exception)] access to parameter b3
-#-----| true -> [finally: exception(Exception)] object creation of type ExceptionC
-#-----| false -> [finally: exception(Exception)] ...;
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3
-#-----| exception(Exception) -> exit M10 (abnormal)
-#-----| true -> [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3
-#-----| exception(ExceptionB) -> exit M10 (abnormal)
-#-----| true -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC
-
-#  209| [finally: exception(ExceptionA)] access to parameter b3
-#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionC
-#-----| false -> [finally: exception(ExceptionA)] ...;
-
-#  209| access to parameter b3
-#-----| true -> object creation of type ExceptionC
-#-----| false -> ...;
-
-#  209| [finally(1): exception(Exception)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally(1): exception(ExceptionB)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(Exception), finally(1): exception(Exception)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(Exception)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally: exception(ExceptionA)] throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| throw ...;
-#-----| exception(ExceptionC) -> exit M10 (abnormal)
-
-#  209| [finally(1): exception(Exception)] object creation of type ExceptionC
-#-----|  -> [finally(1): exception(Exception)] throw ...;
-
-#  209| [finally(1): exception(ExceptionB)] object creation of type ExceptionC
-#-----|  -> [finally(1): exception(ExceptionB)] throw ...;
-
-#  209| [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] throw ...;
-
-#  209| [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...;
-
-#  209| [finally: exception(Exception)] object creation of type ExceptionC
-#-----|  -> [finally: exception(Exception)] throw ...;
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...;
-
-#  209| [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...;
-
-#  209| [finally: exception(ExceptionA)] object creation of type ExceptionC
-#-----|  -> [finally: exception(ExceptionA)] throw ...;
-
-#  209| object creation of type ExceptionC
-#-----|  -> throw ...;
-
-#  211| [finally: exception(Exception)] this access
-#-----|  -> [finally: exception(Exception)] "0"
-
-#  211| [finally: exception(ExceptionA)] this access
-#-----|  -> [finally: exception(ExceptionA)] "0"
-
-#  211| this access
-#-----|  -> "0"
-
-#  211| ... = ...
-#-----|  -> ...;
-
-#  211| [finally: exception(Exception)] ... = ...
-#-----| exception(Exception) -> exit M10 (abnormal)
-
-#  211| [finally: exception(ExceptionA)] ... = ...
-#-----| exception(ExceptionA) -> exit M10 (abnormal)
-
-#  211| ...;
-#-----|  -> this access
-
-#  211| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] this access
-
-#  211| [finally: exception(ExceptionA)] ...;
-#-----|  -> [finally: exception(ExceptionA)] this access
-
-#  211| "0"
-#-----|  -> ... = ...
-
-#  211| [finally: exception(Exception)] "0"
-#-----|  -> [finally: exception(Exception)] ... = ...
-
-#  211| [finally: exception(ExceptionA)] "0"
-#-----|  -> [finally: exception(ExceptionA)] ... = ...
-
-#  213| this access
-#-----|  -> "1"
-
-#  213| ... = ...
-#-----|  -> exit M10 (normal)
-
-#  213| ...;
-#-----|  -> this access
-
-#  213| "1"
-#-----|  -> ... = ...
-
-#  216| enter M11
-#-----|  -> {...}
-
-#  216| exit M11
-
-#  216| exit M11 (normal)
-#-----|  -> exit M11
-
-#  217| {...}
-#-----|  -> try {...} ...
-
-#  218| try {...} ...
-#-----|  -> {...}
-
-#  219| {...}
-#-----|  -> ...;
-
-#  220| call to method WriteLine
-#-----| exception(Exception) -> catch {...}
-#-----|  -> {...}
-
-#  220| ...;
-#-----|  -> "Try"
-
-#  220| "Try"
-#-----|  -> call to method WriteLine
-
-#  222| catch {...}
-#-----|  -> {...}
-
-#  223| {...}
-#-----|  -> ...;
-
-#  224| call to method WriteLine
-#-----|  -> {...}
-
-#  224| ...;
-#-----|  -> "Catch"
-
-#  224| "Catch"
-#-----|  -> call to method WriteLine
-
-#  227| {...}
-#-----|  -> ...;
-
-#  228| call to method WriteLine
-#-----|  -> ...;
-
-#  228| ...;
-#-----|  -> "Finally"
-
-#  228| "Finally"
-#-----|  -> call to method WriteLine
-
-#  230| call to method WriteLine
-#-----|  -> exit M11 (normal)
-
-#  230| ...;
-#-----|  -> "Done"
-
-#  230| "Done"
-#-----|  -> call to method WriteLine
-
-#  233| enter M12
-#-----|  -> {...}
-
-#  233| exit M12
-
-#  233| exit M12 (abnormal)
-#-----|  -> exit M12
-
-#  233| exit M12 (normal)
-#-----|  -> exit M12
-
-#  234| {...}
-#-----|  -> try {...} ...
-
-#  235| try {...} ...
-#-----|  -> {...}
-
-#  236| {...}
-#-----|  -> try {...} ...
-
-#  237| try {...} ...
-#-----|  -> {...}
-
-#  238| {...}
-#-----|  -> if (...) ...
-
-#  239| if (...) ...
-#-----|  -> access to parameter b1
-
-#  239| access to parameter b1
-#-----| true -> object creation of type ExceptionA
-#-----| false -> {...}
-
-#  240| throw ...;
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  240| object creation of type ExceptionA
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  243| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] try {...} ...
-
-#  243| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] try {...} ...
-
-#  243| {...}
-#-----|  -> try {...} ...
-
-#  244| [finally: exception(Exception)] try {...} ...
-#-----|  -> [finally: exception(Exception)] {...}
-
-#  244| [finally: exception(ExceptionA)] try {...} ...
-#-----|  -> [finally: exception(ExceptionA)] {...}
-
-#  244| try {...} ...
-#-----|  -> {...}
-
-#  245| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] if (...) ...
-
-#  245| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] if (...) ...
-
-#  245| {...}
-#-----|  -> if (...) ...
-
-#  246| [finally: exception(Exception)] if (...) ...
-#-----|  -> [finally: exception(Exception)] access to parameter b2
-
-#  246| [finally: exception(ExceptionA)] if (...) ...
-#-----|  -> [finally: exception(ExceptionA)] access to parameter b2
-
-#  246| if (...) ...
-#-----|  -> access to parameter b2
-
-#  246| [finally: exception(Exception)] access to parameter b2
-#-----| true -> [finally: exception(Exception)] object creation of type ExceptionA
-#-----| false -> [finally: exception(Exception)] {...}
-
-#  246| [finally: exception(ExceptionA)] access to parameter b2
-#-----| true -> [finally: exception(ExceptionA)] object creation of type ExceptionA
-#-----| false -> [finally: exception(ExceptionA)] {...}
-
-#  246| access to parameter b2
-#-----| true -> object creation of type ExceptionA
-#-----| false -> {...}
-
-#  247| [finally: exception(Exception)] throw ...;
-#-----| exception(ExceptionA) -> [finally: exception(Exception), finally(1): exception(ExceptionA)] {...}
-
-#  247| [finally: exception(ExceptionA)] throw ...;
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...}
-
-#  247| throw ...;
-#-----| exception(ExceptionA) -> [finally(1): exception(ExceptionA)] {...}
-
-#  247| [finally: exception(Exception)] object creation of type ExceptionA
-#-----|  -> [finally: exception(Exception)] throw ...;
-#-----| exception(Exception) -> [finally: exception(Exception), finally(1): exception(Exception)] {...}
-
-#  247| [finally: exception(ExceptionA)] object creation of type ExceptionA
-#-----|  -> [finally: exception(ExceptionA)] throw ...;
-#-----| exception(Exception) -> [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
-
-#  247| object creation of type ExceptionA
-#-----|  -> throw ...;
-#-----| exception(Exception) -> [finally(1): exception(Exception)] {...}
-
-#  250| [finally(1): exception(Exception)] {...}
-#-----|  -> [finally(1): exception(Exception)] ...;
-
-#  250| [finally(1): exception(ExceptionA)] {...}
-#-----|  -> [finally(1): exception(ExceptionA)] ...;
-
-#  250| [finally: exception(Exception), finally(1): exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] ...;
-
-#  250| [finally: exception(Exception), finally(1): exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] ...;
-
-#  250| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  250| [finally: exception(ExceptionA), finally(1): exception(Exception)] {...}
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] ...;
-
-#  250| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...;
-
-#  250| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] ...;
-
-#  250| {...}
-#-----|  -> ...;
-
-#  251| [finally(1): exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  251| [finally(1): exception(ExceptionA)] call to method WriteLine
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  251| [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  251| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  251| [finally: exception(ExceptionA)] call to method WriteLine
-#-----| exception(ExceptionA) -> [finally: exception(ExceptionA)] {...}
-
-#  251| call to method WriteLine
-#-----|  -> ...;
-
-#  251| ...;
-#-----|  -> "Inner finally"
-
-#  251| [finally(1): exception(Exception)] ...;
-#-----|  -> [finally(1): exception(Exception)] "Inner finally"
-
-#  251| [finally(1): exception(ExceptionA)] ...;
-#-----|  -> [finally(1): exception(ExceptionA)] "Inner finally"
-
-#  251| [finally: exception(Exception), finally(1): exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally"
-
-#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] ...;
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally"
-
-#  251| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "Inner finally"
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] ...;
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally"
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...;
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally"
-
-#  251| [finally: exception(ExceptionA)] ...;
-#-----|  -> [finally: exception(ExceptionA)] "Inner finally"
-
-#  251| "Inner finally"
-#-----|  -> call to method WriteLine
-
-#  251| [finally(1): exception(Exception)] "Inner finally"
-#-----|  -> [finally(1): exception(Exception)] call to method WriteLine
-
-#  251| [finally(1): exception(ExceptionA)] "Inner finally"
-#-----|  -> [finally(1): exception(ExceptionA)] call to method WriteLine
-
-#  251| [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally"
-#-----|  -> [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine
-
-#  251| [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally"
-#-----|  -> [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine
-
-#  251| [finally: exception(Exception)] "Inner finally"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally"
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine
-
-#  251| [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally"
-#-----|  -> [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine
-
-#  251| [finally: exception(ExceptionA)] "Inner finally"
-#-----|  -> [finally: exception(ExceptionA)] call to method WriteLine
-
-#  254| call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----|  -> {...}
-
-#  254| ...;
-#-----|  -> "Mid finally"
-
-#  254| "Mid finally"
-#-----|  -> call to method WriteLine
-
-#  257| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  257| [finally: exception(ExceptionA)] {...}
-#-----|  -> [finally: exception(ExceptionA)] ...;
-
-#  257| {...}
-#-----|  -> ...;
-
-#  258| [finally: exception(Exception)] call to method WriteLine
-#-----| exception(Exception) -> exit M12 (abnormal)
-
-#  258| [finally: exception(ExceptionA)] call to method WriteLine
-#-----| exception(ExceptionA) -> exit M12 (abnormal)
-
-#  258| call to method WriteLine
-#-----|  -> ...;
-
-#  258| ...;
-#-----|  -> "Outer finally"
-
-#  258| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "Outer finally"
-
-#  258| [finally: exception(ExceptionA)] ...;
-#-----|  -> [finally: exception(ExceptionA)] "Outer finally"
-
-#  258| "Outer finally"
-#-----|  -> call to method WriteLine
-
-#  258| [finally: exception(Exception)] "Outer finally"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  258| [finally: exception(ExceptionA)] "Outer finally"
-#-----|  -> [finally: exception(ExceptionA)] call to method WriteLine
-
-#  260| call to method WriteLine
-#-----|  -> exit M12 (normal)
-
-#  260| ...;
-#-----|  -> "Done"
-
-#  260| "Done"
-#-----|  -> call to method WriteLine
-
-#  263| enter M13
-#-----|  -> {...}
-
-#  263| exit M13
-
-#  263| exit M13 (abnormal)
-#-----|  -> exit M13
-
-#  263| exit M13 (normal)
-#-----|  -> exit M13
-
-#  264| {...}
-#-----|  -> try {...} ...
-
-#  265| try {...} ...
-#-----|  -> {...}
-
-#  266| {...}
-#-----|  -> ...;
-
-#  267| call to method WriteLine
-#-----| exception(Exception) -> [finally: exception(Exception)] {...}
-#-----|  -> {...}
-
-#  267| ...;
-#-----|  -> "1"
-
-#  267| "1"
-#-----|  -> call to method WriteLine
-
-#  270| [finally: exception(Exception)] {...}
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  270| {...}
-#-----|  -> ...;
-
-#  271| [finally: exception(Exception)] call to method WriteLine
-#-----|  -> [finally: exception(Exception)] ...;
-
-#  271| call to method WriteLine
-#-----|  -> ...;
-
-#  271| ...;
-#-----|  -> "3"
-
-#  271| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] "3"
-
-#  271| "3"
-#-----|  -> call to method WriteLine
-
-#  271| [finally: exception(Exception)] "3"
-#-----|  -> [finally: exception(Exception)] call to method WriteLine
-
-#  272| [finally: exception(Exception)] access to parameter i
-#-----|  -> [finally: exception(Exception)] 3
-
-#  272| access to parameter i
-#-----|  -> 3
-
-#  272| ... + ...
-#-----|  -> ... = ...
-
-#  272| ... = ...
-#-----|  -> exit M13 (normal)
-
-#  272| [finally: exception(Exception)] ... + ...
-#-----|  -> [finally: exception(Exception)] ... = ...
-
-#  272| [finally: exception(Exception)] ... = ...
-#-----| exception(Exception) -> exit M13 (abnormal)
-
-#  272| ...;
-#-----|  -> access to parameter i
-
-#  272| [finally: exception(Exception)] ...;
-#-----|  -> [finally: exception(Exception)] access to parameter i
-
-#  272| 3
-#-----|  -> ... + ...
-
-#  272| [finally: exception(Exception)] 3
-#-----|  -> [finally: exception(Exception)] ... + ...
-
-Foreach.cs:
-#    4| call to constructor Object
-#-----|  -> {...}
-
-#    4| enter Foreach
-#-----|  -> call to constructor Object
-
-#    4| exit Foreach
-
-#    4| exit Foreach (normal)
-#-----|  -> exit Foreach
-
-#    4| {...}
-#-----|  -> exit Foreach (normal)
-
-#    6| enter M1
-#-----|  -> {...}
-
-#    6| exit M1
-
-#    6| exit M1 (normal)
-#-----|  -> exit M1
-
-#    7| {...}
-#-----|  -> access to parameter args
-
-#    8| foreach (... ... in ...) ...
-#-----| empty -> exit M1 (normal)
-#-----| non-empty -> String arg
-
-#    8| String arg
-#-----|  -> ;
-
-#    8| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#    9| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   12| enter M2
-#-----|  -> {...}
-
-#   12| exit M2
-
-#   12| exit M2 (normal)
-#-----|  -> exit M2
-
-#   13| {...}
-#-----|  -> access to parameter args
-
-#   14| foreach (... ... in ...) ...
-#-----| empty -> exit M2 (normal)
-#-----| non-empty -> String _
-
-#   14| String _
-#-----|  -> ;
-
-#   14| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   15| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   18| enter M3
-#-----|  -> {...}
-
-#   18| exit M3
-
-#   18| exit M3 (normal)
-#-----|  -> exit M3
-
-#   19| {...}
-#-----|  -> access to parameter e
-
-#   20| foreach (... ... in ...) ...
-#-----| empty -> exit M3 (normal)
-#-----| non-empty -> String x
-
-#   20| String x
-#-----|  -> ;
-
-#   20| access to parameter e
-#-----| non-null -> call to method ToArray<String>
-#-----| null -> call to method Empty<String>
-
-#   20| call to method ToArray<String>
-#-----| non-null -> ... ?? ...
-#-----| null -> call to method Empty<String>
-
-#   20| ... ?? ...
-#-----|  -> foreach (... ... in ...) ...
-
-#   20| call to method Empty<String>
-#-----|  -> ... ?? ...
-
-#   21| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   24| enter M4
-#-----|  -> {...}
-
-#   24| exit M4
-
-#   24| exit M4 (normal)
-#-----|  -> exit M4
-
-#   25| {...}
-#-----|  -> access to parameter args
-
-#   26| foreach (... ... in ...) ...
-#-----| empty -> exit M4 (normal)
-#-----| non-empty -> String x
-
-#   26| (..., ...)
-#-----|  -> ;
-
-#   26| String x
-#-----|  -> Int32 y
-
-#   26| Int32 y
-#-----|  -> (..., ...)
-
-#   26| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   27| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   30| enter M5
-#-----|  -> {...}
-
-#   30| exit M5
-
-#   30| exit M5 (normal)
-#-----|  -> exit M5
-
-#   31| {...}
-#-----|  -> access to parameter args
-
-#   32| foreach (... ... in ...) ...
-#-----| empty -> exit M5 (normal)
-#-----| non-empty -> String x
-
-#   32| (..., ...)
-#-----|  -> ;
-
-#   32| String x
-#-----|  -> Int32 y
-
-#   32| Int32 y
-#-----|  -> (..., ...)
-
-#   32| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   33| ;
-#-----|  -> foreach (... ... in ...) ...
-
-#   36| enter M6
-#-----|  -> {...}
-
-#   36| exit M6
-
-#   36| exit M6 (normal)
-#-----|  -> exit M6
-
-#   37| {...}
-#-----|  -> access to parameter args
-
-#   38| foreach (... ... in ...) ...
-#-----| empty -> exit M6 (normal)
-#-----| non-empty -> String x
-
-#   38| (..., ...)
-#-----|  -> ;
-
-#   38| String x
-#-----|  -> Int32 y
-
-#   38| Int32 y
-#-----|  -> (..., ...)
-
-#   38| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   39| ;
-#-----|  -> foreach (... ... in ...) ...
-
-Initializers.cs:
-#    3| enter Initializers
-#-----|  -> {...}
-
-#    3| exit Initializers
-
-#    3| exit Initializers (normal)
-#-----|  -> exit Initializers
-
-#    3| {...}
-#-----|  -> exit Initializers (normal)
-
-#    5| this access
-#-----|  -> access to field H
-
-#    5| this access
-#-----|  -> access to field H
-
-#    5| ... = ...
-#-----|  -> this access
-
-#    5| ... = ...
-#-----|  -> this access
-
-#    5| access to field H
-#-----|  -> 1
-
-#    5| access to field H
-#-----|  -> 1
-
-#    5| ... + ...
-#-----|  -> ... = ...
-
-#    5| ... + ...
-#-----|  -> ... = ...
-
-#    5| 1
-#-----|  -> ... + ...
-
-#    5| 1
-#-----|  -> ... + ...
-
-#    6| access to property G
-#-----|  -> ... = ...
-
-#    6| access to property G
-#-----|  -> ... = ...
-
-#    6| this access
-#-----|  -> access to field H
-
-#    6| this access
-#-----|  -> access to field H
-
-#    6| ... = ...
-#-----|  -> {...}
-
-#    6| ... = ...
-#-----|  -> {...}
-
-#    6| access to field H
-#-----|  -> 2
-
-#    6| access to field H
-#-----|  -> 2
-
-#    6| ... + ...
-#-----|  -> access to property G
-
-#    6| ... + ...
-#-----|  -> access to property G
-
-#    6| 2
-#-----|  -> ... + ...
-
-#    6| 2
-#-----|  -> ... + ...
-
-#    8| call to constructor Object
-#-----|  -> this access
-
-#    8| enter Initializers
-#-----|  -> call to constructor Object
-
-#    8| exit Initializers
-
-#    8| exit Initializers (normal)
-#-----|  -> exit Initializers
-
-#    8| {...}
-#-----|  -> exit Initializers (normal)
-
-#   10| call to constructor Object
-#-----|  -> this access
-
-#   10| enter Initializers
-#-----|  -> call to constructor Object
-
-#   10| exit Initializers
-
-#   10| exit Initializers (normal)
-#-----|  -> exit Initializers
-
-#   10| {...}
-#-----|  -> exit Initializers (normal)
-
-#   12| enter M
-#-----|  -> {...}
-
-#   12| exit M
-
-#   12| exit M (normal)
-#-----|  -> exit M
-
-#   13| {...}
-#-----|  -> ... ...;
-
-#   14| ... ...;
-#-----|  -> ""
-
-#   14| Initializers i = ...
-#-----|  -> ... ...;
-
-#   14| object creation of type Initializers
-#-----|  -> 0
-
-#   14| ""
-#-----|  -> object creation of type Initializers
-
-#   14| { ..., ... }
-#-----|  -> Initializers i = ...
-
-#   14| ... = ...
-#-----|  -> 1
-
-#   14| 0
-#-----|  -> ... = ...
-
-#   14| access to property G
-#-----|  -> ... = ...
-
-#   14| ... = ...
-#-----|  -> { ..., ... }
-
-#   14| 1
-#-----|  -> access to property G
-
-#   15| ... ...;
-#-----|  -> 2
-
-#   15| Initializers[] iz = ...
-#-----|  -> exit M (normal)
-
-#   15| 2
-#-----|  -> array creation of type Initializers[]
-
-#   15| array creation of type Initializers[]
-#-----|  -> access to local variable i
-
-#   15| { ..., ... }
-#-----|  -> Initializers[] iz = ...
-
-#   15| access to local variable i
-#-----|  -> ""
-
-#   15| object creation of type Initializers
-#-----|  -> { ..., ... }
-
-#   15| ""
-#-----|  -> object creation of type Initializers
-
-#   18| enter H
-#-----|  -> 1
-
-#   18| exit H
-
-#   18| exit H (normal)
-#-----|  -> exit H
-
-#   18| ... = ...
-#-----|  -> exit H (normal)
-
-#   18| 1
-#-----|  -> ... = ...
-
-#   20| call to constructor Object
-#-----|  -> this access
-
-#   20| enter NoConstructor
-#-----|  -> call to constructor Object
-
-#   20| exit NoConstructor
-
-#   20| exit NoConstructor (normal)
-#-----|  -> exit NoConstructor
-
-#   20| {...}
-#-----|  -> exit NoConstructor (normal)
-
-#   22| this access
-#-----|  -> 0
-
-#   22| ... = ...
-#-----|  -> this access
-
-#   22| 0
-#-----|  -> ... = ...
-
-#   23| this access
-#-----|  -> 1
-
-#   23| ... = ...
-#-----|  -> {...}
-
-#   23| 1
-#-----|  -> ... = ...
-
-#   28| this access
-#-----|  -> 2
-
-#   28| this access
-#-----|  -> 2
-
-#   28| ... = ...
-#-----|  -> {...}
-
-#   28| ... = ...
-#-----|  -> {...}
-
-#   28| 2
-#-----|  -> ... = ...
-
-#   28| 2
-#-----|  -> ... = ...
-
-#   31| enter Sub
-#-----|  -> call to constructor NoConstructor
-
-#   31| exit Sub
-
-#   31| exit Sub (normal)
-#-----|  -> exit Sub
-
-#   31| call to constructor NoConstructor
-#-----|  -> this access
-
-#   31| {...}
-#-----|  -> ...;
-
-#   31| this access
-#-----|  -> 3
-
-#   31| ... = ...
-#-----|  -> exit Sub (normal)
-
-#   31| ...;
-#-----|  -> this access
-
-#   31| 3
-#-----|  -> ... = ...
-
-#   33| enter Sub
-#-----|  -> call to constructor Sub
-
-#   33| exit Sub
-
-#   33| exit Sub (normal)
-#-----|  -> exit Sub
-
-#   33| call to constructor Sub
-#-----|  -> {...}
-
-#   33| {...}
-#-----|  -> ...;
-
-#   33| this access
-#-----|  -> access to parameter i
-
-#   33| ... = ...
-#-----|  -> exit Sub (normal)
-
-#   33| ...;
-#-----|  -> this access
-
-#   33| access to parameter i
-#-----|  -> ... = ...
-
-#   35| call to constructor NoConstructor
-#-----|  -> this access
-
-#   35| enter Sub
-#-----|  -> call to constructor NoConstructor
-
-#   35| exit Sub
-
-#   35| exit Sub (normal)
-#-----|  -> exit Sub
-
-#   35| {...}
-#-----|  -> ...;
-
-#   35| this access
-#-----|  -> access to parameter i
-
-#   35| ... = ...
-#-----|  -> exit Sub (normal)
-
-#   35| ...;
-#-----|  -> this access
-
-#   35| access to parameter i
-#-----|  -> access to parameter j
-
-#   35| ... + ...
-#-----|  -> ... = ...
-
-#   35| access to parameter j
-#-----|  -> ... + ...
-
-#   39| call to constructor Object
-#-----|  -> {...}
-
-#   39| enter IndexInitializers
-#-----|  -> call to constructor Object
-
-#   39| exit IndexInitializers
-
-#   39| exit IndexInitializers (normal)
-#-----|  -> exit IndexInitializers
-
-#   39| {...}
-#-----|  -> exit IndexInitializers (normal)
-
-#   41| call to constructor Object
-#-----|  -> {...}
-
-#   41| enter Compound
-#-----|  -> call to constructor Object
-
-#   41| exit Compound
-
-#   41| exit Compound (normal)
-#-----|  -> exit Compound
-
-#   41| {...}
-#-----|  -> exit Compound (normal)
-
-#   51| enter Test
-#-----|  -> {...}
-
-#   51| exit Test
-
-#   51| exit Test (normal)
-#-----|  -> exit Test
-
-#   52| {...}
-#-----|  -> ... ...;
-
-#   54| ... ...;
-#-----|  -> object creation of type Dictionary<Int32,String>
-
-#   54| Dictionary<Int32,String> dict = ...
-#-----|  -> ... ...;
-
-#   54| object creation of type Dictionary<Int32,String>
-#-----|  -> 0
-
-#   54| { ..., ... }
-#-----|  -> Dictionary<Int32,String> dict = ...
-
-#   54| access to indexer
-#-----|  -> ... = ...
-
-#   54| ... = ...
-#-----|  -> 1
-
-#   54| 0
-#-----|  -> "Zero"
-
-#   54| "Zero"
-#-----|  -> access to indexer
-
-#   54| access to indexer
-#-----|  -> ... = ...
-
-#   54| ... = ...
-#-----|  -> access to parameter i
-
-#   54| 1
-#-----|  -> "One"
-
-#   54| "One"
-#-----|  -> access to indexer
-
-#   54| access to indexer
-#-----|  -> ... = ...
-
-#   54| ... = ...
-#-----|  -> { ..., ... }
-
-#   54| access to parameter i
-#-----|  -> 2
-
-#   54| ... + ...
-#-----|  -> "Two"
-
-#   54| 2
-#-----|  -> ... + ...
-
-#   54| "Two"
-#-----|  -> access to indexer
-
-#   57| ... ...;
-#-----|  -> object creation of type Compound
-
-#   57| Compound compound = ...
-#-----|  -> exit Test (normal)
-
-#   57| object creation of type Compound
-#-----|  -> 0
-
-#   58| { ..., ... }
-#-----|  -> Compound compound = ...
-
-#   59| ... = ...
-#-----|  -> 3
-
-#   59| { ..., ... }
-#-----|  -> ... = ...
-
-#   59| access to indexer
-#-----|  -> ... = ...
-
-#   59| ... = ...
-#-----|  -> 1
-
-#   59| 0
-#-----|  -> "Zero"
-
-#   59| "Zero"
-#-----|  -> access to indexer
-
-#   59| access to indexer
-#-----|  -> ... = ...
-
-#   59| ... = ...
-#-----|  -> access to parameter i
-
-#   59| 1
-#-----|  -> "One"
-
-#   59| "One"
-#-----|  -> access to indexer
-
-#   59| access to indexer
-#-----|  -> ... = ...
-
-#   59| ... = ...
-#-----|  -> { ..., ... }
-
-#   59| access to parameter i
-#-----|  -> 2
-
-#   59| ... + ...
-#-----|  -> "Two"
-
-#   59| 2
-#-----|  -> ... + ...
-
-#   59| "Two"
-#-----|  -> access to indexer
-
-#   60| access to property DictionaryProperty
-#-----|  -> ... = ...
-
-#   60| ... = ...
-#-----|  -> 0
-
-#   60| { ..., ... }
-#-----|  -> access to property DictionaryProperty
-
-#   60| access to indexer
-#-----|  -> ... = ...
-
-#   60| ... = ...
-#-----|  -> 2
-
-#   60| 3
-#-----|  -> "Three"
-
-#   60| "Three"
-#-----|  -> access to indexer
-
-#   60| access to indexer
-#-----|  -> ... = ...
-
-#   60| ... = ...
-#-----|  -> access to parameter i
-
-#   60| 2
-#-----|  -> "Two"
-
-#   60| "Two"
-#-----|  -> access to indexer
-
-#   60| access to indexer
-#-----|  -> ... = ...
-
-#   60| ... = ...
-#-----|  -> { ..., ... }
-
-#   60| access to parameter i
-#-----|  -> 1
-
-#   60| ... + ...
-#-----|  -> "One"
-
-#   60| 1
-#-----|  -> ... + ...
-
-#   60| "One"
-#-----|  -> access to indexer
-
-#   61| ... = ...
-#-----|  -> 0
-
-#   61| { ..., ... }
-#-----|  -> ... = ...
-
-#   61| ... = ...
-#-----|  -> access to parameter i
-
-#   61| 0
-#-----|  -> "Zero"
-
-#   61| "Zero"
-#-----|  -> ... = ...
-
-#   61| ... = ...
-#-----|  -> { ..., ... }
-
-#   61| access to parameter i
-#-----|  -> 1
-
-#   61| ... + ...
-#-----|  -> "One"
-
-#   61| 1
-#-----|  -> ... + ...
-
-#   61| "One"
-#-----|  -> ... = ...
-
-#   62| ... = ...
-#-----|  -> 1
-
-#   62| { ..., ... }
-#-----|  -> ... = ...
-
-#   62| ... = ...
-#-----|  -> 1
-
-#   62| 0
-#-----|  -> 1
-
-#   62| 1
-#-----|  -> "i"
-
-#   62| "i"
-#-----|  -> ... = ...
-
-#   62| ... = ...
-#-----|  -> { ..., ... }
-
-#   62| 1
-#-----|  -> access to parameter i
-
-#   62| access to parameter i
-#-----|  -> 0
-
-#   62| ... + ...
-#-----|  -> "1"
-
-#   62| 0
-#-----|  -> ... + ...
-
-#   62| "1"
-#-----|  -> ... = ...
-
-#   63| access to property ArrayProperty
-#-----|  -> ... = ...
-
-#   63| ... = ...
-#-----|  -> 0
-
-#   63| { ..., ... }
-#-----|  -> access to property ArrayProperty
-
-#   63| ... = ...
-#-----|  -> access to parameter i
-
-#   63| 1
-#-----|  -> "One"
-
-#   63| "One"
-#-----|  -> ... = ...
-
-#   63| ... = ...
-#-----|  -> { ..., ... }
-
-#   63| access to parameter i
-#-----|  -> 2
-
-#   63| ... + ...
-#-----|  -> "Two"
-
-#   63| 2
-#-----|  -> ... + ...
-
-#   63| "Two"
-#-----|  -> ... = ...
-
-#   64| access to property ArrayProperty2
-#-----|  -> ... = ...
-
-#   64| ... = ...
-#-----|  -> { ..., ... }
-
-#   64| { ..., ... }
-#-----|  -> access to property ArrayProperty2
-
-#   64| ... = ...
-#-----|  -> 1
-
-#   64| 0
-#-----|  -> 1
-
-#   64| 1
-#-----|  -> "i"
-
-#   64| "i"
-#-----|  -> ... = ...
-
-#   64| ... = ...
-#-----|  -> { ..., ... }
-
-#   64| 1
-#-----|  -> access to parameter i
-
-#   64| access to parameter i
-#-----|  -> 0
-
-#   64| ... + ...
-#-----|  -> "1"
-
-#   64| 0
-#-----|  -> ... + ...
-
-#   64| "1"
-#-----|  -> ... = ...
-
-LoopUnrolling.cs:
-#    5| call to constructor Object
-#-----|  -> {...}
-
-#    5| enter LoopUnrolling
-#-----|  -> call to constructor Object
-
-#    5| exit LoopUnrolling
-
-#    5| exit LoopUnrolling (normal)
-#-----|  -> exit LoopUnrolling
-
-#    5| {...}
-#-----|  -> exit LoopUnrolling (normal)
-
-#    7| enter M1
-#-----|  -> {...}
-
-#    7| exit M1
-
-#    7| exit M1 (normal)
-#-----|  -> exit M1
-
-#    8| {...}
-#-----|  -> if (...) ...
-
-#    9| if (...) ...
-#-----|  -> access to parameter args
-
-#    9| access to parameter args
-#-----|  -> access to property Length
-
-#    9| access to property Length
-#-----|  -> 0
-
-#    9| ... == ...
-#-----| true -> return ...;
-#-----| false -> access to parameter args
-
-#    9| 0
-#-----|  -> ... == ...
-
-#   10| return ...;
-#-----| return -> exit M1 (normal)
-
-#   11| [unroll (line 11)] foreach (... ... in ...) ...
-#-----| non-empty -> String arg
-
-#   11| foreach (... ... in ...) ...
-#-----| empty -> exit M1 (normal)
-#-----| non-empty -> String arg
-
-#   11| String arg
-#-----|  -> ...;
-
-#   11| access to parameter args
-#-----|  -> [unroll (line 11)] foreach (... ... in ...) ...
-
-#   12| call to method WriteLine
-#-----|  -> foreach (... ... in ...) ...
-
-#   12| ...;
-#-----|  -> access to local variable arg
-
-#   12| access to local variable arg
-#-----|  -> call to method WriteLine
-
-#   15| enter M2
-#-----|  -> {...}
-
-#   15| exit M2
-
-#   15| exit M2 (normal)
-#-----|  -> exit M2
-
-#   16| {...}
-#-----|  -> ... ...;
-
-#   17| ... ...;
-#-----|  -> 3
-
-#   17| String[] xs = ...
-#-----|  -> access to local variable xs
-
-#   17| 3
-#-----|  -> array creation of type String[]
-
-#   17| array creation of type String[]
-#-----|  -> "a"
-
-#   17| { ..., ... }
-#-----|  -> String[] xs = ...
-
-#   17| "a"
-#-----|  -> "b"
-
-#   17| "b"
-#-----|  -> "c"
-
-#   17| "c"
-#-----|  -> { ..., ... }
-
-#   18| [unroll (line 18)] foreach (... ... in ...) ...
-#-----| non-empty -> String x
-
-#   18| foreach (... ... in ...) ...
-#-----| empty -> exit M2 (normal)
-#-----| non-empty -> String x
-
-#   18| String x
-#-----|  -> ...;
-
-#   18| access to local variable xs
-#-----|  -> [unroll (line 18)] foreach (... ... in ...) ...
-
-#   19| call to method WriteLine
-#-----|  -> foreach (... ... in ...) ...
-
-#   19| ...;
-#-----|  -> access to local variable x
-
-#   19| access to local variable x
-#-----|  -> call to method WriteLine
-
-#   22| enter M3
-#-----|  -> {...}
-
-#   22| exit M3
-
-#   22| exit M3 (normal)
-#-----|  -> exit M3
-
-#   23| {...}
-#-----|  -> access to parameter args
-
-#   24| foreach (... ... in ...) ...
-#-----| empty -> exit M3 (normal)
-#-----| non-empty -> Char arg
-
-#   24| Char arg
-#-----|  -> access to parameter args
-
-#   24| access to parameter args
-#-----|  -> foreach (... ... in ...) ...
-
-#   25| [unroll (line 25)] foreach (... ... in ...) ...
-#-----| non-empty -> Char arg0
-
-#   25| foreach (... ... in ...) ...
-#-----| empty -> foreach (... ... in ...) ...
-#-----| non-empty -> Char arg0
-
-#   25| Char arg0
-#-----|  -> ...;
-
-#   25| access to parameter args
-#-----|  -> [unroll (line 25)] foreach (... ... in ...) ...
-
-#   26| call to method WriteLine
-#-----|  -> foreach (... ... in ...) ...
-
-#   26| ...;
-#-----|  -> access to local variable arg0
-
-#   26| access to local variable arg0
-#-----|  -> call to method WriteLine
-
-#   29| enter M4
-#-----|  -> {...}
-
-#   29| exit M4
-
-#   29| exit M4 (normal)
-#-----|  -> exit M4
-
-#   30| {...}
-#-----|  -> ... ...;
-
-#   31| ... ...;
-#-----|  -> 0
-
-#   31| String[] xs = ...
-#-----|  -> access to local variable xs
-
-#   31| array creation of type String[]
-#-----|  -> String[] xs = ...
-
-#   31| 0
-#-----|  -> array creation of type String[]
-
-#   32| [skip (line 32)] foreach (... ... in ...) ...
-#-----| empty -> exit M4 (normal)
-
-#   32| access to local variable xs
-#-----|  -> [skip (line 32)] foreach (... ... in ...) ...
-
-#   36| enter M5
-#-----|  -> {...}
-
-#   36| exit M5
-
-#   36| exit M5 (normal)
-#-----|  -> exit M5
-
-#   37| {...}
-#-----|  -> ... ...;
-
-#   38| ... ...;
-#-----|  -> 3
-
-#   38| String[] xs = ...
-#-----|  -> ... ...;
-
-#   38| 3
-#-----|  -> array creation of type String[]
-
-#   38| array creation of type String[]
-#-----|  -> "a"
-
-#   38| { ..., ... }
-#-----|  -> String[] xs = ...
-
-#   38| "a"
-#-----|  -> "b"
-
-#   38| "b"
-#-----|  -> "c"
-
-#   38| "c"
-#-----|  -> { ..., ... }
-
-#   39| ... ...;
-#-----|  -> 3
-
-#   39| String[] ys = ...
-#-----|  -> access to local variable xs
-
-#   39| 3
-#-----|  -> array creation of type String[]
-
-#   39| array creation of type String[]
-#-----|  -> "0"
-
-#   39| { ..., ... }
-#-----|  -> String[] ys = ...
-
-#   39| "0"
-#-----|  -> "1"
-
-#   39| "1"
-#-----|  -> "2"
-
-#   39| "2"
-#-----|  -> { ..., ... }
-
-#   40| [unroll (line 40)] foreach (... ... in ...) ...
-#-----| non-empty -> String x
-
-#   40| foreach (... ... in ...) ...
-#-----| empty -> exit M5 (normal)
-#-----| non-empty -> String x
-
-#   40| String x
-#-----|  -> access to local variable ys
-
-#   40| access to local variable xs
-#-----|  -> [unroll (line 40)] foreach (... ... in ...) ...
-
-#   41| [unroll (line 41)] foreach (... ... in ...) ...
-#-----| non-empty -> String y
-
-#   41| foreach (... ... in ...) ...
-#-----| empty -> foreach (... ... in ...) ...
-#-----| non-empty -> String y
-
-#   41| String y
-#-----|  -> ...;
-
-#   41| access to local variable ys
-#-----|  -> [unroll (line 41)] foreach (... ... in ...) ...
-
-#   42| call to method WriteLine
-#-----|  -> foreach (... ... in ...) ...
-
-#   42| ...;
-#-----|  -> access to local variable x
-
-#   42| access to local variable x
-#-----|  -> access to local variable y
-
-#   42| ... + ...
-#-----|  -> call to method WriteLine
-
-#   42| access to local variable y
-#-----|  -> ... + ...
-
-#   45| enter M6
-#-----|  -> {...}
-
-#   46| {...}
-#-----|  -> ... ...;
-
-#   47| ... ...;
-#-----|  -> 3
-
-#   47| String[] xs = ...
-#-----|  -> access to local variable xs
-
-#   47| 3
-#-----|  -> array creation of type String[]
-
-#   47| array creation of type String[]
-#-----|  -> "a"
-
-#   47| { ..., ... }
-#-----|  -> String[] xs = ...
-
-#   47| "a"
-#-----|  -> "b"
-
-#   47| "b"
-#-----|  -> "c"
-
-#   47| "c"
-#-----|  -> { ..., ... }
-
-#   48| [unroll (line 48)] foreach (... ... in ...) ...
-#-----| non-empty -> String x
-
-#   48| String x
-#-----|  -> {...}
-
-#   48| access to local variable xs
-#-----|  -> [unroll (line 48)] foreach (... ... in ...) ...
-
-#   49| {...}
-#-----|  -> Label:
-
-#   50| Label:
-#-----|  -> ...;
-
-#   50| call to method WriteLine
-#-----|  -> goto ...;
-
-#   50| ...;
-#-----|  -> access to local variable x
-
-#   50| access to local variable x
-#-----|  -> call to method WriteLine
-
-#   51| goto ...;
-#-----| goto(Label) -> Label:
-
-#   55| enter M7
-#-----|  -> {...}
-
-#   55| exit M7
-
-#   55| exit M7 (normal)
-#-----|  -> exit M7
-
-#   56| {...}
-#-----|  -> ... ...;
-
-#   57| ... ...;
-#-----|  -> 3
-
-#   57| String[] xs = ...
-#-----|  -> access to local variable xs
-
-#   57| 3
-#-----|  -> array creation of type String[]
-
-#   57| array creation of type String[]
-#-----|  -> "a"
-
-#   57| { ..., ... }
-#-----|  -> String[] xs = ...
-
-#   57| "a"
-#-----|  -> "b"
-
-#   57| "b"
-#-----|  -> "c"
-
-#   57| "c"
-#-----|  -> { ..., ... }
-
-#   58| [b (line 55): false] foreach (... ... in ...) ...
-#-----| empty -> exit M7 (normal)
-#-----| non-empty -> [b (line 55): false] String x
-
-#   58| [b (line 55): true] foreach (... ... in ...) ...
-#-----| empty -> exit M7 (normal)
-#-----| non-empty -> [b (line 55): true] String x
-
-#   58| [unroll (line 58)] foreach (... ... in ...) ...
-#-----| non-empty -> String x
-
-#   58| String x
-#-----|  -> {...}
-
-#   58| [b (line 55): false] String x
-#-----|  -> [b (line 55): false] {...}
-
-#   58| [b (line 55): true] String x
-#-----|  -> [b (line 55): true] {...}
-
-#   58| access to local variable xs
-#-----|  -> [unroll (line 58)] foreach (... ... in ...) ...
-
-#   59| [b (line 55): false] {...}
-#-----|  -> [b (line 55): false] if (...) ...
-
-#   59| [b (line 55): true] {...}
-#-----|  -> [b (line 55): true] if (...) ...
-
-#   59| {...}
-#-----|  -> if (...) ...
-
-#   60| [b (line 55): false] if (...) ...
-#-----|  -> [b (line 55): false] access to parameter b
-
-#   60| [b (line 55): true] if (...) ...
-#-----|  -> [b (line 55): true] access to parameter b
-
-#   60| if (...) ...
-#-----|  -> access to parameter b
-
-#   60| [b (line 55): false] access to parameter b
-#-----| false -> [b (line 55): false] if (...) ...
-
-#   60| [b (line 55): true] access to parameter b
-#-----| true -> [b (line 55): true] ...;
-
-#   60| access to parameter b
-#-----| true -> [b (line 55): true] ...;
-#-----| false -> [b (line 55): false] if (...) ...
-
-#   61| [b (line 55): true] call to method WriteLine
-#-----|  -> [b (line 55): true] if (...) ...
-
-#   61| [b (line 55): true] ...;
-#-----|  -> [b (line 55): true] access to local variable x
-
-#   61| [b (line 55): true] access to local variable x
-#-----|  -> [b (line 55): true] call to method WriteLine
-
-#   62| [b (line 55): false] if (...) ...
-#-----|  -> [b (line 55): false] access to parameter b
-
-#   62| [b (line 55): true] if (...) ...
-#-----|  -> [b (line 55): true] access to parameter b
-
-#   62| [b (line 55): false] access to parameter b
-#-----| false -> [b (line 55): false] foreach (... ... in ...) ...
-
-#   62| [b (line 55): true] access to parameter b
-#-----| true -> [b (line 55): true] ...;
-
-#   63| [b (line 55): true] call to method WriteLine
-#-----|  -> [b (line 55): true] foreach (... ... in ...) ...
-
-#   63| [b (line 55): true] ...;
-#-----|  -> [b (line 55): true] access to local variable x
-
-#   63| [b (line 55): true] access to local variable x
-#-----|  -> [b (line 55): true] call to method WriteLine
-
-#   67| enter M8
-#-----|  -> {...}
-
-#   67| exit M8
-
-#   67| exit M8 (normal)
-#-----|  -> exit M8
-
-#   68| {...}
-#-----|  -> if (...) ...
-
-#   69| if (...) ...
-#-----|  -> access to parameter args
-
-#   69| [false] !...
-#-----| false -> ...;
-
-#   69| [true] !...
-#-----| true -> return ...;
-
-#   69| access to parameter args
-#-----|  -> call to method Any<String>
-
-#   69| call to method Any<String>
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#   70| return ...;
-#-----| return -> exit M8 (normal)
-
-#   71| access to parameter args
-#-----|  -> call to method Clear
-
-#   71| call to method Clear
-#-----|  -> access to parameter args
-
-#   71| ...;
-#-----|  -> access to parameter args
-
-#   72| [skip (line 72)] foreach (... ... in ...) ...
-#-----| empty -> exit M8 (normal)
-
-#   72| access to parameter args
-#-----|  -> [skip (line 72)] foreach (... ... in ...) ...
-
-#   76| enter M9
-#-----|  -> {...}
-
-#   76| exit M9
-
-#   76| exit M9 (normal)
-#-----|  -> exit M9
-
-#   77| {...}
-#-----|  -> ... ...;
-
-#   78| ... ...;
-#-----|  -> 2
-
-#   78| String[,] xs = ...
-#-----|  -> access to local variable xs
-
-#   78| array creation of type String[,]
-#-----|  -> String[,] xs = ...
-
-#   78| 2
-#-----|  -> 0
-
-#   78| 0
-#-----|  -> array creation of type String[,]
-
-#   79| [skip (line 79)] foreach (... ... in ...) ...
-#-----| empty -> exit M9 (normal)
-
-#   79| access to local variable xs
-#-----|  -> [skip (line 79)] foreach (... ... in ...) ...
-
-#   85| enter M10
-#-----|  -> {...}
-
-#   85| exit M10
-
-#   85| exit M10 (normal)
-#-----|  -> exit M10
-
-#   86| {...}
-#-----|  -> ... ...;
-
-#   87| ... ...;
-#-----|  -> 0
-
-#   87| String[,] xs = ...
-#-----|  -> access to local variable xs
-
-#   87| array creation of type String[,]
-#-----|  -> String[,] xs = ...
-
-#   87| 0
-#-----|  -> 2
-
-#   87| 2
-#-----|  -> array creation of type String[,]
-
-#   88| [skip (line 88)] foreach (... ... in ...) ...
-#-----| empty -> exit M10 (normal)
-
-#   88| access to local variable xs
-#-----|  -> [skip (line 88)] foreach (... ... in ...) ...
-
-#   94| enter M11
-#-----|  -> {...}
-
-#   94| exit M11
-
-#   94| exit M11 (normal)
-#-----|  -> exit M11
-
-#   95| {...}
-#-----|  -> ... ...;
-
-#   96| ... ...;
-#-----|  -> 2
-
-#   96| String[,] xs = ...
-#-----|  -> access to local variable xs
-
-#   96| array creation of type String[,]
-#-----|  -> String[,] xs = ...
-
-#   96| 2
-#-----|  -> 2
-
-#   96| 2
-#-----|  -> array creation of type String[,]
-
-#   97| [unroll (line 97)] foreach (... ... in ...) ...
-#-----| non-empty -> String x
-
-#   97| foreach (... ... in ...) ...
-#-----| empty -> exit M11 (normal)
-#-----| non-empty -> String x
-
-#   97| String x
-#-----|  -> {...}
-
-#   97| access to local variable xs
-#-----|  -> [unroll (line 97)] foreach (... ... in ...) ...
-
-#   98| {...}
-#-----|  -> ...;
-
-#   99| call to method WriteLine
-#-----|  -> foreach (... ... in ...) ...
-
-#   99| ...;
-#-----|  -> access to local variable x
-
-#   99| access to local variable x
-#-----|  -> call to method WriteLine
-
-MultiImplementationA.cs:
-#    4| call to constructor Object
-#-----|  -> {...}
-
-#    4| enter C1
-#-----|  -> call to constructor Object
-#-----|  -> call to constructor Object
-
-#    4| exit C1
-
-#    4| exit C1 (normal)
-#-----|  -> exit C1
-
-#    4| {...}
-#-----|  -> exit C1 (normal)
-
-#    6| enter get_P1
-#-----|  -> null
-#-----|  -> 0
-
-#    6| exit get_P1
-
-#    6| exit get_P1 (abnormal)
-#-----|  -> exit get_P1
-
-#    6| exit get_P1 (normal)
-#-----|  -> exit get_P1
-
-#    6| throw ...
-#-----| exception(NullReferenceException) -> exit get_P1 (abnormal)
-
-#    6| null
-#-----|  -> throw ...
-
-#    7| enter get_P2
-#-----|  -> {...}
-#-----|  -> {...}
-
-#    7| exit get_P2
-
-#    7| exit get_P2 (abnormal)
-#-----|  -> exit get_P2
-
-#    7| exit get_P2 (normal)
-#-----|  -> exit get_P2
-
-#    7| {...}
-#-----|  -> null
-
-#    7| throw ...;
-#-----| exception(NullReferenceException) -> exit get_P2 (abnormal)
-
-#    7| null
-#-----|  -> throw ...;
-
-#    7| enter set_P2
-#-----|  -> {...}
-#-----|  -> {...}
-
-#    7| exit set_P2
-
-#    7| exit set_P2 (abnormal)
-#-----|  -> exit set_P2
-
-#    7| exit set_P2 (normal)
-#-----|  -> exit set_P2
-
-#    7| {...}
-#-----|  -> null
-
-#    7| throw ...;
-#-----| exception(NullReferenceException) -> exit set_P2 (abnormal)
-
-#    7| null
-#-----|  -> throw ...;
-
-#    8| enter M
-#-----|  -> null
-#-----|  -> 2
-
-#    8| exit M
-
-#    8| exit M (abnormal)
-#-----|  -> exit M
-
-#    8| exit M (normal)
-#-----|  -> exit M
-
-#    8| throw ...
-#-----| exception(NullReferenceException) -> exit M (abnormal)
-
-#    8| null
-#-----|  -> throw ...
-
-#   13| this access
-#-----|  -> 0
-
-#   13| ... = ...
-#-----|  -> this access
-
-#   13| 0
-#-----|  -> ... = ...
-
-#   14| access to parameter i
-#-----|  -> exit get_Item (normal)
-
-#   14| enter get_Item
-#-----|  -> access to parameter i
-#-----|  -> null
-
-#   14| exit get_Item
-
-#   14| exit get_Item (abnormal)
-#-----|  -> exit get_Item
-
-#   14| exit get_Item (normal)
-#-----|  -> exit get_Item
-
-#   15| enter get_Item
-#-----|  -> {...}
-#-----|  -> {...}
-
-#   15| exit get_Item
-
-#   15| exit get_Item (abnormal)
-#-----|  -> exit get_Item
-
-#   15| exit get_Item (normal)
-#-----|  -> exit get_Item
-
-#   15| {...}
-#-----|  -> access to parameter s
-
-#   15| return ...;
-#-----| return -> exit get_Item (normal)
-
-#   15| access to parameter s
-#-----|  -> return ...;
-
-#   15| enter set_Item
-#-----|  -> {...}
-#-----|  -> {...}
-
-#   15| exit set_Item
-
-#   15| exit set_Item (normal)
-#-----|  -> exit set_Item
-
-#   15| {...}
-#-----|  -> exit set_Item (normal)
-
-#   16| enter M1
-#-----|  -> {...}
-#-----|  -> {...}
-
-#   16| exit M1
-
-#   16| exit M1 (normal)
-#-----|  -> exit M1
-
-#   17| {...}
-#-----|  -> M2(...)
-
-#   18| M2(...)
-#-----|  -> exit M1 (normal)
-
-#   18| enter M2
-#-----|  -> 0
-
-#   18| exit M2
-
-#   18| exit M2 (normal)
-#-----|  -> exit M2
-
-#   18| 0
-#-----|  -> exit M2 (normal)
-
-#   20| call to constructor Object
-#-----|  -> this access
-
-#   20| enter C2
-#-----|  -> call to constructor Object
-#-----|  -> call to constructor Object
-
-#   20| exit C2
-
-#   20| exit C2 (abnormal)
-#-----|  -> exit C2
-
-#   20| exit C2 (normal)
-#-----|  -> exit C2
-
-#   20| {...}
-#-----|  -> ...;
-
-#   20| this access
-#-----|  -> access to parameter i
-
-#   20| ... = ...
-#-----|  -> exit C2 (normal)
-
-#   20| ...;
-#-----|  -> this access
-
-#   20| access to parameter i
-#-----|  -> ... = ...
-
-#   21| enter C2
-#-----|  -> 0
-#-----|  -> 1
-
-#   21| exit C2
-
-#   21| exit C2 (normal)
-#-----|  -> exit C2
-
-#   21| call to constructor C2
-#-----|  -> {...}
-
-#   21| 0
-#-----|  -> call to constructor C2
-
-#   21| {...}
-#-----|  -> exit C2 (normal)
-
-#   22| enter ~C2
-#-----|  -> {...}
-#-----|  -> {...}
-
-#   22| exit ~C2
-
-#   22| exit ~C2 (abnormal)
-#-----|  -> exit ~C2
-
-#   22| exit ~C2 (normal)
-#-----|  -> exit ~C2
-
-#   22| {...}
-#-----|  -> exit ~C2 (normal)
-
-#   23| enter implicit conversion
-#-----|  -> null
-#-----|  -> null
-
-#   23| exit implicit conversion
-
-#   23| exit implicit conversion (abnormal)
-#-----|  -> exit implicit conversion
-
-#   23| exit implicit conversion (normal)
-#-----|  -> exit implicit conversion
-
-#   23| null
-#-----|  -> exit implicit conversion (normal)
-
-#   24| access to property P
-#-----|  -> ... = ...
-
-#   24| this access
-#-----|  -> 0
-
-#   24| ... = ...
-#-----|  -> {...}
-
-#   24| 0
-#-----|  -> access to property P
-
-#   28| call to constructor Object
-#-----|  -> {...}
-
-#   28| enter C3
-#-----|  -> call to constructor Object
-#-----|  -> call to constructor Object
-
-#   28| exit C3
-
-#   28| exit C3 (normal)
-#-----|  -> exit C3
-
-#   28| {...}
-#-----|  -> exit C3 (normal)
-
-#   30| enter get_P3
-#-----|  -> null
-
-#   30| exit get_P3
-
-#   30| exit get_P3 (abnormal)
-#-----|  -> exit get_P3
-
-#   30| throw ...
-#-----| exception(NullReferenceException) -> exit get_P3 (abnormal)
-
-#   30| null
-#-----|  -> throw ...
-
-#   34| call to constructor Object
-#-----|  -> {...}
-
-#   34| enter C4
-#-----|  -> call to constructor Object
-#-----|  -> call to constructor Object
-
-#   34| exit C4
-
-#   34| exit C4 (normal)
-#-----|  -> exit C4
-
-#   34| {...}
-#-----|  -> exit C4 (normal)
-
-#   36| enter M1
-#-----|  -> {...}
-#-----|  -> 0
-
-#   36| exit M1
-
-#   36| exit M1 (abnormal)
-#-----|  -> exit M1
-
-#   36| exit M1 (normal)
-#-----|  -> exit M1
-
-#   36| {...}
-#-----|  -> null
-
-#   36| throw ...;
-#-----| exception(NullReferenceException) -> exit M1 (abnormal)
-
-#   36| null
-#-----|  -> throw ...;
-
-#   37| enter M2
-#-----|  -> {...}
-
-#   37| exit M2
-
-#   37| exit M2 (abnormal)
-#-----|  -> exit M2
-
-#   37| {...}
-#-----|  -> null
-
-#   37| throw ...;
-#-----| exception(NullReferenceException) -> exit M2 (abnormal)
-
-#   37| null
-#-----|  -> throw ...;
-
-MultiImplementationB.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| {...}
-#-----|  -> exit C1 (normal)
-
-#    3| 0
-#-----|  -> exit get_P1 (normal)
-
-#    4| {...}
-#-----|  -> 1
-
-#    4| return ...;
-#-----| return -> exit get_P2 (normal)
-
-#    4| 1
-#-----|  -> return ...;
-
-#    4| {...}
-#-----|  -> exit set_P2 (normal)
-
-#    5| 2
-#-----|  -> exit M (normal)
-
-#   11| this access
-#-----|  -> 1
-
-#   11| ... = ...
-#-----|  -> this access
-
-#   11| 1
-#-----|  -> ... = ...
-
-#   12| throw ...
-#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
-
-#   12| null
-#-----|  -> throw ...
-
-#   13| {...}
-#-----|  -> null
-
-#   13| throw ...;
-#-----| exception(NullReferenceException) -> exit get_Item (abnormal)
-
-#   13| null
-#-----|  -> throw ...;
-
-#   13| {...}
-#-----|  -> exit set_Item (normal)
-
-#   15| {...}
-#-----|  -> M2(...)
-
-#   16| M2(...)
-#-----|  -> exit M1 (normal)
-
-#   16| enter M2
-#-----|  -> null
-
-#   16| exit M2
-
-#   16| exit M2 (abnormal)
-#-----|  -> exit M2
-
-#   16| throw ...
-#-----| exception(NullReferenceException) -> exit M2 (abnormal)
-
-#   16| null
-#-----|  -> throw ...
-
-#   18| call to constructor Object
-#-----|  -> this access
-
-#   18| {...}
-#-----|  -> null
-
-#   18| throw ...;
-#-----| exception(NullReferenceException) -> exit C2 (abnormal)
-
-#   18| null
-#-----|  -> throw ...;
-
-#   19| call to constructor C2
-#-----|  -> {...}
-
-#   19| 1
-#-----|  -> call to constructor C2
-
-#   19| {...}
-#-----|  -> exit C2 (normal)
-
-#   20| {...}
-#-----|  -> null
-
-#   20| throw ...;
-#-----| exception(NullReferenceException) -> exit ~C2 (abnormal)
-
-#   20| null
-#-----|  -> throw ...;
-
-#   21| throw ...
-#-----| exception(NullReferenceException) -> exit implicit conversion (abnormal)
-
-#   21| null
-#-----|  -> throw ...
-
-#   22| access to property P
-#-----|  -> ... = ...
-
-#   22| this access
-#-----|  -> 1
-
-#   22| ... = ...
-#-----|  -> {...}
-
-#   22| 1
-#-----|  -> access to property P
-
-#   25| call to constructor Object
-#-----|  -> {...}
-
-#   25| {...}
-#-----|  -> exit C3 (normal)
-
-#   30| call to constructor Object
-#-----|  -> {...}
-
-#   30| {...}
-#-----|  -> exit C4 (normal)
-
-#   32| 0
-#-----|  -> exit M1 (normal)
-
-NullCoalescing.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter NullCoalescing
-#-----|  -> call to constructor Object
-
-#    1| exit NullCoalescing
-
-#    1| exit NullCoalescing (normal)
-#-----|  -> exit NullCoalescing
-
-#    1| {...}
-#-----|  -> exit NullCoalescing (normal)
-
-#    3| enter M1
-#-----|  -> access to parameter i
-
-#    3| exit M1
-
-#    3| exit M1 (normal)
-#-----|  -> exit M1
-
-#    3| access to parameter i
-#-----| non-null -> ... ?? ...
-#-----| null -> 0
-
-#    3| ... ?? ...
-#-----|  -> exit M1 (normal)
-
-#    3| 0
-#-----|  -> ... ?? ...
-
-#    5| enter M2
-#-----|  -> access to parameter b
-
-#    5| exit M2
-
-#    5| exit M2 (normal)
-#-----|  -> exit M2
-
-#    5| ... ? ... : ...
-#-----|  -> exit M2 (normal)
-
-#    5| access to parameter b
-#-----| false -> [false] ... ?? ...
-#-----| true -> [true] ... ?? ...
-#-----| null -> false
-
-#    5| [false] ... ?? ...
-#-----| false -> 1
-
-#    5| [true] ... ?? ...
-#-----| true -> 0
-
-#    5| false
-#-----| false -> [false] ... ?? ...
-
-#    5| 0
-#-----|  -> ... ? ... : ...
-
-#    5| 1
-#-----|  -> ... ? ... : ...
-
-#    7| enter M3
-#-----|  -> access to parameter s1
-
-#    7| exit M3
-
-#    7| exit M3 (normal)
-#-----|  -> exit M3
-
-#    7| access to parameter s1
-#-----| non-null -> ... ?? ...
-#-----| null -> access to parameter s2
-
-#    7| ... ?? ...
-#-----|  -> exit M3 (normal)
-
-#    7| access to parameter s2
-#-----| non-null -> ... ?? ...
-#-----| null -> ""
-
-#    7| ... ?? ...
-#-----|  -> ... ?? ...
-
-#    7| ""
-#-----|  -> ... ?? ...
-
-#    9| enter M4
-#-----|  -> access to parameter b
-
-#    9| exit M4
-
-#    9| exit M4 (normal)
-#-----|  -> exit M4
-
-#    9| ... ?? ...
-#-----|  -> exit M4 (normal)
-
-#    9| access to parameter b
-#-----| true -> access to parameter s
-#-----| false -> access to parameter s
-
-#    9| [non-null] ... ? ... : ...
-#-----| non-null -> ... ?? ...
-
-#    9| [null] ... ? ... : ...
-#-----| null -> ""
-
-#    9| access to parameter s
-#-----| non-null -> [non-null] ... ? ... : ...
-#-----| null -> [null] ... ? ... : ...
-
-#    9| access to parameter s
-#-----| non-null -> [non-null] ... ? ... : ...
-#-----| null -> [null] ... ? ... : ...
-
-#    9| ""
-#-----| non-null -> ... ?? ...
-
-#    9| ... ?? ...
-#-----|  -> ... ?? ...
-
-#   11| enter M5
-#-----|  -> access to parameter b1
-
-#   11| exit M5
-
-#   11| exit M5 (normal)
-#-----|  -> exit M5
-
-#   11| ... ? ... : ...
-#-----|  -> exit M5 (normal)
-
-#   11| access to parameter b1
-#-----| false -> [false] ... ?? ...
-#-----| true -> [true] ... ?? ...
-#-----| null -> access to parameter b2
-
-#   11| [false] ... ?? ...
-#-----| false -> 1
-
-#   11| [true] ... ?? ...
-#-----| true -> 0
-
-#   11| access to parameter b2
-#-----| false -> [false] ... && ...
-#-----| true -> access to parameter b3
-
-#   11| [false] ... && ...
-#-----| false -> [false] ... ?? ...
-
-#   11| [true] ... && ...
-#-----| true -> [true] ... ?? ...
-
-#   11| access to parameter b3
-#-----| false -> [false] ... && ...
-#-----| true -> [true] ... && ...
-
-#   11| 0
-#-----|  -> ... ? ... : ...
-
-#   11| 1
-#-----|  -> ... ? ... : ...
-
-#   13| enter M6
-#-----|  -> {...}
-
-#   13| exit M6
-
-#   13| exit M6 (normal)
-#-----|  -> exit M6
-
-#   14| {...}
-#-----|  -> ... ...;
-
-#   15| ... ...;
-#-----|  -> null
-
-#   15| Int32 j = ...
-#-----|  -> ... ...;
-
-#   15| (...) ...
-#-----| null -> 0
-
-#   15| ... ?? ...
-#-----|  -> Int32 j = ...
-
-#   15| null
-#-----|  -> (...) ...
-
-#   15| 0
-#-----|  -> ... ?? ...
-
-#   16| ... ...;
-#-----|  -> ""
-
-#   16| String s = ...
-#-----|  -> ...;
-
-#   16| ""
-#-----| non-null -> ... ?? ...
-
-#   16| ... ?? ...
-#-----|  -> String s = ...
-
-#   17| ... = ...
-#-----|  -> exit M6 (normal)
-
-#   17| ...;
-#-----|  -> access to parameter i
-
-#   17| (...) ...
-#-----| non-null -> ... ?? ...
-
-#   17| ... ?? ...
-#-----|  -> ... = ...
-
-#   17| access to parameter i
-#-----|  -> (...) ...
-
-PartialImplementationA.cs:
-#    3| call to constructor Object
-#-----|  -> this access
-
-#    3| enter Partial
-#-----|  -> call to constructor Object
-
-#    3| exit Partial
-
-#    3| exit Partial (normal)
-#-----|  -> exit Partial
-
-#    3| {...}
-#-----|  -> exit Partial (normal)
-
-PartialImplementationB.cs:
-#    3| this access
-#-----|  -> 0
-
-#    3| this access
-#-----|  -> 0
-
-#    3| ... = ...
-#-----|  -> this access
-
-#    3| ... = ...
-#-----|  -> this access
-
-#    3| 0
-#-----|  -> ... = ...
-
-#    3| 0
-#-----|  -> ... = ...
-
-#    4| call to constructor Object
-#-----|  -> this access
-
-#    4| enter Partial
-#-----|  -> call to constructor Object
-
-#    4| exit Partial
-
-#    4| exit Partial (normal)
-#-----|  -> exit Partial
-
-#    4| {...}
-#-----|  -> exit Partial (normal)
-
-#    5| access to property P
-#-----|  -> ... = ...
-
-#    5| access to property P
-#-----|  -> ... = ...
-
-#    5| this access
-#-----|  -> 0
-
-#    5| this access
-#-----|  -> 0
-
-#    5| ... = ...
-#-----|  -> {...}
-
-#    5| ... = ...
-#-----|  -> {...}
-
-#    5| 0
-#-----|  -> access to property P
-
-#    5| 0
-#-----|  -> access to property P
-
-Patterns.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter Patterns
-#-----|  -> call to constructor Object
-
-#    3| exit Patterns
-
-#    3| exit Patterns (normal)
-#-----|  -> exit Patterns
-
-#    3| {...}
-#-----|  -> exit Patterns (normal)
-
-#    5| enter M1
-#-----|  -> {...}
-
-#    5| exit M1
-
-#    5| exit M1 (normal)
-#-----|  -> exit M1
-
-#    6| {...}
-#-----|  -> ... ...;
-
-#    7| ... ...;
-#-----|  -> null
-
-#    7| Object o = ...
-#-----|  -> if (...) ...
-
-#    7| null
-#-----|  -> Object o = ...
-
-#    8| if (...) ...
-#-----|  -> access to local variable o
-
-#    8| access to local variable o
-#-----|  -> Int32 i1
-
-#    8| [false] ... is ...
-#-----| false -> if (...) ...
-
-#    8| [true] ... is ...
-#-----| true -> {...}
-
-#    8| Int32 i1
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#    9| {...}
-#-----|  -> ...;
-
-#   10| call to method WriteLine
-#-----|  -> switch (...) {...}
-
-#   10| ...;
-#-----|  -> "int "
-
-#   10| $"..."
-#-----|  -> call to method WriteLine
-
-#   10| "int "
-#-----|  -> access to local variable i1
-
-#   10| access to local variable i1
-#-----|  -> $"..."
-
-#   12| if (...) ...
-#-----|  -> access to local variable o
-
-#   12| access to local variable o
-#-----|  -> String s1
-
-#   12| [false] ... is ...
-#-----| false -> if (...) ...
-
-#   12| [true] ... is ...
-#-----| true -> {...}
-
-#   12| String s1
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#   13| {...}
-#-----|  -> ...;
-
-#   14| call to method WriteLine
-#-----|  -> switch (...) {...}
-
-#   14| ...;
-#-----|  -> "string "
-
-#   14| $"..."
-#-----|  -> call to method WriteLine
-
-#   14| "string "
-#-----|  -> access to local variable s1
-
-#   14| access to local variable s1
-#-----|  -> $"..."
-
-#   16| if (...) ...
-#-----|  -> access to local variable o
-
-#   16| access to local variable o
-#-----|  -> Object v1
-
-#   16| [false] ... is ...
-#-----| false -> switch (...) {...}
-
-#   16| [true] ... is ...
-#-----| true -> {...}
-
-#   16| Object v1
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#   17| {...}
-#-----|  -> switch (...) {...}
-
-#   20| switch (...) {...}
-#-----|  -> access to local variable o
-
-#   20| access to local variable o
-#-----|  -> case ...:
-
-#   22| case ...:
-#-----|  -> "xyz"
-
-#   22| "xyz"
-#-----| match -> break;
-#-----| no-match -> case ...:
-
-#   23| break;
-#-----| break -> switch (...) {...}
-
-#   24| case ...:
-#-----|  -> Int32 i2
-
-#   24| Int32 i2
-#-----| match -> access to local variable i2
-#-----| no-match -> case ...:
-
-#   24| access to local variable i2
-#-----|  -> 0
-
-#   24| ... > ...
-#-----| true -> ...;
-#-----| false -> case ...:
-
-#   24| 0
-#-----|  -> ... > ...
-
-#   25| call to method WriteLine
-#-----|  -> break;
-
-#   25| ...;
-#-----|  -> "positive "
-
-#   25| $"..."
-#-----|  -> call to method WriteLine
-
-#   25| "positive "
-#-----|  -> access to local variable i2
-
-#   25| access to local variable i2
-#-----|  -> $"..."
-
-#   26| break;
-#-----| break -> switch (...) {...}
-
-#   27| case ...:
-#-----|  -> Int32 i3
-
-#   27| Int32 i3
-#-----| match -> ...;
-#-----| no-match -> case ...:
-
-#   28| call to method WriteLine
-#-----|  -> break;
-
-#   28| ...;
-#-----|  -> "int "
-
-#   28| $"..."
-#-----|  -> call to method WriteLine
-
-#   28| "int "
-#-----|  -> access to local variable i3
-
-#   28| access to local variable i3
-#-----|  -> $"..."
-
-#   29| break;
-#-----| break -> switch (...) {...}
-
-#   30| case ...:
-#-----|  -> String s2
-
-#   30| String s2
-#-----| match -> ...;
-#-----| no-match -> case ...:
-
-#   31| call to method WriteLine
-#-----|  -> break;
-
-#   31| ...;
-#-----|  -> "string "
-
-#   31| $"..."
-#-----|  -> call to method WriteLine
-
-#   31| "string "
-#-----|  -> access to local variable s2
-
-#   31| access to local variable s2
-#-----|  -> $"..."
-
-#   32| break;
-#-----| break -> switch (...) {...}
-
-#   33| case ...:
-#-----|  -> Object v2
-
-#   33| Object v2
-#-----| match -> break;
-#-----| no-match -> default:
-
-#   34| break;
-#-----| break -> switch (...) {...}
-
-#   35| default:
-#-----|  -> ...;
-
-#   36| call to method WriteLine
-#-----|  -> break;
-
-#   36| ...;
-#-----|  -> "Something else"
-
-#   36| "Something else"
-#-----|  -> call to method WriteLine
-
-#   37| break;
-#-----| break -> switch (...) {...}
-
-#   40| switch (...) {...}
-#-----|  -> access to local variable o
-
-#   40| access to local variable o
-#-----|  -> exit M1 (normal)
-
-#   47| enter M2
-#-----|  -> access to parameter c
-
-#   47| exit M2
-
-#   47| exit M2 (normal)
-#-----|  -> exit M2
-
-#   48| access to parameter c
-#-----|  -> a
-
-#   48| ... is ...
-#-----|  -> exit M2 (normal)
-
-#   48| not ...
-#-----|  -> ... is ...
-
-#   48| a
-#-----|  -> not ...
-
-#   50| enter M3
-#-----|  -> access to parameter c
-
-#   50| exit M3
-
-#   50| exit M3 (normal)
-#-----|  -> exit M3
-
-#   51| access to parameter c
-#-----|  -> null
-
-#   51| [false] ... is ...
-#-----| false -> access to parameter c
-
-#   51| [true] ... is ...
-#-----| true -> access to parameter c
-
-#   51| ... ? ... : ...
-#-----|  -> exit M3 (normal)
-
-#   51| [match] not ...
-#-----| match -> [true] ... is ...
-
-#   51| [no-match] not ...
-#-----| no-match -> [false] ... is ...
-
-#   51| null
-#-----| match -> [no-match] not ...
-#-----| no-match -> [match] not ...
-
-#   51| access to parameter c
-#-----|  -> 1
-
-#   51| ... is ...
-#-----|  -> ... ? ... : ...
-
-#   51| 1
-#-----|  -> ... is ...
-
-#   51| access to parameter c
-#-----|  -> 2
-
-#   51| ... is ...
-#-----|  -> ... ? ... : ...
-
-#   51| 2
-#-----|  -> ... is ...
-
-#   53| enter M4
-#-----|  -> access to parameter c
-
-#   53| exit M4
-
-#   53| exit M4 (normal)
-#-----|  -> exit M4
-
-#   54| access to parameter c
-#-----|  -> Patterns u
-
-#   54| ... is ...
-#-----|  -> exit M4 (normal)
-
-#   54| not ...
-#-----|  -> ... is ...
-
-#   54| Patterns u
-#-----| no-match -> { ... }
-#-----| match -> 1
-
-#   54| { ... }
-#-----|  -> not ...
-
-#   54| [match] { ... }
-#-----| match -> { ... }
-
-#   54| [no-match] { ... }
-#-----| no-match -> { ... }
-
-#   54| 1
-#-----| match -> [match] { ... }
-#-----| no-match -> [no-match] { ... }
-
-#   56| enter M5
-#-----|  -> {...}
-
-#   56| exit M5
-
-#   56| exit M5 (normal)
-#-----|  -> exit M5
-
-#   57| {...}
-#-----|  -> access to parameter i
-
-#   58| return ...;
-#-----| return -> exit M5 (normal)
-
-#   58| access to parameter i
-#-----|  -> 1
-
-#   58| ... switch { ... }
-#-----|  -> return ...;
-
-#   60| [match] not ...
-#-----| match -> "not 1"
-
-#   60| [no-match] not ...
-#-----| no-match -> _
-
-#   60| ... => ...
-#-----|  -> ... switch { ... }
-
-#   60| 1
-#-----| match -> [no-match] not ...
-#-----| no-match -> [match] not ...
-
-#   60| "not 1"
-#-----|  -> ... => ...
-
-#   61| _
-#-----| match -> "other"
-
-#   61| ... => ...
-#-----|  -> ... switch { ... }
-
-#   61| "other"
-#-----|  -> ... => ...
-
-#   65| enter M6
-#-----|  -> {...}
-
-#   65| exit M6
-
-#   65| exit M6 (normal)
-#-----|  -> exit M6
-
-#   66| {...}
-#-----|  -> 2
-
-#   67| return ...;
-#-----| return -> exit M6 (normal)
-
-#   67| 2
-#-----|  -> 2
-
-#   67| ... switch { ... }
-#-----|  -> return ...;
-
-#   69| [no-match] not ...
-#-----| no-match -> 2
-
-#   69| 2
-#-----| match -> [no-match] not ...
-
-#   70| 2
-#-----| match -> "possible"
-
-#   70| ... => ...
-#-----|  -> ... switch { ... }
-
-#   70| "possible"
-#-----|  -> ... => ...
-
-#   74| enter M7
-#-----|  -> {...}
-
-#   74| exit M7
-
-#   74| exit M7 (normal)
-#-----|  -> exit M7
-
-#   75| {...}
-#-----|  -> access to parameter i
-
-#   76| return ...;
-#-----| return -> exit M7 (normal)
-
-#   76| access to parameter i
-#-----|  -> 1
-
-#   76| ... switch { ... }
-#-----|  -> return ...;
-
-#   78| > ...
-#-----| match -> "> 1"
-#-----| no-match -> 0
-
-#   78| ... => ...
-#-----|  -> ... switch { ... }
-
-#   78| 1
-#-----|  -> > ...
-
-#   78| "> 1"
-#-----|  -> ... => ...
-
-#   79| < ...
-#-----| match -> "< 0"
-#-----| no-match -> 1
-
-#   79| ... => ...
-#-----|  -> ... switch { ... }
-
-#   79| 0
-#-----|  -> < ...
-
-#   79| "< 0"
-#-----|  -> ... => ...
-
-#   80| 1
-#-----| match -> "1"
-#-----| no-match -> _
-
-#   80| ... => ...
-#-----|  -> ... switch { ... }
-
-#   80| "1"
-#-----|  -> ... => ...
-
-#   81| _
-#-----| match -> "0"
-
-#   81| ... => ...
-#-----|  -> ... switch { ... }
-
-#   81| "0"
-#-----|  -> ... => ...
-
-#   85| enter M8
-#-----|  -> access to parameter i
-
-#   85| exit M8
-
-#   85| exit M8 (normal)
-#-----|  -> exit M8
-
-#   85| access to parameter i
-#-----|  -> 1
-
-#   85| [false] ... is ...
-#-----| false -> "2"
-
-#   85| [true] ... is ...
-#-----| true -> "not 2"
-
-#   85| ... ? ... : ...
-#-----|  -> exit M8 (normal)
-
-#   85| 1
-#-----| match -> [match] ... or ...
-#-----| no-match -> 2
-
-#   85| [match] ... or ...
-#-----| match -> [true] ... is ...
-
-#   85| [no-match] ... or ...
-#-----| no-match -> [false] ... is ...
-
-#   85| [match] not ...
-#-----| match -> [match] ... or ...
-
-#   85| [no-match] not ...
-#-----| no-match -> [no-match] ... or ...
-
-#   85| 2
-#-----| match -> [no-match] not ...
-#-----| no-match -> [match] not ...
-
-#   85| "not 2"
-#-----|  -> ... ? ... : ...
-
-#   85| "2"
-#-----|  -> ... ? ... : ...
-
-#   87| enter M9
-#-----|  -> access to parameter i
-
-#   87| exit M9
-
-#   87| exit M9 (normal)
-#-----|  -> exit M9
-
-#   87| access to parameter i
-#-----|  -> 1
-
-#   87| [false] ... is ...
-#-----| false -> "not 1"
-
-#   87| [true] ... is ...
-#-----| true -> "1"
-
-#   87| ... ? ... : ...
-#-----|  -> exit M9 (normal)
-
-#   87| 1
-#-----| no-match -> [no-match] ... and ...
-#-----| match -> 2
-
-#   87| [match] ... and ...
-#-----| match -> [true] ... is ...
-
-#   87| [no-match] ... and ...
-#-----| no-match -> [false] ... is ...
-
-#   87| [match] not ...
-#-----| match -> [match] ... and ...
-
-#   87| [no-match] not ...
-#-----| no-match -> [no-match] ... and ...
-
-#   87| 2
-#-----| match -> [no-match] not ...
-#-----| no-match -> [match] not ...
-
-#   87| "1"
-#-----|  -> ... ? ... : ...
-
-#   87| "not 1"
-#-----|  -> ... ? ... : ...
-
-#   93| enter M10
-#-----|  -> {...}
-
-#   93| exit M10
-
-#   93| exit M10 (normal)
-#-----|  -> exit M10
-
-#   94| {...}
-#-----|  -> if (...) ...
-
-#   95| if (...) ...
-#-----|  -> this access
-
-#   95| this access
-#-----|  -> access to constant A
-
-#   95| [false] ... is ...
-#-----| false -> exit M10 (normal)
-
-#   95| [true] ... is ...
-#-----| true -> {...}
-
-#   95| [match] { ... }
-#-----| match -> [true] ... is ...
-
-#   95| [match] { ... }
-#-----| match -> [match] { ... }
-
-#   95| [no-match] { ... }
-#-----| no-match -> [false] ... is ...
-
-#   95| [no-match] { ... }
-#-----| no-match -> [no-match] { ... }
-
-#   95| access to constant A
-#-----| match -> [match] ... or ...
-#-----| no-match -> access to constant B
-
-#   95| [match] ... or ...
-#-----| match -> [match] { ... }
-
-#   95| [no-match] ... or ...
-#-----| no-match -> [no-match] { ... }
-
-#   95| access to constant B
-#-----| match -> [match] ... or ...
-#-----| no-match -> [no-match] ... or ...
-
-#   96| {...}
-#-----|  -> ...;
-
-#   97| call to method WriteLine
-#-----|  -> exit M10 (normal)
-
-#   97| ...;
-#-----|  -> "not C"
-
-#   97| "not C"
-#-----|  -> call to method WriteLine
-
-PostDominance.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter PostDominance
-#-----|  -> call to constructor Object
-
-#    3| exit PostDominance
-
-#    3| exit PostDominance (normal)
-#-----|  -> exit PostDominance
-
-#    3| {...}
-#-----|  -> exit PostDominance (normal)
-
-#    5| enter M1
-#-----|  -> {...}
-
-#    5| exit M1
-
-#    5| exit M1 (normal)
-#-----|  -> exit M1
-
-#    6| {...}
-#-----|  -> ...;
-
-#    7| call to method WriteLine
-#-----|  -> exit M1 (normal)
-
-#    7| ...;
-#-----|  -> access to parameter s
-
-#    7| access to parameter s
-#-----|  -> call to method WriteLine
-
-#   10| enter M2
-#-----|  -> {...}
-
-#   10| exit M2
-
-#   10| exit M2 (normal)
-#-----|  -> exit M2
-
-#   11| {...}
-#-----|  -> if (...) ...
-
-#   12| if (...) ...
-#-----|  -> access to parameter s
-
-#   12| access to parameter s
-#-----|  -> null
-
-#   12| [false] ... is ...
-#-----| false -> ...;
-
-#   12| [true] ... is ...
-#-----| true -> return ...;
-
-#   12| null
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#   13| return ...;
-#-----| return -> exit M2 (normal)
-
-#   14| call to method WriteLine
-#-----|  -> exit M2 (normal)
-
-#   14| ...;
-#-----|  -> access to parameter s
-
-#   14| access to parameter s
-#-----|  -> call to method WriteLine
-
-#   17| enter M3
-#-----|  -> {...}
-
-#   17| exit M3
-
-#   17| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   17| exit M3 (normal)
-#-----|  -> exit M3
-
-#   18| {...}
-#-----|  -> if (...) ...
-
-#   19| if (...) ...
-#-----|  -> access to parameter s
-
-#   19| access to parameter s
-#-----|  -> null
-
-#   19| [false] ... is ...
-#-----| false -> ...;
-
-#   19| [true] ... is ...
-#-----| true -> nameof(...)
-
-#   19| null
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#   20| throw ...;
-#-----| exception(ArgumentNullException) -> exit M3 (abnormal)
-
-#   20| object creation of type ArgumentNullException
-#-----|  -> throw ...;
-
-#   20| nameof(...)
-#-----|  -> object creation of type ArgumentNullException
-
-#   21| call to method WriteLine
-#-----|  -> exit M3 (normal)
-
-#   21| ...;
-#-----|  -> access to parameter s
-
-#   21| access to parameter s
-#-----|  -> call to method WriteLine
-
-Qualifiers.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter Qualifiers
-#-----|  -> call to constructor Object
-
-#    1| exit Qualifiers
-
-#    1| exit Qualifiers (normal)
-#-----|  -> exit Qualifiers
-
-#    1| {...}
-#-----|  -> exit Qualifiers (normal)
-
-#    7| enter Method
-#-----|  -> null
-
-#    7| exit Method
-
-#    7| exit Method (normal)
-#-----|  -> exit Method
-
-#    7| null
-#-----|  -> exit Method (normal)
-
-#    8| enter StaticMethod
-#-----|  -> null
-
-#    8| exit StaticMethod
-
-#    8| exit StaticMethod (normal)
-#-----|  -> exit StaticMethod
-
-#    8| null
-#-----|  -> exit StaticMethod (normal)
-
-#   10| enter M
-#-----|  -> {...}
-
-#   10| exit M
-
-#   10| exit M (normal)
-#-----|  -> exit M
-
-#   11| {...}
-#-----|  -> ... ...;
-
-#   12| ... ...;
-#-----|  -> this access
-
-#   12| Qualifiers q = ...
-#-----|  -> ...;
-
-#   12| access to field Field
-#-----|  -> Qualifiers q = ...
-
-#   12| this access
-#-----|  -> access to field Field
-
-#   13| ... = ...
-#-----|  -> ...;
-
-#   13| ...;
-#-----|  -> this access
-
-#   13| access to property Property
-#-----|  -> ... = ...
-
-#   13| this access
-#-----|  -> access to property Property
-
-#   14| ... = ...
-#-----|  -> ...;
-
-#   14| ...;
-#-----|  -> this access
-
-#   14| call to method Method
-#-----|  -> ... = ...
-
-#   14| this access
-#-----|  -> call to method Method
-
-#   16| ... = ...
-#-----|  -> ...;
-
-#   16| ...;
-#-----|  -> this access
-
-#   16| this access
-#-----|  -> access to field Field
-
-#   16| access to field Field
-#-----|  -> ... = ...
-
-#   17| ... = ...
-#-----|  -> ...;
-
-#   17| ...;
-#-----|  -> this access
-
-#   17| this access
-#-----|  -> access to property Property
-
-#   17| access to property Property
-#-----|  -> ... = ...
-
-#   18| ... = ...
-#-----|  -> ...;
-
-#   18| ...;
-#-----|  -> this access
-
-#   18| this access
-#-----|  -> call to method Method
-
-#   18| call to method Method
-#-----|  -> ... = ...
-
-#   20| ... = ...
-#-----|  -> ...;
-
-#   20| ...;
-#-----|  -> access to field StaticField
-
-#   20| access to field StaticField
-#-----|  -> ... = ...
-
-#   21| ... = ...
-#-----|  -> ...;
-
-#   21| ...;
-#-----|  -> access to property StaticProperty
-
-#   21| access to property StaticProperty
-#-----|  -> ... = ...
-
-#   22| ... = ...
-#-----|  -> ...;
-
-#   22| ...;
-#-----|  -> call to method StaticMethod
-
-#   22| call to method StaticMethod
-#-----|  -> ... = ...
-
-#   24| ... = ...
-#-----|  -> ...;
-
-#   24| ...;
-#-----|  -> access to field StaticField
-
-#   24| access to field StaticField
-#-----|  -> ... = ...
-
-#   25| ... = ...
-#-----|  -> ...;
-
-#   25| ...;
-#-----|  -> access to property StaticProperty
-
-#   25| access to property StaticProperty
-#-----|  -> ... = ...
-
-#   26| ... = ...
-#-----|  -> ...;
-
-#   26| ...;
-#-----|  -> call to method StaticMethod
-
-#   26| call to method StaticMethod
-#-----|  -> ... = ...
-
-#   28| ... = ...
-#-----|  -> ...;
-
-#   28| ...;
-#-----|  -> access to field StaticField
-
-#   28| access to field StaticField
-#-----|  -> access to field Field
-
-#   28| access to field Field
-#-----|  -> ... = ...
-
-#   29| ... = ...
-#-----|  -> ...;
-
-#   29| ...;
-#-----|  -> access to property StaticProperty
-
-#   29| access to property StaticProperty
-#-----|  -> access to property Property
-
-#   29| access to property Property
-#-----|  -> ... = ...
-
-#   30| ... = ...
-#-----|  -> exit M (normal)
-
-#   30| ...;
-#-----|  -> call to method StaticMethod
-
-#   30| call to method StaticMethod
-#-----|  -> call to method Method
-
-#   30| call to method Method
-#-----|  -> ... = ...
-
-Switch.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter Switch
-#-----|  -> call to constructor Object
-
-#    3| exit Switch
-
-#    3| exit Switch (normal)
-#-----|  -> exit Switch
-
-#    3| {...}
-#-----|  -> exit Switch (normal)
-
-#    5| enter M1
-#-----|  -> {...}
-
-#    5| exit M1
-
-#    5| exit M1 (normal)
-#-----|  -> exit M1
-
-#    6| {...}
-#-----|  -> switch (...) {...}
-
-#    7| switch (...) {...}
-#-----|  -> access to parameter o
-
-#    7| access to parameter o
-#-----|  -> exit M1 (normal)
-
-#   10| enter M2
-#-----|  -> {...}
-
-#   10| exit M2
-
-#   10| exit M2 (abnormal)
-#-----|  -> exit M2
-
-#   10| exit M2 (normal)
-#-----|  -> exit M2
-
-#   11| {...}
-#-----|  -> switch (...) {...}
-
-#   12| switch (...) {...}
-#-----|  -> access to parameter o
-
-#   12| access to parameter o
-#-----|  -> case ...:
-
-#   14| case ...:
-#-----|  -> "a"
-
-#   14| "a"
-#-----| match -> return ...;
-#-----| no-match -> case ...:
-
-#   15| return ...;
-#-----| return -> exit M2 (normal)
-
-#   16| case ...:
-#-----|  -> 0
-
-#   16| 0
-#-----| match -> object creation of type Exception
-#-----| no-match -> case ...:
-
-#   17| throw ...;
-#-----| exception(Exception) -> exit M2 (abnormal)
-
-#   17| object creation of type Exception
-#-----|  -> throw ...;
-
-#   18| case ...:
-#-----|  -> null
-
-#   18| null
-#-----| match -> goto default;
-#-----| no-match -> case ...:
-
-#   19| goto default;
-#-----| goto(default) -> default:
-
-#   20| case ...:
-#-----|  -> Int32 i
-
-#   20| Int32 i
-#-----| match -> if (...) ...
-#-----| no-match -> case ...:
-
-#   21| if (...) ...
-#-----|  -> access to parameter o
-
-#   21| access to parameter o
-#-----|  -> null
-
-#   21| ... == ...
-#-----| true -> return ...;
-#-----| false -> 0
-
-#   21| null
-#-----|  -> ... == ...
-
-#   22| return ...;
-#-----| return -> exit M2 (normal)
-
-#   23| goto case ...;
-#-----| goto(0) -> case ...:
-
-#   23| 0
-#-----|  -> goto case ...;
-
-#   24| case ...:
-#-----|  -> String s
-
-#   24| String s
-#-----| match -> access to local variable s
-#-----| no-match -> case ...:
-
-#   24| access to local variable s
-#-----|  -> access to property Length
-
-#   24| access to property Length
-#-----|  -> 0
-
-#   24| ... > ...
-#-----| false -> [false] ... && ...
-#-----| true -> access to local variable s
-
-#   24| [false] ... && ...
-#-----| false -> case ...:
-
-#   24| [true] ... && ...
-#-----| true -> ...;
-
-#   24| 0
-#-----|  -> ... > ...
-
-#   24| access to local variable s
-#-----|  -> "a"
-
-#   24| ... != ...
-#-----| false -> [false] ... && ...
-#-----| true -> [true] ... && ...
-
-#   24| "a"
-#-----|  -> ... != ...
-
-#   25| call to method WriteLine
-#-----|  -> return ...;
-
-#   25| ...;
-#-----|  -> access to local variable s
-
-#   25| access to local variable s
-#-----|  -> call to method WriteLine
-
-#   26| return ...;
-#-----| return -> exit M2 (normal)
-
-#   27| case ...:
-#-----|  -> Double d
-
-#   27| Double d
-#-----| match -> call to method Throw
-#-----| no-match -> default:
-
-#   27| call to method Throw
-#-----| exception(Exception) -> exit M2 (abnormal)
-
-#   28| Label:
-#-----|  -> return ...;
-
-#   29| return ...;
-#-----| return -> exit M2 (normal)
-
-#   30| default:
-#-----|  -> goto ...;
-
-#   31| goto ...;
-#-----| goto(Label) -> Label:
-
-#   35| enter M3
-#-----|  -> {...}
-
-#   35| exit M3
-
-#   35| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   36| {...}
-#-----|  -> switch (...) {...}
-
-#   37| switch (...) {...}
-#-----|  -> call to method Throw
-
-#   37| call to method Throw
-#-----| exception(Exception) -> exit M3 (abnormal)
-
-#   44| enter M4
-#-----|  -> {...}
-
-#   44| exit M4
-
-#   44| exit M4 (normal)
-#-----|  -> exit M4
-
-#   45| {...}
-#-----|  -> switch (...) {...}
-
-#   46| switch (...) {...}
-#-----|  -> access to parameter o
-
-#   46| access to parameter o
-#-----|  -> case ...:
-
-#   48| case ...:
-#-----|  -> access to type Int32
-
-#   48| access to type Int32
-#-----| match -> break;
-#-----| no-match -> case ...:
-
-#   49| break;
-#-----| break -> exit M4 (normal)
-
-#   50| case ...:
-#-----|  -> access to type Boolean
-
-#   50| access to type Boolean
-#-----| no-match -> exit M4 (normal)
-#-----| match -> access to parameter o
-
-#   50| access to parameter o
-#-----|  -> null
-
-#   50| ... != ...
-#-----| false -> exit M4 (normal)
-#-----| true -> break;
-
-#   50| null
-#-----|  -> ... != ...
-
-#   51| break;
-#-----| break -> exit M4 (normal)
-
-#   55| enter M5
-#-----|  -> {...}
-
-#   55| exit M5
-
-#   55| exit M5 (normal)
-#-----|  -> exit M5
-
-#   56| {...}
-#-----|  -> switch (...) {...}
-
-#   57| switch (...) {...}
-#-----|  -> 1
-
-#   57| 1
-#-----|  -> 2
-
-#   57| ... + ...
-#-----|  -> case ...:
-
-#   57| 2
-#-----|  -> ... + ...
-
-#   59| case ...:
-#-----|  -> 2
-
-#   59| 2
-#-----| no-match -> case ...:
-
-#   61| case ...:
-#-----|  -> 3
-
-#   61| 3
-#-----| match -> break;
-
-#   62| break;
-#-----| break -> exit M5 (normal)
-
-#   66| enter M6
-#-----|  -> {...}
-
-#   66| exit M6
-
-#   66| exit M6 (normal)
-#-----|  -> exit M6
-
-#   67| {...}
-#-----|  -> switch (...) {...}
-
-#   68| switch (...) {...}
-#-----|  -> access to parameter s
-
-#   68| (...) ...
-#-----|  -> case ...:
-
-#   68| access to parameter s
-#-----|  -> (...) ...
-
-#   70| case ...:
-#-----|  -> access to type Int32
-
-#   70| access to type Int32
-#-----| no-match -> case ...:
-
-#   72| case ...:
-#-----|  -> ""
-
-#   72| ""
-#-----| no-match -> exit M6 (normal)
-#-----| match -> break;
-
-#   73| break;
-#-----| break -> exit M6 (normal)
-
-#   77| enter M7
-#-----|  -> {...}
-
-#   77| exit M7
-
-#   77| exit M7 (normal)
-#-----|  -> exit M7
-
-#   78| {...}
-#-----|  -> switch (...) {...}
-
-#   79| switch (...) {...}
-#-----|  -> access to parameter i
-
-#   79| access to parameter i
-#-----|  -> case ...:
-
-#   81| case ...:
-#-----|  -> 1
-
-#   81| 1
-#-----| match -> true
-#-----| no-match -> case ...:
-
-#   82| return ...;
-#-----| return -> exit M7 (normal)
-
-#   82| true
-#-----|  -> return ...;
-
-#   83| case ...:
-#-----|  -> 2
-
-#   83| 2
-#-----| match -> if (...) ...
-#-----| no-match -> false
-
-#   84| if (...) ...
-#-----|  -> access to parameter j
-
-#   84| access to parameter j
-#-----|  -> 2
-
-#   84| ... > ...
-#-----| true -> break;
-#-----| false -> true
-
-#   84| 2
-#-----|  -> ... > ...
-
-#   85| break;
-#-----| break -> false
-
-#   86| return ...;
-#-----| return -> exit M7 (normal)
-
-#   86| true
-#-----|  -> return ...;
-
-#   88| return ...;
-#-----| return -> exit M7 (normal)
-
-#   88| false
-#-----|  -> return ...;
-
-#   91| enter M8
-#-----|  -> {...}
-
-#   91| exit M8
-
-#   91| exit M8 (normal)
-#-----|  -> exit M8
-
-#   92| {...}
-#-----|  -> switch (...) {...}
-
-#   93| switch (...) {...}
-#-----|  -> access to parameter o
-
-#   93| access to parameter o
-#-----|  -> case ...:
-
-#   95| case ...:
-#-----|  -> access to type Int32
-
-#   95| access to type Int32
-#-----| match -> true
-#-----| no-match -> false
-
-#   96| return ...;
-#-----| return -> exit M8 (normal)
-
-#   96| true
-#-----|  -> return ...;
-
-#   98| return ...;
-#-----| return -> exit M8 (normal)
-
-#   98| false
-#-----|  -> return ...;
-
-#  101| enter M9
-#-----|  -> {...}
-
-#  101| exit M9
-
-#  101| exit M9 (normal)
-#-----|  -> exit M9
-
-#  102| {...}
-#-----|  -> switch (...) {...}
-
-#  103| switch (...) {...}
-#-----|  -> access to parameter s
-
-#  103| access to parameter s
-#-----| non-null -> access to property Length
-#-----| null -> case ...:
-
-#  103| access to property Length
-#-----|  -> case ...:
-
-#  105| case ...:
-#-----|  -> 0
-
-#  105| 0
-#-----| match -> 0
-#-----| no-match -> case ...:
-
-#  105| return ...;
-#-----| return -> exit M9 (normal)
-
-#  105| 0
-#-----|  -> return ...;
-
-#  106| case ...:
-#-----|  -> 1
-
-#  106| 1
-#-----| match -> 1
-#-----| no-match -> 1
-
-#  106| return ...;
-#-----| return -> exit M9 (normal)
-
-#  106| 1
-#-----|  -> return ...;
-
-#  108| return ...;
-#-----| return -> exit M9 (normal)
-
-#  108| -...
-#-----|  -> return ...;
-
-#  108| 1
-#-----|  -> -...
-
-#  111| enter Throw
-#-----|  -> object creation of type Exception
-
-#  111| exit Throw
-
-#  111| exit Throw (abnormal)
-#-----|  -> exit Throw
-
-#  111| throw ...
-#-----| exception(Exception) -> exit Throw (abnormal)
-
-#  111| object creation of type Exception
-#-----|  -> throw ...
-
-#  113| enter M10
-#-----|  -> {...}
-
-#  113| exit M10
-
-#  113| exit M10 (normal)
-#-----|  -> exit M10
-
-#  114| {...}
-#-----|  -> switch (...) {...}
-
-#  115| switch (...) {...}
-#-----|  -> access to parameter s
-
-#  115| access to parameter s
-#-----|  -> access to property Length
-
-#  115| access to property Length
-#-----|  -> case ...:
-
-#  117| case ...:
-#-----|  -> 3
-
-#  117| 3
-#-----| match -> access to parameter s
-#-----| no-match -> case ...:
-
-#  117| access to parameter s
-#-----|  -> "foo"
-
-#  117| ... == ...
-#-----| true -> 1
-#-----| false -> case ...:
-
-#  117| "foo"
-#-----|  -> ... == ...
-
-#  117| return ...;
-#-----| return -> exit M10 (normal)
-
-#  117| 1
-#-----|  -> return ...;
-
-#  118| case ...:
-#-----|  -> 2
-
-#  118| 2
-#-----| match -> access to parameter s
-#-----| no-match -> 1
-
-#  118| access to parameter s
-#-----|  -> "fu"
-
-#  118| ... == ...
-#-----| true -> 2
-#-----| false -> 1
-
-#  118| "fu"
-#-----|  -> ... == ...
-
-#  118| return ...;
-#-----| return -> exit M10 (normal)
-
-#  118| 2
-#-----|  -> return ...;
-
-#  120| return ...;
-#-----| return -> exit M10 (normal)
-
-#  120| -...
-#-----|  -> return ...;
-
-#  120| 1
-#-----|  -> -...
-
-#  123| enter M11
-#-----|  -> {...}
-
-#  123| exit M11
-
-#  123| exit M11 (normal)
-#-----|  -> exit M11
-
-#  124| {...}
-#-----|  -> if (...) ...
-
-#  125| if (...) ...
-#-----|  -> access to parameter o
-
-#  125| access to parameter o
-#-----|  -> Boolean b
-
-#  125| [false] ... switch { ... }
-#-----| false -> exit M11 (normal)
-
-#  125| [true] ... switch { ... }
-#-----| true -> return ...;
-
-#  125| Boolean b
-#-----| match -> access to local variable b
-#-----| no-match -> _
-
-#  125| [false] ... => ...
-#-----| false -> [false] ... switch { ... }
-
-#  125| [true] ... => ...
-#-----| true -> [true] ... switch { ... }
-
-#  125| access to local variable b
-#-----| false -> [false] ... => ...
-#-----| true -> [true] ... => ...
-
-#  125| _
-#-----| match -> false
-
-#  125| [false] ... => ...
-#-----| false -> [false] ... switch { ... }
-
-#  125| false
-#-----| false -> [false] ... => ...
-
-#  126| return ...;
-#-----| return -> exit M11 (normal)
-
-#  129| enter M12
-#-----|  -> {...}
-
-#  129| exit M12
-
-#  129| exit M12 (normal)
-#-----|  -> exit M12
-
-#  130| {...}
-#-----|  -> access to parameter o
-
-#  131| return ...;
-#-----| return -> exit M12 (normal)
-
-#  131| call to method ToString
-#-----|  -> return ...;
-
-#  131| access to parameter o
-#-----|  -> String s
-
-#  131| [non-null] ... switch { ... }
-#-----| non-null -> call to method ToString
-
-#  131| [null] ... switch { ... }
-#-----| null -> return ...;
-
-#  131| String s
-#-----| match -> access to local variable s
-#-----| no-match -> _
-
-#  131| [non-null] ... => ...
-#-----| non-null -> [non-null] ... switch { ... }
-
-#  131| [null] ... => ...
-#-----| null -> [null] ... switch { ... }
-
-#  131| access to local variable s
-#-----| non-null -> [non-null] ... => ...
-#-----| null -> [null] ... => ...
-
-#  131| _
-#-----| match -> null
-
-#  131| [null] ... => ...
-#-----| null -> [null] ... switch { ... }
-
-#  131| null
-#-----| null -> [null] ... => ...
-
-#  134| enter M13
-#-----|  -> {...}
-
-#  134| exit M13
-
-#  134| exit M13 (normal)
-#-----|  -> exit M13
-
-#  135| {...}
-#-----|  -> switch (...) {...}
-
-#  136| switch (...) {...}
-#-----|  -> access to parameter i
-
-#  136| access to parameter i
-#-----|  -> case ...:
-
-#  138| default:
-#-----|  -> 1
-
-#  138| return ...;
-#-----| return -> exit M13 (normal)
-
-#  138| -...
-#-----|  -> return ...;
-
-#  138| 1
-#-----|  -> -...
-
-#  139| case ...:
-#-----|  -> 1
-
-#  139| 1
-#-----| match -> 1
-#-----| no-match -> case ...:
-
-#  139| return ...;
-#-----| return -> exit M13 (normal)
-
-#  139| 1
-#-----|  -> return ...;
-
-#  140| case ...:
-#-----|  -> 2
-
-#  140| 2
-#-----| no-match -> default:
-#-----| match -> 2
-
-#  140| return ...;
-#-----| return -> exit M13 (normal)
-
-#  140| 2
-#-----|  -> return ...;
-
-#  144| enter M14
-#-----|  -> {...}
-
-#  144| exit M14
-
-#  144| exit M14 (normal)
-#-----|  -> exit M14
-
-#  145| {...}
-#-----|  -> switch (...) {...}
-
-#  146| switch (...) {...}
-#-----|  -> access to parameter i
-
-#  146| access to parameter i
-#-----|  -> case ...:
-
-#  148| case ...:
-#-----|  -> 1
-
-#  148| 1
-#-----| match -> 1
-#-----| no-match -> case ...:
-
-#  148| return ...;
-#-----| return -> exit M14 (normal)
-
-#  148| 1
-#-----|  -> return ...;
-
-#  149| default:
-#-----|  -> 1
-
-#  149| return ...;
-#-----| return -> exit M14 (normal)
-
-#  149| -...
-#-----|  -> return ...;
-
-#  149| 1
-#-----|  -> -...
-
-#  150| case ...:
-#-----|  -> 2
-
-#  150| 2
-#-----| no-match -> default:
-#-----| match -> 2
-
-#  150| return ...;
-#-----| return -> exit M14 (normal)
-
-#  150| 2
-#-----|  -> return ...;
-
-#  154| enter M15
-#-----|  -> {...}
-
-#  154| exit M15
-
-#  154| exit M15 (abnormal)
-#-----|  -> exit M15
-
-#  154| exit M15 (normal)
-#-----|  -> exit M15
-
-#  155| {...}
-#-----|  -> ... ...;
-
-#  156| ... ...;
-#-----|  -> access to parameter b
-
-#  156| String s = ...
-#-----|  -> if (...) ...
-
-#  156| access to parameter b
-#-----|  -> true
-
-#  156| ... switch { ... }
-#-----|  -> String s = ...
-
-#  156| true
-#-----| match -> "a"
-#-----| no-match -> false
-
-#  156| ... => ...
-#-----|  -> ... switch { ... }
-
-#  156| "a"
-#-----|  -> ... => ...
-
-#  156| false
-#-----| exception(InvalidOperationException) -> exit M15 (abnormal)
-#-----| match -> "b"
-
-#  156| ... => ...
-#-----|  -> ... switch { ... }
-
-#  156| "b"
-#-----|  -> ... => ...
-
-#  157| if (...) ...
-#-----|  -> access to parameter b
-
-#  157| access to parameter b
-#-----| true -> ...;
-#-----| false -> ...;
-
-#  158| call to method WriteLine
-#-----|  -> exit M15 (normal)
-
-#  158| ...;
-#-----|  -> "a = "
-
-#  158| $"..."
-#-----|  -> call to method WriteLine
-
-#  158| "a = "
-#-----|  -> access to local variable s
-
-#  158| access to local variable s
-#-----|  -> $"..."
-
-#  160| call to method WriteLine
-#-----|  -> exit M15 (normal)
-
-#  160| ...;
-#-----|  -> "b = "
-
-#  160| $"..."
-#-----|  -> call to method WriteLine
-
-#  160| "b = "
-#-----|  -> access to local variable s
-
-#  160| access to local variable s
-#-----|  -> $"..."
-
-TypeAccesses.cs:
-#    1| call to constructor Object
-#-----|  -> {...}
-
-#    1| enter TypeAccesses
-#-----|  -> call to constructor Object
-
-#    1| exit TypeAccesses
-
-#    1| exit TypeAccesses (normal)
-#-----|  -> exit TypeAccesses
-
-#    1| {...}
-#-----|  -> exit TypeAccesses (normal)
-
-#    3| enter M
-#-----|  -> {...}
-
-#    3| exit M
-
-#    3| exit M (normal)
-#-----|  -> exit M
-
-#    4| {...}
-#-----|  -> ... ...;
-
-#    5| ... ...;
-#-----|  -> access to parameter o
-
-#    5| String s = ...
-#-----|  -> ...;
-
-#    5| (...) ...
-#-----|  -> String s = ...
-
-#    5| access to parameter o
-#-----|  -> (...) ...
-
-#    6| ... = ...
-#-----|  -> if (...) ...
-
-#    6| ...;
-#-----|  -> access to parameter o
-
-#    6| access to parameter o
-#-----|  -> ... as ...
-
-#    6| ... as ...
-#-----|  -> ... = ...
-
-#    7| if (...) ...
-#-----|  -> access to parameter o
-
-#    7| access to parameter o
-#-----|  -> Int32 j
-
-#    7| [false] ... is ...
-#-----| false -> ... ...;
-
-#    7| [true] ... is ...
-#-----| true -> ;
-
-#    7| Int32 j
-#-----| match -> [true] ... is ...
-#-----| no-match -> [false] ... is ...
-
-#    7| ;
-#-----|  -> ... ...;
-
-#    8| ... ...;
-#-----|  -> typeof(...)
-
-#    8| Type t = ...
-#-----|  -> exit M (normal)
-
-#    8| typeof(...)
-#-----|  -> Type t = ...
-
-VarDecls.cs:
-#    3| call to constructor Object
-#-----|  -> {...}
-
-#    3| enter VarDecls
-#-----|  -> call to constructor Object
-
-#    3| exit VarDecls
-
-#    3| exit VarDecls (normal)
-#-----|  -> exit VarDecls
-
-#    3| {...}
-#-----|  -> exit VarDecls (normal)
-
-#    5| enter M1
-#-----|  -> {...}
-
-#    5| exit M1
-
-#    5| exit M1 (normal)
-#-----|  -> exit M1
-
-#    6| {...}
-#-----|  -> fixed(...) { ... }
-
-#    7| fixed(...) { ... }
-#-----|  -> access to parameter strings
-
-#    7| Char* c1 = ...
-#-----|  -> access to parameter strings
-
-#    7| access to parameter strings
-#-----|  -> 0
-
-#    7| (...) ...
-#-----|  -> Char* c1 = ...
-
-#    7| access to array element
-#-----|  -> (...) ...
-
-#    7| 0
-#-----|  -> access to array element
-
-#    7| Char* c2 = ...
-#-----|  -> {...}
-
-#    7| access to parameter strings
-#-----|  -> 1
-
-#    7| (...) ...
-#-----|  -> Char* c2 = ...
-
-#    7| access to array element
-#-----|  -> (...) ...
-
-#    7| 1
-#-----|  -> access to array element
-
-#    8| {...}
-#-----|  -> access to local variable c1
-
-#    9| return ...;
-#-----| return -> exit M1 (normal)
-
-#    9| (...) ...
-#-----|  -> return ...;
-
-#    9| access to local variable c1
-#-----|  -> (...) ...
-
-#   13| enter M2
-#-----|  -> {...}
-
-#   13| exit M2
-
-#   13| exit M2 (normal)
-#-----|  -> exit M2
-
-#   14| {...}
-#-----|  -> ... ...;
-
-#   15| ... ...;
-#-----|  -> access to parameter s
-
-#   15| String s1 = ...
-#-----|  -> access to parameter s
-
-#   15| access to parameter s
-#-----|  -> String s1 = ...
-
-#   15| String s2 = ...
-#-----|  -> access to local variable s1
-
-#   15| access to parameter s
-#-----|  -> String s2 = ...
-
-#   16| return ...;
-#-----| return -> exit M2 (normal)
-
-#   16| access to local variable s1
-#-----|  -> access to local variable s2
-
-#   16| ... + ...
-#-----|  -> return ...;
-
-#   16| access to local variable s2
-#-----|  -> ... + ...
-
-#   19| enter M3
-#-----|  -> {...}
-
-#   19| exit M3
-
-#   19| exit M3 (normal)
-#-----|  -> exit M3
-
-#   20| {...}
-#-----|  -> using (...) {...}
-
-#   21| using (...) {...}
-#-----|  -> object creation of type C
-
-#   21| object creation of type C
-#-----|  -> ;
-
-#   22| ;
-#-----|  -> using (...) {...}
-
-#   24| using (...) {...}
-#-----|  -> object creation of type C
-
-#   24| C x = ...
-#-----|  -> object creation of type C
-
-#   24| object creation of type C
-#-----|  -> C x = ...
-
-#   24| C y = ...
-#-----|  -> access to parameter b
-
-#   24| object creation of type C
-#-----|  -> C y = ...
-
-#   25| return ...;
-#-----| return -> exit M3 (normal)
-
-#   25| access to parameter b
-#-----| true -> access to local variable x
-#-----| false -> access to local variable y
-
-#   25| ... ? ... : ...
-#-----|  -> return ...;
-
-#   25| access to local variable x
-#-----|  -> ... ? ... : ...
-
-#   25| access to local variable y
-#-----|  -> ... ? ... : ...
-
-#   28| call to constructor Object
-#-----|  -> {...}
-
-#   28| enter C
-#-----|  -> call to constructor Object
-
-#   28| exit C
-
-#   28| exit C (normal)
-#-----|  -> exit C
-
-#   28| {...}
-#-----|  -> exit C (normal)
-
-#   28| enter Dispose
-#-----|  -> {...}
-
-#   28| exit Dispose
-
-#   28| exit Dispose (normal)
-#-----|  -> exit Dispose
-
-#   28| {...}
-#-----|  -> exit Dispose (normal)
-
-cflow.cs:
-#    5| enter Main
-#-----|  -> {...}
-
-#    5| exit Main
-
-#    5| exit Main (normal)
-#-----|  -> exit Main
-
-#    6| {...}
-#-----|  -> ... ...;
-
-#    7| ... ...;
-#-----|  -> access to parameter args
-
-#    7| Int32 a = ...
-#-----|  -> ...;
-
-#    7| access to parameter args
-#-----|  -> access to property Length
-
-#    7| access to property Length
-#-----|  -> Int32 a = ...
-
-#    9| ... = ...
-#-----|  -> if (...) ...
-
-#    9| ...;
-#-----|  -> object creation of type ControlFlow
-
-#    9| object creation of type ControlFlow
-#-----|  -> access to local variable a
-
-#    9| call to method Switch
-#-----|  -> ... = ...
-
-#    9| access to local variable a
-#-----|  -> call to method Switch
-
-#   11| if (...) ...
-#-----|  -> access to local variable a
-
-#   11| access to local variable a
-#-----|  -> 3
-
-#   11| ... > ...
-#-----| true -> ...;
-#-----| false -> while (...) ...
-
-#   11| 3
-#-----|  -> ... > ...
-
-#   12| call to method WriteLine
-#-----|  -> while (...) ...
-
-#   12| ...;
-#-----|  -> "more than a few"
-
-#   12| "more than a few"
-#-----|  -> call to method WriteLine
-
-#   14| while (...) ...
-#-----|  -> access to local variable a
-
-#   14| access to local variable a
-#-----|  -> 0
-
-#   14| ... > ...
-#-----| true -> {...}
-#-----| false -> do ... while (...);
-
-#   14| 0
-#-----|  -> ... > ...
-
-#   15| {...}
-#-----|  -> ...;
-
-#   16| call to method WriteLine
-#-----|  -> access to local variable a
-
-#   16| ...;
-#-----|  -> access to local variable a
-
-#   16| access to local variable a
-#-----|  -> ...--
-
-#   16| ...--
-#-----|  -> 100
-
-#   16| ... * ...
-#-----|  -> call to method WriteLine
-
-#   16| 100
-#-----|  -> ... * ...
-
-#   19| do ... while (...);
-#-----|  -> {...}
-
-#   20| {...}
-#-----|  -> ...;
-
-#   21| call to method WriteLine
-#-----|  -> access to local variable a
-
-#   21| ...;
-#-----|  -> access to local variable a
-
-#   21| -...
-#-----|  -> call to method WriteLine
-
-#   21| access to local variable a
-#-----|  -> ...++
-
-#   21| ...++
-#-----|  -> -...
-
-#   22| access to local variable a
-#-----|  -> 10
-
-#   22| ... < ...
-#-----| true -> {...}
-#-----| false -> for (...;...;...) ...
-
-#   22| 10
-#-----|  -> ... < ...
-
-#   24| for (...;...;...) ...
-#-----|  -> 1
-
-#   24| Int32 i = ...
-#-----|  -> access to local variable i
-
-#   24| 1
-#-----|  -> Int32 i = ...
-
-#   24| access to local variable i
-#-----|  -> 20
-
-#   24| ... <= ...
-#-----| false -> exit Main (normal)
-#-----| true -> {...}
-
-#   24| 20
-#-----|  -> ... <= ...
-
-#   24| access to local variable i
-#-----|  -> ...++
-
-#   24| ...++
-#-----|  -> access to local variable i
-
-#   25| {...}
-#-----|  -> if (...) ...
-
-#   26| if (...) ...
-#-----|  -> access to local variable i
-
-#   26| access to local variable i
-#-----|  -> 3
-
-#   26| ... % ...
-#-----|  -> 0
-
-#   26| ... == ...
-#-----| false -> [false] ... && ...
-#-----| true -> access to local variable i
-
-#   26| [false] ... && ...
-#-----| false -> if (...) ...
-
-#   26| [true] ... && ...
-#-----| true -> ...;
-
-#   26| 3
-#-----|  -> ... % ...
-
-#   26| 0
-#-----|  -> ... == ...
-
-#   26| access to local variable i
-#-----|  -> 5
-
-#   26| ... % ...
-#-----|  -> 0
-
-#   26| ... == ...
-#-----| false -> [false] ... && ...
-#-----| true -> [true] ... && ...
-
-#   26| 5
-#-----|  -> ... % ...
-
-#   26| 0
-#-----|  -> ... == ...
-
-#   27| call to method WriteLine
-#-----|  -> access to local variable i
-
-#   27| ...;
-#-----|  -> "FizzBuzz"
-
-#   27| "FizzBuzz"
-#-----|  -> call to method WriteLine
-
-#   28| if (...) ...
-#-----|  -> access to local variable i
-
-#   28| access to local variable i
-#-----|  -> 3
-
-#   28| ... % ...
-#-----|  -> 0
-
-#   28| ... == ...
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   28| 3
-#-----|  -> ... % ...
-
-#   28| 0
-#-----|  -> ... == ...
-
-#   29| call to method WriteLine
-#-----|  -> access to local variable i
-
-#   29| ...;
-#-----|  -> "Fizz"
-
-#   29| "Fizz"
-#-----|  -> call to method WriteLine
-
-#   30| if (...) ...
-#-----|  -> access to local variable i
-
-#   30| access to local variable i
-#-----|  -> 5
-
-#   30| ... % ...
-#-----|  -> 0
-
-#   30| ... == ...
-#-----| true -> ...;
-#-----| false -> ...;
-
-#   30| 5
-#-----|  -> ... % ...
-
-#   30| 0
-#-----|  -> ... == ...
-
-#   31| call to method WriteLine
-#-----|  -> access to local variable i
-
-#   31| ...;
-#-----|  -> "Buzz"
-
-#   31| "Buzz"
-#-----|  -> call to method WriteLine
-
-#   33| call to method WriteLine
-#-----|  -> access to local variable i
-
-#   33| ...;
-#-----|  -> access to local variable i
-
-#   33| access to local variable i
-#-----|  -> call to method WriteLine
-
-#   37| enter Switch
-#-----|  -> {...}
-
-#   37| exit Switch
-
-#   37| exit Switch (abnormal)
-#-----|  -> exit Switch
-
-#   37| exit Switch (normal)
-#-----|  -> exit Switch
-
-#   38| {...}
-#-----|  -> switch (...) {...}
-
-#   39| switch (...) {...}
-#-----|  -> access to parameter a
-
-#   39| access to parameter a
-#-----|  -> case ...:
-
-#   41| case ...:
-#-----|  -> 1
-
-#   41| 1
-#-----| match -> ...;
-#-----| no-match -> case ...:
-
-#   42| call to method WriteLine
-#-----|  -> 2
-
-#   42| ...;
-#-----|  -> "1"
-
-#   42| "1"
-#-----|  -> call to method WriteLine
-
-#   43| goto case ...;
-#-----| goto(2) -> case ...:
-
-#   43| 2
-#-----|  -> goto case ...;
-
-#   44| case ...:
-#-----|  -> 2
-
-#   44| 2
-#-----| match -> ...;
-#-----| no-match -> case ...:
-
-#   45| call to method WriteLine
-#-----|  -> 1
-
-#   45| ...;
-#-----|  -> "2"
-
-#   45| "2"
-#-----|  -> call to method WriteLine
-
-#   46| goto case ...;
-#-----| goto(1) -> case ...:
-
-#   46| 1
-#-----|  -> goto case ...;
-
-#   47| case ...:
-#-----|  -> 3
-
-#   47| 3
-#-----| match -> ...;
-#-----| no-match -> switch (...) {...}
-
-#   48| call to method WriteLine
-#-----|  -> break;
-
-#   48| ...;
-#-----|  -> "3"
-
-#   48| "3"
-#-----|  -> call to method WriteLine
-
-#   49| break;
-#-----| break -> switch (...) {...}
-
-#   51| switch (...) {...}
-#-----|  -> access to parameter a
-
-#   51| access to parameter a
-#-----|  -> case ...:
-
-#   53| case ...:
-#-----|  -> 42
-
-#   53| 42
-#-----| match -> ...;
-#-----| no-match -> default:
-
-#   54| call to method WriteLine
-#-----|  -> break;
-
-#   54| ...;
-#-----|  -> "The answer"
-
-#   54| "The answer"
-#-----|  -> call to method WriteLine
-
-#   55| break;
-#-----| break -> switch (...) {...}
-
-#   56| default:
-#-----|  -> ...;
-
-#   57| call to method WriteLine
-#-----|  -> break;
-
-#   57| ...;
-#-----|  -> "Not the answer"
-
-#   57| "Not the answer"
-#-----|  -> call to method WriteLine
-
-#   58| break;
-#-----| break -> switch (...) {...}
-
-#   60| switch (...) {...}
-#-----|  -> this access
-
-#   60| call to method Parse
-#-----|  -> case ...:
-
-#   60| access to field Field
-#-----|  -> call to method Parse
-
-#   60| this access
-#-----|  -> access to field Field
-
-#   62| case ...:
-#-----|  -> 0
-
-#   62| 0
-#-----| match -> if (...) ...
-#-----| no-match -> access to parameter a
-
-#   63| if (...) ...
-#-----|  -> this access
-
-#   63| [false] !...
-#-----| false -> break;
-
-#   63| [true] !...
-#-----| true -> object creation of type NullReferenceException
-
-#   63| access to field Field
-#-----|  -> ""
-
-#   63| this access
-#-----|  -> access to field Field
-
-#   63| ... == ...
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#   63| ""
-#-----|  -> ... == ...
-
-#   64| throw ...;
-#-----| exception(NullReferenceException) -> exit Switch (abnormal)
-
-#   64| object creation of type NullReferenceException
-#-----|  -> throw ...;
-
-#   65| break;
-#-----| break -> access to parameter a
-
-#   67| return ...;
-#-----| return -> exit Switch (normal)
-
-#   67| access to parameter a
-#-----|  -> return ...;
-
-#   70| enter M
-#-----|  -> {...}
-
-#   70| exit M
-
-#   70| exit M (normal)
-#-----|  -> exit M
-
-#   71| {...}
-#-----|  -> if (...) ...
-
-#   72| if (...) ...
-#-----|  -> access to parameter s
-
-#   72| access to parameter s
-#-----|  -> null
-
-#   72| ... == ...
-#-----| true -> return ...;
-#-----| false -> if (...) ...
-
-#   72| null
-#-----|  -> ... == ...
-
-#   73| return ...;
-#-----| return -> exit M (normal)
-
-#   74| if (...) ...
-#-----|  -> access to parameter s
-
-#   74| access to parameter s
-#-----|  -> access to property Length
-
-#   74| access to property Length
-#-----|  -> 0
-
-#   74| ... > ...
-#-----| true -> {...}
-#-----| false -> {...}
-
-#   74| 0
-#-----|  -> ... > ...
-
-#   75| {...}
-#-----|  -> ...;
-
-#   76| call to method WriteLine
-#-----|  -> exit M (normal)
-
-#   76| ...;
-#-----|  -> access to parameter s
-
-#   76| access to parameter s
-#-----|  -> call to method WriteLine
-
-#   79| {...}
-#-----|  -> ...;
-
-#   80| call to method WriteLine
-#-----|  -> exit M (normal)
-
-#   80| ...;
-#-----|  -> "<empty string>"
-
-#   80| "<empty string>"
-#-----|  -> call to method WriteLine
-
-#   84| enter M2
-#-----|  -> {...}
-
-#   84| exit M2
-
-#   84| exit M2 (normal)
-#-----|  -> exit M2
-
-#   85| {...}
-#-----|  -> if (...) ...
-
-#   86| if (...) ...
-#-----|  -> access to parameter s
-
-#   86| access to parameter s
-#-----|  -> null
-
-#   86| ... != ...
-#-----| false -> [false] ... && ...
-#-----| true -> access to parameter s
-
-#   86| [false] ... && ...
-#-----| false -> exit M2 (normal)
-
-#   86| [true] ... && ...
-#-----| true -> ...;
-
-#   86| null
-#-----|  -> ... != ...
-
-#   86| access to parameter s
-#-----|  -> access to property Length
-
-#   86| access to property Length
-#-----|  -> 0
-
-#   86| ... > ...
-#-----| false -> [false] ... && ...
-#-----| true -> [true] ... && ...
-
-#   86| 0
-#-----|  -> ... > ...
-
-#   87| call to method WriteLine
-#-----|  -> exit M2 (normal)
-
-#   87| ...;
-#-----|  -> access to parameter s
-
-#   87| access to parameter s
-#-----|  -> call to method WriteLine
-
-#   90| enter M3
-#-----|  -> {...}
-
-#   90| exit M3
-
-#   90| exit M3 (abnormal)
-#-----|  -> exit M3
-
-#   90| exit M3 (normal)
-#-----|  -> exit M3
-
-#   91| {...}
-#-----|  -> if (...) ...
-
-#   92| if (...) ...
-#-----|  -> access to parameter s
-
-#   92| call to method Equals
-#-----| true -> "s"
-#-----| false -> ...;
-
-#   92| access to parameter s
-#-----|  -> null
-
-#   92| null
-#-----|  -> call to method Equals
-
-#   93| throw ...;
-#-----| exception(ArgumentNullException) -> exit M3 (abnormal)
-
-#   93| object creation of type ArgumentNullException
-#-----|  -> throw ...;
-
-#   93| "s"
-#-----|  -> object creation of type ArgumentNullException
-
-#   94| call to method WriteLine
-#-----|  -> if (...) ...
-
-#   94| ...;
-#-----|  -> access to parameter s
-
-#   94| access to parameter s
-#-----|  -> call to method WriteLine
-
-#   96| if (...) ...
-#-----|  -> this access
-
-#   96| access to field Field
-#-----|  -> null
-
-#   96| this access
-#-----|  -> access to field Field
-
-#   96| ... != ...
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   96| null
-#-----|  -> ... != ...
-
-#   97| call to method WriteLine
-#-----|  -> if (...) ...
-
-#   97| ...;
-#-----|  -> object creation of type ControlFlow
-
-#   97| object creation of type ControlFlow
-#-----|  -> access to field Field
-
-#   97| access to field Field
-#-----|  -> call to method WriteLine
-
-#   99| if (...) ...
-#-----|  -> this access
-
-#   99| access to field Field
-#-----|  -> null
-
-#   99| this access
-#-----|  -> access to field Field
-
-#   99| ... != ...
-#-----| true -> ...;
-#-----| false -> if (...) ...
-
-#   99| null
-#-----|  -> ... != ...
-
-#  100| call to method WriteLine
-#-----|  -> if (...) ...
-
-#  100| ...;
-#-----|  -> this access
-
-#  100| this access
-#-----|  -> access to field Field
-
-#  100| access to field Field
-#-----|  -> call to method WriteLine
-
-#  102| if (...) ...
-#-----|  -> this access
-
-#  102| this access
-#-----|  -> access to property Prop
-
-#  102| access to property Prop
-#-----|  -> null
-
-#  102| ... != ...
-#-----| false -> exit M3 (normal)
-#-----| true -> ...;
-
-#  102| null
-#-----|  -> ... != ...
-
-#  103| call to method WriteLine
-#-----|  -> exit M3 (normal)
-
-#  103| ...;
-#-----|  -> this access
-
-#  103| access to property Prop
-#-----|  -> call to method WriteLine
-
-#  103| this access
-#-----|  -> access to property Prop
-
-#  106| enter M4
-#-----|  -> {...}
-
-#  106| exit M4
-
-#  106| exit M4 (normal)
-#-----|  -> exit M4
-
-#  107| {...}
-#-----|  -> if (...) ...
-
-#  108| if (...) ...
-#-----|  -> access to parameter s
-
-#  108| access to parameter s
-#-----|  -> null
-
-#  108| ... != ...
-#-----| true -> {...}
-#-----| false -> ...;
-
-#  108| null
-#-----|  -> ... != ...
-
-#  109| {...}
-#-----|  -> while (...) ...
-
-#  110| while (...) ...
-#-----|  -> true
-
-#  110| true
-#-----| true -> {...}
-
-#  111| {...}
-#-----|  -> ...;
-
-#  112| call to method WriteLine
-#-----|  -> true
-
-#  112| ...;
-#-----|  -> access to parameter s
-
-#  112| access to parameter s
-#-----|  -> call to method WriteLine
-
-#  116| call to method WriteLine
-#-----|  -> exit M4 (normal)
-
-#  116| ...;
-#-----|  -> access to parameter s
-
-#  116| access to parameter s
-#-----|  -> call to method WriteLine
-
-#  119| enter M5
-#-----|  -> {...}
-
-#  119| exit M5
-
-#  119| exit M5 (normal)
-#-----|  -> exit M5
-
-#  120| {...}
-#-----|  -> ... ...;
-
-#  121| ... ...;
-#-----|  -> access to parameter s
-
-#  121| String x = ...
-#-----|  -> ...;
-
-#  121| access to parameter s
-#-----|  -> String x = ...
-
-#  122| ... = ...
-#-----|  -> access to local variable x
-
-#  122| ...;
-#-----|  -> access to local variable x
-
-#  122| access to local variable x
-#-----|  -> " "
-
-#  122| ... + ...
-#-----|  -> ... = ...
-
-#  122| " "
-#-----|  -> ... + ...
-
-#  123| return ...;
-#-----| return -> exit M5 (normal)
-
-#  123| access to local variable x
-#-----|  -> return ...;
-
-#  127| enter get_Prop
-#-----|  -> {...}
-
-#  127| exit get_Prop
-
-#  127| exit get_Prop (normal)
-#-----|  -> exit get_Prop
-
-#  127| {...}
-#-----|  -> this access
-
-#  127| return ...;
-#-----| return -> exit get_Prop (normal)
-
-#  127| access to field Field
-#-----|  -> null
-
-#  127| this access
-#-----|  -> access to field Field
-
-#  127| ... == ...
-#-----| true -> ""
-#-----| false -> this access
-
-#  127| ... ? ... : ...
-#-----|  -> return ...;
-
-#  127| null
-#-----|  -> ... == ...
-
-#  127| ""
-#-----|  -> ... ? ... : ...
-
-#  127| access to field Field
-#-----|  -> ... ? ... : ...
-
-#  127| this access
-#-----|  -> access to field Field
-
-#  127| enter set_Prop
-#-----|  -> {...}
-
-#  127| exit set_Prop
-
-#  127| exit set_Prop (normal)
-#-----|  -> exit set_Prop
-
-#  127| {...}
-#-----|  -> ...;
-
-#  127| this access
-#-----|  -> access to parameter value
-
-#  127| ... = ...
-#-----|  -> exit set_Prop (normal)
-
-#  127| ...;
-#-----|  -> this access
-
-#  127| access to parameter value
-#-----|  -> ... = ...
-
-#  129| call to constructor Object
-#-----|  -> {...}
-
-#  129| enter ControlFlow
-#-----|  -> call to constructor Object
-
-#  129| exit ControlFlow
-
-#  129| exit ControlFlow (normal)
-#-----|  -> exit ControlFlow
-
-#  130| {...}
-#-----|  -> ...;
-
-#  131| this access
-#-----|  -> access to parameter s
-
-#  131| ... = ...
-#-----|  -> exit ControlFlow (normal)
-
-#  131| ...;
-#-----|  -> this access
-
-#  131| access to parameter s
-#-----|  -> ... = ...
-
-#  134| enter ControlFlow
-#-----|  -> access to parameter i
-
-#  134| exit ControlFlow
-
-#  134| exit ControlFlow (normal)
-#-----|  -> exit ControlFlow
-
-#  134| call to constructor ControlFlow
-#-----|  -> {...}
-
-#  134| (...) ...
-#-----|  -> ""
-
-#  134| access to parameter i
-#-----|  -> (...) ...
-
-#  134| ... + ...
-#-----|  -> call to constructor ControlFlow
-
-#  134| ""
-#-----|  -> ... + ...
-
-#  134| {...}
-#-----|  -> exit ControlFlow (normal)
-
-#  136| enter ControlFlow
-#-----|  -> 0
-
-#  136| exit ControlFlow
-
-#  136| exit ControlFlow (normal)
-#-----|  -> exit ControlFlow
-
-#  136| call to constructor ControlFlow
-#-----|  -> {...}
-
-#  136| 0
-#-----|  -> 1
-
-#  136| ... + ...
-#-----|  -> call to constructor ControlFlow
-
-#  136| 1
-#-----|  -> ... + ...
-
-#  136| {...}
-#-----|  -> exit ControlFlow (normal)
-
-#  138| enter +
-#-----|  -> {...}
-
-#  138| exit +
-
-#  138| exit + (normal)
-#-----|  -> exit +
-
-#  139| {...}
-#-----|  -> ...;
-
-#  140| call to method WriteLine
-#-----|  -> access to parameter y
-
-#  140| ...;
-#-----|  -> access to parameter x
-
-#  140| access to parameter x
-#-----|  -> call to method WriteLine
-
-#  141| return ...;
-#-----| return -> exit + (normal)
-
-#  141| access to parameter y
-#-----|  -> return ...;
-
-#  144| enter get_Item
-#-----|  -> {...}
-
-#  144| exit get_Item
-
-#  144| exit get_Item (normal)
-#-----|  -> exit get_Item
-
-#  144| {...}
-#-----|  -> access to parameter i
-
-#  144| return ...;
-#-----| return -> exit get_Item (normal)
-
-#  144| (...) ...
-#-----|  -> ""
-
-#  144| access to parameter i
-#-----|  -> (...) ...
-
-#  144| ... + ...
-#-----|  -> return ...;
-
-#  144| ""
-#-----|  -> ... + ...
-
-#  144| enter set_Item
-#-----|  -> {...}
-
-#  144| exit set_Item
-
-#  144| exit set_Item (normal)
-#-----|  -> exit set_Item
-
-#  144| {...}
-#-----|  -> exit set_Item (normal)
-
-#  146| enter For
-#-----|  -> {...}
-
-#  146| exit For
-
-#  146| exit For (normal)
-#-----|  -> exit For
-
-#  147| {...}
-#-----|  -> ... ...;
-
-#  148| ... ...;
-#-----|  -> 0
-
-#  148| Int32 x = ...
-#-----|  -> for (...;...;...) ...
-
-#  148| 0
-#-----|  -> Int32 x = ...
-
-#  149| for (...;...;...) ...
-#-----|  -> access to local variable x
-
-#  149| access to local variable x
-#-----|  -> 10
-
-#  149| ... < ...
-#-----| true -> ...;
-#-----| false -> for (...;...;...) ...
-
-#  149| 10
-#-----|  -> ... < ...
-
-#  149| ++...
-#-----|  -> access to local variable x
-
-#  149| access to local variable x
-#-----|  -> ++...
-
-#  150| call to method WriteLine
-#-----|  -> access to local variable x
-
-#  150| ...;
-#-----|  -> access to local variable x
-
-#  150| access to local variable x
-#-----|  -> call to method WriteLine
-
-#  152| for (...;...;...) ...
-#-----|  -> {...}
-
-#  152| access to local variable x
-#-----|  -> ...++
-
-#  152| ...++
-#-----|  -> {...}
-
-#  153| {...}
-#-----|  -> ...;
-
-#  154| call to method WriteLine
-#-----|  -> if (...) ...
-
-#  154| ...;
-#-----|  -> access to local variable x
-
-#  154| access to local variable x
-#-----|  -> call to method WriteLine
-
-#  155| if (...) ...
-#-----|  -> access to local variable x
-
-#  155| access to local variable x
-#-----|  -> 20
-
-#  155| ... > ...
-#-----| false -> access to local variable x
-#-----| true -> break;
-
-#  155| 20
-#-----|  -> ... > ...
-
-#  156| break;
-#-----| break -> for (...;...;...) ...
-
-#  159| for (...;...;...) ...
-#-----|  -> {...}
-
-#  160| {...}
-#-----|  -> ...;
-
-#  161| call to method WriteLine
-#-----|  -> ...;
-
-#  161| ...;
-#-----|  -> access to local variable x
-
-#  161| access to local variable x
-#-----|  -> call to method WriteLine
-
-#  162| access to local variable x
-#-----|  -> ...++
-
-#  162| ...++
-#-----|  -> if (...) ...
-
-#  162| ...;
-#-----|  -> access to local variable x
-
-#  163| if (...) ...
-#-----|  -> access to local variable x
-
-#  163| access to local variable x
-#-----|  -> 30
-
-#  163| ... > ...
-#-----| false -> {...}
-#-----| true -> break;
-
-#  163| 30
-#-----|  -> ... > ...
-
-#  164| break;
-#-----| break -> for (...;...;...) ...
-
-#  167| for (...;...;...) ...
-#-----|  -> access to local variable x
-
-#  167| access to local variable x
-#-----|  -> 40
-
-#  167| ... < ...
-#-----| true -> {...}
-#-----| false -> for (...;...;...) ...
-
-#  167| 40
-#-----|  -> ... < ...
-
-#  168| {...}
-#-----|  -> ...;
-
-#  169| call to method WriteLine
-#-----|  -> ...;
-
-#  169| ...;
-#-----|  -> access to local variable x
-
-#  169| access to local variable x
-#-----|  -> call to method WriteLine
-
-#  170| access to local variable x
-#-----|  -> ...++
-
-#  170| ...++
-#-----|  -> access to local variable x
-
-#  170| ...;
-#-----|  -> access to local variable x
-
-#  173| for (...;...;...) ...
-#-----|  -> 0
-
-#  173| Int32 i = ...
-#-----|  -> 0
-
-#  173| 0
-#-----|  -> Int32 i = ...
-
-#  173| Int32 j = ...
-#-----|  -> access to local variable i
-
-#  173| 0
-#-----|  -> Int32 j = ...
-
-#  173| access to local variable i
-#-----|  -> access to local variable j
-
-#  173| ... + ...
-#-----|  -> 10
-
-#  173| ... < ...
-#-----| false -> exit For (normal)
-#-----| true -> {...}
-
-#  173| access to local variable j
-#-----|  -> ... + ...
-
-#  173| 10
-#-----|  -> ... < ...
-
-#  173| access to local variable i
-#-----|  -> ...++
-
-#  173| ...++
-#-----|  -> access to local variable j
-
-#  173| access to local variable j
-#-----|  -> ...++
-
-#  173| ...++
-#-----|  -> access to local variable i
-
-#  174| {...}
-#-----|  -> ...;
-
-#  175| call to method WriteLine
-#-----|  -> access to local variable i
-
-#  175| ...;
-#-----|  -> access to local variable i
-
-#  175| access to local variable i
-#-----|  -> access to local variable j
-
-#  175| ... + ...
-#-----|  -> call to method WriteLine
-
-#  175| access to local variable j
-#-----|  -> ... + ...
-
-#  179| enter Lambdas
-#-----|  -> {...}
-
-#  179| exit Lambdas
-
-#  179| exit Lambdas (normal)
-#-----|  -> exit Lambdas
-
-#  180| {...}
-#-----|  -> ... ...;
-
-#  181| ... ...;
-#-----|  -> (...) => ...
-
-#  181| Func<Int32,Int32> y = ...
-#-----|  -> ... ...;
-
-#  181| (...) => ...
-#-----|  -> Func<Int32,Int32> y = ...
-
-#  181| enter (...) => ...
-#-----|  -> access to parameter x
-
-#  181| exit (...) => ...
-
-#  181| exit (...) => ... (normal)
-#-----|  -> exit (...) => ...
-
-#  181| access to parameter x
-#-----|  -> 1
-
-#  181| ... + ...
-#-----|  -> exit (...) => ... (normal)
-
-#  181| 1
-#-----|  -> ... + ...
-
-#  182| ... ...;
-#-----|  -> delegate(...) { ... }
-
-#  182| Func<Int32,Int32> z = ...
-#-----|  -> exit Lambdas (normal)
-
-#  182| delegate(...) { ... }
-#-----|  -> Func<Int32,Int32> z = ...
-
-#  182| enter delegate(...) { ... }
-#-----|  -> {...}
-
-#  182| exit delegate(...) { ... }
-
-#  182| exit delegate(...) { ... } (normal)
-#-----|  -> exit delegate(...) { ... }
-
-#  182| {...}
-#-----|  -> access to parameter x
-
-#  182| return ...;
-#-----| return -> exit delegate(...) { ... } (normal)
-
-#  182| access to parameter x
-#-----|  -> 1
-
-#  182| ... + ...
-#-----|  -> return ...;
-
-#  182| 1
-#-----|  -> ... + ...
-
-#  185| enter LogicalOr
-#-----|  -> {...}
-
-#  185| exit LogicalOr
-
-#  185| exit LogicalOr (normal)
-#-----|  -> exit LogicalOr
-
-#  186| {...}
-#-----|  -> if (...) ...
-
-#  187| if (...) ...
-#-----|  -> 1
-
-#  187| 1
-#-----|  -> 2
-
-#  187| ... == ...
-#-----| false -> 2
-
-#  187| [false] ... || ...
-#-----| false -> 1
-
-#  187| [false] ... || ...
-#-----| false -> ...;
-
-#  187| 2
-#-----|  -> ... == ...
-
-#  187| 2
-#-----|  -> 3
-
-#  187| ... == ...
-#-----| false -> [false] ... || ...
-
-#  187| 3
-#-----|  -> ... == ...
-
-#  187| 1
-#-----|  -> 3
-
-#  187| ... == ...
-#-----| false -> [false] ... && ...
-
-#  187| [false] ... && ...
-#-----| false -> [false] ... || ...
-
-#  187| 3
-#-----|  -> ... == ...
-
-#  190| call to method WriteLine
-#-----|  -> exit LogicalOr (normal)
-
-#  190| ...;
-#-----|  -> "This should happen"
-
-#  190| "This should happen"
-#-----|  -> call to method WriteLine
-
-#  193| enter Booleans
-#-----|  -> {...}
-
-#  193| exit Booleans
-
-#  193| exit Booleans (abnormal)
-#-----|  -> exit Booleans
-
-#  193| exit Booleans (normal)
-#-----|  -> exit Booleans
-
-#  194| {...}
-#-----|  -> ... ...;
-
-#  195| ... ...;
-#-----|  -> this access
-
-#  195| Boolean b = ...
-#-----|  -> if (...) ...
-
-#  195| access to field Field
-#-----|  -> access to property Length
-
-#  195| this access
-#-----|  -> access to field Field
-
-#  195| access to property Length
-#-----|  -> 0
-
-#  195| ... > ...
-#-----| false -> ... && ...
-#-----| true -> this access
-
-#  195| ... && ...
-#-----|  -> Boolean b = ...
-
-#  195| 0
-#-----|  -> ... > ...
-
-#  195| !...
-#-----|  -> ... && ...
-
-#  195| access to field Field
-#-----|  -> access to property Length
-
-#  195| this access
-#-----|  -> access to field Field
-
-#  195| access to property Length
-#-----|  -> 1
-
-#  195| ... == ...
-#-----|  -> !...
-
-#  195| 1
-#-----|  -> ... == ...
-
-#  197| if (...) ...
-#-----|  -> this access
-
-#  197| [false] !...
-#-----| false -> if (...) ...
-
-#  197| [true] !...
-#-----| true -> ...;
-
-#  197| access to field Field
-#-----|  -> access to property Length
-
-#  197| this access
-#-----|  -> access to field Field
-
-#  197| access to property Length
-#-----|  -> 0
-
-#  197| ... == ...
-#-----| true -> false
-#-----| false -> true
-
-#  197| [false] ... ? ... : ...
-#-----| false -> [true] !...
-
-#  197| [true] ... ? ... : ...
-#-----| true -> [false] !...
-
-#  197| 0
-#-----|  -> ... == ...
-
-#  197| false
-#-----| false -> [false] ... ? ... : ...
-
-#  197| true
-#-----| true -> [true] ... ? ... : ...
-
-#  198| ... = ...
-#-----|  -> if (...) ...
-
-#  198| ...;
-#-----|  -> this access
-
-#  198| access to field Field
-#-----|  -> access to property Length
-
-#  198| this access
-#-----|  -> access to field Field
-
-#  198| access to property Length
-#-----|  -> 0
-
-#  198| ... == ...
-#-----| true -> false
-#-----| false -> true
-
-#  198| ... ? ... : ...
-#-----|  -> ... = ...
-
-#  198| 0
-#-----|  -> ... == ...
-
-#  198| false
-#-----|  -> ... ? ... : ...
-
-#  198| true
-#-----|  -> ... ? ... : ...
-
-#  200| if (...) ...
-#-----|  -> this access
-
-#  200| [false] !...
-#-----| false -> this access
-
-#  200| [true] !...
-#-----| true -> [true] ... || ...
-
-#  200| [false] ... || ...
-#-----| false -> exit Booleans (normal)
-
-#  200| [true] ... || ...
-#-----| true -> {...}
-
-#  200| access to field Field
-#-----|  -> access to property Length
-
-#  200| this access
-#-----|  -> access to field Field
-
-#  200| access to property Length
-#-----|  -> 0
-
-#  200| ... == ...
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#  200| 0
-#-----|  -> ... == ...
-
-#  200| [false] !...
-#-----| false -> [false] ... || ...
-
-#  200| [true] !...
-#-----| true -> [true] ... || ...
-
-#  200| [false] !...
-#-----| false -> [true] !...
-
-#  200| [true] !...
-#-----| true -> [false] !...
-
-#  200| access to field Field
-#-----|  -> access to property Length
-
-#  200| this access
-#-----|  -> access to field Field
-
-#  200| access to property Length
-#-----|  -> 1
-
-#  200| ... == ...
-#-----| false -> [false] ... && ...
-#-----| true -> access to local variable b
-
-#  200| [false] ... && ...
-#-----| false -> [true] !...
-
-#  200| [true] ... && ...
-#-----| true -> [false] !...
-
-#  200| 1
-#-----|  -> ... == ...
-
-#  200| access to local variable b
-#-----| false -> [false] ... && ...
-#-----| true -> [true] ... && ...
-
-#  201| {...}
-#-----|  -> {...}
-
-#  202| {...}
-#-----|  -> object creation of type Exception
-
-#  203| throw ...;
-#-----| exception(Exception) -> exit Booleans (abnormal)
-
-#  203| object creation of type Exception
-#-----|  -> throw ...;
-
-#  208| enter Do
-#-----|  -> {...}
-
-#  208| exit Do
-
-#  208| exit Do (normal)
-#-----|  -> exit Do
-
-#  209| {...}
-#-----|  -> do ... while (...);
-
-#  210| do ... while (...);
-#-----|  -> {...}
-
-#  211| {...}
-#-----|  -> ...;
-
-#  212| access to field Field
-#-----|  -> "a"
-
-#  212| this access
-#-----|  -> this access
-
-#  212| this access
-#-----|  -> access to field Field
-
-#  212| ... + ...
-#-----|  -> ... = ...
-
-#  212| ... = ...
-#-----|  -> if (...) ...
-
-#  212| ...;
-#-----|  -> this access
-
-#  212| "a"
-#-----|  -> ... + ...
-
-#  213| if (...) ...
-#-----|  -> this access
-
-#  213| access to field Field
-#-----|  -> access to property Length
-
-#  213| this access
-#-----|  -> access to field Field
-
-#  213| access to property Length
-#-----|  -> 0
-
-#  213| ... > ...
-#-----| true -> {...}
-#-----| false -> if (...) ...
-
-#  213| 0
-#-----|  -> ... > ...
-
-#  214| {...}
-#-----|  -> continue;
-
-#  215| continue;
-#-----| continue -> this access
-
-#  217| if (...) ...
-#-----|  -> this access
-
-#  217| access to field Field
-#-----|  -> access to property Length
-
-#  217| this access
-#-----|  -> access to field Field
-
-#  217| access to property Length
-#-----|  -> 0
-
-#  217| ... < ...
-#-----| true -> {...}
-#-----| false -> this access
-
-#  217| 0
-#-----|  -> ... < ...
-
-#  218| {...}
-#-----|  -> break;
-
-#  219| break;
-#-----| break -> exit Do (normal)
-
-#  221| access to field Field
-#-----|  -> access to property Length
-
-#  221| this access
-#-----|  -> access to field Field
-
-#  221| access to property Length
-#-----|  -> 10
-
-#  221| ... < ...
-#-----| false -> exit Do (normal)
-#-----| true -> {...}
-
-#  221| 10
-#-----|  -> ... < ...
-
-#  224| enter Foreach
-#-----|  -> {...}
-
-#  224| exit Foreach
-
-#  224| exit Foreach (normal)
-#-----|  -> exit Foreach
-
-#  225| {...}
-#-----|  -> "a"
-
-#  226| foreach (... ... in ...) ...
-#-----| empty -> exit Foreach (normal)
-#-----| non-empty -> String x
-
-#  226| String x
-#-----|  -> {...}
-
-#  226| call to method Repeat<String>
-#-----|  -> foreach (... ... in ...) ...
-
-#  226| "a"
-#-----|  -> 10
-
-#  226| 10
-#-----|  -> call to method Repeat<String>
-
-#  227| {...}
-#-----|  -> ...;
-
-#  228| access to field Field
-#-----|  -> access to local variable x
-
-#  228| this access
-#-----|  -> this access
-
-#  228| this access
-#-----|  -> access to field Field
-
-#  228| ... + ...
-#-----|  -> ... = ...
-
-#  228| ... = ...
-#-----|  -> if (...) ...
-
-#  228| ...;
-#-----|  -> this access
-
-#  228| access to local variable x
-#-----|  -> ... + ...
-
-#  229| if (...) ...
-#-----|  -> this access
-
-#  229| access to field Field
-#-----|  -> access to property Length
-
-#  229| this access
-#-----|  -> access to field Field
-
-#  229| access to property Length
-#-----|  -> 0
-
-#  229| ... > ...
-#-----| true -> {...}
-#-----| false -> if (...) ...
-
-#  229| 0
-#-----|  -> ... > ...
-
-#  230| {...}
-#-----|  -> continue;
-
-#  231| continue;
-#-----| continue -> foreach (... ... in ...) ...
-
-#  233| if (...) ...
-#-----|  -> this access
-
-#  233| access to field Field
-#-----|  -> access to property Length
-
-#  233| this access
-#-----|  -> access to field Field
-
-#  233| access to property Length
-#-----|  -> 0
-
-#  233| ... < ...
-#-----| false -> foreach (... ... in ...) ...
-#-----| true -> {...}
-
-#  233| 0
-#-----|  -> ... < ...
-
-#  234| {...}
-#-----|  -> break;
-
-#  235| break;
-#-----| break -> exit Foreach (normal)
-
-#  240| enter Goto
-#-----|  -> {...}
-
-#  240| exit Goto
-
-#  240| exit Goto (normal)
-#-----|  -> exit Goto
-
-#  241| {...}
-#-----|  -> Label:
-
-#  242| Label:
-#-----|  -> if (...) ...
-
-#  242| if (...) ...
-#-----|  -> this access
-
-#  242| [false] !...
-#-----| false -> if (...) ...
-
-#  242| [true] !...
-#-----| true -> {...}
-
-#  242| [false] !...
-#-----| false -> [true] !...
-
-#  242| [true] !...
-#-----| true -> [false] !...
-
-#  242| access to field Field
-#-----|  -> access to property Length
-
-#  242| this access
-#-----|  -> access to field Field
-
-#  242| access to property Length
-#-----|  -> 0
-
-#  242| ... == ...
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#  242| 0
-#-----|  -> ... == ...
-
-#  242| {...}
-#-----|  -> if (...) ...
-
-#  244| if (...) ...
-#-----|  -> this access
-
-#  244| access to field Field
-#-----|  -> access to property Length
-
-#  244| this access
-#-----|  -> access to field Field
-
-#  244| access to property Length
-#-----|  -> 0
-
-#  244| ... > ...
-#-----| true -> goto ...;
-#-----| false -> switch (...) {...}
-
-#  244| 0
-#-----|  -> ... > ...
-
-#  244| goto ...;
-#-----| goto(Label) -> Label:
-
-#  246| switch (...) {...}
-#-----|  -> this access
-
-#  246| access to field Field
-#-----|  -> access to property Length
-
-#  246| this access
-#-----|  -> access to field Field
-
-#  246| access to property Length
-#-----|  -> 3
-
-#  246| ... + ...
-#-----|  -> case ...:
-
-#  246| 3
-#-----|  -> ... + ...
-
-#  248| case ...:
-#-----|  -> 0
-
-#  248| 0
-#-----| match -> goto default;
-#-----| no-match -> case ...:
-
-#  249| goto default;
-#-----| goto(default) -> default:
-
-#  250| case ...:
-#-----|  -> 1
-
-#  250| 1
-#-----| match -> ...;
-#-----| no-match -> case ...:
-
-#  251| call to method WriteLine
-#-----|  -> break;
-
-#  251| ...;
-#-----|  -> 1
-
-#  251| 1
-#-----|  -> call to method WriteLine
-
-#  252| break;
-#-----| break -> exit Goto (normal)
-
-#  253| case ...:
-#-----|  -> 2
-
-#  253| 2
-#-----| match -> goto ...;
-#-----| no-match -> default:
-
-#  254| goto ...;
-#-----| goto(Label) -> Label:
-
-#  255| default:
-#-----|  -> ...;
-
-#  256| call to method WriteLine
-#-----|  -> break;
-
-#  256| ...;
-#-----|  -> 0
-
-#  256| 0
-#-----|  -> call to method WriteLine
-
-#  257| break;
-#-----| break -> exit Goto (normal)
-
-#  261| enter Yield
-#-----|  -> {...}
-
-#  261| exit Yield
-
-#  261| exit Yield (normal)
-#-----|  -> exit Yield
-
-#  262| {...}
-#-----|  -> 0
-
-#  263| yield return ...;
-#-----|  -> for (...;...;...) ...
-
-#  263| 0
-#-----|  -> yield return ...;
-
-#  264| for (...;...;...) ...
-#-----|  -> 1
-
-#  264| Int32 i = ...
-#-----|  -> access to local variable i
-
-#  264| 1
-#-----|  -> Int32 i = ...
-
-#  264| access to local variable i
-#-----|  -> 10
-
-#  264| ... < ...
-#-----| true -> {...}
-#-----| false -> try {...} ...
-
-#  264| 10
-#-----|  -> ... < ...
-
-#  264| access to local variable i
-#-----|  -> ...++
-
-#  264| ...++
-#-----|  -> access to local variable i
-
-#  265| {...}
-#-----|  -> access to local variable i
-
-#  266| yield return ...;
-#-----|  -> access to local variable i
-
-#  266| access to local variable i
-#-----|  -> yield return ...;
-
-#  268| try {...} ...
-#-----|  -> {...}
-
-#  269| {...}
-#-----|  -> yield break;
-
-#  270| yield break;
-#-----| return -> [finally: return] {...}
-
-#  274| [finally: return] {...}
-#-----|  -> [finally: return] ...;
-
-#  275| [finally: return] call to method WriteLine
-#-----| return -> exit Yield (normal)
-
-#  275| [finally: return] ...;
-#-----|  -> [finally: return] "not dead"
-
-#  275| [finally: return] "not dead"
-#-----|  -> [finally: return] call to method WriteLine
-
-#  282| enter ControlFlowSub
-#-----|  -> call to constructor ControlFlow
-
-#  282| exit ControlFlowSub
-
-#  282| exit ControlFlowSub (normal)
-#-----|  -> exit ControlFlowSub
-
-#  282| call to constructor ControlFlow
-#-----|  -> {...}
-
-#  282| {...}
-#-----|  -> exit ControlFlowSub (normal)
-
-#  284| enter ControlFlowSub
-#-----|  -> call to constructor ControlFlowSub
-
-#  284| exit ControlFlowSub
-
-#  284| exit ControlFlowSub (normal)
-#-----|  -> exit ControlFlowSub
-
-#  284| call to constructor ControlFlowSub
-#-----|  -> {...}
-
-#  284| {...}
-#-----|  -> exit ControlFlowSub (normal)
-
-#  286| enter ControlFlowSub
-#-----|  -> access to parameter i
-
-#  286| exit ControlFlowSub
-
-#  286| exit ControlFlowSub (normal)
-#-----|  -> exit ControlFlowSub
-
-#  286| call to constructor ControlFlowSub
-#-----|  -> {...}
-
-#  286| access to parameter i
-#-----|  -> call to method ToString
-
-#  286| call to method ToString
-#-----|  -> call to constructor ControlFlowSub
-
-#  286| {...}
-#-----|  -> exit ControlFlowSub (normal)
-
-#  289| call to constructor Object
-#-----|  -> {...}
-
-#  289| enter DelegateCall
-#-----|  -> call to constructor Object
-
-#  289| exit DelegateCall
-
-#  289| exit DelegateCall (normal)
-#-----|  -> exit DelegateCall
-
-#  289| {...}
-#-----|  -> exit DelegateCall (normal)
-
-#  291| enter M
-#-----|  -> access to parameter f
-
-#  291| exit M
-
-#  291| exit M (normal)
-#-----|  -> exit M
-
-#  291| access to parameter f
-#-----|  -> 0
-
-#  291| delegate call
-#-----|  -> exit M (normal)
-
-#  291| 0
-#-----|  -> delegate call
-
-#  296| call to constructor Object
-#-----|  -> {...}
-
-#  296| enter NegationInConstructor
-#-----|  -> call to constructor Object
-
-#  296| exit NegationInConstructor
-
-#  296| exit NegationInConstructor (normal)
-#-----|  -> exit NegationInConstructor
-
-#  296| {...}
-#-----|  -> exit NegationInConstructor (normal)
-
-#  298| enter M
-#-----|  -> {...}
-
-#  298| exit M
-
-#  298| exit M (normal)
-#-----|  -> exit M
-
-#  299| {...}
-#-----|  -> ...;
-
-#  300| object creation of type NegationInConstructor
-#-----|  -> exit M (normal)
-
-#  300| ...;
-#-----|  -> 0
-
-#  300| 0
-#-----|  -> access to parameter i
-
-#  300| [false] !...
-#-----| false -> ... && ...
-
-#  300| [true] !...
-#-----| true -> access to parameter s
-
-#  300| ... && ...
-#-----|  -> ""
-
-#  300| access to parameter i
-#-----|  -> 0
-
-#  300| ... > ...
-#-----| false -> [true] !...
-#-----| true -> [false] !...
-
-#  300| 0
-#-----|  -> ... > ...
-
-#  300| access to parameter s
-#-----|  -> null
-
-#  300| ... != ...
-#-----|  -> ... && ...
-
-#  300| null
-#-----|  -> ... != ...
-
-#  300| ""
-#-----|  -> object creation of type NegationInConstructor
-
-#  304| call to constructor Object
-#-----|  -> {...}
-
-#  304| enter LambdaGetter
-#-----|  -> call to constructor Object
-
-#  304| exit LambdaGetter
-
-#  304| exit LambdaGetter (normal)
-#-----|  -> exit LambdaGetter
-
-#  304| {...}
-#-----|  -> exit LambdaGetter (normal)
-
-#  306| (...) => ...
-#-----|  -> exit get__getter (normal)
-
-#  306| enter (...) => ...
-#-----|  -> {...}
-
-#  306| enter get__getter
-#-----|  -> (...) => ...
-
-#  306| exit (...) => ...
-
-#  306| exit (...) => ... (normal)
-#-----|  -> exit (...) => ...
-
-#  306| exit get__getter
-
-#  306| exit get__getter (normal)
-#-----|  -> exit get__getter
-
-#  307| {...}
-#-----|  -> ... ...;
-
-#  308| ... ...;
-#-----|  -> access to parameter o
-
-#  308| Object x = ...
-#-----|  -> access to local variable x
-
-#  308| access to parameter o
-#-----|  -> Object x = ...
-
-#  309| return ...;
-#-----| return -> exit (...) => ... (normal)
-
-#  309| access to local variable x
-#-----|  -> return ...;
+| AccessorCalls.cs:1:7:1:19 | call to constructor Object | AccessorCalls.cs:1:7:1:19 | {...} |  |
+| AccessorCalls.cs:1:7:1:19 | enter AccessorCalls | AccessorCalls.cs:1:7:1:19 | call to constructor Object |  |
+| AccessorCalls.cs:1:7:1:19 | exit AccessorCalls (normal) | AccessorCalls.cs:1:7:1:19 | exit AccessorCalls |  |
+| AccessorCalls.cs:1:7:1:19 | {...} | AccessorCalls.cs:1:7:1:19 | exit AccessorCalls (normal) |  |
+| AccessorCalls.cs:5:23:5:25 | enter get_Item | AccessorCalls.cs:5:30:5:30 | access to parameter i |  |
+| AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) | AccessorCalls.cs:5:23:5:25 | exit get_Item |  |
+| AccessorCalls.cs:5:30:5:30 | access to parameter i | AccessorCalls.cs:5:23:5:25 | exit get_Item (normal) |  |
+| AccessorCalls.cs:5:33:5:35 | enter set_Item | AccessorCalls.cs:5:37:5:39 | {...} |  |
+| AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) | AccessorCalls.cs:5:33:5:35 | exit set_Item |  |
+| AccessorCalls.cs:5:37:5:39 | {...} | AccessorCalls.cs:5:33:5:35 | exit set_Item (normal) |  |
+| AccessorCalls.cs:7:32:7:34 | enter add_Event | AccessorCalls.cs:7:36:7:38 | {...} |  |
+| AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) | AccessorCalls.cs:7:32:7:34 | exit add_Event |  |
+| AccessorCalls.cs:7:36:7:38 | {...} | AccessorCalls.cs:7:32:7:34 | exit add_Event (normal) |  |
+| AccessorCalls.cs:7:40:7:45 | enter remove_Event | AccessorCalls.cs:7:47:7:49 | {...} |  |
+| AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) | AccessorCalls.cs:7:40:7:45 | exit remove_Event |  |
+| AccessorCalls.cs:7:47:7:49 | {...} | AccessorCalls.cs:7:40:7:45 | exit remove_Event (normal) |  |
+| AccessorCalls.cs:10:10:10:11 | enter M1 | AccessorCalls.cs:11:5:17:5 | {...} |  |
+| AccessorCalls.cs:10:10:10:11 | exit M1 (normal) | AccessorCalls.cs:10:10:10:11 | exit M1 |  |
+| AccessorCalls.cs:11:5:17:5 | {...} | AccessorCalls.cs:12:9:12:32 | ...; |  |
+| AccessorCalls.cs:12:9:12:12 | this access | AccessorCalls.cs:12:22:12:25 | this access |  |
+| AccessorCalls.cs:12:9:12:31 | ... = ... | AccessorCalls.cs:13:9:13:30 | ...; |  |
+| AccessorCalls.cs:12:9:12:32 | ...; | AccessorCalls.cs:12:9:12:12 | this access |  |
+| AccessorCalls.cs:12:22:12:25 | this access | AccessorCalls.cs:12:22:12:31 | access to field Field |  |
+| AccessorCalls.cs:12:22:12:31 | access to field Field | AccessorCalls.cs:12:9:12:31 | ... = ... |  |
+| AccessorCalls.cs:13:9:13:12 | this access | AccessorCalls.cs:13:21:13:24 | this access |  |
+| AccessorCalls.cs:13:9:13:17 | access to property Prop | AccessorCalls.cs:13:9:13:29 | ... = ... |  |
+| AccessorCalls.cs:13:9:13:29 | ... = ... | AccessorCalls.cs:14:9:14:26 | ...; |  |
+| AccessorCalls.cs:13:9:13:30 | ...; | AccessorCalls.cs:13:9:13:12 | this access |  |
+| AccessorCalls.cs:13:21:13:24 | this access | AccessorCalls.cs:13:21:13:29 | access to property Prop |  |
+| AccessorCalls.cs:13:21:13:29 | access to property Prop | AccessorCalls.cs:13:9:13:17 | access to property Prop |  |
+| AccessorCalls.cs:14:9:14:12 | this access | AccessorCalls.cs:14:14:14:14 | 0 |  |
+| AccessorCalls.cs:14:9:14:15 | access to indexer | AccessorCalls.cs:14:9:14:25 | ... = ... |  |
+| AccessorCalls.cs:14:9:14:25 | ... = ... | AccessorCalls.cs:15:9:15:24 | ...; |  |
+| AccessorCalls.cs:14:9:14:26 | ...; | AccessorCalls.cs:14:9:14:12 | this access |  |
+| AccessorCalls.cs:14:14:14:14 | 0 | AccessorCalls.cs:14:19:14:22 | this access |  |
+| AccessorCalls.cs:14:19:14:22 | this access | AccessorCalls.cs:14:24:14:24 | 1 |  |
+| AccessorCalls.cs:14:19:14:25 | access to indexer | AccessorCalls.cs:14:9:14:15 | access to indexer |  |
+| AccessorCalls.cs:14:24:14:24 | 1 | AccessorCalls.cs:14:19:14:25 | access to indexer |  |
+| AccessorCalls.cs:15:9:15:12 | this access | AccessorCalls.cs:15:23:15:23 | access to parameter e |  |
+| AccessorCalls.cs:15:9:15:18 | access to event Event | AccessorCalls.cs:15:9:15:23 | ... += ... |  |
+| AccessorCalls.cs:15:9:15:23 | ... += ... | AccessorCalls.cs:16:9:16:24 | ...; |  |
+| AccessorCalls.cs:15:9:15:24 | ...; | AccessorCalls.cs:15:9:15:12 | this access |  |
+| AccessorCalls.cs:15:23:15:23 | access to parameter e | AccessorCalls.cs:15:9:15:18 | access to event Event |  |
+| AccessorCalls.cs:16:9:16:12 | this access | AccessorCalls.cs:16:23:16:23 | access to parameter e |  |
+| AccessorCalls.cs:16:9:16:18 | access to event Event | AccessorCalls.cs:16:9:16:23 | ... -= ... |  |
+| AccessorCalls.cs:16:9:16:23 | ... -= ... | AccessorCalls.cs:10:10:10:11 | exit M1 (normal) |  |
+| AccessorCalls.cs:16:9:16:24 | ...; | AccessorCalls.cs:16:9:16:12 | this access |  |
+| AccessorCalls.cs:16:23:16:23 | access to parameter e | AccessorCalls.cs:16:9:16:18 | access to event Event |  |
+| AccessorCalls.cs:19:10:19:11 | enter M2 | AccessorCalls.cs:20:5:26:5 | {...} |  |
+| AccessorCalls.cs:19:10:19:11 | exit M2 (normal) | AccessorCalls.cs:19:10:19:11 | exit M2 |  |
+| AccessorCalls.cs:20:5:26:5 | {...} | AccessorCalls.cs:21:9:21:36 | ...; |  |
+| AccessorCalls.cs:21:9:21:12 | this access | AccessorCalls.cs:21:9:21:14 | access to field x |  |
+| AccessorCalls.cs:21:9:21:14 | access to field x | AccessorCalls.cs:21:24:21:27 | this access |  |
+| AccessorCalls.cs:21:9:21:35 | ... = ... | AccessorCalls.cs:22:9:22:34 | ...; |  |
+| AccessorCalls.cs:21:9:21:36 | ...; | AccessorCalls.cs:21:9:21:12 | this access |  |
+| AccessorCalls.cs:21:24:21:27 | this access | AccessorCalls.cs:21:24:21:29 | access to field x |  |
+| AccessorCalls.cs:21:24:21:29 | access to field x | AccessorCalls.cs:21:24:21:35 | access to field Field |  |
+| AccessorCalls.cs:21:24:21:35 | access to field Field | AccessorCalls.cs:21:9:21:35 | ... = ... |  |
+| AccessorCalls.cs:22:9:22:12 | this access | AccessorCalls.cs:22:9:22:14 | access to field x |  |
+| AccessorCalls.cs:22:9:22:14 | access to field x | AccessorCalls.cs:22:23:22:26 | this access |  |
+| AccessorCalls.cs:22:9:22:19 | access to property Prop | AccessorCalls.cs:22:9:22:33 | ... = ... |  |
+| AccessorCalls.cs:22:9:22:33 | ... = ... | AccessorCalls.cs:23:9:23:30 | ...; |  |
+| AccessorCalls.cs:22:9:22:34 | ...; | AccessorCalls.cs:22:9:22:12 | this access |  |
+| AccessorCalls.cs:22:23:22:26 | this access | AccessorCalls.cs:22:23:22:28 | access to field x |  |
+| AccessorCalls.cs:22:23:22:28 | access to field x | AccessorCalls.cs:22:23:22:33 | access to property Prop |  |
+| AccessorCalls.cs:22:23:22:33 | access to property Prop | AccessorCalls.cs:22:9:22:19 | access to property Prop |  |
+| AccessorCalls.cs:23:9:23:12 | this access | AccessorCalls.cs:23:9:23:14 | access to field x |  |
+| AccessorCalls.cs:23:9:23:14 | access to field x | AccessorCalls.cs:23:16:23:16 | 0 |  |
+| AccessorCalls.cs:23:9:23:17 | access to indexer | AccessorCalls.cs:23:9:23:29 | ... = ... |  |
+| AccessorCalls.cs:23:9:23:29 | ... = ... | AccessorCalls.cs:24:9:24:26 | ...; |  |
+| AccessorCalls.cs:23:9:23:30 | ...; | AccessorCalls.cs:23:9:23:12 | this access |  |
+| AccessorCalls.cs:23:16:23:16 | 0 | AccessorCalls.cs:23:21:23:24 | this access |  |
+| AccessorCalls.cs:23:21:23:24 | this access | AccessorCalls.cs:23:21:23:26 | access to field x |  |
+| AccessorCalls.cs:23:21:23:26 | access to field x | AccessorCalls.cs:23:28:23:28 | 1 |  |
+| AccessorCalls.cs:23:21:23:29 | access to indexer | AccessorCalls.cs:23:9:23:17 | access to indexer |  |
+| AccessorCalls.cs:23:28:23:28 | 1 | AccessorCalls.cs:23:21:23:29 | access to indexer |  |
+| AccessorCalls.cs:24:9:24:12 | this access | AccessorCalls.cs:24:9:24:14 | access to field x |  |
+| AccessorCalls.cs:24:9:24:14 | access to field x | AccessorCalls.cs:24:25:24:25 | access to parameter e |  |
+| AccessorCalls.cs:24:9:24:20 | access to event Event | AccessorCalls.cs:24:9:24:25 | ... += ... |  |
+| AccessorCalls.cs:24:9:24:25 | ... += ... | AccessorCalls.cs:25:9:25:26 | ...; |  |
+| AccessorCalls.cs:24:9:24:26 | ...; | AccessorCalls.cs:24:9:24:12 | this access |  |
+| AccessorCalls.cs:24:25:24:25 | access to parameter e | AccessorCalls.cs:24:9:24:20 | access to event Event |  |
+| AccessorCalls.cs:25:9:25:12 | this access | AccessorCalls.cs:25:9:25:14 | access to field x |  |
+| AccessorCalls.cs:25:9:25:14 | access to field x | AccessorCalls.cs:25:25:25:25 | access to parameter e |  |
+| AccessorCalls.cs:25:9:25:20 | access to event Event | AccessorCalls.cs:25:9:25:25 | ... -= ... |  |
+| AccessorCalls.cs:25:9:25:25 | ... -= ... | AccessorCalls.cs:19:10:19:11 | exit M2 (normal) |  |
+| AccessorCalls.cs:25:9:25:26 | ...; | AccessorCalls.cs:25:9:25:12 | this access |  |
+| AccessorCalls.cs:25:25:25:25 | access to parameter e | AccessorCalls.cs:25:9:25:20 | access to event Event |  |
+| AccessorCalls.cs:28:10:28:11 | enter M3 | AccessorCalls.cs:29:5:33:5 | {...} |  |
+| AccessorCalls.cs:28:10:28:11 | exit M3 (normal) | AccessorCalls.cs:28:10:28:11 | exit M3 |  |
+| AccessorCalls.cs:29:5:33:5 | {...} | AccessorCalls.cs:30:9:30:21 | ...; |  |
+| AccessorCalls.cs:30:9:30:12 | this access | AccessorCalls.cs:30:9:30:18 | access to field Field |  |
+| AccessorCalls.cs:30:9:30:18 | access to field Field | AccessorCalls.cs:30:9:30:20 | ...++ |  |
+| AccessorCalls.cs:30:9:30:20 | ...++ | AccessorCalls.cs:31:9:31:20 | ...; |  |
+| AccessorCalls.cs:30:9:30:21 | ...; | AccessorCalls.cs:30:9:30:12 | this access |  |
+| AccessorCalls.cs:31:9:31:12 | this access | AccessorCalls.cs:31:9:31:17 | access to property Prop |  |
+| AccessorCalls.cs:31:9:31:17 | access to property Prop | AccessorCalls.cs:31:9:31:19 | ...++ |  |
+| AccessorCalls.cs:31:9:31:19 | ...++ | AccessorCalls.cs:32:9:32:18 | ...; |  |
+| AccessorCalls.cs:31:9:31:20 | ...; | AccessorCalls.cs:31:9:31:12 | this access |  |
+| AccessorCalls.cs:32:9:32:12 | this access | AccessorCalls.cs:32:14:32:14 | 0 |  |
+| AccessorCalls.cs:32:9:32:15 | access to indexer | AccessorCalls.cs:32:9:32:17 | ...++ |  |
+| AccessorCalls.cs:32:9:32:17 | ...++ | AccessorCalls.cs:28:10:28:11 | exit M3 (normal) |  |
+| AccessorCalls.cs:32:9:32:18 | ...; | AccessorCalls.cs:32:9:32:12 | this access |  |
+| AccessorCalls.cs:32:14:32:14 | 0 | AccessorCalls.cs:32:9:32:15 | access to indexer |  |
+| AccessorCalls.cs:35:10:35:11 | enter M4 | AccessorCalls.cs:36:5:40:5 | {...} |  |
+| AccessorCalls.cs:35:10:35:11 | exit M4 (normal) | AccessorCalls.cs:35:10:35:11 | exit M4 |  |
+| AccessorCalls.cs:36:5:40:5 | {...} | AccessorCalls.cs:37:9:37:23 | ...; |  |
+| AccessorCalls.cs:37:9:37:12 | this access | AccessorCalls.cs:37:9:37:14 | access to field x |  |
+| AccessorCalls.cs:37:9:37:14 | access to field x | AccessorCalls.cs:37:9:37:20 | access to field Field |  |
+| AccessorCalls.cs:37:9:37:20 | access to field Field | AccessorCalls.cs:37:9:37:22 | ...++ |  |
+| AccessorCalls.cs:37:9:37:22 | ...++ | AccessorCalls.cs:38:9:38:22 | ...; |  |
+| AccessorCalls.cs:37:9:37:23 | ...; | AccessorCalls.cs:37:9:37:12 | this access |  |
+| AccessorCalls.cs:38:9:38:12 | this access | AccessorCalls.cs:38:9:38:14 | access to field x |  |
+| AccessorCalls.cs:38:9:38:14 | access to field x | AccessorCalls.cs:38:9:38:19 | access to property Prop |  |
+| AccessorCalls.cs:38:9:38:19 | access to property Prop | AccessorCalls.cs:38:9:38:21 | ...++ |  |
+| AccessorCalls.cs:38:9:38:21 | ...++ | AccessorCalls.cs:39:9:39:20 | ...; |  |
+| AccessorCalls.cs:38:9:38:22 | ...; | AccessorCalls.cs:38:9:38:12 | this access |  |
+| AccessorCalls.cs:39:9:39:12 | this access | AccessorCalls.cs:39:9:39:14 | access to field x |  |
+| AccessorCalls.cs:39:9:39:14 | access to field x | AccessorCalls.cs:39:16:39:16 | 0 |  |
+| AccessorCalls.cs:39:9:39:17 | access to indexer | AccessorCalls.cs:39:9:39:19 | ...++ |  |
+| AccessorCalls.cs:39:9:39:19 | ...++ | AccessorCalls.cs:35:10:35:11 | exit M4 (normal) |  |
+| AccessorCalls.cs:39:9:39:20 | ...; | AccessorCalls.cs:39:9:39:12 | this access |  |
+| AccessorCalls.cs:39:16:39:16 | 0 | AccessorCalls.cs:39:9:39:17 | access to indexer |  |
+| AccessorCalls.cs:42:10:42:11 | enter M5 | AccessorCalls.cs:43:5:47:5 | {...} |  |
+| AccessorCalls.cs:42:10:42:11 | exit M5 (normal) | AccessorCalls.cs:42:10:42:11 | exit M5 |  |
+| AccessorCalls.cs:43:5:47:5 | {...} | AccessorCalls.cs:44:9:44:33 | ...; |  |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:12 | this access |  |
+| AccessorCalls.cs:44:9:44:12 | this access | AccessorCalls.cs:44:9:44:18 | access to field Field |  |
+| AccessorCalls.cs:44:9:44:18 | access to field Field | AccessorCalls.cs:44:23:44:26 | this access |  |
+| AccessorCalls.cs:44:9:44:32 | ... + ... | AccessorCalls.cs:44:9:44:32 | ... = ... |  |
+| AccessorCalls.cs:44:9:44:32 | ... = ... | AccessorCalls.cs:45:9:45:31 | ...; |  |
+| AccessorCalls.cs:44:9:44:33 | ...; | AccessorCalls.cs:44:9:44:12 | this access |  |
+| AccessorCalls.cs:44:23:44:26 | this access | AccessorCalls.cs:44:23:44:32 | access to field Field |  |
+| AccessorCalls.cs:44:23:44:32 | access to field Field | AccessorCalls.cs:44:9:44:32 | ... + ... |  |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:12 | this access |  |
+| AccessorCalls.cs:45:9:45:12 | this access | AccessorCalls.cs:45:9:45:17 | access to property Prop |  |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... = ... |  |
+| AccessorCalls.cs:45:9:45:17 | access to property Prop | AccessorCalls.cs:45:22:45:25 | this access |  |
+| AccessorCalls.cs:45:9:45:30 | ... + ... | AccessorCalls.cs:45:9:45:17 | access to property Prop |  |
+| AccessorCalls.cs:45:9:45:30 | ... = ... | AccessorCalls.cs:46:9:46:27 | ...; |  |
+| AccessorCalls.cs:45:9:45:31 | ...; | AccessorCalls.cs:45:9:45:12 | this access |  |
+| AccessorCalls.cs:45:22:45:25 | this access | AccessorCalls.cs:45:22:45:30 | access to property Prop |  |
+| AccessorCalls.cs:45:22:45:30 | access to property Prop | AccessorCalls.cs:45:9:45:30 | ... + ... |  |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |  |
+| AccessorCalls.cs:46:9:46:12 | this access | AccessorCalls.cs:46:14:46:14 | 0 |  |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... = ... |  |
+| AccessorCalls.cs:46:9:46:15 | access to indexer | AccessorCalls.cs:46:20:46:23 | this access |  |
+| AccessorCalls.cs:46:9:46:26 | ... + ... | AccessorCalls.cs:46:9:46:15 | access to indexer |  |
+| AccessorCalls.cs:46:9:46:26 | ... = ... | AccessorCalls.cs:42:10:42:11 | exit M5 (normal) |  |
+| AccessorCalls.cs:46:9:46:27 | ...; | AccessorCalls.cs:46:9:46:12 | this access |  |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:12 | this access |  |
+| AccessorCalls.cs:46:14:46:14 | 0 | AccessorCalls.cs:46:9:46:15 | access to indexer |  |
+| AccessorCalls.cs:46:20:46:23 | this access | AccessorCalls.cs:46:25:46:25 | 0 |  |
+| AccessorCalls.cs:46:20:46:26 | access to indexer | AccessorCalls.cs:46:9:46:26 | ... + ... |  |
+| AccessorCalls.cs:46:25:46:25 | 0 | AccessorCalls.cs:46:20:46:26 | access to indexer |  |
+| AccessorCalls.cs:49:10:49:11 | enter M6 | AccessorCalls.cs:50:5:54:5 | {...} |  |
+| AccessorCalls.cs:49:10:49:11 | exit M6 (normal) | AccessorCalls.cs:49:10:49:11 | exit M6 |  |
+| AccessorCalls.cs:50:5:54:5 | {...} | AccessorCalls.cs:51:9:51:37 | ...; |  |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |  |
+| AccessorCalls.cs:51:9:51:12 | this access | AccessorCalls.cs:51:9:51:14 | access to field x |  |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:12 | this access |  |
+| AccessorCalls.cs:51:9:51:14 | access to field x | AccessorCalls.cs:51:9:51:20 | access to field Field |  |
+| AccessorCalls.cs:51:9:51:20 | access to field Field | AccessorCalls.cs:51:25:51:28 | this access |  |
+| AccessorCalls.cs:51:9:51:36 | ... + ... | AccessorCalls.cs:51:9:51:36 | ... = ... |  |
+| AccessorCalls.cs:51:9:51:36 | ... = ... | AccessorCalls.cs:52:9:52:35 | ...; |  |
+| AccessorCalls.cs:51:9:51:37 | ...; | AccessorCalls.cs:51:9:51:12 | this access |  |
+| AccessorCalls.cs:51:25:51:28 | this access | AccessorCalls.cs:51:25:51:30 | access to field x |  |
+| AccessorCalls.cs:51:25:51:30 | access to field x | AccessorCalls.cs:51:25:51:36 | access to field Field |  |
+| AccessorCalls.cs:51:25:51:36 | access to field Field | AccessorCalls.cs:51:9:51:36 | ... + ... |  |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |  |
+| AccessorCalls.cs:52:9:52:12 | this access | AccessorCalls.cs:52:9:52:14 | access to field x |  |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:12 | this access |  |
+| AccessorCalls.cs:52:9:52:14 | access to field x | AccessorCalls.cs:52:9:52:19 | access to property Prop |  |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... = ... |  |
+| AccessorCalls.cs:52:9:52:19 | access to property Prop | AccessorCalls.cs:52:24:52:27 | this access |  |
+| AccessorCalls.cs:52:9:52:34 | ... + ... | AccessorCalls.cs:52:9:52:19 | access to property Prop |  |
+| AccessorCalls.cs:52:9:52:34 | ... = ... | AccessorCalls.cs:53:9:53:31 | ...; |  |
+| AccessorCalls.cs:52:9:52:35 | ...; | AccessorCalls.cs:52:9:52:12 | this access |  |
+| AccessorCalls.cs:52:24:52:27 | this access | AccessorCalls.cs:52:24:52:29 | access to field x |  |
+| AccessorCalls.cs:52:24:52:29 | access to field x | AccessorCalls.cs:52:24:52:34 | access to property Prop |  |
+| AccessorCalls.cs:52:24:52:34 | access to property Prop | AccessorCalls.cs:52:9:52:34 | ... + ... |  |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x |  |
+| AccessorCalls.cs:53:9:53:12 | this access | AccessorCalls.cs:53:9:53:14 | access to field x |  |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |  |
+| AccessorCalls.cs:53:9:53:14 | access to field x | AccessorCalls.cs:53:16:53:16 | 0 |  |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... = ... |  |
+| AccessorCalls.cs:53:9:53:17 | access to indexer | AccessorCalls.cs:53:22:53:25 | this access |  |
+| AccessorCalls.cs:53:9:53:30 | ... + ... | AccessorCalls.cs:53:9:53:17 | access to indexer |  |
+| AccessorCalls.cs:53:9:53:30 | ... = ... | AccessorCalls.cs:49:10:49:11 | exit M6 (normal) |  |
+| AccessorCalls.cs:53:9:53:31 | ...; | AccessorCalls.cs:53:9:53:12 | this access |  |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:12 | this access |  |
+| AccessorCalls.cs:53:16:53:16 | 0 | AccessorCalls.cs:53:9:53:17 | access to indexer |  |
+| AccessorCalls.cs:53:22:53:25 | this access | AccessorCalls.cs:53:22:53:27 | access to field x |  |
+| AccessorCalls.cs:53:22:53:27 | access to field x | AccessorCalls.cs:53:29:53:29 | 0 |  |
+| AccessorCalls.cs:53:22:53:30 | access to indexer | AccessorCalls.cs:53:9:53:30 | ... + ... |  |
+| AccessorCalls.cs:53:29:53:29 | 0 | AccessorCalls.cs:53:22:53:30 | access to indexer |  |
+| AccessorCalls.cs:56:10:56:11 | enter M7 | AccessorCalls.cs:57:5:59:5 | {...} |  |
+| AccessorCalls.cs:56:10:56:11 | exit M7 (normal) | AccessorCalls.cs:56:10:56:11 | exit M7 |  |
+| AccessorCalls.cs:57:5:59:5 | {...} | AccessorCalls.cs:58:9:58:86 | ...; |  |
+| AccessorCalls.cs:58:9:58:45 | (..., ...) | AccessorCalls.cs:58:50:58:53 | this access |  |
+| AccessorCalls.cs:58:9:58:85 | ... = ... | AccessorCalls.cs:56:10:56:11 | exit M7 (normal) |  |
+| AccessorCalls.cs:58:9:58:86 | ...; | AccessorCalls.cs:58:10:58:13 | this access |  |
+| AccessorCalls.cs:58:10:58:13 | this access | AccessorCalls.cs:58:22:58:25 | this access |  |
+| AccessorCalls.cs:58:22:58:25 | this access | AccessorCalls.cs:58:37:58:40 | this access |  |
+| AccessorCalls.cs:58:22:58:30 | access to property Prop | AccessorCalls.cs:58:37:58:43 | access to indexer |  |
+| AccessorCalls.cs:58:33:58:44 | (..., ...) | AccessorCalls.cs:58:9:58:45 | (..., ...) |  |
+| AccessorCalls.cs:58:37:58:40 | this access | AccessorCalls.cs:58:42:58:42 | 0 |  |
+| AccessorCalls.cs:58:37:58:43 | access to indexer | AccessorCalls.cs:58:9:58:85 | ... = ... |  |
+| AccessorCalls.cs:58:42:58:42 | 0 | AccessorCalls.cs:58:33:58:44 | (..., ...) |  |
+| AccessorCalls.cs:58:49:58:85 | (..., ...) | AccessorCalls.cs:58:22:58:30 | access to property Prop |  |
+| AccessorCalls.cs:58:50:58:53 | this access | AccessorCalls.cs:58:50:58:59 | access to field Field |  |
+| AccessorCalls.cs:58:50:58:59 | access to field Field | AccessorCalls.cs:58:62:58:65 | this access |  |
+| AccessorCalls.cs:58:62:58:65 | this access | AccessorCalls.cs:58:62:58:70 | access to property Prop |  |
+| AccessorCalls.cs:58:62:58:70 | access to property Prop | AccessorCalls.cs:58:74:58:74 | 0 |  |
+| AccessorCalls.cs:58:73:58:84 | (..., ...) | AccessorCalls.cs:58:49:58:85 | (..., ...) |  |
+| AccessorCalls.cs:58:74:58:74 | 0 | AccessorCalls.cs:58:77:58:80 | this access |  |
+| AccessorCalls.cs:58:77:58:80 | this access | AccessorCalls.cs:58:82:58:82 | 1 |  |
+| AccessorCalls.cs:58:77:58:83 | access to indexer | AccessorCalls.cs:58:73:58:84 | (..., ...) |  |
+| AccessorCalls.cs:58:82:58:82 | 1 | AccessorCalls.cs:58:77:58:83 | access to indexer |  |
+| AccessorCalls.cs:61:10:61:11 | enter M8 | AccessorCalls.cs:62:5:64:5 | {...} |  |
+| AccessorCalls.cs:61:10:61:11 | exit M8 (normal) | AccessorCalls.cs:61:10:61:11 | exit M8 |  |
+| AccessorCalls.cs:62:5:64:5 | {...} | AccessorCalls.cs:63:9:63:98 | ...; |  |
+| AccessorCalls.cs:63:9:63:51 | (..., ...) | AccessorCalls.cs:63:56:63:59 | this access |  |
+| AccessorCalls.cs:63:9:63:97 | ... = ... | AccessorCalls.cs:61:10:61:11 | exit M8 (normal) |  |
+| AccessorCalls.cs:63:9:63:98 | ...; | AccessorCalls.cs:63:10:63:13 | this access |  |
+| AccessorCalls.cs:63:10:63:13 | this access | AccessorCalls.cs:63:10:63:15 | access to field x |  |
+| AccessorCalls.cs:63:10:63:15 | access to field x | AccessorCalls.cs:63:24:63:27 | this access |  |
+| AccessorCalls.cs:63:24:63:27 | this access | AccessorCalls.cs:63:24:63:29 | access to field x |  |
+| AccessorCalls.cs:63:24:63:29 | access to field x | AccessorCalls.cs:63:41:63:44 | this access |  |
+| AccessorCalls.cs:63:24:63:34 | access to property Prop | AccessorCalls.cs:63:41:63:49 | access to indexer |  |
+| AccessorCalls.cs:63:37:63:50 | (..., ...) | AccessorCalls.cs:63:9:63:51 | (..., ...) |  |
+| AccessorCalls.cs:63:41:63:44 | this access | AccessorCalls.cs:63:41:63:46 | access to field x |  |
+| AccessorCalls.cs:63:41:63:46 | access to field x | AccessorCalls.cs:63:48:63:48 | 0 |  |
+| AccessorCalls.cs:63:41:63:49 | access to indexer | AccessorCalls.cs:63:9:63:97 | ... = ... |  |
+| AccessorCalls.cs:63:48:63:48 | 0 | AccessorCalls.cs:63:37:63:50 | (..., ...) |  |
+| AccessorCalls.cs:63:55:63:97 | (..., ...) | AccessorCalls.cs:63:24:63:34 | access to property Prop |  |
+| AccessorCalls.cs:63:56:63:59 | this access | AccessorCalls.cs:63:56:63:61 | access to field x |  |
+| AccessorCalls.cs:63:56:63:61 | access to field x | AccessorCalls.cs:63:56:63:67 | access to field Field |  |
+| AccessorCalls.cs:63:56:63:67 | access to field Field | AccessorCalls.cs:63:70:63:73 | this access |  |
+| AccessorCalls.cs:63:70:63:73 | this access | AccessorCalls.cs:63:70:63:75 | access to field x |  |
+| AccessorCalls.cs:63:70:63:75 | access to field x | AccessorCalls.cs:63:70:63:80 | access to property Prop |  |
+| AccessorCalls.cs:63:70:63:80 | access to property Prop | AccessorCalls.cs:63:84:63:84 | 0 |  |
+| AccessorCalls.cs:63:83:63:96 | (..., ...) | AccessorCalls.cs:63:55:63:97 | (..., ...) |  |
+| AccessorCalls.cs:63:84:63:84 | 0 | AccessorCalls.cs:63:87:63:90 | this access |  |
+| AccessorCalls.cs:63:87:63:90 | this access | AccessorCalls.cs:63:87:63:92 | access to field x |  |
+| AccessorCalls.cs:63:87:63:92 | access to field x | AccessorCalls.cs:63:94:63:94 | 1 |  |
+| AccessorCalls.cs:63:87:63:95 | access to indexer | AccessorCalls.cs:63:83:63:96 | (..., ...) |  |
+| AccessorCalls.cs:63:94:63:94 | 1 | AccessorCalls.cs:63:87:63:95 | access to indexer |  |
+| AccessorCalls.cs:66:10:66:11 | enter M9 | AccessorCalls.cs:67:5:74:5 | {...} |  |
+| AccessorCalls.cs:66:10:66:11 | exit M9 (normal) | AccessorCalls.cs:66:10:66:11 | exit M9 |  |
+| AccessorCalls.cs:67:5:74:5 | {...} | AccessorCalls.cs:68:9:68:22 | ... ...; |  |
+| AccessorCalls.cs:68:9:68:22 | ... ...; | AccessorCalls.cs:68:21:68:21 | access to parameter o |  |
+| AccessorCalls.cs:68:17:68:21 | dynamic d = ... | AccessorCalls.cs:69:9:69:36 | ...; |  |
+| AccessorCalls.cs:68:21:68:21 | access to parameter o | AccessorCalls.cs:68:17:68:21 | dynamic d = ... |  |
+| AccessorCalls.cs:69:9:69:9 | access to local variable d | AccessorCalls.cs:69:24:69:24 | access to local variable d |  |
+| AccessorCalls.cs:69:9:69:20 | dynamic access to member MaybeProp1 | AccessorCalls.cs:69:9:69:35 | ... = ... |  |
+| AccessorCalls.cs:69:9:69:35 | ... = ... | AccessorCalls.cs:70:9:70:22 | ...; |  |
+| AccessorCalls.cs:69:9:69:36 | ...; | AccessorCalls.cs:69:9:69:9 | access to local variable d |  |
+| AccessorCalls.cs:69:24:69:24 | access to local variable d | AccessorCalls.cs:69:24:69:35 | dynamic access to member MaybeProp2 |  |
+| AccessorCalls.cs:69:24:69:35 | dynamic access to member MaybeProp2 | AccessorCalls.cs:69:9:69:20 | dynamic access to member MaybeProp1 |  |
+| AccessorCalls.cs:70:9:70:9 | access to local variable d | AccessorCalls.cs:70:9:70:19 | dynamic access to member MaybeProp |  |
+| AccessorCalls.cs:70:9:70:19 | dynamic access to member MaybeProp | AccessorCalls.cs:70:9:70:21 | dynamic call to operator ++ |  |
+| AccessorCalls.cs:70:9:70:21 | dynamic call to operator ++ | AccessorCalls.cs:71:9:71:26 | ...; |  |
+| AccessorCalls.cs:70:9:70:22 | ...; | AccessorCalls.cs:70:9:70:9 | access to local variable d |  |
+| AccessorCalls.cs:71:9:71:9 | access to local variable d | AccessorCalls.cs:71:9:71:9 | access to local variable d |  |
+| AccessorCalls.cs:71:9:71:9 | access to local variable d | AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent |  |
+| AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | AccessorCalls.cs:71:9:71:25 | ... = ... |  |
+| AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent | AccessorCalls.cs:71:25:71:25 | access to parameter e |  |
+| AccessorCalls.cs:71:9:71:25 | ... = ... | AccessorCalls.cs:72:9:72:21 | ...; |  |
+| AccessorCalls.cs:71:9:71:25 | dynamic call to operator + | AccessorCalls.cs:71:9:71:20 | dynamic access to member MaybeEvent |  |
+| AccessorCalls.cs:71:9:71:26 | ...; | AccessorCalls.cs:71:9:71:9 | access to local variable d |  |
+| AccessorCalls.cs:71:25:71:25 | access to parameter e | AccessorCalls.cs:71:9:71:25 | dynamic call to operator + |  |
+| AccessorCalls.cs:72:9:72:9 | access to local variable d | AccessorCalls.cs:72:11:72:11 | 0 |  |
+| AccessorCalls.cs:72:9:72:9 | access to local variable d | AccessorCalls.cs:72:11:72:11 | 0 |  |
+| AccessorCalls.cs:72:9:72:12 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | ... = ... |  |
+| AccessorCalls.cs:72:9:72:12 | dynamic access to element | AccessorCalls.cs:72:17:72:17 | access to local variable d |  |
+| AccessorCalls.cs:72:9:72:20 | ... = ... | AccessorCalls.cs:73:9:73:84 | ...; |  |
+| AccessorCalls.cs:72:9:72:20 | dynamic call to operator + | AccessorCalls.cs:72:9:72:12 | dynamic access to element |  |
+| AccessorCalls.cs:72:9:72:21 | ...; | AccessorCalls.cs:72:9:72:9 | access to local variable d |  |
+| AccessorCalls.cs:72:11:72:11 | 0 | AccessorCalls.cs:72:9:72:9 | access to local variable d |  |
+| AccessorCalls.cs:72:11:72:11 | 0 | AccessorCalls.cs:72:9:72:12 | dynamic access to element |  |
+| AccessorCalls.cs:72:17:72:17 | access to local variable d | AccessorCalls.cs:72:19:72:19 | 1 |  |
+| AccessorCalls.cs:72:17:72:20 | dynamic access to element | AccessorCalls.cs:72:9:72:20 | dynamic call to operator + |  |
+| AccessorCalls.cs:72:19:72:19 | 1 | AccessorCalls.cs:72:17:72:20 | dynamic access to element |  |
+| AccessorCalls.cs:73:9:73:44 | (..., ...) | AccessorCalls.cs:73:49:73:49 | access to local variable d |  |
+| AccessorCalls.cs:73:9:73:83 | ... = ... | AccessorCalls.cs:66:10:66:11 | exit M9 (normal) |  |
+| AccessorCalls.cs:73:9:73:84 | ...; | AccessorCalls.cs:73:10:73:10 | access to local variable d |  |
+| AccessorCalls.cs:73:10:73:10 | access to local variable d | AccessorCalls.cs:73:24:73:27 | this access |  |
+| AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:24:73:32 | access to property Prop |  |
+| AccessorCalls.cs:73:24:73:27 | this access | AccessorCalls.cs:73:39:73:39 | access to local variable d |  |
+| AccessorCalls.cs:73:24:73:32 | access to property Prop | AccessorCalls.cs:73:39:73:42 | dynamic access to element |  |
+| AccessorCalls.cs:73:35:73:43 | (..., ...) | AccessorCalls.cs:73:9:73:44 | (..., ...) |  |
+| AccessorCalls.cs:73:39:73:39 | access to local variable d | AccessorCalls.cs:73:41:73:41 | 0 |  |
+| AccessorCalls.cs:73:39:73:42 | dynamic access to element | AccessorCalls.cs:73:9:73:83 | ... = ... |  |
+| AccessorCalls.cs:73:41:73:41 | 0 | AccessorCalls.cs:73:35:73:43 | (..., ...) |  |
+| AccessorCalls.cs:73:48:73:83 | (..., ...) | AccessorCalls.cs:73:10:73:21 | dynamic access to member MaybeProp1 |  |
+| AccessorCalls.cs:73:49:73:49 | access to local variable d | AccessorCalls.cs:73:49:73:60 | dynamic access to member MaybeProp1 |  |
+| AccessorCalls.cs:73:49:73:60 | dynamic access to member MaybeProp1 | AccessorCalls.cs:73:63:73:66 | this access |  |
+| AccessorCalls.cs:73:63:73:66 | this access | AccessorCalls.cs:73:63:73:71 | access to property Prop |  |
+| AccessorCalls.cs:73:63:73:71 | access to property Prop | AccessorCalls.cs:73:75:73:75 | 0 |  |
+| AccessorCalls.cs:73:74:73:82 | (..., ...) | AccessorCalls.cs:73:48:73:83 | (..., ...) |  |
+| AccessorCalls.cs:73:75:73:75 | 0 | AccessorCalls.cs:73:78:73:78 | access to local variable d |  |
+| AccessorCalls.cs:73:78:73:78 | access to local variable d | AccessorCalls.cs:73:80:73:80 | 1 |  |
+| AccessorCalls.cs:73:78:73:81 | dynamic access to element | AccessorCalls.cs:73:74:73:82 | (..., ...) |  |
+| AccessorCalls.cs:73:80:73:80 | 1 | AccessorCalls.cs:73:78:73:81 | dynamic access to element |  |
+| ArrayCreation.cs:1:7:1:19 | call to constructor Object | ArrayCreation.cs:1:7:1:19 | {...} |  |
+| ArrayCreation.cs:1:7:1:19 | enter ArrayCreation | ArrayCreation.cs:1:7:1:19 | call to constructor Object |  |
+| ArrayCreation.cs:1:7:1:19 | exit ArrayCreation (normal) | ArrayCreation.cs:1:7:1:19 | exit ArrayCreation |  |
+| ArrayCreation.cs:1:7:1:19 | {...} | ArrayCreation.cs:1:7:1:19 | exit ArrayCreation (normal) |  |
+| ArrayCreation.cs:3:11:3:12 | enter M1 | ArrayCreation.cs:3:27:3:27 | 0 |  |
+| ArrayCreation.cs:3:11:3:12 | exit M1 (normal) | ArrayCreation.cs:3:11:3:12 | exit M1 |  |
+| ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] | ArrayCreation.cs:3:11:3:12 | exit M1 (normal) |  |
+| ArrayCreation.cs:3:27:3:27 | 0 | ArrayCreation.cs:3:19:3:28 | array creation of type Int32[] |  |
+| ArrayCreation.cs:5:12:5:13 | enter M2 | ArrayCreation.cs:5:28:5:28 | 0 |  |
+| ArrayCreation.cs:5:12:5:13 | exit M2 (normal) | ArrayCreation.cs:5:12:5:13 | exit M2 |  |
+| ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] | ArrayCreation.cs:5:12:5:13 | exit M2 (normal) |  |
+| ArrayCreation.cs:5:28:5:28 | 0 | ArrayCreation.cs:5:31:5:31 | 1 |  |
+| ArrayCreation.cs:5:31:5:31 | 1 | ArrayCreation.cs:5:20:5:32 | array creation of type Int32[,] |  |
+| ArrayCreation.cs:7:11:7:12 | enter M3 | ArrayCreation.cs:7:19:7:36 | 2 |  |
+| ArrayCreation.cs:7:11:7:12 | exit M3 (normal) | ArrayCreation.cs:7:11:7:12 | exit M3 |  |
+| ArrayCreation.cs:7:19:7:36 | 2 | ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] |  |
+| ArrayCreation.cs:7:19:7:36 | array creation of type Int32[] | ArrayCreation.cs:7:31:7:31 | 0 |  |
+| ArrayCreation.cs:7:29:7:36 | { ..., ... } | ArrayCreation.cs:7:11:7:12 | exit M3 (normal) |  |
+| ArrayCreation.cs:7:31:7:31 | 0 | ArrayCreation.cs:7:34:7:34 | 1 |  |
+| ArrayCreation.cs:7:34:7:34 | 1 | ArrayCreation.cs:7:29:7:36 | { ..., ... } |  |
+| ArrayCreation.cs:9:12:9:13 | enter M4 | ArrayCreation.cs:9:20:9:52 | 2 |  |
+| ArrayCreation.cs:9:12:9:13 | exit M4 (normal) | ArrayCreation.cs:9:12:9:13 | exit M4 |  |
+| ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | 2 |  |
+| ArrayCreation.cs:9:20:9:52 | 2 | ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] |  |
+| ArrayCreation.cs:9:20:9:52 | array creation of type Int32[,] | ArrayCreation.cs:9:35:9:35 | 0 |  |
+| ArrayCreation.cs:9:31:9:52 | { ..., ... } | ArrayCreation.cs:9:12:9:13 | exit M4 (normal) |  |
+| ArrayCreation.cs:9:33:9:40 | { ..., ... } | ArrayCreation.cs:9:45:9:45 | 2 |  |
+| ArrayCreation.cs:9:35:9:35 | 0 | ArrayCreation.cs:9:38:9:38 | 1 |  |
+| ArrayCreation.cs:9:38:9:38 | 1 | ArrayCreation.cs:9:33:9:40 | { ..., ... } |  |
+| ArrayCreation.cs:9:43:9:50 | { ..., ... } | ArrayCreation.cs:9:31:9:52 | { ..., ... } |  |
+| ArrayCreation.cs:9:45:9:45 | 2 | ArrayCreation.cs:9:48:9:48 | 3 |  |
+| ArrayCreation.cs:9:48:9:48 | 3 | ArrayCreation.cs:9:43:9:50 | { ..., ... } |  |
+| Assert.cs:5:7:5:17 | call to constructor Object | Assert.cs:5:7:5:17 | {...} |  |
+| Assert.cs:5:7:5:17 | enter AssertTests | Assert.cs:5:7:5:17 | call to constructor Object |  |
+| Assert.cs:5:7:5:17 | exit AssertTests (normal) | Assert.cs:5:7:5:17 | exit AssertTests |  |
+| Assert.cs:5:7:5:17 | {...} | Assert.cs:5:7:5:17 | exit AssertTests (normal) |  |
+| Assert.cs:7:10:7:11 | enter M1 | Assert.cs:8:5:12:5 | {...} |  |
+| Assert.cs:7:10:7:11 | exit M1 (abnormal) | Assert.cs:7:10:7:11 | exit M1 |  |
+| Assert.cs:7:10:7:11 | exit M1 (normal) | Assert.cs:7:10:7:11 | exit M1 |  |
+| Assert.cs:8:5:12:5 | {...} | Assert.cs:9:9:9:33 | ... ...; |  |
+| Assert.cs:9:9:9:33 | ... ...; | Assert.cs:9:20:9:20 | access to parameter b |  |
+| Assert.cs:9:16:9:32 | String s = ... | Assert.cs:10:9:10:32 | ...; |  |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:24:9:27 | null | true |
+| Assert.cs:9:20:9:20 | access to parameter b | Assert.cs:9:31:9:32 | "" | false |
+| Assert.cs:9:20:9:32 | ... ? ... : ... | Assert.cs:9:16:9:32 | String s = ... |  |
+| Assert.cs:9:24:9:27 | null | Assert.cs:9:20:9:32 | ... ? ... : ... |  |
+| Assert.cs:9:31:9:32 | "" | Assert.cs:9:20:9:32 | ... ? ... : ... |  |
+| Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | Assert.cs:7:10:7:11 | exit M1 (abnormal) | exit |
+| Assert.cs:10:9:10:31 | [assertion success] call to method Assert | Assert.cs:11:9:11:36 | ...; |  |
+| Assert.cs:10:9:10:32 | ...; | Assert.cs:10:22:10:22 | access to local variable s |  |
+| Assert.cs:10:22:10:22 | access to local variable s | Assert.cs:10:27:10:30 | null |  |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion failure] call to method Assert | false |
+| Assert.cs:10:22:10:30 | ... != ... | Assert.cs:10:9:10:31 | [assertion success] call to method Assert | true |
+| Assert.cs:10:27:10:30 | null | Assert.cs:10:22:10:30 | ... != ... |  |
+| Assert.cs:11:9:11:35 | call to method WriteLine | Assert.cs:7:10:7:11 | exit M1 (normal) |  |
+| Assert.cs:11:9:11:36 | ...; | Assert.cs:11:27:11:27 | access to local variable s |  |
+| Assert.cs:11:27:11:27 | access to local variable s | Assert.cs:11:27:11:34 | access to property Length |  |
+| Assert.cs:11:27:11:34 | access to property Length | Assert.cs:11:9:11:35 | call to method WriteLine |  |
+| Assert.cs:14:10:14:11 | enter M2 | Assert.cs:15:5:19:5 | {...} |  |
+| Assert.cs:14:10:14:11 | exit M2 (abnormal) | Assert.cs:14:10:14:11 | exit M2 |  |
+| Assert.cs:14:10:14:11 | exit M2 (normal) | Assert.cs:14:10:14:11 | exit M2 |  |
+| Assert.cs:15:5:19:5 | {...} | Assert.cs:16:9:16:33 | ... ...; |  |
+| Assert.cs:16:9:16:33 | ... ...; | Assert.cs:16:20:16:20 | access to parameter b |  |
+| Assert.cs:16:16:16:32 | String s = ... | Assert.cs:17:9:17:25 | ...; |  |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:24:16:27 | null | true |
+| Assert.cs:16:20:16:20 | access to parameter b | Assert.cs:16:31:16:32 | "" | false |
+| Assert.cs:16:20:16:32 | ... ? ... : ... | Assert.cs:16:16:16:32 | String s = ... |  |
+| Assert.cs:16:24:16:27 | null | Assert.cs:16:20:16:32 | ... ? ... : ... |  |
+| Assert.cs:16:31:16:32 | "" | Assert.cs:16:20:16:32 | ... ? ... : ... |  |
+| Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | Assert.cs:14:10:14:11 | exit M2 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | Assert.cs:18:9:18:36 | ...; |  |
+| Assert.cs:17:9:17:25 | ...; | Assert.cs:17:23:17:23 | access to local variable s |  |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion failure] call to method IsNull | non-null |
+| Assert.cs:17:23:17:23 | access to local variable s | Assert.cs:17:9:17:24 | [assertion success] call to method IsNull | null |
+| Assert.cs:18:9:18:35 | call to method WriteLine | Assert.cs:14:10:14:11 | exit M2 (normal) |  |
+| Assert.cs:18:9:18:36 | ...; | Assert.cs:18:27:18:27 | access to local variable s |  |
+| Assert.cs:18:27:18:27 | access to local variable s | Assert.cs:18:27:18:34 | access to property Length |  |
+| Assert.cs:18:27:18:34 | access to property Length | Assert.cs:18:9:18:35 | call to method WriteLine |  |
+| Assert.cs:21:10:21:11 | enter M3 | Assert.cs:22:5:26:5 | {...} |  |
+| Assert.cs:21:10:21:11 | exit M3 (abnormal) | Assert.cs:21:10:21:11 | exit M3 |  |
+| Assert.cs:21:10:21:11 | exit M3 (normal) | Assert.cs:21:10:21:11 | exit M3 |  |
+| Assert.cs:22:5:26:5 | {...} | Assert.cs:23:9:23:33 | ... ...; |  |
+| Assert.cs:23:9:23:33 | ... ...; | Assert.cs:23:20:23:20 | access to parameter b |  |
+| Assert.cs:23:16:23:32 | String s = ... | Assert.cs:24:9:24:28 | ...; |  |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:24:23:27 | null | true |
+| Assert.cs:23:20:23:20 | access to parameter b | Assert.cs:23:31:23:32 | "" | false |
+| Assert.cs:23:20:23:32 | ... ? ... : ... | Assert.cs:23:16:23:32 | String s = ... |  |
+| Assert.cs:23:24:23:27 | null | Assert.cs:23:20:23:32 | ... ? ... : ... |  |
+| Assert.cs:23:31:23:32 | "" | Assert.cs:23:20:23:32 | ... ? ... : ... |  |
+| Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | Assert.cs:21:10:21:11 | exit M3 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | Assert.cs:25:9:25:36 | ...; |  |
+| Assert.cs:24:9:24:28 | ...; | Assert.cs:24:26:24:26 | access to local variable s |  |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion failure] call to method IsNotNull | null |
+| Assert.cs:24:26:24:26 | access to local variable s | Assert.cs:24:9:24:27 | [assertion success] call to method IsNotNull | non-null |
+| Assert.cs:25:9:25:35 | call to method WriteLine | Assert.cs:21:10:21:11 | exit M3 (normal) |  |
+| Assert.cs:25:9:25:36 | ...; | Assert.cs:25:27:25:27 | access to local variable s |  |
+| Assert.cs:25:27:25:27 | access to local variable s | Assert.cs:25:27:25:34 | access to property Length |  |
+| Assert.cs:25:27:25:34 | access to property Length | Assert.cs:25:9:25:35 | call to method WriteLine |  |
+| Assert.cs:28:10:28:11 | enter M4 | Assert.cs:29:5:33:5 | {...} |  |
+| Assert.cs:28:10:28:11 | exit M4 (abnormal) | Assert.cs:28:10:28:11 | exit M4 |  |
+| Assert.cs:28:10:28:11 | exit M4 (normal) | Assert.cs:28:10:28:11 | exit M4 |  |
+| Assert.cs:29:5:33:5 | {...} | Assert.cs:30:9:30:33 | ... ...; |  |
+| Assert.cs:30:9:30:33 | ... ...; | Assert.cs:30:20:30:20 | access to parameter b |  |
+| Assert.cs:30:16:30:32 | String s = ... | Assert.cs:31:9:31:33 | ...; |  |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:24:30:27 | null | true |
+| Assert.cs:30:20:30:20 | access to parameter b | Assert.cs:30:31:30:32 | "" | false |
+| Assert.cs:30:20:30:32 | ... ? ... : ... | Assert.cs:30:16:30:32 | String s = ... |  |
+| Assert.cs:30:24:30:27 | null | Assert.cs:30:20:30:32 | ... ? ... : ... |  |
+| Assert.cs:30:31:30:32 | "" | Assert.cs:30:20:30:32 | ... ? ... : ... |  |
+| Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | Assert.cs:28:10:28:11 | exit M4 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | Assert.cs:32:9:32:36 | ...; |  |
+| Assert.cs:31:9:31:33 | ...; | Assert.cs:31:23:31:23 | access to local variable s |  |
+| Assert.cs:31:23:31:23 | access to local variable s | Assert.cs:31:28:31:31 | null |  |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:31:23:31:31 | ... == ... | Assert.cs:31:9:31:32 | [assertion success] call to method IsTrue | true |
+| Assert.cs:31:28:31:31 | null | Assert.cs:31:23:31:31 | ... == ... |  |
+| Assert.cs:32:9:32:35 | call to method WriteLine | Assert.cs:28:10:28:11 | exit M4 (normal) |  |
+| Assert.cs:32:9:32:36 | ...; | Assert.cs:32:27:32:27 | access to local variable s |  |
+| Assert.cs:32:27:32:27 | access to local variable s | Assert.cs:32:27:32:34 | access to property Length |  |
+| Assert.cs:32:27:32:34 | access to property Length | Assert.cs:32:9:32:35 | call to method WriteLine |  |
+| Assert.cs:35:10:35:11 | enter M5 | Assert.cs:36:5:40:5 | {...} |  |
+| Assert.cs:35:10:35:11 | exit M5 (abnormal) | Assert.cs:35:10:35:11 | exit M5 |  |
+| Assert.cs:35:10:35:11 | exit M5 (normal) | Assert.cs:35:10:35:11 | exit M5 |  |
+| Assert.cs:36:5:40:5 | {...} | Assert.cs:37:9:37:33 | ... ...; |  |
+| Assert.cs:37:9:37:33 | ... ...; | Assert.cs:37:20:37:20 | access to parameter b |  |
+| Assert.cs:37:16:37:32 | String s = ... | Assert.cs:38:9:38:33 | ...; |  |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:24:37:27 | null | true |
+| Assert.cs:37:20:37:20 | access to parameter b | Assert.cs:37:31:37:32 | "" | false |
+| Assert.cs:37:20:37:32 | ... ? ... : ... | Assert.cs:37:16:37:32 | String s = ... |  |
+| Assert.cs:37:24:37:27 | null | Assert.cs:37:20:37:32 | ... ? ... : ... |  |
+| Assert.cs:37:31:37:32 | "" | Assert.cs:37:20:37:32 | ... ? ... : ... |  |
+| Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | Assert.cs:35:10:35:11 | exit M5 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | Assert.cs:39:9:39:36 | ...; |  |
+| Assert.cs:38:9:38:33 | ...; | Assert.cs:38:23:38:23 | access to local variable s |  |
+| Assert.cs:38:23:38:23 | access to local variable s | Assert.cs:38:28:38:31 | null |  |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:38:23:38:31 | ... != ... | Assert.cs:38:9:38:32 | [assertion success] call to method IsTrue | true |
+| Assert.cs:38:28:38:31 | null | Assert.cs:38:23:38:31 | ... != ... |  |
+| Assert.cs:39:9:39:35 | call to method WriteLine | Assert.cs:35:10:35:11 | exit M5 (normal) |  |
+| Assert.cs:39:9:39:36 | ...; | Assert.cs:39:27:39:27 | access to local variable s |  |
+| Assert.cs:39:27:39:27 | access to local variable s | Assert.cs:39:27:39:34 | access to property Length |  |
+| Assert.cs:39:27:39:34 | access to property Length | Assert.cs:39:9:39:35 | call to method WriteLine |  |
+| Assert.cs:42:10:42:11 | enter M6 | Assert.cs:43:5:47:5 | {...} |  |
+| Assert.cs:42:10:42:11 | exit M6 (abnormal) | Assert.cs:42:10:42:11 | exit M6 |  |
+| Assert.cs:42:10:42:11 | exit M6 (normal) | Assert.cs:42:10:42:11 | exit M6 |  |
+| Assert.cs:43:5:47:5 | {...} | Assert.cs:44:9:44:33 | ... ...; |  |
+| Assert.cs:44:9:44:33 | ... ...; | Assert.cs:44:20:44:20 | access to parameter b |  |
+| Assert.cs:44:16:44:32 | String s = ... | Assert.cs:45:9:45:34 | ...; |  |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:24:44:27 | null | true |
+| Assert.cs:44:20:44:20 | access to parameter b | Assert.cs:44:31:44:32 | "" | false |
+| Assert.cs:44:20:44:32 | ... ? ... : ... | Assert.cs:44:16:44:32 | String s = ... |  |
+| Assert.cs:44:24:44:27 | null | Assert.cs:44:20:44:32 | ... ? ... : ... |  |
+| Assert.cs:44:31:44:32 | "" | Assert.cs:44:20:44:32 | ... ? ... : ... |  |
+| Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | Assert.cs:42:10:42:11 | exit M6 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | Assert.cs:46:9:46:36 | ...; |  |
+| Assert.cs:45:9:45:34 | ...; | Assert.cs:45:24:45:24 | access to local variable s |  |
+| Assert.cs:45:24:45:24 | access to local variable s | Assert.cs:45:29:45:32 | null |  |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:45:24:45:32 | ... != ... | Assert.cs:45:9:45:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:45:29:45:32 | null | Assert.cs:45:24:45:32 | ... != ... |  |
+| Assert.cs:46:9:46:35 | call to method WriteLine | Assert.cs:42:10:42:11 | exit M6 (normal) |  |
+| Assert.cs:46:9:46:36 | ...; | Assert.cs:46:27:46:27 | access to local variable s |  |
+| Assert.cs:46:27:46:27 | access to local variable s | Assert.cs:46:27:46:34 | access to property Length |  |
+| Assert.cs:46:27:46:34 | access to property Length | Assert.cs:46:9:46:35 | call to method WriteLine |  |
+| Assert.cs:49:10:49:11 | enter M7 | Assert.cs:50:5:54:5 | {...} |  |
+| Assert.cs:49:10:49:11 | exit M7 (abnormal) | Assert.cs:49:10:49:11 | exit M7 |  |
+| Assert.cs:49:10:49:11 | exit M7 (normal) | Assert.cs:49:10:49:11 | exit M7 |  |
+| Assert.cs:50:5:54:5 | {...} | Assert.cs:51:9:51:33 | ... ...; |  |
+| Assert.cs:51:9:51:33 | ... ...; | Assert.cs:51:20:51:20 | access to parameter b |  |
+| Assert.cs:51:16:51:32 | String s = ... | Assert.cs:52:9:52:34 | ...; |  |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:24:51:27 | null | true |
+| Assert.cs:51:20:51:20 | access to parameter b | Assert.cs:51:31:51:32 | "" | false |
+| Assert.cs:51:20:51:32 | ... ? ... : ... | Assert.cs:51:16:51:32 | String s = ... |  |
+| Assert.cs:51:24:51:27 | null | Assert.cs:51:20:51:32 | ... ? ... : ... |  |
+| Assert.cs:51:31:51:32 | "" | Assert.cs:51:20:51:32 | ... ? ... : ... |  |
+| Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | Assert.cs:49:10:49:11 | exit M7 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | Assert.cs:53:9:53:36 | ...; |  |
+| Assert.cs:52:9:52:34 | ...; | Assert.cs:52:24:52:24 | access to local variable s |  |
+| Assert.cs:52:24:52:24 | access to local variable s | Assert.cs:52:29:52:32 | null |  |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:52:24:52:32 | ... == ... | Assert.cs:52:9:52:33 | [assertion success] call to method IsFalse | false |
+| Assert.cs:52:29:52:32 | null | Assert.cs:52:24:52:32 | ... == ... |  |
+| Assert.cs:53:9:53:35 | call to method WriteLine | Assert.cs:49:10:49:11 | exit M7 (normal) |  |
+| Assert.cs:53:9:53:36 | ...; | Assert.cs:53:27:53:27 | access to local variable s |  |
+| Assert.cs:53:27:53:27 | access to local variable s | Assert.cs:53:27:53:34 | access to property Length |  |
+| Assert.cs:53:27:53:34 | access to property Length | Assert.cs:53:9:53:35 | call to method WriteLine |  |
+| Assert.cs:56:10:56:11 | enter M8 | Assert.cs:57:5:61:5 | {...} |  |
+| Assert.cs:56:10:56:11 | exit M8 (abnormal) | Assert.cs:56:10:56:11 | exit M8 |  |
+| Assert.cs:56:10:56:11 | exit M8 (normal) | Assert.cs:56:10:56:11 | exit M8 |  |
+| Assert.cs:57:5:61:5 | {...} | Assert.cs:58:9:58:33 | ... ...; |  |
+| Assert.cs:58:9:58:33 | ... ...; | Assert.cs:58:20:58:20 | access to parameter b |  |
+| Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): false] ...; |  |
+| Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... | Assert.cs:59:9:59:38 | [b (line 56): true] ...; |  |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:24:58:27 | [b (line 56): true] null | true |
+| Assert.cs:58:20:58:20 | access to parameter b | Assert.cs:58:31:58:32 | [b (line 56): false] "" | false |
+| Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): false] String s = ... |  |
+| Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... | Assert.cs:58:16:58:32 | [b (line 56): true] String s = ... |  |
+| Assert.cs:58:24:58:27 | [b (line 56): true] null | Assert.cs:58:20:58:32 | [b (line 56): true] ... ? ... : ... |  |
+| Assert.cs:58:31:58:32 | [b (line 56): false] "" | Assert.cs:58:20:58:32 | [b (line 56): false] ... ? ... : ... |  |
+| Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | Assert.cs:56:10:56:11 | exit M8 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | Assert.cs:60:9:60:36 | ...; |  |
+| Assert.cs:59:9:59:38 | [b (line 56): false] ...; | Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s |  |
+| Assert.cs:59:9:59:38 | [b (line 56): true] ...; | Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s |  |
+| Assert.cs:59:23:59:23 | [b (line 56): false] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): false] null |  |
+| Assert.cs:59:23:59:23 | [b (line 56): true] access to local variable s | Assert.cs:59:28:59:31 | [b (line 56): true] null |  |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | false |
+| Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | true |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:23:59:36 | [false] ... && ... | false |
+| Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... | Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | true |
+| Assert.cs:59:23:59:36 | [false] ... && ... | Assert.cs:59:9:59:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:59:23:59:36 | [true] ... && ... | Assert.cs:59:9:59:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:59:28:59:31 | [b (line 56): false] null | Assert.cs:59:23:59:31 | [b (line 56): false] ... != ... |  |
+| Assert.cs:59:28:59:31 | [b (line 56): true] null | Assert.cs:59:23:59:31 | [b (line 56): true] ... != ... |  |
+| Assert.cs:59:36:59:36 | [b (line 56): false] access to parameter b | Assert.cs:59:23:59:36 | [false] ... && ... | false |
+| Assert.cs:59:36:59:36 | [b (line 56): true] access to parameter b | Assert.cs:59:23:59:36 | [true] ... && ... | true |
+| Assert.cs:60:9:60:35 | call to method WriteLine | Assert.cs:56:10:56:11 | exit M8 (normal) |  |
+| Assert.cs:60:9:60:36 | ...; | Assert.cs:60:27:60:27 | access to local variable s |  |
+| Assert.cs:60:27:60:27 | access to local variable s | Assert.cs:60:27:60:34 | access to property Length |  |
+| Assert.cs:60:27:60:34 | access to property Length | Assert.cs:60:9:60:35 | call to method WriteLine |  |
+| Assert.cs:63:10:63:11 | enter M9 | Assert.cs:64:5:68:5 | {...} |  |
+| Assert.cs:63:10:63:11 | exit M9 (abnormal) | Assert.cs:63:10:63:11 | exit M9 |  |
+| Assert.cs:63:10:63:11 | exit M9 (normal) | Assert.cs:63:10:63:11 | exit M9 |  |
+| Assert.cs:64:5:68:5 | {...} | Assert.cs:65:9:65:33 | ... ...; |  |
+| Assert.cs:65:9:65:33 | ... ...; | Assert.cs:65:20:65:20 | access to parameter b |  |
+| Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): false] ...; |  |
+| Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... | Assert.cs:66:9:66:39 | [b (line 63): true] ...; |  |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:24:65:27 | [b (line 63): true] null | true |
+| Assert.cs:65:20:65:20 | access to parameter b | Assert.cs:65:31:65:32 | [b (line 63): false] "" | false |
+| Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): false] String s = ... |  |
+| Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... | Assert.cs:65:16:65:32 | [b (line 63): true] String s = ... |  |
+| Assert.cs:65:24:65:27 | [b (line 63): true] null | Assert.cs:65:20:65:32 | [b (line 63): true] ... ? ... : ... |  |
+| Assert.cs:65:31:65:32 | [b (line 63): false] "" | Assert.cs:65:20:65:32 | [b (line 63): false] ... ? ... : ... |  |
+| Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | Assert.cs:63:10:63:11 | exit M9 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | Assert.cs:67:9:67:36 | ...; |  |
+| Assert.cs:66:9:66:39 | [b (line 63): false] ...; | Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s |  |
+| Assert.cs:66:9:66:39 | [b (line 63): true] ...; | Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s |  |
+| Assert.cs:66:24:66:24 | [b (line 63): false] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): false] null |  |
+| Assert.cs:66:24:66:24 | [b (line 63): true] access to local variable s | Assert.cs:66:29:66:32 | [b (line 63): true] null |  |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
+| Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | false |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
+| Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... | Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | false |
+| Assert.cs:66:24:66:37 | [false] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:66:24:66:37 | [true] ... \|\| ... | Assert.cs:66:9:66:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:66:29:66:32 | [b (line 63): false] null | Assert.cs:66:24:66:32 | [b (line 63): false] ... == ... |  |
+| Assert.cs:66:29:66:32 | [b (line 63): true] null | Assert.cs:66:24:66:32 | [b (line 63): true] ... == ... |  |
+| Assert.cs:66:37:66:37 | [b (line 63): false] access to parameter b | Assert.cs:66:24:66:37 | [false] ... \|\| ... | false |
+| Assert.cs:66:37:66:37 | [b (line 63): true] access to parameter b | Assert.cs:66:24:66:37 | [true] ... \|\| ... | true |
+| Assert.cs:67:9:67:35 | call to method WriteLine | Assert.cs:63:10:63:11 | exit M9 (normal) |  |
+| Assert.cs:67:9:67:36 | ...; | Assert.cs:67:27:67:27 | access to local variable s |  |
+| Assert.cs:67:27:67:27 | access to local variable s | Assert.cs:67:27:67:34 | access to property Length |  |
+| Assert.cs:67:27:67:34 | access to property Length | Assert.cs:67:9:67:35 | call to method WriteLine |  |
+| Assert.cs:70:10:70:12 | enter M10 | Assert.cs:71:5:75:5 | {...} |  |
+| Assert.cs:70:10:70:12 | exit M10 (abnormal) | Assert.cs:70:10:70:12 | exit M10 |  |
+| Assert.cs:70:10:70:12 | exit M10 (normal) | Assert.cs:70:10:70:12 | exit M10 |  |
+| Assert.cs:71:5:75:5 | {...} | Assert.cs:72:9:72:33 | ... ...; |  |
+| Assert.cs:72:9:72:33 | ... ...; | Assert.cs:72:20:72:20 | access to parameter b |  |
+| Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): false] ...; |  |
+| Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... | Assert.cs:73:9:73:38 | [b (line 70): true] ...; |  |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:24:72:27 | [b (line 70): true] null | true |
+| Assert.cs:72:20:72:20 | access to parameter b | Assert.cs:72:31:72:32 | [b (line 70): false] "" | false |
+| Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): false] String s = ... |  |
+| Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... | Assert.cs:72:16:72:32 | [b (line 70): true] String s = ... |  |
+| Assert.cs:72:24:72:27 | [b (line 70): true] null | Assert.cs:72:20:72:32 | [b (line 70): true] ... ? ... : ... |  |
+| Assert.cs:72:31:72:32 | [b (line 70): false] "" | Assert.cs:72:20:72:32 | [b (line 70): false] ... ? ... : ... |  |
+| Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | Assert.cs:70:10:70:12 | exit M10 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | Assert.cs:74:9:74:36 | ...; |  |
+| Assert.cs:73:9:73:38 | [b (line 70): false] ...; | Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s |  |
+| Assert.cs:73:9:73:38 | [b (line 70): true] ...; | Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s |  |
+| Assert.cs:73:23:73:23 | [b (line 70): false] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): false] null |  |
+| Assert.cs:73:23:73:23 | [b (line 70): true] access to local variable s | Assert.cs:73:28:73:31 | [b (line 70): true] null |  |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | false |
+| Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | true |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:23:73:36 | [false] ... && ... | false |
+| Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... | Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | true |
+| Assert.cs:73:23:73:36 | [false] ... && ... | Assert.cs:73:9:73:37 | [assertion failure] call to method IsTrue | false |
+| Assert.cs:73:23:73:36 | [true] ... && ... | Assert.cs:73:9:73:37 | [assertion success] call to method IsTrue | true |
+| Assert.cs:73:28:73:31 | [b (line 70): false] null | Assert.cs:73:23:73:31 | [b (line 70): false] ... == ... |  |
+| Assert.cs:73:28:73:31 | [b (line 70): true] null | Assert.cs:73:23:73:31 | [b (line 70): true] ... == ... |  |
+| Assert.cs:73:36:73:36 | [b (line 70): false] access to parameter b | Assert.cs:73:23:73:36 | [false] ... && ... | false |
+| Assert.cs:73:36:73:36 | [b (line 70): true] access to parameter b | Assert.cs:73:23:73:36 | [true] ... && ... | true |
+| Assert.cs:74:9:74:35 | call to method WriteLine | Assert.cs:70:10:70:12 | exit M10 (normal) |  |
+| Assert.cs:74:9:74:36 | ...; | Assert.cs:74:27:74:27 | access to local variable s |  |
+| Assert.cs:74:27:74:27 | access to local variable s | Assert.cs:74:27:74:34 | access to property Length |  |
+| Assert.cs:74:27:74:34 | access to property Length | Assert.cs:74:9:74:35 | call to method WriteLine |  |
+| Assert.cs:77:10:77:12 | enter M11 | Assert.cs:78:5:82:5 | {...} |  |
+| Assert.cs:77:10:77:12 | exit M11 (abnormal) | Assert.cs:77:10:77:12 | exit M11 |  |
+| Assert.cs:77:10:77:12 | exit M11 (normal) | Assert.cs:77:10:77:12 | exit M11 |  |
+| Assert.cs:78:5:82:5 | {...} | Assert.cs:79:9:79:33 | ... ...; |  |
+| Assert.cs:79:9:79:33 | ... ...; | Assert.cs:79:20:79:20 | access to parameter b |  |
+| Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): false] ...; |  |
+| Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... | Assert.cs:80:9:80:39 | [b (line 77): true] ...; |  |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:24:79:27 | [b (line 77): true] null | true |
+| Assert.cs:79:20:79:20 | access to parameter b | Assert.cs:79:31:79:32 | [b (line 77): false] "" | false |
+| Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): false] String s = ... |  |
+| Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... | Assert.cs:79:16:79:32 | [b (line 77): true] String s = ... |  |
+| Assert.cs:79:24:79:27 | [b (line 77): true] null | Assert.cs:79:20:79:32 | [b (line 77): true] ... ? ... : ... |  |
+| Assert.cs:79:31:79:32 | [b (line 77): false] "" | Assert.cs:79:20:79:32 | [b (line 77): false] ... ? ... : ... |  |
+| Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | Assert.cs:77:10:77:12 | exit M11 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | Assert.cs:81:9:81:36 | ...; |  |
+| Assert.cs:80:9:80:39 | [b (line 77): false] ...; | Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s |  |
+| Assert.cs:80:9:80:39 | [b (line 77): true] ...; | Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s |  |
+| Assert.cs:80:24:80:24 | [b (line 77): false] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): false] null |  |
+| Assert.cs:80:24:80:24 | [b (line 77): true] access to local variable s | Assert.cs:80:29:80:32 | [b (line 77): true] null |  |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
+| Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | false |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
+| Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... | Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | false |
+| Assert.cs:80:24:80:37 | [false] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion success] call to method IsFalse | false |
+| Assert.cs:80:24:80:37 | [true] ... \|\| ... | Assert.cs:80:9:80:38 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:80:29:80:32 | [b (line 77): false] null | Assert.cs:80:24:80:32 | [b (line 77): false] ... != ... |  |
+| Assert.cs:80:29:80:32 | [b (line 77): true] null | Assert.cs:80:24:80:32 | [b (line 77): true] ... != ... |  |
+| Assert.cs:80:37:80:37 | [b (line 77): false] access to parameter b | Assert.cs:80:24:80:37 | [false] ... \|\| ... | false |
+| Assert.cs:80:37:80:37 | [b (line 77): true] access to parameter b | Assert.cs:80:24:80:37 | [true] ... \|\| ... | true |
+| Assert.cs:81:9:81:35 | call to method WriteLine | Assert.cs:77:10:77:12 | exit M11 (normal) |  |
+| Assert.cs:81:9:81:36 | ...; | Assert.cs:81:27:81:27 | access to local variable s |  |
+| Assert.cs:81:27:81:27 | access to local variable s | Assert.cs:81:27:81:34 | access to property Length |  |
+| Assert.cs:81:27:81:34 | access to property Length | Assert.cs:81:9:81:35 | call to method WriteLine |  |
+| Assert.cs:84:10:84:12 | enter M12 | Assert.cs:85:5:129:5 | {...} |  |
+| Assert.cs:84:10:84:12 | exit M12 (abnormal) | Assert.cs:84:10:84:12 | exit M12 |  |
+| Assert.cs:84:10:84:12 | exit M12 (normal) | Assert.cs:84:10:84:12 | exit M12 |  |
+| Assert.cs:85:5:129:5 | {...} | Assert.cs:86:9:86:33 | ... ...; |  |
+| Assert.cs:86:9:86:33 | ... ...; | Assert.cs:86:20:86:20 | access to parameter b |  |
+| Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): false] ...; |  |
+| Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... | Assert.cs:87:9:87:32 | [b (line 84): true] ...; |  |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:24:86:27 | [b (line 84): true] null | true |
+| Assert.cs:86:20:86:20 | access to parameter b | Assert.cs:86:31:86:32 | [b (line 84): false] "" | false |
+| Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): false] String s = ... |  |
+| Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... | Assert.cs:86:16:86:32 | [b (line 84): true] String s = ... |  |
+| Assert.cs:86:24:86:27 | [b (line 84): true] null | Assert.cs:86:20:86:32 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:86:31:86:32 | [b (line 84): false] "" | Assert.cs:86:20:86:32 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exit |
+| Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exit |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): false] ...; |  |
+| Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | Assert.cs:88:9:88:36 | [b (line 84): true] ...; |  |
+| Assert.cs:87:9:87:32 | [b (line 84): false] ...; | Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:87:9:87:32 | [b (line 84): true] ...; | Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:87:22:87:22 | [b (line 84): false] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): false] null |  |
+| Assert.cs:87:22:87:22 | [b (line 84): true] access to local variable s | Assert.cs:87:27:87:30 | [b (line 84): true] null |  |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): false] call to method Assert | false |
+| Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): false] call to method Assert | true |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion failure, b (line 84): true] call to method Assert | false |
+| Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... | Assert.cs:87:9:87:31 | [assertion success, b (line 84): true] call to method Assert | true |
+| Assert.cs:87:27:87:30 | [b (line 84): false] null | Assert.cs:87:22:87:30 | [b (line 84): false] ... != ... |  |
+| Assert.cs:87:27:87:30 | [b (line 84): true] null | Assert.cs:87:22:87:30 | [b (line 84): true] ... != ... |  |
+| Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): false] ...; |  |
+| Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine | Assert.cs:90:9:90:26 | [b (line 84): true] ...; |  |
+| Assert.cs:88:9:88:36 | [b (line 84): false] ...; | Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:88:9:88:36 | [b (line 84): true] ...; | Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:88:27:88:27 | [b (line 84): false] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:88:27:88:27 | [b (line 84): true] access to local variable s | Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:88:27:88:34 | [b (line 84): false] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:88:27:88:34 | [b (line 84): true] access to property Length | Assert.cs:88:9:88:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): false] ...; |  |
+| Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... | Assert.cs:91:9:91:25 | [b (line 84): true] ...; |  |
+| Assert.cs:90:9:90:26 | [b (line 84): false] ...; | Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:90:9:90:26 | [b (line 84): true] ...; | Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:90:13:90:13 | [b (line 84): false] access to parameter b | Assert.cs:90:24:90:25 | [b (line 84): false] "" | false |
+| Assert.cs:90:13:90:13 | [b (line 84): true] access to parameter b | Assert.cs:90:17:90:20 | [b (line 84): true] null | true |
+| Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:90:9:90:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:90:17:90:20 | [b (line 84): true] null | Assert.cs:90:13:90:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:90:24:90:25 | [b (line 84): false] "" | Assert.cs:90:13:90:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): false] ...; |  |
+| Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | Assert.cs:92:9:92:36 | [b (line 84): true] ...; |  |
+| Assert.cs:91:9:91:25 | [b (line 84): false] ...; | Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:91:9:91:25 | [b (line 84): true] ...; | Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): false] call to method IsNull | non-null |
+| Assert.cs:91:23:91:23 | [b (line 84): false] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): false] call to method IsNull | null |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion failure, b (line 84): true] call to method IsNull | non-null |
+| Assert.cs:91:23:91:23 | [b (line 84): true] access to local variable s | Assert.cs:91:9:91:24 | [assertion success, b (line 84): true] call to method IsNull | null |
+| Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): false] ...; |  |
+| Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine | Assert.cs:94:9:94:26 | [b (line 84): true] ...; |  |
+| Assert.cs:92:9:92:36 | [b (line 84): false] ...; | Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:92:9:92:36 | [b (line 84): true] ...; | Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:92:27:92:27 | [b (line 84): false] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:92:27:92:27 | [b (line 84): true] access to local variable s | Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:92:27:92:34 | [b (line 84): false] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:92:27:92:34 | [b (line 84): true] access to property Length | Assert.cs:92:9:92:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): false] ...; |  |
+| Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... | Assert.cs:95:9:95:28 | [b (line 84): true] ...; |  |
+| Assert.cs:94:9:94:26 | [b (line 84): false] ...; | Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:94:9:94:26 | [b (line 84): true] ...; | Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:94:13:94:13 | [b (line 84): false] access to parameter b | Assert.cs:94:24:94:25 | [b (line 84): false] "" | false |
+| Assert.cs:94:13:94:13 | [b (line 84): true] access to parameter b | Assert.cs:94:17:94:20 | [b (line 84): true] null | true |
+| Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:94:9:94:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:94:17:94:20 | [b (line 84): true] null | Assert.cs:94:13:94:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:94:24:94:25 | [b (line 84): false] "" | Assert.cs:94:13:94:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): false] ...; |  |
+| Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | Assert.cs:96:9:96:36 | [b (line 84): true] ...; |  |
+| Assert.cs:95:9:95:28 | [b (line 84): false] ...; | Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:95:9:95:28 | [b (line 84): true] ...; | Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): false] call to method IsNotNull | null |
+| Assert.cs:95:26:95:26 | [b (line 84): false] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): false] call to method IsNotNull | non-null |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion failure, b (line 84): true] call to method IsNotNull | null |
+| Assert.cs:95:26:95:26 | [b (line 84): true] access to local variable s | Assert.cs:95:9:95:27 | [assertion success, b (line 84): true] call to method IsNotNull | non-null |
+| Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): false] ...; |  |
+| Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine | Assert.cs:98:9:98:26 | [b (line 84): true] ...; |  |
+| Assert.cs:96:9:96:36 | [b (line 84): false] ...; | Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:96:9:96:36 | [b (line 84): true] ...; | Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:96:27:96:27 | [b (line 84): false] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:96:27:96:27 | [b (line 84): true] access to local variable s | Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:96:27:96:34 | [b (line 84): false] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:96:27:96:34 | [b (line 84): true] access to property Length | Assert.cs:96:9:96:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): false] ...; |  |
+| Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... | Assert.cs:99:9:99:33 | [b (line 84): true] ...; |  |
+| Assert.cs:98:9:98:26 | [b (line 84): false] ...; | Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:98:9:98:26 | [b (line 84): true] ...; | Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:98:13:98:13 | [b (line 84): false] access to parameter b | Assert.cs:98:24:98:25 | [b (line 84): false] "" | false |
+| Assert.cs:98:13:98:13 | [b (line 84): true] access to parameter b | Assert.cs:98:17:98:20 | [b (line 84): true] null | true |
+| Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:98:9:98:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:98:17:98:20 | [b (line 84): true] null | Assert.cs:98:13:98:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:98:24:98:25 | [b (line 84): false] "" | Assert.cs:98:13:98:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): false] ...; |  |
+| Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:100:9:100:36 | [b (line 84): true] ...; |  |
+| Assert.cs:99:9:99:33 | [b (line 84): false] ...; | Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:99:9:99:33 | [b (line 84): true] ...; | Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:99:23:99:23 | [b (line 84): false] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): false] null |  |
+| Assert.cs:99:23:99:23 | [b (line 84): true] access to local variable s | Assert.cs:99:28:99:31 | [b (line 84): true] null |  |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... | Assert.cs:99:9:99:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:99:28:99:31 | [b (line 84): false] null | Assert.cs:99:23:99:31 | [b (line 84): false] ... == ... |  |
+| Assert.cs:99:28:99:31 | [b (line 84): true] null | Assert.cs:99:23:99:31 | [b (line 84): true] ... == ... |  |
+| Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): false] ...; |  |
+| Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine | Assert.cs:102:9:102:26 | [b (line 84): true] ...; |  |
+| Assert.cs:100:9:100:36 | [b (line 84): false] ...; | Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:100:9:100:36 | [b (line 84): true] ...; | Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:100:27:100:27 | [b (line 84): false] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:100:27:100:27 | [b (line 84): true] access to local variable s | Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:100:27:100:34 | [b (line 84): false] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:100:27:100:34 | [b (line 84): true] access to property Length | Assert.cs:100:9:100:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): false] ...; |  |
+| Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... | Assert.cs:103:9:103:33 | [b (line 84): true] ...; |  |
+| Assert.cs:102:9:102:26 | [b (line 84): false] ...; | Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:102:9:102:26 | [b (line 84): true] ...; | Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:102:13:102:13 | [b (line 84): false] access to parameter b | Assert.cs:102:24:102:25 | [b (line 84): false] "" | false |
+| Assert.cs:102:13:102:13 | [b (line 84): true] access to parameter b | Assert.cs:102:17:102:20 | [b (line 84): true] null | true |
+| Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:102:9:102:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:102:17:102:20 | [b (line 84): true] null | Assert.cs:102:13:102:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:102:24:102:25 | [b (line 84): false] "" | Assert.cs:102:13:102:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): false] ...; |  |
+| Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:104:9:104:36 | [b (line 84): true] ...; |  |
+| Assert.cs:103:9:103:33 | [b (line 84): false] ...; | Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:103:9:103:33 | [b (line 84): true] ...; | Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:103:23:103:23 | [b (line 84): false] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): false] null |  |
+| Assert.cs:103:23:103:23 | [b (line 84): true] access to local variable s | Assert.cs:103:28:103:31 | [b (line 84): true] null |  |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): false] call to method IsTrue | true |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... | Assert.cs:103:9:103:32 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:103:28:103:31 | [b (line 84): false] null | Assert.cs:103:23:103:31 | [b (line 84): false] ... != ... |  |
+| Assert.cs:103:28:103:31 | [b (line 84): true] null | Assert.cs:103:23:103:31 | [b (line 84): true] ... != ... |  |
+| Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): false] ...; |  |
+| Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine | Assert.cs:106:9:106:26 | [b (line 84): true] ...; |  |
+| Assert.cs:104:9:104:36 | [b (line 84): false] ...; | Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:104:9:104:36 | [b (line 84): true] ...; | Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:104:27:104:27 | [b (line 84): false] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:104:27:104:27 | [b (line 84): true] access to local variable s | Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:104:27:104:34 | [b (line 84): false] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:104:27:104:34 | [b (line 84): true] access to property Length | Assert.cs:104:9:104:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): false] ...; |  |
+| Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... | Assert.cs:107:9:107:34 | [b (line 84): true] ...; |  |
+| Assert.cs:106:9:106:26 | [b (line 84): false] ...; | Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:106:9:106:26 | [b (line 84): true] ...; | Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:106:13:106:13 | [b (line 84): false] access to parameter b | Assert.cs:106:24:106:25 | [b (line 84): false] "" | false |
+| Assert.cs:106:13:106:13 | [b (line 84): true] access to parameter b | Assert.cs:106:17:106:20 | [b (line 84): true] null | true |
+| Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:106:9:106:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:106:17:106:20 | [b (line 84): true] null | Assert.cs:106:13:106:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:106:24:106:25 | [b (line 84): false] "" | Assert.cs:106:13:106:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): false] ...; |  |
+| Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:108:9:108:36 | [b (line 84): true] ...; |  |
+| Assert.cs:107:9:107:34 | [b (line 84): false] ...; | Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:107:9:107:34 | [b (line 84): true] ...; | Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:107:24:107:24 | [b (line 84): false] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): false] null |  |
+| Assert.cs:107:24:107:24 | [b (line 84): true] access to local variable s | Assert.cs:107:29:107:32 | [b (line 84): true] null |  |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... | Assert.cs:107:9:107:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:107:29:107:32 | [b (line 84): false] null | Assert.cs:107:24:107:32 | [b (line 84): false] ... != ... |  |
+| Assert.cs:107:29:107:32 | [b (line 84): true] null | Assert.cs:107:24:107:32 | [b (line 84): true] ... != ... |  |
+| Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): false] ...; |  |
+| Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine | Assert.cs:110:9:110:26 | [b (line 84): true] ...; |  |
+| Assert.cs:108:9:108:36 | [b (line 84): false] ...; | Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:108:9:108:36 | [b (line 84): true] ...; | Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:108:27:108:27 | [b (line 84): false] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:108:27:108:27 | [b (line 84): true] access to local variable s | Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:108:27:108:34 | [b (line 84): false] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:108:27:108:34 | [b (line 84): true] access to property Length | Assert.cs:108:9:108:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): false] ...; |  |
+| Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... | Assert.cs:111:9:111:34 | [b (line 84): true] ...; |  |
+| Assert.cs:110:9:110:26 | [b (line 84): false] ...; | Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:110:9:110:26 | [b (line 84): true] ...; | Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:110:13:110:13 | [b (line 84): false] access to parameter b | Assert.cs:110:24:110:25 | [b (line 84): false] "" | false |
+| Assert.cs:110:13:110:13 | [b (line 84): true] access to parameter b | Assert.cs:110:17:110:20 | [b (line 84): true] null | true |
+| Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:110:9:110:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:110:17:110:20 | [b (line 84): true] null | Assert.cs:110:13:110:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:110:24:110:25 | [b (line 84): false] "" | Assert.cs:110:13:110:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): false] ...; |  |
+| Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:112:9:112:36 | [b (line 84): true] ...; |  |
+| Assert.cs:111:9:111:34 | [b (line 84): false] ...; | Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:111:9:111:34 | [b (line 84): true] ...; | Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:111:24:111:24 | [b (line 84): false] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): false] null |  |
+| Assert.cs:111:24:111:24 | [b (line 84): true] access to local variable s | Assert.cs:111:29:111:32 | [b (line 84): true] null |  |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): false] call to method IsFalse | true |
+| Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): false] call to method IsFalse | false |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... | Assert.cs:111:9:111:33 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:111:29:111:32 | [b (line 84): false] null | Assert.cs:111:24:111:32 | [b (line 84): false] ... == ... |  |
+| Assert.cs:111:29:111:32 | [b (line 84): true] null | Assert.cs:111:24:111:32 | [b (line 84): true] ... == ... |  |
+| Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): false] ...; |  |
+| Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine | Assert.cs:114:9:114:26 | [b (line 84): true] ...; |  |
+| Assert.cs:112:9:112:36 | [b (line 84): false] ...; | Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:112:9:112:36 | [b (line 84): true] ...; | Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:112:27:112:27 | [b (line 84): false] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length |  |
+| Assert.cs:112:27:112:27 | [b (line 84): true] access to local variable s | Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:112:27:112:34 | [b (line 84): false] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): false] call to method WriteLine |  |
+| Assert.cs:112:27:112:34 | [b (line 84): true] access to property Length | Assert.cs:112:9:112:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): false] ...; |  |
+| Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... | Assert.cs:115:9:115:38 | [b (line 84): true] ...; |  |
+| Assert.cs:114:9:114:26 | [b (line 84): false] ...; | Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b |  |
+| Assert.cs:114:9:114:26 | [b (line 84): true] ...; | Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:114:13:114:13 | [b (line 84): false] access to parameter b | Assert.cs:114:24:114:25 | [b (line 84): false] "" | false |
+| Assert.cs:114:13:114:13 | [b (line 84): true] access to parameter b | Assert.cs:114:17:114:20 | [b (line 84): true] null | true |
+| Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): false] ... = ... |  |
+| Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:114:9:114:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:114:17:114:20 | [b (line 84): true] null | Assert.cs:114:13:114:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:114:24:114:25 | [b (line 84): false] "" | Assert.cs:114:13:114:25 | [b (line 84): false] ... ? ... : ... |  |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:116:9:116:36 | [b (line 84): true] ...; |  |
+| Assert.cs:115:9:115:38 | [b (line 84): false] ...; | Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s |  |
+| Assert.cs:115:9:115:38 | [b (line 84): true] ...; | Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:115:23:115:23 | [b (line 84): false] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): false] null |  |
+| Assert.cs:115:23:115:23 | [b (line 84): true] access to local variable s | Assert.cs:115:28:115:31 | [b (line 84): true] null |  |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
+| Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | true |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | false |
+| Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... | Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): false] call to method IsTrue | false |
+| Assert.cs:115:23:115:36 | [false, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | Assert.cs:115:9:115:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:115:28:115:31 | [b (line 84): false] null | Assert.cs:115:23:115:31 | [b (line 84): false] ... != ... |  |
+| Assert.cs:115:28:115:31 | [b (line 84): true] null | Assert.cs:115:23:115:31 | [b (line 84): true] ... != ... |  |
+| Assert.cs:115:36:115:36 | [b (line 84): false] access to parameter b | Assert.cs:115:23:115:36 | [false, b (line 84): false] ... && ... | false |
+| Assert.cs:115:36:115:36 | [b (line 84): true] access to parameter b | Assert.cs:115:23:115:36 | [true, b (line 84): true] ... && ... | true |
+| Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine | Assert.cs:118:9:118:26 | [b (line 84): true] ...; |  |
+| Assert.cs:116:9:116:36 | [b (line 84): true] ...; | Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:116:27:116:27 | [b (line 84): true] access to local variable s | Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:116:27:116:34 | [b (line 84): true] access to property Length | Assert.cs:116:9:116:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... | Assert.cs:119:9:119:40 | [b (line 84): true] ...; |  |
+| Assert.cs:118:9:118:26 | [b (line 84): true] ...; | Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:118:13:118:13 | [b (line 84): true] access to parameter b | Assert.cs:118:17:118:20 | [b (line 84): true] null | true |
+| Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:118:9:118:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:118:17:118:20 | [b (line 84): true] null | Assert.cs:118:13:118:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | Assert.cs:120:9:120:36 | [b (line 84): true] ...; |  |
+| Assert.cs:119:9:119:40 | [b (line 84): true] ...; | Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:119:24:119:24 | [b (line 84): true] access to local variable s | Assert.cs:119:29:119:32 | [b (line 84): true] null |  |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | true |
+| Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... | Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion success, b (line 84): true] call to method IsFalse | false |
+| Assert.cs:119:24:119:38 | [true, b (line 84): true] ... \|\| ... | Assert.cs:119:9:119:39 | [assertion failure, b (line 84): true] call to method IsFalse | true |
+| Assert.cs:119:29:119:32 | [b (line 84): true] null | Assert.cs:119:24:119:32 | [b (line 84): true] ... == ... |  |
+| Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | Assert.cs:119:24:119:38 | [false, b (line 84): true] ... \|\| ... | false |
+| Assert.cs:119:38:119:38 | [b (line 84): true] access to parameter b | Assert.cs:119:37:119:38 | [false, b (line 84): true] !... | true |
+| Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine | Assert.cs:122:9:122:26 | [b (line 84): true] ...; |  |
+| Assert.cs:120:9:120:36 | [b (line 84): true] ...; | Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:120:27:120:27 | [b (line 84): true] access to local variable s | Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:120:27:120:34 | [b (line 84): true] access to property Length | Assert.cs:120:9:120:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... | Assert.cs:123:9:123:38 | [b (line 84): true] ...; |  |
+| Assert.cs:122:9:122:26 | [b (line 84): true] ...; | Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:122:13:122:13 | [b (line 84): true] access to parameter b | Assert.cs:122:17:122:20 | [b (line 84): true] null | true |
+| Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:122:9:122:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:122:17:122:20 | [b (line 84): true] null | Assert.cs:122:13:122:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | Assert.cs:124:9:124:36 | [b (line 84): true] ...; |  |
+| Assert.cs:123:9:123:38 | [b (line 84): true] ...; | Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:123:23:123:23 | [b (line 84): true] access to local variable s | Assert.cs:123:28:123:31 | [b (line 84): true] null |  |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | false |
+| Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... | Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | true |
+| Assert.cs:123:23:123:36 | [false, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion failure, b (line 84): true] call to method IsTrue | false |
+| Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | Assert.cs:123:9:123:37 | [assertion success, b (line 84): true] call to method IsTrue | true |
+| Assert.cs:123:28:123:31 | [b (line 84): true] null | Assert.cs:123:23:123:31 | [b (line 84): true] ... == ... |  |
+| Assert.cs:123:36:123:36 | [b (line 84): true] access to parameter b | Assert.cs:123:23:123:36 | [true, b (line 84): true] ... && ... | true |
+| Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine | Assert.cs:126:9:126:26 | [b (line 84): true] ...; |  |
+| Assert.cs:124:9:124:36 | [b (line 84): true] ...; | Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:124:27:124:27 | [b (line 84): true] access to local variable s | Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length |  |
+| Assert.cs:124:27:124:34 | [b (line 84): true] access to property Length | Assert.cs:124:9:124:35 | [b (line 84): true] call to method WriteLine |  |
+| Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... | Assert.cs:127:9:127:40 | [b (line 84): true] ...; |  |
+| Assert.cs:126:9:126:26 | [b (line 84): true] ...; | Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b |  |
+| Assert.cs:126:13:126:13 | [b (line 84): true] access to parameter b | Assert.cs:126:17:126:20 | [b (line 84): true] null | true |
+| Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... | Assert.cs:126:9:126:25 | [b (line 84): true] ... = ... |  |
+| Assert.cs:126:17:126:20 | [b (line 84): true] null | Assert.cs:126:13:126:25 | [b (line 84): true] ... ? ... : ... |  |
+| Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | Assert.cs:84:10:84:12 | exit M12 (abnormal) | exception(AssertFailedException) |
+| Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | Assert.cs:128:9:128:36 | ...; |  |
+| Assert.cs:127:9:127:40 | [b (line 84): true] ...; | Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s |  |
+| Assert.cs:127:24:127:24 | [b (line 84): true] access to local variable s | Assert.cs:127:29:127:32 | [b (line 84): true] null |  |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:24:127:38 | [true] ... \|\| ... | true |
+| Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... | Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | false |
+| Assert.cs:127:24:127:38 | [false] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion success] call to method IsFalse | false |
+| Assert.cs:127:24:127:38 | [true] ... \|\| ... | Assert.cs:127:9:127:39 | [assertion failure] call to method IsFalse | true |
+| Assert.cs:127:29:127:32 | [b (line 84): true] null | Assert.cs:127:24:127:32 | [b (line 84): true] ... != ... |  |
+| Assert.cs:127:37:127:38 | [false] !... | Assert.cs:127:24:127:38 | [false] ... \|\| ... | false |
+| Assert.cs:127:38:127:38 | [b (line 84): true] access to parameter b | Assert.cs:127:37:127:38 | [false] !... | true |
+| Assert.cs:128:9:128:35 | call to method WriteLine | Assert.cs:84:10:84:12 | exit M12 (normal) |  |
+| Assert.cs:128:9:128:36 | ...; | Assert.cs:128:27:128:27 | access to local variable s |  |
+| Assert.cs:128:27:128:27 | access to local variable s | Assert.cs:128:27:128:34 | access to property Length |  |
+| Assert.cs:128:27:128:34 | access to property Length | Assert.cs:128:9:128:35 | call to method WriteLine |  |
+| Assert.cs:131:18:131:32 | enter AssertTrueFalse | Assert.cs:135:5:136:5 | {...} |  |
+| Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) | Assert.cs:131:18:131:32 | exit AssertTrueFalse |  |
+| Assert.cs:135:5:136:5 | {...} | Assert.cs:131:18:131:32 | exit AssertTrueFalse (normal) |  |
+| Assert.cs:138:10:138:12 | enter M13 | Assert.cs:139:5:142:5 | {...} |  |
+| Assert.cs:138:10:138:12 | exit M13 (abnormal) | Assert.cs:138:10:138:12 | exit M13 |  |
+| Assert.cs:138:10:138:12 | exit M13 (normal) | Assert.cs:138:10:138:12 | exit M13 |  |
+| Assert.cs:139:5:142:5 | {...} | Assert.cs:140:9:140:36 | ...; |  |
+| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | exception(Exception) |
+| Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse | Assert.cs:138:10:138:12 | exit M13 (abnormal) | exception(Exception) |
+| Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse | Assert.cs:141:9:141:15 | return ...; |  |
+| Assert.cs:140:9:140:35 | this access | Assert.cs:140:25:140:26 | access to parameter b1 |  |
+| Assert.cs:140:9:140:36 | ...; | Assert.cs:140:9:140:35 | this access |  |
+| Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | false |
+| Assert.cs:140:25:140:26 | access to parameter b1 | Assert.cs:140:29:140:30 | access to parameter b2 | true |
+| Assert.cs:140:29:140:30 | [assertion failure] access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | false, true |
+| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | true |
+| Assert.cs:140:29:140:30 | access to parameter b2 | Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | false |
+| Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |  |
+| Assert.cs:140:33:140:34 | [assertion failure] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion failure] call to method AssertTrueFalse |  |
+| Assert.cs:140:33:140:34 | [assertion success] access to parameter b3 | Assert.cs:140:9:140:35 | [assertion success] call to method AssertTrueFalse |  |
+| Assert.cs:141:9:141:15 | return ...; | Assert.cs:138:10:138:12 | exit M13 (normal) | return |
+| Assignments.cs:1:7:1:17 | call to constructor Object | Assignments.cs:1:7:1:17 | {...} |  |
+| Assignments.cs:1:7:1:17 | enter Assignments | Assignments.cs:1:7:1:17 | call to constructor Object |  |
+| Assignments.cs:1:7:1:17 | exit Assignments (normal) | Assignments.cs:1:7:1:17 | exit Assignments |  |
+| Assignments.cs:1:7:1:17 | {...} | Assignments.cs:1:7:1:17 | exit Assignments (normal) |  |
+| Assignments.cs:3:10:3:10 | enter M | Assignments.cs:4:5:15:5 | {...} |  |
+| Assignments.cs:3:10:3:10 | exit M (normal) | Assignments.cs:3:10:3:10 | exit M |  |
+| Assignments.cs:4:5:15:5 | {...} | Assignments.cs:5:9:5:18 | ... ...; |  |
+| Assignments.cs:5:9:5:18 | ... ...; | Assignments.cs:5:17:5:17 | 0 |  |
+| Assignments.cs:5:13:5:17 | Int32 x = ... | Assignments.cs:6:9:6:15 | ...; |  |
+| Assignments.cs:5:17:5:17 | 0 | Assignments.cs:5:13:5:17 | Int32 x = ... |  |
+| Assignments.cs:6:9:6:9 | access to local variable x | Assignments.cs:6:14:6:14 | 1 |  |
+| Assignments.cs:6:9:6:14 | ... + ... | Assignments.cs:6:9:6:14 | ... = ... |  |
+| Assignments.cs:6:9:6:14 | ... = ... | Assignments.cs:8:9:8:22 | ... ...; |  |
+| Assignments.cs:6:9:6:15 | ...; | Assignments.cs:6:9:6:9 | access to local variable x |  |
+| Assignments.cs:6:14:6:14 | 1 | Assignments.cs:6:9:6:14 | ... + ... |  |
+| Assignments.cs:8:9:8:22 | ... ...; | Assignments.cs:8:21:8:21 | 0 |  |
+| Assignments.cs:8:17:8:21 | dynamic d = ... | Assignments.cs:9:9:9:15 | ...; |  |
+| Assignments.cs:8:21:8:21 | 0 | Assignments.cs:8:21:8:21 | (...) ... |  |
+| Assignments.cs:8:21:8:21 | (...) ... | Assignments.cs:8:17:8:21 | dynamic d = ... |  |
+| Assignments.cs:9:9:9:9 | access to local variable d | Assignments.cs:9:14:9:14 | 2 |  |
+| Assignments.cs:9:9:9:14 | ... = ... | Assignments.cs:11:9:11:34 | ... ...; |  |
+| Assignments.cs:9:9:9:14 | dynamic call to operator - | Assignments.cs:9:9:9:14 | ... = ... |  |
+| Assignments.cs:9:9:9:15 | ...; | Assignments.cs:9:9:9:9 | access to local variable d |  |
+| Assignments.cs:9:14:9:14 | 2 | Assignments.cs:9:9:9:14 | dynamic call to operator - |  |
+| Assignments.cs:11:9:11:34 | ... ...; | Assignments.cs:11:17:11:33 | object creation of type Assignments |  |
+| Assignments.cs:11:13:11:33 | Assignments a = ... | Assignments.cs:12:9:12:18 | ...; |  |
+| Assignments.cs:11:17:11:33 | object creation of type Assignments | Assignments.cs:11:13:11:33 | Assignments a = ... |  |
+| Assignments.cs:12:9:12:9 | access to local variable a | Assignments.cs:12:14:12:17 | this access |  |
+| Assignments.cs:12:9:12:17 | ... = ... | Assignments.cs:14:9:14:36 | ...; |  |
+| Assignments.cs:12:9:12:17 | call to operator + | Assignments.cs:12:9:12:17 | ... = ... |  |
+| Assignments.cs:12:9:12:18 | ...; | Assignments.cs:12:9:12:9 | access to local variable a |  |
+| Assignments.cs:12:14:12:17 | this access | Assignments.cs:12:9:12:17 | call to operator + |  |
+| Assignments.cs:14:9:14:13 | access to event Event | Assignments.cs:14:9:14:35 | ... += ... |  |
+| Assignments.cs:14:9:14:13 | this access | Assignments.cs:14:18:14:35 | (...) => ... |  |
+| Assignments.cs:14:9:14:35 | ... += ... | Assignments.cs:3:10:3:10 | exit M (normal) |  |
+| Assignments.cs:14:9:14:36 | ...; | Assignments.cs:14:9:14:13 | this access |  |
+| Assignments.cs:14:18:14:35 | (...) => ... | Assignments.cs:14:9:14:13 | access to event Event |  |
+| Assignments.cs:14:18:14:35 | enter (...) => ... | Assignments.cs:14:33:14:35 | {...} |  |
+| Assignments.cs:14:18:14:35 | exit (...) => ... (normal) | Assignments.cs:14:18:14:35 | exit (...) => ... |  |
+| Assignments.cs:14:33:14:35 | {...} | Assignments.cs:14:18:14:35 | exit (...) => ... (normal) |  |
+| Assignments.cs:17:40:17:40 | enter + | Assignments.cs:18:5:20:5 | {...} |  |
+| Assignments.cs:17:40:17:40 | exit + (normal) | Assignments.cs:17:40:17:40 | exit + |  |
+| Assignments.cs:18:5:20:5 | {...} | Assignments.cs:19:16:19:16 | access to parameter x |  |
+| Assignments.cs:19:9:19:17 | return ...; | Assignments.cs:17:40:17:40 | exit + (normal) | return |
+| Assignments.cs:19:16:19:16 | access to parameter x | Assignments.cs:19:9:19:17 | return ...; |  |
+| BreakInTry.cs:1:7:1:16 | call to constructor Object | BreakInTry.cs:1:7:1:16 | {...} |  |
+| BreakInTry.cs:1:7:1:16 | enter BreakInTry | BreakInTry.cs:1:7:1:16 | call to constructor Object |  |
+| BreakInTry.cs:1:7:1:16 | exit BreakInTry (normal) | BreakInTry.cs:1:7:1:16 | exit BreakInTry |  |
+| BreakInTry.cs:1:7:1:16 | {...} | BreakInTry.cs:1:7:1:16 | exit BreakInTry (normal) |  |
+| BreakInTry.cs:3:10:3:11 | enter M1 | BreakInTry.cs:4:5:18:5 | {...} |  |
+| BreakInTry.cs:3:10:3:11 | exit M1 (normal) | BreakInTry.cs:3:10:3:11 | exit M1 |  |
+| BreakInTry.cs:4:5:18:5 | {...} | BreakInTry.cs:5:9:17:9 | try {...} ... |  |
+| BreakInTry.cs:5:9:17:9 | try {...} ... | BreakInTry.cs:6:9:12:9 | {...} |  |
+| BreakInTry.cs:6:9:12:9 | {...} | BreakInTry.cs:7:33:7:36 | access to parameter args |  |
+| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:7:26:7:28 | String arg | non-empty |
+| BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | BreakInTry.cs:14:9:17:9 | {...} | empty |
+| BreakInTry.cs:7:26:7:28 | String arg | BreakInTry.cs:8:13:11:13 | {...} |  |
+| BreakInTry.cs:7:33:7:36 | access to parameter args | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... |  |
+| BreakInTry.cs:8:13:11:13 | {...} | BreakInTry.cs:9:17:10:26 | if (...) ... |  |
+| BreakInTry.cs:9:17:10:26 | if (...) ... | BreakInTry.cs:9:21:9:23 | access to local variable arg |  |
+| BreakInTry.cs:9:21:9:23 | access to local variable arg | BreakInTry.cs:9:28:9:31 | null |  |
+| BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:7:13:11:13 | foreach (... ... in ...) ... | false |
+| BreakInTry.cs:9:21:9:31 | ... == ... | BreakInTry.cs:10:21:10:26 | break; | true |
+| BreakInTry.cs:9:28:9:31 | null | BreakInTry.cs:9:21:9:31 | ... == ... |  |
+| BreakInTry.cs:10:21:10:26 | break; | BreakInTry.cs:14:9:17:9 | {...} | break |
+| BreakInTry.cs:14:9:17:9 | {...} | BreakInTry.cs:15:13:16:17 | if (...) ... |  |
+| BreakInTry.cs:15:13:16:17 | if (...) ... | BreakInTry.cs:15:17:15:20 | access to parameter args |  |
+| BreakInTry.cs:15:17:15:20 | access to parameter args | BreakInTry.cs:15:25:15:28 | null |  |
+| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:3:10:3:11 | exit M1 (normal) | false |
+| BreakInTry.cs:15:17:15:28 | ... == ... | BreakInTry.cs:16:17:16:17 | ; | true |
+| BreakInTry.cs:15:25:15:28 | null | BreakInTry.cs:15:17:15:28 | ... == ... |  |
+| BreakInTry.cs:16:17:16:17 | ; | BreakInTry.cs:3:10:3:11 | exit M1 (normal) |  |
+| BreakInTry.cs:20:10:20:11 | enter M2 | BreakInTry.cs:21:5:36:5 | {...} |  |
+| BreakInTry.cs:20:10:20:11 | exit M2 (normal) | BreakInTry.cs:20:10:20:11 | exit M2 |  |
+| BreakInTry.cs:21:5:36:5 | {...} | BreakInTry.cs:22:29:22:32 | access to parameter args |  |
+| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:22:22:22:24 | String arg | non-empty |
+| BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | BreakInTry.cs:35:7:35:7 | ; | empty |
+| BreakInTry.cs:22:22:22:24 | String arg | BreakInTry.cs:23:9:34:9 | {...} |  |
+| BreakInTry.cs:22:29:22:32 | access to parameter args | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |  |
+| BreakInTry.cs:23:9:34:9 | {...} | BreakInTry.cs:24:13:33:13 | try {...} ... |  |
+| BreakInTry.cs:24:13:33:13 | try {...} ... | BreakInTry.cs:25:13:28:13 | {...} |  |
+| BreakInTry.cs:25:13:28:13 | {...} | BreakInTry.cs:26:17:27:26 | if (...) ... |  |
+| BreakInTry.cs:26:17:27:26 | if (...) ... | BreakInTry.cs:26:21:26:23 | access to local variable arg |  |
+| BreakInTry.cs:26:21:26:23 | access to local variable arg | BreakInTry.cs:26:28:26:31 | null |  |
+| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:27:21:27:26 | break; | true |
+| BreakInTry.cs:26:21:26:31 | ... == ... | BreakInTry.cs:30:13:33:13 | {...} | false |
+| BreakInTry.cs:26:28:26:31 | null | BreakInTry.cs:26:21:26:31 | ... == ... |  |
+| BreakInTry.cs:27:21:27:26 | break; | BreakInTry.cs:30:13:33:13 | [finally: break] {...} | break |
+| BreakInTry.cs:30:13:33:13 | [finally: break] {...} | BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... |  |
+| BreakInTry.cs:30:13:33:13 | {...} | BreakInTry.cs:31:17:32:21 | if (...) ... |  |
+| BreakInTry.cs:31:17:32:21 | [finally: break] if (...) ... | BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args |  |
+| BreakInTry.cs:31:17:32:21 | if (...) ... | BreakInTry.cs:31:21:31:24 | access to parameter args |  |
+| BreakInTry.cs:31:21:31:24 | [finally: break] access to parameter args | BreakInTry.cs:31:29:31:32 | [finally: break] null |  |
+| BreakInTry.cs:31:21:31:24 | access to parameter args | BreakInTry.cs:31:29:31:32 | null |  |
+| BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... | false |
+| BreakInTry.cs:31:21:31:32 | ... == ... | BreakInTry.cs:32:21:32:21 | ; | true |
+| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:32:21:32:21 | [finally: break] ; | true |
+| BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... | BreakInTry.cs:35:7:35:7 | ; | false |
+| BreakInTry.cs:31:29:31:32 | [finally: break] null | BreakInTry.cs:31:21:31:32 | [finally: break] ... == ... |  |
+| BreakInTry.cs:31:29:31:32 | null | BreakInTry.cs:31:21:31:32 | ... == ... |  |
+| BreakInTry.cs:32:21:32:21 | ; | BreakInTry.cs:22:9:34:9 | foreach (... ... in ...) ... |  |
+| BreakInTry.cs:32:21:32:21 | [finally: break] ; | BreakInTry.cs:35:7:35:7 | ; | break |
+| BreakInTry.cs:35:7:35:7 | ; | BreakInTry.cs:20:10:20:11 | exit M2 (normal) |  |
+| BreakInTry.cs:38:10:38:11 | enter M3 | BreakInTry.cs:39:5:54:5 | {...} |  |
+| BreakInTry.cs:38:10:38:11 | exit M3 (normal) | BreakInTry.cs:38:10:38:11 | exit M3 |  |
+| BreakInTry.cs:39:5:54:5 | {...} | BreakInTry.cs:40:9:52:9 | try {...} ... |  |
+| BreakInTry.cs:40:9:52:9 | try {...} ... | BreakInTry.cs:41:9:44:9 | {...} |  |
+| BreakInTry.cs:41:9:44:9 | {...} | BreakInTry.cs:42:13:43:23 | if (...) ... |  |
+| BreakInTry.cs:42:13:43:23 | if (...) ... | BreakInTry.cs:42:17:42:20 | access to parameter args |  |
+| BreakInTry.cs:42:17:42:20 | access to parameter args | BreakInTry.cs:42:25:42:28 | null |  |
+| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:43:17:43:23 | return ...; | true |
+| BreakInTry.cs:42:17:42:28 | ... == ... | BreakInTry.cs:46:9:52:9 | {...} | false |
+| BreakInTry.cs:42:25:42:28 | null | BreakInTry.cs:42:17:42:28 | ... == ... |  |
+| BreakInTry.cs:43:17:43:23 | return ...; | BreakInTry.cs:46:9:52:9 | [finally: return] {...} | return |
+| BreakInTry.cs:46:9:52:9 | [finally: return] {...} | BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args |  |
+| BreakInTry.cs:46:9:52:9 | {...} | BreakInTry.cs:47:33:47:36 | access to parameter args |  |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | return |
+| BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | [finally: return] String arg | non-empty |
+| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:47:26:47:28 | String arg | non-empty |
+| BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | BreakInTry.cs:53:7:53:7 | ; | empty |
+| BreakInTry.cs:47:26:47:28 | String arg | BreakInTry.cs:48:13:51:13 | {...} |  |
+| BreakInTry.cs:47:26:47:28 | [finally: return] String arg | BreakInTry.cs:48:13:51:13 | [finally: return] {...} |  |
+| BreakInTry.cs:47:33:47:36 | [finally: return] access to parameter args | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... |  |
+| BreakInTry.cs:47:33:47:36 | access to parameter args | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... |  |
+| BreakInTry.cs:48:13:51:13 | [finally: return] {...} | BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... |  |
+| BreakInTry.cs:48:13:51:13 | {...} | BreakInTry.cs:49:17:50:26 | if (...) ... |  |
+| BreakInTry.cs:49:17:50:26 | [finally: return] if (...) ... | BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg |  |
+| BreakInTry.cs:49:17:50:26 | if (...) ... | BreakInTry.cs:49:21:49:23 | access to local variable arg |  |
+| BreakInTry.cs:49:21:49:23 | [finally: return] access to local variable arg | BreakInTry.cs:49:28:49:31 | [finally: return] null |  |
+| BreakInTry.cs:49:21:49:23 | access to local variable arg | BreakInTry.cs:49:28:49:31 | null |  |
+| BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:47:13:51:13 | foreach (... ... in ...) ... | false |
+| BreakInTry.cs:49:21:49:31 | ... == ... | BreakInTry.cs:50:21:50:26 | break; | true |
+| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:47:13:51:13 | [finally: return] foreach (... ... in ...) ... | false |
+| BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... | BreakInTry.cs:50:21:50:26 | [finally: return] break; | true |
+| BreakInTry.cs:49:28:49:31 | [finally: return] null | BreakInTry.cs:49:21:49:31 | [finally: return] ... == ... |  |
+| BreakInTry.cs:49:28:49:31 | null | BreakInTry.cs:49:21:49:31 | ... == ... |  |
+| BreakInTry.cs:50:21:50:26 | [finally: return] break; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) | return |
+| BreakInTry.cs:50:21:50:26 | break; | BreakInTry.cs:53:7:53:7 | ; | break |
+| BreakInTry.cs:53:7:53:7 | ; | BreakInTry.cs:38:10:38:11 | exit M3 (normal) |  |
+| BreakInTry.cs:56:10:56:11 | enter M4 | BreakInTry.cs:57:5:71:5 | {...} |  |
+| BreakInTry.cs:56:10:56:11 | exit M4 (normal) | BreakInTry.cs:56:10:56:11 | exit M4 |  |
+| BreakInTry.cs:57:5:71:5 | {...} | BreakInTry.cs:58:9:70:9 | try {...} ... |  |
+| BreakInTry.cs:58:9:70:9 | try {...} ... | BreakInTry.cs:59:9:62:9 | {...} |  |
+| BreakInTry.cs:59:9:62:9 | {...} | BreakInTry.cs:60:13:61:23 | if (...) ... |  |
+| BreakInTry.cs:60:13:61:23 | if (...) ... | BreakInTry.cs:60:17:60:20 | access to parameter args |  |
+| BreakInTry.cs:60:17:60:20 | access to parameter args | BreakInTry.cs:60:25:60:28 | null |  |
+| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:61:17:61:23 | return ...; | true |
+| BreakInTry.cs:60:17:60:28 | ... == ... | BreakInTry.cs:64:9:70:9 | {...} | false |
+| BreakInTry.cs:60:25:60:28 | null | BreakInTry.cs:60:17:60:28 | ... == ... |  |
+| BreakInTry.cs:61:17:61:23 | return ...; | BreakInTry.cs:64:9:70:9 | [finally: return] {...} | return |
+| BreakInTry.cs:64:9:70:9 | [finally: return] {...} | BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args |  |
+| BreakInTry.cs:64:9:70:9 | {...} | BreakInTry.cs:65:33:65:36 | access to parameter args |  |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | return |
+| BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | [finally: return] String arg | non-empty |
+| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | empty |
+| BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | BreakInTry.cs:65:26:65:28 | String arg | non-empty |
+| BreakInTry.cs:65:26:65:28 | String arg | BreakInTry.cs:66:13:69:13 | {...} |  |
+| BreakInTry.cs:65:26:65:28 | [finally: return] String arg | BreakInTry.cs:66:13:69:13 | [finally: return] {...} |  |
+| BreakInTry.cs:65:33:65:36 | [finally: return] access to parameter args | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... |  |
+| BreakInTry.cs:65:33:65:36 | access to parameter args | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... |  |
+| BreakInTry.cs:66:13:69:13 | [finally: return] {...} | BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... |  |
+| BreakInTry.cs:66:13:69:13 | {...} | BreakInTry.cs:67:17:68:26 | if (...) ... |  |
+| BreakInTry.cs:67:17:68:26 | [finally: return] if (...) ... | BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg |  |
+| BreakInTry.cs:67:17:68:26 | if (...) ... | BreakInTry.cs:67:21:67:23 | access to local variable arg |  |
+| BreakInTry.cs:67:21:67:23 | [finally: return] access to local variable arg | BreakInTry.cs:67:28:67:31 | [finally: return] null |  |
+| BreakInTry.cs:67:21:67:23 | access to local variable arg | BreakInTry.cs:67:28:67:31 | null |  |
+| BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:65:13:69:13 | foreach (... ... in ...) ... | false |
+| BreakInTry.cs:67:21:67:31 | ... == ... | BreakInTry.cs:68:21:68:26 | break; | true |
+| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:65:13:69:13 | [finally: return] foreach (... ... in ...) ... | false |
+| BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... | BreakInTry.cs:68:21:68:26 | [finally: return] break; | true |
+| BreakInTry.cs:67:28:67:31 | [finally: return] null | BreakInTry.cs:67:21:67:31 | [finally: return] ... == ... |  |
+| BreakInTry.cs:67:28:67:31 | null | BreakInTry.cs:67:21:67:31 | ... == ... |  |
+| BreakInTry.cs:68:21:68:26 | [finally: return] break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | return |
+| BreakInTry.cs:68:21:68:26 | break; | BreakInTry.cs:56:10:56:11 | exit M4 (normal) | break |
+| CompileTimeOperators.cs:3:7:3:26 | call to constructor Object | CompileTimeOperators.cs:3:7:3:26 | {...} |  |
+| CompileTimeOperators.cs:3:7:3:26 | enter CompileTimeOperators | CompileTimeOperators.cs:3:7:3:26 | call to constructor Object |  |
+| CompileTimeOperators.cs:3:7:3:26 | exit CompileTimeOperators (normal) | CompileTimeOperators.cs:3:7:3:26 | exit CompileTimeOperators |  |
+| CompileTimeOperators.cs:3:7:3:26 | {...} | CompileTimeOperators.cs:3:7:3:26 | exit CompileTimeOperators (normal) |  |
+| CompileTimeOperators.cs:5:9:5:15 | enter Default | CompileTimeOperators.cs:6:5:8:5 | {...} |  |
+| CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | CompileTimeOperators.cs:5:9:5:15 | exit Default |  |
+| CompileTimeOperators.cs:6:5:8:5 | {...} | CompileTimeOperators.cs:7:16:7:27 | default(...) |  |
+| CompileTimeOperators.cs:7:9:7:28 | return ...; | CompileTimeOperators.cs:5:9:5:15 | exit Default (normal) | return |
+| CompileTimeOperators.cs:7:16:7:27 | default(...) | CompileTimeOperators.cs:7:9:7:28 | return ...; |  |
+| CompileTimeOperators.cs:10:9:10:14 | enter Sizeof | CompileTimeOperators.cs:11:5:13:5 | {...} |  |
+| CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof |  |
+| CompileTimeOperators.cs:11:5:13:5 | {...} | CompileTimeOperators.cs:12:16:12:26 | sizeof(..) |  |
+| CompileTimeOperators.cs:12:9:12:27 | return ...; | CompileTimeOperators.cs:10:9:10:14 | exit Sizeof (normal) | return |
+| CompileTimeOperators.cs:12:16:12:26 | sizeof(..) | CompileTimeOperators.cs:12:9:12:27 | return ...; |  |
+| CompileTimeOperators.cs:15:10:15:15 | enter Typeof | CompileTimeOperators.cs:16:5:18:5 | {...} |  |
+| CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | CompileTimeOperators.cs:15:10:15:15 | exit Typeof |  |
+| CompileTimeOperators.cs:16:5:18:5 | {...} | CompileTimeOperators.cs:17:16:17:26 | typeof(...) |  |
+| CompileTimeOperators.cs:17:9:17:27 | return ...; | CompileTimeOperators.cs:15:10:15:15 | exit Typeof (normal) | return |
+| CompileTimeOperators.cs:17:16:17:26 | typeof(...) | CompileTimeOperators.cs:17:9:17:27 | return ...; |  |
+| CompileTimeOperators.cs:20:12:20:17 | enter Nameof | CompileTimeOperators.cs:21:5:23:5 | {...} |  |
+| CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | CompileTimeOperators.cs:20:12:20:17 | exit Nameof |  |
+| CompileTimeOperators.cs:21:5:23:5 | {...} | CompileTimeOperators.cs:22:16:22:24 | nameof(...) |  |
+| CompileTimeOperators.cs:22:9:22:25 | return ...; | CompileTimeOperators.cs:20:12:20:17 | exit Nameof (normal) | return |
+| CompileTimeOperators.cs:22:16:22:24 | nameof(...) | CompileTimeOperators.cs:22:9:22:25 | return ...; |  |
+| CompileTimeOperators.cs:26:7:26:22 | call to constructor Object | CompileTimeOperators.cs:26:7:26:22 | {...} |  |
+| CompileTimeOperators.cs:26:7:26:22 | enter GotoInTryFinally | CompileTimeOperators.cs:26:7:26:22 | call to constructor Object |  |
+| CompileTimeOperators.cs:26:7:26:22 | exit GotoInTryFinally (normal) | CompileTimeOperators.cs:26:7:26:22 | exit GotoInTryFinally |  |
+| CompileTimeOperators.cs:26:7:26:22 | {...} | CompileTimeOperators.cs:26:7:26:22 | exit GotoInTryFinally (normal) |  |
+| CompileTimeOperators.cs:28:10:28:10 | enter M | CompileTimeOperators.cs:29:5:41:5 | {...} |  |
+| CompileTimeOperators.cs:28:10:28:10 | exit M (normal) | CompileTimeOperators.cs:28:10:28:10 | exit M |  |
+| CompileTimeOperators.cs:29:5:41:5 | {...} | CompileTimeOperators.cs:30:9:38:9 | try {...} ... |  |
+| CompileTimeOperators.cs:30:9:38:9 | try {...} ... | CompileTimeOperators.cs:31:9:34:9 | {...} |  |
+| CompileTimeOperators.cs:31:9:34:9 | {...} | CompileTimeOperators.cs:32:13:32:21 | goto ...; |  |
+| CompileTimeOperators.cs:32:13:32:21 | goto ...; | CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | goto(End) |
+| CompileTimeOperators.cs:36:9:38:9 | [finally: goto(End)] {...} | CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; |  |
+| CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine | CompileTimeOperators.cs:40:9:40:11 | End: | goto(End) |
+| CompileTimeOperators.cs:37:13:37:41 | [finally: goto(End)] ...; | CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" |  |
+| CompileTimeOperators.cs:37:31:37:39 | [finally: goto(End)] "Finally" | CompileTimeOperators.cs:37:13:37:40 | [finally: goto(End)] call to method WriteLine |  |
+| CompileTimeOperators.cs:40:9:40:11 | End: | CompileTimeOperators.cs:40:14:40:38 | ...; |  |
+| CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine | CompileTimeOperators.cs:28:10:28:10 | exit M (normal) |  |
+| CompileTimeOperators.cs:40:14:40:38 | ...; | CompileTimeOperators.cs:40:32:40:36 | "End" |  |
+| CompileTimeOperators.cs:40:32:40:36 | "End" | CompileTimeOperators.cs:40:14:40:37 | call to method WriteLine |  |
+| ConditionalAccess.cs:1:7:1:23 | call to constructor Object | ConditionalAccess.cs:1:7:1:23 | {...} |  |
+| ConditionalAccess.cs:1:7:1:23 | enter ConditionalAccess | ConditionalAccess.cs:1:7:1:23 | call to constructor Object |  |
+| ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess |  |
+| ConditionalAccess.cs:1:7:1:23 | {...} | ConditionalAccess.cs:1:7:1:23 | exit ConditionalAccess (normal) |  |
+| ConditionalAccess.cs:3:12:3:13 | enter M1 | ConditionalAccess.cs:3:26:3:26 | access to parameter i |  |
+| ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | ConditionalAccess.cs:3:12:3:13 | exit M1 |  |
+| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | null |
+| ConditionalAccess.cs:3:26:3:26 | access to parameter i | ConditionalAccess.cs:3:26:3:38 | call to method ToString | non-null |
+| ConditionalAccess.cs:3:26:3:38 | call to method ToString | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) | null |
+| ConditionalAccess.cs:3:26:3:38 | call to method ToString | ConditionalAccess.cs:3:26:3:49 | call to method ToLower | non-null |
+| ConditionalAccess.cs:3:26:3:49 | call to method ToLower | ConditionalAccess.cs:3:12:3:13 | exit M1 (normal) |  |
+| ConditionalAccess.cs:5:10:5:11 | enter M2 | ConditionalAccess.cs:5:26:5:26 | access to parameter s |  |
+| ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | ConditionalAccess.cs:5:10:5:11 | exit M2 |  |
+| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) | null |
+| ConditionalAccess.cs:5:26:5:26 | access to parameter s | ConditionalAccess.cs:5:26:5:34 | access to property Length | non-null |
+| ConditionalAccess.cs:5:26:5:34 | access to property Length | ConditionalAccess.cs:5:10:5:11 | exit M2 (normal) |  |
+| ConditionalAccess.cs:7:10:7:11 | enter M3 | ConditionalAccess.cs:7:39:7:40 | access to parameter s1 |  |
+| ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | ConditionalAccess.cs:7:10:7:11 | exit M3 |  |
+| ConditionalAccess.cs:7:38:7:55 | access to property Length | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) |  |
+| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:39:7:46 | ... ?? ... | non-null |
+| ConditionalAccess.cs:7:39:7:40 | access to parameter s1 | ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | null |
+| ConditionalAccess.cs:7:39:7:46 | ... ?? ... | ConditionalAccess.cs:7:38:7:55 | access to property Length | non-null |
+| ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | ConditionalAccess.cs:7:38:7:55 | access to property Length | non-null |
+| ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | ConditionalAccess.cs:7:10:7:11 | exit M3 (normal) | null |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [non-null] ... ?? ... | non-null |
+| ConditionalAccess.cs:7:45:7:46 | access to parameter s2 | ConditionalAccess.cs:7:39:7:46 | [null] ... ?? ... | null |
+| ConditionalAccess.cs:9:9:9:10 | enter M4 | ConditionalAccess.cs:9:25:9:25 | access to parameter s |  |
+| ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) | ConditionalAccess.cs:9:9:9:10 | exit M4 |  |
+| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:25:9:33 | access to property Length | non-null |
+| ConditionalAccess.cs:9:25:9:25 | access to parameter s | ConditionalAccess.cs:9:38:9:38 | 0 | null |
+| ConditionalAccess.cs:9:25:9:33 | access to property Length | ConditionalAccess.cs:9:25:9:38 | ... ?? ... | non-null |
+| ConditionalAccess.cs:9:25:9:33 | access to property Length | ConditionalAccess.cs:9:38:9:38 | 0 | null |
+| ConditionalAccess.cs:9:25:9:38 | ... ?? ... | ConditionalAccess.cs:9:9:9:10 | exit M4 (normal) |  |
+| ConditionalAccess.cs:9:38:9:38 | 0 | ConditionalAccess.cs:9:25:9:38 | ... ?? ... |  |
+| ConditionalAccess.cs:11:9:11:10 | enter M5 | ConditionalAccess.cs:12:5:17:5 | {...} |  |
+| ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | ConditionalAccess.cs:11:9:11:10 | exit M5 |  |
+| ConditionalAccess.cs:12:5:17:5 | {...} | ConditionalAccess.cs:13:9:16:21 | if (...) ... |  |
+| ConditionalAccess.cs:13:9:16:21 | if (...) ... | ConditionalAccess.cs:13:13:13:13 | access to parameter s |  |
+| ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:13:13:21 | access to property Length | non-null |
+| ConditionalAccess.cs:13:13:13:13 | access to parameter s | ConditionalAccess.cs:13:25:13:25 | 0 | null |
+| ConditionalAccess.cs:13:13:13:21 | access to property Length | ConditionalAccess.cs:13:25:13:25 | 0 |  |
+| ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:14:20:14:20 | 0 | true |
+| ConditionalAccess.cs:13:13:13:25 | ... > ... | ConditionalAccess.cs:16:20:16:20 | 1 | false |
+| ConditionalAccess.cs:13:25:13:25 | 0 | ConditionalAccess.cs:13:25:13:25 | (...) ... |  |
+| ConditionalAccess.cs:13:25:13:25 | (...) ... | ConditionalAccess.cs:13:13:13:25 | ... > ... |  |
+| ConditionalAccess.cs:14:13:14:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | return |
+| ConditionalAccess.cs:14:20:14:20 | 0 | ConditionalAccess.cs:14:13:14:21 | return ...; |  |
+| ConditionalAccess.cs:16:13:16:21 | return ...; | ConditionalAccess.cs:11:9:11:10 | exit M5 (normal) | return |
+| ConditionalAccess.cs:16:20:16:20 | 1 | ConditionalAccess.cs:16:13:16:21 | return ...; |  |
+| ConditionalAccess.cs:19:12:19:13 | enter M6 | ConditionalAccess.cs:19:40:19:41 | access to parameter s1 |  |
+| ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | ConditionalAccess.cs:19:12:19:13 | exit M6 |  |
+| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) | null |
+| ConditionalAccess.cs:19:40:19:41 | access to parameter s1 | ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | non-null |
+| ConditionalAccess.cs:19:40:19:60 | call to method CommaJoinWith | ConditionalAccess.cs:19:12:19:13 | exit M6 (normal) |  |
+| ConditionalAccess.cs:19:58:19:59 | access to parameter s2 | ConditionalAccess.cs:19:40:19:60 | call to method CommaJoinWith |  |
+| ConditionalAccess.cs:21:10:21:11 | enter M7 | ConditionalAccess.cs:22:5:26:5 | {...} |  |
+| ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) | ConditionalAccess.cs:21:10:21:11 | exit M7 |  |
+| ConditionalAccess.cs:22:5:26:5 | {...} | ConditionalAccess.cs:23:9:23:39 | ... ...; |  |
+| ConditionalAccess.cs:23:9:23:39 | ... ...; | ConditionalAccess.cs:23:26:23:29 | null |  |
+| ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | ConditionalAccess.cs:24:9:24:38 | ... ...; |  |
+| ConditionalAccess.cs:23:18:23:29 | (...) ... | ConditionalAccess.cs:23:13:23:38 | Nullable<Int32> j = ... | null |
+| ConditionalAccess.cs:23:26:23:29 | null | ConditionalAccess.cs:23:18:23:29 | (...) ... |  |
+| ConditionalAccess.cs:24:9:24:38 | ... ...; | ConditionalAccess.cs:24:24:24:24 | access to parameter i |  |
+| ConditionalAccess.cs:24:13:24:37 | String s = ... | ConditionalAccess.cs:25:9:25:33 | ...; |  |
+| ConditionalAccess.cs:24:17:24:37 | call to method ToString | ConditionalAccess.cs:24:13:24:37 | String s = ... |  |
+| ConditionalAccess.cs:24:18:24:24 | (...) ... | ConditionalAccess.cs:24:17:24:37 | call to method ToString | non-null |
+| ConditionalAccess.cs:24:24:24:24 | access to parameter i | ConditionalAccess.cs:24:18:24:24 | (...) ... |  |
+| ConditionalAccess.cs:25:9:25:32 | ... = ... | ConditionalAccess.cs:21:10:21:11 | exit M7 (normal) |  |
+| ConditionalAccess.cs:25:9:25:33 | ...; | ConditionalAccess.cs:25:13:25:14 | "" |  |
+| ConditionalAccess.cs:25:13:25:14 | "" | ConditionalAccess.cs:25:31:25:31 | access to local variable s | non-null |
+| ConditionalAccess.cs:25:13:25:32 | call to method CommaJoinWith | ConditionalAccess.cs:25:9:25:32 | ... = ... |  |
+| ConditionalAccess.cs:25:31:25:31 | access to local variable s | ConditionalAccess.cs:25:13:25:32 | call to method CommaJoinWith |  |
+| ConditionalAccess.cs:30:10:30:12 | enter Out | ConditionalAccess.cs:30:32:30:32 | 0 |  |
+| ConditionalAccess.cs:30:10:30:12 | exit Out (normal) | ConditionalAccess.cs:30:10:30:12 | exit Out |  |
+| ConditionalAccess.cs:30:28:30:32 | ... = ... | ConditionalAccess.cs:30:10:30:12 | exit Out (normal) |  |
+| ConditionalAccess.cs:30:32:30:32 | 0 | ConditionalAccess.cs:30:28:30:32 | ... = ... |  |
+| ConditionalAccess.cs:32:10:32:11 | enter M8 | ConditionalAccess.cs:33:5:36:5 | {...} |  |
+| ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | ConditionalAccess.cs:32:10:32:11 | exit M8 |  |
+| ConditionalAccess.cs:33:5:36:5 | {...} | ConditionalAccess.cs:34:9:34:14 | ...; |  |
+| ConditionalAccess.cs:34:9:34:13 | ... = ... | ConditionalAccess.cs:35:9:35:25 | ...; |  |
+| ConditionalAccess.cs:34:9:34:14 | ...; | ConditionalAccess.cs:34:13:34:13 | 0 |  |
+| ConditionalAccess.cs:34:13:34:13 | 0 | ConditionalAccess.cs:34:9:34:13 | ... = ... |  |
+| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) | null |
+| ConditionalAccess.cs:35:9:35:12 | access to property Prop | ConditionalAccess.cs:35:9:35:24 | call to method Out | non-null |
+| ConditionalAccess.cs:35:9:35:12 | this access | ConditionalAccess.cs:35:9:35:12 | access to property Prop |  |
+| ConditionalAccess.cs:35:9:35:24 | call to method Out | ConditionalAccess.cs:32:10:32:11 | exit M8 (normal) |  |
+| ConditionalAccess.cs:35:9:35:25 | ...; | ConditionalAccess.cs:35:9:35:12 | this access |  |
+| ConditionalAccess.cs:41:26:41:38 | enter CommaJoinWith | ConditionalAccess.cs:41:70:41:71 | access to parameter s1 |  |
+| ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith |  |
+| ConditionalAccess.cs:41:70:41:71 | access to parameter s1 | ConditionalAccess.cs:41:75:41:78 | ", " |  |
+| ConditionalAccess.cs:41:70:41:78 | ... + ... | ConditionalAccess.cs:41:82:41:83 | access to parameter s2 |  |
+| ConditionalAccess.cs:41:70:41:83 | ... + ... | ConditionalAccess.cs:41:26:41:38 | exit CommaJoinWith (normal) |  |
+| ConditionalAccess.cs:41:75:41:78 | ", " | ConditionalAccess.cs:41:70:41:78 | ... + ... |  |
+| ConditionalAccess.cs:41:82:41:83 | access to parameter s2 | ConditionalAccess.cs:41:70:41:83 | ... + ... |  |
+| Conditions.cs:1:7:1:16 | call to constructor Object | Conditions.cs:1:7:1:16 | {...} |  |
+| Conditions.cs:1:7:1:16 | enter Conditions | Conditions.cs:1:7:1:16 | call to constructor Object |  |
+| Conditions.cs:1:7:1:16 | exit Conditions (normal) | Conditions.cs:1:7:1:16 | exit Conditions |  |
+| Conditions.cs:1:7:1:16 | {...} | Conditions.cs:1:7:1:16 | exit Conditions (normal) |  |
+| Conditions.cs:3:10:3:19 | enter IncrOrDecr | Conditions.cs:4:5:9:5 | {...} |  |
+| Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | Conditions.cs:3:10:3:19 | exit IncrOrDecr |  |
+| Conditions.cs:4:5:9:5 | {...} | Conditions.cs:5:9:6:16 | if (...) ... |  |
+| Conditions.cs:5:9:6:16 | if (...) ... | Conditions.cs:5:13:5:15 | access to parameter inc |  |
+| Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | true |
+| Conditions.cs:5:13:5:15 | access to parameter inc | Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | false |
+| Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x | Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ |  |
+| Conditions.cs:6:13:6:15 | [inc (line 3): true] ...++ | Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... |  |
+| Conditions.cs:6:13:6:16 | [inc (line 3): true] ...; | Conditions.cs:6:13:6:13 | [inc (line 3): true] access to parameter x |  |
+| Conditions.cs:7:9:8:16 | [inc (line 3): false] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc |  |
+| Conditions.cs:7:9:8:16 | [inc (line 3): true] if (...) ... | Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc |  |
+| Conditions.cs:7:13:7:16 | [false] !... | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) | false |
+| Conditions.cs:7:13:7:16 | [true] !... | Conditions.cs:8:13:8:16 | ...; | true |
+| Conditions.cs:7:14:7:16 | [inc (line 3): false] access to parameter inc | Conditions.cs:7:13:7:16 | [true] !... | false |
+| Conditions.cs:7:14:7:16 | [inc (line 3): true] access to parameter inc | Conditions.cs:7:13:7:16 | [false] !... | true |
+| Conditions.cs:8:13:8:13 | access to parameter x | Conditions.cs:8:13:8:15 | ...-- |  |
+| Conditions.cs:8:13:8:15 | ...-- | Conditions.cs:3:10:3:19 | exit IncrOrDecr (normal) |  |
+| Conditions.cs:8:13:8:16 | ...; | Conditions.cs:8:13:8:13 | access to parameter x |  |
+| Conditions.cs:11:9:11:10 | enter M1 | Conditions.cs:12:5:20:5 | {...} |  |
+| Conditions.cs:11:9:11:10 | exit M1 (normal) | Conditions.cs:11:9:11:10 | exit M1 |  |
+| Conditions.cs:12:5:20:5 | {...} | Conditions.cs:13:9:13:18 | ... ...; |  |
+| Conditions.cs:13:9:13:18 | ... ...; | Conditions.cs:13:17:13:17 | 0 |  |
+| Conditions.cs:13:13:13:17 | Int32 x = ... | Conditions.cs:14:9:15:16 | if (...) ... |  |
+| Conditions.cs:13:17:13:17 | 0 | Conditions.cs:13:13:13:17 | Int32 x = ... |  |
+| Conditions.cs:14:9:15:16 | if (...) ... | Conditions.cs:14:13:14:13 | access to parameter b |  |
+| Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | true |
+| Conditions.cs:14:13:14:13 | access to parameter b | Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | false |
+| Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x | Conditions.cs:15:13:15:15 | [b (line 11): true] ...++ |  |
+| Conditions.cs:15:13:15:15 | [b (line 11): true] ...++ | Conditions.cs:16:9:18:20 | [b (line 11): true] if (...) ... |  |
+| Conditions.cs:15:13:15:16 | [b (line 11): true] ...; | Conditions.cs:15:13:15:13 | [b (line 11): true] access to local variable x |  |
+| Conditions.cs:16:9:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:16:13:16:13 | [b (line 11): false] access to local variable x |  |
+| Conditions.cs:16:9:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:16:13:16:13 | [b (line 11): true] access to local variable x |  |
+| Conditions.cs:16:13:16:13 | [b (line 11): false] access to local variable x | Conditions.cs:16:17:16:17 | [b (line 11): false] 0 |  |
+| Conditions.cs:16:13:16:13 | [b (line 11): true] access to local variable x | Conditions.cs:16:17:16:17 | [b (line 11): true] 0 |  |
+| Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | true |
+| Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | false |
+| Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | true |
+| Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... | Conditions.cs:19:16:19:16 | access to local variable x | false |
+| Conditions.cs:16:17:16:17 | [b (line 11): false] 0 | Conditions.cs:16:13:16:17 | [b (line 11): false] ... > ... |  |
+| Conditions.cs:16:17:16:17 | [b (line 11): true] 0 | Conditions.cs:16:13:16:17 | [b (line 11): true] ... > ... |  |
+| Conditions.cs:17:13:18:20 | [b (line 11): false] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b |  |
+| Conditions.cs:17:13:18:20 | [b (line 11): true] if (...) ... | Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b |  |
+| Conditions.cs:17:17:17:18 | [false] !... | Conditions.cs:19:16:19:16 | access to local variable x | false |
+| Conditions.cs:17:17:17:18 | [true] !... | Conditions.cs:18:17:18:20 | ...; | true |
+| Conditions.cs:17:18:17:18 | [b (line 11): false] access to parameter b | Conditions.cs:17:17:17:18 | [true] !... | false |
+| Conditions.cs:17:18:17:18 | [b (line 11): true] access to parameter b | Conditions.cs:17:17:17:18 | [false] !... | true |
+| Conditions.cs:18:17:18:17 | access to local variable x | Conditions.cs:18:17:18:19 | ...-- |  |
+| Conditions.cs:18:17:18:19 | ...-- | Conditions.cs:19:16:19:16 | access to local variable x |  |
+| Conditions.cs:18:17:18:20 | ...; | Conditions.cs:18:17:18:17 | access to local variable x |  |
+| Conditions.cs:19:9:19:17 | return ...; | Conditions.cs:11:9:11:10 | exit M1 (normal) | return |
+| Conditions.cs:19:16:19:16 | access to local variable x | Conditions.cs:19:9:19:17 | return ...; |  |
+| Conditions.cs:22:9:22:10 | enter M2 | Conditions.cs:23:5:31:5 | {...} |  |
+| Conditions.cs:22:9:22:10 | exit M2 (normal) | Conditions.cs:22:9:22:10 | exit M2 |  |
+| Conditions.cs:23:5:31:5 | {...} | Conditions.cs:24:9:24:18 | ... ...; |  |
+| Conditions.cs:24:9:24:18 | ... ...; | Conditions.cs:24:17:24:17 | 0 |  |
+| Conditions.cs:24:13:24:17 | Int32 x = ... | Conditions.cs:25:9:27:20 | if (...) ... |  |
+| Conditions.cs:24:17:24:17 | 0 | Conditions.cs:24:13:24:17 | Int32 x = ... |  |
+| Conditions.cs:25:9:27:20 | if (...) ... | Conditions.cs:25:13:25:14 | access to parameter b1 |  |
+| Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:26:13:27:20 | if (...) ... | true |
+| Conditions.cs:25:13:25:14 | access to parameter b1 | Conditions.cs:28:9:29:16 | if (...) ... | false |
+| Conditions.cs:26:13:27:20 | if (...) ... | Conditions.cs:26:17:26:18 | access to parameter b2 |  |
+| Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | true |
+| Conditions.cs:26:17:26:18 | access to parameter b2 | Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | false |
+| Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x | Conditions.cs:27:17:27:19 | [b2 (line 22): true] ...++ |  |
+| Conditions.cs:27:17:27:19 | [b2 (line 22): true] ...++ | Conditions.cs:28:9:29:16 | [b2 (line 22): true] if (...) ... |  |
+| Conditions.cs:27:17:27:20 | [b2 (line 22): true] ...; | Conditions.cs:27:17:27:17 | [b2 (line 22): true] access to local variable x |  |
+| Conditions.cs:28:9:29:16 | [b2 (line 22): false] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 |  |
+| Conditions.cs:28:9:29:16 | [b2 (line 22): true] if (...) ... | Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 |  |
+| Conditions.cs:28:9:29:16 | if (...) ... | Conditions.cs:28:13:28:14 | access to parameter b2 |  |
+| Conditions.cs:28:13:28:14 | [b2 (line 22): false] access to parameter b2 | Conditions.cs:30:16:30:16 | access to local variable x | false |
+| Conditions.cs:28:13:28:14 | [b2 (line 22): true] access to parameter b2 | Conditions.cs:29:13:29:16 | ...; | true |
+| Conditions.cs:28:13:28:14 | access to parameter b2 | Conditions.cs:29:13:29:16 | ...; | true |
+| Conditions.cs:28:13:28:14 | access to parameter b2 | Conditions.cs:30:16:30:16 | access to local variable x | false |
+| Conditions.cs:29:13:29:13 | access to local variable x | Conditions.cs:29:13:29:15 | ...++ |  |
+| Conditions.cs:29:13:29:15 | ...++ | Conditions.cs:30:16:30:16 | access to local variable x |  |
+| Conditions.cs:29:13:29:16 | ...; | Conditions.cs:29:13:29:13 | access to local variable x |  |
+| Conditions.cs:30:9:30:17 | return ...; | Conditions.cs:22:9:22:10 | exit M2 (normal) | return |
+| Conditions.cs:30:16:30:16 | access to local variable x | Conditions.cs:30:9:30:17 | return ...; |  |
+| Conditions.cs:33:9:33:10 | enter M3 | Conditions.cs:34:5:44:5 | {...} |  |
+| Conditions.cs:33:9:33:10 | exit M3 (normal) | Conditions.cs:33:9:33:10 | exit M3 |  |
+| Conditions.cs:34:5:44:5 | {...} | Conditions.cs:35:9:35:18 | ... ...; |  |
+| Conditions.cs:35:9:35:18 | ... ...; | Conditions.cs:35:17:35:17 | 0 |  |
+| Conditions.cs:35:13:35:17 | Int32 x = ... | Conditions.cs:36:9:36:23 | ... ...; |  |
+| Conditions.cs:35:17:35:17 | 0 | Conditions.cs:35:13:35:17 | Int32 x = ... |  |
+| Conditions.cs:36:9:36:23 | ... ...; | Conditions.cs:36:18:36:22 | false |  |
+| Conditions.cs:36:13:36:22 | Boolean b2 = ... | Conditions.cs:37:9:38:20 | if (...) ... |  |
+| Conditions.cs:36:18:36:22 | false | Conditions.cs:36:13:36:22 | Boolean b2 = ... |  |
+| Conditions.cs:37:9:38:20 | if (...) ... | Conditions.cs:37:13:37:14 | access to parameter b1 |  |
+| Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:38:13:38:20 | ...; | true |
+| Conditions.cs:37:13:37:14 | access to parameter b1 | Conditions.cs:39:9:40:16 | if (...) ... | false |
+| Conditions.cs:38:13:38:19 | ... = ... | Conditions.cs:39:9:40:16 | if (...) ... |  |
+| Conditions.cs:38:13:38:20 | ...; | Conditions.cs:38:18:38:19 | access to parameter b1 |  |
+| Conditions.cs:38:18:38:19 | access to parameter b1 | Conditions.cs:38:13:38:19 | ... = ... |  |
+| Conditions.cs:39:9:40:16 | if (...) ... | Conditions.cs:39:13:39:14 | access to local variable b2 |  |
+| Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | true |
+| Conditions.cs:39:13:39:14 | access to local variable b2 | Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | false |
+| Conditions.cs:40:13:40:13 | [b2 (line 39): true] access to local variable x | Conditions.cs:40:13:40:15 | [b2 (line 39): true] ...++ |  |
+| Conditions.cs:40:13:40:15 | [b2 (line 39): true] ...++ | Conditions.cs:41:9:42:16 | [b2 (line 39): true] if (...) ... |  |
+| Conditions.cs:40:13:40:16 | [b2 (line 39): true] ...; | Conditions.cs:40:13:40:13 | [b2 (line 39): true] access to local variable x |  |
+| Conditions.cs:41:9:42:16 | [b2 (line 39): false] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 |  |
+| Conditions.cs:41:9:42:16 | [b2 (line 39): true] if (...) ... | Conditions.cs:41:13:41:14 | [b2 (line 39): true] access to local variable b2 |  |
+| Conditions.cs:41:13:41:14 | [b2 (line 39): false] access to local variable b2 | Conditions.cs:43:16:43:16 | access to local variable x | false |
+| Conditions.cs:41:13:41:14 | [b2 (line 39): true] access to local variable b2 | Conditions.cs:42:13:42:16 | ...; | true |
+| Conditions.cs:42:13:42:13 | access to local variable x | Conditions.cs:42:13:42:15 | ...++ |  |
+| Conditions.cs:42:13:42:15 | ...++ | Conditions.cs:43:16:43:16 | access to local variable x |  |
+| Conditions.cs:42:13:42:16 | ...; | Conditions.cs:42:13:42:13 | access to local variable x |  |
+| Conditions.cs:43:9:43:17 | return ...; | Conditions.cs:33:9:33:10 | exit M3 (normal) | return |
+| Conditions.cs:43:16:43:16 | access to local variable x | Conditions.cs:43:9:43:17 | return ...; |  |
+| Conditions.cs:46:9:46:10 | enter M4 | Conditions.cs:47:5:55:5 | {...} |  |
+| Conditions.cs:46:9:46:10 | exit M4 (normal) | Conditions.cs:46:9:46:10 | exit M4 |  |
+| Conditions.cs:47:5:55:5 | {...} | Conditions.cs:48:9:48:18 | ... ...; |  |
+| Conditions.cs:48:9:48:18 | ... ...; | Conditions.cs:48:17:48:17 | 0 |  |
+| Conditions.cs:48:13:48:17 | Int32 y = ... | Conditions.cs:49:9:53:9 | while (...) ... |  |
+| Conditions.cs:48:17:48:17 | 0 | Conditions.cs:48:13:48:17 | Int32 y = ... |  |
+| Conditions.cs:49:9:53:9 | while (...) ... | Conditions.cs:49:16:49:16 | access to parameter x |  |
+| Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | Conditions.cs:49:16:49:18 | [b (line 46): false] ...-- |  |
+| Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x | Conditions.cs:49:16:49:18 | [b (line 46): true] ...-- |  |
+| Conditions.cs:49:16:49:16 | access to parameter x | Conditions.cs:49:16:49:18 | ...-- |  |
+| Conditions.cs:49:16:49:18 | ...-- | Conditions.cs:49:22:49:22 | 0 |  |
+| Conditions.cs:49:16:49:18 | [b (line 46): false] ...-- | Conditions.cs:49:22:49:22 | [b (line 46): false] 0 |  |
+| Conditions.cs:49:16:49:18 | [b (line 46): true] ...-- | Conditions.cs:49:22:49:22 | [b (line 46): true] 0 |  |
+| Conditions.cs:49:16:49:22 | ... > ... | Conditions.cs:50:9:53:9 | {...} | true |
+| Conditions.cs:49:16:49:22 | ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | false |
+| Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | true |
+| Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | false |
+| Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | true |
+| Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... | Conditions.cs:54:16:54:16 | access to local variable y | false |
+| Conditions.cs:49:22:49:22 | 0 | Conditions.cs:49:16:49:22 | ... > ... |  |
+| Conditions.cs:49:22:49:22 | [b (line 46): false] 0 | Conditions.cs:49:16:49:22 | [b (line 46): false] ... > ... |  |
+| Conditions.cs:49:22:49:22 | [b (line 46): true] 0 | Conditions.cs:49:16:49:22 | [b (line 46): true] ... > ... |  |
+| Conditions.cs:50:9:53:9 | [b (line 46): false] {...} | Conditions.cs:51:13:52:20 | [b (line 46): false] if (...) ... |  |
+| Conditions.cs:50:9:53:9 | [b (line 46): true] {...} | Conditions.cs:51:13:52:20 | [b (line 46): true] if (...) ... |  |
+| Conditions.cs:50:9:53:9 | {...} | Conditions.cs:51:13:52:20 | if (...) ... |  |
+| Conditions.cs:51:13:52:20 | [b (line 46): false] if (...) ... | Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b |  |
+| Conditions.cs:51:13:52:20 | [b (line 46): true] if (...) ... | Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b |  |
+| Conditions.cs:51:13:52:20 | if (...) ... | Conditions.cs:51:17:51:17 | access to parameter b |  |
+| Conditions.cs:51:17:51:17 | [b (line 46): false] access to parameter b | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | false |
+| Conditions.cs:51:17:51:17 | [b (line 46): true] access to parameter b | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | true |
+| Conditions.cs:51:17:51:17 | access to parameter b | Conditions.cs:49:16:49:16 | [b (line 46): false] access to parameter x | false |
+| Conditions.cs:51:17:51:17 | access to parameter b | Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | true |
+| Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y | Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ |  |
+| Conditions.cs:52:17:52:19 | [b (line 46): true] ...++ | Conditions.cs:49:16:49:16 | [b (line 46): true] access to parameter x |  |
+| Conditions.cs:52:17:52:20 | [b (line 46): true] ...; | Conditions.cs:52:17:52:17 | [b (line 46): true] access to local variable y |  |
+| Conditions.cs:54:9:54:17 | return ...; | Conditions.cs:46:9:46:10 | exit M4 (normal) | return |
+| Conditions.cs:54:16:54:16 | access to local variable y | Conditions.cs:54:9:54:17 | return ...; |  |
+| Conditions.cs:57:9:57:10 | enter M5 | Conditions.cs:58:5:68:5 | {...} |  |
+| Conditions.cs:57:9:57:10 | exit M5 (normal) | Conditions.cs:57:9:57:10 | exit M5 |  |
+| Conditions.cs:58:5:68:5 | {...} | Conditions.cs:59:9:59:18 | ... ...; |  |
+| Conditions.cs:59:9:59:18 | ... ...; | Conditions.cs:59:17:59:17 | 0 |  |
+| Conditions.cs:59:13:59:17 | Int32 y = ... | Conditions.cs:60:9:64:9 | while (...) ... |  |
+| Conditions.cs:59:17:59:17 | 0 | Conditions.cs:59:13:59:17 | Int32 y = ... |  |
+| Conditions.cs:60:9:64:9 | while (...) ... | Conditions.cs:60:16:60:16 | access to parameter x |  |
+| Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | Conditions.cs:60:16:60:18 | [b (line 57): false] ...-- |  |
+| Conditions.cs:60:16:60:16 | [b (line 57): true] access to parameter x | Conditions.cs:60:16:60:18 | [b (line 57): true] ...-- |  |
+| Conditions.cs:60:16:60:16 | access to parameter x | Conditions.cs:60:16:60:18 | ...-- |  |
+| Conditions.cs:60:16:60:18 | ...-- | Conditions.cs:60:22:60:22 | 0 |  |
+| Conditions.cs:60:16:60:18 | [b (line 57): false] ...-- | Conditions.cs:60:22:60:22 | [b (line 57): false] 0 |  |
+| Conditions.cs:60:16:60:18 | [b (line 57): true] ...-- | Conditions.cs:60:22:60:22 | [b (line 57): true] 0 |  |
+| Conditions.cs:60:16:60:22 | ... > ... | Conditions.cs:61:9:64:9 | {...} | true |
+| Conditions.cs:60:16:60:22 | ... > ... | Conditions.cs:65:9:66:16 | if (...) ... | false |
+| Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | true |
+| Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... | Conditions.cs:65:9:66:16 | [b (line 57): false] if (...) ... | false |
+| Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | Conditions.cs:61:9:64:9 | [b (line 57): true] {...} | true |
+| Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... | Conditions.cs:65:9:66:16 | [b (line 57): true] if (...) ... | false |
+| Conditions.cs:60:22:60:22 | 0 | Conditions.cs:60:16:60:22 | ... > ... |  |
+| Conditions.cs:60:22:60:22 | [b (line 57): false] 0 | Conditions.cs:60:16:60:22 | [b (line 57): false] ... > ... |  |
+| Conditions.cs:60:22:60:22 | [b (line 57): true] 0 | Conditions.cs:60:16:60:22 | [b (line 57): true] ... > ... |  |
+| Conditions.cs:61:9:64:9 | [b (line 57): false] {...} | Conditions.cs:62:13:63:20 | [b (line 57): false] if (...) ... |  |
+| Conditions.cs:61:9:64:9 | [b (line 57): true] {...} | Conditions.cs:62:13:63:20 | [b (line 57): true] if (...) ... |  |
+| Conditions.cs:61:9:64:9 | {...} | Conditions.cs:62:13:63:20 | if (...) ... |  |
+| Conditions.cs:62:13:63:20 | [b (line 57): false] if (...) ... | Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b |  |
+| Conditions.cs:62:13:63:20 | [b (line 57): true] if (...) ... | Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b |  |
+| Conditions.cs:62:13:63:20 | if (...) ... | Conditions.cs:62:17:62:17 | access to parameter b |  |
+| Conditions.cs:62:17:62:17 | [b (line 57): false] access to parameter b | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | false |
+| Conditions.cs:62:17:62:17 | [b (line 57): true] access to parameter b | Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | true |
+| Conditions.cs:62:17:62:17 | access to parameter b | Conditions.cs:60:16:60:16 | [b (line 57): false] access to parameter x | false |
+| Conditions.cs:62:17:62:17 | access to parameter b | Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | true |
+| Conditions.cs:63:17:63:17 | [b (line 57): true] access to local variable y | Conditions.cs:63:17:63:19 | [b (line 57): true] ...++ |  |
+| Conditions.cs:63:17:63:19 | [b (line 57): true] ...++ | Conditions.cs:60:16:60:16 | [b (line 57): true] access to parameter x |  |
+| Conditions.cs:63:17:63:20 | [b (line 57): true] ...; | Conditions.cs:63:17:63:17 | [b (line 57): true] access to local variable y |  |
+| Conditions.cs:65:9:66:16 | [b (line 57): false] if (...) ... | Conditions.cs:65:13:65:13 | [b (line 57): false] access to parameter b |  |
+| Conditions.cs:65:9:66:16 | [b (line 57): true] if (...) ... | Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b |  |
+| Conditions.cs:65:9:66:16 | if (...) ... | Conditions.cs:65:13:65:13 | access to parameter b |  |
+| Conditions.cs:65:13:65:13 | [b (line 57): false] access to parameter b | Conditions.cs:67:16:67:16 | access to local variable y | false |
+| Conditions.cs:65:13:65:13 | [b (line 57): true] access to parameter b | Conditions.cs:66:13:66:16 | ...; | true |
+| Conditions.cs:65:13:65:13 | access to parameter b | Conditions.cs:66:13:66:16 | ...; | true |
+| Conditions.cs:65:13:65:13 | access to parameter b | Conditions.cs:67:16:67:16 | access to local variable y | false |
+| Conditions.cs:66:13:66:13 | access to local variable y | Conditions.cs:66:13:66:15 | ...++ |  |
+| Conditions.cs:66:13:66:15 | ...++ | Conditions.cs:67:16:67:16 | access to local variable y |  |
+| Conditions.cs:66:13:66:16 | ...; | Conditions.cs:66:13:66:13 | access to local variable y |  |
+| Conditions.cs:67:9:67:17 | return ...; | Conditions.cs:57:9:57:10 | exit M5 (normal) | return |
+| Conditions.cs:67:16:67:16 | access to local variable y | Conditions.cs:67:9:67:17 | return ...; |  |
+| Conditions.cs:70:9:70:10 | enter M6 | Conditions.cs:71:5:84:5 | {...} |  |
+| Conditions.cs:70:9:70:10 | exit M6 (normal) | Conditions.cs:70:9:70:10 | exit M6 |  |
+| Conditions.cs:71:5:84:5 | {...} | Conditions.cs:72:9:72:30 | ... ...; |  |
+| Conditions.cs:72:9:72:30 | ... ...; | Conditions.cs:72:17:72:18 | access to parameter ss |  |
+| Conditions.cs:72:13:72:29 | Boolean b = ... | Conditions.cs:73:9:73:18 | ... ...; |  |
+| Conditions.cs:72:17:72:18 | access to parameter ss | Conditions.cs:72:17:72:25 | access to property Length |  |
+| Conditions.cs:72:17:72:25 | access to property Length | Conditions.cs:72:29:72:29 | 0 |  |
+| Conditions.cs:72:17:72:29 | ... > ... | Conditions.cs:72:13:72:29 | Boolean b = ... |  |
+| Conditions.cs:72:29:72:29 | 0 | Conditions.cs:72:17:72:29 | ... > ... |  |
+| Conditions.cs:73:9:73:18 | ... ...; | Conditions.cs:73:17:73:17 | 0 |  |
+| Conditions.cs:73:13:73:17 | Int32 x = ... | Conditions.cs:74:27:74:28 | access to parameter ss |  |
+| Conditions.cs:73:17:73:17 | 0 | Conditions.cs:73:13:73:17 | Int32 x = ... |  |
+| Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:74:22:74:22 | String _ | non-empty |
+| Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | Conditions.cs:81:9:82:16 | if (...) ... | empty |
+| Conditions.cs:74:22:74:22 | String _ | Conditions.cs:75:9:80:9 | {...} |  |
+| Conditions.cs:74:27:74:28 | access to parameter ss | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... |  |
+| Conditions.cs:75:9:80:9 | {...} | Conditions.cs:76:13:77:20 | if (...) ... |  |
+| Conditions.cs:76:13:77:20 | if (...) ... | Conditions.cs:76:17:76:17 | access to local variable b |  |
+| Conditions.cs:76:17:76:17 | access to local variable b | Conditions.cs:77:17:77:20 | ...; | true |
+| Conditions.cs:76:17:76:17 | access to local variable b | Conditions.cs:78:13:79:26 | if (...) ... | false |
+| Conditions.cs:77:17:77:17 | access to local variable x | Conditions.cs:77:17:77:19 | ...++ |  |
+| Conditions.cs:77:17:77:19 | ...++ | Conditions.cs:78:13:79:26 | if (...) ... |  |
+| Conditions.cs:77:17:77:20 | ...; | Conditions.cs:77:17:77:17 | access to local variable x |  |
+| Conditions.cs:78:13:79:26 | if (...) ... | Conditions.cs:78:17:78:17 | access to local variable x |  |
+| Conditions.cs:78:17:78:17 | access to local variable x | Conditions.cs:78:21:78:21 | 0 |  |
+| Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... | false |
+| Conditions.cs:78:17:78:21 | ... > ... | Conditions.cs:79:17:79:26 | ...; | true |
+| Conditions.cs:78:21:78:21 | 0 | Conditions.cs:78:17:78:21 | ... > ... |  |
+| Conditions.cs:79:17:79:25 | ... = ... | Conditions.cs:74:9:80:9 | foreach (... ... in ...) ... |  |
+| Conditions.cs:79:17:79:26 | ...; | Conditions.cs:79:21:79:25 | false |  |
+| Conditions.cs:79:21:79:25 | false | Conditions.cs:79:17:79:25 | ... = ... |  |
+| Conditions.cs:81:9:82:16 | if (...) ... | Conditions.cs:81:13:81:13 | access to local variable b |  |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:82:13:82:16 | ...; | true |
+| Conditions.cs:81:13:81:13 | access to local variable b | Conditions.cs:83:16:83:16 | access to local variable x | false |
+| Conditions.cs:82:13:82:13 | access to local variable x | Conditions.cs:82:13:82:15 | ...++ |  |
+| Conditions.cs:82:13:82:15 | ...++ | Conditions.cs:83:16:83:16 | access to local variable x |  |
+| Conditions.cs:82:13:82:16 | ...; | Conditions.cs:82:13:82:13 | access to local variable x |  |
+| Conditions.cs:83:9:83:17 | return ...; | Conditions.cs:70:9:70:10 | exit M6 (normal) | return |
+| Conditions.cs:83:16:83:16 | access to local variable x | Conditions.cs:83:9:83:17 | return ...; |  |
+| Conditions.cs:86:9:86:10 | enter M7 | Conditions.cs:87:5:100:5 | {...} |  |
+| Conditions.cs:86:9:86:10 | exit M7 (normal) | Conditions.cs:86:9:86:10 | exit M7 |  |
+| Conditions.cs:87:5:100:5 | {...} | Conditions.cs:88:9:88:30 | ... ...; |  |
+| Conditions.cs:88:9:88:30 | ... ...; | Conditions.cs:88:17:88:18 | access to parameter ss |  |
+| Conditions.cs:88:13:88:29 | Boolean b = ... | Conditions.cs:89:9:89:18 | ... ...; |  |
+| Conditions.cs:88:17:88:18 | access to parameter ss | Conditions.cs:88:17:88:25 | access to property Length |  |
+| Conditions.cs:88:17:88:25 | access to property Length | Conditions.cs:88:29:88:29 | 0 |  |
+| Conditions.cs:88:17:88:29 | ... > ... | Conditions.cs:88:13:88:29 | Boolean b = ... |  |
+| Conditions.cs:88:29:88:29 | 0 | Conditions.cs:88:17:88:29 | ... > ... |  |
+| Conditions.cs:89:9:89:18 | ... ...; | Conditions.cs:89:17:89:17 | 0 |  |
+| Conditions.cs:89:13:89:17 | Int32 x = ... | Conditions.cs:90:27:90:28 | access to parameter ss |  |
+| Conditions.cs:89:17:89:17 | 0 | Conditions.cs:89:13:89:17 | Int32 x = ... |  |
+| Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:90:22:90:22 | String _ | non-empty |
+| Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | Conditions.cs:99:16:99:16 | access to local variable x | empty |
+| Conditions.cs:90:22:90:22 | String _ | Conditions.cs:91:9:98:9 | {...} |  |
+| Conditions.cs:90:27:90:28 | access to parameter ss | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... |  |
+| Conditions.cs:91:9:98:9 | {...} | Conditions.cs:92:13:93:20 | if (...) ... |  |
+| Conditions.cs:92:13:93:20 | if (...) ... | Conditions.cs:92:17:92:17 | access to local variable b |  |
+| Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:93:17:93:20 | ...; | true |
+| Conditions.cs:92:17:92:17 | access to local variable b | Conditions.cs:94:13:95:26 | if (...) ... | false |
+| Conditions.cs:93:17:93:17 | access to local variable x | Conditions.cs:93:17:93:19 | ...++ |  |
+| Conditions.cs:93:17:93:19 | ...++ | Conditions.cs:94:13:95:26 | if (...) ... |  |
+| Conditions.cs:93:17:93:20 | ...; | Conditions.cs:93:17:93:17 | access to local variable x |  |
+| Conditions.cs:94:13:95:26 | if (...) ... | Conditions.cs:94:17:94:17 | access to local variable x |  |
+| Conditions.cs:94:17:94:17 | access to local variable x | Conditions.cs:94:21:94:21 | 0 |  |
+| Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:95:17:95:26 | ...; | true |
+| Conditions.cs:94:17:94:21 | ... > ... | Conditions.cs:96:13:97:20 | if (...) ... | false |
+| Conditions.cs:94:21:94:21 | 0 | Conditions.cs:94:17:94:21 | ... > ... |  |
+| Conditions.cs:95:17:95:25 | ... = ... | Conditions.cs:96:13:97:20 | if (...) ... |  |
+| Conditions.cs:95:17:95:26 | ...; | Conditions.cs:95:21:95:25 | false |  |
+| Conditions.cs:95:21:95:25 | false | Conditions.cs:95:17:95:25 | ... = ... |  |
+| Conditions.cs:96:13:97:20 | if (...) ... | Conditions.cs:96:17:96:17 | access to local variable b |  |
+| Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... | false |
+| Conditions.cs:96:17:96:17 | access to local variable b | Conditions.cs:97:17:97:20 | ...; | true |
+| Conditions.cs:97:17:97:17 | access to local variable x | Conditions.cs:97:17:97:19 | ...++ |  |
+| Conditions.cs:97:17:97:19 | ...++ | Conditions.cs:90:9:98:9 | foreach (... ... in ...) ... |  |
+| Conditions.cs:97:17:97:20 | ...; | Conditions.cs:97:17:97:17 | access to local variable x |  |
+| Conditions.cs:99:9:99:17 | return ...; | Conditions.cs:86:9:86:10 | exit M7 (normal) | return |
+| Conditions.cs:99:16:99:16 | access to local variable x | Conditions.cs:99:9:99:17 | return ...; |  |
+| Conditions.cs:102:12:102:13 | enter M8 | Conditions.cs:103:5:111:5 | {...} |  |
+| Conditions.cs:102:12:102:13 | exit M8 (normal) | Conditions.cs:102:12:102:13 | exit M8 |  |
+| Conditions.cs:103:5:111:5 | {...} | Conditions.cs:104:9:104:29 | ... ...; |  |
+| Conditions.cs:104:9:104:29 | ... ...; | Conditions.cs:104:17:104:17 | access to parameter b |  |
+| Conditions.cs:104:13:104:28 | String x = ... | Conditions.cs:105:9:106:20 | if (...) ... |  |
+| Conditions.cs:104:17:104:17 | access to parameter b | Conditions.cs:104:17:104:28 | call to method ToString |  |
+| Conditions.cs:104:17:104:28 | call to method ToString | Conditions.cs:104:13:104:28 | String x = ... |  |
+| Conditions.cs:105:9:106:20 | if (...) ... | Conditions.cs:105:13:105:13 | access to parameter b |  |
+| Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | true |
+| Conditions.cs:105:13:105:13 | access to parameter b | Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | false |
+| Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x | Conditions.cs:106:18:106:19 | [b (line 102): true] "" |  |
+| Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... | Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... |  |
+| Conditions.cs:106:13:106:19 | [b (line 102): true] ... = ... | Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... |  |
+| Conditions.cs:106:13:106:20 | [b (line 102): true] ...; | Conditions.cs:106:13:106:13 | [b (line 102): true] access to local variable x |  |
+| Conditions.cs:106:18:106:19 | [b (line 102): true] "" | Conditions.cs:106:13:106:19 | [b (line 102): true] ... + ... |  |
+| Conditions.cs:107:9:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:107:13:107:13 | [b (line 102): false] access to local variable x |  |
+| Conditions.cs:107:9:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:107:13:107:13 | [b (line 102): true] access to local variable x |  |
+| Conditions.cs:107:13:107:13 | [b (line 102): false] access to local variable x | Conditions.cs:107:13:107:20 | [b (line 102): false] access to property Length |  |
+| Conditions.cs:107:13:107:13 | [b (line 102): true] access to local variable x | Conditions.cs:107:13:107:20 | [b (line 102): true] access to property Length |  |
+| Conditions.cs:107:13:107:20 | [b (line 102): false] access to property Length | Conditions.cs:107:24:107:24 | [b (line 102): false] 0 |  |
+| Conditions.cs:107:13:107:20 | [b (line 102): true] access to property Length | Conditions.cs:107:24:107:24 | [b (line 102): true] 0 |  |
+| Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | true |
+| Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
+| Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | true |
+| Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... | Conditions.cs:110:16:110:16 | access to local variable x | false |
+| Conditions.cs:107:24:107:24 | [b (line 102): false] 0 | Conditions.cs:107:13:107:24 | [b (line 102): false] ... > ... |  |
+| Conditions.cs:107:24:107:24 | [b (line 102): true] 0 | Conditions.cs:107:13:107:24 | [b (line 102): true] ... > ... |  |
+| Conditions.cs:108:13:109:24 | [b (line 102): false] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b |  |
+| Conditions.cs:108:13:109:24 | [b (line 102): true] if (...) ... | Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b |  |
+| Conditions.cs:108:17:108:18 | [false] !... | Conditions.cs:110:16:110:16 | access to local variable x | false |
+| Conditions.cs:108:17:108:18 | [true] !... | Conditions.cs:109:17:109:24 | ...; | true |
+| Conditions.cs:108:18:108:18 | [b (line 102): false] access to parameter b | Conditions.cs:108:17:108:18 | [true] !... | false |
+| Conditions.cs:108:18:108:18 | [b (line 102): true] access to parameter b | Conditions.cs:108:17:108:18 | [false] !... | true |
+| Conditions.cs:109:17:109:17 | access to local variable x | Conditions.cs:109:22:109:23 | "" |  |
+| Conditions.cs:109:17:109:23 | ... + ... | Conditions.cs:109:17:109:23 | ... = ... |  |
+| Conditions.cs:109:17:109:23 | ... = ... | Conditions.cs:110:16:110:16 | access to local variable x |  |
+| Conditions.cs:109:17:109:24 | ...; | Conditions.cs:109:17:109:17 | access to local variable x |  |
+| Conditions.cs:109:22:109:23 | "" | Conditions.cs:109:17:109:23 | ... + ... |  |
+| Conditions.cs:110:9:110:17 | return ...; | Conditions.cs:102:12:102:13 | exit M8 (normal) | return |
+| Conditions.cs:110:16:110:16 | access to local variable x | Conditions.cs:110:9:110:17 | return ...; |  |
+| Conditions.cs:113:10:113:11 | enter M9 | Conditions.cs:114:5:124:5 | {...} |  |
+| Conditions.cs:113:10:113:11 | exit M9 (normal) | Conditions.cs:113:10:113:11 | exit M9 |  |
+| Conditions.cs:114:5:124:5 | {...} | Conditions.cs:115:9:115:24 | ... ...; |  |
+| Conditions.cs:115:9:115:24 | ... ...; | Conditions.cs:115:20:115:23 | null |  |
+| Conditions.cs:115:16:115:23 | String s = ... | Conditions.cs:116:9:123:9 | for (...;...;...) ... |  |
+| Conditions.cs:115:20:115:23 | null | Conditions.cs:115:16:115:23 | String s = ... |  |
+| Conditions.cs:116:9:123:9 | for (...;...;...) ... | Conditions.cs:116:22:116:22 | 0 |  |
+| Conditions.cs:116:18:116:22 | Int32 i = ... | Conditions.cs:116:25:116:25 | access to local variable i |  |
+| Conditions.cs:116:22:116:22 | 0 | Conditions.cs:116:18:116:22 | Int32 i = ... |  |
+| Conditions.cs:116:25:116:25 | access to local variable i | Conditions.cs:116:29:116:32 | access to parameter args |  |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:113:10:113:11 | exit M9 (normal) | false |
+| Conditions.cs:116:25:116:39 | ... < ... | Conditions.cs:117:9:123:9 | {...} | true |
+| Conditions.cs:116:29:116:32 | access to parameter args | Conditions.cs:116:29:116:39 | access to property Length |  |
+| Conditions.cs:116:29:116:39 | access to property Length | Conditions.cs:116:25:116:39 | ... < ... |  |
+| Conditions.cs:116:42:116:42 | access to local variable i | Conditions.cs:116:42:116:44 | ...++ |  |
+| Conditions.cs:116:42:116:44 | ...++ | Conditions.cs:116:25:116:25 | access to local variable i |  |
+| Conditions.cs:117:9:123:9 | {...} | Conditions.cs:118:13:118:44 | ... ...; |  |
+| Conditions.cs:118:13:118:44 | ... ...; | Conditions.cs:118:24:118:24 | access to local variable i |  |
+| Conditions.cs:118:17:118:43 | Boolean last = ... | Conditions.cs:119:13:120:23 | if (...) ... |  |
+| Conditions.cs:118:24:118:24 | access to local variable i | Conditions.cs:118:29:118:32 | access to parameter args |  |
+| Conditions.cs:118:24:118:43 | ... == ... | Conditions.cs:118:17:118:43 | Boolean last = ... |  |
+| Conditions.cs:118:29:118:32 | access to parameter args | Conditions.cs:118:29:118:39 | access to property Length |  |
+| Conditions.cs:118:29:118:39 | access to property Length | Conditions.cs:118:43:118:43 | 1 |  |
+| Conditions.cs:118:29:118:43 | ... - ... | Conditions.cs:118:24:118:43 | ... == ... |  |
+| Conditions.cs:118:43:118:43 | 1 | Conditions.cs:118:29:118:43 | ... - ... |  |
+| Conditions.cs:119:13:120:23 | if (...) ... | Conditions.cs:119:18:119:21 | access to local variable last |  |
+| Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | false |
+| Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [false, last (line 118): true] !... | true |
+| Conditions.cs:119:18:119:21 | access to local variable last | Conditions.cs:119:17:119:21 | [true, last (line 118): false] !... | false |
+| Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... | Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... |  |
+| Conditions.cs:120:17:120:23 | [last (line 118): false] ...; | Conditions.cs:120:21:120:22 | [last (line 118): false] "" |  |
+| Conditions.cs:120:21:120:22 | [last (line 118): false] "" | Conditions.cs:120:17:120:22 | [last (line 118): false] ... = ... |  |
+| Conditions.cs:121:13:122:25 | [last (line 118): false] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last |  |
+| Conditions.cs:121:13:122:25 | [last (line 118): true] if (...) ... | Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last |  |
+| Conditions.cs:121:17:121:20 | [last (line 118): false] access to local variable last | Conditions.cs:116:42:116:42 | access to local variable i | false |
+| Conditions.cs:121:17:121:20 | [last (line 118): true] access to local variable last | Conditions.cs:122:17:122:25 | ...; | true |
+| Conditions.cs:122:17:122:24 | ... = ... | Conditions.cs:116:42:116:42 | access to local variable i |  |
+| Conditions.cs:122:17:122:25 | ...; | Conditions.cs:122:21:122:24 | null |  |
+| Conditions.cs:122:21:122:24 | null | Conditions.cs:122:17:122:24 | ... = ... |  |
+| Conditions.cs:129:10:129:12 | enter M10 | Conditions.cs:130:5:141:5 | {...} |  |
+| Conditions.cs:130:5:141:5 | {...} | Conditions.cs:131:9:140:9 | while (...) ... |  |
+| Conditions.cs:131:9:140:9 | while (...) ... | Conditions.cs:131:16:131:19 | true |  |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | true |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | true |
+| Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true | Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:131:16:131:19 | true | Conditions.cs:132:9:140:9 | {...} | true |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... |  |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |  |
+| Conditions.cs:132:9:140:9 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |  |
+| Conditions.cs:132:9:140:9 | {...} | Conditions.cs:133:13:139:13 | if (...) ... |  |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access |  |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access |  |
+| Conditions.cs:133:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access |  |
+| Conditions.cs:133:13:139:13 | if (...) ... | Conditions.cs:133:17:133:22 | this access |  |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): false] access to field Field1 |  |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | true |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field1 |  |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:133:17:133:22 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |  |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:131:16:131:19 | [Field1 (line 129): false] true | false |
+| Conditions.cs:133:17:133:22 | access to field Field1 | Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | true |
+| Conditions.cs:133:17:133:22 | this access | Conditions.cs:133:17:133:22 | access to field Field1 |  |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): false] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... |  |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... |  |
+| Conditions.cs:134:13:139:13 | [Field1 (line 129): true] {...} | Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... |  |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): false] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access |  |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |  |
+| Conditions.cs:135:17:138:17 | [Field1 (line 129): true] if (...) ... | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access |  |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): false] access to field Field2 |  |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field2 |  |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): false] true | false |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 | Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | true |
+| Conditions.cs:135:21:135:26 | [Field1 (line 129): true] this access | Conditions.cs:135:21:135:26 | [Field1 (line 129): true] access to field Field2 |  |
+| Conditions.cs:136:17:138:17 | [Field1 (line 129): true, Field2 (line 129): true] {...} | Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; |  |
+| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 | Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString |  |
+| Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] access to field Field1 |  |
+| Conditions.cs:137:21:137:37 | [Field1 (line 129): true, Field2 (line 129): true] call to method ToString | Conditions.cs:131:16:131:19 | [Field1 (line 129): true, Field2 (line 129): true] true |  |
+| Conditions.cs:137:21:137:38 | [Field1 (line 129): true, Field2 (line 129): true] ...; | Conditions.cs:137:21:137:26 | [Field1 (line 129): true, Field2 (line 129): true] this access |  |
+| Conditions.cs:143:10:143:12 | enter M11 | Conditions.cs:144:5:150:5 | {...} |  |
+| Conditions.cs:143:10:143:12 | exit M11 (normal) | Conditions.cs:143:10:143:12 | exit M11 |  |
+| Conditions.cs:144:5:150:5 | {...} | Conditions.cs:145:9:145:30 | ... ...; |  |
+| Conditions.cs:145:9:145:30 | ... ...; | Conditions.cs:145:17:145:17 | access to parameter b |  |
+| Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... |  |
+| Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... | Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... |  |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | true |
+| Conditions.cs:145:17:145:17 | access to parameter b | Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | false |
+| Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): false] String s = ... |  |
+| Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... | Conditions.cs:145:13:145:29 | [b (line 143): true] String s = ... |  |
+| Conditions.cs:145:21:145:23 | [b (line 143): true] "a" | Conditions.cs:145:17:145:29 | [b (line 143): true] ... ? ... : ... |  |
+| Conditions.cs:145:27:145:29 | [b (line 143): false] "b" | Conditions.cs:145:17:145:29 | [b (line 143): false] ... ? ... : ... |  |
+| Conditions.cs:146:9:149:49 | [b (line 143): false] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b |  |
+| Conditions.cs:146:9:149:49 | [b (line 143): true] if (...) ... | Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b |  |
+| Conditions.cs:146:13:146:13 | [b (line 143): false] access to parameter b | Conditions.cs:149:13:149:49 | ...; | false |
+| Conditions.cs:146:13:146:13 | [b (line 143): true] access to parameter b | Conditions.cs:147:13:147:49 | ...; | true |
+| Conditions.cs:147:13:147:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) |  |
+| Conditions.cs:147:13:147:49 | ...; | Conditions.cs:147:40:147:43 | "a = " |  |
+| Conditions.cs:147:38:147:47 | $"..." | Conditions.cs:147:13:147:48 | call to method WriteLine |  |
+| Conditions.cs:147:40:147:43 | "a = " | Conditions.cs:147:45:147:45 | access to local variable s |  |
+| Conditions.cs:147:45:147:45 | access to local variable s | Conditions.cs:147:38:147:47 | $"..." |  |
+| Conditions.cs:149:13:149:48 | call to method WriteLine | Conditions.cs:143:10:143:12 | exit M11 (normal) |  |
+| Conditions.cs:149:13:149:49 | ...; | Conditions.cs:149:40:149:43 | "b = " |  |
+| Conditions.cs:149:38:149:47 | $"..." | Conditions.cs:149:13:149:48 | call to method WriteLine |  |
+| Conditions.cs:149:40:149:43 | "b = " | Conditions.cs:149:45:149:45 | access to local variable s |  |
+| Conditions.cs:149:45:149:45 | access to local variable s | Conditions.cs:149:38:149:47 | $"..." |  |
+| ExitMethods.cs:6:7:6:17 | call to constructor Object | ExitMethods.cs:6:7:6:17 | {...} |  |
+| ExitMethods.cs:6:7:6:17 | enter ExitMethods | ExitMethods.cs:6:7:6:17 | call to constructor Object |  |
+| ExitMethods.cs:6:7:6:17 | exit ExitMethods (normal) | ExitMethods.cs:6:7:6:17 | exit ExitMethods |  |
+| ExitMethods.cs:6:7:6:17 | {...} | ExitMethods.cs:6:7:6:17 | exit ExitMethods (normal) |  |
+| ExitMethods.cs:8:10:8:11 | enter M1 | ExitMethods.cs:9:5:12:5 | {...} |  |
+| ExitMethods.cs:8:10:8:11 | exit M1 (normal) | ExitMethods.cs:8:10:8:11 | exit M1 |  |
+| ExitMethods.cs:9:5:12:5 | {...} | ExitMethods.cs:10:9:10:25 | ...; |  |
+| ExitMethods.cs:10:9:10:24 | call to method ErrorMaybe | ExitMethods.cs:11:9:11:15 | return ...; |  |
+| ExitMethods.cs:10:9:10:25 | ...; | ExitMethods.cs:10:20:10:23 | true |  |
+| ExitMethods.cs:10:20:10:23 | true | ExitMethods.cs:10:9:10:24 | call to method ErrorMaybe |  |
+| ExitMethods.cs:11:9:11:15 | return ...; | ExitMethods.cs:8:10:8:11 | exit M1 (normal) | return |
+| ExitMethods.cs:14:10:14:11 | enter M2 | ExitMethods.cs:15:5:18:5 | {...} |  |
+| ExitMethods.cs:14:10:14:11 | exit M2 (normal) | ExitMethods.cs:14:10:14:11 | exit M2 |  |
+| ExitMethods.cs:15:5:18:5 | {...} | ExitMethods.cs:16:9:16:26 | ...; |  |
+| ExitMethods.cs:16:9:16:25 | call to method ErrorMaybe | ExitMethods.cs:17:9:17:15 | return ...; |  |
+| ExitMethods.cs:16:9:16:26 | ...; | ExitMethods.cs:16:20:16:24 | false |  |
+| ExitMethods.cs:16:20:16:24 | false | ExitMethods.cs:16:9:16:25 | call to method ErrorMaybe |  |
+| ExitMethods.cs:17:9:17:15 | return ...; | ExitMethods.cs:14:10:14:11 | exit M2 (normal) | return |
+| ExitMethods.cs:20:10:20:11 | enter M3 | ExitMethods.cs:21:5:24:5 | {...} |  |
+| ExitMethods.cs:20:10:20:11 | exit M3 (abnormal) | ExitMethods.cs:20:10:20:11 | exit M3 |  |
+| ExitMethods.cs:21:5:24:5 | {...} | ExitMethods.cs:22:9:22:26 | ...; |  |
+| ExitMethods.cs:22:9:22:25 | call to method ErrorAlways | ExitMethods.cs:20:10:20:11 | exit M3 (abnormal) | exception(ArgumentException), exception(Exception) |
+| ExitMethods.cs:22:9:22:26 | ...; | ExitMethods.cs:22:21:22:24 | true |  |
+| ExitMethods.cs:22:21:22:24 | true | ExitMethods.cs:22:9:22:25 | call to method ErrorAlways |  |
+| ExitMethods.cs:26:10:26:11 | enter M4 | ExitMethods.cs:27:5:30:5 | {...} |  |
+| ExitMethods.cs:26:10:26:11 | exit M4 (abnormal) | ExitMethods.cs:26:10:26:11 | exit M4 |  |
+| ExitMethods.cs:27:5:30:5 | {...} | ExitMethods.cs:28:9:28:15 | ...; |  |
+| ExitMethods.cs:28:9:28:14 | call to method Exit | ExitMethods.cs:26:10:26:11 | exit M4 (abnormal) | exit |
+| ExitMethods.cs:28:9:28:14 | this access | ExitMethods.cs:28:9:28:14 | call to method Exit |  |
+| ExitMethods.cs:28:9:28:15 | ...; | ExitMethods.cs:28:9:28:14 | this access |  |
+| ExitMethods.cs:32:10:32:11 | enter M5 | ExitMethods.cs:33:5:36:5 | {...} |  |
+| ExitMethods.cs:32:10:32:11 | exit M5 (abnormal) | ExitMethods.cs:32:10:32:11 | exit M5 |  |
+| ExitMethods.cs:33:5:36:5 | {...} | ExitMethods.cs:34:9:34:26 | ...; |  |
+| ExitMethods.cs:34:9:34:25 | call to method ApplicationExit | ExitMethods.cs:32:10:32:11 | exit M5 (abnormal) | exit |
+| ExitMethods.cs:34:9:34:25 | this access | ExitMethods.cs:34:9:34:25 | call to method ApplicationExit |  |
+| ExitMethods.cs:34:9:34:26 | ...; | ExitMethods.cs:34:9:34:25 | this access |  |
+| ExitMethods.cs:38:10:38:11 | enter M6 | ExitMethods.cs:39:5:52:5 | {...} |  |
+| ExitMethods.cs:38:10:38:11 | exit M6 (normal) | ExitMethods.cs:38:10:38:11 | exit M6 |  |
+| ExitMethods.cs:39:5:52:5 | {...} | ExitMethods.cs:40:9:51:9 | try {...} ... |  |
+| ExitMethods.cs:40:9:51:9 | try {...} ... | ExitMethods.cs:41:9:43:9 | {...} |  |
+| ExitMethods.cs:41:9:43:9 | {...} | ExitMethods.cs:42:13:42:31 | ...; |  |
+| ExitMethods.cs:42:13:42:30 | call to method ErrorAlways | ExitMethods.cs:44:9:47:9 | [exception: ArgumentException] catch (...) {...} | exception(ArgumentException) |
+| ExitMethods.cs:42:13:42:30 | call to method ErrorAlways | ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| ExitMethods.cs:42:13:42:31 | ...; | ExitMethods.cs:42:25:42:29 | false |  |
+| ExitMethods.cs:42:25:42:29 | false | ExitMethods.cs:42:13:42:30 | call to method ErrorAlways |  |
+| ExitMethods.cs:44:9:47:9 | [exception: ArgumentException] catch (...) {...} | ExitMethods.cs:45:9:47:9 | {...} | match |
+| ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:45:9:47:9 | {...} | match |
+| ExitMethods.cs:44:9:47:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:48:9:51:9 | [exception: Exception] catch (...) {...} | no-match |
+| ExitMethods.cs:45:9:47:9 | {...} | ExitMethods.cs:46:13:46:19 | return ...; |  |
+| ExitMethods.cs:46:13:46:19 | return ...; | ExitMethods.cs:38:10:38:11 | exit M6 (normal) | return |
+| ExitMethods.cs:48:9:51:9 | [exception: Exception] catch (...) {...} | ExitMethods.cs:49:9:51:9 | {...} | match |
+| ExitMethods.cs:49:9:51:9 | {...} | ExitMethods.cs:50:13:50:19 | return ...; |  |
+| ExitMethods.cs:50:13:50:19 | return ...; | ExitMethods.cs:38:10:38:11 | exit M6 (normal) | return |
+| ExitMethods.cs:54:10:54:11 | enter M7 | ExitMethods.cs:55:5:58:5 | {...} |  |
+| ExitMethods.cs:54:10:54:11 | exit M7 (abnormal) | ExitMethods.cs:54:10:54:11 | exit M7 |  |
+| ExitMethods.cs:55:5:58:5 | {...} | ExitMethods.cs:56:9:56:23 | ...; |  |
+| ExitMethods.cs:56:9:56:22 | call to method ErrorAlways2 | ExitMethods.cs:54:10:54:11 | exit M7 (abnormal) | exception(Exception) |
+| ExitMethods.cs:56:9:56:23 | ...; | ExitMethods.cs:56:9:56:22 | call to method ErrorAlways2 |  |
+| ExitMethods.cs:60:10:60:11 | enter M8 | ExitMethods.cs:61:5:64:5 | {...} |  |
+| ExitMethods.cs:60:10:60:11 | exit M8 (abnormal) | ExitMethods.cs:60:10:60:11 | exit M8 |  |
+| ExitMethods.cs:61:5:64:5 | {...} | ExitMethods.cs:62:9:62:23 | ...; |  |
+| ExitMethods.cs:62:9:62:22 | call to method ErrorAlways3 | ExitMethods.cs:60:10:60:11 | exit M8 (abnormal) | exception(Exception) |
+| ExitMethods.cs:62:9:62:23 | ...; | ExitMethods.cs:62:9:62:22 | call to method ErrorAlways3 |  |
+| ExitMethods.cs:66:17:66:26 | enter ErrorMaybe | ExitMethods.cs:67:5:70:5 | {...} |  |
+| ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (abnormal) | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe |  |
+| ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (normal) | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe |  |
+| ExitMethods.cs:67:5:70:5 | {...} | ExitMethods.cs:68:9:69:34 | if (...) ... |  |
+| ExitMethods.cs:68:9:69:34 | if (...) ... | ExitMethods.cs:68:13:68:13 | access to parameter b |  |
+| ExitMethods.cs:68:13:68:13 | access to parameter b | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (normal) | false |
+| ExitMethods.cs:68:13:68:13 | access to parameter b | ExitMethods.cs:69:19:69:33 | object creation of type Exception | true |
+| ExitMethods.cs:69:13:69:34 | throw ...; | ExitMethods.cs:66:17:66:26 | exit ErrorMaybe (abnormal) | exception(Exception) |
+| ExitMethods.cs:69:19:69:33 | object creation of type Exception | ExitMethods.cs:69:13:69:34 | throw ...; |  |
+| ExitMethods.cs:72:17:72:27 | enter ErrorAlways | ExitMethods.cs:73:5:78:5 | {...} |  |
+| ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | ExitMethods.cs:72:17:72:27 | exit ErrorAlways |  |
+| ExitMethods.cs:73:5:78:5 | {...} | ExitMethods.cs:74:9:77:45 | if (...) ... |  |
+| ExitMethods.cs:74:9:77:45 | if (...) ... | ExitMethods.cs:74:13:74:13 | access to parameter b |  |
+| ExitMethods.cs:74:13:74:13 | access to parameter b | ExitMethods.cs:75:19:75:33 | object creation of type Exception | true |
+| ExitMethods.cs:74:13:74:13 | access to parameter b | ExitMethods.cs:77:41:77:43 | "b" | false |
+| ExitMethods.cs:75:13:75:34 | throw ...; | ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | exception(Exception) |
+| ExitMethods.cs:75:19:75:33 | object creation of type Exception | ExitMethods.cs:75:13:75:34 | throw ...; |  |
+| ExitMethods.cs:77:13:77:45 | throw ...; | ExitMethods.cs:72:17:72:27 | exit ErrorAlways (abnormal) | exception(ArgumentException) |
+| ExitMethods.cs:77:19:77:44 | object creation of type ArgumentException | ExitMethods.cs:77:13:77:45 | throw ...; |  |
+| ExitMethods.cs:77:41:77:43 | "b" | ExitMethods.cs:77:19:77:44 | object creation of type ArgumentException |  |
+| ExitMethods.cs:80:17:80:28 | enter ErrorAlways2 | ExitMethods.cs:81:5:83:5 | {...} |  |
+| ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 (abnormal) | ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 |  |
+| ExitMethods.cs:81:5:83:5 | {...} | ExitMethods.cs:82:15:82:29 | object creation of type Exception |  |
+| ExitMethods.cs:82:9:82:30 | throw ...; | ExitMethods.cs:80:17:80:28 | exit ErrorAlways2 (abnormal) | exception(Exception) |
+| ExitMethods.cs:82:15:82:29 | object creation of type Exception | ExitMethods.cs:82:9:82:30 | throw ...; |  |
+| ExitMethods.cs:85:17:85:28 | enter ErrorAlways3 | ExitMethods.cs:85:41:85:55 | object creation of type Exception |  |
+| ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 (abnormal) | ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 |  |
+| ExitMethods.cs:85:35:85:55 | throw ... | ExitMethods.cs:85:17:85:28 | exit ErrorAlways3 (abnormal) | exception(Exception) |
+| ExitMethods.cs:85:41:85:55 | object creation of type Exception | ExitMethods.cs:85:35:85:55 | throw ... |  |
+| ExitMethods.cs:87:10:87:13 | enter Exit | ExitMethods.cs:88:5:90:5 | {...} |  |
+| ExitMethods.cs:87:10:87:13 | exit Exit (abnormal) | ExitMethods.cs:87:10:87:13 | exit Exit |  |
+| ExitMethods.cs:88:5:90:5 | {...} | ExitMethods.cs:89:9:89:28 | ...; |  |
+| ExitMethods.cs:89:9:89:27 | call to method Exit | ExitMethods.cs:87:10:87:13 | exit Exit (abnormal) | exit |
+| ExitMethods.cs:89:9:89:28 | ...; | ExitMethods.cs:89:26:89:26 | 0 |  |
+| ExitMethods.cs:89:26:89:26 | 0 | ExitMethods.cs:89:9:89:27 | call to method Exit |  |
+| ExitMethods.cs:92:10:92:18 | enter ExitInTry | ExitMethods.cs:93:5:103:5 | {...} |  |
+| ExitMethods.cs:92:10:92:18 | exit ExitInTry (abnormal) | ExitMethods.cs:92:10:92:18 | exit ExitInTry |  |
+| ExitMethods.cs:93:5:103:5 | {...} | ExitMethods.cs:94:9:102:9 | try {...} ... |  |
+| ExitMethods.cs:94:9:102:9 | try {...} ... | ExitMethods.cs:95:9:97:9 | {...} |  |
+| ExitMethods.cs:95:9:97:9 | {...} | ExitMethods.cs:96:13:96:19 | ...; |  |
+| ExitMethods.cs:96:13:96:18 | call to method Exit | ExitMethods.cs:92:10:92:18 | exit ExitInTry (abnormal) | exit |
+| ExitMethods.cs:96:13:96:18 | this access | ExitMethods.cs:96:13:96:18 | call to method Exit |  |
+| ExitMethods.cs:96:13:96:19 | ...; | ExitMethods.cs:96:13:96:18 | this access |  |
+| ExitMethods.cs:105:10:105:24 | enter ApplicationExit | ExitMethods.cs:106:5:108:5 | {...} |  |
+| ExitMethods.cs:105:10:105:24 | exit ApplicationExit (abnormal) | ExitMethods.cs:105:10:105:24 | exit ApplicationExit |  |
+| ExitMethods.cs:106:5:108:5 | {...} | ExitMethods.cs:107:9:107:48 | ...; |  |
+| ExitMethods.cs:107:9:107:47 | call to method Exit | ExitMethods.cs:105:10:105:24 | exit ApplicationExit (abnormal) | exit |
+| ExitMethods.cs:107:9:107:48 | ...; | ExitMethods.cs:107:9:107:47 | call to method Exit |  |
+| ExitMethods.cs:110:13:110:21 | enter ThrowExpr | ExitMethods.cs:111:5:113:5 | {...} |  |
+| ExitMethods.cs:110:13:110:21 | exit ThrowExpr (abnormal) | ExitMethods.cs:110:13:110:21 | exit ThrowExpr |  |
+| ExitMethods.cs:110:13:110:21 | exit ThrowExpr (normal) | ExitMethods.cs:110:13:110:21 | exit ThrowExpr |  |
+| ExitMethods.cs:111:5:113:5 | {...} | ExitMethods.cs:112:16:112:20 | access to parameter input |  |
+| ExitMethods.cs:112:9:112:77 | return ...; | ExitMethods.cs:110:13:110:21 | exit ThrowExpr (normal) | return |
+| ExitMethods.cs:112:16:112:20 | access to parameter input | ExitMethods.cs:112:25:112:25 | 0 |  |
+| ExitMethods.cs:112:16:112:25 | ... != ... | ExitMethods.cs:112:29:112:29 | 1 | true |
+| ExitMethods.cs:112:16:112:25 | ... != ... | ExitMethods.cs:112:69:112:75 | "input" | false |
+| ExitMethods.cs:112:16:112:76 | ... ? ... : ... | ExitMethods.cs:112:9:112:77 | return ...; |  |
+| ExitMethods.cs:112:25:112:25 | 0 | ExitMethods.cs:112:25:112:25 | (...) ... |  |
+| ExitMethods.cs:112:25:112:25 | (...) ... | ExitMethods.cs:112:16:112:25 | ... != ... |  |
+| ExitMethods.cs:112:29:112:29 | 1 | ExitMethods.cs:112:29:112:29 | (...) ... |  |
+| ExitMethods.cs:112:29:112:29 | (...) ... | ExitMethods.cs:112:33:112:37 | access to parameter input |  |
+| ExitMethods.cs:112:29:112:37 | ... / ... | ExitMethods.cs:112:16:112:76 | ... ? ... : ... |  |
+| ExitMethods.cs:112:33:112:37 | access to parameter input | ExitMethods.cs:112:29:112:37 | ... / ... |  |
+| ExitMethods.cs:112:41:112:76 | throw ... | ExitMethods.cs:110:13:110:21 | exit ThrowExpr (abnormal) | exception(ArgumentException) |
+| ExitMethods.cs:112:47:112:76 | object creation of type ArgumentException | ExitMethods.cs:112:41:112:76 | throw ... |  |
+| ExitMethods.cs:112:69:112:75 | "input" | ExitMethods.cs:112:47:112:76 | object creation of type ArgumentException |  |
+| ExitMethods.cs:115:16:115:34 | enter ExtensionMethodCall | ExitMethods.cs:116:5:118:5 | {...} |  |
+| ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall (normal) | ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall |  |
+| ExitMethods.cs:116:5:118:5 | {...} | ExitMethods.cs:117:16:117:16 | access to parameter s |  |
+| ExitMethods.cs:117:9:117:39 | return ...; | ExitMethods.cs:115:16:115:34 | exit ExtensionMethodCall (normal) | return |
+| ExitMethods.cs:117:16:117:16 | access to parameter s | ExitMethods.cs:117:27:117:29 | - |  |
+| ExitMethods.cs:117:16:117:30 | call to method Contains | ExitMethods.cs:117:34:117:34 | 0 | true |
+| ExitMethods.cs:117:16:117:30 | call to method Contains | ExitMethods.cs:117:38:117:38 | 1 | false |
+| ExitMethods.cs:117:16:117:38 | ... ? ... : ... | ExitMethods.cs:117:9:117:39 | return ...; |  |
+| ExitMethods.cs:117:27:117:29 | - | ExitMethods.cs:117:16:117:30 | call to method Contains |  |
+| ExitMethods.cs:117:34:117:34 | 0 | ExitMethods.cs:117:16:117:38 | ... ? ... : ... |  |
+| ExitMethods.cs:117:38:117:38 | 1 | ExitMethods.cs:117:16:117:38 | ... ? ... : ... |  |
+| ExitMethods.cs:120:17:120:32 | enter FailingAssertion | ExitMethods.cs:121:5:124:5 | {...} |  |
+| ExitMethods.cs:120:17:120:32 | exit FailingAssertion (abnormal) | ExitMethods.cs:120:17:120:32 | exit FailingAssertion |  |
+| ExitMethods.cs:121:5:124:5 | {...} | ExitMethods.cs:122:9:122:29 | ...; |  |
+| ExitMethods.cs:122:9:122:28 | [assertion failure] call to method IsTrue | ExitMethods.cs:120:17:120:32 | exit FailingAssertion (abnormal) | exception(AssertFailedException) |
+| ExitMethods.cs:122:9:122:29 | ...; | ExitMethods.cs:122:23:122:27 | false |  |
+| ExitMethods.cs:122:23:122:27 | false | ExitMethods.cs:122:9:122:28 | [assertion failure] call to method IsTrue | false |
+| ExitMethods.cs:126:17:126:33 | enter FailingAssertion2 | ExitMethods.cs:127:5:130:5 | {...} |  |
+| ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 (abnormal) | ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 |  |
+| ExitMethods.cs:127:5:130:5 | {...} | ExitMethods.cs:128:9:128:27 | ...; |  |
+| ExitMethods.cs:128:9:128:26 | call to method FailingAssertion | ExitMethods.cs:126:17:126:33 | exit FailingAssertion2 (abnormal) | exception(AssertFailedException) |
+| ExitMethods.cs:128:9:128:26 | this access | ExitMethods.cs:128:9:128:26 | call to method FailingAssertion |  |
+| ExitMethods.cs:128:9:128:27 | ...; | ExitMethods.cs:128:9:128:26 | this access |  |
+| ExitMethods.cs:132:10:132:20 | enter AssertFalse | ExitMethods.cs:132:48:132:48 | access to parameter b |  |
+| ExitMethods.cs:132:10:132:20 | exit AssertFalse (abnormal) | ExitMethods.cs:132:10:132:20 | exit AssertFalse |  |
+| ExitMethods.cs:132:10:132:20 | exit AssertFalse (normal) | ExitMethods.cs:132:10:132:20 | exit AssertFalse |  |
+| ExitMethods.cs:132:33:132:49 | [assertion failure] call to method IsFalse | ExitMethods.cs:132:10:132:20 | exit AssertFalse (abnormal) | exception(AssertFailedException) |
+| ExitMethods.cs:132:33:132:49 | [assertion success] call to method IsFalse | ExitMethods.cs:132:10:132:20 | exit AssertFalse (normal) |  |
+| ExitMethods.cs:132:48:132:48 | access to parameter b | ExitMethods.cs:132:33:132:49 | [assertion failure] call to method IsFalse | true |
+| ExitMethods.cs:132:48:132:48 | access to parameter b | ExitMethods.cs:132:33:132:49 | [assertion success] call to method IsFalse | false |
+| ExitMethods.cs:134:17:134:33 | enter FailingAssertion3 | ExitMethods.cs:135:5:138:5 | {...} |  |
+| ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 (abnormal) | ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 |  |
+| ExitMethods.cs:135:5:138:5 | {...} | ExitMethods.cs:136:9:136:26 | ...; |  |
+| ExitMethods.cs:136:9:136:25 | [assertion failure] call to method AssertFalse | ExitMethods.cs:134:17:134:33 | exit FailingAssertion3 (abnormal) | exception(AssertFailedException) |
+| ExitMethods.cs:136:9:136:25 | this access | ExitMethods.cs:136:21:136:24 | true |  |
+| ExitMethods.cs:136:9:136:26 | ...; | ExitMethods.cs:136:9:136:25 | this access |  |
+| ExitMethods.cs:136:21:136:24 | true | ExitMethods.cs:136:9:136:25 | [assertion failure] call to method AssertFalse | true |
+| ExitMethods.cs:140:17:140:42 | enter ExceptionDispatchInfoThrow | ExitMethods.cs:141:5:147:5 | {...} |  |
+| ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow |  |
+| ExitMethods.cs:141:5:147:5 | {...} | ExitMethods.cs:142:9:145:53 | if (...) ... |  |
+| ExitMethods.cs:142:9:145:53 | if (...) ... | ExitMethods.cs:142:13:142:13 | access to parameter b |  |
+| ExitMethods.cs:142:13:142:13 | access to parameter b | ExitMethods.cs:143:13:143:43 | ...; | true |
+| ExitMethods.cs:142:13:142:13 | access to parameter b | ExitMethods.cs:145:13:145:53 | ...; | false |
+| ExitMethods.cs:143:13:143:42 | call to method Throw | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | exception(ArgumentException) |
+| ExitMethods.cs:143:13:143:43 | ...; | ExitMethods.cs:143:41:143:41 | access to parameter e |  |
+| ExitMethods.cs:143:41:143:41 | access to parameter e | ExitMethods.cs:143:13:143:42 | call to method Throw |  |
+| ExitMethods.cs:145:13:145:44 | call to method Capture | ExitMethods.cs:145:13:145:52 | call to method Throw |  |
+| ExitMethods.cs:145:13:145:52 | call to method Throw | ExitMethods.cs:140:17:140:42 | exit ExceptionDispatchInfoThrow (abnormal) | exception(Exception) |
+| ExitMethods.cs:145:13:145:53 | ...; | ExitMethods.cs:145:43:145:43 | access to parameter e |  |
+| ExitMethods.cs:145:43:145:43 | access to parameter e | ExitMethods.cs:145:13:145:44 | call to method Capture |  |
+| Extensions.cs:5:23:5:29 | enter ToInt32 | Extensions.cs:6:5:8:5 | {...} |  |
+| Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | Extensions.cs:5:23:5:29 | exit ToInt32 |  |
+| Extensions.cs:6:5:8:5 | {...} | Extensions.cs:7:28:7:28 | access to parameter s |  |
+| Extensions.cs:7:9:7:30 | return ...; | Extensions.cs:5:23:5:29 | exit ToInt32 (normal) | return |
+| Extensions.cs:7:16:7:29 | call to method Parse | Extensions.cs:7:9:7:30 | return ...; |  |
+| Extensions.cs:7:28:7:28 | access to parameter s | Extensions.cs:7:16:7:29 | call to method Parse |  |
+| Extensions.cs:10:24:10:29 | enter ToBool | Extensions.cs:11:5:13:5 | {...} |  |
+| Extensions.cs:10:24:10:29 | exit ToBool (normal) | Extensions.cs:10:24:10:29 | exit ToBool |  |
+| Extensions.cs:11:5:13:5 | {...} | Extensions.cs:12:16:12:16 | access to parameter f |  |
+| Extensions.cs:12:9:12:20 | return ...; | Extensions.cs:10:24:10:29 | exit ToBool (normal) | return |
+| Extensions.cs:12:16:12:16 | access to parameter f | Extensions.cs:12:18:12:18 | access to parameter s |  |
+| Extensions.cs:12:16:12:19 | delegate call | Extensions.cs:12:9:12:20 | return ...; |  |
+| Extensions.cs:12:18:12:18 | access to parameter s | Extensions.cs:12:16:12:19 | delegate call |  |
+| Extensions.cs:15:23:15:33 | enter CallToInt32 | Extensions.cs:15:48:15:50 | "0" |  |
+| Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) | Extensions.cs:15:23:15:33 | exit CallToInt32 |  |
+| Extensions.cs:15:40:15:51 | call to method ToInt32 | Extensions.cs:15:23:15:33 | exit CallToInt32 (normal) |  |
+| Extensions.cs:15:48:15:50 | "0" | Extensions.cs:15:40:15:51 | call to method ToInt32 |  |
+| Extensions.cs:20:17:20:20 | enter Main | Extensions.cs:21:5:26:5 | {...} |  |
+| Extensions.cs:20:17:20:20 | exit Main (normal) | Extensions.cs:20:17:20:20 | exit Main |  |
+| Extensions.cs:21:5:26:5 | {...} | Extensions.cs:22:9:22:20 | ...; |  |
+| Extensions.cs:22:9:22:9 | access to parameter s | Extensions.cs:22:9:22:19 | call to method ToInt32 |  |
+| Extensions.cs:22:9:22:19 | call to method ToInt32 | Extensions.cs:23:9:23:31 | ...; |  |
+| Extensions.cs:22:9:22:20 | ...; | Extensions.cs:22:9:22:9 | access to parameter s |  |
+| Extensions.cs:23:9:23:30 | call to method ToInt32 | Extensions.cs:24:9:24:46 | ...; |  |
+| Extensions.cs:23:9:23:31 | ...; | Extensions.cs:23:28:23:29 | "" |  |
+| Extensions.cs:23:28:23:29 | "" | Extensions.cs:23:9:23:30 | call to method ToInt32 |  |
+| Extensions.cs:24:9:24:45 | call to method ToBool | Extensions.cs:25:9:25:34 | ...; |  |
+| Extensions.cs:24:9:24:46 | ...; | Extensions.cs:24:27:24:32 | "true" |  |
+| Extensions.cs:24:27:24:32 | "true" | Extensions.cs:24:35:24:44 | access to method Parse |  |
+| Extensions.cs:24:35:24:44 | access to method Parse | Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> |  |
+| Extensions.cs:24:35:24:44 | delegate creation of type Func<String,Boolean> | Extensions.cs:24:9:24:45 | call to method ToBool |  |
+| Extensions.cs:25:9:25:14 | "true" | Extensions.cs:25:23:25:32 | access to method Parse |  |
+| Extensions.cs:25:9:25:33 | call to method ToBool | Extensions.cs:20:17:20:20 | exit Main (normal) |  |
+| Extensions.cs:25:9:25:34 | ...; | Extensions.cs:25:9:25:14 | "true" |  |
+| Extensions.cs:25:23:25:32 | access to method Parse | Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> |  |
+| Extensions.cs:25:23:25:32 | delegate creation of type Func<String,Boolean> | Extensions.cs:25:9:25:33 | call to method ToBool |  |
+| Finally.cs:3:14:3:20 | call to constructor Object | Finally.cs:3:14:3:20 | {...} |  |
+| Finally.cs:3:14:3:20 | enter Finally | Finally.cs:3:14:3:20 | call to constructor Object |  |
+| Finally.cs:3:14:3:20 | exit Finally (normal) | Finally.cs:3:14:3:20 | exit Finally |  |
+| Finally.cs:3:14:3:20 | {...} | Finally.cs:3:14:3:20 | exit Finally (normal) |  |
+| Finally.cs:7:10:7:11 | enter M1 | Finally.cs:8:5:17:5 | {...} |  |
+| Finally.cs:7:10:7:11 | exit M1 (abnormal) | Finally.cs:7:10:7:11 | exit M1 |  |
+| Finally.cs:7:10:7:11 | exit M1 (normal) | Finally.cs:7:10:7:11 | exit M1 |  |
+| Finally.cs:8:5:17:5 | {...} | Finally.cs:9:9:16:9 | try {...} ... |  |
+| Finally.cs:9:9:16:9 | try {...} ... | Finally.cs:10:9:12:9 | {...} |  |
+| Finally.cs:10:9:12:9 | {...} | Finally.cs:11:13:11:38 | ...; |  |
+| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:11:13:11:37 | call to method WriteLine | Finally.cs:14:9:16:9 | {...} |  |
+| Finally.cs:11:13:11:38 | ...; | Finally.cs:11:31:11:36 | "Try1" |  |
+| Finally.cs:11:31:11:36 | "Try1" | Finally.cs:11:13:11:37 | call to method WriteLine |  |
+| Finally.cs:14:9:16:9 | [finally: exception(Exception)] {...} | Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:14:9:16:9 | {...} | Finally.cs:15:13:15:41 | ...; |  |
+| Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (abnormal) | exception(Exception) |
+| Finally.cs:15:13:15:40 | call to method WriteLine | Finally.cs:7:10:7:11 | exit M1 (normal) |  |
+| Finally.cs:15:13:15:41 | ...; | Finally.cs:15:31:15:39 | "Finally" |  |
+| Finally.cs:15:13:15:41 | [finally: exception(Exception)] ...; | Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" |  |
+| Finally.cs:15:31:15:39 | "Finally" | Finally.cs:15:13:15:40 | call to method WriteLine |  |
+| Finally.cs:15:31:15:39 | [finally: exception(Exception)] "Finally" | Finally.cs:15:13:15:40 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:19:10:19:11 | enter M2 | Finally.cs:20:5:52:5 | {...} |  |
+| Finally.cs:19:10:19:11 | exit M2 (abnormal) | Finally.cs:19:10:19:11 | exit M2 |  |
+| Finally.cs:19:10:19:11 | exit M2 (normal) | Finally.cs:19:10:19:11 | exit M2 |  |
+| Finally.cs:20:5:52:5 | {...} | Finally.cs:21:9:51:9 | try {...} ... |  |
+| Finally.cs:21:9:51:9 | try {...} ... | Finally.cs:22:9:25:9 | {...} |  |
+| Finally.cs:22:9:25:9 | {...} | Finally.cs:23:13:23:38 | ...; |  |
+| Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:24:13:24:19 | return ...; |  |
+| Finally.cs:23:13:23:37 | call to method WriteLine | Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:23:13:23:38 | ...; | Finally.cs:23:31:23:36 | "Try2" |  |
+| Finally.cs:23:31:23:36 | "Try2" | Finally.cs:23:13:23:37 | call to method WriteLine |  |
+| Finally.cs:24:13:24:19 | return ...; | Finally.cs:49:9:51:9 | [finally: return] {...} | return |
+| Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | match |
+| Finally.cs:26:9:29:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | no-match |
+| Finally.cs:26:38:26:39 | [exception: Exception] IOException ex | Finally.cs:26:48:26:51 | [exception: Exception] true |  |
+| Finally.cs:26:48:26:51 | [exception: Exception] true | Finally.cs:27:9:29:9 | {...} | true |
+| Finally.cs:27:9:29:9 | {...} | Finally.cs:28:13:28:18 | throw ...; |  |
+| Finally.cs:28:13:28:18 | throw ...; | Finally.cs:49:9:51:9 | [finally: exception(IOException)] {...} | exception(IOException) |
+| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | match |
+| Finally.cs:30:9:40:9 | [exception: Exception] catch (...) {...} | Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | no-match |
+| Finally.cs:30:41:30:42 | [exception: Exception] ArgumentException ex | Finally.cs:31:9:40:9 | {...} |  |
+| Finally.cs:31:9:40:9 | {...} | Finally.cs:32:13:39:13 | try {...} ... |  |
+| Finally.cs:32:13:39:13 | try {...} ... | Finally.cs:33:13:35:13 | {...} |  |
+| Finally.cs:33:13:35:13 | {...} | Finally.cs:34:17:34:32 | if (...) ... |  |
+| Finally.cs:34:17:34:32 | if (...) ... | Finally.cs:34:21:34:24 | true |  |
+| Finally.cs:34:21:34:24 | true | Finally.cs:34:27:34:32 | throw ...; | true |
+| Finally.cs:34:27:34:32 | throw ...; | Finally.cs:37:13:39:13 | [finally: exception(ArgumentException)] {...} | exception(ArgumentException) |
+| Finally.cs:37:13:39:13 | [finally: exception(ArgumentException)] {...} | Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" |  |
+| Finally.cs:38:17:38:44 | [finally: exception(ArgumentException)] throw ...; | Finally.cs:49:9:51:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception | Finally.cs:38:17:38:44 | [finally: exception(ArgumentException)] throw ...; |  |
+| Finally.cs:38:37:38:42 | [finally: exception(ArgumentException)] "Boo!" | Finally.cs:38:23:38:43 | [finally: exception(ArgumentException)] object creation of type Exception |  |
+| Finally.cs:41:9:43:9 | [exception: Exception] catch (...) {...} | Finally.cs:42:9:43:9 | {...} | match |
+| Finally.cs:42:9:43:9 | {...} | Finally.cs:49:9:51:9 | {...} |  |
+| Finally.cs:49:9:51:9 | [finally: exception(Exception)] {...} | Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:49:9:51:9 | [finally: exception(IOException)] {...} | Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; |  |
+| Finally.cs:49:9:51:9 | [finally: return] {...} | Finally.cs:50:13:50:41 | [finally: return] ...; |  |
+| Finally.cs:49:9:51:9 | {...} | Finally.cs:50:13:50:41 | ...; |  |
+| Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | exception(Exception) |
+| Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (abnormal) | exception(IOException) |
+| Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) | return |
+| Finally.cs:50:13:50:40 | call to method WriteLine | Finally.cs:19:10:19:11 | exit M2 (normal) |  |
+| Finally.cs:50:13:50:41 | ...; | Finally.cs:50:31:50:39 | "Finally" |  |
+| Finally.cs:50:13:50:41 | [finally: exception(Exception)] ...; | Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" |  |
+| Finally.cs:50:13:50:41 | [finally: exception(IOException)] ...; | Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" |  |
+| Finally.cs:50:13:50:41 | [finally: return] ...; | Finally.cs:50:31:50:39 | [finally: return] "Finally" |  |
+| Finally.cs:50:31:50:39 | "Finally" | Finally.cs:50:13:50:40 | call to method WriteLine |  |
+| Finally.cs:50:31:50:39 | [finally: exception(Exception)] "Finally" | Finally.cs:50:13:50:40 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:50:31:50:39 | [finally: exception(IOException)] "Finally" | Finally.cs:50:13:50:40 | [finally: exception(IOException)] call to method WriteLine |  |
+| Finally.cs:50:31:50:39 | [finally: return] "Finally" | Finally.cs:50:13:50:40 | [finally: return] call to method WriteLine |  |
+| Finally.cs:54:10:54:11 | enter M3 | Finally.cs:55:5:72:5 | {...} |  |
+| Finally.cs:54:10:54:11 | exit M3 (abnormal) | Finally.cs:54:10:54:11 | exit M3 |  |
+| Finally.cs:54:10:54:11 | exit M3 (normal) | Finally.cs:54:10:54:11 | exit M3 |  |
+| Finally.cs:55:5:72:5 | {...} | Finally.cs:56:9:71:9 | try {...} ... |  |
+| Finally.cs:56:9:71:9 | try {...} ... | Finally.cs:57:9:60:9 | {...} |  |
+| Finally.cs:57:9:60:9 | {...} | Finally.cs:58:13:58:38 | ...; |  |
+| Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:59:13:59:19 | return ...; |  |
+| Finally.cs:58:13:58:37 | call to method WriteLine | Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:58:13:58:38 | ...; | Finally.cs:58:31:58:36 | "Try3" |  |
+| Finally.cs:58:31:58:36 | "Try3" | Finally.cs:58:13:58:37 | call to method WriteLine |  |
+| Finally.cs:59:13:59:19 | return ...; | Finally.cs:69:9:71:9 | [finally: return] {...} | return |
+| Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | match |
+| Finally.cs:61:9:64:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | no-match |
+| Finally.cs:61:38:61:39 | [exception: Exception] IOException ex | Finally.cs:61:48:61:51 | [exception: Exception] true |  |
+| Finally.cs:61:48:61:51 | [exception: Exception] true | Finally.cs:62:9:64:9 | {...} | true |
+| Finally.cs:62:9:64:9 | {...} | Finally.cs:63:13:63:18 | throw ...; |  |
+| Finally.cs:63:13:63:18 | throw ...; | Finally.cs:69:9:71:9 | [finally: exception(IOException)] {...} | exception(IOException) |
+| Finally.cs:65:9:67:9 | [exception: Exception] catch (...) {...} | Finally.cs:65:26:65:26 | [exception: Exception] Exception e | match |
+| Finally.cs:65:26:65:26 | [exception: Exception] Exception e | Finally.cs:65:35:65:35 | [exception: Exception] access to local variable e |  |
+| Finally.cs:65:35:65:35 | [exception: Exception] access to local variable e | Finally.cs:65:35:65:43 | [exception: Exception] access to property Message |  |
+| Finally.cs:65:35:65:43 | [exception: Exception] access to property Message | Finally.cs:65:48:65:51 | [exception: Exception] null |  |
+| Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | Finally.cs:66:9:67:9 | {...} | true |
+| Finally.cs:65:35:65:51 | [exception: Exception] ... != ... | Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:65:48:65:51 | [exception: Exception] null | Finally.cs:65:35:65:51 | [exception: Exception] ... != ... |  |
+| Finally.cs:66:9:67:9 | {...} | Finally.cs:69:9:71:9 | {...} |  |
+| Finally.cs:69:9:71:9 | [finally: exception(Exception)] {...} | Finally.cs:70:13:70:41 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:69:9:71:9 | [finally: exception(IOException)] {...} | Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; |  |
+| Finally.cs:69:9:71:9 | [finally: return] {...} | Finally.cs:70:13:70:41 | [finally: return] ...; |  |
+| Finally.cs:69:9:71:9 | {...} | Finally.cs:70:13:70:41 | ...; |  |
+| Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | exception(Exception) |
+| Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (abnormal) | exception(IOException) |
+| Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) | return |
+| Finally.cs:70:13:70:40 | call to method WriteLine | Finally.cs:54:10:54:11 | exit M3 (normal) |  |
+| Finally.cs:70:13:70:41 | ...; | Finally.cs:70:31:70:39 | "Finally" |  |
+| Finally.cs:70:13:70:41 | [finally: exception(Exception)] ...; | Finally.cs:70:31:70:39 | [finally: exception(Exception)] "Finally" |  |
+| Finally.cs:70:13:70:41 | [finally: exception(IOException)] ...; | Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" |  |
+| Finally.cs:70:13:70:41 | [finally: return] ...; | Finally.cs:70:31:70:39 | [finally: return] "Finally" |  |
+| Finally.cs:70:31:70:39 | "Finally" | Finally.cs:70:13:70:40 | call to method WriteLine |  |
+| Finally.cs:70:31:70:39 | [finally: exception(Exception)] "Finally" | Finally.cs:70:13:70:40 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:70:31:70:39 | [finally: exception(IOException)] "Finally" | Finally.cs:70:13:70:40 | [finally: exception(IOException)] call to method WriteLine |  |
+| Finally.cs:70:31:70:39 | [finally: return] "Finally" | Finally.cs:70:13:70:40 | [finally: return] call to method WriteLine |  |
+| Finally.cs:74:10:74:11 | enter M4 | Finally.cs:75:5:101:5 | {...} |  |
+| Finally.cs:74:10:74:11 | exit M4 (abnormal) | Finally.cs:74:10:74:11 | exit M4 |  |
+| Finally.cs:74:10:74:11 | exit M4 (normal) | Finally.cs:74:10:74:11 | exit M4 |  |
+| Finally.cs:75:5:101:5 | {...} | Finally.cs:76:9:76:19 | ... ...; |  |
+| Finally.cs:76:9:76:19 | ... ...; | Finally.cs:76:17:76:18 | 10 |  |
+| Finally.cs:76:13:76:18 | Int32 i = ... | Finally.cs:77:9:100:9 | while (...) ... |  |
+| Finally.cs:76:17:76:18 | 10 | Finally.cs:76:13:76:18 | Int32 i = ... |  |
+| Finally.cs:77:9:100:9 | while (...) ... | Finally.cs:77:16:77:16 | access to local variable i |  |
+| Finally.cs:77:16:77:16 | access to local variable i | Finally.cs:77:20:77:20 | 0 |  |
+| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:74:10:74:11 | exit M4 (normal) | false |
+| Finally.cs:77:16:77:20 | ... > ... | Finally.cs:78:9:100:9 | {...} | true |
+| Finally.cs:77:20:77:20 | 0 | Finally.cs:77:16:77:20 | ... > ... |  |
+| Finally.cs:78:9:100:9 | {...} | Finally.cs:79:13:99:13 | try {...} ... |  |
+| Finally.cs:79:13:99:13 | try {...} ... | Finally.cs:80:13:87:13 | {...} |  |
+| Finally.cs:80:13:87:13 | {...} | Finally.cs:81:17:82:27 | if (...) ... |  |
+| Finally.cs:81:17:82:27 | if (...) ... | Finally.cs:81:21:81:21 | access to local variable i |  |
+| Finally.cs:81:21:81:21 | access to local variable i | Finally.cs:81:26:81:26 | 0 |  |
+| Finally.cs:81:21:81:26 | ... == ... | Finally.cs:82:21:82:27 | return ...; | true |
+| Finally.cs:81:21:81:26 | ... == ... | Finally.cs:83:17:84:29 | if (...) ... | false |
+| Finally.cs:81:26:81:26 | 0 | Finally.cs:81:21:81:26 | ... == ... |  |
+| Finally.cs:82:21:82:27 | return ...; | Finally.cs:89:13:99:13 | [finally: return] {...} | return |
+| Finally.cs:83:17:84:29 | if (...) ... | Finally.cs:83:21:83:21 | access to local variable i |  |
+| Finally.cs:83:21:83:21 | access to local variable i | Finally.cs:83:26:83:26 | 1 |  |
+| Finally.cs:83:21:83:26 | ... == ... | Finally.cs:84:21:84:29 | continue; | true |
+| Finally.cs:83:21:83:26 | ... == ... | Finally.cs:85:17:86:26 | if (...) ... | false |
+| Finally.cs:83:26:83:26 | 1 | Finally.cs:83:21:83:26 | ... == ... |  |
+| Finally.cs:84:21:84:29 | continue; | Finally.cs:89:13:99:13 | [finally: continue] {...} | continue |
+| Finally.cs:85:17:86:26 | if (...) ... | Finally.cs:85:21:85:21 | access to local variable i |  |
+| Finally.cs:85:21:85:21 | access to local variable i | Finally.cs:85:26:85:26 | 2 |  |
+| Finally.cs:85:21:85:26 | ... == ... | Finally.cs:86:21:86:26 | break; | true |
+| Finally.cs:85:21:85:26 | ... == ... | Finally.cs:89:13:99:13 | {...} | false |
+| Finally.cs:85:26:85:26 | 2 | Finally.cs:85:21:85:26 | ... == ... |  |
+| Finally.cs:86:21:86:26 | break; | Finally.cs:89:13:99:13 | [finally: break] {...} | break |
+| Finally.cs:89:13:99:13 | [finally: break] {...} | Finally.cs:90:17:98:17 | [finally: break] try {...} ... |  |
+| Finally.cs:89:13:99:13 | [finally: continue] {...} | Finally.cs:90:17:98:17 | [finally: continue] try {...} ... |  |
+| Finally.cs:89:13:99:13 | [finally: return] {...} | Finally.cs:90:17:98:17 | [finally: return] try {...} ... |  |
+| Finally.cs:89:13:99:13 | {...} | Finally.cs:90:17:98:17 | try {...} ... |  |
+| Finally.cs:90:17:98:17 | [finally: break] try {...} ... | Finally.cs:91:17:94:17 | [finally: break] {...} |  |
+| Finally.cs:90:17:98:17 | [finally: continue] try {...} ... | Finally.cs:91:17:94:17 | [finally: continue] {...} |  |
+| Finally.cs:90:17:98:17 | [finally: return] try {...} ... | Finally.cs:91:17:94:17 | [finally: return] {...} |  |
+| Finally.cs:90:17:98:17 | try {...} ... | Finally.cs:91:17:94:17 | {...} |  |
+| Finally.cs:91:17:94:17 | [finally: break] {...} | Finally.cs:92:21:93:46 | [finally: break] if (...) ... |  |
+| Finally.cs:91:17:94:17 | [finally: continue] {...} | Finally.cs:92:21:93:46 | [finally: continue] if (...) ... |  |
+| Finally.cs:91:17:94:17 | [finally: return] {...} | Finally.cs:92:21:93:46 | [finally: return] if (...) ... |  |
+| Finally.cs:91:17:94:17 | {...} | Finally.cs:92:21:93:46 | if (...) ... |  |
+| Finally.cs:92:21:93:46 | [finally: break] if (...) ... | Finally.cs:92:25:92:25 | [finally: break] access to local variable i |  |
+| Finally.cs:92:21:93:46 | [finally: continue] if (...) ... | Finally.cs:92:25:92:25 | [finally: continue] access to local variable i |  |
+| Finally.cs:92:21:93:46 | [finally: return] if (...) ... | Finally.cs:92:25:92:25 | [finally: return] access to local variable i |  |
+| Finally.cs:92:21:93:46 | if (...) ... | Finally.cs:92:25:92:25 | access to local variable i |  |
+| Finally.cs:92:25:92:25 | [finally: break] access to local variable i | Finally.cs:92:30:92:30 | [finally: break] 3 |  |
+| Finally.cs:92:25:92:25 | [finally: continue] access to local variable i | Finally.cs:92:30:92:30 | [finally: continue] 3 |  |
+| Finally.cs:92:25:92:25 | [finally: return] access to local variable i | Finally.cs:92:30:92:30 | [finally: return] 3 |  |
+| Finally.cs:92:25:92:25 | access to local variable i | Finally.cs:92:30:92:30 | 3 |  |
+| Finally.cs:92:25:92:30 | ... == ... | Finally.cs:93:31:93:45 | object creation of type Exception | true |
+| Finally.cs:92:25:92:30 | ... == ... | Finally.cs:96:17:98:17 | {...} | false |
+| Finally.cs:92:25:92:30 | [finally: break] ... == ... | Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | true |
+| Finally.cs:92:25:92:30 | [finally: break] ... == ... | Finally.cs:96:17:98:17 | [finally: break] {...} | false |
+| Finally.cs:92:25:92:30 | [finally: continue] ... == ... | Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | true |
+| Finally.cs:92:25:92:30 | [finally: continue] ... == ... | Finally.cs:96:17:98:17 | [finally: continue] {...} | false |
+| Finally.cs:92:25:92:30 | [finally: return] ... == ... | Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | true |
+| Finally.cs:92:25:92:30 | [finally: return] ... == ... | Finally.cs:96:17:98:17 | [finally: return] {...} | false |
+| Finally.cs:92:30:92:30 | 3 | Finally.cs:92:25:92:30 | ... == ... |  |
+| Finally.cs:92:30:92:30 | [finally: break] 3 | Finally.cs:92:25:92:30 | [finally: break] ... == ... |  |
+| Finally.cs:92:30:92:30 | [finally: continue] 3 | Finally.cs:92:25:92:30 | [finally: continue] ... == ... |  |
+| Finally.cs:92:30:92:30 | [finally: return] 3 | Finally.cs:92:25:92:30 | [finally: return] ... == ... |  |
+| Finally.cs:93:25:93:46 | [finally: break] throw ...; | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:25:93:46 | [finally: continue] throw ...; | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:25:93:46 | [finally: return] throw ...; | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:25:93:46 | throw ...; | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: break] throw ...; |  |
+| Finally.cs:93:31:93:45 | [finally: break] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: continue] throw ...; |  |
+| Finally.cs:93:31:93:45 | [finally: continue] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:93:25:93:46 | [finally: return] throw ...; |  |
+| Finally.cs:93:31:93:45 | [finally: return] object creation of type Exception | Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:93:25:93:46 | throw ...; |  |
+| Finally.cs:93:31:93:45 | object creation of type Exception | Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:96:17:98:17 | [finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: break, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: break] {...} | Finally.cs:97:21:97:24 | [finally: break] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: continue, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: continue] {...} | Finally.cs:97:21:97:24 | [finally: continue] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: return, finally(1): exception(Exception)] {...} | Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; |  |
+| Finally.cs:96:17:98:17 | [finally: return] {...} | Finally.cs:97:21:97:24 | [finally: return] ...; |  |
+| Finally.cs:96:17:98:17 | {...} | Finally.cs:97:21:97:24 | ...; |  |
+| Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: break] access to local variable i | Finally.cs:97:21:97:23 | [finally: break] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: continue] access to local variable i | Finally.cs:97:21:97:23 | [finally: continue] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i | Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- |  |
+| Finally.cs:97:21:97:21 | [finally: return] access to local variable i | Finally.cs:97:21:97:23 | [finally: return] ...-- |  |
+| Finally.cs:97:21:97:21 | access to local variable i | Finally.cs:97:21:97:23 | ...-- |  |
+| Finally.cs:97:21:97:23 | ...-- | Finally.cs:77:16:77:16 | access to local variable i |  |
+| Finally.cs:97:21:97:23 | [finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: break, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: break] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | break |
+| Finally.cs:97:21:97:23 | [finally: continue, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: continue] ...-- | Finally.cs:77:16:77:16 | access to local variable i | continue |
+| Finally.cs:97:21:97:23 | [finally: return, finally(1): exception(Exception)] ...-- | Finally.cs:74:10:74:11 | exit M4 (abnormal) | exception(Exception) |
+| Finally.cs:97:21:97:23 | [finally: return] ...-- | Finally.cs:74:10:74:11 | exit M4 (normal) | return |
+| Finally.cs:97:21:97:24 | ...; | Finally.cs:97:21:97:21 | access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally(1): exception(Exception)] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: break, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: break, finally(1): exception(Exception)] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: break] ...; | Finally.cs:97:21:97:21 | [finally: break] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: continue, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: continue, finally(1): exception(Exception)] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: continue] ...; | Finally.cs:97:21:97:21 | [finally: continue] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: return, finally(1): exception(Exception)] ...; | Finally.cs:97:21:97:21 | [finally: return, finally(1): exception(Exception)] access to local variable i |  |
+| Finally.cs:97:21:97:24 | [finally: return] ...; | Finally.cs:97:21:97:21 | [finally: return] access to local variable i |  |
+| Finally.cs:103:10:103:11 | enter M5 | Finally.cs:104:5:119:5 | {...} |  |
+| Finally.cs:103:10:103:11 | exit M5 (abnormal) | Finally.cs:103:10:103:11 | exit M5 |  |
+| Finally.cs:103:10:103:11 | exit M5 (normal) | Finally.cs:103:10:103:11 | exit M5 |  |
+| Finally.cs:104:5:119:5 | {...} | Finally.cs:105:9:118:9 | try {...} ... |  |
+| Finally.cs:105:9:118:9 | try {...} ... | Finally.cs:106:9:111:9 | {...} |  |
+| Finally.cs:106:9:111:9 | {...} | Finally.cs:107:13:108:23 | if (...) ... |  |
+| Finally.cs:107:13:108:23 | if (...) ... | Finally.cs:107:17:107:21 | this access |  |
+| Finally.cs:107:17:107:21 | access to field Field | Finally.cs:107:17:107:28 | access to property Length |  |
+| Finally.cs:107:17:107:21 | access to field Field | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | exception(NullReferenceException) |
+| Finally.cs:107:17:107:21 | this access | Finally.cs:107:17:107:21 | access to field Field |  |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:107:33:107:33 | 0 |  |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:107:17:107:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | exception(NullReferenceException) |
+| Finally.cs:107:17:107:33 | ... == ... | Finally.cs:108:17:108:23 | return ...; | true |
+| Finally.cs:107:17:107:33 | ... == ... | Finally.cs:109:13:110:49 | if (...) ... | false |
+| Finally.cs:107:33:107:33 | 0 | Finally.cs:107:17:107:33 | ... == ... |  |
+| Finally.cs:108:17:108:23 | return ...; | Finally.cs:113:9:118:9 | [finally: return] {...} | return |
+| Finally.cs:109:13:110:49 | if (...) ... | Finally.cs:109:17:109:21 | this access |  |
+| Finally.cs:109:17:109:21 | access to field Field | Finally.cs:109:17:109:28 | access to property Length |  |
+| Finally.cs:109:17:109:21 | access to field Field | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | exception(NullReferenceException) |
+| Finally.cs:109:17:109:21 | this access | Finally.cs:109:17:109:21 | access to field Field |  |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:109:33:109:33 | 1 |  |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:109:17:109:28 | access to property Length | Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | exception(NullReferenceException) |
+| Finally.cs:109:17:109:33 | ... == ... | Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | true |
+| Finally.cs:109:17:109:33 | ... == ... | Finally.cs:113:9:118:9 | {...} | false |
+| Finally.cs:109:33:109:33 | 1 | Finally.cs:109:17:109:33 | ... == ... |  |
+| Finally.cs:110:17:110:49 | throw ...; | Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | exception(OutOfMemoryException) |
+| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:110:17:110:49 | throw ...; |  |
+| Finally.cs:110:23:110:48 | object creation of type OutOfMemoryException | Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:113:9:118:9 | [finally: exception(Exception)] {...} | Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:113:9:118:9 | [finally: exception(NullReferenceException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... |  |
+| Finally.cs:113:9:118:9 | [finally: exception(OutOfMemoryException)] {...} | Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... |  |
+| Finally.cs:113:9:118:9 | [finally: return] {...} | Finally.cs:114:13:115:41 | [finally: return] if (...) ... |  |
+| Finally.cs:113:9:118:9 | {...} | Finally.cs:114:13:115:41 | if (...) ... |  |
+| Finally.cs:114:13:115:41 | [finally: exception(Exception)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access |  |
+| Finally.cs:114:13:115:41 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access |  |
+| Finally.cs:114:13:115:41 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access |  |
+| Finally.cs:114:13:115:41 | [finally: return] if (...) ... | Finally.cs:114:19:114:23 | [finally: return] this access |  |
+| Finally.cs:114:13:115:41 | if (...) ... | Finally.cs:114:19:114:23 | this access |  |
+| Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false, finally: return] !... | Finally.cs:116:13:117:37 | [finally: return] if (...) ... | false |
+| Finally.cs:114:17:114:36 | [false] !... | Finally.cs:116:13:117:37 | if (...) ... | false |
+| Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | true |
+| Finally.cs:114:17:114:36 | [true, finally: return] !... | Finally.cs:115:17:115:41 | [finally: return] ...; | true |
+| Finally.cs:114:17:114:36 | [true] !... | Finally.cs:115:17:115:41 | ...; | true |
+| Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length |  |
+| Finally.cs:114:19:114:23 | [finally: exception(Exception)] this access | Finally.cs:114:19:114:23 | [finally: exception(Exception)] access to field Field |  |
+| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length |  |
+| Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] this access | Finally.cs:114:19:114:23 | [finally: exception(NullReferenceException)] access to field Field |  |
+| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length |  |
+| Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:114:19:114:23 | [finally: exception(OutOfMemoryException)] access to field Field |  |
+| Finally.cs:114:19:114:23 | [finally: return] access to field Field | Finally.cs:114:19:114:30 | [finally: return] access to property Length |  |
+| Finally.cs:114:19:114:23 | [finally: return] this access | Finally.cs:114:19:114:23 | [finally: return] access to field Field |  |
+| Finally.cs:114:19:114:23 | access to field Field | Finally.cs:114:19:114:30 | access to property Length |  |
+| Finally.cs:114:19:114:23 | this access | Finally.cs:114:19:114:23 | access to field Field |  |
+| Finally.cs:114:19:114:30 | [finally: exception(Exception)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 |  |
+| Finally.cs:114:19:114:30 | [finally: exception(NullReferenceException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 |  |
+| Finally.cs:114:19:114:30 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 |  |
+| Finally.cs:114:19:114:30 | [finally: return] access to property Length | Finally.cs:114:35:114:35 | [finally: return] 0 |  |
+| Finally.cs:114:19:114:30 | access to property Length | Finally.cs:114:35:114:35 | 0 |  |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [false] !... | true |
+| Finally.cs:114:19:114:35 | ... == ... | Finally.cs:114:17:114:36 | [true] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(Exception)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(Exception)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(NullReferenceException)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(NullReferenceException)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [false, finally: exception(OutOfMemoryException)] !... | true |
+| Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... | Finally.cs:114:17:114:36 | [true, finally: exception(OutOfMemoryException)] !... | false |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [false, finally: return] !... | true |
+| Finally.cs:114:19:114:35 | [finally: return] ... == ... | Finally.cs:114:17:114:36 | [true, finally: return] !... | false |
+| Finally.cs:114:35:114:35 | 0 | Finally.cs:114:19:114:35 | ... == ... |  |
+| Finally.cs:114:35:114:35 | [finally: exception(Exception)] 0 | Finally.cs:114:19:114:35 | [finally: exception(Exception)] ... == ... |  |
+| Finally.cs:114:35:114:35 | [finally: exception(NullReferenceException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(NullReferenceException)] ... == ... |  |
+| Finally.cs:114:35:114:35 | [finally: exception(OutOfMemoryException)] 0 | Finally.cs:114:19:114:35 | [finally: exception(OutOfMemoryException)] ... == ... |  |
+| Finally.cs:114:35:114:35 | [finally: return] 0 | Finally.cs:114:19:114:35 | [finally: return] ... == ... |  |
+| Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... |  |
+| Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... |  |
+| Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine | Finally.cs:116:13:117:37 | [finally: return] if (...) ... |  |
+| Finally.cs:115:17:115:40 | call to method WriteLine | Finally.cs:116:13:117:37 | if (...) ... |  |
+| Finally.cs:115:17:115:41 | ...; | Finally.cs:115:35:115:39 | this access |  |
+| Finally.cs:115:17:115:41 | [finally: exception(Exception)] ...; | Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access |  |
+| Finally.cs:115:17:115:41 | [finally: exception(NullReferenceException)] ...; | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] this access |  |
+| Finally.cs:115:17:115:41 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] this access |  |
+| Finally.cs:115:17:115:41 | [finally: return] ...; | Finally.cs:115:35:115:39 | [finally: return] this access |  |
+| Finally.cs:115:35:115:39 | [finally: exception(Exception)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:115:35:115:39 | [finally: exception(Exception)] this access | Finally.cs:115:35:115:39 | [finally: exception(Exception)] access to field Field |  |
+| Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(NullReferenceException)] call to method WriteLine |  |
+| Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] this access | Finally.cs:115:35:115:39 | [finally: exception(NullReferenceException)] access to field Field |  |
+| Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:115:17:115:40 | [finally: exception(OutOfMemoryException)] call to method WriteLine |  |
+| Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:115:35:115:39 | [finally: exception(OutOfMemoryException)] access to field Field |  |
+| Finally.cs:115:35:115:39 | [finally: return] access to field Field | Finally.cs:115:17:115:40 | [finally: return] call to method WriteLine |  |
+| Finally.cs:115:35:115:39 | [finally: return] this access | Finally.cs:115:35:115:39 | [finally: return] access to field Field |  |
+| Finally.cs:115:35:115:39 | access to field Field | Finally.cs:115:17:115:40 | call to method WriteLine |  |
+| Finally.cs:115:35:115:39 | this access | Finally.cs:115:35:115:39 | access to field Field |  |
+| Finally.cs:116:13:117:37 | [finally: exception(Exception)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access |  |
+| Finally.cs:116:13:117:37 | [finally: exception(NullReferenceException)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] this access |  |
+| Finally.cs:116:13:117:37 | [finally: exception(OutOfMemoryException)] if (...) ... | Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] this access |  |
+| Finally.cs:116:13:117:37 | [finally: return] if (...) ... | Finally.cs:116:17:116:21 | [finally: return] this access |  |
+| Finally.cs:116:13:117:37 | if (...) ... | Finally.cs:116:17:116:21 | this access |  |
+| Finally.cs:116:17:116:21 | [finally: exception(Exception)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(Exception)] access to property Length |  |
+| Finally.cs:116:17:116:21 | [finally: exception(Exception)] this access | Finally.cs:116:17:116:21 | [finally: exception(Exception)] access to field Field |  |
+| Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(NullReferenceException)] access to property Length |  |
+| Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] this access | Finally.cs:116:17:116:21 | [finally: exception(NullReferenceException)] access to field Field |  |
+| Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] access to field Field | Finally.cs:116:17:116:28 | [finally: exception(OutOfMemoryException)] access to property Length |  |
+| Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] this access | Finally.cs:116:17:116:21 | [finally: exception(OutOfMemoryException)] access to field Field |  |
+| Finally.cs:116:17:116:21 | [finally: return] access to field Field | Finally.cs:116:17:116:28 | [finally: return] access to property Length |  |
+| Finally.cs:116:17:116:21 | [finally: return] this access | Finally.cs:116:17:116:21 | [finally: return] access to field Field |  |
+| Finally.cs:116:17:116:21 | access to field Field | Finally.cs:116:17:116:28 | access to property Length |  |
+| Finally.cs:116:17:116:21 | this access | Finally.cs:116:17:116:21 | access to field Field |  |
+| Finally.cs:116:17:116:28 | [finally: exception(Exception)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(Exception)] 0 |  |
+| Finally.cs:116:17:116:28 | [finally: exception(NullReferenceException)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(NullReferenceException)] 0 |  |
+| Finally.cs:116:17:116:28 | [finally: exception(OutOfMemoryException)] access to property Length | Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 |  |
+| Finally.cs:116:17:116:28 | [finally: return] access to property Length | Finally.cs:116:32:116:32 | [finally: return] 0 |  |
+| Finally.cs:116:17:116:28 | access to property Length | Finally.cs:116:32:116:32 | 0 |  |
+| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | false |
+| Finally.cs:116:17:116:32 | ... > ... | Finally.cs:117:17:117:37 | ...; | true |
+| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(Exception) |
+| Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | true |
+| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(NullReferenceException) |
+| Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | true |
+| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(OutOfMemoryException) |
+| Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... | Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | true |
+| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:103:10:103:11 | exit M5 (normal) | return |
+| Finally.cs:116:17:116:32 | [finally: return] ... > ... | Finally.cs:117:17:117:37 | [finally: return] ...; | true |
+| Finally.cs:116:32:116:32 | 0 | Finally.cs:116:17:116:32 | ... > ... |  |
+| Finally.cs:116:32:116:32 | [finally: exception(Exception)] 0 | Finally.cs:116:17:116:32 | [finally: exception(Exception)] ... > ... |  |
+| Finally.cs:116:32:116:32 | [finally: exception(NullReferenceException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(NullReferenceException)] ... > ... |  |
+| Finally.cs:116:32:116:32 | [finally: exception(OutOfMemoryException)] 0 | Finally.cs:116:17:116:32 | [finally: exception(OutOfMemoryException)] ... > ... |  |
+| Finally.cs:116:32:116:32 | [finally: return] 0 | Finally.cs:116:17:116:32 | [finally: return] ... > ... |  |
+| Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(Exception) |
+| Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(NullReferenceException) |
+| Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (abnormal) | exception(OutOfMemoryException) |
+| Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) | return |
+| Finally.cs:117:17:117:36 | call to method WriteLine | Finally.cs:103:10:103:11 | exit M5 (normal) |  |
+| Finally.cs:117:17:117:37 | ...; | Finally.cs:117:35:117:35 | 1 |  |
+| Finally.cs:117:17:117:37 | [finally: exception(Exception)] ...; | Finally.cs:117:35:117:35 | [finally: exception(Exception)] 1 |  |
+| Finally.cs:117:17:117:37 | [finally: exception(NullReferenceException)] ...; | Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 |  |
+| Finally.cs:117:17:117:37 | [finally: exception(OutOfMemoryException)] ...; | Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 |  |
+| Finally.cs:117:17:117:37 | [finally: return] ...; | Finally.cs:117:35:117:35 | [finally: return] 1 |  |
+| Finally.cs:117:35:117:35 | 1 | Finally.cs:117:17:117:36 | call to method WriteLine |  |
+| Finally.cs:117:35:117:35 | [finally: exception(Exception)] 1 | Finally.cs:117:17:117:36 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:117:35:117:35 | [finally: exception(NullReferenceException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(NullReferenceException)] call to method WriteLine |  |
+| Finally.cs:117:35:117:35 | [finally: exception(OutOfMemoryException)] 1 | Finally.cs:117:17:117:36 | [finally: exception(OutOfMemoryException)] call to method WriteLine |  |
+| Finally.cs:117:35:117:35 | [finally: return] 1 | Finally.cs:117:17:117:36 | [finally: return] call to method WriteLine |  |
+| Finally.cs:121:10:121:11 | enter M6 | Finally.cs:122:5:131:5 | {...} |  |
+| Finally.cs:121:10:121:11 | exit M6 (normal) | Finally.cs:121:10:121:11 | exit M6 |  |
+| Finally.cs:122:5:131:5 | {...} | Finally.cs:123:9:130:9 | try {...} ... |  |
+| Finally.cs:123:9:130:9 | try {...} ... | Finally.cs:124:9:126:9 | {...} |  |
+| Finally.cs:124:9:126:9 | {...} | Finally.cs:125:13:125:41 | ... ...; |  |
+| Finally.cs:125:13:125:41 | ... ...; | Finally.cs:125:24:125:24 | 0 |  |
+| Finally.cs:125:17:125:40 | Double temp = ... | Finally.cs:121:10:121:11 | exit M6 (normal) |  |
+| Finally.cs:125:24:125:24 | 0 | Finally.cs:125:24:125:24 | (...) ... |  |
+| Finally.cs:125:24:125:24 | (...) ... | Finally.cs:125:28:125:40 | access to constant E |  |
+| Finally.cs:125:24:125:40 | ... / ... | Finally.cs:125:17:125:40 | Double temp = ... |  |
+| Finally.cs:125:28:125:40 | access to constant E | Finally.cs:125:24:125:40 | ... / ... |  |
+| Finally.cs:133:10:133:11 | enter M7 | Finally.cs:134:5:145:5 | {...} |  |
+| Finally.cs:133:10:133:11 | exit M7 (abnormal) | Finally.cs:133:10:133:11 | exit M7 |  |
+| Finally.cs:134:5:145:5 | {...} | Finally.cs:135:9:143:9 | try {...} ... |  |
+| Finally.cs:135:9:143:9 | try {...} ... | Finally.cs:136:9:138:9 | {...} |  |
+| Finally.cs:136:9:138:9 | {...} | Finally.cs:137:13:137:37 | ...; |  |
+| Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:137:13:137:36 | call to method WriteLine | Finally.cs:140:9:143:9 | {...} |  |
+| Finally.cs:137:13:137:37 | ...; | Finally.cs:137:31:137:35 | "Try" |  |
+| Finally.cs:137:31:137:35 | "Try" | Finally.cs:137:13:137:36 | call to method WriteLine |  |
+| Finally.cs:140:9:143:9 | [finally: exception(Exception)] {...} | Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" |  |
+| Finally.cs:140:9:143:9 | {...} | Finally.cs:141:41:141:42 | "" |  |
+| Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | exception(ArgumentException) |
+| Finally.cs:141:13:141:44 | throw ...; | Finally.cs:133:10:133:11 | exit M7 (abnormal) | exception(ArgumentException) |
+| Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException | Finally.cs:141:13:141:44 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:141:19:141:43 | object creation of type ArgumentException | Finally.cs:141:13:141:44 | throw ...; |  |
+| Finally.cs:141:41:141:42 | "" | Finally.cs:141:19:141:43 | object creation of type ArgumentException |  |
+| Finally.cs:141:41:141:42 | [finally: exception(Exception)] "" | Finally.cs:141:19:141:43 | [finally: exception(Exception)] object creation of type ArgumentException |  |
+| Finally.cs:147:10:147:11 | enter M8 | Finally.cs:148:5:170:5 | {...} |  |
+| Finally.cs:147:10:147:11 | exit M8 (abnormal) | Finally.cs:147:10:147:11 | exit M8 |  |
+| Finally.cs:147:10:147:11 | exit M8 (normal) | Finally.cs:147:10:147:11 | exit M8 |  |
+| Finally.cs:148:5:170:5 | {...} | Finally.cs:149:9:169:9 | try {...} ... |  |
+| Finally.cs:149:9:169:9 | try {...} ... | Finally.cs:150:9:153:9 | {...} |  |
+| Finally.cs:150:9:153:9 | {...} | Finally.cs:151:13:152:50 | if (...) ... |  |
+| Finally.cs:151:13:152:50 | if (...) ... | Finally.cs:151:17:151:20 | access to parameter args |  |
+| Finally.cs:151:17:151:20 | access to parameter args | Finally.cs:151:25:151:28 | null |  |
+| Finally.cs:151:17:151:28 | ... == ... | Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | true |
+| Finally.cs:151:17:151:28 | ... == ... | Finally.cs:155:9:169:9 | {...} | false |
+| Finally.cs:151:25:151:28 | null | Finally.cs:151:17:151:28 | ... == ... |  |
+| Finally.cs:152:17:152:50 | throw ...; | Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} | exception(ArgumentNullException) |
+| Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:152:17:152:50 | throw ...; |  |
+| Finally.cs:152:23:152:49 | object creation of type ArgumentNullException | Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:155:9:169:9 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:156:13:168:13 | [finally: exception(ArgumentNullException)] try {...} ... |  |
+| Finally.cs:155:9:169:9 | [finally: exception(Exception)] {...} | Finally.cs:156:13:168:13 | [finally: exception(Exception)] try {...} ... |  |
+| Finally.cs:155:9:169:9 | {...} | Finally.cs:156:13:168:13 | try {...} ... |  |
+| Finally.cs:156:13:168:13 | [finally: exception(ArgumentNullException)] try {...} ... | Finally.cs:157:13:160:13 | [finally: exception(ArgumentNullException)] {...} |  |
+| Finally.cs:156:13:168:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:157:13:160:13 | [finally: exception(Exception)] {...} |  |
+| Finally.cs:156:13:168:13 | try {...} ... | Finally.cs:157:13:160:13 | {...} |  |
+| Finally.cs:157:13:160:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:158:17:159:45 | [finally: exception(ArgumentNullException)] if (...) ... |  |
+| Finally.cs:157:13:160:13 | [finally: exception(Exception)] {...} | Finally.cs:158:17:159:45 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:157:13:160:13 | {...} | Finally.cs:158:17:159:45 | if (...) ... |  |
+| Finally.cs:158:17:159:45 | [finally: exception(ArgumentNullException)] if (...) ... | Finally.cs:158:21:158:24 | [finally: exception(ArgumentNullException)] access to parameter args |  |
+| Finally.cs:158:17:159:45 | [finally: exception(Exception)] if (...) ... | Finally.cs:158:21:158:24 | [finally: exception(Exception)] access to parameter args |  |
+| Finally.cs:158:17:159:45 | if (...) ... | Finally.cs:158:21:158:24 | access to parameter args |  |
+| Finally.cs:158:21:158:24 | [finally: exception(ArgumentNullException)] access to parameter args | Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length |  |
+| Finally.cs:158:21:158:24 | [finally: exception(Exception)] access to parameter args | Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length |  |
+| Finally.cs:158:21:158:24 | access to parameter args | Finally.cs:158:21:158:31 | access to property Length |  |
+| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 |  |
+| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:158:21:158:31 | [finally: exception(ArgumentNullException)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} | exception(NullReferenceException) |
+| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 |  |
+| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:158:21:158:31 | [finally: exception(Exception)] access to property Length | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} | exception(NullReferenceException) |
+| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:158:36:158:36 | 1 |  |
+| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:158:21:158:31 | access to property Length | Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | exception(NullReferenceException) |
+| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:147:10:147:11 | exit M8 (normal) | false |
+| Finally.cs:158:21:158:36 | ... == ... | Finally.cs:159:41:159:43 | "1" | true |
+| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(ArgumentNullException) |
+| Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | true |
+| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(Exception) |
+| Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... | Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | true |
+| Finally.cs:158:36:158:36 | 1 | Finally.cs:158:21:158:36 | ... == ... |  |
+| Finally.cs:158:36:158:36 | [finally: exception(ArgumentNullException)] 1 | Finally.cs:158:21:158:36 | [finally: exception(ArgumentNullException)] ... == ... |  |
+| Finally.cs:158:36:158:36 | [finally: exception(Exception)] 1 | Finally.cs:158:21:158:36 | [finally: exception(Exception)] ... == ... |  |
+| Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:21:159:45 | throw ...; | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | Finally.cs:159:21:159:45 | [finally: exception(ArgumentNullException)] throw ...; |  |
+| Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception | Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception | Finally.cs:159:21:159:45 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception | Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:27:159:44 | object creation of type Exception | Finally.cs:159:21:159:45 | throw ...; |  |
+| Finally.cs:159:27:159:44 | object creation of type Exception | Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | exception(Exception) |
+| Finally.cs:159:41:159:43 | "1" | Finally.cs:159:27:159:44 | object creation of type Exception |  |
+| Finally.cs:159:41:159:43 | [finally: exception(ArgumentNullException)] "1" | Finally.cs:159:27:159:44 | [finally: exception(ArgumentNullException)] object creation of type Exception |  |
+| Finally.cs:159:41:159:43 | [finally: exception(Exception)] "1" | Finally.cs:159:27:159:44 | [finally: exception(Exception)] object creation of type Exception |  |
+| Finally.cs:161:13:164:13 | [exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [exception: Exception] Exception e | match |
+| Finally.cs:161:13:164:13 | [exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [exception: NullReferenceException] Exception e | match |
+| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: Exception] Exception e | match |
+| Finally.cs:161:13:164:13 | [finally: exception(ArgumentNullException), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e | match |
+| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: Exception] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: Exception] Exception e | match |
+| Finally.cs:161:13:164:13 | [finally: exception(Exception), exception: NullReferenceException] catch (...) {...} | Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: NullReferenceException] Exception e | match |
+| Finally.cs:161:30:161:30 | [exception: Exception] Exception e | Finally.cs:161:39:161:39 | [exception: Exception] access to local variable e |  |
+| Finally.cs:161:30:161:30 | [exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [exception: NullReferenceException] access to local variable e |  |
+| Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: Exception] Exception e | Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: Exception] access to local variable e |  |
+| Finally.cs:161:30:161:30 | [finally: exception(ArgumentNullException), exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e |  |
+| Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: Exception] Exception e | Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: Exception] access to local variable e |  |
+| Finally.cs:161:30:161:30 | [finally: exception(Exception), exception: NullReferenceException] Exception e | Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: NullReferenceException] access to local variable e |  |
+| Finally.cs:161:39:161:39 | [exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [exception: Exception] access to property Message |  |
+| Finally.cs:161:39:161:39 | [exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [exception: NullReferenceException] access to property Message |  |
+| Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: Exception] access to property Message |  |
+| Finally.cs:161:39:161:39 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message |  |
+| Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: Exception] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: Exception] access to property Message |  |
+| Finally.cs:161:39:161:39 | [finally: exception(Exception), exception: NullReferenceException] access to local variable e | Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: NullReferenceException] access to property Message |  |
+| Finally.cs:161:39:161:47 | [exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [exception: Exception] "1" |  |
+| Finally.cs:161:39:161:47 | [exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [exception: NullReferenceException] "1" |  |
+| Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: Exception] "1" |  |
+| Finally.cs:161:39:161:47 | [finally: exception(ArgumentNullException), exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] "1" |  |
+| Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: Exception] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: Exception] "1" |  |
+| Finally.cs:161:39:161:47 | [finally: exception(Exception), exception: NullReferenceException] access to property Message | Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: NullReferenceException] "1" |  |
+| Finally.cs:161:39:161:54 | [exception: Exception] ... == ... | Finally.cs:162:13:164:13 | {...} | true |
+| Finally.cs:161:39:161:54 | [exception: Exception] ... == ... | Finally.cs:165:13:168:13 | catch {...} | false |
+| Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | {...} | true |
+| Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | catch {...} | false |
+| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | true |
+| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | false |
+| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | true |
+| Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | false |
+| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | true |
+| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | false |
+| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | true |
+| Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... | Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | false |
+| Finally.cs:161:52:161:54 | [exception: Exception] "1" | Finally.cs:161:39:161:54 | [exception: Exception] ... == ... |  |
+| Finally.cs:161:52:161:54 | [exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [exception: NullReferenceException] ... == ... |  |
+| Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: Exception] "1" | Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: Exception] ... == ... |  |
+| Finally.cs:161:52:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [finally: exception(ArgumentNullException), exception: NullReferenceException] ... == ... |  |
+| Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: Exception] "1" | Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: Exception] ... == ... |  |
+| Finally.cs:161:52:161:54 | [finally: exception(Exception), exception: NullReferenceException] "1" | Finally.cs:161:39:161:54 | [finally: exception(Exception), exception: NullReferenceException] ... == ... |  |
+| Finally.cs:162:13:164:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; |  |
+| Finally.cs:162:13:164:13 | [finally: exception(Exception)] {...} | Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:162:13:164:13 | {...} | Finally.cs:163:17:163:43 | ...; |  |
+| Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(ArgumentNullException) |
+| Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(Exception) |
+| Finally.cs:163:17:163:42 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) |  |
+| Finally.cs:163:17:163:43 | ...; | Finally.cs:163:35:163:38 | access to parameter args |  |
+| Finally.cs:163:17:163:43 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:163:35:163:38 | [finally: exception(ArgumentNullException)] access to parameter args |  |
+| Finally.cs:163:17:163:43 | [finally: exception(Exception)] ...; | Finally.cs:163:35:163:38 | [finally: exception(Exception)] access to parameter args |  |
+| Finally.cs:163:35:163:38 | [finally: exception(ArgumentNullException)] access to parameter args | Finally.cs:163:40:163:40 | [finally: exception(ArgumentNullException)] 0 |  |
+| Finally.cs:163:35:163:38 | [finally: exception(Exception)] access to parameter args | Finally.cs:163:40:163:40 | [finally: exception(Exception)] 0 |  |
+| Finally.cs:163:35:163:38 | access to parameter args | Finally.cs:163:40:163:40 | 0 |  |
+| Finally.cs:163:35:163:41 | [finally: exception(ArgumentNullException)] access to array element | Finally.cs:163:17:163:42 | [finally: exception(ArgumentNullException)] call to method WriteLine |  |
+| Finally.cs:163:35:163:41 | [finally: exception(Exception)] access to array element | Finally.cs:163:17:163:42 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:163:35:163:41 | access to array element | Finally.cs:163:17:163:42 | call to method WriteLine |  |
+| Finally.cs:163:40:163:40 | 0 | Finally.cs:163:35:163:41 | access to array element |  |
+| Finally.cs:163:40:163:40 | [finally: exception(ArgumentNullException)] 0 | Finally.cs:163:35:163:41 | [finally: exception(ArgumentNullException)] access to array element |  |
+| Finally.cs:163:40:163:40 | [finally: exception(Exception)] 0 | Finally.cs:163:35:163:41 | [finally: exception(Exception)] access to array element |  |
+| Finally.cs:165:13:168:13 | [finally: exception(ArgumentNullException)] catch {...} | Finally.cs:166:13:168:13 | [finally: exception(ArgumentNullException)] {...} |  |
+| Finally.cs:165:13:168:13 | [finally: exception(Exception)] catch {...} | Finally.cs:166:13:168:13 | [finally: exception(Exception)] {...} |  |
+| Finally.cs:165:13:168:13 | catch {...} | Finally.cs:166:13:168:13 | {...} |  |
+| Finally.cs:166:13:168:13 | [finally: exception(ArgumentNullException)] {...} | Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; |  |
+| Finally.cs:166:13:168:13 | [finally: exception(Exception)] {...} | Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:166:13:168:13 | {...} | Finally.cs:167:17:167:38 | ...; |  |
+| Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(ArgumentNullException) |
+| Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (abnormal) | exception(Exception) |
+| Finally.cs:167:17:167:37 | call to method WriteLine | Finally.cs:147:10:147:11 | exit M8 (normal) |  |
+| Finally.cs:167:17:167:38 | ...; | Finally.cs:167:35:167:36 | "" |  |
+| Finally.cs:167:17:167:38 | [finally: exception(ArgumentNullException)] ...; | Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" |  |
+| Finally.cs:167:17:167:38 | [finally: exception(Exception)] ...; | Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" |  |
+| Finally.cs:167:35:167:36 | "" | Finally.cs:167:17:167:37 | call to method WriteLine |  |
+| Finally.cs:167:35:167:36 | [finally: exception(ArgumentNullException)] "" | Finally.cs:167:17:167:37 | [finally: exception(ArgumentNullException)] call to method WriteLine |  |
+| Finally.cs:167:35:167:36 | [finally: exception(Exception)] "" | Finally.cs:167:17:167:37 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:172:11:172:20 | call to constructor Exception | Finally.cs:172:11:172:20 | {...} |  |
+| Finally.cs:172:11:172:20 | enter ExceptionA | Finally.cs:172:11:172:20 | call to constructor Exception |  |
+| Finally.cs:172:11:172:20 | exit ExceptionA (normal) | Finally.cs:172:11:172:20 | exit ExceptionA |  |
+| Finally.cs:172:11:172:20 | {...} | Finally.cs:172:11:172:20 | exit ExceptionA (normal) |  |
+| Finally.cs:173:11:173:20 | call to constructor Exception | Finally.cs:173:11:173:20 | {...} |  |
+| Finally.cs:173:11:173:20 | enter ExceptionB | Finally.cs:173:11:173:20 | call to constructor Exception |  |
+| Finally.cs:173:11:173:20 | exit ExceptionB (normal) | Finally.cs:173:11:173:20 | exit ExceptionB |  |
+| Finally.cs:173:11:173:20 | {...} | Finally.cs:173:11:173:20 | exit ExceptionB (normal) |  |
+| Finally.cs:174:11:174:20 | call to constructor Exception | Finally.cs:174:11:174:20 | {...} |  |
+| Finally.cs:174:11:174:20 | enter ExceptionC | Finally.cs:174:11:174:20 | call to constructor Exception |  |
+| Finally.cs:174:11:174:20 | exit ExceptionC (normal) | Finally.cs:174:11:174:20 | exit ExceptionC |  |
+| Finally.cs:174:11:174:20 | {...} | Finally.cs:174:11:174:20 | exit ExceptionC (normal) |  |
+| Finally.cs:176:10:176:11 | enter M9 | Finally.cs:177:5:193:5 | {...} |  |
+| Finally.cs:176:10:176:11 | exit M9 (abnormal) | Finally.cs:176:10:176:11 | exit M9 |  |
+| Finally.cs:176:10:176:11 | exit M9 (normal) | Finally.cs:176:10:176:11 | exit M9 |  |
+| Finally.cs:177:5:193:5 | {...} | Finally.cs:178:9:192:9 | try {...} ... |  |
+| Finally.cs:178:9:192:9 | try {...} ... | Finally.cs:179:9:181:9 | {...} |  |
+| Finally.cs:179:9:181:9 | {...} | Finally.cs:180:13:180:43 | if (...) ... |  |
+| Finally.cs:180:13:180:43 | if (...) ... | Finally.cs:180:17:180:18 | access to parameter b1 |  |
+| Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | true |
+| Finally.cs:180:17:180:18 | access to parameter b1 | Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | false |
+| Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; | Finally.cs:183:9:192:9 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | exception(ExceptionA) |
+| Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:180:21:180:43 | [b1 (line 176): true] throw ...; |  |
+| Finally.cs:180:27:180:42 | [b1 (line 176): true] object creation of type ExceptionA | Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} | exception(Exception) |
+| Finally.cs:183:9:192:9 | [b1 (line 176): false] {...} | Finally.cs:184:13:191:13 | [b1 (line 176): false] try {...} ... |  |
+| Finally.cs:183:9:192:9 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:184:13:191:13 | [finally: exception(Exception), b1 (line 176): true] try {...} ... |  |
+| Finally.cs:183:9:192:9 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:184:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] try {...} ... |  |
+| Finally.cs:184:13:191:13 | [b1 (line 176): false] try {...} ... | Finally.cs:185:13:187:13 | [b1 (line 176): false] {...} |  |
+| Finally.cs:184:13:191:13 | [finally: exception(Exception), b1 (line 176): true] try {...} ... | Finally.cs:185:13:187:13 | [finally: exception(Exception), b1 (line 176): true] {...} |  |
+| Finally.cs:184:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] try {...} ... | Finally.cs:185:13:187:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} |  |
+| Finally.cs:185:13:187:13 | [b1 (line 176): false] {...} | Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... |  |
+| Finally.cs:185:13:187:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... |  |
+| Finally.cs:185:13:187:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... |  |
+| Finally.cs:186:17:186:47 | [b1 (line 176): false] if (...) ... | Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 |  |
+| Finally.cs:186:17:186:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 |  |
+| Finally.cs:186:17:186:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 |  |
+| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (normal) | false |
+| Finally.cs:186:21:186:22 | [b1 (line 176): false] access to parameter b2 | Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | true |
+| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(Exception) |
+| Finally.cs:186:21:186:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | true |
+| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(ExceptionA) |
+| Finally.cs:186:21:186:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b2 | Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | true |
+| Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | exception(ExceptionB) |
+| Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | exception(ExceptionB) |
+| Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | exception(ExceptionB) |
+| Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [b1 (line 176): false, b2 (line 176): true] throw ...; |  |
+| Finally.cs:186:31:186:46 | [b1 (line 176): false, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | exception(Exception) |
+| Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] throw ...; |  |
+| Finally.cs:186:31:186:46 | [finally: exception(Exception), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | exception(Exception) |
+| Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:186:25:186:47 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] throw ...; |  |
+| Finally.cs:186:31:186:46 | [finally: exception(ExceptionA), b1 (line 176): true, b2 (line 176): true] object creation of type ExceptionB | Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | exception(Exception) |
+| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(Exception) |
+| Finally.cs:188:13:191:13 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:13:191:13 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(Exception) |
+| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:13:191:13 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(Exception) |
+| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:13:191:13 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] catch (...) {...} | Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | match |
+| Finally.cs:188:38:188:39 | [exception: Exception, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | true |
+| Finally.cs:188:38:188:39 | [exception: ExceptionB, b1 (line 176): false, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | true |
+| Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | true |
+| Finally.cs:188:38:188:39 | [finally: exception(Exception), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | true |
+| Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: Exception, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | true |
+| Finally.cs:188:38:188:39 | [finally: exception(ExceptionA), exception: ExceptionB, b1 (line 176): true, b2 (line 176): true] access to parameter b2 | Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | true |
+| Finally.cs:189:13:191:13 | [b1 (line 176): false] {...} | Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... |  |
+| Finally.cs:189:13:191:13 | [finally: exception(Exception), b1 (line 176): true] {...} | Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... |  |
+| Finally.cs:189:13:191:13 | [finally: exception(ExceptionA), b1 (line 176): true] {...} | Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... |  |
+| Finally.cs:190:17:190:47 | [b1 (line 176): false] if (...) ... | Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 |  |
+| Finally.cs:190:17:190:47 | [finally: exception(Exception), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 |  |
+| Finally.cs:190:17:190:47 | [finally: exception(ExceptionA), b1 (line 176): true] if (...) ... | Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 |  |
+| Finally.cs:190:21:190:22 | [b1 (line 176): false] access to parameter b1 | Finally.cs:176:10:176:11 | exit M9 (normal) | false |
+| Finally.cs:190:21:190:22 | [finally: exception(Exception), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:190:21:190:22 | [finally: exception(ExceptionA), b1 (line 176): true] access to parameter b1 | Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
+| Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(ExceptionC) |
+| Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:176:10:176:11 | exit M9 (abnormal) | exception(ExceptionC) |
+| Finally.cs:190:31:190:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:190:31:190:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:190:25:190:47 | [finally: exception(ExceptionA)] throw ...; |  |
+| Finally.cs:195:10:195:12 | enter M10 | Finally.cs:196:5:214:5 | {...} |  |
+| Finally.cs:195:10:195:12 | exit M10 (abnormal) | Finally.cs:195:10:195:12 | exit M10 |  |
+| Finally.cs:195:10:195:12 | exit M10 (normal) | Finally.cs:195:10:195:12 | exit M10 |  |
+| Finally.cs:196:5:214:5 | {...} | Finally.cs:197:9:212:9 | try {...} ... |  |
+| Finally.cs:197:9:212:9 | try {...} ... | Finally.cs:198:9:200:9 | {...} |  |
+| Finally.cs:198:9:200:9 | {...} | Finally.cs:199:13:199:43 | if (...) ... |  |
+| Finally.cs:199:13:199:43 | if (...) ... | Finally.cs:199:17:199:18 | access to parameter b1 |  |
+| Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:199:27:199:42 | object creation of type ExceptionA | true |
+| Finally.cs:199:17:199:18 | access to parameter b1 | Finally.cs:202:9:212:9 | {...} | false |
+| Finally.cs:199:21:199:43 | throw ...; | Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:199:21:199:43 | throw ...; |  |
+| Finally.cs:199:27:199:42 | object creation of type ExceptionA | Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:202:9:212:9 | [finally: exception(Exception)] {...} | Finally.cs:203:13:210:13 | [finally: exception(Exception)] try {...} ... |  |
+| Finally.cs:202:9:212:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:203:13:210:13 | [finally: exception(ExceptionA)] try {...} ... |  |
+| Finally.cs:202:9:212:9 | {...} | Finally.cs:203:13:210:13 | try {...} ... |  |
+| Finally.cs:203:13:210:13 | [finally: exception(Exception)] try {...} ... | Finally.cs:204:13:206:13 | [finally: exception(Exception)] {...} |  |
+| Finally.cs:203:13:210:13 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:204:13:206:13 | [finally: exception(ExceptionA)] {...} |  |
+| Finally.cs:203:13:210:13 | try {...} ... | Finally.cs:204:13:206:13 | {...} |  |
+| Finally.cs:204:13:206:13 | [finally: exception(Exception)] {...} | Finally.cs:205:17:205:47 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:204:13:206:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:205:17:205:47 | [finally: exception(ExceptionA)] if (...) ... |  |
+| Finally.cs:204:13:206:13 | {...} | Finally.cs:205:17:205:47 | if (...) ... |  |
+| Finally.cs:205:17:205:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 |  |
+| Finally.cs:205:17:205:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 |  |
+| Finally.cs:205:17:205:47 | if (...) ... | Finally.cs:205:21:205:22 | access to parameter b2 |  |
+| Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | true |
+| Finally.cs:205:21:205:22 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | false |
+| Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | true |
+| Finally.cs:205:21:205:22 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | false |
+| Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:205:31:205:46 | object creation of type ExceptionB | true |
+| Finally.cs:205:21:205:22 | access to parameter b2 | Finally.cs:208:13:210:13 | {...} | false |
+| Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | exception(ExceptionB) |
+| Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | exception(ExceptionB) |
+| Finally.cs:205:25:205:47 | throw ...; | Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | exception(ExceptionB) |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:205:31:205:46 | [finally: exception(Exception)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:205:25:205:47 | [finally: exception(ExceptionA)] throw ...; |  |
+| Finally.cs:205:31:205:46 | [finally: exception(ExceptionA)] object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:205:25:205:47 | throw ...; |  |
+| Finally.cs:205:31:205:46 | object creation of type ExceptionB | Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:208:13:210:13 | [finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... |  |
+| Finally.cs:208:13:210:13 | {...} | Finally.cs:209:17:209:47 | if (...) ... |  |
+| Finally.cs:209:17:209:47 | [finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 |  |
+| Finally.cs:209:17:209:47 | if (...) ... | Finally.cs:209:21:209:22 | access to parameter b3 |  |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(Exception)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | false |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(Exception) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(Exception)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionB) |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | [finally: exception(ExceptionA)] access to parameter b3 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | false |
+| Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:209:31:209:46 | object creation of type ExceptionC | true |
+| Finally.cs:209:21:209:22 | access to parameter b3 | Finally.cs:211:13:211:29 | ...; | false |
+| Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:25:209:47 | throw ...; | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionC) |
+| Finally.cs:209:31:209:46 | [finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(Exception)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally(1): exception(ExceptionB)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(Exception)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception), finally(1): exception(ExceptionB)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(Exception)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(Exception)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA), finally(1): exception(ExceptionB)] throw ...; |  |
+| Finally.cs:209:31:209:46 | [finally: exception(ExceptionA)] object creation of type ExceptionC | Finally.cs:209:25:209:47 | [finally: exception(ExceptionA)] throw ...; |  |
+| Finally.cs:209:31:209:46 | object creation of type ExceptionC | Finally.cs:209:25:209:47 | throw ...; |  |
+| Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access | Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" |  |
+| Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access | Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" |  |
+| Finally.cs:211:13:211:16 | this access | Finally.cs:211:26:211:28 | "0" |  |
+| Finally.cs:211:13:211:28 | ... = ... | Finally.cs:213:9:213:25 | ...; |  |
+| Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(Exception) |
+| Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | Finally.cs:195:10:195:12 | exit M10 (abnormal) | exception(ExceptionA) |
+| Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:16 | this access |  |
+| Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:16 | [finally: exception(Exception)] this access |  |
+| Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:16 | [finally: exception(ExceptionA)] this access |  |
+| Finally.cs:211:26:211:28 | "0" | Finally.cs:211:13:211:28 | ... = ... |  |
+| Finally.cs:211:26:211:28 | [finally: exception(Exception)] "0" | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... |  |
+| Finally.cs:211:26:211:28 | [finally: exception(ExceptionA)] "0" | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... |  |
+| Finally.cs:213:9:213:12 | this access | Finally.cs:213:22:213:24 | "1" |  |
+| Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 (normal) |  |
+| Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access |  |
+| Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... |  |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} |  |
+| Finally.cs:216:10:216:12 | exit M11 (normal) | Finally.cs:216:10:216:12 | exit M11 |  |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... |  |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} |  |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; |  |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:222:9:225:9 | catch {...} | exception(Exception) |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |  |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" |  |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:36 | call to method WriteLine |  |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:223:9:225:9 | {...} |  |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:39 | ...; |  |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |  |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:31:224:37 | "Catch" |  |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:38 | call to method WriteLine |  |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:41 | ...; |  |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; |  |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" |  |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine |  |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 (normal) |  |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" |  |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine |  |
+| Finally.cs:233:10:233:12 | enter M12 | Finally.cs:234:5:261:5 | {...} |  |
+| Finally.cs:233:10:233:12 | exit M12 (abnormal) | Finally.cs:233:10:233:12 | exit M12 |  |
+| Finally.cs:233:10:233:12 | exit M12 (normal) | Finally.cs:233:10:233:12 | exit M12 |  |
+| Finally.cs:234:5:261:5 | {...} | Finally.cs:235:9:259:9 | try {...} ... |  |
+| Finally.cs:235:9:259:9 | try {...} ... | Finally.cs:236:9:255:9 | {...} |  |
+| Finally.cs:236:9:255:9 | {...} | Finally.cs:237:13:253:13 | try {...} ... |  |
+| Finally.cs:237:13:253:13 | try {...} ... | Finally.cs:238:13:241:13 | {...} |  |
+| Finally.cs:238:13:241:13 | {...} | Finally.cs:239:17:240:43 | if (...) ... |  |
+| Finally.cs:239:17:240:43 | if (...) ... | Finally.cs:239:21:239:22 | access to parameter b1 |  |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:240:27:240:42 | object creation of type ExceptionA | true |
+| Finally.cs:239:21:239:22 | access to parameter b1 | Finally.cs:243:13:253:13 | {...} | false |
+| Finally.cs:240:21:240:43 | throw ...; | Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:240:21:240:43 | throw ...; |  |
+| Finally.cs:240:27:240:42 | object creation of type ExceptionA | Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:243:13:253:13 | [finally: exception(Exception)] {...} | Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... |  |
+| Finally.cs:243:13:253:13 | [finally: exception(ExceptionA)] {...} | Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... |  |
+| Finally.cs:243:13:253:13 | {...} | Finally.cs:244:17:252:17 | try {...} ... |  |
+| Finally.cs:244:17:252:17 | [finally: exception(Exception)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} |  |
+| Finally.cs:244:17:252:17 | [finally: exception(ExceptionA)] try {...} ... | Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} |  |
+| Finally.cs:244:17:252:17 | try {...} ... | Finally.cs:245:17:248:17 | {...} |  |
+| Finally.cs:245:17:248:17 | [finally: exception(Exception)] {...} | Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... |  |
+| Finally.cs:245:17:248:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... |  |
+| Finally.cs:245:17:248:17 | {...} | Finally.cs:246:21:247:47 | if (...) ... |  |
+| Finally.cs:246:21:247:47 | [finally: exception(Exception)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 |  |
+| Finally.cs:246:21:247:47 | [finally: exception(ExceptionA)] if (...) ... | Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 |  |
+| Finally.cs:246:21:247:47 | if (...) ... | Finally.cs:246:25:246:26 | access to parameter b2 |  |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | [finally: exception(Exception)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | false |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | [finally: exception(ExceptionA)] access to parameter b2 | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | false |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:247:31:247:46 | object creation of type ExceptionA | true |
+| Finally.cs:246:25:246:26 | access to parameter b2 | Finally.cs:250:17:252:17 | {...} | false |
+| Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:247:25:247:47 | throw ...; | Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(Exception)] throw ...; |  |
+| Finally.cs:247:31:247:46 | [finally: exception(Exception)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:247:25:247:47 | [finally: exception(ExceptionA)] throw ...; |  |
+| Finally.cs:247:31:247:46 | [finally: exception(ExceptionA)] object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:247:25:247:47 | throw ...; |  |
+| Finally.cs:247:31:247:46 | object creation of type ExceptionA | Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:250:17:252:17 | [finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(Exception)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; |  |
+| Finally.cs:250:17:252:17 | [finally: exception(ExceptionA)] {...} | Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; |  |
+| Finally.cs:250:17:252:17 | {...} | Finally.cs:251:21:251:55 | ...; |  |
+| Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | exception(ExceptionA) |
+| Finally.cs:251:21:251:54 | call to method WriteLine | Finally.cs:254:13:254:45 | ...; |  |
+| Finally.cs:251:21:251:55 | ...; | Finally.cs:251:39:251:53 | "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(Exception)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" |  |
+| Finally.cs:251:21:251:55 | [finally: exception(ExceptionA)] ...; | Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" |  |
+| Finally.cs:251:39:251:53 | "Inner finally" | Finally.cs:251:21:251:54 | call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(Exception)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally(1): exception(ExceptionA)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(Exception)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception), finally(1): exception(ExceptionA)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(Exception)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(Exception)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA), finally(1): exception(ExceptionA)] call to method WriteLine |  |
+| Finally.cs:251:39:251:53 | [finally: exception(ExceptionA)] "Inner finally" | Finally.cs:251:21:251:54 | [finally: exception(ExceptionA)] call to method WriteLine |  |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:254:13:254:44 | call to method WriteLine | Finally.cs:257:9:259:9 | {...} |  |
+| Finally.cs:254:13:254:45 | ...; | Finally.cs:254:31:254:43 | "Mid finally" |  |
+| Finally.cs:254:31:254:43 | "Mid finally" | Finally.cs:254:13:254:44 | call to method WriteLine |  |
+| Finally.cs:257:9:259:9 | [finally: exception(Exception)] {...} | Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:257:9:259:9 | [finally: exception(ExceptionA)] {...} | Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; |  |
+| Finally.cs:257:9:259:9 | {...} | Finally.cs:258:13:258:47 | ...; |  |
+| Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | exception(Exception) |
+| Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (abnormal) | exception(ExceptionA) |
+| Finally.cs:258:13:258:46 | call to method WriteLine | Finally.cs:260:9:260:34 | ...; |  |
+| Finally.cs:258:13:258:47 | ...; | Finally.cs:258:31:258:45 | "Outer finally" |  |
+| Finally.cs:258:13:258:47 | [finally: exception(Exception)] ...; | Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" |  |
+| Finally.cs:258:13:258:47 | [finally: exception(ExceptionA)] ...; | Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" |  |
+| Finally.cs:258:31:258:45 | "Outer finally" | Finally.cs:258:13:258:46 | call to method WriteLine |  |
+| Finally.cs:258:31:258:45 | [finally: exception(Exception)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:258:31:258:45 | [finally: exception(ExceptionA)] "Outer finally" | Finally.cs:258:13:258:46 | [finally: exception(ExceptionA)] call to method WriteLine |  |
+| Finally.cs:260:9:260:33 | call to method WriteLine | Finally.cs:233:10:233:12 | exit M12 (normal) |  |
+| Finally.cs:260:9:260:34 | ...; | Finally.cs:260:27:260:32 | "Done" |  |
+| Finally.cs:260:27:260:32 | "Done" | Finally.cs:260:9:260:33 | call to method WriteLine |  |
+| Finally.cs:263:10:263:12 | enter M13 | Finally.cs:264:5:274:5 | {...} |  |
+| Finally.cs:263:10:263:12 | exit M13 (abnormal) | Finally.cs:263:10:263:12 | exit M13 |  |
+| Finally.cs:263:10:263:12 | exit M13 (normal) | Finally.cs:263:10:263:12 | exit M13 |  |
+| Finally.cs:264:5:274:5 | {...} | Finally.cs:265:9:273:9 | try {...} ... |  |
+| Finally.cs:265:9:273:9 | try {...} ... | Finally.cs:266:9:268:9 | {...} |  |
+| Finally.cs:266:9:268:9 | {...} | Finally.cs:267:13:267:35 | ...; |  |
+| Finally.cs:267:13:267:34 | call to method WriteLine | Finally.cs:270:9:273:9 | [finally: exception(Exception)] {...} | exception(Exception) |
+| Finally.cs:267:13:267:34 | call to method WriteLine | Finally.cs:270:9:273:9 | {...} |  |
+| Finally.cs:267:13:267:35 | ...; | Finally.cs:267:31:267:33 | "1" |  |
+| Finally.cs:267:31:267:33 | "1" | Finally.cs:267:13:267:34 | call to method WriteLine |  |
+| Finally.cs:270:9:273:9 | [finally: exception(Exception)] {...} | Finally.cs:271:13:271:35 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:270:9:273:9 | {...} | Finally.cs:271:13:271:35 | ...; |  |
+| Finally.cs:271:13:271:34 | [finally: exception(Exception)] call to method WriteLine | Finally.cs:272:13:272:19 | [finally: exception(Exception)] ...; |  |
+| Finally.cs:271:13:271:34 | call to method WriteLine | Finally.cs:272:13:272:19 | ...; |  |
+| Finally.cs:271:13:271:35 | ...; | Finally.cs:271:31:271:33 | "3" |  |
+| Finally.cs:271:13:271:35 | [finally: exception(Exception)] ...; | Finally.cs:271:31:271:33 | [finally: exception(Exception)] "3" |  |
+| Finally.cs:271:31:271:33 | "3" | Finally.cs:271:13:271:34 | call to method WriteLine |  |
+| Finally.cs:271:31:271:33 | [finally: exception(Exception)] "3" | Finally.cs:271:13:271:34 | [finally: exception(Exception)] call to method WriteLine |  |
+| Finally.cs:272:13:272:13 | [finally: exception(Exception)] access to parameter i | Finally.cs:272:18:272:18 | [finally: exception(Exception)] 3 |  |
+| Finally.cs:272:13:272:13 | access to parameter i | Finally.cs:272:18:272:18 | 3 |  |
+| Finally.cs:272:13:272:18 | ... + ... | Finally.cs:272:13:272:18 | ... = ... |  |
+| Finally.cs:272:13:272:18 | ... = ... | Finally.cs:263:10:263:12 | exit M13 (normal) |  |
+| Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... + ... | Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... = ... |  |
+| Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... = ... | Finally.cs:263:10:263:12 | exit M13 (abnormal) | exception(Exception) |
+| Finally.cs:272:13:272:19 | ...; | Finally.cs:272:13:272:13 | access to parameter i |  |
+| Finally.cs:272:13:272:19 | [finally: exception(Exception)] ...; | Finally.cs:272:13:272:13 | [finally: exception(Exception)] access to parameter i |  |
+| Finally.cs:272:18:272:18 | 3 | Finally.cs:272:13:272:18 | ... + ... |  |
+| Finally.cs:272:18:272:18 | [finally: exception(Exception)] 3 | Finally.cs:272:13:272:18 | [finally: exception(Exception)] ... + ... |  |
+| Foreach.cs:4:7:4:13 | call to constructor Object | Foreach.cs:4:7:4:13 | {...} |  |
+| Foreach.cs:4:7:4:13 | enter Foreach | Foreach.cs:4:7:4:13 | call to constructor Object |  |
+| Foreach.cs:4:7:4:13 | exit Foreach (normal) | Foreach.cs:4:7:4:13 | exit Foreach |  |
+| Foreach.cs:4:7:4:13 | {...} | Foreach.cs:4:7:4:13 | exit Foreach (normal) |  |
+| Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} |  |
+| Foreach.cs:6:10:6:11 | exit M1 (normal) | Foreach.cs:6:10:6:11 | exit M1 |  |
+| Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args |  |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 (normal) | empty |
+| Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:22:8:24 | String arg | non-empty |
+| Foreach.cs:8:22:8:24 | String arg | Foreach.cs:9:13:9:13 | ; |  |
+| Foreach.cs:8:29:8:32 | access to parameter args | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |  |
+| Foreach.cs:9:13:9:13 | ; | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |  |
+| Foreach.cs:12:10:12:11 | enter M2 | Foreach.cs:13:5:16:5 | {...} |  |
+| Foreach.cs:12:10:12:11 | exit M2 (normal) | Foreach.cs:12:10:12:11 | exit M2 |  |
+| Foreach.cs:13:5:16:5 | {...} | Foreach.cs:14:27:14:30 | access to parameter args |  |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:12:10:12:11 | exit M2 (normal) | empty |
+| Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... | Foreach.cs:14:22:14:22 | String _ | non-empty |
+| Foreach.cs:14:22:14:22 | String _ | Foreach.cs:15:13:15:13 | ; |  |
+| Foreach.cs:14:27:14:30 | access to parameter args | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |  |
+| Foreach.cs:15:13:15:13 | ; | Foreach.cs:14:9:15:13 | foreach (... ... in ...) ... |  |
+| Foreach.cs:18:10:18:11 | enter M3 | Foreach.cs:19:5:22:5 | {...} |  |
+| Foreach.cs:18:10:18:11 | exit M3 (normal) | Foreach.cs:18:10:18:11 | exit M3 |  |
+| Foreach.cs:19:5:22:5 | {...} | Foreach.cs:20:27:20:27 | access to parameter e |  |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:18:10:18:11 | exit M3 (normal) | empty |
+| Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... | Foreach.cs:20:22:20:22 | String x | non-empty |
+| Foreach.cs:20:22:20:22 | String x | Foreach.cs:21:11:21:11 | ; |  |
+| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:27:20:38 | call to method ToArray<String> | non-null |
+| Foreach.cs:20:27:20:27 | access to parameter e | Foreach.cs:20:43:20:68 | call to method Empty<String> | null |
+| Foreach.cs:20:27:20:38 | call to method ToArray<String> | Foreach.cs:20:27:20:68 | ... ?? ... | non-null |
+| Foreach.cs:20:27:20:38 | call to method ToArray<String> | Foreach.cs:20:43:20:68 | call to method Empty<String> | null |
+| Foreach.cs:20:27:20:68 | ... ?? ... | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:20:43:20:68 | call to method Empty<String> | Foreach.cs:20:27:20:68 | ... ?? ... |  |
+| Foreach.cs:21:11:21:11 | ; | Foreach.cs:20:9:21:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:24:10:24:11 | enter M4 | Foreach.cs:25:5:28:5 | {...} |  |
+| Foreach.cs:24:10:24:11 | exit M4 (normal) | Foreach.cs:24:10:24:11 | exit M4 |  |
+| Foreach.cs:25:5:28:5 | {...} | Foreach.cs:26:36:26:39 | access to parameter args |  |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:24:10:24:11 | exit M4 (normal) | empty |
+| Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... | Foreach.cs:26:23:26:23 | String x | non-empty |
+| Foreach.cs:26:18:26:31 | (..., ...) | Foreach.cs:27:11:27:11 | ; |  |
+| Foreach.cs:26:23:26:23 | String x | Foreach.cs:26:30:26:30 | Int32 y |  |
+| Foreach.cs:26:30:26:30 | Int32 y | Foreach.cs:26:18:26:31 | (..., ...) |  |
+| Foreach.cs:26:36:26:39 | access to parameter args | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:27:11:27:11 | ; | Foreach.cs:26:9:27:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:30:10:30:11 | enter M5 | Foreach.cs:31:5:34:5 | {...} |  |
+| Foreach.cs:30:10:30:11 | exit M5 (normal) | Foreach.cs:30:10:30:11 | exit M5 |  |
+| Foreach.cs:31:5:34:5 | {...} | Foreach.cs:32:32:32:35 | access to parameter args |  |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:30:10:30:11 | exit M5 (normal) | empty |
+| Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... | Foreach.cs:32:23:32:23 | String x | non-empty |
+| Foreach.cs:32:18:32:27 | (..., ...) | Foreach.cs:33:11:33:11 | ; |  |
+| Foreach.cs:32:23:32:23 | String x | Foreach.cs:32:26:32:26 | Int32 y |  |
+| Foreach.cs:32:26:32:26 | Int32 y | Foreach.cs:32:18:32:27 | (..., ...) |  |
+| Foreach.cs:32:32:32:35 | access to parameter args | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:33:11:33:11 | ; | Foreach.cs:32:9:33:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:36:10:36:11 | enter M6 | Foreach.cs:37:5:40:5 | {...} |  |
+| Foreach.cs:36:10:36:11 | exit M6 (normal) | Foreach.cs:36:10:36:11 | exit M6 |  |
+| Foreach.cs:37:5:40:5 | {...} | Foreach.cs:38:39:38:42 | access to parameter args |  |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:36:10:36:11 | exit M6 (normal) | empty |
+| Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... | Foreach.cs:38:26:38:26 | String x | non-empty |
+| Foreach.cs:38:18:38:34 | (..., ...) | Foreach.cs:39:11:39:11 | ; |  |
+| Foreach.cs:38:26:38:26 | String x | Foreach.cs:38:33:38:33 | Int32 y |  |
+| Foreach.cs:38:33:38:33 | Int32 y | Foreach.cs:38:18:38:34 | (..., ...) |  |
+| Foreach.cs:38:39:38:42 | access to parameter args | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |  |
+| Foreach.cs:39:11:39:11 | ; | Foreach.cs:38:9:39:11 | foreach (... ... in ...) ... |  |
+| Initializers.cs:3:7:3:18 | enter Initializers | Initializers.cs:3:7:3:18 | {...} |  |
+| Initializers.cs:3:7:3:18 | exit Initializers (normal) | Initializers.cs:3:7:3:18 | exit Initializers |  |
+| Initializers.cs:3:7:3:18 | {...} | Initializers.cs:3:7:3:18 | exit Initializers (normal) |  |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H |  |
+| Initializers.cs:5:9:5:9 | this access | Initializers.cs:5:13:5:13 | access to field H |  |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access |  |
+| Initializers.cs:5:9:5:17 | ... = ... | Initializers.cs:6:9:6:9 | this access |  |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 |  |
+| Initializers.cs:5:13:5:13 | access to field H | Initializers.cs:5:17:5:17 | 1 |  |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... |  |
+| Initializers.cs:5:13:5:17 | ... + ... | Initializers.cs:5:9:5:17 | ... = ... |  |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... |  |
+| Initializers.cs:5:17:5:17 | 1 | Initializers.cs:5:13:5:17 | ... + ... |  |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... |  |
+| Initializers.cs:6:9:6:9 | access to property G | Initializers.cs:6:25:6:31 | ... = ... |  |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H |  |
+| Initializers.cs:6:9:6:9 | this access | Initializers.cs:6:27:6:27 | access to field H |  |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:8:20:8:22 | {...} |  |
+| Initializers.cs:6:25:6:31 | ... = ... | Initializers.cs:10:28:10:30 | {...} |  |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 |  |
+| Initializers.cs:6:27:6:27 | access to field H | Initializers.cs:6:31:6:31 | 2 |  |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G |  |
+| Initializers.cs:6:27:6:31 | ... + ... | Initializers.cs:6:9:6:9 | access to property G |  |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |  |
+| Initializers.cs:6:31:6:31 | 2 | Initializers.cs:6:27:6:31 | ... + ... |  |
+| Initializers.cs:8:5:8:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access |  |
+| Initializers.cs:8:5:8:16 | enter Initializers | Initializers.cs:8:5:8:16 | call to constructor Object |  |
+| Initializers.cs:8:5:8:16 | exit Initializers (normal) | Initializers.cs:8:5:8:16 | exit Initializers |  |
+| Initializers.cs:8:20:8:22 | {...} | Initializers.cs:8:5:8:16 | exit Initializers (normal) |  |
+| Initializers.cs:10:5:10:16 | call to constructor Object | Initializers.cs:5:9:5:9 | this access |  |
+| Initializers.cs:10:5:10:16 | enter Initializers | Initializers.cs:10:5:10:16 | call to constructor Object |  |
+| Initializers.cs:10:5:10:16 | exit Initializers (normal) | Initializers.cs:10:5:10:16 | exit Initializers |  |
+| Initializers.cs:10:28:10:30 | {...} | Initializers.cs:10:5:10:16 | exit Initializers (normal) |  |
+| Initializers.cs:12:10:12:10 | enter M | Initializers.cs:13:5:16:5 | {...} |  |
+| Initializers.cs:12:10:12:10 | exit M (normal) | Initializers.cs:12:10:12:10 | exit M |  |
+| Initializers.cs:13:5:16:5 | {...} | Initializers.cs:14:9:14:54 | ... ...; |  |
+| Initializers.cs:14:9:14:54 | ... ...; | Initializers.cs:14:34:14:35 | "" |  |
+| Initializers.cs:14:13:14:53 | Initializers i = ... | Initializers.cs:15:9:15:64 | ... ...; |  |
+| Initializers.cs:14:17:14:53 | object creation of type Initializers | Initializers.cs:14:44:14:44 | 0 |  |
+| Initializers.cs:14:34:14:35 | "" | Initializers.cs:14:17:14:53 | object creation of type Initializers |  |
+| Initializers.cs:14:38:14:53 | { ..., ... } | Initializers.cs:14:13:14:53 | Initializers i = ... |  |
+| Initializers.cs:14:40:14:44 | ... = ... | Initializers.cs:14:51:14:51 | 1 |  |
+| Initializers.cs:14:44:14:44 | 0 | Initializers.cs:14:40:14:44 | ... = ... |  |
+| Initializers.cs:14:47:14:47 | access to property G | Initializers.cs:14:47:14:51 | ... = ... |  |
+| Initializers.cs:14:47:14:51 | ... = ... | Initializers.cs:14:38:14:53 | { ..., ... } |  |
+| Initializers.cs:14:51:14:51 | 1 | Initializers.cs:14:47:14:47 | access to property G |  |
+| Initializers.cs:15:9:15:64 | ... ...; | Initializers.cs:15:18:15:63 | 2 |  |
+| Initializers.cs:15:13:15:63 | Initializers[] iz = ... | Initializers.cs:12:10:12:10 | exit M (normal) |  |
+| Initializers.cs:15:18:15:63 | 2 | Initializers.cs:15:18:15:63 | array creation of type Initializers[] |  |
+| Initializers.cs:15:18:15:63 | array creation of type Initializers[] | Initializers.cs:15:39:15:39 | access to local variable i |  |
+| Initializers.cs:15:37:15:63 | { ..., ... } | Initializers.cs:15:13:15:63 | Initializers[] iz = ... |  |
+| Initializers.cs:15:39:15:39 | access to local variable i | Initializers.cs:15:59:15:60 | "" |  |
+| Initializers.cs:15:42:15:61 | object creation of type Initializers | Initializers.cs:15:37:15:63 | { ..., ... } |  |
+| Initializers.cs:15:59:15:60 | "" | Initializers.cs:15:42:15:61 | object creation of type Initializers |  |
+| Initializers.cs:18:16:18:16 | enter H | Initializers.cs:18:20:18:20 | 1 |  |
+| Initializers.cs:18:16:18:16 | exit H (normal) | Initializers.cs:18:16:18:16 | exit H |  |
+| Initializers.cs:18:16:18:20 | ... = ... | Initializers.cs:18:16:18:16 | exit H (normal) |  |
+| Initializers.cs:18:20:18:20 | 1 | Initializers.cs:18:16:18:20 | ... = ... |  |
+| Initializers.cs:20:11:20:23 | call to constructor Object | Initializers.cs:22:23:22:23 | this access |  |
+| Initializers.cs:20:11:20:23 | enter NoConstructor | Initializers.cs:20:11:20:23 | call to constructor Object |  |
+| Initializers.cs:20:11:20:23 | exit NoConstructor (normal) | Initializers.cs:20:11:20:23 | exit NoConstructor |  |
+| Initializers.cs:20:11:20:23 | {...} | Initializers.cs:20:11:20:23 | exit NoConstructor (normal) |  |
+| Initializers.cs:22:23:22:23 | this access | Initializers.cs:22:27:22:27 | 0 |  |
+| Initializers.cs:22:23:22:27 | ... = ... | Initializers.cs:23:23:23:23 | this access |  |
+| Initializers.cs:22:27:22:27 | 0 | Initializers.cs:22:23:22:27 | ... = ... |  |
+| Initializers.cs:23:23:23:23 | this access | Initializers.cs:23:27:23:27 | 1 |  |
+| Initializers.cs:23:23:23:27 | ... = ... | Initializers.cs:20:11:20:23 | {...} |  |
+| Initializers.cs:23:27:23:27 | 1 | Initializers.cs:23:23:23:27 | ... = ... |  |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |  |
+| Initializers.cs:28:13:28:13 | this access | Initializers.cs:28:17:28:17 | 2 |  |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:31:24:31:33 | {...} |  |
+| Initializers.cs:28:13:28:17 | ... = ... | Initializers.cs:35:27:35:40 | {...} |  |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |  |
+| Initializers.cs:28:17:28:17 | 2 | Initializers.cs:28:13:28:17 | ... = ... |  |
+| Initializers.cs:31:9:31:11 | enter Sub | Initializers.cs:31:17:31:20 | call to constructor NoConstructor |  |
+| Initializers.cs:31:9:31:11 | exit Sub (normal) | Initializers.cs:31:9:31:11 | exit Sub |  |
+| Initializers.cs:31:17:31:20 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access |  |
+| Initializers.cs:31:24:31:33 | {...} | Initializers.cs:31:26:31:31 | ...; |  |
+| Initializers.cs:31:26:31:26 | this access | Initializers.cs:31:30:31:30 | 3 |  |
+| Initializers.cs:31:26:31:30 | ... = ... | Initializers.cs:31:9:31:11 | exit Sub (normal) |  |
+| Initializers.cs:31:26:31:31 | ...; | Initializers.cs:31:26:31:26 | this access |  |
+| Initializers.cs:31:30:31:30 | 3 | Initializers.cs:31:26:31:30 | ... = ... |  |
+| Initializers.cs:33:9:33:11 | enter Sub | Initializers.cs:33:22:33:25 | call to constructor Sub |  |
+| Initializers.cs:33:9:33:11 | exit Sub (normal) | Initializers.cs:33:9:33:11 | exit Sub |  |
+| Initializers.cs:33:22:33:25 | call to constructor Sub | Initializers.cs:33:29:33:38 | {...} |  |
+| Initializers.cs:33:29:33:38 | {...} | Initializers.cs:33:31:33:36 | ...; |  |
+| Initializers.cs:33:31:33:31 | this access | Initializers.cs:33:35:33:35 | access to parameter i |  |
+| Initializers.cs:33:31:33:35 | ... = ... | Initializers.cs:33:9:33:11 | exit Sub (normal) |  |
+| Initializers.cs:33:31:33:36 | ...; | Initializers.cs:33:31:33:31 | this access |  |
+| Initializers.cs:33:35:33:35 | access to parameter i | Initializers.cs:33:31:33:35 | ... = ... |  |
+| Initializers.cs:35:9:35:11 | call to constructor NoConstructor | Initializers.cs:28:13:28:13 | this access |  |
+| Initializers.cs:35:9:35:11 | enter Sub | Initializers.cs:35:9:35:11 | call to constructor NoConstructor |  |
+| Initializers.cs:35:9:35:11 | exit Sub (normal) | Initializers.cs:35:9:35:11 | exit Sub |  |
+| Initializers.cs:35:27:35:40 | {...} | Initializers.cs:35:29:35:38 | ...; |  |
+| Initializers.cs:35:29:35:29 | this access | Initializers.cs:35:33:35:33 | access to parameter i |  |
+| Initializers.cs:35:29:35:37 | ... = ... | Initializers.cs:35:9:35:11 | exit Sub (normal) |  |
+| Initializers.cs:35:29:35:38 | ...; | Initializers.cs:35:29:35:29 | this access |  |
+| Initializers.cs:35:33:35:33 | access to parameter i | Initializers.cs:35:37:35:37 | access to parameter j |  |
+| Initializers.cs:35:33:35:37 | ... + ... | Initializers.cs:35:29:35:37 | ... = ... |  |
+| Initializers.cs:35:37:35:37 | access to parameter j | Initializers.cs:35:33:35:37 | ... + ... |  |
+| Initializers.cs:39:7:39:23 | call to constructor Object | Initializers.cs:39:7:39:23 | {...} |  |
+| Initializers.cs:39:7:39:23 | enter IndexInitializers | Initializers.cs:39:7:39:23 | call to constructor Object |  |
+| Initializers.cs:39:7:39:23 | exit IndexInitializers (normal) | Initializers.cs:39:7:39:23 | exit IndexInitializers |  |
+| Initializers.cs:39:7:39:23 | {...} | Initializers.cs:39:7:39:23 | exit IndexInitializers (normal) |  |
+| Initializers.cs:41:11:41:18 | call to constructor Object | Initializers.cs:41:11:41:18 | {...} |  |
+| Initializers.cs:41:11:41:18 | enter Compound | Initializers.cs:41:11:41:18 | call to constructor Object |  |
+| Initializers.cs:41:11:41:18 | exit Compound (normal) | Initializers.cs:41:11:41:18 | exit Compound |  |
+| Initializers.cs:41:11:41:18 | {...} | Initializers.cs:41:11:41:18 | exit Compound (normal) |  |
+| Initializers.cs:51:10:51:13 | enter Test | Initializers.cs:52:5:66:5 | {...} |  |
+| Initializers.cs:51:10:51:13 | exit Test (normal) | Initializers.cs:51:10:51:13 | exit Test |  |
+| Initializers.cs:52:5:66:5 | {...} | Initializers.cs:54:9:54:96 | ... ...; |  |
+| Initializers.cs:54:9:54:96 | ... ...; | Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> |  |
+| Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... | Initializers.cs:57:9:65:10 | ... ...; |  |
+| Initializers.cs:54:20:54:95 | object creation of type Dictionary<Int32,String> | Initializers.cs:54:53:54:53 | 0 |  |
+| Initializers.cs:54:50:54:95 | { ..., ... } | Initializers.cs:54:13:54:95 | Dictionary<Int32,String> dict = ... |  |
+| Initializers.cs:54:52:54:54 | access to indexer | Initializers.cs:54:52:54:63 | ... = ... |  |
+| Initializers.cs:54:52:54:63 | ... = ... | Initializers.cs:54:67:54:67 | 1 |  |
+| Initializers.cs:54:53:54:53 | 0 | Initializers.cs:54:58:54:63 | "Zero" |  |
+| Initializers.cs:54:58:54:63 | "Zero" | Initializers.cs:54:52:54:54 | access to indexer |  |
+| Initializers.cs:54:66:54:68 | access to indexer | Initializers.cs:54:66:54:76 | ... = ... |  |
+| Initializers.cs:54:66:54:76 | ... = ... | Initializers.cs:54:80:54:80 | access to parameter i |  |
+| Initializers.cs:54:67:54:67 | 1 | Initializers.cs:54:72:54:76 | "One" |  |
+| Initializers.cs:54:72:54:76 | "One" | Initializers.cs:54:66:54:68 | access to indexer |  |
+| Initializers.cs:54:79:54:85 | access to indexer | Initializers.cs:54:79:54:93 | ... = ... |  |
+| Initializers.cs:54:79:54:93 | ... = ... | Initializers.cs:54:50:54:95 | { ..., ... } |  |
+| Initializers.cs:54:80:54:80 | access to parameter i | Initializers.cs:54:84:54:84 | 2 |  |
+| Initializers.cs:54:80:54:84 | ... + ... | Initializers.cs:54:89:54:93 | "Two" |  |
+| Initializers.cs:54:84:54:84 | 2 | Initializers.cs:54:80:54:84 | ... + ... |  |
+| Initializers.cs:54:89:54:93 | "Two" | Initializers.cs:54:79:54:85 | access to indexer |  |
+| Initializers.cs:57:9:65:10 | ... ...; | Initializers.cs:57:24:65:9 | object creation of type Compound |  |
+| Initializers.cs:57:13:65:9 | Compound compound = ... | Initializers.cs:51:10:51:13 | exit Test (normal) |  |
+| Initializers.cs:57:24:65:9 | object creation of type Compound | Initializers.cs:59:34:59:34 | 0 |  |
+| Initializers.cs:58:9:65:9 | { ..., ... } | Initializers.cs:57:13:65:9 | Compound compound = ... |  |
+| Initializers.cs:59:13:59:76 | ... = ... | Initializers.cs:60:37:60:37 | 3 |  |
+| Initializers.cs:59:31:59:76 | { ..., ... } | Initializers.cs:59:13:59:76 | ... = ... |  |
+| Initializers.cs:59:33:59:35 | access to indexer | Initializers.cs:59:33:59:44 | ... = ... |  |
+| Initializers.cs:59:33:59:44 | ... = ... | Initializers.cs:59:48:59:48 | 1 |  |
+| Initializers.cs:59:34:59:34 | 0 | Initializers.cs:59:39:59:44 | "Zero" |  |
+| Initializers.cs:59:39:59:44 | "Zero" | Initializers.cs:59:33:59:35 | access to indexer |  |
+| Initializers.cs:59:47:59:49 | access to indexer | Initializers.cs:59:47:59:57 | ... = ... |  |
+| Initializers.cs:59:47:59:57 | ... = ... | Initializers.cs:59:61:59:61 | access to parameter i |  |
+| Initializers.cs:59:48:59:48 | 1 | Initializers.cs:59:53:59:57 | "One" |  |
+| Initializers.cs:59:53:59:57 | "One" | Initializers.cs:59:47:59:49 | access to indexer |  |
+| Initializers.cs:59:60:59:66 | access to indexer | Initializers.cs:59:60:59:74 | ... = ... |  |
+| Initializers.cs:59:60:59:74 | ... = ... | Initializers.cs:59:31:59:76 | { ..., ... } |  |
+| Initializers.cs:59:61:59:61 | access to parameter i | Initializers.cs:59:65:59:65 | 2 |  |
+| Initializers.cs:59:61:59:65 | ... + ... | Initializers.cs:59:70:59:74 | "Two" |  |
+| Initializers.cs:59:65:59:65 | 2 | Initializers.cs:59:61:59:65 | ... + ... |  |
+| Initializers.cs:59:70:59:74 | "Two" | Initializers.cs:59:60:59:66 | access to indexer |  |
+| Initializers.cs:60:13:60:30 | access to property DictionaryProperty | Initializers.cs:60:13:60:80 | ... = ... |  |
+| Initializers.cs:60:13:60:80 | ... = ... | Initializers.cs:61:29:61:29 | 0 |  |
+| Initializers.cs:60:34:60:80 | { ..., ... } | Initializers.cs:60:13:60:30 | access to property DictionaryProperty |  |
+| Initializers.cs:60:36:60:38 | access to indexer | Initializers.cs:60:36:60:48 | ... = ... |  |
+| Initializers.cs:60:36:60:48 | ... = ... | Initializers.cs:60:52:60:52 | 2 |  |
+| Initializers.cs:60:37:60:37 | 3 | Initializers.cs:60:42:60:48 | "Three" |  |
+| Initializers.cs:60:42:60:48 | "Three" | Initializers.cs:60:36:60:38 | access to indexer |  |
+| Initializers.cs:60:51:60:53 | access to indexer | Initializers.cs:60:51:60:61 | ... = ... |  |
+| Initializers.cs:60:51:60:61 | ... = ... | Initializers.cs:60:65:60:65 | access to parameter i |  |
+| Initializers.cs:60:52:60:52 | 2 | Initializers.cs:60:57:60:61 | "Two" |  |
+| Initializers.cs:60:57:60:61 | "Two" | Initializers.cs:60:51:60:53 | access to indexer |  |
+| Initializers.cs:60:64:60:70 | access to indexer | Initializers.cs:60:64:60:78 | ... = ... |  |
+| Initializers.cs:60:64:60:78 | ... = ... | Initializers.cs:60:34:60:80 | { ..., ... } |  |
+| Initializers.cs:60:65:60:65 | access to parameter i | Initializers.cs:60:69:60:69 | 1 |  |
+| Initializers.cs:60:65:60:69 | ... + ... | Initializers.cs:60:74:60:78 | "One" |  |
+| Initializers.cs:60:69:60:69 | 1 | Initializers.cs:60:65:60:69 | ... + ... |  |
+| Initializers.cs:60:74:60:78 | "One" | Initializers.cs:60:64:60:70 | access to indexer |  |
+| Initializers.cs:61:13:61:58 | ... = ... | Initializers.cs:62:30:62:30 | 0 |  |
+| Initializers.cs:61:26:61:58 | { ..., ... } | Initializers.cs:61:13:61:58 | ... = ... |  |
+| Initializers.cs:61:28:61:39 | ... = ... | Initializers.cs:61:43:61:43 | access to parameter i |  |
+| Initializers.cs:61:29:61:29 | 0 | Initializers.cs:61:34:61:39 | "Zero" |  |
+| Initializers.cs:61:34:61:39 | "Zero" | Initializers.cs:61:28:61:39 | ... = ... |  |
+| Initializers.cs:61:42:61:56 | ... = ... | Initializers.cs:61:26:61:58 | { ..., ... } |  |
+| Initializers.cs:61:43:61:43 | access to parameter i | Initializers.cs:61:47:61:47 | 1 |  |
+| Initializers.cs:61:43:61:47 | ... + ... | Initializers.cs:61:52:61:56 | "One" |  |
+| Initializers.cs:61:47:61:47 | 1 | Initializers.cs:61:43:61:47 | ... + ... |  |
+| Initializers.cs:61:52:61:56 | "One" | Initializers.cs:61:42:61:56 | ... = ... |  |
+| Initializers.cs:62:13:62:60 | ... = ... | Initializers.cs:63:32:63:32 | 1 |  |
+| Initializers.cs:62:27:62:60 | { ..., ... } | Initializers.cs:62:13:62:60 | ... = ... |  |
+| Initializers.cs:62:29:62:40 | ... = ... | Initializers.cs:62:44:62:44 | 1 |  |
+| Initializers.cs:62:30:62:30 | 0 | Initializers.cs:62:33:62:33 | 1 |  |
+| Initializers.cs:62:33:62:33 | 1 | Initializers.cs:62:38:62:40 | "i" |  |
+| Initializers.cs:62:38:62:40 | "i" | Initializers.cs:62:29:62:40 | ... = ... |  |
+| Initializers.cs:62:43:62:58 | ... = ... | Initializers.cs:62:27:62:60 | { ..., ... } |  |
+| Initializers.cs:62:44:62:44 | 1 | Initializers.cs:62:47:62:47 | access to parameter i |  |
+| Initializers.cs:62:47:62:47 | access to parameter i | Initializers.cs:62:51:62:51 | 0 |  |
+| Initializers.cs:62:47:62:51 | ... + ... | Initializers.cs:62:56:62:58 | "1" |  |
+| Initializers.cs:62:51:62:51 | 0 | Initializers.cs:62:47:62:51 | ... + ... |  |
+| Initializers.cs:62:56:62:58 | "1" | Initializers.cs:62:43:62:58 | ... = ... |  |
+| Initializers.cs:63:13:63:25 | access to property ArrayProperty | Initializers.cs:63:13:63:60 | ... = ... |  |
+| Initializers.cs:63:13:63:60 | ... = ... | Initializers.cs:64:33:64:33 | 0 |  |
+| Initializers.cs:63:29:63:60 | { ..., ... } | Initializers.cs:63:13:63:25 | access to property ArrayProperty |  |
+| Initializers.cs:63:31:63:41 | ... = ... | Initializers.cs:63:45:63:45 | access to parameter i |  |
+| Initializers.cs:63:32:63:32 | 1 | Initializers.cs:63:37:63:41 | "One" |  |
+| Initializers.cs:63:37:63:41 | "One" | Initializers.cs:63:31:63:41 | ... = ... |  |
+| Initializers.cs:63:44:63:58 | ... = ... | Initializers.cs:63:29:63:60 | { ..., ... } |  |
+| Initializers.cs:63:45:63:45 | access to parameter i | Initializers.cs:63:49:63:49 | 2 |  |
+| Initializers.cs:63:45:63:49 | ... + ... | Initializers.cs:63:54:63:58 | "Two" |  |
+| Initializers.cs:63:49:63:49 | 2 | Initializers.cs:63:45:63:49 | ... + ... |  |
+| Initializers.cs:63:54:63:58 | "Two" | Initializers.cs:63:44:63:58 | ... = ... |  |
+| Initializers.cs:64:13:64:26 | access to property ArrayProperty2 | Initializers.cs:64:13:64:63 | ... = ... |  |
+| Initializers.cs:64:13:64:63 | ... = ... | Initializers.cs:58:9:65:9 | { ..., ... } |  |
+| Initializers.cs:64:30:64:63 | { ..., ... } | Initializers.cs:64:13:64:26 | access to property ArrayProperty2 |  |
+| Initializers.cs:64:32:64:43 | ... = ... | Initializers.cs:64:47:64:47 | 1 |  |
+| Initializers.cs:64:33:64:33 | 0 | Initializers.cs:64:36:64:36 | 1 |  |
+| Initializers.cs:64:36:64:36 | 1 | Initializers.cs:64:41:64:43 | "i" |  |
+| Initializers.cs:64:41:64:43 | "i" | Initializers.cs:64:32:64:43 | ... = ... |  |
+| Initializers.cs:64:46:64:61 | ... = ... | Initializers.cs:64:30:64:63 | { ..., ... } |  |
+| Initializers.cs:64:47:64:47 | 1 | Initializers.cs:64:50:64:50 | access to parameter i |  |
+| Initializers.cs:64:50:64:50 | access to parameter i | Initializers.cs:64:54:64:54 | 0 |  |
+| Initializers.cs:64:50:64:54 | ... + ... | Initializers.cs:64:59:64:61 | "1" |  |
+| Initializers.cs:64:54:64:54 | 0 | Initializers.cs:64:50:64:54 | ... + ... |  |
+| Initializers.cs:64:59:64:61 | "1" | Initializers.cs:64:46:64:61 | ... = ... |  |
+| LoopUnrolling.cs:5:7:5:19 | call to constructor Object | LoopUnrolling.cs:5:7:5:19 | {...} |  |
+| LoopUnrolling.cs:5:7:5:19 | enter LoopUnrolling | LoopUnrolling.cs:5:7:5:19 | call to constructor Object |  |
+| LoopUnrolling.cs:5:7:5:19 | exit LoopUnrolling (normal) | LoopUnrolling.cs:5:7:5:19 | exit LoopUnrolling |  |
+| LoopUnrolling.cs:5:7:5:19 | {...} | LoopUnrolling.cs:5:7:5:19 | exit LoopUnrolling (normal) |  |
+| LoopUnrolling.cs:7:10:7:11 | enter M1 | LoopUnrolling.cs:8:5:13:5 | {...} |  |
+| LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | LoopUnrolling.cs:7:10:7:11 | exit M1 |  |
+| LoopUnrolling.cs:8:5:13:5 | {...} | LoopUnrolling.cs:9:9:10:19 | if (...) ... |  |
+| LoopUnrolling.cs:9:9:10:19 | if (...) ... | LoopUnrolling.cs:9:13:9:16 | access to parameter args |  |
+| LoopUnrolling.cs:9:13:9:16 | access to parameter args | LoopUnrolling.cs:9:13:9:23 | access to property Length |  |
+| LoopUnrolling.cs:9:13:9:23 | access to property Length | LoopUnrolling.cs:9:28:9:28 | 0 |  |
+| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:10:13:10:19 | return ...; | true |
+| LoopUnrolling.cs:9:13:9:28 | ... == ... | LoopUnrolling.cs:11:29:11:32 | access to parameter args | false |
+| LoopUnrolling.cs:9:28:9:28 | 0 | LoopUnrolling.cs:9:13:9:28 | ... == ... |  |
+| LoopUnrolling.cs:10:13:10:19 | return ...; | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | return |
+| LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | non-empty |
+| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:7:10:7:11 | exit M1 (normal) | empty |
+| LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... | LoopUnrolling.cs:11:22:11:24 | String arg | non-empty |
+| LoopUnrolling.cs:11:22:11:24 | String arg | LoopUnrolling.cs:12:13:12:35 | ...; |  |
+| LoopUnrolling.cs:11:29:11:32 | access to parameter args | LoopUnrolling.cs:11:9:12:35 | [unroll (line 11)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:12:13:12:34 | call to method WriteLine | LoopUnrolling.cs:11:9:12:35 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:12:13:12:35 | ...; | LoopUnrolling.cs:12:31:12:33 | access to local variable arg |  |
+| LoopUnrolling.cs:12:31:12:33 | access to local variable arg | LoopUnrolling.cs:12:13:12:34 | call to method WriteLine |  |
+| LoopUnrolling.cs:15:10:15:11 | enter M2 | LoopUnrolling.cs:16:5:20:5 | {...} |  |
+| LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | LoopUnrolling.cs:15:10:15:11 | exit M2 |  |
+| LoopUnrolling.cs:16:5:20:5 | {...} | LoopUnrolling.cs:17:9:17:48 | ... ...; |  |
+| LoopUnrolling.cs:17:9:17:48 | ... ...; | LoopUnrolling.cs:17:18:17:47 | 3 |  |
+| LoopUnrolling.cs:17:13:17:47 | String[] xs = ... | LoopUnrolling.cs:18:27:18:28 | access to local variable xs |  |
+| LoopUnrolling.cs:17:18:17:47 | 3 | LoopUnrolling.cs:17:18:17:47 | array creation of type String[] |  |
+| LoopUnrolling.cs:17:18:17:47 | array creation of type String[] | LoopUnrolling.cs:17:33:17:35 | "a" |  |
+| LoopUnrolling.cs:17:31:17:47 | { ..., ... } | LoopUnrolling.cs:17:13:17:47 | String[] xs = ... |  |
+| LoopUnrolling.cs:17:33:17:35 | "a" | LoopUnrolling.cs:17:38:17:40 | "b" |  |
+| LoopUnrolling.cs:17:38:17:40 | "b" | LoopUnrolling.cs:17:43:17:45 | "c" |  |
+| LoopUnrolling.cs:17:43:17:45 | "c" | LoopUnrolling.cs:17:31:17:47 | { ..., ... } |  |
+| LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | non-empty |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:15:10:15:11 | exit M2 (normal) | empty |
+| LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... | LoopUnrolling.cs:18:22:18:22 | String x | non-empty |
+| LoopUnrolling.cs:18:22:18:22 | String x | LoopUnrolling.cs:19:13:19:33 | ...; |  |
+| LoopUnrolling.cs:18:27:18:28 | access to local variable xs | LoopUnrolling.cs:18:9:19:33 | [unroll (line 18)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:19:13:19:32 | call to method WriteLine | LoopUnrolling.cs:18:9:19:33 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:19:13:19:33 | ...; | LoopUnrolling.cs:19:31:19:31 | access to local variable x |  |
+| LoopUnrolling.cs:19:31:19:31 | access to local variable x | LoopUnrolling.cs:19:13:19:32 | call to method WriteLine |  |
+| LoopUnrolling.cs:22:10:22:11 | enter M3 | LoopUnrolling.cs:23:5:27:5 | {...} |  |
+| LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | LoopUnrolling.cs:22:10:22:11 | exit M3 |  |
+| LoopUnrolling.cs:23:5:27:5 | {...} | LoopUnrolling.cs:24:29:24:32 | access to parameter args |  |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:22:10:22:11 | exit M3 (normal) | empty |
+| LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:22:24:24 | Char arg | non-empty |
+| LoopUnrolling.cs:24:22:24:24 | Char arg | LoopUnrolling.cs:25:34:25:37 | access to parameter args |  |
+| LoopUnrolling.cs:24:29:24:32 | access to parameter args | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | non-empty |
+| LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:24:9:26:40 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... | LoopUnrolling.cs:25:26:25:29 | Char arg0 | non-empty |
+| LoopUnrolling.cs:25:26:25:29 | Char arg0 | LoopUnrolling.cs:26:17:26:40 | ...; |  |
+| LoopUnrolling.cs:25:34:25:37 | access to parameter args | LoopUnrolling.cs:25:13:26:40 | [unroll (line 25)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:26:17:26:39 | call to method WriteLine | LoopUnrolling.cs:25:13:26:40 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:26:17:26:40 | ...; | LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 |  |
+| LoopUnrolling.cs:26:35:26:38 | access to local variable arg0 | LoopUnrolling.cs:26:17:26:39 | call to method WriteLine |  |
+| LoopUnrolling.cs:29:10:29:11 | enter M4 | LoopUnrolling.cs:30:5:34:5 | {...} |  |
+| LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | LoopUnrolling.cs:29:10:29:11 | exit M4 |  |
+| LoopUnrolling.cs:30:5:34:5 | {...} | LoopUnrolling.cs:31:9:31:31 | ... ...; |  |
+| LoopUnrolling.cs:31:9:31:31 | ... ...; | LoopUnrolling.cs:31:29:31:29 | 0 |  |
+| LoopUnrolling.cs:31:13:31:30 | String[] xs = ... | LoopUnrolling.cs:32:27:32:28 | access to local variable xs |  |
+| LoopUnrolling.cs:31:18:31:30 | array creation of type String[] | LoopUnrolling.cs:31:13:31:30 | String[] xs = ... |  |
+| LoopUnrolling.cs:31:29:31:29 | 0 | LoopUnrolling.cs:31:18:31:30 | array creation of type String[] |  |
+| LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... | LoopUnrolling.cs:29:10:29:11 | exit M4 (normal) | empty |
+| LoopUnrolling.cs:32:27:32:28 | access to local variable xs | LoopUnrolling.cs:32:9:33:33 | [skip (line 32)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:36:10:36:11 | enter M5 | LoopUnrolling.cs:37:5:43:5 | {...} |  |
+| LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | LoopUnrolling.cs:36:10:36:11 | exit M5 |  |
+| LoopUnrolling.cs:37:5:43:5 | {...} | LoopUnrolling.cs:38:9:38:48 | ... ...; |  |
+| LoopUnrolling.cs:38:9:38:48 | ... ...; | LoopUnrolling.cs:38:18:38:47 | 3 |  |
+| LoopUnrolling.cs:38:13:38:47 | String[] xs = ... | LoopUnrolling.cs:39:9:39:48 | ... ...; |  |
+| LoopUnrolling.cs:38:18:38:47 | 3 | LoopUnrolling.cs:38:18:38:47 | array creation of type String[] |  |
+| LoopUnrolling.cs:38:18:38:47 | array creation of type String[] | LoopUnrolling.cs:38:33:38:35 | "a" |  |
+| LoopUnrolling.cs:38:31:38:47 | { ..., ... } | LoopUnrolling.cs:38:13:38:47 | String[] xs = ... |  |
+| LoopUnrolling.cs:38:33:38:35 | "a" | LoopUnrolling.cs:38:38:38:40 | "b" |  |
+| LoopUnrolling.cs:38:38:38:40 | "b" | LoopUnrolling.cs:38:43:38:45 | "c" |  |
+| LoopUnrolling.cs:38:43:38:45 | "c" | LoopUnrolling.cs:38:31:38:47 | { ..., ... } |  |
+| LoopUnrolling.cs:39:9:39:48 | ... ...; | LoopUnrolling.cs:39:18:39:47 | 3 |  |
+| LoopUnrolling.cs:39:13:39:47 | String[] ys = ... | LoopUnrolling.cs:40:27:40:28 | access to local variable xs |  |
+| LoopUnrolling.cs:39:18:39:47 | 3 | LoopUnrolling.cs:39:18:39:47 | array creation of type String[] |  |
+| LoopUnrolling.cs:39:18:39:47 | array creation of type String[] | LoopUnrolling.cs:39:33:39:35 | "0" |  |
+| LoopUnrolling.cs:39:31:39:47 | { ..., ... } | LoopUnrolling.cs:39:13:39:47 | String[] ys = ... |  |
+| LoopUnrolling.cs:39:33:39:35 | "0" | LoopUnrolling.cs:39:38:39:40 | "1" |  |
+| LoopUnrolling.cs:39:38:39:40 | "1" | LoopUnrolling.cs:39:43:39:45 | "2" |  |
+| LoopUnrolling.cs:39:43:39:45 | "2" | LoopUnrolling.cs:39:31:39:47 | { ..., ... } |  |
+| LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | non-empty |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:36:10:36:11 | exit M5 (normal) | empty |
+| LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:22:40:22 | String x | non-empty |
+| LoopUnrolling.cs:40:22:40:22 | String x | LoopUnrolling.cs:41:31:41:32 | access to local variable ys |  |
+| LoopUnrolling.cs:40:27:40:28 | access to local variable xs | LoopUnrolling.cs:40:9:42:41 | [unroll (line 40)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | non-empty |
+| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:40:9:42:41 | foreach (... ... in ...) ... | empty |
+| LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... | LoopUnrolling.cs:41:26:41:26 | String y | non-empty |
+| LoopUnrolling.cs:41:26:41:26 | String y | LoopUnrolling.cs:42:17:42:41 | ...; |  |
+| LoopUnrolling.cs:41:31:41:32 | access to local variable ys | LoopUnrolling.cs:41:13:42:41 | [unroll (line 41)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:42:17:42:40 | call to method WriteLine | LoopUnrolling.cs:41:13:42:41 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:42:17:42:41 | ...; | LoopUnrolling.cs:42:35:42:35 | access to local variable x |  |
+| LoopUnrolling.cs:42:35:42:35 | access to local variable x | LoopUnrolling.cs:42:39:42:39 | access to local variable y |  |
+| LoopUnrolling.cs:42:35:42:39 | ... + ... | LoopUnrolling.cs:42:17:42:40 | call to method WriteLine |  |
+| LoopUnrolling.cs:42:39:42:39 | access to local variable y | LoopUnrolling.cs:42:35:42:39 | ... + ... |  |
+| LoopUnrolling.cs:45:10:45:11 | enter M6 | LoopUnrolling.cs:46:5:53:5 | {...} |  |
+| LoopUnrolling.cs:46:5:53:5 | {...} | LoopUnrolling.cs:47:9:47:48 | ... ...; |  |
+| LoopUnrolling.cs:47:9:47:48 | ... ...; | LoopUnrolling.cs:47:18:47:47 | 3 |  |
+| LoopUnrolling.cs:47:13:47:47 | String[] xs = ... | LoopUnrolling.cs:48:27:48:28 | access to local variable xs |  |
+| LoopUnrolling.cs:47:18:47:47 | 3 | LoopUnrolling.cs:47:18:47:47 | array creation of type String[] |  |
+| LoopUnrolling.cs:47:18:47:47 | array creation of type String[] | LoopUnrolling.cs:47:33:47:35 | "a" |  |
+| LoopUnrolling.cs:47:31:47:47 | { ..., ... } | LoopUnrolling.cs:47:13:47:47 | String[] xs = ... |  |
+| LoopUnrolling.cs:47:33:47:35 | "a" | LoopUnrolling.cs:47:38:47:40 | "b" |  |
+| LoopUnrolling.cs:47:38:47:40 | "b" | LoopUnrolling.cs:47:43:47:45 | "c" |  |
+| LoopUnrolling.cs:47:43:47:45 | "c" | LoopUnrolling.cs:47:31:47:47 | { ..., ... } |  |
+| LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... | LoopUnrolling.cs:48:22:48:22 | String x | non-empty |
+| LoopUnrolling.cs:48:22:48:22 | String x | LoopUnrolling.cs:49:9:52:9 | {...} |  |
+| LoopUnrolling.cs:48:27:48:28 | access to local variable xs | LoopUnrolling.cs:48:9:52:9 | [unroll (line 48)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:49:9:52:9 | {...} | LoopUnrolling.cs:50:9:50:13 | Label: |  |
+| LoopUnrolling.cs:50:9:50:13 | Label: | LoopUnrolling.cs:50:16:50:36 | ...; |  |
+| LoopUnrolling.cs:50:16:50:35 | call to method WriteLine | LoopUnrolling.cs:51:13:51:23 | goto ...; |  |
+| LoopUnrolling.cs:50:16:50:36 | ...; | LoopUnrolling.cs:50:34:50:34 | access to local variable x |  |
+| LoopUnrolling.cs:50:34:50:34 | access to local variable x | LoopUnrolling.cs:50:16:50:35 | call to method WriteLine |  |
+| LoopUnrolling.cs:51:13:51:23 | goto ...; | LoopUnrolling.cs:50:9:50:13 | Label: | goto(Label) |
+| LoopUnrolling.cs:55:10:55:11 | enter M7 | LoopUnrolling.cs:56:5:65:5 | {...} |  |
+| LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | LoopUnrolling.cs:55:10:55:11 | exit M7 |  |
+| LoopUnrolling.cs:56:5:65:5 | {...} | LoopUnrolling.cs:57:9:57:48 | ... ...; |  |
+| LoopUnrolling.cs:57:9:57:48 | ... ...; | LoopUnrolling.cs:57:18:57:47 | 3 |  |
+| LoopUnrolling.cs:57:13:57:47 | String[] xs = ... | LoopUnrolling.cs:58:27:58:28 | access to local variable xs |  |
+| LoopUnrolling.cs:57:18:57:47 | 3 | LoopUnrolling.cs:57:18:57:47 | array creation of type String[] |  |
+| LoopUnrolling.cs:57:18:57:47 | array creation of type String[] | LoopUnrolling.cs:57:33:57:35 | "a" |  |
+| LoopUnrolling.cs:57:31:57:47 | { ..., ... } | LoopUnrolling.cs:57:13:57:47 | String[] xs = ... |  |
+| LoopUnrolling.cs:57:33:57:35 | "a" | LoopUnrolling.cs:57:38:57:40 | "b" |  |
+| LoopUnrolling.cs:57:38:57:40 | "b" | LoopUnrolling.cs:57:43:57:45 | "c" |  |
+| LoopUnrolling.cs:57:43:57:45 | "c" | LoopUnrolling.cs:57:31:57:47 | { ..., ... } |  |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | non-empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:55:10:55:11 | exit M7 (normal) | empty |
+| LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | non-empty |
+| LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... | LoopUnrolling.cs:58:22:58:22 | String x | non-empty |
+| LoopUnrolling.cs:58:22:58:22 | String x | LoopUnrolling.cs:59:9:64:9 | {...} |  |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): false] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} |  |
+| LoopUnrolling.cs:58:22:58:22 | [b (line 55): true] String x | LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} |  |
+| LoopUnrolling.cs:58:27:58:28 | access to local variable xs | LoopUnrolling.cs:58:9:64:9 | [unroll (line 58)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:59:9:64:9 | [b (line 55): false] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... |  |
+| LoopUnrolling.cs:59:9:64:9 | [b (line 55): true] {...} | LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... |  |
+| LoopUnrolling.cs:59:9:64:9 | {...} | LoopUnrolling.cs:60:13:61:37 | if (...) ... |  |
+| LoopUnrolling.cs:60:13:61:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b |  |
+| LoopUnrolling.cs:60:13:61:37 | [b (line 55): true] if (...) ... | LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b |  |
+| LoopUnrolling.cs:60:13:61:37 | if (...) ... | LoopUnrolling.cs:60:17:60:17 | access to parameter b |  |
+| LoopUnrolling.cs:60:17:60:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
+| LoopUnrolling.cs:60:17:60:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | true |
+| LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | true |
+| LoopUnrolling.cs:60:17:60:17 | access to parameter b | LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | false |
+| LoopUnrolling.cs:61:17:61:36 | [b (line 55): true] call to method WriteLine | LoopUnrolling.cs:62:13:63:37 | [b (line 55): true] if (...) ... |  |
+| LoopUnrolling.cs:61:17:61:37 | [b (line 55): true] ...; | LoopUnrolling.cs:61:35:61:35 | [b (line 55): true] access to local variable x |  |
+| LoopUnrolling.cs:61:35:61:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:61:17:61:36 | [b (line 55): true] call to method WriteLine |  |
+| LoopUnrolling.cs:62:13:63:37 | [b (line 55): false] if (...) ... | LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b |  |
+| LoopUnrolling.cs:62:13:63:37 | [b (line 55): true] if (...) ... | LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b |  |
+| LoopUnrolling.cs:62:17:62:17 | [b (line 55): false] access to parameter b | LoopUnrolling.cs:58:9:64:9 | [b (line 55): false] foreach (... ... in ...) ... | false |
+| LoopUnrolling.cs:62:17:62:17 | [b (line 55): true] access to parameter b | LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | true |
+| LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine | LoopUnrolling.cs:58:9:64:9 | [b (line 55): true] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:63:17:63:37 | [b (line 55): true] ...; | LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x |  |
+| LoopUnrolling.cs:63:35:63:35 | [b (line 55): true] access to local variable x | LoopUnrolling.cs:63:17:63:36 | [b (line 55): true] call to method WriteLine |  |
+| LoopUnrolling.cs:67:10:67:11 | enter M8 | LoopUnrolling.cs:68:5:74:5 | {...} |  |
+| LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | LoopUnrolling.cs:67:10:67:11 | exit M8 |  |
+| LoopUnrolling.cs:68:5:74:5 | {...} | LoopUnrolling.cs:69:9:70:19 | if (...) ... |  |
+| LoopUnrolling.cs:69:9:70:19 | if (...) ... | LoopUnrolling.cs:69:14:69:17 | access to parameter args |  |
+| LoopUnrolling.cs:69:13:69:23 | [false] !... | LoopUnrolling.cs:71:9:71:21 | ...; | false |
+| LoopUnrolling.cs:69:13:69:23 | [true] !... | LoopUnrolling.cs:70:13:70:19 | return ...; | true |
+| LoopUnrolling.cs:69:14:69:17 | access to parameter args | LoopUnrolling.cs:69:14:69:23 | call to method Any<String> |  |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any<String> | LoopUnrolling.cs:69:13:69:23 | [false] !... | true |
+| LoopUnrolling.cs:69:14:69:23 | call to method Any<String> | LoopUnrolling.cs:69:13:69:23 | [true] !... | false |
+| LoopUnrolling.cs:70:13:70:19 | return ...; | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | return |
+| LoopUnrolling.cs:71:9:71:12 | access to parameter args | LoopUnrolling.cs:71:9:71:20 | call to method Clear |  |
+| LoopUnrolling.cs:71:9:71:20 | call to method Clear | LoopUnrolling.cs:72:29:72:32 | access to parameter args |  |
+| LoopUnrolling.cs:71:9:71:21 | ...; | LoopUnrolling.cs:71:9:71:12 | access to parameter args |  |
+| LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... | LoopUnrolling.cs:67:10:67:11 | exit M8 (normal) | empty |
+| LoopUnrolling.cs:72:29:72:32 | access to parameter args | LoopUnrolling.cs:72:9:73:35 | [skip (line 72)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:76:10:76:11 | enter M9 | LoopUnrolling.cs:77:5:83:5 | {...} |  |
+| LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | LoopUnrolling.cs:76:10:76:11 | exit M9 |  |
+| LoopUnrolling.cs:77:5:83:5 | {...} | LoopUnrolling.cs:78:9:78:34 | ... ...; |  |
+| LoopUnrolling.cs:78:9:78:34 | ... ...; | LoopUnrolling.cs:78:29:78:29 | 2 |  |
+| LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... | LoopUnrolling.cs:79:27:79:28 | access to local variable xs |  |
+| LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] | LoopUnrolling.cs:78:13:78:33 | String[,] xs = ... |  |
+| LoopUnrolling.cs:78:29:78:29 | 2 | LoopUnrolling.cs:78:32:78:32 | 0 |  |
+| LoopUnrolling.cs:78:32:78:32 | 0 | LoopUnrolling.cs:78:18:78:33 | array creation of type String[,] |  |
+| LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... | LoopUnrolling.cs:76:10:76:11 | exit M9 (normal) | empty |
+| LoopUnrolling.cs:79:27:79:28 | access to local variable xs | LoopUnrolling.cs:79:9:82:9 | [skip (line 79)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:85:10:85:12 | enter M10 | LoopUnrolling.cs:86:5:92:5 | {...} |  |
+| LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | LoopUnrolling.cs:85:10:85:12 | exit M10 |  |
+| LoopUnrolling.cs:86:5:92:5 | {...} | LoopUnrolling.cs:87:9:87:34 | ... ...; |  |
+| LoopUnrolling.cs:87:9:87:34 | ... ...; | LoopUnrolling.cs:87:29:87:29 | 0 |  |
+| LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... | LoopUnrolling.cs:88:27:88:28 | access to local variable xs |  |
+| LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] | LoopUnrolling.cs:87:13:87:33 | String[,] xs = ... |  |
+| LoopUnrolling.cs:87:29:87:29 | 0 | LoopUnrolling.cs:87:32:87:32 | 2 |  |
+| LoopUnrolling.cs:87:32:87:32 | 2 | LoopUnrolling.cs:87:18:87:33 | array creation of type String[,] |  |
+| LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... | LoopUnrolling.cs:85:10:85:12 | exit M10 (normal) | empty |
+| LoopUnrolling.cs:88:27:88:28 | access to local variable xs | LoopUnrolling.cs:88:9:91:9 | [skip (line 88)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:94:10:94:12 | enter M11 | LoopUnrolling.cs:95:5:101:5 | {...} |  |
+| LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | LoopUnrolling.cs:94:10:94:12 | exit M11 |  |
+| LoopUnrolling.cs:95:5:101:5 | {...} | LoopUnrolling.cs:96:9:96:34 | ... ...; |  |
+| LoopUnrolling.cs:96:9:96:34 | ... ...; | LoopUnrolling.cs:96:29:96:29 | 2 |  |
+| LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... | LoopUnrolling.cs:97:27:97:28 | access to local variable xs |  |
+| LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] | LoopUnrolling.cs:96:13:96:33 | String[,] xs = ... |  |
+| LoopUnrolling.cs:96:29:96:29 | 2 | LoopUnrolling.cs:96:32:96:32 | 2 |  |
+| LoopUnrolling.cs:96:32:96:32 | 2 | LoopUnrolling.cs:96:18:96:33 | array creation of type String[,] |  |
+| LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | non-empty |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:94:10:94:12 | exit M11 (normal) | empty |
+| LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... | LoopUnrolling.cs:97:22:97:22 | String x | non-empty |
+| LoopUnrolling.cs:97:22:97:22 | String x | LoopUnrolling.cs:98:9:100:9 | {...} |  |
+| LoopUnrolling.cs:97:27:97:28 | access to local variable xs | LoopUnrolling.cs:97:9:100:9 | [unroll (line 97)] foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:98:9:100:9 | {...} | LoopUnrolling.cs:99:13:99:33 | ...; |  |
+| LoopUnrolling.cs:99:13:99:32 | call to method WriteLine | LoopUnrolling.cs:97:9:100:9 | foreach (... ... in ...) ... |  |
+| LoopUnrolling.cs:99:13:99:33 | ...; | LoopUnrolling.cs:99:31:99:31 | access to local variable x |  |
+| LoopUnrolling.cs:99:31:99:31 | access to local variable x | LoopUnrolling.cs:99:13:99:32 | call to method WriteLine |  |
+| MultiImplementationA.cs:4:7:4:8 | call to constructor Object | MultiImplementationA.cs:4:7:4:8 | {...} |  |
+| MultiImplementationA.cs:4:7:4:8 | enter C1 | MultiImplementationA.cs:4:7:4:8 | call to constructor Object |  |
+| MultiImplementationA.cs:4:7:4:8 | enter C1 | MultiImplementationB.cs:1:7:1:8 | call to constructor Object |  |
+| MultiImplementationA.cs:4:7:4:8 | exit C1 (normal) | MultiImplementationA.cs:4:7:4:8 | exit C1 |  |
+| MultiImplementationA.cs:4:7:4:8 | {...} | MultiImplementationA.cs:4:7:4:8 | exit C1 (normal) |  |
+| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationA.cs:6:28:6:31 | null |  |
+| MultiImplementationA.cs:6:22:6:31 | enter get_P1 | MultiImplementationB.cs:3:22:3:22 | 0 |  |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |  |
+| MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) | MultiImplementationA.cs:6:22:6:31 | exit get_P1 |  |
+| MultiImplementationA.cs:6:22:6:31 | throw ... | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:6:28:6:31 | null | MultiImplementationA.cs:6:22:6:31 | throw ... |  |
+| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationA.cs:7:25:7:39 | {...} |  |
+| MultiImplementationA.cs:7:21:7:23 | enter get_P2 | MultiImplementationB.cs:4:25:4:37 | {...} |  |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 |  |
+| MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | MultiImplementationA.cs:7:21:7:23 | exit get_P2 |  |
+| MultiImplementationA.cs:7:25:7:39 | {...} | MultiImplementationA.cs:7:33:7:36 | null |  |
+| MultiImplementationA.cs:7:27:7:37 | throw ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:33:7:36 | null | MultiImplementationA.cs:7:27:7:37 | throw ...; |  |
+| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationA.cs:7:45:7:59 | {...} |  |
+| MultiImplementationA.cs:7:41:7:43 | enter set_P2 | MultiImplementationB.cs:4:43:4:45 | {...} |  |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 |  |
+| MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) | MultiImplementationA.cs:7:41:7:43 | exit set_P2 |  |
+| MultiImplementationA.cs:7:45:7:59 | {...} | MultiImplementationA.cs:7:53:7:56 | null |  |
+| MultiImplementationA.cs:7:47:7:57 | throw ...; | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:7:53:7:56 | null | MultiImplementationA.cs:7:47:7:57 | throw ...; |  |
+| MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationA.cs:8:29:8:32 | null |  |
+| MultiImplementationA.cs:8:16:8:16 | enter M | MultiImplementationB.cs:5:23:5:23 | 2 |  |
+| MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | MultiImplementationA.cs:8:16:8:16 | exit M |  |
+| MultiImplementationA.cs:8:16:8:16 | exit M (normal) | MultiImplementationA.cs:8:16:8:16 | exit M |  |
+| MultiImplementationA.cs:8:23:8:32 | throw ... | MultiImplementationA.cs:8:16:8:16 | exit M (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:8:29:8:32 | null | MultiImplementationA.cs:8:23:8:32 | throw ... |  |
+| MultiImplementationA.cs:13:16:13:16 | this access | MultiImplementationA.cs:13:20:13:20 | 0 |  |
+| MultiImplementationA.cs:13:16:13:20 | ... = ... | MultiImplementationA.cs:24:16:24:16 | this access |  |
+| MultiImplementationA.cs:13:20:13:20 | 0 | MultiImplementationA.cs:13:16:13:20 | ... = ... |  |
+| MultiImplementationA.cs:14:31:14:31 | access to parameter i | MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) |  |
+| MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationA.cs:14:31:14:31 | access to parameter i |  |
+| MultiImplementationA.cs:14:31:14:31 | enter get_Item | MultiImplementationB.cs:12:37:12:40 | null |  |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item |  |
+| MultiImplementationA.cs:14:31:14:31 | exit get_Item (normal) | MultiImplementationA.cs:14:31:14:31 | exit get_Item |  |
+| MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationA.cs:15:40:15:52 | {...} |  |
+| MultiImplementationA.cs:15:36:15:38 | enter get_Item | MultiImplementationB.cs:13:40:13:54 | {...} |  |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item |  |
+| MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | MultiImplementationA.cs:15:36:15:38 | exit get_Item |  |
+| MultiImplementationA.cs:15:40:15:52 | {...} | MultiImplementationA.cs:15:49:15:49 | access to parameter s |  |
+| MultiImplementationA.cs:15:42:15:50 | return ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (normal) | return |
+| MultiImplementationA.cs:15:49:15:49 | access to parameter s | MultiImplementationA.cs:15:42:15:50 | return ...; |  |
+| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationA.cs:15:58:15:60 | {...} |  |
+| MultiImplementationA.cs:15:54:15:56 | enter set_Item | MultiImplementationB.cs:13:60:13:62 | {...} |  |
+| MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) | MultiImplementationA.cs:15:54:15:56 | exit set_Item |  |
+| MultiImplementationA.cs:15:58:15:60 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |  |
+| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationA.cs:17:5:19:5 | {...} |  |
+| MultiImplementationA.cs:16:17:16:18 | enter M1 | MultiImplementationB.cs:15:5:17:5 | {...} |  |
+| MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) | MultiImplementationA.cs:16:17:16:18 | exit M1 |  |
+| MultiImplementationA.cs:17:5:19:5 | {...} | MultiImplementationA.cs:18:9:18:22 | M2(...) |  |
+| MultiImplementationA.cs:18:9:18:22 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |  |
+| MultiImplementationA.cs:18:9:18:22 | enter M2 | MultiImplementationA.cs:18:21:18:21 | 0 |  |
+| MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) | MultiImplementationA.cs:18:9:18:22 | exit M2 |  |
+| MultiImplementationA.cs:18:21:18:21 | 0 | MultiImplementationA.cs:18:9:18:22 | exit M2 (normal) |  |
+| MultiImplementationA.cs:20:12:20:13 | call to constructor Object | MultiImplementationA.cs:13:16:13:16 | this access |  |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationA.cs:20:12:20:13 | call to constructor Object |  |
+| MultiImplementationA.cs:20:12:20:13 | enter C2 | MultiImplementationB.cs:18:12:18:13 | call to constructor Object |  |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | MultiImplementationA.cs:20:12:20:13 | exit C2 |  |
+| MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) | MultiImplementationA.cs:20:12:20:13 | exit C2 |  |
+| MultiImplementationA.cs:20:22:20:31 | {...} | MultiImplementationA.cs:20:24:20:29 | ...; |  |
+| MultiImplementationA.cs:20:24:20:24 | this access | MultiImplementationA.cs:20:28:20:28 | access to parameter i |  |
+| MultiImplementationA.cs:20:24:20:28 | ... = ... | MultiImplementationA.cs:20:12:20:13 | exit C2 (normal) |  |
+| MultiImplementationA.cs:20:24:20:29 | ...; | MultiImplementationA.cs:20:24:20:24 | this access |  |
+| MultiImplementationA.cs:20:28:20:28 | access to parameter i | MultiImplementationA.cs:20:24:20:28 | ... = ... |  |
+| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationA.cs:21:24:21:24 | 0 |  |
+| MultiImplementationA.cs:21:12:21:13 | enter C2 | MultiImplementationB.cs:19:24:19:24 | 1 |  |
+| MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) | MultiImplementationA.cs:21:12:21:13 | exit C2 |  |
+| MultiImplementationA.cs:21:19:21:22 | call to constructor C2 | MultiImplementationA.cs:21:27:21:29 | {...} |  |
+| MultiImplementationA.cs:21:24:21:24 | 0 | MultiImplementationA.cs:21:19:21:22 | call to constructor C2 |  |
+| MultiImplementationA.cs:21:27:21:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |  |
+| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationA.cs:22:11:22:13 | {...} |  |
+| MultiImplementationA.cs:22:6:22:7 | enter ~C2 | MultiImplementationB.cs:20:11:20:25 | {...} |  |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 |  |
+| MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) | MultiImplementationA.cs:22:6:22:7 | exit ~C2 |  |
+| MultiImplementationA.cs:22:11:22:13 | {...} | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (normal) |  |
+| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationA.cs:23:50:23:53 | null |  |
+| MultiImplementationA.cs:23:28:23:35 | enter implicit conversion | MultiImplementationB.cs:21:56:21:59 | null |  |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion |  |
+| MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion |  |
+| MultiImplementationA.cs:23:50:23:53 | null | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (normal) |  |
+| MultiImplementationA.cs:24:16:24:16 | access to property P | MultiImplementationA.cs:24:32:24:34 | ... = ... |  |
+| MultiImplementationA.cs:24:16:24:16 | this access | MultiImplementationA.cs:24:34:24:34 | 0 |  |
+| MultiImplementationA.cs:24:32:24:34 | ... = ... | MultiImplementationA.cs:20:22:20:31 | {...} |  |
+| MultiImplementationA.cs:24:34:24:34 | 0 | MultiImplementationA.cs:24:16:24:16 | access to property P |  |
+| MultiImplementationA.cs:28:7:28:8 | call to constructor Object | MultiImplementationA.cs:28:7:28:8 | {...} |  |
+| MultiImplementationA.cs:28:7:28:8 | enter C3 | MultiImplementationA.cs:28:7:28:8 | call to constructor Object |  |
+| MultiImplementationA.cs:28:7:28:8 | enter C3 | MultiImplementationB.cs:25:7:25:8 | call to constructor Object |  |
+| MultiImplementationA.cs:28:7:28:8 | exit C3 (normal) | MultiImplementationA.cs:28:7:28:8 | exit C3 |  |
+| MultiImplementationA.cs:28:7:28:8 | {...} | MultiImplementationA.cs:28:7:28:8 | exit C3 (normal) |  |
+| MultiImplementationA.cs:30:21:30:23 | enter get_P3 | MultiImplementationA.cs:30:34:30:37 | null |  |
+| MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | MultiImplementationA.cs:30:21:30:23 | exit get_P3 |  |
+| MultiImplementationA.cs:30:28:30:37 | throw ... | MultiImplementationA.cs:30:21:30:23 | exit get_P3 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:30:34:30:37 | null | MultiImplementationA.cs:30:28:30:37 | throw ... |  |
+| MultiImplementationA.cs:34:15:34:16 | call to constructor Object | MultiImplementationA.cs:34:15:34:16 | {...} |  |
+| MultiImplementationA.cs:34:15:34:16 | enter C4 | MultiImplementationA.cs:34:15:34:16 | call to constructor Object |  |
+| MultiImplementationA.cs:34:15:34:16 | enter C4 | MultiImplementationB.cs:30:15:30:16 | call to constructor Object |  |
+| MultiImplementationA.cs:34:15:34:16 | exit C4 (normal) | MultiImplementationA.cs:34:15:34:16 | exit C4 |  |
+| MultiImplementationA.cs:34:15:34:16 | {...} | MultiImplementationA.cs:34:15:34:16 | exit C4 (normal) |  |
+| MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationA.cs:36:14:36:28 | {...} |  |
+| MultiImplementationA.cs:36:9:36:10 | enter M1 | MultiImplementationB.cs:32:17:32:17 | 0 |  |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | MultiImplementationA.cs:36:9:36:10 | exit M1 |  |
+| MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) | MultiImplementationA.cs:36:9:36:10 | exit M1 |  |
+| MultiImplementationA.cs:36:14:36:28 | {...} | MultiImplementationA.cs:36:22:36:25 | null |  |
+| MultiImplementationA.cs:36:16:36:26 | throw ...; | MultiImplementationA.cs:36:9:36:10 | exit M1 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:36:22:36:25 | null | MultiImplementationA.cs:36:16:36:26 | throw ...; |  |
+| MultiImplementationA.cs:37:9:37:10 | enter M2 | MultiImplementationA.cs:37:14:37:28 | {...} |  |
+| MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | MultiImplementationA.cs:37:9:37:10 | exit M2 |  |
+| MultiImplementationA.cs:37:14:37:28 | {...} | MultiImplementationA.cs:37:22:37:25 | null |  |
+| MultiImplementationA.cs:37:16:37:26 | throw ...; | MultiImplementationA.cs:37:9:37:10 | exit M2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationA.cs:37:22:37:25 | null | MultiImplementationA.cs:37:16:37:26 | throw ...; |  |
+| MultiImplementationB.cs:1:7:1:8 | call to constructor Object | MultiImplementationB.cs:1:7:1:8 | {...} |  |
+| MultiImplementationB.cs:1:7:1:8 | {...} | MultiImplementationA.cs:4:7:4:8 | exit C1 (normal) |  |
+| MultiImplementationB.cs:3:22:3:22 | 0 | MultiImplementationA.cs:6:22:6:31 | exit get_P1 (normal) |  |
+| MultiImplementationB.cs:4:25:4:37 | {...} | MultiImplementationB.cs:4:34:4:34 | 1 |  |
+| MultiImplementationB.cs:4:27:4:35 | return ...; | MultiImplementationA.cs:7:21:7:23 | exit get_P2 (normal) | return |
+| MultiImplementationB.cs:4:34:4:34 | 1 | MultiImplementationB.cs:4:27:4:35 | return ...; |  |
+| MultiImplementationB.cs:4:43:4:45 | {...} | MultiImplementationA.cs:7:41:7:43 | exit set_P2 (normal) |  |
+| MultiImplementationB.cs:5:23:5:23 | 2 | MultiImplementationA.cs:8:16:8:16 | exit M (normal) |  |
+| MultiImplementationB.cs:11:16:11:16 | this access | MultiImplementationB.cs:11:20:11:20 | 1 |  |
+| MultiImplementationB.cs:11:16:11:20 | ... = ... | MultiImplementationB.cs:22:16:22:16 | this access |  |
+| MultiImplementationB.cs:11:20:11:20 | 1 | MultiImplementationB.cs:11:16:11:20 | ... = ... |  |
+| MultiImplementationB.cs:12:31:12:40 | throw ... | MultiImplementationA.cs:14:31:14:31 | exit get_Item (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:12:37:12:40 | null | MultiImplementationB.cs:12:31:12:40 | throw ... |  |
+| MultiImplementationB.cs:13:40:13:54 | {...} | MultiImplementationB.cs:13:48:13:51 | null |  |
+| MultiImplementationB.cs:13:42:13:52 | throw ...; | MultiImplementationA.cs:15:36:15:38 | exit get_Item (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:13:48:13:51 | null | MultiImplementationB.cs:13:42:13:52 | throw ...; |  |
+| MultiImplementationB.cs:13:60:13:62 | {...} | MultiImplementationA.cs:15:54:15:56 | exit set_Item (normal) |  |
+| MultiImplementationB.cs:15:5:17:5 | {...} | MultiImplementationB.cs:16:9:16:31 | M2(...) |  |
+| MultiImplementationB.cs:16:9:16:31 | M2(...) | MultiImplementationA.cs:16:17:16:18 | exit M1 (normal) |  |
+| MultiImplementationB.cs:16:9:16:31 | enter M2 | MultiImplementationB.cs:16:27:16:30 | null |  |
+| MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | MultiImplementationB.cs:16:9:16:31 | exit M2 |  |
+| MultiImplementationB.cs:16:21:16:30 | throw ... | MultiImplementationB.cs:16:9:16:31 | exit M2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:16:27:16:30 | null | MultiImplementationB.cs:16:21:16:30 | throw ... |  |
+| MultiImplementationB.cs:18:12:18:13 | call to constructor Object | MultiImplementationB.cs:11:16:11:16 | this access |  |
+| MultiImplementationB.cs:18:22:18:36 | {...} | MultiImplementationB.cs:18:30:18:33 | null |  |
+| MultiImplementationB.cs:18:24:18:34 | throw ...; | MultiImplementationA.cs:20:12:20:13 | exit C2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:18:30:18:33 | null | MultiImplementationB.cs:18:24:18:34 | throw ...; |  |
+| MultiImplementationB.cs:19:19:19:22 | call to constructor C2 | MultiImplementationB.cs:19:27:19:29 | {...} |  |
+| MultiImplementationB.cs:19:24:19:24 | 1 | MultiImplementationB.cs:19:19:19:22 | call to constructor C2 |  |
+| MultiImplementationB.cs:19:27:19:29 | {...} | MultiImplementationA.cs:21:12:21:13 | exit C2 (normal) |  |
+| MultiImplementationB.cs:20:11:20:25 | {...} | MultiImplementationB.cs:20:19:20:22 | null |  |
+| MultiImplementationB.cs:20:13:20:23 | throw ...; | MultiImplementationA.cs:22:6:22:7 | exit ~C2 (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:20:19:20:22 | null | MultiImplementationB.cs:20:13:20:23 | throw ...; |  |
+| MultiImplementationB.cs:21:50:21:59 | throw ... | MultiImplementationA.cs:23:28:23:35 | exit implicit conversion (abnormal) | exception(NullReferenceException) |
+| MultiImplementationB.cs:21:56:21:59 | null | MultiImplementationB.cs:21:50:21:59 | throw ... |  |
+| MultiImplementationB.cs:22:16:22:16 | access to property P | MultiImplementationB.cs:22:32:22:34 | ... = ... |  |
+| MultiImplementationB.cs:22:16:22:16 | this access | MultiImplementationB.cs:22:34:22:34 | 1 |  |
+| MultiImplementationB.cs:22:32:22:34 | ... = ... | MultiImplementationB.cs:18:22:18:36 | {...} |  |
+| MultiImplementationB.cs:22:34:22:34 | 1 | MultiImplementationB.cs:22:16:22:16 | access to property P |  |
+| MultiImplementationB.cs:25:7:25:8 | call to constructor Object | MultiImplementationB.cs:25:7:25:8 | {...} |  |
+| MultiImplementationB.cs:25:7:25:8 | {...} | MultiImplementationA.cs:28:7:28:8 | exit C3 (normal) |  |
+| MultiImplementationB.cs:30:15:30:16 | call to constructor Object | MultiImplementationB.cs:30:15:30:16 | {...} |  |
+| MultiImplementationB.cs:30:15:30:16 | {...} | MultiImplementationA.cs:34:15:34:16 | exit C4 (normal) |  |
+| MultiImplementationB.cs:32:17:32:17 | 0 | MultiImplementationA.cs:36:9:36:10 | exit M1 (normal) |  |
+| NullCoalescing.cs:1:7:1:20 | call to constructor Object | NullCoalescing.cs:1:7:1:20 | {...} |  |
+| NullCoalescing.cs:1:7:1:20 | enter NullCoalescing | NullCoalescing.cs:1:7:1:20 | call to constructor Object |  |
+| NullCoalescing.cs:1:7:1:20 | exit NullCoalescing (normal) | NullCoalescing.cs:1:7:1:20 | exit NullCoalescing |  |
+| NullCoalescing.cs:1:7:1:20 | {...} | NullCoalescing.cs:1:7:1:20 | exit NullCoalescing (normal) |  |
+| NullCoalescing.cs:3:9:3:10 | enter M1 | NullCoalescing.cs:3:23:3:23 | access to parameter i |  |
+| NullCoalescing.cs:3:9:3:10 | exit M1 (normal) | NullCoalescing.cs:3:9:3:10 | exit M1 |  |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:23:3:28 | ... ?? ... | non-null |
+| NullCoalescing.cs:3:23:3:23 | access to parameter i | NullCoalescing.cs:3:28:3:28 | 0 | null |
+| NullCoalescing.cs:3:23:3:28 | ... ?? ... | NullCoalescing.cs:3:9:3:10 | exit M1 (normal) |  |
+| NullCoalescing.cs:3:28:3:28 | 0 | NullCoalescing.cs:3:23:3:28 | ... ?? ... |  |
+| NullCoalescing.cs:5:9:5:10 | enter M2 | NullCoalescing.cs:5:25:5:25 | access to parameter b |  |
+| NullCoalescing.cs:5:9:5:10 | exit M2 (normal) | NullCoalescing.cs:5:9:5:10 | exit M2 |  |
+| NullCoalescing.cs:5:24:5:43 | ... ? ... : ... | NullCoalescing.cs:5:9:5:10 | exit M2 (normal) |  |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | false |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | true |
+| NullCoalescing.cs:5:25:5:25 | access to parameter b | NullCoalescing.cs:5:30:5:34 | false | null |
+| NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | NullCoalescing.cs:5:43:5:43 | 1 | false |
+| NullCoalescing.cs:5:25:5:34 | [true] ... ?? ... | NullCoalescing.cs:5:39:5:39 | 0 | true |
+| NullCoalescing.cs:5:30:5:34 | false | NullCoalescing.cs:5:25:5:34 | [false] ... ?? ... | false |
+| NullCoalescing.cs:5:39:5:39 | 0 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |  |
+| NullCoalescing.cs:5:43:5:43 | 1 | NullCoalescing.cs:5:24:5:43 | ... ? ... : ... |  |
+| NullCoalescing.cs:7:12:7:13 | enter M3 | NullCoalescing.cs:7:40:7:41 | access to parameter s1 |  |
+| NullCoalescing.cs:7:12:7:13 | exit M3 (normal) | NullCoalescing.cs:7:12:7:13 | exit M3 |  |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:40:7:53 | ... ?? ... | non-null |
+| NullCoalescing.cs:7:40:7:41 | access to parameter s1 | NullCoalescing.cs:7:46:7:47 | access to parameter s2 | null |
+| NullCoalescing.cs:7:40:7:53 | ... ?? ... | NullCoalescing.cs:7:12:7:13 | exit M3 (normal) |  |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:46:7:53 | ... ?? ... | non-null |
+| NullCoalescing.cs:7:46:7:47 | access to parameter s2 | NullCoalescing.cs:7:52:7:53 | "" | null |
+| NullCoalescing.cs:7:46:7:53 | ... ?? ... | NullCoalescing.cs:7:40:7:53 | ... ?? ... |  |
+| NullCoalescing.cs:7:52:7:53 | "" | NullCoalescing.cs:7:46:7:53 | ... ?? ... |  |
+| NullCoalescing.cs:9:12:9:13 | enter M4 | NullCoalescing.cs:9:37:9:37 | access to parameter b |  |
+| NullCoalescing.cs:9:12:9:13 | exit M4 (normal) | NullCoalescing.cs:9:12:9:13 | exit M4 |  |
+| NullCoalescing.cs:9:36:9:58 | ... ?? ... | NullCoalescing.cs:9:12:9:13 | exit M4 (normal) |  |
+| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:41:9:41 | access to parameter s | true |
+| NullCoalescing.cs:9:37:9:37 | access to parameter b | NullCoalescing.cs:9:45:9:45 | access to parameter s | false |
+| NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... | non-null |
+| NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | NullCoalescing.cs:9:51:9:52 | "" | null |
+| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | non-null |
+| NullCoalescing.cs:9:41:9:41 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | null |
+| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [non-null] ... ? ... : ... | non-null |
+| NullCoalescing.cs:9:45:9:45 | access to parameter s | NullCoalescing.cs:9:37:9:45 | [null] ... ? ... : ... | null |
+| NullCoalescing.cs:9:51:9:52 | "" | NullCoalescing.cs:9:51:9:58 | ... ?? ... | non-null |
+| NullCoalescing.cs:9:51:9:58 | ... ?? ... | NullCoalescing.cs:9:36:9:58 | ... ?? ... |  |
+| NullCoalescing.cs:11:9:11:10 | enter M5 | NullCoalescing.cs:11:44:11:45 | access to parameter b1 |  |
+| NullCoalescing.cs:11:9:11:10 | exit M5 (normal) | NullCoalescing.cs:11:9:11:10 | exit M5 |  |
+| NullCoalescing.cs:11:43:11:68 | ... ? ... : ... | NullCoalescing.cs:11:9:11:10 | exit M5 (normal) |  |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | false |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | true |
+| NullCoalescing.cs:11:44:11:45 | access to parameter b1 | NullCoalescing.cs:11:51:11:52 | access to parameter b2 | null |
+| NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | NullCoalescing.cs:11:68:11:68 | 1 | false |
+| NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | NullCoalescing.cs:11:64:11:64 | 0 | true |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | false |
+| NullCoalescing.cs:11:51:11:52 | access to parameter b2 | NullCoalescing.cs:11:57:11:58 | access to parameter b3 | true |
+| NullCoalescing.cs:11:51:11:58 | [false] ... && ... | NullCoalescing.cs:11:44:11:59 | [false] ... ?? ... | false |
+| NullCoalescing.cs:11:51:11:58 | [true] ... && ... | NullCoalescing.cs:11:44:11:59 | [true] ... ?? ... | true |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [false] ... && ... | false |
+| NullCoalescing.cs:11:57:11:58 | access to parameter b3 | NullCoalescing.cs:11:51:11:58 | [true] ... && ... | true |
+| NullCoalescing.cs:11:64:11:64 | 0 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |  |
+| NullCoalescing.cs:11:68:11:68 | 1 | NullCoalescing.cs:11:43:11:68 | ... ? ... : ... |  |
+| NullCoalescing.cs:13:10:13:11 | enter M6 | NullCoalescing.cs:14:5:18:5 | {...} |  |
+| NullCoalescing.cs:13:10:13:11 | exit M6 (normal) | NullCoalescing.cs:13:10:13:11 | exit M6 |  |
+| NullCoalescing.cs:14:5:18:5 | {...} | NullCoalescing.cs:15:9:15:32 | ... ...; |  |
+| NullCoalescing.cs:15:9:15:32 | ... ...; | NullCoalescing.cs:15:23:15:26 | null |  |
+| NullCoalescing.cs:15:13:15:31 | Int32 j = ... | NullCoalescing.cs:16:9:16:26 | ... ...; |  |
+| NullCoalescing.cs:15:17:15:26 | (...) ... | NullCoalescing.cs:15:31:15:31 | 0 | null |
+| NullCoalescing.cs:15:17:15:31 | ... ?? ... | NullCoalescing.cs:15:13:15:31 | Int32 j = ... |  |
+| NullCoalescing.cs:15:23:15:26 | null | NullCoalescing.cs:15:17:15:26 | (...) ... |  |
+| NullCoalescing.cs:15:31:15:31 | 0 | NullCoalescing.cs:15:17:15:31 | ... ?? ... |  |
+| NullCoalescing.cs:16:9:16:26 | ... ...; | NullCoalescing.cs:16:17:16:18 | "" |  |
+| NullCoalescing.cs:16:13:16:25 | String s = ... | NullCoalescing.cs:17:9:17:25 | ...; |  |
+| NullCoalescing.cs:16:17:16:18 | "" | NullCoalescing.cs:16:17:16:25 | ... ?? ... | non-null |
+| NullCoalescing.cs:16:17:16:25 | ... ?? ... | NullCoalescing.cs:16:13:16:25 | String s = ... |  |
+| NullCoalescing.cs:17:9:17:24 | ... = ... | NullCoalescing.cs:13:10:13:11 | exit M6 (normal) |  |
+| NullCoalescing.cs:17:9:17:25 | ...; | NullCoalescing.cs:17:19:17:19 | access to parameter i |  |
+| NullCoalescing.cs:17:13:17:19 | (...) ... | NullCoalescing.cs:17:13:17:24 | ... ?? ... | non-null |
+| NullCoalescing.cs:17:13:17:24 | ... ?? ... | NullCoalescing.cs:17:9:17:24 | ... = ... |  |
+| NullCoalescing.cs:17:19:17:19 | access to parameter i | NullCoalescing.cs:17:13:17:19 | (...) ... |  |
+| PartialImplementationA.cs:3:12:3:18 | call to constructor Object | PartialImplementationB.cs:3:16:3:16 | this access |  |
+| PartialImplementationA.cs:3:12:3:18 | enter Partial | PartialImplementationA.cs:3:12:3:18 | call to constructor Object |  |
+| PartialImplementationA.cs:3:12:3:18 | exit Partial (normal) | PartialImplementationA.cs:3:12:3:18 | exit Partial |  |
+| PartialImplementationA.cs:3:27:3:29 | {...} | PartialImplementationA.cs:3:12:3:18 | exit Partial (normal) |  |
+| PartialImplementationB.cs:3:16:3:16 | this access | PartialImplementationB.cs:3:20:3:20 | 0 |  |
+| PartialImplementationB.cs:3:16:3:16 | this access | PartialImplementationB.cs:3:20:3:20 | 0 |  |
+| PartialImplementationB.cs:3:16:3:20 | ... = ... | PartialImplementationB.cs:5:16:5:16 | this access |  |
+| PartialImplementationB.cs:3:16:3:20 | ... = ... | PartialImplementationB.cs:5:16:5:16 | this access |  |
+| PartialImplementationB.cs:3:20:3:20 | 0 | PartialImplementationB.cs:3:16:3:20 | ... = ... |  |
+| PartialImplementationB.cs:3:20:3:20 | 0 | PartialImplementationB.cs:3:16:3:20 | ... = ... |  |
+| PartialImplementationB.cs:4:12:4:18 | call to constructor Object | PartialImplementationB.cs:3:16:3:16 | this access |  |
+| PartialImplementationB.cs:4:12:4:18 | enter Partial | PartialImplementationB.cs:4:12:4:18 | call to constructor Object |  |
+| PartialImplementationB.cs:4:12:4:18 | exit Partial (normal) | PartialImplementationB.cs:4:12:4:18 | exit Partial |  |
+| PartialImplementationB.cs:4:22:4:24 | {...} | PartialImplementationB.cs:4:12:4:18 | exit Partial (normal) |  |
+| PartialImplementationB.cs:5:16:5:16 | access to property P | PartialImplementationB.cs:5:32:5:34 | ... = ... |  |
+| PartialImplementationB.cs:5:16:5:16 | access to property P | PartialImplementationB.cs:5:32:5:34 | ... = ... |  |
+| PartialImplementationB.cs:5:16:5:16 | this access | PartialImplementationB.cs:5:34:5:34 | 0 |  |
+| PartialImplementationB.cs:5:16:5:16 | this access | PartialImplementationB.cs:5:34:5:34 | 0 |  |
+| PartialImplementationB.cs:5:32:5:34 | ... = ... | PartialImplementationA.cs:3:27:3:29 | {...} |  |
+| PartialImplementationB.cs:5:32:5:34 | ... = ... | PartialImplementationB.cs:4:22:4:24 | {...} |  |
+| PartialImplementationB.cs:5:34:5:34 | 0 | PartialImplementationB.cs:5:16:5:16 | access to property P |  |
+| PartialImplementationB.cs:5:34:5:34 | 0 | PartialImplementationB.cs:5:16:5:16 | access to property P |  |
+| Patterns.cs:3:7:3:14 | call to constructor Object | Patterns.cs:3:7:3:14 | {...} |  |
+| Patterns.cs:3:7:3:14 | enter Patterns | Patterns.cs:3:7:3:14 | call to constructor Object |  |
+| Patterns.cs:3:7:3:14 | exit Patterns (normal) | Patterns.cs:3:7:3:14 | exit Patterns |  |
+| Patterns.cs:3:7:3:14 | {...} | Patterns.cs:3:7:3:14 | exit Patterns (normal) |  |
+| Patterns.cs:5:10:5:11 | enter M1 | Patterns.cs:6:5:43:5 | {...} |  |
+| Patterns.cs:5:10:5:11 | exit M1 (normal) | Patterns.cs:5:10:5:11 | exit M1 |  |
+| Patterns.cs:6:5:43:5 | {...} | Patterns.cs:7:9:7:24 | ... ...; |  |
+| Patterns.cs:7:9:7:24 | ... ...; | Patterns.cs:7:20:7:23 | null |  |
+| Patterns.cs:7:16:7:23 | Object o = ... | Patterns.cs:8:9:18:9 | if (...) ... |  |
+| Patterns.cs:7:20:7:23 | null | Patterns.cs:7:16:7:23 | Object o = ... |  |
+| Patterns.cs:8:9:18:9 | if (...) ... | Patterns.cs:8:13:8:13 | access to local variable o |  |
+| Patterns.cs:8:13:8:13 | access to local variable o | Patterns.cs:8:18:8:23 | Int32 i1 |  |
+| Patterns.cs:8:13:8:23 | [false] ... is ... | Patterns.cs:12:14:18:9 | if (...) ... | false |
+| Patterns.cs:8:13:8:23 | [true] ... is ... | Patterns.cs:9:9:11:9 | {...} | true |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [false] ... is ... | no-match |
+| Patterns.cs:8:18:8:23 | Int32 i1 | Patterns.cs:8:13:8:23 | [true] ... is ... | match |
+| Patterns.cs:9:9:11:9 | {...} | Patterns.cs:10:13:10:43 | ...; |  |
+| Patterns.cs:10:13:10:42 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} |  |
+| Patterns.cs:10:13:10:43 | ...; | Patterns.cs:10:33:10:36 | "int " |  |
+| Patterns.cs:10:31:10:41 | $"..." | Patterns.cs:10:13:10:42 | call to method WriteLine |  |
+| Patterns.cs:10:33:10:36 | "int " | Patterns.cs:10:38:10:39 | access to local variable i1 |  |
+| Patterns.cs:10:38:10:39 | access to local variable i1 | Patterns.cs:10:31:10:41 | $"..." |  |
+| Patterns.cs:12:14:18:9 | if (...) ... | Patterns.cs:12:18:12:18 | access to local variable o |  |
+| Patterns.cs:12:18:12:18 | access to local variable o | Patterns.cs:12:23:12:31 | String s1 |  |
+| Patterns.cs:12:18:12:31 | [false] ... is ... | Patterns.cs:16:14:18:9 | if (...) ... | false |
+| Patterns.cs:12:18:12:31 | [true] ... is ... | Patterns.cs:13:9:15:9 | {...} | true |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [false] ... is ... | no-match |
+| Patterns.cs:12:23:12:31 | String s1 | Patterns.cs:12:18:12:31 | [true] ... is ... | match |
+| Patterns.cs:13:9:15:9 | {...} | Patterns.cs:14:13:14:46 | ...; |  |
+| Patterns.cs:14:13:14:45 | call to method WriteLine | Patterns.cs:20:9:38:9 | switch (...) {...} |  |
+| Patterns.cs:14:13:14:46 | ...; | Patterns.cs:14:33:14:39 | "string " |  |
+| Patterns.cs:14:31:14:44 | $"..." | Patterns.cs:14:13:14:45 | call to method WriteLine |  |
+| Patterns.cs:14:33:14:39 | "string " | Patterns.cs:14:41:14:42 | access to local variable s1 |  |
+| Patterns.cs:14:41:14:42 | access to local variable s1 | Patterns.cs:14:31:14:44 | $"..." |  |
+| Patterns.cs:16:14:18:9 | if (...) ... | Patterns.cs:16:18:16:18 | access to local variable o |  |
+| Patterns.cs:16:18:16:18 | access to local variable o | Patterns.cs:16:23:16:28 | Object v1 |  |
+| Patterns.cs:16:18:16:28 | [false] ... is ... | Patterns.cs:20:9:38:9 | switch (...) {...} | false |
+| Patterns.cs:16:18:16:28 | [true] ... is ... | Patterns.cs:17:9:18:9 | {...} | true |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [false] ... is ... | no-match |
+| Patterns.cs:16:23:16:28 | Object v1 | Patterns.cs:16:18:16:28 | [true] ... is ... | match |
+| Patterns.cs:17:9:18:9 | {...} | Patterns.cs:20:9:38:9 | switch (...) {...} |  |
+| Patterns.cs:20:9:38:9 | switch (...) {...} | Patterns.cs:20:17:20:17 | access to local variable o |  |
+| Patterns.cs:20:17:20:17 | access to local variable o | Patterns.cs:22:13:22:23 | case ...: |  |
+| Patterns.cs:22:13:22:23 | case ...: | Patterns.cs:22:18:22:22 | "xyz" |  |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:23:17:23:22 | break; | match |
+| Patterns.cs:22:18:22:22 | "xyz" | Patterns.cs:24:13:24:36 | case ...: | no-match |
+| Patterns.cs:23:17:23:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:24:13:24:36 | case ...: | Patterns.cs:24:18:24:23 | Int32 i2 |  |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:24:30:24:31 | access to local variable i2 | match |
+| Patterns.cs:24:18:24:23 | Int32 i2 | Patterns.cs:27:13:27:24 | case ...: | no-match |
+| Patterns.cs:24:30:24:31 | access to local variable i2 | Patterns.cs:24:35:24:35 | 0 |  |
+| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:25:17:25:52 | ...; | true |
+| Patterns.cs:24:30:24:35 | ... > ... | Patterns.cs:27:13:27:24 | case ...: | false |
+| Patterns.cs:24:35:24:35 | 0 | Patterns.cs:24:30:24:35 | ... > ... |  |
+| Patterns.cs:25:17:25:51 | call to method WriteLine | Patterns.cs:26:17:26:22 | break; |  |
+| Patterns.cs:25:17:25:52 | ...; | Patterns.cs:25:37:25:45 | "positive " |  |
+| Patterns.cs:25:35:25:50 | $"..." | Patterns.cs:25:17:25:51 | call to method WriteLine |  |
+| Patterns.cs:25:37:25:45 | "positive " | Patterns.cs:25:47:25:48 | access to local variable i2 |  |
+| Patterns.cs:25:47:25:48 | access to local variable i2 | Patterns.cs:25:35:25:50 | $"..." |  |
+| Patterns.cs:26:17:26:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:27:13:27:24 | case ...: | Patterns.cs:27:18:27:23 | Int32 i3 |  |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:28:17:28:47 | ...; | match |
+| Patterns.cs:27:18:27:23 | Int32 i3 | Patterns.cs:30:13:30:27 | case ...: | no-match |
+| Patterns.cs:28:17:28:46 | call to method WriteLine | Patterns.cs:29:17:29:22 | break; |  |
+| Patterns.cs:28:17:28:47 | ...; | Patterns.cs:28:37:28:40 | "int " |  |
+| Patterns.cs:28:35:28:45 | $"..." | Patterns.cs:28:17:28:46 | call to method WriteLine |  |
+| Patterns.cs:28:37:28:40 | "int " | Patterns.cs:28:42:28:43 | access to local variable i3 |  |
+| Patterns.cs:28:42:28:43 | access to local variable i3 | Patterns.cs:28:35:28:45 | $"..." |  |
+| Patterns.cs:29:17:29:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:30:13:30:27 | case ...: | Patterns.cs:30:18:30:26 | String s2 |  |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:31:17:31:50 | ...; | match |
+| Patterns.cs:30:18:30:26 | String s2 | Patterns.cs:33:13:33:24 | case ...: | no-match |
+| Patterns.cs:31:17:31:49 | call to method WriteLine | Patterns.cs:32:17:32:22 | break; |  |
+| Patterns.cs:31:17:31:50 | ...; | Patterns.cs:31:37:31:43 | "string " |  |
+| Patterns.cs:31:35:31:48 | $"..." | Patterns.cs:31:17:31:49 | call to method WriteLine |  |
+| Patterns.cs:31:37:31:43 | "string " | Patterns.cs:31:45:31:46 | access to local variable s2 |  |
+| Patterns.cs:31:45:31:46 | access to local variable s2 | Patterns.cs:31:35:31:48 | $"..." |  |
+| Patterns.cs:32:17:32:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:33:13:33:24 | case ...: | Patterns.cs:33:18:33:23 | Object v2 |  |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:34:17:34:22 | break; | match |
+| Patterns.cs:33:18:33:23 | Object v2 | Patterns.cs:35:13:35:20 | default: | no-match |
+| Patterns.cs:34:17:34:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:35:13:35:20 | default: | Patterns.cs:36:17:36:52 | ...; |  |
+| Patterns.cs:36:17:36:51 | call to method WriteLine | Patterns.cs:37:17:37:22 | break; |  |
+| Patterns.cs:36:17:36:52 | ...; | Patterns.cs:36:35:36:50 | "Something else" |  |
+| Patterns.cs:36:35:36:50 | "Something else" | Patterns.cs:36:17:36:51 | call to method WriteLine |  |
+| Patterns.cs:37:17:37:22 | break; | Patterns.cs:40:9:42:9 | switch (...) {...} | break |
+| Patterns.cs:40:9:42:9 | switch (...) {...} | Patterns.cs:40:17:40:17 | access to local variable o |  |
+| Patterns.cs:40:17:40:17 | access to local variable o | Patterns.cs:5:10:5:11 | exit M1 (normal) |  |
+| Patterns.cs:47:24:47:25 | enter M2 | Patterns.cs:48:9:48:9 | access to parameter c |  |
+| Patterns.cs:47:24:47:25 | exit M2 (normal) | Patterns.cs:47:24:47:25 | exit M2 |  |
+| Patterns.cs:48:9:48:9 | access to parameter c | Patterns.cs:48:18:48:20 | a |  |
+| Patterns.cs:48:9:48:20 | ... is ... | Patterns.cs:47:24:47:25 | exit M2 (normal) |  |
+| Patterns.cs:48:14:48:20 | not ... | Patterns.cs:48:9:48:20 | ... is ... |  |
+| Patterns.cs:48:18:48:20 | a | Patterns.cs:48:14:48:20 | not ... |  |
+| Patterns.cs:50:24:50:25 | enter M3 | Patterns.cs:51:9:51:9 | access to parameter c |  |
+| Patterns.cs:50:24:50:25 | exit M3 (normal) | Patterns.cs:50:24:50:25 | exit M3 |  |
+| Patterns.cs:51:9:51:9 | access to parameter c | Patterns.cs:51:18:51:21 | null |  |
+| Patterns.cs:51:9:51:21 | [false] ... is ... | Patterns.cs:51:34:51:34 | access to parameter c | false |
+| Patterns.cs:51:9:51:21 | [true] ... is ... | Patterns.cs:51:25:51:25 | access to parameter c | true |
+| Patterns.cs:51:9:51:39 | ... ? ... : ... | Patterns.cs:50:24:50:25 | exit M3 (normal) |  |
+| Patterns.cs:51:14:51:21 | [match] not ... | Patterns.cs:51:9:51:21 | [true] ... is ... | match |
+| Patterns.cs:51:14:51:21 | [no-match] not ... | Patterns.cs:51:9:51:21 | [false] ... is ... | no-match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [match] not ... | no-match |
+| Patterns.cs:51:18:51:21 | null | Patterns.cs:51:14:51:21 | [no-match] not ... | match |
+| Patterns.cs:51:25:51:25 | access to parameter c | Patterns.cs:51:30:51:30 | 1 |  |
+| Patterns.cs:51:25:51:30 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |  |
+| Patterns.cs:51:30:51:30 | 1 | Patterns.cs:51:25:51:30 | ... is ... |  |
+| Patterns.cs:51:34:51:34 | access to parameter c | Patterns.cs:51:39:51:39 | 2 |  |
+| Patterns.cs:51:34:51:39 | ... is ... | Patterns.cs:51:9:51:39 | ... ? ... : ... |  |
+| Patterns.cs:51:39:51:39 | 2 | Patterns.cs:51:34:51:39 | ... is ... |  |
+| Patterns.cs:53:24:53:25 | enter M4 | Patterns.cs:54:9:54:9 | access to parameter c |  |
+| Patterns.cs:53:24:53:25 | exit M4 (normal) | Patterns.cs:53:24:53:25 | exit M4 |  |
+| Patterns.cs:54:9:54:9 | access to parameter c | Patterns.cs:54:18:54:37 | Patterns u |  |
+| Patterns.cs:54:9:54:37 | ... is ... | Patterns.cs:53:24:53:25 | exit M4 (normal) |  |
+| Patterns.cs:54:14:54:37 | not ... | Patterns.cs:54:9:54:37 | ... is ... |  |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:18:54:37 | { ... } | no-match |
+| Patterns.cs:54:18:54:37 | Patterns u | Patterns.cs:54:33:54:33 | 1 | match |
+| Patterns.cs:54:18:54:37 | { ... } | Patterns.cs:54:14:54:37 | not ... |  |
+| Patterns.cs:54:27:54:35 | [match] { ... } | Patterns.cs:54:18:54:37 | { ... } | match |
+| Patterns.cs:54:27:54:35 | [no-match] { ... } | Patterns.cs:54:18:54:37 | { ... } | no-match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [match] { ... } | match |
+| Patterns.cs:54:33:54:33 | 1 | Patterns.cs:54:27:54:35 | [no-match] { ... } | no-match |
+| Patterns.cs:56:26:56:27 | enter M5 | Patterns.cs:57:5:63:5 | {...} |  |
+| Patterns.cs:56:26:56:27 | exit M5 (normal) | Patterns.cs:56:26:56:27 | exit M5 |  |
+| Patterns.cs:57:5:63:5 | {...} | Patterns.cs:58:16:58:16 | access to parameter i |  |
+| Patterns.cs:58:9:62:10 | return ...; | Patterns.cs:56:26:56:27 | exit M5 (normal) | return |
+| Patterns.cs:58:16:58:16 | access to parameter i | Patterns.cs:60:17:60:17 | 1 |  |
+| Patterns.cs:58:16:62:9 | ... switch { ... } | Patterns.cs:58:9:62:10 | return ...; |  |
+| Patterns.cs:60:13:60:17 | [match] not ... | Patterns.cs:60:22:60:28 | "not 1" | match |
+| Patterns.cs:60:13:60:17 | [no-match] not ... | Patterns.cs:61:13:61:13 | _ | no-match |
+| Patterns.cs:60:13:60:28 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } |  |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [match] not ... | no-match |
+| Patterns.cs:60:17:60:17 | 1 | Patterns.cs:60:13:60:17 | [no-match] not ... | match |
+| Patterns.cs:60:22:60:28 | "not 1" | Patterns.cs:60:13:60:28 | ... => ... |  |
+| Patterns.cs:61:13:61:13 | _ | Patterns.cs:61:18:61:24 | "other" | match |
+| Patterns.cs:61:13:61:24 | ... => ... | Patterns.cs:58:16:62:9 | ... switch { ... } |  |
+| Patterns.cs:61:18:61:24 | "other" | Patterns.cs:61:13:61:24 | ... => ... |  |
+| Patterns.cs:65:26:65:27 | enter M6 | Patterns.cs:66:5:72:5 | {...} |  |
+| Patterns.cs:65:26:65:27 | exit M6 (normal) | Patterns.cs:65:26:65:27 | exit M6 |  |
+| Patterns.cs:66:5:72:5 | {...} | Patterns.cs:67:16:67:16 | 2 |  |
+| Patterns.cs:67:9:71:10 | return ...; | Patterns.cs:65:26:65:27 | exit M6 (normal) | return |
+| Patterns.cs:67:16:67:16 | 2 | Patterns.cs:69:17:69:17 | 2 |  |
+| Patterns.cs:67:16:71:9 | ... switch { ... } | Patterns.cs:67:9:71:10 | return ...; |  |
+| Patterns.cs:69:13:69:17 | [no-match] not ... | Patterns.cs:70:13:70:13 | 2 | no-match |
+| Patterns.cs:69:17:69:17 | 2 | Patterns.cs:69:13:69:17 | [no-match] not ... | match |
+| Patterns.cs:70:13:70:13 | 2 | Patterns.cs:70:18:70:27 | "possible" | match |
+| Patterns.cs:70:13:70:27 | ... => ... | Patterns.cs:67:16:71:9 | ... switch { ... } |  |
+| Patterns.cs:70:18:70:27 | "possible" | Patterns.cs:70:13:70:27 | ... => ... |  |
+| Patterns.cs:74:26:74:27 | enter M7 | Patterns.cs:75:5:83:5 | {...} |  |
+| Patterns.cs:74:26:74:27 | exit M7 (normal) | Patterns.cs:74:26:74:27 | exit M7 |  |
+| Patterns.cs:75:5:83:5 | {...} | Patterns.cs:76:16:76:16 | access to parameter i |  |
+| Patterns.cs:76:9:82:10 | return ...; | Patterns.cs:74:26:74:27 | exit M7 (normal) | return |
+| Patterns.cs:76:16:76:16 | access to parameter i | Patterns.cs:78:15:78:15 | 1 |  |
+| Patterns.cs:76:16:82:9 | ... switch { ... } | Patterns.cs:76:9:82:10 | return ...; |  |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:78:20:78:24 | "> 1" | match |
+| Patterns.cs:78:13:78:15 | > ... | Patterns.cs:79:15:79:15 | 0 | no-match |
+| Patterns.cs:78:13:78:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } |  |
+| Patterns.cs:78:15:78:15 | 1 | Patterns.cs:78:13:78:15 | > ... |  |
+| Patterns.cs:78:20:78:24 | "> 1" | Patterns.cs:78:13:78:24 | ... => ... |  |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:79:20:79:24 | "< 0" | match |
+| Patterns.cs:79:13:79:15 | < ... | Patterns.cs:80:13:80:13 | 1 | no-match |
+| Patterns.cs:79:13:79:24 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } |  |
+| Patterns.cs:79:15:79:15 | 0 | Patterns.cs:79:13:79:15 | < ... |  |
+| Patterns.cs:79:20:79:24 | "< 0" | Patterns.cs:79:13:79:24 | ... => ... |  |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:80:18:80:20 | "1" | match |
+| Patterns.cs:80:13:80:13 | 1 | Patterns.cs:81:13:81:13 | _ | no-match |
+| Patterns.cs:80:13:80:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } |  |
+| Patterns.cs:80:18:80:20 | "1" | Patterns.cs:80:13:80:20 | ... => ... |  |
+| Patterns.cs:81:13:81:13 | _ | Patterns.cs:81:18:81:20 | "0" | match |
+| Patterns.cs:81:13:81:20 | ... => ... | Patterns.cs:76:16:82:9 | ... switch { ... } |  |
+| Patterns.cs:81:18:81:20 | "0" | Patterns.cs:81:13:81:20 | ... => ... |  |
+| Patterns.cs:85:26:85:27 | enter M8 | Patterns.cs:85:39:85:39 | access to parameter i |  |
+| Patterns.cs:85:26:85:27 | exit M8 (normal) | Patterns.cs:85:26:85:27 | exit M8 |  |
+| Patterns.cs:85:39:85:39 | access to parameter i | Patterns.cs:85:44:85:44 | 1 |  |
+| Patterns.cs:85:39:85:53 | [false] ... is ... | Patterns.cs:85:67:85:69 | "2" | false |
+| Patterns.cs:85:39:85:53 | [true] ... is ... | Patterns.cs:85:57:85:63 | "not 2" | true |
+| Patterns.cs:85:39:85:69 | ... ? ... : ... | Patterns.cs:85:26:85:27 | exit M8 (normal) |  |
+| Patterns.cs:85:44:85:44 | 1 | Patterns.cs:85:44:85:53 | [match] ... or ... | match |
+| Patterns.cs:85:44:85:44 | 1 | Patterns.cs:85:53:85:53 | 2 | no-match |
+| Patterns.cs:85:44:85:53 | [match] ... or ... | Patterns.cs:85:39:85:53 | [true] ... is ... | match |
+| Patterns.cs:85:44:85:53 | [no-match] ... or ... | Patterns.cs:85:39:85:53 | [false] ... is ... | no-match |
+| Patterns.cs:85:49:85:53 | [match] not ... | Patterns.cs:85:44:85:53 | [match] ... or ... | match |
+| Patterns.cs:85:49:85:53 | [no-match] not ... | Patterns.cs:85:44:85:53 | [no-match] ... or ... | no-match |
+| Patterns.cs:85:53:85:53 | 2 | Patterns.cs:85:49:85:53 | [match] not ... | no-match |
+| Patterns.cs:85:53:85:53 | 2 | Patterns.cs:85:49:85:53 | [no-match] not ... | match |
+| Patterns.cs:85:57:85:63 | "not 2" | Patterns.cs:85:39:85:69 | ... ? ... : ... |  |
+| Patterns.cs:85:67:85:69 | "2" | Patterns.cs:85:39:85:69 | ... ? ... : ... |  |
+| Patterns.cs:87:26:87:27 | enter M9 | Patterns.cs:87:39:87:39 | access to parameter i |  |
+| Patterns.cs:87:26:87:27 | exit M9 (normal) | Patterns.cs:87:26:87:27 | exit M9 |  |
+| Patterns.cs:87:39:87:39 | access to parameter i | Patterns.cs:87:44:87:44 | 1 |  |
+| Patterns.cs:87:39:87:54 | [false] ... is ... | Patterns.cs:87:64:87:70 | "not 1" | false |
+| Patterns.cs:87:39:87:54 | [true] ... is ... | Patterns.cs:87:58:87:60 | "1" | true |
+| Patterns.cs:87:39:87:70 | ... ? ... : ... | Patterns.cs:87:26:87:27 | exit M9 (normal) |  |
+| Patterns.cs:87:44:87:44 | 1 | Patterns.cs:87:44:87:54 | [no-match] ... and ... | no-match |
+| Patterns.cs:87:44:87:44 | 1 | Patterns.cs:87:54:87:54 | 2 | match |
+| Patterns.cs:87:44:87:54 | [match] ... and ... | Patterns.cs:87:39:87:54 | [true] ... is ... | match |
+| Patterns.cs:87:44:87:54 | [no-match] ... and ... | Patterns.cs:87:39:87:54 | [false] ... is ... | no-match |
+| Patterns.cs:87:50:87:54 | [match] not ... | Patterns.cs:87:44:87:54 | [match] ... and ... | match |
+| Patterns.cs:87:50:87:54 | [no-match] not ... | Patterns.cs:87:44:87:54 | [no-match] ... and ... | no-match |
+| Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [match] not ... | no-match |
+| Patterns.cs:87:54:87:54 | 2 | Patterns.cs:87:50:87:54 | [no-match] not ... | match |
+| Patterns.cs:87:58:87:60 | "1" | Patterns.cs:87:39:87:70 | ... ? ... : ... |  |
+| Patterns.cs:87:64:87:70 | "not 1" | Patterns.cs:87:39:87:70 | ... ? ... : ... |  |
+| Patterns.cs:93:17:93:19 | enter M10 | Patterns.cs:94:5:99:5 | {...} |  |
+| Patterns.cs:93:17:93:19 | exit M10 (normal) | Patterns.cs:93:17:93:19 | exit M10 |  |
+| Patterns.cs:94:5:99:5 | {...} | Patterns.cs:95:9:98:9 | if (...) ... |  |
+| Patterns.cs:95:9:98:9 | if (...) ... | Patterns.cs:95:13:95:16 | this access |  |
+| Patterns.cs:95:13:95:16 | this access | Patterns.cs:95:29:95:31 | access to constant A |  |
+| Patterns.cs:95:13:95:40 | [false] ... is ... | Patterns.cs:93:17:93:19 | exit M10 (normal) | false |
+| Patterns.cs:95:13:95:40 | [true] ... is ... | Patterns.cs:96:9:98:9 | {...} | true |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:13:95:40 | [true] ... is ... | match |
+| Patterns.cs:95:21:95:40 | [match] { ... } | Patterns.cs:95:21:95:40 | [match] { ... } | match |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:13:95:40 | [false] ... is ... | no-match |
+| Patterns.cs:95:21:95:40 | [no-match] { ... } | Patterns.cs:95:21:95:40 | [no-match] { ... } | no-match |
+| Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:29:95:38 | [match] ... or ... | match |
+| Patterns.cs:95:29:95:31 | access to constant A | Patterns.cs:95:36:95:38 | access to constant B | no-match |
+| Patterns.cs:95:29:95:38 | [match] ... or ... | Patterns.cs:95:21:95:40 | [match] { ... } | match |
+| Patterns.cs:95:29:95:38 | [no-match] ... or ... | Patterns.cs:95:21:95:40 | [no-match] { ... } | no-match |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [match] ... or ... | match |
+| Patterns.cs:95:36:95:38 | access to constant B | Patterns.cs:95:29:95:38 | [no-match] ... or ... | no-match |
+| Patterns.cs:96:9:98:9 | {...} | Patterns.cs:97:13:97:39 | ...; |  |
+| Patterns.cs:97:13:97:38 | call to method WriteLine | Patterns.cs:93:17:93:19 | exit M10 (normal) |  |
+| Patterns.cs:97:13:97:39 | ...; | Patterns.cs:97:31:97:37 | "not C" |  |
+| Patterns.cs:97:31:97:37 | "not C" | Patterns.cs:97:13:97:38 | call to method WriteLine |  |
+| PostDominance.cs:3:7:3:19 | call to constructor Object | PostDominance.cs:3:7:3:19 | {...} |  |
+| PostDominance.cs:3:7:3:19 | enter PostDominance | PostDominance.cs:3:7:3:19 | call to constructor Object |  |
+| PostDominance.cs:3:7:3:19 | exit PostDominance (normal) | PostDominance.cs:3:7:3:19 | exit PostDominance |  |
+| PostDominance.cs:3:7:3:19 | {...} | PostDominance.cs:3:7:3:19 | exit PostDominance (normal) |  |
+| PostDominance.cs:5:10:5:11 | enter M1 | PostDominance.cs:6:5:8:5 | {...} |  |
+| PostDominance.cs:5:10:5:11 | exit M1 (normal) | PostDominance.cs:5:10:5:11 | exit M1 |  |
+| PostDominance.cs:6:5:8:5 | {...} | PostDominance.cs:7:9:7:29 | ...; |  |
+| PostDominance.cs:7:9:7:28 | call to method WriteLine | PostDominance.cs:5:10:5:11 | exit M1 (normal) |  |
+| PostDominance.cs:7:9:7:29 | ...; | PostDominance.cs:7:27:7:27 | access to parameter s |  |
+| PostDominance.cs:7:27:7:27 | access to parameter s | PostDominance.cs:7:9:7:28 | call to method WriteLine |  |
+| PostDominance.cs:10:10:10:11 | enter M2 | PostDominance.cs:11:5:15:5 | {...} |  |
+| PostDominance.cs:10:10:10:11 | exit M2 (normal) | PostDominance.cs:10:10:10:11 | exit M2 |  |
+| PostDominance.cs:11:5:15:5 | {...} | PostDominance.cs:12:9:13:19 | if (...) ... |  |
+| PostDominance.cs:12:9:13:19 | if (...) ... | PostDominance.cs:12:13:12:13 | access to parameter s |  |
+| PostDominance.cs:12:13:12:13 | access to parameter s | PostDominance.cs:12:18:12:21 | null |  |
+| PostDominance.cs:12:13:12:21 | [false] ... is ... | PostDominance.cs:14:9:14:29 | ...; | false |
+| PostDominance.cs:12:13:12:21 | [true] ... is ... | PostDominance.cs:13:13:13:19 | return ...; | true |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [false] ... is ... | no-match |
+| PostDominance.cs:12:18:12:21 | null | PostDominance.cs:12:13:12:21 | [true] ... is ... | match |
+| PostDominance.cs:13:13:13:19 | return ...; | PostDominance.cs:10:10:10:11 | exit M2 (normal) | return |
+| PostDominance.cs:14:9:14:28 | call to method WriteLine | PostDominance.cs:10:10:10:11 | exit M2 (normal) |  |
+| PostDominance.cs:14:9:14:29 | ...; | PostDominance.cs:14:27:14:27 | access to parameter s |  |
+| PostDominance.cs:14:27:14:27 | access to parameter s | PostDominance.cs:14:9:14:28 | call to method WriteLine |  |
+| PostDominance.cs:17:10:17:11 | enter M3 | PostDominance.cs:18:5:22:5 | {...} |  |
+| PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | PostDominance.cs:17:10:17:11 | exit M3 |  |
+| PostDominance.cs:17:10:17:11 | exit M3 (normal) | PostDominance.cs:17:10:17:11 | exit M3 |  |
+| PostDominance.cs:18:5:22:5 | {...} | PostDominance.cs:19:9:20:55 | if (...) ... |  |
+| PostDominance.cs:19:9:20:55 | if (...) ... | PostDominance.cs:19:13:19:13 | access to parameter s |  |
+| PostDominance.cs:19:13:19:13 | access to parameter s | PostDominance.cs:19:18:19:21 | null |  |
+| PostDominance.cs:19:13:19:21 | [false] ... is ... | PostDominance.cs:21:9:21:29 | ...; | false |
+| PostDominance.cs:19:13:19:21 | [true] ... is ... | PostDominance.cs:20:45:20:53 | nameof(...) | true |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [false] ... is ... | no-match |
+| PostDominance.cs:19:18:19:21 | null | PostDominance.cs:19:13:19:21 | [true] ... is ... | match |
+| PostDominance.cs:20:13:20:55 | throw ...; | PostDominance.cs:17:10:17:11 | exit M3 (abnormal) | exception(ArgumentNullException) |
+| PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException | PostDominance.cs:20:13:20:55 | throw ...; |  |
+| PostDominance.cs:20:45:20:53 | nameof(...) | PostDominance.cs:20:19:20:54 | object creation of type ArgumentNullException |  |
+| PostDominance.cs:21:9:21:28 | call to method WriteLine | PostDominance.cs:17:10:17:11 | exit M3 (normal) |  |
+| PostDominance.cs:21:9:21:29 | ...; | PostDominance.cs:21:27:21:27 | access to parameter s |  |
+| PostDominance.cs:21:27:21:27 | access to parameter s | PostDominance.cs:21:9:21:28 | call to method WriteLine |  |
+| Qualifiers.cs:1:7:1:16 | call to constructor Object | Qualifiers.cs:1:7:1:16 | {...} |  |
+| Qualifiers.cs:1:7:1:16 | enter Qualifiers | Qualifiers.cs:1:7:1:16 | call to constructor Object |  |
+| Qualifiers.cs:1:7:1:16 | exit Qualifiers (normal) | Qualifiers.cs:1:7:1:16 | exit Qualifiers |  |
+| Qualifiers.cs:1:7:1:16 | {...} | Qualifiers.cs:1:7:1:16 | exit Qualifiers (normal) |  |
+| Qualifiers.cs:7:16:7:21 | enter Method | Qualifiers.cs:7:28:7:31 | null |  |
+| Qualifiers.cs:7:16:7:21 | exit Method (normal) | Qualifiers.cs:7:16:7:21 | exit Method |  |
+| Qualifiers.cs:7:28:7:31 | null | Qualifiers.cs:7:16:7:21 | exit Method (normal) |  |
+| Qualifiers.cs:8:23:8:34 | enter StaticMethod | Qualifiers.cs:8:41:8:44 | null |  |
+| Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) | Qualifiers.cs:8:23:8:34 | exit StaticMethod |  |
+| Qualifiers.cs:8:41:8:44 | null | Qualifiers.cs:8:23:8:34 | exit StaticMethod (normal) |  |
+| Qualifiers.cs:10:10:10:10 | enter M | Qualifiers.cs:11:5:31:5 | {...} |  |
+| Qualifiers.cs:10:10:10:10 | exit M (normal) | Qualifiers.cs:10:10:10:10 | exit M |  |
+| Qualifiers.cs:11:5:31:5 | {...} | Qualifiers.cs:12:9:12:22 | ... ...; |  |
+| Qualifiers.cs:12:9:12:22 | ... ...; | Qualifiers.cs:12:17:12:21 | this access |  |
+| Qualifiers.cs:12:13:12:21 | Qualifiers q = ... | Qualifiers.cs:13:9:13:21 | ...; |  |
+| Qualifiers.cs:12:17:12:21 | access to field Field | Qualifiers.cs:12:13:12:21 | Qualifiers q = ... |  |
+| Qualifiers.cs:12:17:12:21 | this access | Qualifiers.cs:12:17:12:21 | access to field Field |  |
+| Qualifiers.cs:13:9:13:20 | ... = ... | Qualifiers.cs:14:9:14:21 | ...; |  |
+| Qualifiers.cs:13:9:13:21 | ...; | Qualifiers.cs:13:13:13:20 | this access |  |
+| Qualifiers.cs:13:13:13:20 | access to property Property | Qualifiers.cs:13:9:13:20 | ... = ... |  |
+| Qualifiers.cs:13:13:13:20 | this access | Qualifiers.cs:13:13:13:20 | access to property Property |  |
+| Qualifiers.cs:14:9:14:20 | ... = ... | Qualifiers.cs:16:9:16:23 | ...; |  |
+| Qualifiers.cs:14:9:14:21 | ...; | Qualifiers.cs:14:13:14:20 | this access |  |
+| Qualifiers.cs:14:13:14:20 | call to method Method | Qualifiers.cs:14:9:14:20 | ... = ... |  |
+| Qualifiers.cs:14:13:14:20 | this access | Qualifiers.cs:14:13:14:20 | call to method Method |  |
+| Qualifiers.cs:16:9:16:22 | ... = ... | Qualifiers.cs:17:9:17:26 | ...; |  |
+| Qualifiers.cs:16:9:16:23 | ...; | Qualifiers.cs:16:13:16:16 | this access |  |
+| Qualifiers.cs:16:13:16:16 | this access | Qualifiers.cs:16:13:16:22 | access to field Field |  |
+| Qualifiers.cs:16:13:16:22 | access to field Field | Qualifiers.cs:16:9:16:22 | ... = ... |  |
+| Qualifiers.cs:17:9:17:25 | ... = ... | Qualifiers.cs:18:9:18:26 | ...; |  |
+| Qualifiers.cs:17:9:17:26 | ...; | Qualifiers.cs:17:13:17:16 | this access |  |
+| Qualifiers.cs:17:13:17:16 | this access | Qualifiers.cs:17:13:17:25 | access to property Property |  |
+| Qualifiers.cs:17:13:17:25 | access to property Property | Qualifiers.cs:17:9:17:25 | ... = ... |  |
+| Qualifiers.cs:18:9:18:25 | ... = ... | Qualifiers.cs:20:9:20:24 | ...; |  |
+| Qualifiers.cs:18:9:18:26 | ...; | Qualifiers.cs:18:13:18:16 | this access |  |
+| Qualifiers.cs:18:13:18:16 | this access | Qualifiers.cs:18:13:18:25 | call to method Method |  |
+| Qualifiers.cs:18:13:18:25 | call to method Method | Qualifiers.cs:18:9:18:25 | ... = ... |  |
+| Qualifiers.cs:20:9:20:23 | ... = ... | Qualifiers.cs:21:9:21:27 | ...; |  |
+| Qualifiers.cs:20:9:20:24 | ...; | Qualifiers.cs:20:13:20:23 | access to field StaticField |  |
+| Qualifiers.cs:20:13:20:23 | access to field StaticField | Qualifiers.cs:20:9:20:23 | ... = ... |  |
+| Qualifiers.cs:21:9:21:26 | ... = ... | Qualifiers.cs:22:9:22:27 | ...; |  |
+| Qualifiers.cs:21:9:21:27 | ...; | Qualifiers.cs:21:13:21:26 | access to property StaticProperty |  |
+| Qualifiers.cs:21:13:21:26 | access to property StaticProperty | Qualifiers.cs:21:9:21:26 | ... = ... |  |
+| Qualifiers.cs:22:9:22:26 | ... = ... | Qualifiers.cs:24:9:24:35 | ...; |  |
+| Qualifiers.cs:22:9:22:27 | ...; | Qualifiers.cs:22:13:22:26 | call to method StaticMethod |  |
+| Qualifiers.cs:22:13:22:26 | call to method StaticMethod | Qualifiers.cs:22:9:22:26 | ... = ... |  |
+| Qualifiers.cs:24:9:24:34 | ... = ... | Qualifiers.cs:25:9:25:38 | ...; |  |
+| Qualifiers.cs:24:9:24:35 | ...; | Qualifiers.cs:24:13:24:34 | access to field StaticField |  |
+| Qualifiers.cs:24:13:24:34 | access to field StaticField | Qualifiers.cs:24:9:24:34 | ... = ... |  |
+| Qualifiers.cs:25:9:25:37 | ... = ... | Qualifiers.cs:26:9:26:38 | ...; |  |
+| Qualifiers.cs:25:9:25:38 | ...; | Qualifiers.cs:25:13:25:37 | access to property StaticProperty |  |
+| Qualifiers.cs:25:13:25:37 | access to property StaticProperty | Qualifiers.cs:25:9:25:37 | ... = ... |  |
+| Qualifiers.cs:26:9:26:37 | ... = ... | Qualifiers.cs:28:9:28:41 | ...; |  |
+| Qualifiers.cs:26:9:26:38 | ...; | Qualifiers.cs:26:13:26:37 | call to method StaticMethod |  |
+| Qualifiers.cs:26:13:26:37 | call to method StaticMethod | Qualifiers.cs:26:9:26:37 | ... = ... |  |
+| Qualifiers.cs:28:9:28:40 | ... = ... | Qualifiers.cs:29:9:29:47 | ...; |  |
+| Qualifiers.cs:28:9:28:41 | ...; | Qualifiers.cs:28:13:28:34 | access to field StaticField |  |
+| Qualifiers.cs:28:13:28:34 | access to field StaticField | Qualifiers.cs:28:13:28:40 | access to field Field |  |
+| Qualifiers.cs:28:13:28:40 | access to field Field | Qualifiers.cs:28:9:28:40 | ... = ... |  |
+| Qualifiers.cs:29:9:29:46 | ... = ... | Qualifiers.cs:30:9:30:47 | ...; |  |
+| Qualifiers.cs:29:9:29:47 | ...; | Qualifiers.cs:29:13:29:37 | access to property StaticProperty |  |
+| Qualifiers.cs:29:13:29:37 | access to property StaticProperty | Qualifiers.cs:29:13:29:46 | access to property Property |  |
+| Qualifiers.cs:29:13:29:46 | access to property Property | Qualifiers.cs:29:9:29:46 | ... = ... |  |
+| Qualifiers.cs:30:9:30:46 | ... = ... | Qualifiers.cs:10:10:10:10 | exit M (normal) |  |
+| Qualifiers.cs:30:9:30:47 | ...; | Qualifiers.cs:30:13:30:37 | call to method StaticMethod |  |
+| Qualifiers.cs:30:13:30:37 | call to method StaticMethod | Qualifiers.cs:30:13:30:46 | call to method Method |  |
+| Qualifiers.cs:30:13:30:46 | call to method Method | Qualifiers.cs:30:9:30:46 | ... = ... |  |
+| Switch.cs:3:7:3:12 | call to constructor Object | Switch.cs:3:7:3:12 | {...} |  |
+| Switch.cs:3:7:3:12 | enter Switch | Switch.cs:3:7:3:12 | call to constructor Object |  |
+| Switch.cs:3:7:3:12 | exit Switch (normal) | Switch.cs:3:7:3:12 | exit Switch |  |
+| Switch.cs:3:7:3:12 | {...} | Switch.cs:3:7:3:12 | exit Switch (normal) |  |
+| Switch.cs:5:10:5:11 | enter M1 | Switch.cs:6:5:8:5 | {...} |  |
+| Switch.cs:5:10:5:11 | exit M1 (normal) | Switch.cs:5:10:5:11 | exit M1 |  |
+| Switch.cs:6:5:8:5 | {...} | Switch.cs:7:9:7:22 | switch (...) {...} |  |
+| Switch.cs:7:9:7:22 | switch (...) {...} | Switch.cs:7:17:7:17 | access to parameter o |  |
+| Switch.cs:7:17:7:17 | access to parameter o | Switch.cs:5:10:5:11 | exit M1 (normal) |  |
+| Switch.cs:10:10:10:11 | enter M2 | Switch.cs:11:5:33:5 | {...} |  |
+| Switch.cs:10:10:10:11 | exit M2 (abnormal) | Switch.cs:10:10:10:11 | exit M2 |  |
+| Switch.cs:10:10:10:11 | exit M2 (normal) | Switch.cs:10:10:10:11 | exit M2 |  |
+| Switch.cs:11:5:33:5 | {...} | Switch.cs:12:9:32:9 | switch (...) {...} |  |
+| Switch.cs:12:9:32:9 | switch (...) {...} | Switch.cs:12:17:12:17 | access to parameter o |  |
+| Switch.cs:12:17:12:17 | access to parameter o | Switch.cs:14:13:14:21 | case ...: |  |
+| Switch.cs:14:13:14:21 | case ...: | Switch.cs:14:18:14:20 | "a" |  |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:15:17:15:23 | return ...; | match |
+| Switch.cs:14:18:14:20 | "a" | Switch.cs:16:13:16:19 | case ...: | no-match |
+| Switch.cs:15:17:15:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | return |
+| Switch.cs:16:13:16:19 | case ...: | Switch.cs:16:18:16:18 | 0 |  |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:17:23:17:37 | object creation of type Exception | match |
+| Switch.cs:16:18:16:18 | 0 | Switch.cs:18:13:18:22 | case ...: | no-match |
+| Switch.cs:17:17:17:38 | throw ...; | Switch.cs:10:10:10:11 | exit M2 (abnormal) | exception(Exception) |
+| Switch.cs:17:23:17:37 | object creation of type Exception | Switch.cs:17:17:17:38 | throw ...; |  |
+| Switch.cs:18:13:18:22 | case ...: | Switch.cs:18:18:18:21 | null |  |
+| Switch.cs:18:18:18:21 | null | Switch.cs:19:17:19:29 | goto default; | match |
+| Switch.cs:18:18:18:21 | null | Switch.cs:20:13:20:23 | case ...: | no-match |
+| Switch.cs:19:17:19:29 | goto default; | Switch.cs:30:13:30:20 | default: | goto(default) |
+| Switch.cs:20:13:20:23 | case ...: | Switch.cs:20:18:20:22 | Int32 i |  |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:21:17:22:27 | if (...) ... | match |
+| Switch.cs:20:18:20:22 | Int32 i | Switch.cs:24:13:24:56 | case ...: | no-match |
+| Switch.cs:21:17:22:27 | if (...) ... | Switch.cs:21:21:21:21 | access to parameter o |  |
+| Switch.cs:21:21:21:21 | access to parameter o | Switch.cs:21:26:21:29 | null |  |
+| Switch.cs:21:21:21:29 | ... == ... | Switch.cs:22:21:22:27 | return ...; | true |
+| Switch.cs:21:21:21:29 | ... == ... | Switch.cs:23:27:23:27 | 0 | false |
+| Switch.cs:21:26:21:29 | null | Switch.cs:21:21:21:29 | ... == ... |  |
+| Switch.cs:22:21:22:27 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | return |
+| Switch.cs:23:17:23:28 | goto case ...; | Switch.cs:16:13:16:19 | case ...: | goto(0) |
+| Switch.cs:23:27:23:27 | 0 | Switch.cs:23:17:23:28 | goto case ...; |  |
+| Switch.cs:24:13:24:56 | case ...: | Switch.cs:24:18:24:25 | String s |  |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:24:32:24:32 | access to local variable s | match |
+| Switch.cs:24:18:24:25 | String s | Switch.cs:27:13:27:39 | case ...: | no-match |
+| Switch.cs:24:32:24:32 | access to local variable s | Switch.cs:24:32:24:39 | access to property Length |  |
+| Switch.cs:24:32:24:39 | access to property Length | Switch.cs:24:43:24:43 | 0 |  |
+| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:24:32:24:43 | ... > ... | Switch.cs:24:48:24:48 | access to local variable s | true |
+| Switch.cs:24:32:24:55 | [false] ... && ... | Switch.cs:27:13:27:39 | case ...: | false |
+| Switch.cs:24:32:24:55 | [true] ... && ... | Switch.cs:25:17:25:37 | ...; | true |
+| Switch.cs:24:43:24:43 | 0 | Switch.cs:24:32:24:43 | ... > ... |  |
+| Switch.cs:24:48:24:48 | access to local variable s | Switch.cs:24:53:24:55 | "a" |  |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [false] ... && ... | false |
+| Switch.cs:24:48:24:55 | ... != ... | Switch.cs:24:32:24:55 | [true] ... && ... | true |
+| Switch.cs:24:53:24:55 | "a" | Switch.cs:24:48:24:55 | ... != ... |  |
+| Switch.cs:25:17:25:36 | call to method WriteLine | Switch.cs:26:17:26:23 | return ...; |  |
+| Switch.cs:25:17:25:37 | ...; | Switch.cs:25:35:25:35 | access to local variable s |  |
+| Switch.cs:25:35:25:35 | access to local variable s | Switch.cs:25:17:25:36 | call to method WriteLine |  |
+| Switch.cs:26:17:26:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | return |
+| Switch.cs:27:13:27:39 | case ...: | Switch.cs:27:18:27:25 | Double d |  |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:27:32:27:38 | call to method Throw | match |
+| Switch.cs:27:18:27:25 | Double d | Switch.cs:30:13:30:20 | default: | no-match |
+| Switch.cs:27:32:27:38 | call to method Throw | Switch.cs:10:10:10:11 | exit M2 (abnormal) | exception(Exception) |
+| Switch.cs:28:13:28:17 | Label: | Switch.cs:29:17:29:23 | return ...; |  |
+| Switch.cs:29:17:29:23 | return ...; | Switch.cs:10:10:10:11 | exit M2 (normal) | return |
+| Switch.cs:30:13:30:20 | default: | Switch.cs:31:17:31:27 | goto ...; |  |
+| Switch.cs:31:17:31:27 | goto ...; | Switch.cs:28:13:28:17 | Label: | goto(Label) |
+| Switch.cs:35:10:35:11 | enter M3 | Switch.cs:36:5:42:5 | {...} |  |
+| Switch.cs:35:10:35:11 | exit M3 (abnormal) | Switch.cs:35:10:35:11 | exit M3 |  |
+| Switch.cs:36:5:42:5 | {...} | Switch.cs:37:9:41:9 | switch (...) {...} |  |
+| Switch.cs:37:9:41:9 | switch (...) {...} | Switch.cs:37:17:37:23 | call to method Throw |  |
+| Switch.cs:37:17:37:23 | call to method Throw | Switch.cs:35:10:35:11 | exit M3 (abnormal) | exception(Exception) |
+| Switch.cs:44:10:44:11 | enter M4 | Switch.cs:45:5:53:5 | {...} |  |
+| Switch.cs:44:10:44:11 | exit M4 (normal) | Switch.cs:44:10:44:11 | exit M4 |  |
+| Switch.cs:45:5:53:5 | {...} | Switch.cs:46:9:52:9 | switch (...) {...} |  |
+| Switch.cs:46:9:52:9 | switch (...) {...} | Switch.cs:46:17:46:17 | access to parameter o |  |
+| Switch.cs:46:17:46:17 | access to parameter o | Switch.cs:48:13:48:23 | case ...: |  |
+| Switch.cs:48:13:48:23 | case ...: | Switch.cs:48:18:48:20 | access to type Int32 |  |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:49:17:49:22 | break; | match |
+| Switch.cs:48:18:48:20 | access to type Int32 | Switch.cs:50:13:50:39 | case ...: | no-match |
+| Switch.cs:49:17:49:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | break |
+| Switch.cs:50:13:50:39 | case ...: | Switch.cs:50:18:50:21 | access to type Boolean |  |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:44:10:44:11 | exit M4 (normal) | no-match |
+| Switch.cs:50:18:50:21 | access to type Boolean | Switch.cs:50:30:50:30 | access to parameter o | match |
+| Switch.cs:50:30:50:30 | access to parameter o | Switch.cs:50:35:50:38 | null |  |
+| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:44:10:44:11 | exit M4 (normal) | false |
+| Switch.cs:50:30:50:38 | ... != ... | Switch.cs:51:17:51:22 | break; | true |
+| Switch.cs:50:35:50:38 | null | Switch.cs:50:30:50:38 | ... != ... |  |
+| Switch.cs:51:17:51:22 | break; | Switch.cs:44:10:44:11 | exit M4 (normal) | break |
+| Switch.cs:55:10:55:11 | enter M5 | Switch.cs:56:5:64:5 | {...} |  |
+| Switch.cs:55:10:55:11 | exit M5 (normal) | Switch.cs:55:10:55:11 | exit M5 |  |
+| Switch.cs:56:5:64:5 | {...} | Switch.cs:57:9:63:9 | switch (...) {...} |  |
+| Switch.cs:57:9:63:9 | switch (...) {...} | Switch.cs:57:17:57:17 | 1 |  |
+| Switch.cs:57:17:57:17 | 1 | Switch.cs:57:21:57:21 | 2 |  |
+| Switch.cs:57:17:57:21 | ... + ... | Switch.cs:59:13:59:19 | case ...: |  |
+| Switch.cs:57:21:57:21 | 2 | Switch.cs:57:17:57:21 | ... + ... |  |
+| Switch.cs:59:13:59:19 | case ...: | Switch.cs:59:18:59:18 | 2 |  |
+| Switch.cs:59:18:59:18 | 2 | Switch.cs:61:13:61:19 | case ...: | no-match |
+| Switch.cs:61:13:61:19 | case ...: | Switch.cs:61:18:61:18 | 3 |  |
+| Switch.cs:61:18:61:18 | 3 | Switch.cs:62:17:62:22 | break; | match |
+| Switch.cs:62:17:62:22 | break; | Switch.cs:55:10:55:11 | exit M5 (normal) | break |
+| Switch.cs:66:10:66:11 | enter M6 | Switch.cs:67:5:75:5 | {...} |  |
+| Switch.cs:66:10:66:11 | exit M6 (normal) | Switch.cs:66:10:66:11 | exit M6 |  |
+| Switch.cs:67:5:75:5 | {...} | Switch.cs:68:9:74:9 | switch (...) {...} |  |
+| Switch.cs:68:9:74:9 | switch (...) {...} | Switch.cs:68:25:68:25 | access to parameter s |  |
+| Switch.cs:68:17:68:25 | (...) ... | Switch.cs:70:13:70:23 | case ...: |  |
+| Switch.cs:68:25:68:25 | access to parameter s | Switch.cs:68:17:68:25 | (...) ... |  |
+| Switch.cs:70:13:70:23 | case ...: | Switch.cs:70:18:70:20 | access to type Int32 |  |
+| Switch.cs:70:18:70:20 | access to type Int32 | Switch.cs:72:13:72:20 | case ...: | no-match |
+| Switch.cs:72:13:72:20 | case ...: | Switch.cs:72:18:72:19 | "" |  |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:66:10:66:11 | exit M6 (normal) | no-match |
+| Switch.cs:72:18:72:19 | "" | Switch.cs:73:17:73:22 | break; | match |
+| Switch.cs:73:17:73:22 | break; | Switch.cs:66:10:66:11 | exit M6 (normal) | break |
+| Switch.cs:77:10:77:11 | enter M7 | Switch.cs:78:5:89:5 | {...} |  |
+| Switch.cs:77:10:77:11 | exit M7 (normal) | Switch.cs:77:10:77:11 | exit M7 |  |
+| Switch.cs:78:5:89:5 | {...} | Switch.cs:79:9:87:9 | switch (...) {...} |  |
+| Switch.cs:79:9:87:9 | switch (...) {...} | Switch.cs:79:17:79:17 | access to parameter i |  |
+| Switch.cs:79:17:79:17 | access to parameter i | Switch.cs:81:13:81:19 | case ...: |  |
+| Switch.cs:81:13:81:19 | case ...: | Switch.cs:81:18:81:18 | 1 |  |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:82:24:82:27 | true | match |
+| Switch.cs:81:18:81:18 | 1 | Switch.cs:83:13:83:19 | case ...: | no-match |
+| Switch.cs:82:17:82:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | return |
+| Switch.cs:82:24:82:27 | true | Switch.cs:82:17:82:28 | return ...; |  |
+| Switch.cs:83:13:83:19 | case ...: | Switch.cs:83:18:83:18 | 2 |  |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:84:17:85:26 | if (...) ... | match |
+| Switch.cs:83:18:83:18 | 2 | Switch.cs:88:16:88:20 | false | no-match |
+| Switch.cs:84:17:85:26 | if (...) ... | Switch.cs:84:21:84:21 | access to parameter j |  |
+| Switch.cs:84:21:84:21 | access to parameter j | Switch.cs:84:25:84:25 | 2 |  |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:85:21:85:26 | break; | true |
+| Switch.cs:84:21:84:25 | ... > ... | Switch.cs:86:24:86:27 | true | false |
+| Switch.cs:84:25:84:25 | 2 | Switch.cs:84:21:84:25 | ... > ... |  |
+| Switch.cs:85:21:85:26 | break; | Switch.cs:88:16:88:20 | false | break |
+| Switch.cs:86:17:86:28 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | return |
+| Switch.cs:86:24:86:27 | true | Switch.cs:86:17:86:28 | return ...; |  |
+| Switch.cs:88:9:88:21 | return ...; | Switch.cs:77:10:77:11 | exit M7 (normal) | return |
+| Switch.cs:88:16:88:20 | false | Switch.cs:88:9:88:21 | return ...; |  |
+| Switch.cs:91:10:91:11 | enter M8 | Switch.cs:92:5:99:5 | {...} |  |
+| Switch.cs:91:10:91:11 | exit M8 (normal) | Switch.cs:91:10:91:11 | exit M8 |  |
+| Switch.cs:92:5:99:5 | {...} | Switch.cs:93:9:97:9 | switch (...) {...} |  |
+| Switch.cs:93:9:97:9 | switch (...) {...} | Switch.cs:93:17:93:17 | access to parameter o |  |
+| Switch.cs:93:17:93:17 | access to parameter o | Switch.cs:95:13:95:23 | case ...: |  |
+| Switch.cs:95:13:95:23 | case ...: | Switch.cs:95:18:95:20 | access to type Int32 |  |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:96:24:96:27 | true | match |
+| Switch.cs:95:18:95:20 | access to type Int32 | Switch.cs:98:16:98:20 | false | no-match |
+| Switch.cs:96:17:96:28 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | return |
+| Switch.cs:96:24:96:27 | true | Switch.cs:96:17:96:28 | return ...; |  |
+| Switch.cs:98:9:98:21 | return ...; | Switch.cs:91:10:91:11 | exit M8 (normal) | return |
+| Switch.cs:98:16:98:20 | false | Switch.cs:98:9:98:21 | return ...; |  |
+| Switch.cs:101:9:101:10 | enter M9 | Switch.cs:102:5:109:5 | {...} |  |
+| Switch.cs:101:9:101:10 | exit M9 (normal) | Switch.cs:101:9:101:10 | exit M9 |  |
+| Switch.cs:102:5:109:5 | {...} | Switch.cs:103:9:107:9 | switch (...) {...} |  |
+| Switch.cs:103:9:107:9 | switch (...) {...} | Switch.cs:103:17:103:17 | access to parameter s |  |
+| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:103:17:103:25 | access to property Length | non-null |
+| Switch.cs:103:17:103:17 | access to parameter s | Switch.cs:105:13:105:19 | case ...: | null |
+| Switch.cs:103:17:103:25 | access to property Length | Switch.cs:105:13:105:19 | case ...: |  |
+| Switch.cs:105:13:105:19 | case ...: | Switch.cs:105:18:105:18 | 0 |  |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:105:28:105:28 | 0 | match |
+| Switch.cs:105:18:105:18 | 0 | Switch.cs:106:13:106:19 | case ...: | no-match |
+| Switch.cs:105:21:105:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | return |
+| Switch.cs:105:28:105:28 | 0 | Switch.cs:105:21:105:29 | return ...; |  |
+| Switch.cs:106:13:106:19 | case ...: | Switch.cs:106:18:106:18 | 1 |  |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:106:28:106:28 | 1 | match |
+| Switch.cs:106:18:106:18 | 1 | Switch.cs:108:17:108:17 | 1 | no-match |
+| Switch.cs:106:21:106:29 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | return |
+| Switch.cs:106:28:106:28 | 1 | Switch.cs:106:21:106:29 | return ...; |  |
+| Switch.cs:108:9:108:18 | return ...; | Switch.cs:101:9:101:10 | exit M9 (normal) | return |
+| Switch.cs:108:16:108:17 | -... | Switch.cs:108:9:108:18 | return ...; |  |
+| Switch.cs:108:17:108:17 | 1 | Switch.cs:108:16:108:17 | -... |  |
+| Switch.cs:111:17:111:21 | enter Throw | Switch.cs:111:34:111:48 | object creation of type Exception |  |
+| Switch.cs:111:17:111:21 | exit Throw (abnormal) | Switch.cs:111:17:111:21 | exit Throw |  |
+| Switch.cs:111:28:111:48 | throw ... | Switch.cs:111:17:111:21 | exit Throw (abnormal) | exception(Exception) |
+| Switch.cs:111:34:111:48 | object creation of type Exception | Switch.cs:111:28:111:48 | throw ... |  |
+| Switch.cs:113:9:113:11 | enter M10 | Switch.cs:114:5:121:5 | {...} |  |
+| Switch.cs:113:9:113:11 | exit M10 (normal) | Switch.cs:113:9:113:11 | exit M10 |  |
+| Switch.cs:114:5:121:5 | {...} | Switch.cs:115:9:119:9 | switch (...) {...} |  |
+| Switch.cs:115:9:119:9 | switch (...) {...} | Switch.cs:115:17:115:17 | access to parameter s |  |
+| Switch.cs:115:17:115:17 | access to parameter s | Switch.cs:115:17:115:24 | access to property Length |  |
+| Switch.cs:115:17:115:24 | access to property Length | Switch.cs:117:13:117:35 | case ...: |  |
+| Switch.cs:117:13:117:35 | case ...: | Switch.cs:117:18:117:18 | 3 |  |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:117:25:117:25 | access to parameter s | match |
+| Switch.cs:117:18:117:18 | 3 | Switch.cs:118:13:118:34 | case ...: | no-match |
+| Switch.cs:117:25:117:25 | access to parameter s | Switch.cs:117:30:117:34 | "foo" |  |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:117:44:117:44 | 1 | true |
+| Switch.cs:117:25:117:34 | ... == ... | Switch.cs:118:13:118:34 | case ...: | false |
+| Switch.cs:117:30:117:34 | "foo" | Switch.cs:117:25:117:34 | ... == ... |  |
+| Switch.cs:117:37:117:45 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | return |
+| Switch.cs:117:44:117:44 | 1 | Switch.cs:117:37:117:45 | return ...; |  |
+| Switch.cs:118:13:118:34 | case ...: | Switch.cs:118:18:118:18 | 2 |  |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:118:25:118:25 | access to parameter s | match |
+| Switch.cs:118:18:118:18 | 2 | Switch.cs:120:17:120:17 | 1 | no-match |
+| Switch.cs:118:25:118:25 | access to parameter s | Switch.cs:118:30:118:33 | "fu" |  |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:118:43:118:43 | 2 | true |
+| Switch.cs:118:25:118:33 | ... == ... | Switch.cs:120:17:120:17 | 1 | false |
+| Switch.cs:118:30:118:33 | "fu" | Switch.cs:118:25:118:33 | ... == ... |  |
+| Switch.cs:118:36:118:44 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | return |
+| Switch.cs:118:43:118:43 | 2 | Switch.cs:118:36:118:44 | return ...; |  |
+| Switch.cs:120:9:120:18 | return ...; | Switch.cs:113:9:113:11 | exit M10 (normal) | return |
+| Switch.cs:120:16:120:17 | -... | Switch.cs:120:9:120:18 | return ...; |  |
+| Switch.cs:120:17:120:17 | 1 | Switch.cs:120:16:120:17 | -... |  |
+| Switch.cs:123:10:123:12 | enter M11 | Switch.cs:124:5:127:5 | {...} |  |
+| Switch.cs:123:10:123:12 | exit M11 (normal) | Switch.cs:123:10:123:12 | exit M11 |  |
+| Switch.cs:124:5:127:5 | {...} | Switch.cs:125:9:126:19 | if (...) ... |  |
+| Switch.cs:125:9:126:19 | if (...) ... | Switch.cs:125:13:125:13 | access to parameter o |  |
+| Switch.cs:125:13:125:13 | access to parameter o | Switch.cs:125:24:125:29 | Boolean b |  |
+| Switch.cs:125:13:125:48 | [false] ... switch { ... } | Switch.cs:123:10:123:12 | exit M11 (normal) | false |
+| Switch.cs:125:13:125:48 | [true] ... switch { ... } | Switch.cs:126:13:126:19 | return ...; | true |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:34:125:34 | access to local variable b | match |
+| Switch.cs:125:24:125:29 | Boolean b | Switch.cs:125:37:125:37 | _ | no-match |
+| Switch.cs:125:24:125:34 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | false |
+| Switch.cs:125:24:125:34 | [true] ... => ... | Switch.cs:125:13:125:48 | [true] ... switch { ... } | true |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [false] ... => ... | false |
+| Switch.cs:125:34:125:34 | access to local variable b | Switch.cs:125:24:125:34 | [true] ... => ... | true |
+| Switch.cs:125:37:125:37 | _ | Switch.cs:125:42:125:46 | false | match |
+| Switch.cs:125:37:125:46 | [false] ... => ... | Switch.cs:125:13:125:48 | [false] ... switch { ... } | false |
+| Switch.cs:125:42:125:46 | false | Switch.cs:125:37:125:46 | [false] ... => ... | false |
+| Switch.cs:126:13:126:19 | return ...; | Switch.cs:123:10:123:12 | exit M11 (normal) | return |
+| Switch.cs:129:12:129:14 | enter M12 | Switch.cs:130:5:132:5 | {...} |  |
+| Switch.cs:129:12:129:14 | exit M12 (normal) | Switch.cs:129:12:129:14 | exit M12 |  |
+| Switch.cs:130:5:132:5 | {...} | Switch.cs:131:17:131:17 | access to parameter o |  |
+| Switch.cs:131:9:131:67 | return ...; | Switch.cs:129:12:129:14 | exit M12 (normal) | return |
+| Switch.cs:131:16:131:66 | call to method ToString | Switch.cs:131:9:131:67 | return ...; |  |
+| Switch.cs:131:17:131:17 | access to parameter o | Switch.cs:131:28:131:35 | String s |  |
+| Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | Switch.cs:131:16:131:66 | call to method ToString | non-null |
+| Switch.cs:131:17:131:53 | [null] ... switch { ... } | Switch.cs:131:9:131:67 | return ...; | null |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:40:131:40 | access to local variable s | match |
+| Switch.cs:131:28:131:35 | String s | Switch.cs:131:43:131:43 | _ | no-match |
+| Switch.cs:131:28:131:40 | [non-null] ... => ... | Switch.cs:131:17:131:53 | [non-null] ... switch { ... } | non-null |
+| Switch.cs:131:28:131:40 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | null |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [non-null] ... => ... | non-null |
+| Switch.cs:131:40:131:40 | access to local variable s | Switch.cs:131:28:131:40 | [null] ... => ... | null |
+| Switch.cs:131:43:131:43 | _ | Switch.cs:131:48:131:51 | null | match |
+| Switch.cs:131:43:131:51 | [null] ... => ... | Switch.cs:131:17:131:53 | [null] ... switch { ... } | null |
+| Switch.cs:131:48:131:51 | null | Switch.cs:131:43:131:51 | [null] ... => ... | null |
+| Switch.cs:134:9:134:11 | enter M13 | Switch.cs:135:5:142:5 | {...} |  |
+| Switch.cs:134:9:134:11 | exit M13 (normal) | Switch.cs:134:9:134:11 | exit M13 |  |
+| Switch.cs:135:5:142:5 | {...} | Switch.cs:136:9:141:9 | switch (...) {...} |  |
+| Switch.cs:136:9:141:9 | switch (...) {...} | Switch.cs:136:17:136:17 | access to parameter i |  |
+| Switch.cs:136:17:136:17 | access to parameter i | Switch.cs:139:13:139:19 | case ...: |  |
+| Switch.cs:138:13:138:20 | default: | Switch.cs:138:30:138:30 | 1 |  |
+| Switch.cs:138:22:138:31 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | return |
+| Switch.cs:138:29:138:30 | -... | Switch.cs:138:22:138:31 | return ...; |  |
+| Switch.cs:138:30:138:30 | 1 | Switch.cs:138:29:138:30 | -... |  |
+| Switch.cs:139:13:139:19 | case ...: | Switch.cs:139:18:139:18 | 1 |  |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:139:28:139:28 | 1 | match |
+| Switch.cs:139:18:139:18 | 1 | Switch.cs:140:13:140:19 | case ...: | no-match |
+| Switch.cs:139:21:139:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | return |
+| Switch.cs:139:28:139:28 | 1 | Switch.cs:139:21:139:29 | return ...; |  |
+| Switch.cs:140:13:140:19 | case ...: | Switch.cs:140:18:140:18 | 2 |  |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:138:13:138:20 | default: | no-match |
+| Switch.cs:140:18:140:18 | 2 | Switch.cs:140:28:140:28 | 2 | match |
+| Switch.cs:140:21:140:29 | return ...; | Switch.cs:134:9:134:11 | exit M13 (normal) | return |
+| Switch.cs:140:28:140:28 | 2 | Switch.cs:140:21:140:29 | return ...; |  |
+| Switch.cs:144:9:144:11 | enter M14 | Switch.cs:145:5:152:5 | {...} |  |
+| Switch.cs:144:9:144:11 | exit M14 (normal) | Switch.cs:144:9:144:11 | exit M14 |  |
+| Switch.cs:145:5:152:5 | {...} | Switch.cs:146:9:151:9 | switch (...) {...} |  |
+| Switch.cs:146:9:151:9 | switch (...) {...} | Switch.cs:146:17:146:17 | access to parameter i |  |
+| Switch.cs:146:17:146:17 | access to parameter i | Switch.cs:148:13:148:19 | case ...: |  |
+| Switch.cs:148:13:148:19 | case ...: | Switch.cs:148:18:148:18 | 1 |  |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:148:28:148:28 | 1 | match |
+| Switch.cs:148:18:148:18 | 1 | Switch.cs:150:13:150:19 | case ...: | no-match |
+| Switch.cs:148:21:148:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | return |
+| Switch.cs:148:28:148:28 | 1 | Switch.cs:148:21:148:29 | return ...; |  |
+| Switch.cs:149:13:149:20 | default: | Switch.cs:149:30:149:30 | 1 |  |
+| Switch.cs:149:22:149:31 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | return |
+| Switch.cs:149:29:149:30 | -... | Switch.cs:149:22:149:31 | return ...; |  |
+| Switch.cs:149:30:149:30 | 1 | Switch.cs:149:29:149:30 | -... |  |
+| Switch.cs:150:13:150:19 | case ...: | Switch.cs:150:18:150:18 | 2 |  |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:149:13:149:20 | default: | no-match |
+| Switch.cs:150:18:150:18 | 2 | Switch.cs:150:28:150:28 | 2 | match |
+| Switch.cs:150:21:150:29 | return ...; | Switch.cs:144:9:144:11 | exit M14 (normal) | return |
+| Switch.cs:150:28:150:28 | 2 | Switch.cs:150:21:150:29 | return ...; |  |
+| Switch.cs:154:10:154:12 | enter M15 | Switch.cs:155:5:161:5 | {...} |  |
+| Switch.cs:154:10:154:12 | exit M15 (abnormal) | Switch.cs:154:10:154:12 | exit M15 |  |
+| Switch.cs:154:10:154:12 | exit M15 (normal) | Switch.cs:154:10:154:12 | exit M15 |  |
+| Switch.cs:155:5:161:5 | {...} | Switch.cs:156:9:156:55 | ... ...; |  |
+| Switch.cs:156:9:156:55 | ... ...; | Switch.cs:156:17:156:17 | access to parameter b |  |
+| Switch.cs:156:13:156:54 | String s = ... | Switch.cs:157:9:160:49 | if (...) ... |  |
+| Switch.cs:156:17:156:17 | access to parameter b | Switch.cs:156:28:156:31 | true |  |
+| Switch.cs:156:17:156:54 | ... switch { ... } | Switch.cs:156:13:156:54 | String s = ... |  |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:36:156:38 | "a" | match |
+| Switch.cs:156:28:156:31 | true | Switch.cs:156:41:156:45 | false | no-match |
+| Switch.cs:156:28:156:38 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } |  |
+| Switch.cs:156:36:156:38 | "a" | Switch.cs:156:28:156:38 | ... => ... |  |
+| Switch.cs:156:41:156:45 | false | Switch.cs:154:10:154:12 | exit M15 (abnormal) | exception(InvalidOperationException) |
+| Switch.cs:156:41:156:45 | false | Switch.cs:156:50:156:52 | "b" | match |
+| Switch.cs:156:41:156:52 | ... => ... | Switch.cs:156:17:156:54 | ... switch { ... } |  |
+| Switch.cs:156:50:156:52 | "b" | Switch.cs:156:41:156:52 | ... => ... |  |
+| Switch.cs:157:9:160:49 | if (...) ... | Switch.cs:157:13:157:13 | access to parameter b |  |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:158:13:158:49 | ...; | true |
+| Switch.cs:157:13:157:13 | access to parameter b | Switch.cs:160:13:160:49 | ...; | false |
+| Switch.cs:158:13:158:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) |  |
+| Switch.cs:158:13:158:49 | ...; | Switch.cs:158:40:158:43 | "a = " |  |
+| Switch.cs:158:38:158:47 | $"..." | Switch.cs:158:13:158:48 | call to method WriteLine |  |
+| Switch.cs:158:40:158:43 | "a = " | Switch.cs:158:45:158:45 | access to local variable s |  |
+| Switch.cs:158:45:158:45 | access to local variable s | Switch.cs:158:38:158:47 | $"..." |  |
+| Switch.cs:160:13:160:48 | call to method WriteLine | Switch.cs:154:10:154:12 | exit M15 (normal) |  |
+| Switch.cs:160:13:160:49 | ...; | Switch.cs:160:40:160:43 | "b = " |  |
+| Switch.cs:160:38:160:47 | $"..." | Switch.cs:160:13:160:48 | call to method WriteLine |  |
+| Switch.cs:160:40:160:43 | "b = " | Switch.cs:160:45:160:45 | access to local variable s |  |
+| Switch.cs:160:45:160:45 | access to local variable s | Switch.cs:160:38:160:47 | $"..." |  |
+| TypeAccesses.cs:1:7:1:18 | call to constructor Object | TypeAccesses.cs:1:7:1:18 | {...} |  |
+| TypeAccesses.cs:1:7:1:18 | enter TypeAccesses | TypeAccesses.cs:1:7:1:18 | call to constructor Object |  |
+| TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses |  |
+| TypeAccesses.cs:1:7:1:18 | {...} | TypeAccesses.cs:1:7:1:18 | exit TypeAccesses (normal) |  |
+| TypeAccesses.cs:3:10:3:10 | enter M | TypeAccesses.cs:4:5:9:5 | {...} |  |
+| TypeAccesses.cs:3:10:3:10 | exit M (normal) | TypeAccesses.cs:3:10:3:10 | exit M |  |
+| TypeAccesses.cs:4:5:9:5 | {...} | TypeAccesses.cs:5:9:5:26 | ... ...; |  |
+| TypeAccesses.cs:5:9:5:26 | ... ...; | TypeAccesses.cs:5:25:5:25 | access to parameter o |  |
+| TypeAccesses.cs:5:13:5:25 | String s = ... | TypeAccesses.cs:6:9:6:24 | ...; |  |
+| TypeAccesses.cs:5:17:5:25 | (...) ... | TypeAccesses.cs:5:13:5:25 | String s = ... |  |
+| TypeAccesses.cs:5:25:5:25 | access to parameter o | TypeAccesses.cs:5:17:5:25 | (...) ... |  |
+| TypeAccesses.cs:6:9:6:23 | ... = ... | TypeAccesses.cs:7:9:7:25 | if (...) ... |  |
+| TypeAccesses.cs:6:9:6:24 | ...; | TypeAccesses.cs:6:13:6:13 | access to parameter o |  |
+| TypeAccesses.cs:6:13:6:13 | access to parameter o | TypeAccesses.cs:6:13:6:23 | ... as ... |  |
+| TypeAccesses.cs:6:13:6:23 | ... as ... | TypeAccesses.cs:6:9:6:23 | ... = ... |  |
+| TypeAccesses.cs:7:9:7:25 | if (...) ... | TypeAccesses.cs:7:13:7:13 | access to parameter o |  |
+| TypeAccesses.cs:7:13:7:13 | access to parameter o | TypeAccesses.cs:7:18:7:22 | Int32 j |  |
+| TypeAccesses.cs:7:13:7:22 | [false] ... is ... | TypeAccesses.cs:8:9:8:28 | ... ...; | false |
+| TypeAccesses.cs:7:13:7:22 | [true] ... is ... | TypeAccesses.cs:7:25:7:25 | ; | true |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [false] ... is ... | no-match |
+| TypeAccesses.cs:7:18:7:22 | Int32 j | TypeAccesses.cs:7:13:7:22 | [true] ... is ... | match |
+| TypeAccesses.cs:7:25:7:25 | ; | TypeAccesses.cs:8:9:8:28 | ... ...; |  |
+| TypeAccesses.cs:8:9:8:28 | ... ...; | TypeAccesses.cs:8:17:8:27 | typeof(...) |  |
+| TypeAccesses.cs:8:13:8:27 | Type t = ... | TypeAccesses.cs:3:10:3:10 | exit M (normal) |  |
+| TypeAccesses.cs:8:17:8:27 | typeof(...) | TypeAccesses.cs:8:13:8:27 | Type t = ... |  |
+| VarDecls.cs:3:7:3:14 | call to constructor Object | VarDecls.cs:3:7:3:14 | {...} |  |
+| VarDecls.cs:3:7:3:14 | enter VarDecls | VarDecls.cs:3:7:3:14 | call to constructor Object |  |
+| VarDecls.cs:3:7:3:14 | exit VarDecls (normal) | VarDecls.cs:3:7:3:14 | exit VarDecls |  |
+| VarDecls.cs:3:7:3:14 | {...} | VarDecls.cs:3:7:3:14 | exit VarDecls (normal) |  |
+| VarDecls.cs:5:18:5:19 | enter M1 | VarDecls.cs:6:5:11:5 | {...} |  |
+| VarDecls.cs:5:18:5:19 | exit M1 (normal) | VarDecls.cs:5:18:5:19 | exit M1 |  |
+| VarDecls.cs:6:5:11:5 | {...} | VarDecls.cs:7:9:10:9 | fixed(...) { ... } |  |
+| VarDecls.cs:7:9:10:9 | fixed(...) { ... } | VarDecls.cs:7:27:7:33 | access to parameter strings |  |
+| VarDecls.cs:7:22:7:36 | Char* c1 = ... | VarDecls.cs:7:44:7:50 | access to parameter strings |  |
+| VarDecls.cs:7:27:7:33 | access to parameter strings | VarDecls.cs:7:35:7:35 | 0 |  |
+| VarDecls.cs:7:27:7:36 | (...) ... | VarDecls.cs:7:22:7:36 | Char* c1 = ... |  |
+| VarDecls.cs:7:27:7:36 | access to array element | VarDecls.cs:7:27:7:36 | (...) ... |  |
+| VarDecls.cs:7:35:7:35 | 0 | VarDecls.cs:7:27:7:36 | access to array element |  |
+| VarDecls.cs:7:39:7:53 | Char* c2 = ... | VarDecls.cs:8:9:10:9 | {...} |  |
+| VarDecls.cs:7:44:7:50 | access to parameter strings | VarDecls.cs:7:52:7:52 | 1 |  |
+| VarDecls.cs:7:44:7:53 | (...) ... | VarDecls.cs:7:39:7:53 | Char* c2 = ... |  |
+| VarDecls.cs:7:44:7:53 | access to array element | VarDecls.cs:7:44:7:53 | (...) ... |  |
+| VarDecls.cs:7:52:7:52 | 1 | VarDecls.cs:7:44:7:53 | access to array element |  |
+| VarDecls.cs:8:9:10:9 | {...} | VarDecls.cs:9:27:9:28 | access to local variable c1 |  |
+| VarDecls.cs:9:13:9:29 | return ...; | VarDecls.cs:5:18:5:19 | exit M1 (normal) | return |
+| VarDecls.cs:9:20:9:28 | (...) ... | VarDecls.cs:9:13:9:29 | return ...; |  |
+| VarDecls.cs:9:27:9:28 | access to local variable c1 | VarDecls.cs:9:20:9:28 | (...) ... |  |
+| VarDecls.cs:13:12:13:13 | enter M2 | VarDecls.cs:14:5:17:5 | {...} |  |
+| VarDecls.cs:13:12:13:13 | exit M2 (normal) | VarDecls.cs:13:12:13:13 | exit M2 |  |
+| VarDecls.cs:14:5:17:5 | {...} | VarDecls.cs:15:9:15:30 | ... ...; |  |
+| VarDecls.cs:15:9:15:30 | ... ...; | VarDecls.cs:15:21:15:21 | access to parameter s |  |
+| VarDecls.cs:15:16:15:21 | String s1 = ... | VarDecls.cs:15:29:15:29 | access to parameter s |  |
+| VarDecls.cs:15:21:15:21 | access to parameter s | VarDecls.cs:15:16:15:21 | String s1 = ... |  |
+| VarDecls.cs:15:24:15:29 | String s2 = ... | VarDecls.cs:16:16:16:17 | access to local variable s1 |  |
+| VarDecls.cs:15:29:15:29 | access to parameter s | VarDecls.cs:15:24:15:29 | String s2 = ... |  |
+| VarDecls.cs:16:9:16:23 | return ...; | VarDecls.cs:13:12:13:13 | exit M2 (normal) | return |
+| VarDecls.cs:16:16:16:17 | access to local variable s1 | VarDecls.cs:16:21:16:22 | access to local variable s2 |  |
+| VarDecls.cs:16:16:16:22 | ... + ... | VarDecls.cs:16:9:16:23 | return ...; |  |
+| VarDecls.cs:16:21:16:22 | access to local variable s2 | VarDecls.cs:16:16:16:22 | ... + ... |  |
+| VarDecls.cs:19:7:19:8 | enter M3 | VarDecls.cs:20:5:26:5 | {...} |  |
+| VarDecls.cs:19:7:19:8 | exit M3 (normal) | VarDecls.cs:19:7:19:8 | exit M3 |  |
+| VarDecls.cs:20:5:26:5 | {...} | VarDecls.cs:21:9:22:13 | using (...) {...} |  |
+| VarDecls.cs:21:9:22:13 | using (...) {...} | VarDecls.cs:21:16:21:22 | object creation of type C |  |
+| VarDecls.cs:21:16:21:22 | object creation of type C | VarDecls.cs:22:13:22:13 | ; |  |
+| VarDecls.cs:22:13:22:13 | ; | VarDecls.cs:24:9:25:29 | using (...) {...} |  |
+| VarDecls.cs:24:9:25:29 | using (...) {...} | VarDecls.cs:24:22:24:28 | object creation of type C |  |
+| VarDecls.cs:24:18:24:28 | C x = ... | VarDecls.cs:24:35:24:41 | object creation of type C |  |
+| VarDecls.cs:24:22:24:28 | object creation of type C | VarDecls.cs:24:18:24:28 | C x = ... |  |
+| VarDecls.cs:24:31:24:41 | C y = ... | VarDecls.cs:25:20:25:20 | access to parameter b |  |
+| VarDecls.cs:24:35:24:41 | object creation of type C | VarDecls.cs:24:31:24:41 | C y = ... |  |
+| VarDecls.cs:25:13:25:29 | return ...; | VarDecls.cs:19:7:19:8 | exit M3 (normal) | return |
+| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:24:25:24 | access to local variable x | true |
+| VarDecls.cs:25:20:25:20 | access to parameter b | VarDecls.cs:25:28:25:28 | access to local variable y | false |
+| VarDecls.cs:25:20:25:28 | ... ? ... : ... | VarDecls.cs:25:13:25:29 | return ...; |  |
+| VarDecls.cs:25:24:25:24 | access to local variable x | VarDecls.cs:25:20:25:28 | ... ? ... : ... |  |
+| VarDecls.cs:25:28:25:28 | access to local variable y | VarDecls.cs:25:20:25:28 | ... ? ... : ... |  |
+| VarDecls.cs:28:11:28:11 | call to constructor Object | VarDecls.cs:28:11:28:11 | {...} |  |
+| VarDecls.cs:28:11:28:11 | enter C | VarDecls.cs:28:11:28:11 | call to constructor Object |  |
+| VarDecls.cs:28:11:28:11 | exit C (normal) | VarDecls.cs:28:11:28:11 | exit C |  |
+| VarDecls.cs:28:11:28:11 | {...} | VarDecls.cs:28:11:28:11 | exit C (normal) |  |
+| VarDecls.cs:28:41:28:47 | enter Dispose | VarDecls.cs:28:51:28:53 | {...} |  |
+| VarDecls.cs:28:41:28:47 | exit Dispose (normal) | VarDecls.cs:28:41:28:47 | exit Dispose |  |
+| VarDecls.cs:28:51:28:53 | {...} | VarDecls.cs:28:41:28:47 | exit Dispose (normal) |  |
+| cflow.cs:5:17:5:20 | enter Main | cflow.cs:6:5:35:5 | {...} |  |
+| cflow.cs:5:17:5:20 | exit Main (normal) | cflow.cs:5:17:5:20 | exit Main |  |
+| cflow.cs:6:5:35:5 | {...} | cflow.cs:7:9:7:28 | ... ...; |  |
+| cflow.cs:7:9:7:28 | ... ...; | cflow.cs:7:17:7:20 | access to parameter args |  |
+| cflow.cs:7:13:7:27 | Int32 a = ... | cflow.cs:9:9:9:40 | ...; |  |
+| cflow.cs:7:17:7:20 | access to parameter args | cflow.cs:7:17:7:27 | access to property Length |  |
+| cflow.cs:7:17:7:27 | access to property Length | cflow.cs:7:13:7:27 | Int32 a = ... |  |
+| cflow.cs:9:9:9:39 | ... = ... | cflow.cs:11:9:12:49 | if (...) ... |  |
+| cflow.cs:9:9:9:40 | ...; | cflow.cs:9:13:9:29 | object creation of type ControlFlow |  |
+| cflow.cs:9:13:9:29 | object creation of type ControlFlow | cflow.cs:9:38:9:38 | access to local variable a |  |
+| cflow.cs:9:13:9:39 | call to method Switch | cflow.cs:9:9:9:39 | ... = ... |  |
+| cflow.cs:9:38:9:38 | access to local variable a | cflow.cs:9:13:9:39 | call to method Switch |  |
+| cflow.cs:11:9:12:49 | if (...) ... | cflow.cs:11:13:11:13 | access to local variable a |  |
+| cflow.cs:11:13:11:13 | access to local variable a | cflow.cs:11:17:11:17 | 3 |  |
+| cflow.cs:11:13:11:17 | ... > ... | cflow.cs:12:13:12:49 | ...; | true |
+| cflow.cs:11:13:11:17 | ... > ... | cflow.cs:14:9:17:9 | while (...) ... | false |
+| cflow.cs:11:17:11:17 | 3 | cflow.cs:11:13:11:17 | ... > ... |  |
+| cflow.cs:12:13:12:48 | call to method WriteLine | cflow.cs:14:9:17:9 | while (...) ... |  |
+| cflow.cs:12:13:12:49 | ...; | cflow.cs:12:31:12:47 | "more than a few" |  |
+| cflow.cs:12:31:12:47 | "more than a few" | cflow.cs:12:13:12:48 | call to method WriteLine |  |
+| cflow.cs:14:9:17:9 | while (...) ... | cflow.cs:14:16:14:16 | access to local variable a |  |
+| cflow.cs:14:16:14:16 | access to local variable a | cflow.cs:14:20:14:20 | 0 |  |
+| cflow.cs:14:16:14:20 | ... > ... | cflow.cs:15:9:17:9 | {...} | true |
+| cflow.cs:14:16:14:20 | ... > ... | cflow.cs:19:9:22:25 | do ... while (...); | false |
+| cflow.cs:14:20:14:20 | 0 | cflow.cs:14:16:14:20 | ... > ... |  |
+| cflow.cs:15:9:17:9 | {...} | cflow.cs:16:13:16:41 | ...; |  |
+| cflow.cs:16:13:16:40 | call to method WriteLine | cflow.cs:14:16:14:16 | access to local variable a |  |
+| cflow.cs:16:13:16:41 | ...; | cflow.cs:16:31:16:31 | access to local variable a |  |
+| cflow.cs:16:31:16:31 | access to local variable a | cflow.cs:16:31:16:33 | ...-- |  |
+| cflow.cs:16:31:16:33 | ...-- | cflow.cs:16:37:16:39 | 100 |  |
+| cflow.cs:16:31:16:39 | ... * ... | cflow.cs:16:13:16:40 | call to method WriteLine |  |
+| cflow.cs:16:37:16:39 | 100 | cflow.cs:16:31:16:39 | ... * ... |  |
+| cflow.cs:19:9:22:25 | do ... while (...); | cflow.cs:20:9:22:9 | {...} |  |
+| cflow.cs:20:9:22:9 | {...} | cflow.cs:21:13:21:36 | ...; |  |
+| cflow.cs:21:13:21:35 | call to method WriteLine | cflow.cs:22:18:22:18 | access to local variable a |  |
+| cflow.cs:21:13:21:36 | ...; | cflow.cs:21:32:21:32 | access to local variable a |  |
+| cflow.cs:21:31:21:34 | -... | cflow.cs:21:13:21:35 | call to method WriteLine |  |
+| cflow.cs:21:32:21:32 | access to local variable a | cflow.cs:21:32:21:34 | ...++ |  |
+| cflow.cs:21:32:21:34 | ...++ | cflow.cs:21:31:21:34 | -... |  |
+| cflow.cs:22:18:22:18 | access to local variable a | cflow.cs:22:22:22:23 | 10 |  |
+| cflow.cs:22:18:22:23 | ... < ... | cflow.cs:20:9:22:9 | {...} | true |
+| cflow.cs:22:18:22:23 | ... < ... | cflow.cs:24:9:34:9 | for (...;...;...) ... | false |
+| cflow.cs:22:22:22:23 | 10 | cflow.cs:22:18:22:23 | ... < ... |  |
+| cflow.cs:24:9:34:9 | for (...;...;...) ... | cflow.cs:24:22:24:22 | 1 |  |
+| cflow.cs:24:18:24:22 | Int32 i = ... | cflow.cs:24:25:24:25 | access to local variable i |  |
+| cflow.cs:24:22:24:22 | 1 | cflow.cs:24:18:24:22 | Int32 i = ... |  |
+| cflow.cs:24:25:24:25 | access to local variable i | cflow.cs:24:30:24:31 | 20 |  |
+| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:5:17:5:20 | exit Main (normal) | false |
+| cflow.cs:24:25:24:31 | ... <= ... | cflow.cs:25:9:34:9 | {...} | true |
+| cflow.cs:24:30:24:31 | 20 | cflow.cs:24:25:24:31 | ... <= ... |  |
+| cflow.cs:24:34:24:34 | access to local variable i | cflow.cs:24:34:24:36 | ...++ |  |
+| cflow.cs:24:34:24:36 | ...++ | cflow.cs:24:25:24:25 | access to local variable i |  |
+| cflow.cs:25:9:34:9 | {...} | cflow.cs:26:13:33:37 | if (...) ... |  |
+| cflow.cs:26:13:33:37 | if (...) ... | cflow.cs:26:17:26:17 | access to local variable i |  |
+| cflow.cs:26:17:26:17 | access to local variable i | cflow.cs:26:21:26:21 | 3 |  |
+| cflow.cs:26:17:26:21 | ... % ... | cflow.cs:26:26:26:26 | 0 |  |
+| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | false |
+| cflow.cs:26:17:26:26 | ... == ... | cflow.cs:26:31:26:31 | access to local variable i | true |
+| cflow.cs:26:17:26:40 | [false] ... && ... | cflow.cs:28:18:33:37 | if (...) ... | false |
+| cflow.cs:26:17:26:40 | [true] ... && ... | cflow.cs:27:17:27:46 | ...; | true |
+| cflow.cs:26:21:26:21 | 3 | cflow.cs:26:17:26:21 | ... % ... |  |
+| cflow.cs:26:26:26:26 | 0 | cflow.cs:26:17:26:26 | ... == ... |  |
+| cflow.cs:26:31:26:31 | access to local variable i | cflow.cs:26:35:26:35 | 5 |  |
+| cflow.cs:26:31:26:35 | ... % ... | cflow.cs:26:40:26:40 | 0 |  |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [false] ... && ... | false |
+| cflow.cs:26:31:26:40 | ... == ... | cflow.cs:26:17:26:40 | [true] ... && ... | true |
+| cflow.cs:26:35:26:35 | 5 | cflow.cs:26:31:26:35 | ... % ... |  |
+| cflow.cs:26:40:26:40 | 0 | cflow.cs:26:31:26:40 | ... == ... |  |
+| cflow.cs:27:17:27:45 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i |  |
+| cflow.cs:27:17:27:46 | ...; | cflow.cs:27:35:27:44 | "FizzBuzz" |  |
+| cflow.cs:27:35:27:44 | "FizzBuzz" | cflow.cs:27:17:27:45 | call to method WriteLine |  |
+| cflow.cs:28:18:33:37 | if (...) ... | cflow.cs:28:22:28:22 | access to local variable i |  |
+| cflow.cs:28:22:28:22 | access to local variable i | cflow.cs:28:26:28:26 | 3 |  |
+| cflow.cs:28:22:28:26 | ... % ... | cflow.cs:28:31:28:31 | 0 |  |
+| cflow.cs:28:22:28:31 | ... == ... | cflow.cs:29:17:29:42 | ...; | true |
+| cflow.cs:28:22:28:31 | ... == ... | cflow.cs:30:18:33:37 | if (...) ... | false |
+| cflow.cs:28:26:28:26 | 3 | cflow.cs:28:22:28:26 | ... % ... |  |
+| cflow.cs:28:31:28:31 | 0 | cflow.cs:28:22:28:31 | ... == ... |  |
+| cflow.cs:29:17:29:41 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i |  |
+| cflow.cs:29:17:29:42 | ...; | cflow.cs:29:35:29:40 | "Fizz" |  |
+| cflow.cs:29:35:29:40 | "Fizz" | cflow.cs:29:17:29:41 | call to method WriteLine |  |
+| cflow.cs:30:18:33:37 | if (...) ... | cflow.cs:30:22:30:22 | access to local variable i |  |
+| cflow.cs:30:22:30:22 | access to local variable i | cflow.cs:30:26:30:26 | 5 |  |
+| cflow.cs:30:22:30:26 | ... % ... | cflow.cs:30:31:30:31 | 0 |  |
+| cflow.cs:30:22:30:31 | ... == ... | cflow.cs:31:17:31:42 | ...; | true |
+| cflow.cs:30:22:30:31 | ... == ... | cflow.cs:33:17:33:37 | ...; | false |
+| cflow.cs:30:26:30:26 | 5 | cflow.cs:30:22:30:26 | ... % ... |  |
+| cflow.cs:30:31:30:31 | 0 | cflow.cs:30:22:30:31 | ... == ... |  |
+| cflow.cs:31:17:31:41 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i |  |
+| cflow.cs:31:17:31:42 | ...; | cflow.cs:31:35:31:40 | "Buzz" |  |
+| cflow.cs:31:35:31:40 | "Buzz" | cflow.cs:31:17:31:41 | call to method WriteLine |  |
+| cflow.cs:33:17:33:36 | call to method WriteLine | cflow.cs:24:34:24:34 | access to local variable i |  |
+| cflow.cs:33:17:33:37 | ...; | cflow.cs:33:35:33:35 | access to local variable i |  |
+| cflow.cs:33:35:33:35 | access to local variable i | cflow.cs:33:17:33:36 | call to method WriteLine |  |
+| cflow.cs:37:17:37:22 | enter Switch | cflow.cs:38:5:68:5 | {...} |  |
+| cflow.cs:37:17:37:22 | exit Switch (abnormal) | cflow.cs:37:17:37:22 | exit Switch |  |
+| cflow.cs:37:17:37:22 | exit Switch (normal) | cflow.cs:37:17:37:22 | exit Switch |  |
+| cflow.cs:38:5:68:5 | {...} | cflow.cs:39:9:50:9 | switch (...) {...} |  |
+| cflow.cs:39:9:50:9 | switch (...) {...} | cflow.cs:39:17:39:17 | access to parameter a |  |
+| cflow.cs:39:17:39:17 | access to parameter a | cflow.cs:41:13:41:19 | case ...: |  |
+| cflow.cs:41:13:41:19 | case ...: | cflow.cs:41:18:41:18 | 1 |  |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:42:17:42:39 | ...; | match |
+| cflow.cs:41:18:41:18 | 1 | cflow.cs:44:13:44:19 | case ...: | no-match |
+| cflow.cs:42:17:42:38 | call to method WriteLine | cflow.cs:43:27:43:27 | 2 |  |
+| cflow.cs:42:17:42:39 | ...; | cflow.cs:42:35:42:37 | "1" |  |
+| cflow.cs:42:35:42:37 | "1" | cflow.cs:42:17:42:38 | call to method WriteLine |  |
+| cflow.cs:43:17:43:28 | goto case ...; | cflow.cs:44:13:44:19 | case ...: | goto(2) |
+| cflow.cs:43:27:43:27 | 2 | cflow.cs:43:17:43:28 | goto case ...; |  |
+| cflow.cs:44:13:44:19 | case ...: | cflow.cs:44:18:44:18 | 2 |  |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:45:17:45:39 | ...; | match |
+| cflow.cs:44:18:44:18 | 2 | cflow.cs:47:13:47:19 | case ...: | no-match |
+| cflow.cs:45:17:45:38 | call to method WriteLine | cflow.cs:46:27:46:27 | 1 |  |
+| cflow.cs:45:17:45:39 | ...; | cflow.cs:45:35:45:37 | "2" |  |
+| cflow.cs:45:35:45:37 | "2" | cflow.cs:45:17:45:38 | call to method WriteLine |  |
+| cflow.cs:46:17:46:28 | goto case ...; | cflow.cs:41:13:41:19 | case ...: | goto(1) |
+| cflow.cs:46:27:46:27 | 1 | cflow.cs:46:17:46:28 | goto case ...; |  |
+| cflow.cs:47:13:47:19 | case ...: | cflow.cs:47:18:47:18 | 3 |  |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:48:17:48:39 | ...; | match |
+| cflow.cs:47:18:47:18 | 3 | cflow.cs:51:9:59:9 | switch (...) {...} | no-match |
+| cflow.cs:48:17:48:38 | call to method WriteLine | cflow.cs:49:17:49:22 | break; |  |
+| cflow.cs:48:17:48:39 | ...; | cflow.cs:48:35:48:37 | "3" |  |
+| cflow.cs:48:35:48:37 | "3" | cflow.cs:48:17:48:38 | call to method WriteLine |  |
+| cflow.cs:49:17:49:22 | break; | cflow.cs:51:9:59:9 | switch (...) {...} | break |
+| cflow.cs:51:9:59:9 | switch (...) {...} | cflow.cs:51:17:51:17 | access to parameter a |  |
+| cflow.cs:51:17:51:17 | access to parameter a | cflow.cs:53:13:53:20 | case ...: |  |
+| cflow.cs:53:13:53:20 | case ...: | cflow.cs:53:18:53:19 | 42 |  |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:54:17:54:48 | ...; | match |
+| cflow.cs:53:18:53:19 | 42 | cflow.cs:56:13:56:20 | default: | no-match |
+| cflow.cs:54:17:54:47 | call to method WriteLine | cflow.cs:55:17:55:22 | break; |  |
+| cflow.cs:54:17:54:48 | ...; | cflow.cs:54:35:54:46 | "The answer" |  |
+| cflow.cs:54:35:54:46 | "The answer" | cflow.cs:54:17:54:47 | call to method WriteLine |  |
+| cflow.cs:55:17:55:22 | break; | cflow.cs:60:9:66:9 | switch (...) {...} | break |
+| cflow.cs:56:13:56:20 | default: | cflow.cs:57:17:57:52 | ...; |  |
+| cflow.cs:57:17:57:51 | call to method WriteLine | cflow.cs:58:17:58:22 | break; |  |
+| cflow.cs:57:17:57:52 | ...; | cflow.cs:57:35:57:50 | "Not the answer" |  |
+| cflow.cs:57:35:57:50 | "Not the answer" | cflow.cs:57:17:57:51 | call to method WriteLine |  |
+| cflow.cs:58:17:58:22 | break; | cflow.cs:60:9:66:9 | switch (...) {...} | break |
+| cflow.cs:60:9:66:9 | switch (...) {...} | cflow.cs:60:27:60:31 | this access |  |
+| cflow.cs:60:17:60:32 | call to method Parse | cflow.cs:62:13:62:19 | case ...: |  |
+| cflow.cs:60:27:60:31 | access to field Field | cflow.cs:60:17:60:32 | call to method Parse |  |
+| cflow.cs:60:27:60:31 | this access | cflow.cs:60:27:60:31 | access to field Field |  |
+| cflow.cs:62:13:62:19 | case ...: | cflow.cs:62:18:62:18 | 0 |  |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:63:17:64:55 | if (...) ... | match |
+| cflow.cs:62:18:62:18 | 0 | cflow.cs:67:16:67:16 | access to parameter a | no-match |
+| cflow.cs:63:17:64:55 | if (...) ... | cflow.cs:63:23:63:27 | this access |  |
+| cflow.cs:63:21:63:34 | [false] !... | cflow.cs:65:17:65:22 | break; | false |
+| cflow.cs:63:21:63:34 | [true] !... | cflow.cs:64:27:64:54 | object creation of type NullReferenceException | true |
+| cflow.cs:63:23:63:27 | access to field Field | cflow.cs:63:32:63:33 | "" |  |
+| cflow.cs:63:23:63:27 | this access | cflow.cs:63:23:63:27 | access to field Field |  |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [false] !... | true |
+| cflow.cs:63:23:63:33 | ... == ... | cflow.cs:63:21:63:34 | [true] !... | false |
+| cflow.cs:63:32:63:33 | "" | cflow.cs:63:23:63:33 | ... == ... |  |
+| cflow.cs:64:21:64:55 | throw ...; | cflow.cs:37:17:37:22 | exit Switch (abnormal) | exception(NullReferenceException) |
+| cflow.cs:64:27:64:54 | object creation of type NullReferenceException | cflow.cs:64:21:64:55 | throw ...; |  |
+| cflow.cs:65:17:65:22 | break; | cflow.cs:67:16:67:16 | access to parameter a | break |
+| cflow.cs:67:9:67:17 | return ...; | cflow.cs:37:17:37:22 | exit Switch (normal) | return |
+| cflow.cs:67:16:67:16 | access to parameter a | cflow.cs:67:9:67:17 | return ...; |  |
+| cflow.cs:70:18:70:18 | enter M | cflow.cs:71:5:82:5 | {...} |  |
+| cflow.cs:70:18:70:18 | exit M (normal) | cflow.cs:70:18:70:18 | exit M |  |
+| cflow.cs:71:5:82:5 | {...} | cflow.cs:72:9:73:19 | if (...) ... |  |
+| cflow.cs:72:9:73:19 | if (...) ... | cflow.cs:72:13:72:13 | access to parameter s |  |
+| cflow.cs:72:13:72:13 | access to parameter s | cflow.cs:72:18:72:21 | null |  |
+| cflow.cs:72:13:72:21 | ... == ... | cflow.cs:73:13:73:19 | return ...; | true |
+| cflow.cs:72:13:72:21 | ... == ... | cflow.cs:74:9:81:9 | if (...) ... | false |
+| cflow.cs:72:18:72:21 | null | cflow.cs:72:13:72:21 | ... == ... |  |
+| cflow.cs:73:13:73:19 | return ...; | cflow.cs:70:18:70:18 | exit M (normal) | return |
+| cflow.cs:74:9:81:9 | if (...) ... | cflow.cs:74:13:74:13 | access to parameter s |  |
+| cflow.cs:74:13:74:13 | access to parameter s | cflow.cs:74:13:74:20 | access to property Length |  |
+| cflow.cs:74:13:74:20 | access to property Length | cflow.cs:74:24:74:24 | 0 |  |
+| cflow.cs:74:13:74:24 | ... > ... | cflow.cs:75:9:77:9 | {...} | true |
+| cflow.cs:74:13:74:24 | ... > ... | cflow.cs:79:9:81:9 | {...} | false |
+| cflow.cs:74:24:74:24 | 0 | cflow.cs:74:13:74:24 | ... > ... |  |
+| cflow.cs:75:9:77:9 | {...} | cflow.cs:76:13:76:33 | ...; |  |
+| cflow.cs:76:13:76:32 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) |  |
+| cflow.cs:76:13:76:33 | ...; | cflow.cs:76:31:76:31 | access to parameter s |  |
+| cflow.cs:76:31:76:31 | access to parameter s | cflow.cs:76:13:76:32 | call to method WriteLine |  |
+| cflow.cs:79:9:81:9 | {...} | cflow.cs:80:13:80:48 | ...; |  |
+| cflow.cs:80:13:80:47 | call to method WriteLine | cflow.cs:70:18:70:18 | exit M (normal) |  |
+| cflow.cs:80:13:80:48 | ...; | cflow.cs:80:31:80:46 | "<empty string>" |  |
+| cflow.cs:80:31:80:46 | "<empty string>" | cflow.cs:80:13:80:47 | call to method WriteLine |  |
+| cflow.cs:84:18:84:19 | enter M2 | cflow.cs:85:5:88:5 | {...} |  |
+| cflow.cs:84:18:84:19 | exit M2 (normal) | cflow.cs:84:18:84:19 | exit M2 |  |
+| cflow.cs:85:5:88:5 | {...} | cflow.cs:86:9:87:33 | if (...) ... |  |
+| cflow.cs:86:9:87:33 | if (...) ... | cflow.cs:86:13:86:13 | access to parameter s |  |
+| cflow.cs:86:13:86:13 | access to parameter s | cflow.cs:86:18:86:21 | null |  |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:13:86:37 | [false] ... && ... | false |
+| cflow.cs:86:13:86:21 | ... != ... | cflow.cs:86:26:86:26 | access to parameter s | true |
+| cflow.cs:86:13:86:37 | [false] ... && ... | cflow.cs:84:18:84:19 | exit M2 (normal) | false |
+| cflow.cs:86:13:86:37 | [true] ... && ... | cflow.cs:87:13:87:33 | ...; | true |
+| cflow.cs:86:18:86:21 | null | cflow.cs:86:13:86:21 | ... != ... |  |
+| cflow.cs:86:26:86:26 | access to parameter s | cflow.cs:86:26:86:33 | access to property Length |  |
+| cflow.cs:86:26:86:33 | access to property Length | cflow.cs:86:37:86:37 | 0 |  |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [false] ... && ... | false |
+| cflow.cs:86:26:86:37 | ... > ... | cflow.cs:86:13:86:37 | [true] ... && ... | true |
+| cflow.cs:86:37:86:37 | 0 | cflow.cs:86:26:86:37 | ... > ... |  |
+| cflow.cs:87:13:87:32 | call to method WriteLine | cflow.cs:84:18:84:19 | exit M2 (normal) |  |
+| cflow.cs:87:13:87:33 | ...; | cflow.cs:87:31:87:31 | access to parameter s |  |
+| cflow.cs:87:31:87:31 | access to parameter s | cflow.cs:87:13:87:32 | call to method WriteLine |  |
+| cflow.cs:90:18:90:19 | enter M3 | cflow.cs:91:5:104:5 | {...} |  |
+| cflow.cs:90:18:90:19 | exit M3 (abnormal) | cflow.cs:90:18:90:19 | exit M3 |  |
+| cflow.cs:90:18:90:19 | exit M3 (normal) | cflow.cs:90:18:90:19 | exit M3 |  |
+| cflow.cs:91:5:104:5 | {...} | cflow.cs:92:9:93:49 | if (...) ... |  |
+| cflow.cs:92:9:93:49 | if (...) ... | cflow.cs:92:20:92:20 | access to parameter s |  |
+| cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:93:45:93:47 | "s" | true |
+| cflow.cs:92:13:92:27 | call to method Equals | cflow.cs:94:9:94:29 | ...; | false |
+| cflow.cs:92:20:92:20 | access to parameter s | cflow.cs:92:23:92:26 | null |  |
+| cflow.cs:92:23:92:26 | null | cflow.cs:92:13:92:27 | call to method Equals |  |
+| cflow.cs:93:13:93:49 | throw ...; | cflow.cs:90:18:90:19 | exit M3 (abnormal) | exception(ArgumentNullException) |
+| cflow.cs:93:19:93:48 | object creation of type ArgumentNullException | cflow.cs:93:13:93:49 | throw ...; |  |
+| cflow.cs:93:45:93:47 | "s" | cflow.cs:93:19:93:48 | object creation of type ArgumentNullException |  |
+| cflow.cs:94:9:94:28 | call to method WriteLine | cflow.cs:96:9:97:55 | if (...) ... |  |
+| cflow.cs:94:9:94:29 | ...; | cflow.cs:94:27:94:27 | access to parameter s |  |
+| cflow.cs:94:27:94:27 | access to parameter s | cflow.cs:94:9:94:28 | call to method WriteLine |  |
+| cflow.cs:96:9:97:55 | if (...) ... | cflow.cs:96:13:96:17 | this access |  |
+| cflow.cs:96:13:96:17 | access to field Field | cflow.cs:96:22:96:25 | null |  |
+| cflow.cs:96:13:96:17 | this access | cflow.cs:96:13:96:17 | access to field Field |  |
+| cflow.cs:96:13:96:25 | ... != ... | cflow.cs:97:13:97:55 | ...; | true |
+| cflow.cs:96:13:96:25 | ... != ... | cflow.cs:99:9:100:42 | if (...) ... | false |
+| cflow.cs:96:22:96:25 | null | cflow.cs:96:13:96:25 | ... != ... |  |
+| cflow.cs:97:13:97:54 | call to method WriteLine | cflow.cs:99:9:100:42 | if (...) ... |  |
+| cflow.cs:97:13:97:55 | ...; | cflow.cs:97:31:97:47 | object creation of type ControlFlow |  |
+| cflow.cs:97:31:97:47 | object creation of type ControlFlow | cflow.cs:97:31:97:53 | access to field Field |  |
+| cflow.cs:97:31:97:53 | access to field Field | cflow.cs:97:13:97:54 | call to method WriteLine |  |
+| cflow.cs:99:9:100:42 | if (...) ... | cflow.cs:99:13:99:17 | this access |  |
+| cflow.cs:99:13:99:17 | access to field Field | cflow.cs:99:22:99:25 | null |  |
+| cflow.cs:99:13:99:17 | this access | cflow.cs:99:13:99:17 | access to field Field |  |
+| cflow.cs:99:13:99:25 | ... != ... | cflow.cs:100:13:100:42 | ...; | true |
+| cflow.cs:99:13:99:25 | ... != ... | cflow.cs:102:9:103:36 | if (...) ... | false |
+| cflow.cs:99:22:99:25 | null | cflow.cs:99:13:99:25 | ... != ... |  |
+| cflow.cs:100:13:100:41 | call to method WriteLine | cflow.cs:102:9:103:36 | if (...) ... |  |
+| cflow.cs:100:13:100:42 | ...; | cflow.cs:100:31:100:34 | this access |  |
+| cflow.cs:100:31:100:34 | this access | cflow.cs:100:31:100:40 | access to field Field |  |
+| cflow.cs:100:31:100:40 | access to field Field | cflow.cs:100:13:100:41 | call to method WriteLine |  |
+| cflow.cs:102:9:103:36 | if (...) ... | cflow.cs:102:13:102:16 | this access |  |
+| cflow.cs:102:13:102:16 | this access | cflow.cs:102:13:102:21 | access to property Prop |  |
+| cflow.cs:102:13:102:21 | access to property Prop | cflow.cs:102:26:102:29 | null |  |
+| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:90:18:90:19 | exit M3 (normal) | false |
+| cflow.cs:102:13:102:29 | ... != ... | cflow.cs:103:13:103:36 | ...; | true |
+| cflow.cs:102:26:102:29 | null | cflow.cs:102:13:102:29 | ... != ... |  |
+| cflow.cs:103:13:103:35 | call to method WriteLine | cflow.cs:90:18:90:19 | exit M3 (normal) |  |
+| cflow.cs:103:13:103:36 | ...; | cflow.cs:103:31:103:34 | this access |  |
+| cflow.cs:103:31:103:34 | access to property Prop | cflow.cs:103:13:103:35 | call to method WriteLine |  |
+| cflow.cs:103:31:103:34 | this access | cflow.cs:103:31:103:34 | access to property Prop |  |
+| cflow.cs:106:18:106:19 | enter M4 | cflow.cs:107:5:117:5 | {...} |  |
+| cflow.cs:106:18:106:19 | exit M4 (normal) | cflow.cs:106:18:106:19 | exit M4 |  |
+| cflow.cs:107:5:117:5 | {...} | cflow.cs:108:9:115:9 | if (...) ... |  |
+| cflow.cs:108:9:115:9 | if (...) ... | cflow.cs:108:13:108:13 | access to parameter s |  |
+| cflow.cs:108:13:108:13 | access to parameter s | cflow.cs:108:18:108:21 | null |  |
+| cflow.cs:108:13:108:21 | ... != ... | cflow.cs:109:9:115:9 | {...} | true |
+| cflow.cs:108:13:108:21 | ... != ... | cflow.cs:116:9:116:29 | ...; | false |
+| cflow.cs:108:18:108:21 | null | cflow.cs:108:13:108:21 | ... != ... |  |
+| cflow.cs:109:9:115:9 | {...} | cflow.cs:110:13:113:13 | while (...) ... |  |
+| cflow.cs:110:13:113:13 | while (...) ... | cflow.cs:110:20:110:23 | true |  |
+| cflow.cs:110:20:110:23 | true | cflow.cs:111:13:113:13 | {...} | true |
+| cflow.cs:111:13:113:13 | {...} | cflow.cs:112:17:112:37 | ...; |  |
+| cflow.cs:112:17:112:36 | call to method WriteLine | cflow.cs:110:20:110:23 | true |  |
+| cflow.cs:112:17:112:37 | ...; | cflow.cs:112:35:112:35 | access to parameter s |  |
+| cflow.cs:112:35:112:35 | access to parameter s | cflow.cs:112:17:112:36 | call to method WriteLine |  |
+| cflow.cs:116:9:116:28 | call to method WriteLine | cflow.cs:106:18:106:19 | exit M4 (normal) |  |
+| cflow.cs:116:9:116:29 | ...; | cflow.cs:116:27:116:27 | access to parameter s |  |
+| cflow.cs:116:27:116:27 | access to parameter s | cflow.cs:116:9:116:28 | call to method WriteLine |  |
+| cflow.cs:119:20:119:21 | enter M5 | cflow.cs:120:5:124:5 | {...} |  |
+| cflow.cs:119:20:119:21 | exit M5 (normal) | cflow.cs:119:20:119:21 | exit M5 |  |
+| cflow.cs:120:5:124:5 | {...} | cflow.cs:121:9:121:18 | ... ...; |  |
+| cflow.cs:121:9:121:18 | ... ...; | cflow.cs:121:17:121:17 | access to parameter s |  |
+| cflow.cs:121:13:121:17 | String x = ... | cflow.cs:122:9:122:20 | ...; |  |
+| cflow.cs:121:17:121:17 | access to parameter s | cflow.cs:121:13:121:17 | String x = ... |  |
+| cflow.cs:122:9:122:19 | ... = ... | cflow.cs:123:16:123:16 | access to local variable x |  |
+| cflow.cs:122:9:122:20 | ...; | cflow.cs:122:13:122:13 | access to local variable x |  |
+| cflow.cs:122:13:122:13 | access to local variable x | cflow.cs:122:17:122:19 | " " |  |
+| cflow.cs:122:13:122:19 | ... + ... | cflow.cs:122:9:122:19 | ... = ... |  |
+| cflow.cs:122:17:122:19 | " " | cflow.cs:122:13:122:19 | ... + ... |  |
+| cflow.cs:123:9:123:17 | return ...; | cflow.cs:119:20:119:21 | exit M5 (normal) | return |
+| cflow.cs:123:16:123:16 | access to local variable x | cflow.cs:123:9:123:17 | return ...; |  |
+| cflow.cs:127:19:127:21 | enter get_Prop | cflow.cs:127:23:127:60 | {...} |  |
+| cflow.cs:127:19:127:21 | exit get_Prop (normal) | cflow.cs:127:19:127:21 | exit get_Prop |  |
+| cflow.cs:127:23:127:60 | {...} | cflow.cs:127:32:127:36 | this access |  |
+| cflow.cs:127:25:127:58 | return ...; | cflow.cs:127:19:127:21 | exit get_Prop (normal) | return |
+| cflow.cs:127:32:127:36 | access to field Field | cflow.cs:127:41:127:44 | null |  |
+| cflow.cs:127:32:127:36 | this access | cflow.cs:127:32:127:36 | access to field Field |  |
+| cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:48:127:49 | "" | true |
+| cflow.cs:127:32:127:44 | ... == ... | cflow.cs:127:53:127:57 | this access | false |
+| cflow.cs:127:32:127:57 | ... ? ... : ... | cflow.cs:127:25:127:58 | return ...; |  |
+| cflow.cs:127:41:127:44 | null | cflow.cs:127:32:127:44 | ... == ... |  |
+| cflow.cs:127:48:127:49 | "" | cflow.cs:127:32:127:57 | ... ? ... : ... |  |
+| cflow.cs:127:53:127:57 | access to field Field | cflow.cs:127:32:127:57 | ... ? ... : ... |  |
+| cflow.cs:127:53:127:57 | this access | cflow.cs:127:53:127:57 | access to field Field |  |
+| cflow.cs:127:62:127:64 | enter set_Prop | cflow.cs:127:66:127:83 | {...} |  |
+| cflow.cs:127:62:127:64 | exit set_Prop (normal) | cflow.cs:127:62:127:64 | exit set_Prop |  |
+| cflow.cs:127:66:127:83 | {...} | cflow.cs:127:68:127:81 | ...; |  |
+| cflow.cs:127:68:127:72 | this access | cflow.cs:127:76:127:80 | access to parameter value |  |
+| cflow.cs:127:68:127:80 | ... = ... | cflow.cs:127:62:127:64 | exit set_Prop (normal) |  |
+| cflow.cs:127:68:127:81 | ...; | cflow.cs:127:68:127:72 | this access |  |
+| cflow.cs:127:76:127:80 | access to parameter value | cflow.cs:127:68:127:80 | ... = ... |  |
+| cflow.cs:129:5:129:15 | call to constructor Object | cflow.cs:130:5:132:5 | {...} |  |
+| cflow.cs:129:5:129:15 | enter ControlFlow | cflow.cs:129:5:129:15 | call to constructor Object |  |
+| cflow.cs:129:5:129:15 | exit ControlFlow (normal) | cflow.cs:129:5:129:15 | exit ControlFlow |  |
+| cflow.cs:130:5:132:5 | {...} | cflow.cs:131:9:131:18 | ...; |  |
+| cflow.cs:131:9:131:13 | this access | cflow.cs:131:17:131:17 | access to parameter s |  |
+| cflow.cs:131:9:131:17 | ... = ... | cflow.cs:129:5:129:15 | exit ControlFlow (normal) |  |
+| cflow.cs:131:9:131:18 | ...; | cflow.cs:131:9:131:13 | this access |  |
+| cflow.cs:131:17:131:17 | access to parameter s | cflow.cs:131:9:131:17 | ... = ... |  |
+| cflow.cs:134:5:134:15 | enter ControlFlow | cflow.cs:134:31:134:31 | access to parameter i |  |
+| cflow.cs:134:5:134:15 | exit ControlFlow (normal) | cflow.cs:134:5:134:15 | exit ControlFlow |  |
+| cflow.cs:134:26:134:29 | call to constructor ControlFlow | cflow.cs:134:39:134:41 | {...} |  |
+| cflow.cs:134:31:134:31 | (...) ... | cflow.cs:134:35:134:36 | "" |  |
+| cflow.cs:134:31:134:31 | access to parameter i | cflow.cs:134:31:134:31 | (...) ... |  |
+| cflow.cs:134:31:134:36 | ... + ... | cflow.cs:134:26:134:29 | call to constructor ControlFlow |  |
+| cflow.cs:134:35:134:36 | "" | cflow.cs:134:31:134:36 | ... + ... |  |
+| cflow.cs:134:39:134:41 | {...} | cflow.cs:134:5:134:15 | exit ControlFlow (normal) |  |
+| cflow.cs:136:12:136:22 | enter ControlFlow | cflow.cs:136:33:136:33 | 0 |  |
+| cflow.cs:136:12:136:22 | exit ControlFlow (normal) | cflow.cs:136:12:136:22 | exit ControlFlow |  |
+| cflow.cs:136:28:136:31 | call to constructor ControlFlow | cflow.cs:136:40:136:42 | {...} |  |
+| cflow.cs:136:33:136:33 | 0 | cflow.cs:136:37:136:37 | 1 |  |
+| cflow.cs:136:33:136:37 | ... + ... | cflow.cs:136:28:136:31 | call to constructor ControlFlow |  |
+| cflow.cs:136:37:136:37 | 1 | cflow.cs:136:33:136:37 | ... + ... |  |
+| cflow.cs:136:40:136:42 | {...} | cflow.cs:136:12:136:22 | exit ControlFlow (normal) |  |
+| cflow.cs:138:40:138:40 | enter + | cflow.cs:139:5:142:5 | {...} |  |
+| cflow.cs:138:40:138:40 | exit + (normal) | cflow.cs:138:40:138:40 | exit + |  |
+| cflow.cs:139:5:142:5 | {...} | cflow.cs:140:9:140:29 | ...; |  |
+| cflow.cs:140:9:140:28 | call to method WriteLine | cflow.cs:141:16:141:16 | access to parameter y |  |
+| cflow.cs:140:9:140:29 | ...; | cflow.cs:140:27:140:27 | access to parameter x |  |
+| cflow.cs:140:27:140:27 | access to parameter x | cflow.cs:140:9:140:28 | call to method WriteLine |  |
+| cflow.cs:141:9:141:17 | return ...; | cflow.cs:138:40:138:40 | exit + (normal) | return |
+| cflow.cs:141:16:141:16 | access to parameter y | cflow.cs:141:9:141:17 | return ...; |  |
+| cflow.cs:144:33:144:35 | enter get_Item | cflow.cs:144:37:144:54 | {...} |  |
+| cflow.cs:144:33:144:35 | exit get_Item (normal) | cflow.cs:144:33:144:35 | exit get_Item |  |
+| cflow.cs:144:37:144:54 | {...} | cflow.cs:144:46:144:46 | access to parameter i |  |
+| cflow.cs:144:39:144:52 | return ...; | cflow.cs:144:33:144:35 | exit get_Item (normal) | return |
+| cflow.cs:144:46:144:46 | (...) ... | cflow.cs:144:50:144:51 | "" |  |
+| cflow.cs:144:46:144:46 | access to parameter i | cflow.cs:144:46:144:46 | (...) ... |  |
+| cflow.cs:144:46:144:51 | ... + ... | cflow.cs:144:39:144:52 | return ...; |  |
+| cflow.cs:144:50:144:51 | "" | cflow.cs:144:46:144:51 | ... + ... |  |
+| cflow.cs:144:56:144:58 | enter set_Item | cflow.cs:144:60:144:62 | {...} |  |
+| cflow.cs:144:56:144:58 | exit set_Item (normal) | cflow.cs:144:56:144:58 | exit set_Item |  |
+| cflow.cs:144:60:144:62 | {...} | cflow.cs:144:56:144:58 | exit set_Item (normal) |  |
+| cflow.cs:146:10:146:12 | enter For | cflow.cs:147:5:177:5 | {...} |  |
+| cflow.cs:146:10:146:12 | exit For (normal) | cflow.cs:146:10:146:12 | exit For |  |
+| cflow.cs:147:5:177:5 | {...} | cflow.cs:148:9:148:18 | ... ...; |  |
+| cflow.cs:148:9:148:18 | ... ...; | cflow.cs:148:17:148:17 | 0 |  |
+| cflow.cs:148:13:148:17 | Int32 x = ... | cflow.cs:149:9:150:33 | for (...;...;...) ... |  |
+| cflow.cs:148:17:148:17 | 0 | cflow.cs:148:13:148:17 | Int32 x = ... |  |
+| cflow.cs:149:9:150:33 | for (...;...;...) ... | cflow.cs:149:16:149:16 | access to local variable x |  |
+| cflow.cs:149:16:149:16 | access to local variable x | cflow.cs:149:20:149:21 | 10 |  |
+| cflow.cs:149:16:149:21 | ... < ... | cflow.cs:150:13:150:33 | ...; | true |
+| cflow.cs:149:16:149:21 | ... < ... | cflow.cs:152:9:157:9 | for (...;...;...) ... | false |
+| cflow.cs:149:20:149:21 | 10 | cflow.cs:149:16:149:21 | ... < ... |  |
+| cflow.cs:149:24:149:26 | ++... | cflow.cs:149:16:149:16 | access to local variable x |  |
+| cflow.cs:149:26:149:26 | access to local variable x | cflow.cs:149:24:149:26 | ++... |  |
+| cflow.cs:150:13:150:32 | call to method WriteLine | cflow.cs:149:26:149:26 | access to local variable x |  |
+| cflow.cs:150:13:150:33 | ...; | cflow.cs:150:31:150:31 | access to local variable x |  |
+| cflow.cs:150:31:150:31 | access to local variable x | cflow.cs:150:13:150:32 | call to method WriteLine |  |
+| cflow.cs:152:9:157:9 | for (...;...;...) ... | cflow.cs:153:9:157:9 | {...} |  |
+| cflow.cs:152:18:152:18 | access to local variable x | cflow.cs:152:18:152:20 | ...++ |  |
+| cflow.cs:152:18:152:20 | ...++ | cflow.cs:153:9:157:9 | {...} |  |
+| cflow.cs:153:9:157:9 | {...} | cflow.cs:154:13:154:33 | ...; |  |
+| cflow.cs:154:13:154:32 | call to method WriteLine | cflow.cs:155:13:156:22 | if (...) ... |  |
+| cflow.cs:154:13:154:33 | ...; | cflow.cs:154:31:154:31 | access to local variable x |  |
+| cflow.cs:154:31:154:31 | access to local variable x | cflow.cs:154:13:154:32 | call to method WriteLine |  |
+| cflow.cs:155:13:156:22 | if (...) ... | cflow.cs:155:17:155:17 | access to local variable x |  |
+| cflow.cs:155:17:155:17 | access to local variable x | cflow.cs:155:21:155:22 | 20 |  |
+| cflow.cs:155:17:155:22 | ... > ... | cflow.cs:152:18:152:18 | access to local variable x | false |
+| cflow.cs:155:17:155:22 | ... > ... | cflow.cs:156:17:156:22 | break; | true |
+| cflow.cs:155:21:155:22 | 20 | cflow.cs:155:17:155:22 | ... > ... |  |
+| cflow.cs:156:17:156:22 | break; | cflow.cs:159:9:165:9 | for (...;...;...) ... | break |
+| cflow.cs:159:9:165:9 | for (...;...;...) ... | cflow.cs:160:9:165:9 | {...} |  |
+| cflow.cs:160:9:165:9 | {...} | cflow.cs:161:13:161:33 | ...; |  |
+| cflow.cs:161:13:161:32 | call to method WriteLine | cflow.cs:162:13:162:16 | ...; |  |
+| cflow.cs:161:13:161:33 | ...; | cflow.cs:161:31:161:31 | access to local variable x |  |
+| cflow.cs:161:31:161:31 | access to local variable x | cflow.cs:161:13:161:32 | call to method WriteLine |  |
+| cflow.cs:162:13:162:13 | access to local variable x | cflow.cs:162:13:162:15 | ...++ |  |
+| cflow.cs:162:13:162:15 | ...++ | cflow.cs:163:13:164:22 | if (...) ... |  |
+| cflow.cs:162:13:162:16 | ...; | cflow.cs:162:13:162:13 | access to local variable x |  |
+| cflow.cs:163:13:164:22 | if (...) ... | cflow.cs:163:17:163:17 | access to local variable x |  |
+| cflow.cs:163:17:163:17 | access to local variable x | cflow.cs:163:21:163:22 | 30 |  |
+| cflow.cs:163:17:163:22 | ... > ... | cflow.cs:160:9:165:9 | {...} | false |
+| cflow.cs:163:17:163:22 | ... > ... | cflow.cs:164:17:164:22 | break; | true |
+| cflow.cs:163:21:163:22 | 30 | cflow.cs:163:17:163:22 | ... > ... |  |
+| cflow.cs:164:17:164:22 | break; | cflow.cs:167:9:171:9 | for (...;...;...) ... | break |
+| cflow.cs:167:9:171:9 | for (...;...;...) ... | cflow.cs:167:16:167:16 | access to local variable x |  |
+| cflow.cs:167:16:167:16 | access to local variable x | cflow.cs:167:20:167:21 | 40 |  |
+| cflow.cs:167:16:167:21 | ... < ... | cflow.cs:168:9:171:9 | {...} | true |
+| cflow.cs:167:16:167:21 | ... < ... | cflow.cs:173:9:176:9 | for (...;...;...) ... | false |
+| cflow.cs:167:20:167:21 | 40 | cflow.cs:167:16:167:21 | ... < ... |  |
+| cflow.cs:168:9:171:9 | {...} | cflow.cs:169:13:169:33 | ...; |  |
+| cflow.cs:169:13:169:32 | call to method WriteLine | cflow.cs:170:13:170:16 | ...; |  |
+| cflow.cs:169:13:169:33 | ...; | cflow.cs:169:31:169:31 | access to local variable x |  |
+| cflow.cs:169:31:169:31 | access to local variable x | cflow.cs:169:13:169:32 | call to method WriteLine |  |
+| cflow.cs:170:13:170:13 | access to local variable x | cflow.cs:170:13:170:15 | ...++ |  |
+| cflow.cs:170:13:170:15 | ...++ | cflow.cs:167:16:167:16 | access to local variable x |  |
+| cflow.cs:170:13:170:16 | ...; | cflow.cs:170:13:170:13 | access to local variable x |  |
+| cflow.cs:173:9:176:9 | for (...;...;...) ... | cflow.cs:173:22:173:22 | 0 |  |
+| cflow.cs:173:18:173:22 | Int32 i = ... | cflow.cs:173:29:173:29 | 0 |  |
+| cflow.cs:173:22:173:22 | 0 | cflow.cs:173:18:173:22 | Int32 i = ... |  |
+| cflow.cs:173:25:173:29 | Int32 j = ... | cflow.cs:173:32:173:32 | access to local variable i |  |
+| cflow.cs:173:29:173:29 | 0 | cflow.cs:173:25:173:29 | Int32 j = ... |  |
+| cflow.cs:173:32:173:32 | access to local variable i | cflow.cs:173:36:173:36 | access to local variable j |  |
+| cflow.cs:173:32:173:36 | ... + ... | cflow.cs:173:40:173:41 | 10 |  |
+| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:146:10:146:12 | exit For (normal) | false |
+| cflow.cs:173:32:173:41 | ... < ... | cflow.cs:174:9:176:9 | {...} | true |
+| cflow.cs:173:36:173:36 | access to local variable j | cflow.cs:173:32:173:36 | ... + ... |  |
+| cflow.cs:173:40:173:41 | 10 | cflow.cs:173:32:173:41 | ... < ... |  |
+| cflow.cs:173:44:173:44 | access to local variable i | cflow.cs:173:44:173:46 | ...++ |  |
+| cflow.cs:173:44:173:46 | ...++ | cflow.cs:173:49:173:49 | access to local variable j |  |
+| cflow.cs:173:49:173:49 | access to local variable j | cflow.cs:173:49:173:51 | ...++ |  |
+| cflow.cs:173:49:173:51 | ...++ | cflow.cs:173:32:173:32 | access to local variable i |  |
+| cflow.cs:174:9:176:9 | {...} | cflow.cs:175:13:175:37 | ...; |  |
+| cflow.cs:175:13:175:36 | call to method WriteLine | cflow.cs:173:44:173:44 | access to local variable i |  |
+| cflow.cs:175:13:175:37 | ...; | cflow.cs:175:31:175:31 | access to local variable i |  |
+| cflow.cs:175:31:175:31 | access to local variable i | cflow.cs:175:35:175:35 | access to local variable j |  |
+| cflow.cs:175:31:175:35 | ... + ... | cflow.cs:175:13:175:36 | call to method WriteLine |  |
+| cflow.cs:175:35:175:35 | access to local variable j | cflow.cs:175:31:175:35 | ... + ... |  |
+| cflow.cs:179:10:179:16 | enter Lambdas | cflow.cs:180:5:183:5 | {...} |  |
+| cflow.cs:179:10:179:16 | exit Lambdas (normal) | cflow.cs:179:10:179:16 | exit Lambdas |  |
+| cflow.cs:180:5:183:5 | {...} | cflow.cs:181:9:181:38 | ... ...; |  |
+| cflow.cs:181:9:181:38 | ... ...; | cflow.cs:181:28:181:37 | (...) => ... |  |
+| cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... | cflow.cs:182:9:182:62 | ... ...; |  |
+| cflow.cs:181:28:181:37 | (...) => ... | cflow.cs:181:24:181:37 | Func<Int32,Int32> y = ... |  |
+| cflow.cs:181:28:181:37 | enter (...) => ... | cflow.cs:181:33:181:33 | access to parameter x |  |
+| cflow.cs:181:28:181:37 | exit (...) => ... (normal) | cflow.cs:181:28:181:37 | exit (...) => ... |  |
+| cflow.cs:181:33:181:33 | access to parameter x | cflow.cs:181:37:181:37 | 1 |  |
+| cflow.cs:181:33:181:37 | ... + ... | cflow.cs:181:28:181:37 | exit (...) => ... (normal) |  |
+| cflow.cs:181:37:181:37 | 1 | cflow.cs:181:33:181:37 | ... + ... |  |
+| cflow.cs:182:9:182:62 | ... ...; | cflow.cs:182:28:182:61 | delegate(...) { ... } |  |
+| cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... | cflow.cs:179:10:179:16 | exit Lambdas (normal) |  |
+| cflow.cs:182:28:182:61 | delegate(...) { ... } | cflow.cs:182:24:182:61 | Func<Int32,Int32> z = ... |  |
+| cflow.cs:182:28:182:61 | enter delegate(...) { ... } | cflow.cs:182:45:182:61 | {...} |  |
+| cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | cflow.cs:182:28:182:61 | exit delegate(...) { ... } |  |
+| cflow.cs:182:45:182:61 | {...} | cflow.cs:182:54:182:54 | access to parameter x |  |
+| cflow.cs:182:47:182:59 | return ...; | cflow.cs:182:28:182:61 | exit delegate(...) { ... } (normal) | return |
+| cflow.cs:182:54:182:54 | access to parameter x | cflow.cs:182:58:182:58 | 1 |  |
+| cflow.cs:182:54:182:58 | ... + ... | cflow.cs:182:47:182:59 | return ...; |  |
+| cflow.cs:182:58:182:58 | 1 | cflow.cs:182:54:182:58 | ... + ... |  |
+| cflow.cs:185:10:185:18 | enter LogicalOr | cflow.cs:186:5:191:5 | {...} |  |
+| cflow.cs:185:10:185:18 | exit LogicalOr (normal) | cflow.cs:185:10:185:18 | exit LogicalOr |  |
+| cflow.cs:186:5:191:5 | {...} | cflow.cs:187:9:190:52 | if (...) ... |  |
+| cflow.cs:187:9:190:52 | if (...) ... | cflow.cs:187:13:187:13 | 1 |  |
+| cflow.cs:187:13:187:13 | 1 | cflow.cs:187:18:187:18 | 2 |  |
+| cflow.cs:187:13:187:18 | ... == ... | cflow.cs:187:23:187:23 | 2 | false |
+| cflow.cs:187:13:187:28 | [false] ... \|\| ... | cflow.cs:187:34:187:34 | 1 | false |
+| cflow.cs:187:13:187:50 | [false] ... \|\| ... | cflow.cs:190:13:190:52 | ...; | false |
+| cflow.cs:187:18:187:18 | 2 | cflow.cs:187:13:187:18 | ... == ... |  |
+| cflow.cs:187:23:187:23 | 2 | cflow.cs:187:28:187:28 | 3 |  |
+| cflow.cs:187:23:187:28 | ... == ... | cflow.cs:187:13:187:28 | [false] ... \|\| ... | false |
+| cflow.cs:187:28:187:28 | 3 | cflow.cs:187:23:187:28 | ... == ... |  |
+| cflow.cs:187:34:187:34 | 1 | cflow.cs:187:39:187:39 | 3 |  |
+| cflow.cs:187:34:187:39 | ... == ... | cflow.cs:187:34:187:49 | [false] ... && ... | false |
+| cflow.cs:187:34:187:49 | [false] ... && ... | cflow.cs:187:13:187:50 | [false] ... \|\| ... | false |
+| cflow.cs:187:39:187:39 | 3 | cflow.cs:187:34:187:39 | ... == ... |  |
+| cflow.cs:190:13:190:51 | call to method WriteLine | cflow.cs:185:10:185:18 | exit LogicalOr (normal) |  |
+| cflow.cs:190:13:190:52 | ...; | cflow.cs:190:31:190:50 | "This should happen" |  |
+| cflow.cs:190:31:190:50 | "This should happen" | cflow.cs:190:13:190:51 | call to method WriteLine |  |
+| cflow.cs:193:10:193:17 | enter Booleans | cflow.cs:194:5:206:5 | {...} |  |
+| cflow.cs:193:10:193:17 | exit Booleans (abnormal) | cflow.cs:193:10:193:17 | exit Booleans |  |
+| cflow.cs:193:10:193:17 | exit Booleans (normal) | cflow.cs:193:10:193:17 | exit Booleans |  |
+| cflow.cs:194:5:206:5 | {...} | cflow.cs:195:9:195:57 | ... ...; |  |
+| cflow.cs:195:9:195:57 | ... ...; | cflow.cs:195:17:195:21 | this access |  |
+| cflow.cs:195:13:195:56 | Boolean b = ... | cflow.cs:197:9:198:49 | if (...) ... |  |
+| cflow.cs:195:17:195:21 | access to field Field | cflow.cs:195:17:195:28 | access to property Length |  |
+| cflow.cs:195:17:195:21 | this access | cflow.cs:195:17:195:21 | access to field Field |  |
+| cflow.cs:195:17:195:28 | access to property Length | cflow.cs:195:32:195:32 | 0 |  |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:17:195:56 | ... && ... | false |
+| cflow.cs:195:17:195:32 | ... > ... | cflow.cs:195:39:195:43 | this access | true |
+| cflow.cs:195:17:195:56 | ... && ... | cflow.cs:195:13:195:56 | Boolean b = ... |  |
+| cflow.cs:195:32:195:32 | 0 | cflow.cs:195:17:195:32 | ... > ... |  |
+| cflow.cs:195:37:195:56 | !... | cflow.cs:195:17:195:56 | ... && ... |  |
+| cflow.cs:195:39:195:43 | access to field Field | cflow.cs:195:39:195:50 | access to property Length |  |
+| cflow.cs:195:39:195:43 | this access | cflow.cs:195:39:195:43 | access to field Field |  |
+| cflow.cs:195:39:195:50 | access to property Length | cflow.cs:195:55:195:55 | 1 |  |
+| cflow.cs:195:39:195:55 | ... == ... | cflow.cs:195:37:195:56 | !... |  |
+| cflow.cs:195:55:195:55 | 1 | cflow.cs:195:39:195:55 | ... == ... |  |
+| cflow.cs:197:9:198:49 | if (...) ... | cflow.cs:197:15:197:19 | this access |  |
+| cflow.cs:197:13:197:47 | [false] !... | cflow.cs:200:9:205:9 | if (...) ... | false |
+| cflow.cs:197:13:197:47 | [true] !... | cflow.cs:198:13:198:49 | ...; | true |
+| cflow.cs:197:15:197:19 | access to field Field | cflow.cs:197:15:197:26 | access to property Length |  |
+| cflow.cs:197:15:197:19 | this access | cflow.cs:197:15:197:19 | access to field Field |  |
+| cflow.cs:197:15:197:26 | access to property Length | cflow.cs:197:31:197:31 | 0 |  |
+| cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:35:197:39 | false | true |
+| cflow.cs:197:15:197:31 | ... == ... | cflow.cs:197:43:197:46 | true | false |
+| cflow.cs:197:15:197:46 | [false] ... ? ... : ... | cflow.cs:197:13:197:47 | [true] !... | false |
+| cflow.cs:197:15:197:46 | [true] ... ? ... : ... | cflow.cs:197:13:197:47 | [false] !... | true |
+| cflow.cs:197:31:197:31 | 0 | cflow.cs:197:15:197:31 | ... == ... |  |
+| cflow.cs:197:35:197:39 | false | cflow.cs:197:15:197:46 | [false] ... ? ... : ... | false |
+| cflow.cs:197:43:197:46 | true | cflow.cs:197:15:197:46 | [true] ... ? ... : ... | true |
+| cflow.cs:198:13:198:48 | ... = ... | cflow.cs:200:9:205:9 | if (...) ... |  |
+| cflow.cs:198:13:198:49 | ...; | cflow.cs:198:17:198:21 | this access |  |
+| cflow.cs:198:17:198:21 | access to field Field | cflow.cs:198:17:198:28 | access to property Length |  |
+| cflow.cs:198:17:198:21 | this access | cflow.cs:198:17:198:21 | access to field Field |  |
+| cflow.cs:198:17:198:28 | access to property Length | cflow.cs:198:33:198:33 | 0 |  |
+| cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:37:198:41 | false | true |
+| cflow.cs:198:17:198:33 | ... == ... | cflow.cs:198:45:198:48 | true | false |
+| cflow.cs:198:17:198:48 | ... ? ... : ... | cflow.cs:198:13:198:48 | ... = ... |  |
+| cflow.cs:198:33:198:33 | 0 | cflow.cs:198:17:198:33 | ... == ... |  |
+| cflow.cs:198:37:198:41 | false | cflow.cs:198:17:198:48 | ... ? ... : ... |  |
+| cflow.cs:198:45:198:48 | true | cflow.cs:198:17:198:48 | ... ? ... : ... |  |
+| cflow.cs:200:9:205:9 | if (...) ... | cflow.cs:200:15:200:19 | this access |  |
+| cflow.cs:200:13:200:32 | [false] !... | cflow.cs:200:40:200:44 | this access | false |
+| cflow.cs:200:13:200:32 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | true |
+| cflow.cs:200:13:200:62 | [false] ... \|\| ... | cflow.cs:193:10:193:17 | exit Booleans (normal) | false |
+| cflow.cs:200:13:200:62 | [true] ... \|\| ... | cflow.cs:201:9:205:9 | {...} | true |
+| cflow.cs:200:15:200:19 | access to field Field | cflow.cs:200:15:200:26 | access to property Length |  |
+| cflow.cs:200:15:200:19 | this access | cflow.cs:200:15:200:19 | access to field Field |  |
+| cflow.cs:200:15:200:26 | access to property Length | cflow.cs:200:31:200:31 | 0 |  |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [false] !... | true |
+| cflow.cs:200:15:200:31 | ... == ... | cflow.cs:200:13:200:32 | [true] !... | false |
+| cflow.cs:200:31:200:31 | 0 | cflow.cs:200:15:200:31 | ... == ... |  |
+| cflow.cs:200:37:200:62 | [false] !... | cflow.cs:200:13:200:62 | [false] ... \|\| ... | false |
+| cflow.cs:200:37:200:62 | [true] !... | cflow.cs:200:13:200:62 | [true] ... \|\| ... | true |
+| cflow.cs:200:38:200:62 | [false] !... | cflow.cs:200:37:200:62 | [true] !... | false |
+| cflow.cs:200:38:200:62 | [true] !... | cflow.cs:200:37:200:62 | [false] !... | true |
+| cflow.cs:200:40:200:44 | access to field Field | cflow.cs:200:40:200:51 | access to property Length |  |
+| cflow.cs:200:40:200:44 | this access | cflow.cs:200:40:200:44 | access to field Field |  |
+| cflow.cs:200:40:200:51 | access to property Length | cflow.cs:200:56:200:56 | 1 |  |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:40:200:61 | [false] ... && ... | false |
+| cflow.cs:200:40:200:56 | ... == ... | cflow.cs:200:61:200:61 | access to local variable b | true |
+| cflow.cs:200:40:200:61 | [false] ... && ... | cflow.cs:200:38:200:62 | [true] !... | false |
+| cflow.cs:200:40:200:61 | [true] ... && ... | cflow.cs:200:38:200:62 | [false] !... | true |
+| cflow.cs:200:56:200:56 | 1 | cflow.cs:200:40:200:56 | ... == ... |  |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [false] ... && ... | false |
+| cflow.cs:200:61:200:61 | access to local variable b | cflow.cs:200:40:200:61 | [true] ... && ... | true |
+| cflow.cs:201:9:205:9 | {...} | cflow.cs:202:13:204:13 | {...} |  |
+| cflow.cs:202:13:204:13 | {...} | cflow.cs:203:23:203:37 | object creation of type Exception |  |
+| cflow.cs:203:17:203:38 | throw ...; | cflow.cs:193:10:193:17 | exit Booleans (abnormal) | exception(Exception) |
+| cflow.cs:203:23:203:37 | object creation of type Exception | cflow.cs:203:17:203:38 | throw ...; |  |
+| cflow.cs:208:10:208:11 | enter Do | cflow.cs:209:5:222:5 | {...} |  |
+| cflow.cs:208:10:208:11 | exit Do (normal) | cflow.cs:208:10:208:11 | exit Do |  |
+| cflow.cs:209:5:222:5 | {...} | cflow.cs:210:9:221:36 | do ... while (...); |  |
+| cflow.cs:210:9:221:36 | do ... while (...); | cflow.cs:211:9:221:9 | {...} |  |
+| cflow.cs:211:9:221:9 | {...} | cflow.cs:212:13:212:25 | ...; |  |
+| cflow.cs:212:13:212:17 | access to field Field | cflow.cs:212:22:212:24 | "a" |  |
+| cflow.cs:212:13:212:17 | this access | cflow.cs:212:13:212:17 | access to field Field |  |
+| cflow.cs:212:13:212:17 | this access | cflow.cs:212:13:212:17 | this access |  |
+| cflow.cs:212:13:212:24 | ... + ... | cflow.cs:212:13:212:24 | ... = ... |  |
+| cflow.cs:212:13:212:24 | ... = ... | cflow.cs:213:13:216:13 | if (...) ... |  |
+| cflow.cs:212:13:212:25 | ...; | cflow.cs:212:13:212:17 | this access |  |
+| cflow.cs:212:22:212:24 | "a" | cflow.cs:212:13:212:24 | ... + ... |  |
+| cflow.cs:213:13:216:13 | if (...) ... | cflow.cs:213:17:213:21 | this access |  |
+| cflow.cs:213:17:213:21 | access to field Field | cflow.cs:213:17:213:28 | access to property Length |  |
+| cflow.cs:213:17:213:21 | this access | cflow.cs:213:17:213:21 | access to field Field |  |
+| cflow.cs:213:17:213:28 | access to property Length | cflow.cs:213:32:213:32 | 0 |  |
+| cflow.cs:213:17:213:32 | ... > ... | cflow.cs:214:13:216:13 | {...} | true |
+| cflow.cs:213:17:213:32 | ... > ... | cflow.cs:217:13:220:13 | if (...) ... | false |
+| cflow.cs:213:32:213:32 | 0 | cflow.cs:213:17:213:32 | ... > ... |  |
+| cflow.cs:214:13:216:13 | {...} | cflow.cs:215:17:215:25 | continue; |  |
+| cflow.cs:215:17:215:25 | continue; | cflow.cs:221:18:221:22 | this access | continue |
+| cflow.cs:217:13:220:13 | if (...) ... | cflow.cs:217:17:217:21 | this access |  |
+| cflow.cs:217:17:217:21 | access to field Field | cflow.cs:217:17:217:28 | access to property Length |  |
+| cflow.cs:217:17:217:21 | this access | cflow.cs:217:17:217:21 | access to field Field |  |
+| cflow.cs:217:17:217:28 | access to property Length | cflow.cs:217:32:217:32 | 0 |  |
+| cflow.cs:217:17:217:32 | ... < ... | cflow.cs:218:13:220:13 | {...} | true |
+| cflow.cs:217:17:217:32 | ... < ... | cflow.cs:221:18:221:22 | this access | false |
+| cflow.cs:217:32:217:32 | 0 | cflow.cs:217:17:217:32 | ... < ... |  |
+| cflow.cs:218:13:220:13 | {...} | cflow.cs:219:17:219:22 | break; |  |
+| cflow.cs:219:17:219:22 | break; | cflow.cs:208:10:208:11 | exit Do (normal) | break |
+| cflow.cs:221:18:221:22 | access to field Field | cflow.cs:221:18:221:29 | access to property Length |  |
+| cflow.cs:221:18:221:22 | this access | cflow.cs:221:18:221:22 | access to field Field |  |
+| cflow.cs:221:18:221:29 | access to property Length | cflow.cs:221:33:221:34 | 10 |  |
+| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:208:10:208:11 | exit Do (normal) | false |
+| cflow.cs:221:18:221:34 | ... < ... | cflow.cs:211:9:221:9 | {...} | true |
+| cflow.cs:221:33:221:34 | 10 | cflow.cs:221:18:221:34 | ... < ... |  |
+| cflow.cs:224:10:224:16 | enter Foreach | cflow.cs:225:5:238:5 | {...} |  |
+| cflow.cs:224:10:224:16 | exit Foreach (normal) | cflow.cs:224:10:224:16 | exit Foreach |  |
+| cflow.cs:225:5:238:5 | {...} | cflow.cs:226:57:226:59 | "a" |  |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:224:10:224:16 | exit Foreach (normal) | empty |
+| cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | cflow.cs:226:22:226:22 | String x | non-empty |
+| cflow.cs:226:22:226:22 | String x | cflow.cs:227:9:237:9 | {...} |  |
+| cflow.cs:226:27:226:64 | call to method Repeat<String> | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... |  |
+| cflow.cs:226:57:226:59 | "a" | cflow.cs:226:62:226:63 | 10 |  |
+| cflow.cs:226:62:226:63 | 10 | cflow.cs:226:27:226:64 | call to method Repeat<String> |  |
+| cflow.cs:227:9:237:9 | {...} | cflow.cs:228:13:228:23 | ...; |  |
+| cflow.cs:228:13:228:17 | access to field Field | cflow.cs:228:22:228:22 | access to local variable x |  |
+| cflow.cs:228:13:228:17 | this access | cflow.cs:228:13:228:17 | access to field Field |  |
+| cflow.cs:228:13:228:17 | this access | cflow.cs:228:13:228:17 | this access |  |
+| cflow.cs:228:13:228:22 | ... + ... | cflow.cs:228:13:228:22 | ... = ... |  |
+| cflow.cs:228:13:228:22 | ... = ... | cflow.cs:229:13:232:13 | if (...) ... |  |
+| cflow.cs:228:13:228:23 | ...; | cflow.cs:228:13:228:17 | this access |  |
+| cflow.cs:228:22:228:22 | access to local variable x | cflow.cs:228:13:228:22 | ... + ... |  |
+| cflow.cs:229:13:232:13 | if (...) ... | cflow.cs:229:17:229:21 | this access |  |
+| cflow.cs:229:17:229:21 | access to field Field | cflow.cs:229:17:229:28 | access to property Length |  |
+| cflow.cs:229:17:229:21 | this access | cflow.cs:229:17:229:21 | access to field Field |  |
+| cflow.cs:229:17:229:28 | access to property Length | cflow.cs:229:32:229:32 | 0 |  |
+| cflow.cs:229:17:229:32 | ... > ... | cflow.cs:230:13:232:13 | {...} | true |
+| cflow.cs:229:17:229:32 | ... > ... | cflow.cs:233:13:236:13 | if (...) ... | false |
+| cflow.cs:229:32:229:32 | 0 | cflow.cs:229:17:229:32 | ... > ... |  |
+| cflow.cs:230:13:232:13 | {...} | cflow.cs:231:17:231:25 | continue; |  |
+| cflow.cs:231:17:231:25 | continue; | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | continue |
+| cflow.cs:233:13:236:13 | if (...) ... | cflow.cs:233:17:233:21 | this access |  |
+| cflow.cs:233:17:233:21 | access to field Field | cflow.cs:233:17:233:28 | access to property Length |  |
+| cflow.cs:233:17:233:21 | this access | cflow.cs:233:17:233:21 | access to field Field |  |
+| cflow.cs:233:17:233:28 | access to property Length | cflow.cs:233:32:233:32 | 0 |  |
+| cflow.cs:233:17:233:32 | ... < ... | cflow.cs:226:9:237:9 | foreach (... ... in ...) ... | false |
+| cflow.cs:233:17:233:32 | ... < ... | cflow.cs:234:13:236:13 | {...} | true |
+| cflow.cs:233:32:233:32 | 0 | cflow.cs:233:17:233:32 | ... < ... |  |
+| cflow.cs:234:13:236:13 | {...} | cflow.cs:235:17:235:22 | break; |  |
+| cflow.cs:235:17:235:22 | break; | cflow.cs:224:10:224:16 | exit Foreach (normal) | break |
+| cflow.cs:240:10:240:13 | enter Goto | cflow.cs:241:5:259:5 | {...} |  |
+| cflow.cs:240:10:240:13 | exit Goto (normal) | cflow.cs:240:10:240:13 | exit Goto |  |
+| cflow.cs:241:5:259:5 | {...} | cflow.cs:242:5:242:9 | Label: |  |
+| cflow.cs:242:5:242:9 | Label: | cflow.cs:242:12:242:41 | if (...) ... |  |
+| cflow.cs:242:12:242:41 | if (...) ... | cflow.cs:242:19:242:23 | this access |  |
+| cflow.cs:242:16:242:36 | [false] !... | cflow.cs:244:9:244:41 | if (...) ... | false |
+| cflow.cs:242:16:242:36 | [true] !... | cflow.cs:242:39:242:41 | {...} | true |
+| cflow.cs:242:17:242:36 | [false] !... | cflow.cs:242:16:242:36 | [true] !... | false |
+| cflow.cs:242:17:242:36 | [true] !... | cflow.cs:242:16:242:36 | [false] !... | true |
+| cflow.cs:242:19:242:23 | access to field Field | cflow.cs:242:19:242:30 | access to property Length |  |
+| cflow.cs:242:19:242:23 | this access | cflow.cs:242:19:242:23 | access to field Field |  |
+| cflow.cs:242:19:242:30 | access to property Length | cflow.cs:242:35:242:35 | 0 |  |
+| cflow.cs:242:19:242:35 | ... == ... | cflow.cs:242:17:242:36 | [false] !... | true |
+| cflow.cs:242:19:242:35 | ... == ... | cflow.cs:242:17:242:36 | [true] !... | false |
+| cflow.cs:242:35:242:35 | 0 | cflow.cs:242:19:242:35 | ... == ... |  |
+| cflow.cs:242:39:242:41 | {...} | cflow.cs:244:9:244:41 | if (...) ... |  |
+| cflow.cs:244:9:244:41 | if (...) ... | cflow.cs:244:13:244:17 | this access |  |
+| cflow.cs:244:13:244:17 | access to field Field | cflow.cs:244:13:244:24 | access to property Length |  |
+| cflow.cs:244:13:244:17 | this access | cflow.cs:244:13:244:17 | access to field Field |  |
+| cflow.cs:244:13:244:24 | access to property Length | cflow.cs:244:28:244:28 | 0 |  |
+| cflow.cs:244:13:244:28 | ... > ... | cflow.cs:244:31:244:41 | goto ...; | true |
+| cflow.cs:244:13:244:28 | ... > ... | cflow.cs:246:9:258:9 | switch (...) {...} | false |
+| cflow.cs:244:28:244:28 | 0 | cflow.cs:244:13:244:28 | ... > ... |  |
+| cflow.cs:244:31:244:41 | goto ...; | cflow.cs:242:5:242:9 | Label: | goto(Label) |
+| cflow.cs:246:9:258:9 | switch (...) {...} | cflow.cs:246:17:246:21 | this access |  |
+| cflow.cs:246:17:246:21 | access to field Field | cflow.cs:246:17:246:28 | access to property Length |  |
+| cflow.cs:246:17:246:21 | this access | cflow.cs:246:17:246:21 | access to field Field |  |
+| cflow.cs:246:17:246:28 | access to property Length | cflow.cs:246:32:246:32 | 3 |  |
+| cflow.cs:246:17:246:32 | ... + ... | cflow.cs:248:13:248:19 | case ...: |  |
+| cflow.cs:246:32:246:32 | 3 | cflow.cs:246:17:246:32 | ... + ... |  |
+| cflow.cs:248:13:248:19 | case ...: | cflow.cs:248:18:248:18 | 0 |  |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:249:17:249:29 | goto default; | match |
+| cflow.cs:248:18:248:18 | 0 | cflow.cs:250:13:250:19 | case ...: | no-match |
+| cflow.cs:249:17:249:29 | goto default; | cflow.cs:255:13:255:20 | default: | goto(default) |
+| cflow.cs:250:13:250:19 | case ...: | cflow.cs:250:18:250:18 | 1 |  |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:251:17:251:37 | ...; | match |
+| cflow.cs:250:18:250:18 | 1 | cflow.cs:253:13:253:19 | case ...: | no-match |
+| cflow.cs:251:17:251:36 | call to method WriteLine | cflow.cs:252:17:252:22 | break; |  |
+| cflow.cs:251:17:251:37 | ...; | cflow.cs:251:35:251:35 | 1 |  |
+| cflow.cs:251:35:251:35 | 1 | cflow.cs:251:17:251:36 | call to method WriteLine |  |
+| cflow.cs:252:17:252:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | break |
+| cflow.cs:253:13:253:19 | case ...: | cflow.cs:253:18:253:18 | 2 |  |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:254:17:254:27 | goto ...; | match |
+| cflow.cs:253:18:253:18 | 2 | cflow.cs:255:13:255:20 | default: | no-match |
+| cflow.cs:254:17:254:27 | goto ...; | cflow.cs:242:5:242:9 | Label: | goto(Label) |
+| cflow.cs:255:13:255:20 | default: | cflow.cs:256:17:256:37 | ...; |  |
+| cflow.cs:256:17:256:36 | call to method WriteLine | cflow.cs:257:17:257:22 | break; |  |
+| cflow.cs:256:17:256:37 | ...; | cflow.cs:256:35:256:35 | 0 |  |
+| cflow.cs:256:35:256:35 | 0 | cflow.cs:256:17:256:36 | call to method WriteLine |  |
+| cflow.cs:257:17:257:22 | break; | cflow.cs:240:10:240:13 | exit Goto (normal) | break |
+| cflow.cs:261:49:261:53 | enter Yield | cflow.cs:262:5:277:5 | {...} |  |
+| cflow.cs:261:49:261:53 | exit Yield (normal) | cflow.cs:261:49:261:53 | exit Yield |  |
+| cflow.cs:262:5:277:5 | {...} | cflow.cs:263:22:263:22 | 0 |  |
+| cflow.cs:263:9:263:23 | yield return ...; | cflow.cs:264:9:267:9 | for (...;...;...) ... |  |
+| cflow.cs:263:22:263:22 | 0 | cflow.cs:263:9:263:23 | yield return ...; |  |
+| cflow.cs:264:9:267:9 | for (...;...;...) ... | cflow.cs:264:22:264:22 | 1 |  |
+| cflow.cs:264:18:264:22 | Int32 i = ... | cflow.cs:264:25:264:25 | access to local variable i |  |
+| cflow.cs:264:22:264:22 | 1 | cflow.cs:264:18:264:22 | Int32 i = ... |  |
+| cflow.cs:264:25:264:25 | access to local variable i | cflow.cs:264:29:264:30 | 10 |  |
+| cflow.cs:264:25:264:30 | ... < ... | cflow.cs:265:9:267:9 | {...} | true |
+| cflow.cs:264:25:264:30 | ... < ... | cflow.cs:268:9:276:9 | try {...} ... | false |
+| cflow.cs:264:29:264:30 | 10 | cflow.cs:264:25:264:30 | ... < ... |  |
+| cflow.cs:264:33:264:33 | access to local variable i | cflow.cs:264:33:264:35 | ...++ |  |
+| cflow.cs:264:33:264:35 | ...++ | cflow.cs:264:25:264:25 | access to local variable i |  |
+| cflow.cs:265:9:267:9 | {...} | cflow.cs:266:26:266:26 | access to local variable i |  |
+| cflow.cs:266:13:266:27 | yield return ...; | cflow.cs:264:33:264:33 | access to local variable i |  |
+| cflow.cs:266:26:266:26 | access to local variable i | cflow.cs:266:13:266:27 | yield return ...; |  |
+| cflow.cs:268:9:276:9 | try {...} ... | cflow.cs:269:9:272:9 | {...} |  |
+| cflow.cs:269:9:272:9 | {...} | cflow.cs:270:13:270:24 | yield break; |  |
+| cflow.cs:270:13:270:24 | yield break; | cflow.cs:274:9:276:9 | [finally: return] {...} | return |
+| cflow.cs:274:9:276:9 | [finally: return] {...} | cflow.cs:275:13:275:42 | [finally: return] ...; |  |
+| cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine | cflow.cs:261:49:261:53 | exit Yield (normal) | return |
+| cflow.cs:275:13:275:42 | [finally: return] ...; | cflow.cs:275:31:275:40 | [finally: return] "not dead" |  |
+| cflow.cs:275:31:275:40 | [finally: return] "not dead" | cflow.cs:275:13:275:41 | [finally: return] call to method WriteLine |  |
+| cflow.cs:282:5:282:18 | enter ControlFlowSub | cflow.cs:282:24:282:27 | call to constructor ControlFlow |  |
+| cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) | cflow.cs:282:5:282:18 | exit ControlFlowSub |  |
+| cflow.cs:282:24:282:27 | call to constructor ControlFlow | cflow.cs:282:31:282:33 | {...} |  |
+| cflow.cs:282:31:282:33 | {...} | cflow.cs:282:5:282:18 | exit ControlFlowSub (normal) |  |
+| cflow.cs:284:5:284:18 | enter ControlFlowSub | cflow.cs:284:32:284:35 | call to constructor ControlFlowSub |  |
+| cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) | cflow.cs:284:5:284:18 | exit ControlFlowSub |  |
+| cflow.cs:284:32:284:35 | call to constructor ControlFlowSub | cflow.cs:284:39:284:41 | {...} |  |
+| cflow.cs:284:39:284:41 | {...} | cflow.cs:284:5:284:18 | exit ControlFlowSub (normal) |  |
+| cflow.cs:286:5:286:18 | enter ControlFlowSub | cflow.cs:286:34:286:34 | access to parameter i |  |
+| cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) | cflow.cs:286:5:286:18 | exit ControlFlowSub |  |
+| cflow.cs:286:29:286:32 | call to constructor ControlFlowSub | cflow.cs:286:48:286:50 | {...} |  |
+| cflow.cs:286:34:286:34 | access to parameter i | cflow.cs:286:34:286:45 | call to method ToString |  |
+| cflow.cs:286:34:286:45 | call to method ToString | cflow.cs:286:29:286:32 | call to constructor ControlFlowSub |  |
+| cflow.cs:286:48:286:50 | {...} | cflow.cs:286:5:286:18 | exit ControlFlowSub (normal) |  |
+| cflow.cs:289:7:289:18 | call to constructor Object | cflow.cs:289:7:289:18 | {...} |  |
+| cflow.cs:289:7:289:18 | enter DelegateCall | cflow.cs:289:7:289:18 | call to constructor Object |  |
+| cflow.cs:289:7:289:18 | exit DelegateCall (normal) | cflow.cs:289:7:289:18 | exit DelegateCall |  |
+| cflow.cs:289:7:289:18 | {...} | cflow.cs:289:7:289:18 | exit DelegateCall (normal) |  |
+| cflow.cs:291:12:291:12 | enter M | cflow.cs:291:38:291:38 | access to parameter f |  |
+| cflow.cs:291:12:291:12 | exit M (normal) | cflow.cs:291:12:291:12 | exit M |  |
+| cflow.cs:291:38:291:38 | access to parameter f | cflow.cs:291:40:291:40 | 0 |  |
+| cflow.cs:291:38:291:41 | delegate call | cflow.cs:291:12:291:12 | exit M (normal) |  |
+| cflow.cs:291:40:291:40 | 0 | cflow.cs:291:38:291:41 | delegate call |  |
+| cflow.cs:296:5:296:25 | call to constructor Object | cflow.cs:296:52:296:54 | {...} |  |
+| cflow.cs:296:5:296:25 | enter NegationInConstructor | cflow.cs:296:5:296:25 | call to constructor Object |  |
+| cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) | cflow.cs:296:5:296:25 | exit NegationInConstructor |  |
+| cflow.cs:296:52:296:54 | {...} | cflow.cs:296:5:296:25 | exit NegationInConstructor (normal) |  |
+| cflow.cs:298:10:298:10 | enter M | cflow.cs:299:5:301:5 | {...} |  |
+| cflow.cs:298:10:298:10 | exit M (normal) | cflow.cs:298:10:298:10 | exit M |  |
+| cflow.cs:299:5:301:5 | {...} | cflow.cs:300:9:300:73 | ...; |  |
+| cflow.cs:300:9:300:72 | object creation of type NegationInConstructor | cflow.cs:298:10:298:10 | exit M (normal) |  |
+| cflow.cs:300:9:300:73 | ...; | cflow.cs:300:38:300:38 | 0 |  |
+| cflow.cs:300:38:300:38 | 0 | cflow.cs:300:46:300:46 | access to parameter i |  |
+| cflow.cs:300:44:300:51 | [false] !... | cflow.cs:300:44:300:64 | ... && ... | false |
+| cflow.cs:300:44:300:51 | [true] !... | cflow.cs:300:56:300:56 | access to parameter s | true |
+| cflow.cs:300:44:300:64 | ... && ... | cflow.cs:300:70:300:71 | "" |  |
+| cflow.cs:300:46:300:46 | access to parameter i | cflow.cs:300:50:300:50 | 0 |  |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [false] !... | true |
+| cflow.cs:300:46:300:50 | ... > ... | cflow.cs:300:44:300:51 | [true] !... | false |
+| cflow.cs:300:50:300:50 | 0 | cflow.cs:300:46:300:50 | ... > ... |  |
+| cflow.cs:300:56:300:56 | access to parameter s | cflow.cs:300:61:300:64 | null |  |
+| cflow.cs:300:56:300:64 | ... != ... | cflow.cs:300:44:300:64 | ... && ... |  |
+| cflow.cs:300:61:300:64 | null | cflow.cs:300:56:300:64 | ... != ... |  |
+| cflow.cs:300:70:300:71 | "" | cflow.cs:300:9:300:72 | object creation of type NegationInConstructor |  |
+| cflow.cs:304:7:304:18 | call to constructor Object | cflow.cs:304:7:304:18 | {...} |  |
+| cflow.cs:304:7:304:18 | enter LambdaGetter | cflow.cs:304:7:304:18 | call to constructor Object |  |
+| cflow.cs:304:7:304:18 | exit LambdaGetter (normal) | cflow.cs:304:7:304:18 | exit LambdaGetter |  |
+| cflow.cs:304:7:304:18 | {...} | cflow.cs:304:7:304:18 | exit LambdaGetter (normal) |  |
+| cflow.cs:306:60:310:5 | (...) => ... | cflow.cs:306:60:310:5 | exit get__getter (normal) |  |
+| cflow.cs:306:60:310:5 | enter (...) => ... | cflow.cs:307:5:310:5 | {...} |  |
+| cflow.cs:306:60:310:5 | enter get__getter | cflow.cs:306:60:310:5 | (...) => ... |  |
+| cflow.cs:306:60:310:5 | exit (...) => ... (normal) | cflow.cs:306:60:310:5 | exit (...) => ... |  |
+| cflow.cs:306:60:310:5 | exit get__getter (normal) | cflow.cs:306:60:310:5 | exit get__getter |  |
+| cflow.cs:307:5:310:5 | {...} | cflow.cs:308:9:308:21 | ... ...; |  |
+| cflow.cs:308:9:308:21 | ... ...; | cflow.cs:308:20:308:20 | access to parameter o |  |
+| cflow.cs:308:16:308:20 | Object x = ... | cflow.cs:309:16:309:16 | access to local variable x |  |
+| cflow.cs:308:20:308:20 | access to parameter o | cflow.cs:308:16:308:20 | Object x = ... |  |
+| cflow.cs:309:9:309:17 | return ...; | cflow.cs:306:60:310:5 | exit (...) => ... (normal) | return |
+| cflow.cs:309:16:309:16 | access to local variable x | cflow.cs:309:9:309:17 | return ...; |  |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.ql
@@ -1,12 +1,3 @@
-/**
- * @kind graph
- */
-
 import csharp
 import Common
-
-private class MyRelevantNode extends SourceControlFlowNode {
-  string getOrderDisambiguation() { result = "" }
-}
-
-import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>
+import semmle.code.csharp.controlflow.internal.ControlFlowGraphImpl::TestOutput<SourceControlFlowNode>

--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -1,6995 +1,2391 @@
-break_ensure.rb:
-#    1| enter m1
-#-----|  -> x
-
-#    1| exit m1
-
-#    1| exit m1 (abnormal)
-#-----|  -> exit m1
-
-#    1| exit m1 (normal)
-#-----|  -> exit m1
-
-#    1| m1
-#-----|  -> m2
-
-#    1| enter break_ensure.rb
-#-----|  -> m1
-
-#    1| exit break_ensure.rb
-
-#    1| exit break_ensure.rb (normal)
-#-----|  -> exit break_ensure.rb
-
-#    1| x
-#-----|  -> x
-
-#    2| while ...
-#-----|  -> self
-
-#    2| x
-#-----|  -> 0
-
-#    2| ... < ...
-#-----| false -> while ...
-#-----| true -> x
-#-----| raise -> [ensure: raise] self
-
-#    2| 0
-#-----|  -> ... < ...
-
-#    2| do ...
-#-----|  -> x
-
-#    3| if ...
-#-----|  -> do ...
-
-#    3| x
-#-----|  -> 0
-
-#    3| ... > ...
-#-----| raise -> while ...
-#-----| false -> if ...
-#-----| true -> break
-
-#    3| 0
-#-----|  -> ... > ...
-
-#    4| break
-#-----| break -> while ...
-
-#    7| [ensure: raise] ensure ...
-#-----| raise -> exit m1 (abnormal)
-
-#    7| ensure ...
-#-----|  -> exit m1 (normal)
-
-#    8| [ensure: raise] if ...
-#-----|  -> [ensure: raise] ensure ...
-
-#    8| if ...
-#-----|  -> ensure ...
-
-#    8| [ensure: raise] call to elements
-#-----|  -> [ensure: raise] call to nil?
-
-#    8| [ensure: raise] self
-#-----|  -> [ensure: raise] call to elements
-
-#    8| call to elements
-#-----|  -> call to nil?
-
-#    8| self
-#-----|  -> call to elements
-
-#    8| [ensure: raise] call to nil?
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] self
-
-#    8| call to nil?
-#-----| false -> if ...
-#-----| true -> self
-
-#    8| [ensure: raise] then ...
-#-----|  -> [ensure: raise] if ...
-
-#    8| then ...
-#-----|  -> if ...
-
-#    9| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] then ...
-
-#    9| [ensure: raise] self
-#-----|  -> [ensure: raise] elements nil
-
-#    9| call to puts
-#-----|  -> then ...
-
-#    9| self
-#-----|  -> elements nil
-
-#    9| "elements nil"
-#-----|  -> call to puts
-
-#    9| [ensure: raise] "elements nil"
-#-----|  -> [ensure: raise] call to puts
-
-#    9| [ensure: raise] elements nil
-#-----|  -> [ensure: raise] "elements nil"
-
-#    9| elements nil
-#-----|  -> "elements nil"
-
-#   13| enter m2
-#-----|  -> x
-
-#   13| exit m2
-
-#   13| exit m2 (normal)
-#-----|  -> exit m2
-
-#   13| m2
-#-----|  -> m3
-
-#   13| x
-#-----|  -> y
-
-#   13| y
-#-----|  -> x
-
-#   14| while ...
-#-----|  -> exit m2 (normal)
-
-#   14| x
-#-----|  -> 0
-
-#   14| ... < ...
-#-----| false -> while ...
-#-----| true -> x
-
-#   14| 0
-#-----|  -> ... < ...
-
-#   14| do ...
-#-----|  -> x
-
-#   16| if ...
-#-----|  -> y
-
-#   16| x
-#-----|  -> 0
-
-#   16| ... > ...
-#-----| false -> if ...
-#-----| true -> break
-#-----| raise -> [ensure: raise] y
-
-#   16| 0
-#-----|  -> ... > ...
-
-#   17| break
-#-----| break -> [ensure: break] y
-
-#   19| [ensure: break] ensure ...
-#-----| break -> while ...
-
-#   19| [ensure: raise] ensure ...
-#-----| raise -> while ...
-
-#   19| ensure ...
-#-----|  -> do ...
-
-#   20| [ensure: break] if ...
-#-----|  -> [ensure: break] ensure ...
-
-#   20| [ensure: raise] if ...
-#-----|  -> [ensure: raise] ensure ...
-
-#   20| if ...
-#-----|  -> ensure ...
-
-#   20| [ensure: break] y
-#-----|  -> [ensure: break] call to nil?
-
-#   20| [ensure: raise] y
-#-----|  -> [ensure: raise] call to nil?
-
-#   20| y
-#-----|  -> call to nil?
-
-#   20| [ensure: break] call to nil?
-#-----| false -> [ensure: break] if ...
-#-----| true -> [ensure: break] self
-
-#   20| [ensure: raise] call to nil?
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] self
-
-#   20| call to nil?
-#-----| false -> if ...
-#-----| true -> self
-
-#   20| [ensure: break] then ...
-#-----|  -> [ensure: break] if ...
-
-#   20| [ensure: raise] then ...
-#-----|  -> [ensure: raise] if ...
-
-#   20| then ...
-#-----|  -> if ...
-
-#   21| [ensure: break] call to puts
-#-----|  -> [ensure: break] then ...
-
-#   21| [ensure: break] self
-#-----|  -> [ensure: break] y nil
-
-#   21| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] then ...
-
-#   21| [ensure: raise] self
-#-----|  -> [ensure: raise] y nil
-
-#   21| call to puts
-#-----|  -> then ...
-
-#   21| self
-#-----|  -> y nil
-
-#   21| "y nil"
-#-----|  -> call to puts
-
-#   21| [ensure: break] "y nil"
-#-----|  -> [ensure: break] call to puts
-
-#   21| [ensure: raise] "y nil"
-#-----|  -> [ensure: raise] call to puts
-
-#   21| [ensure: break] y nil
-#-----|  -> [ensure: break] "y nil"
-
-#   21| [ensure: raise] y nil
-#-----|  -> [ensure: raise] "y nil"
-
-#   21| y nil
-#-----|  -> "y nil"
-
-#   27| enter m3
-#-----|  -> x
-
-#   27| exit m3
-
-#   27| exit m3 (abnormal)
-#-----|  -> exit m3
-
-#   27| exit m3 (normal)
-#-----|  -> exit m3
-
-#   27| m3
-#-----|  -> m4
-
-#   27| x
-#-----|  -> y
-
-#   27| y
-#-----|  -> x
-
-#   29| if ...
-#-----|  -> y
-
-#   29| x
-#-----|  -> call to nil?
-
-#   29| call to nil?
-#-----| false -> if ...
-#-----| true -> return
-#-----| raise -> [ensure: raise] y
-
-#   30| return
-#-----| return -> [ensure: return] y
-
-#   32| [ensure: raise] ensure ...
-#-----| raise -> exit m3 (abnormal)
-
-#   32| [ensure: return] ensure ...
-#-----| return -> exit m3 (normal)
-
-#   32| ensure ...
-#-----|  -> self
-
-#   33| [ensure: raise] while ...
-#-----|  -> [ensure: raise] ensure ...
-
-#   33| [ensure: return] while ...
-#-----|  -> [ensure: return] ensure ...
-
-#   33| while ...
-#-----|  -> ensure ...
-
-#   33| [ensure: raise] y
-#-----|  -> [ensure: raise] 0
-
-#   33| [ensure: return] y
-#-----|  -> [ensure: return] 0
-
-#   33| y
-#-----|  -> 0
-
-#   33| ... < ...
-#-----| false -> while ...
-#-----| true -> x
-
-#   33| [ensure: raise] ... < ...
-#-----| false -> [ensure: raise] while ...
-#-----| true -> [ensure: raise] x
-
-#   33| [ensure: return] ... < ...
-#-----| false -> [ensure: return] while ...
-#-----| true -> [ensure: return] x
-
-#   33| 0
-#-----|  -> ... < ...
-
-#   33| [ensure: raise] 0
-#-----|  -> [ensure: raise] ... < ...
-
-#   33| [ensure: return] 0
-#-----|  -> [ensure: return] ... < ...
-
-#   33| [ensure: raise] do ...
-#-----|  -> [ensure: raise] y
-
-#   33| [ensure: return] do ...
-#-----|  -> [ensure: return] y
-
-#   33| do ...
-#-----|  -> y
-
-#   35| [ensure: raise] if ...
-#-----|  -> [ensure: raise] do ...
-
-#   35| [ensure: return] if ...
-#-----|  -> [ensure: return] do ...
-
-#   35| if ...
-#-----|  -> do ...
-
-#   35| [ensure: raise] x
-#-----|  -> [ensure: raise] 0
-
-#   35| [ensure: return] x
-#-----|  -> [ensure: return] 0
-
-#   35| x
-#-----|  -> 0
-
-#   35| ... > ...
-#-----| false -> if ...
-#-----| true -> break
-
-#   35| [ensure: raise] ... > ...
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] break
-
-#   35| [ensure: return] ... > ...
-#-----| false -> [ensure: return] if ...
-#-----| true -> [ensure: return] break
-
-#   35| 0
-#-----|  -> ... > ...
-
-#   35| [ensure: raise] 0
-#-----|  -> [ensure: raise] ... > ...
-
-#   35| [ensure: return] 0
-#-----|  -> [ensure: return] ... > ...
-
-#   36| [ensure: raise] break
-#-----| break -> [ensure: raise] while ...
-
-#   36| [ensure: return] break
-#-----| break -> [ensure: return] while ...
-
-#   36| break
-#-----| break -> while ...
-
-#   41| call to puts
-#-----|  -> exit m3 (normal)
-
-#   41| self
-#-----|  -> Done
-
-#   41| "Done"
-#-----|  -> call to puts
-
-#   41| Done
-#-----|  -> "Done"
-
-#   44| enter m4
-#-----|  -> x
-
-#   44| exit m4
-
-#   44| exit m4 (normal)
-#-----|  -> exit m4
-
-#   44| m4
-#-----|  -> exit break_ensure.rb (normal)
-
-#   44| x
-#-----|  -> x
-
-#   45| while ...
-#-----|  -> exit m4 (normal)
-
-#   45| x
-#-----|  -> 0
-
-#   45| ... < ...
-#-----| false -> while ...
-#-----| true -> x
-
-#   45| 0
-#-----|  -> ... < ...
-
-#   45| do ...
-#-----|  -> x
-
-#   47| if ...
-#-----|  -> x
-
-#   47| x
-#-----|  -> 1
-
-#   47| ... > ...
-#-----| false -> if ...
-#-----| true -> self
-#-----| raise -> [ensure: raise] x
-
-#   47| 1
-#-----|  -> ... > ...
-
-#   48| call to raise
-#-----| raise -> [ensure: raise] x
-
-#   48| self
-#-----|  -> ""
-
-#   48| ""
-#-----|  -> call to raise
-
-#   50| [ensure: raise] ensure ...
-#-----| raise -> while ...
-
-#   50| ensure ...
-#-----|  -> do ...
-
-#   51| [ensure: raise] if ...
-#-----|  -> [ensure: raise] ensure ...
-
-#   51| if ...
-#-----|  -> ensure ...
-
-#   51| [ensure: raise] x
-#-----|  -> [ensure: raise] 0
-
-#   51| x
-#-----|  -> 0
-
-#   51| ... > ...
-#-----| false -> if ...
-#-----| true -> 10
-
-#   51| [ensure: raise] ... > ...
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] 10
-
-#   51| 0
-#-----|  -> ... > ...
-
-#   51| [ensure: raise] 0
-#-----|  -> [ensure: raise] ... > ...
-
-#   52| [ensure: raise] break
-#-----| break -> while ...
-
-#   52| break
-#-----| break -> while ...
-
-#   52| 10
-#-----|  -> break
-
-#   52| [ensure: raise] 10
-#-----|  -> [ensure: raise] break
-
-case.rb:
-#    1| enter if_in_case
-#-----|  -> self
-
-#    1| exit if_in_case
-
-#    1| exit if_in_case (normal)
-#-----|  -> exit if_in_case
-
-#    1| if_in_case
-#-----|  -> case_match
-
-#    1| enter case.rb
-#-----|  -> if_in_case
-
-#    1| exit case.rb
-
-#    1| exit case.rb (normal)
-#-----|  -> exit case.rb
-
-#    2| case ...
-#-----|  -> exit if_in_case (normal)
-
-#    2| call to x1
-#-----|  -> 1
-
-#    2| self
-#-----|  -> call to x1
-
-#    3| [match] when ...
-#-----| match -> self
-
-#    3| [no-match] when ...
-#-----| no-match -> 2
-
-#    3| 1
-#-----| match -> [match] when ...
-#-----| no-match -> [no-match] when ...
-
-#    3| then ...
-#-----|  -> case ...
-
-#    3| ( ... )
-#-----|  -> then ...
-
-#    3| if ...
-#-----|  -> ( ... )
-
-#    3| call to x2
-#-----| false -> if ...
-#-----| true -> self
-
-#    3| self
-#-----|  -> call to x2
-
-#    3| then ...
-#-----|  -> if ...
-
-#    3| call to puts
-#-----|  -> then ...
-
-#    3| self
-#-----|  -> x2
-
-#    3| "x2"
-#-----|  -> call to puts
-
-#    3| x2
-#-----|  -> "x2"
-
-#    4| [match] when ...
-#-----| match -> self
-
-#    4| [no-match] when ...
-#-----| no-match -> case ...
-
-#    4| 2
-#-----| match -> [match] when ...
-#-----| no-match -> [no-match] when ...
-
-#    4| then ...
-#-----|  -> case ...
-
-#    4| call to puts
-#-----|  -> then ...
-
-#    4| self
-#-----|  -> 2
-
-#    4| "2"
-#-----|  -> call to puts
-
-#    4| 2
-#-----|  -> "2"
-
-#    8| case_match
-#-----|  -> case_match_no_match
-
-#    8| enter case_match
-#-----|  -> value
-
-#    8| exit case_match
-
-#    8| exit case_match (normal)
-#-----|  -> exit case_match
-
-#    8| value
-#-----|  -> value
-
-#    9| case ...
-#-----|  -> exit case_match (normal)
-
-#    9| value
-#-----|  -> in ... then ...
-
-#   10| in ... then ...
-#-----|  -> 0
-
-#   10| 0
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   11| in ... then ...
-#-----|  -> 1
-
-#   11| 1
-#-----| match -> 3
-#-----| no-match -> in ... then ...
-
-#   11| then ...
-#-----|  -> case ...
-
-#   11| 3
-#-----|  -> then ...
-
-#   12| in ... then ...
-#-----|  -> 2
-
-#   12| 2
-#-----| match -> 4
-#-----| no-match -> in ... then ...
-
-#   12| then ...
-#-----|  -> case ...
-
-#   13| 4
-#-----|  -> then ...
-
-#   14| in ... then ...
-#-----|  -> x
-
-#   14| x
-#-----| match -> x
-
-#   14| x
-#-----|  -> 5
-
-#   14| ... == ...
-#-----| true -> 6
-#-----| false -> in ... then ...
-
-#   14| 5
-#-----|  -> ... == ...
-
-#   14| then ...
-#-----|  -> case ...
-
-#   14| 6
-#-----|  -> then ...
-
-#   15| in ... then ...
-#-----|  -> x
-
-#   15| x
-#-----| match -> x
-
-#   15| x
-#-----|  -> 0
-
-#   15| ... < ...
-#-----| false -> 7
-#-----| true -> 8
-
-#   15| 0
-#-----|  -> ... < ...
-
-#   15| then ...
-#-----|  -> case ...
-
-#   15| 7
-#-----|  -> then ...
-
-#   16| else ...
-#-----|  -> case ...
-
-#   16| 8
-#-----|  -> else ...
-
-#   20| case_match_no_match
-#-----|  -> case_match_raise
-
-#   20| enter case_match_no_match
-#-----|  -> value
-
-#   20| exit case_match_no_match
-
-#   20| exit case_match_no_match (abnormal)
-#-----|  -> exit case_match_no_match
-
-#   20| exit case_match_no_match (normal)
-#-----|  -> exit case_match_no_match
-
-#   20| value
-#-----|  -> value
-
-#   21| case ...
-#-----|  -> exit case_match_no_match (normal)
-
-#   21| value
-#-----|  -> in ... then ...
-
-#   22| in ... then ...
-#-----|  -> 1
-
-#   22| 1
-#-----| raise -> exit case_match_no_match (abnormal)
-#-----| match -> case ...
-
-#   26| case_match_raise
-#-----|  -> case_match_array
-
-#   26| enter case_match_raise
-#-----|  -> value
-
-#   26| exit case_match_raise
-
-#   26| exit case_match_raise (abnormal)
-#-----|  -> exit case_match_raise
-
-#   26| exit case_match_raise (normal)
-#-----|  -> exit case_match_raise
-
-#   26| value
-#-----|  -> value
-
-#   27| case ...
-#-----|  -> exit case_match_raise (normal)
-
-#   27| value
-#-----|  -> in ... then ...
-
-#   28| in ... then ...
-#-----|  -> -> { ... }
-
-#   28| -> { ... }
-#-----| raise -> exit case_match_raise (abnormal)
-#-----| match -> case ...
-
-#   28| enter -> { ... }
-#-----|  -> x
-
-#   28| exit -> { ... }
-
-#   28| exit -> { ... } (abnormal)
-#-----|  -> exit -> { ... }
-
-#   28| x
-#-----|  -> self
-
-#   28| call to raise
-#-----| raise -> exit -> { ... } (abnormal)
-
-#   28| self
-#-----|  -> oops
-
-#   28| "oops"
-#-----|  -> call to raise
-
-#   28| oops
-#-----|  -> "oops"
-
-#   32| case_match_array
-#-----|  -> case_match_find
-
-#   32| enter case_match_array
-#-----|  -> value
-
-#   32| exit case_match_array
-
-#   32| exit case_match_array (abnormal)
-#-----|  -> exit case_match_array
-
-#   32| exit case_match_array (normal)
-#-----|  -> exit case_match_array
-
-#   32| value
-#-----|  -> value
-
-#   33| case ...
-#-----|  -> exit case_match_array (normal)
-
-#   33| value
-#-----|  -> in ... then ...
-
-#   34| in ... then ...
-#-----|  -> [ ..., * ]
-
-#   34| [ ..., * ]
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   35| in ... then ...
-#-----|  -> [ ..., * ]
-
-#   35| [ ..., * ]
-#-----| false, match, true -> x
-#-----| no-match -> in ... then ...
-
-#   35| x
-#-----| match -> case ...
-
-#   36| in ... then ...
-#-----|  -> [ ..., * ]
-
-#   36| [ ..., * ]
-#-----| false, match, true -> x
-#-----| no-match -> in ... then ...
-
-#   36| x
-#-----| match -> case ...
-
-#   37| in ... then ...
-#-----|  -> Bar
-
-#   37| Bar
-#-----| raise -> exit case_match_array (abnormal)
-#-----| match -> [ ..., * ]
-
-#   37| [ ..., * ]
-#-----| raise -> exit case_match_array (abnormal)
-#-----| false, match, true -> a
-
-#   37| a
-#-----| match -> b
-
-#   37| b
-#-----| match -> c
-
-#   37| c
-#-----|  -> d
-
-#   37| d
-#-----| match -> e
-
-#   37| e
-#-----| match -> case ...
-
-#   41| case_match_find
-#-----|  -> case_match_hash
-
-#   41| enter case_match_find
-#-----|  -> value
-
-#   41| exit case_match_find
-
-#   41| exit case_match_find (abnormal)
-#-----|  -> exit case_match_find
-
-#   41| exit case_match_find (normal)
-#-----|  -> exit case_match_find
-
-#   41| value
-#-----|  -> value
-
-#   42| case ...
-#-----|  -> exit case_match_find (normal)
-
-#   42| value
-#-----|  -> in ... then ...
-
-#   43| in ... then ...
-#-----|  -> [ *,...,* ]
-
-#   43| [ *,...,* ]
-#-----| raise -> exit case_match_find (abnormal)
-#-----| false, match, true -> x
-
-#   43| x
-#-----|  -> 1
-
-#   43| 1
-#-----| raise -> exit case_match_find (abnormal)
-#-----| match -> 2
-
-#   43| 2
-#-----| raise -> exit case_match_find (abnormal)
-#-----| match -> y
-
-#   43| y
-#-----|  -> case ...
-
-#   47| case_match_hash
-#-----|  -> case_match_variable
-
-#   47| enter case_match_hash
-#-----|  -> value
-
-#   47| exit case_match_hash
-
-#   47| exit case_match_hash (abnormal)
-#-----|  -> exit case_match_hash
-
-#   47| exit case_match_hash (normal)
-#-----|  -> exit case_match_hash
-
-#   47| value
-#-----|  -> value
-
-#   48| case ...
-#-----|  -> exit case_match_hash (normal)
-
-#   48| value
-#-----|  -> in ... then ...
-
-#   49| in ... then ...
-#-----|  -> Foo
-
-#   49| Foo
-#-----|  -> Bar
-
-#   49| Bar
-#-----| match -> { ..., ** }
-#-----| no-match -> in ... then ...
-
-#   49| { ..., ** }
-#-----| false, match, true -> 1
-#-----| no-match -> in ... then ...
-
-#   49| 1
-#-----| match -> a
-#-----| no-match -> in ... then ...
-
-#   49| a
-#-----| match -> rest
-
-#   49| rest
-#-----|  -> case ...
-
-#   50| in ... then ...
-#-----|  -> Bar
-
-#   50| Bar
-#-----| match -> { ..., ** }
-#-----| no-match -> in ... then ...
-
-#   50| { ..., ** }
-#-----| false, match, true -> 1
-#-----| no-match -> in ... then ...
-
-#   50| 1
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   51| in ... then ...
-#-----|  -> Bar
-
-#   51| Bar
-#-----| raise -> exit case_match_hash (abnormal)
-#-----| match -> { ..., ** }
-
-#   51| { ..., ** }
-#-----| raise -> exit case_match_hash (abnormal)
-#-----| false, match, true -> case ...
-
-#   55| case_match_variable
-#-----|  -> case_match_underscore
-
-#   55| enter case_match_variable
-#-----|  -> value
-
-#   55| exit case_match_variable
-
-#   55| exit case_match_variable (normal)
-#-----|  -> exit case_match_variable
-
-#   55| value
-#-----|  -> value
-
-#   56| case ...
-#-----|  -> exit case_match_variable (normal)
-
-#   56| value
-#-----|  -> in ... then ...
-
-#   57| in ... then ...
-#-----|  -> 5
-
-#   57| 5
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   58| in ... then ...
-#-----|  -> var
-
-#   58| var
-#-----| match -> case ...
-
-#   63| case_match_underscore
-#-----|  -> case_match_various
-
-#   63| enter case_match_underscore
-#-----|  -> value
-
-#   63| exit case_match_underscore
-
-#   63| exit case_match_underscore (normal)
-#-----|  -> exit case_match_underscore
-
-#   63| value
-#-----|  -> value
-
-#   64| case ...
-#-----|  -> exit case_match_underscore (normal)
-
-#   64| value
-#-----|  -> in ... then ...
-
-#   65| in ... then ...
-#-----|  -> ... | ...
-
-#   65| 5
-#-----| match -> case ...
-#-----| no-match -> _
-
-#   65| ... | ...
-#-----|  -> 5
-
-#   65| _
-#-----| match -> case ...
-
-#   69| case_match_various
-#-----|  -> case_match_guard_no_else
-
-#   69| enter case_match_various
-#-----|  -> value
-
-#   69| exit case_match_various
-
-#   69| exit case_match_various (abnormal)
-#-----|  -> exit case_match_various
-
-#   69| exit case_match_various (normal)
-#-----|  -> exit case_match_various
-
-#   69| value
-#-----|  -> foo
-
-#   70| foo
-#-----|  -> 42
-
-#   70| ... = ...
-#-----|  -> value
-
-#   70| 42
-#-----|  -> ... = ...
-
-#   72| case ...
-#-----|  -> exit case_match_various (normal)
-
-#   72| value
-#-----|  -> in ... then ...
-
-#   73| in ... then ...
-#-----|  -> 5
-
-#   73| 5
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   74| in ... then ...
-#-----|  -> ^...
-
-#   74| ^...
-#-----|  -> foo
-
-#   74| foo
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   75| in ... then ...
-#-----|  -> string
-
-#   75| "string"
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   75| string
-#-----|  -> "string"
-
-#   76| in ... then ...
-#-----|  -> Array
-
-#   76| Array
-#-----|  -> foo
-
-#   76| call to []
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   76| "foo"
-#-----|  -> bar
-
-#   76| foo
-#-----|  -> "foo"
-
-#   76| "bar"
-#-----|  -> call to []
-
-#   76| bar
-#-----|  -> "bar"
-
-#   77| in ... then ...
-#-----|  -> Array
-
-#   77| Array
-#-----|  -> foo
-
-#   77| call to []
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   77| :"foo"
-#-----|  -> bar
-
-#   77| foo
-#-----|  -> :"foo"
-
-#   77| :"bar"
-#-----|  -> call to []
-
-#   77| bar
-#-----|  -> :"bar"
-
-#   78| in ... then ...
-#-----|  -> .*abc[0-9]
-
-#   78| /.*abc[0-9]/
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   78| .*abc[0-9]
-#-----|  -> /.*abc[0-9]/
-
-#   79| in ... then ...
-#-----|  -> 5
-
-#   79| 5
-#-----|  -> 10
-
-#   79| _ .. _
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   79| 10
-#-----|  -> _ .. _
-
-#   80| in ... then ...
-#-----|  -> 10
-
-#   80| _ .. _
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   80| 10
-#-----|  -> _ .. _
-
-#   81| in ... then ...
-#-----|  -> 5
-
-#   81| 5
-#-----|  -> _ .. _
-
-#   81| _ .. _
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   82| in ... then ...
-#-----|  -> ... => ...
-
-#   82| 5
-#-----| match -> x
-#-----| no-match -> in ... then ...
-
-#   82| ... => ...
-#-----|  -> 5
-
-#   82| x
-#-----| match -> 1
-
-#   82| then ...
-#-----|  -> case ...
-
-#   82| 1
-#-----|  -> then ...
-
-#   83| in ... then ...
-#-----|  -> ... | ...
-
-#   83| 5
-#-----| match -> case ...
-#-----| no-match -> ^...
-
-#   83| ... | ...
-#-----|  -> 5
-
-#   83| ^...
-#-----|  -> foo
-
-#   83| foo
-#-----| match -> case ...
-#-----| no-match -> string
-
-#   83| "string"
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   83| string
-#-----|  -> "string"
-
-#   84| in ... then ...
-#-----|  -> Foo
-
-#   84| Foo
-#-----|  -> Bar
-
-#   84| Bar
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   85| in ... then ...
-#-----|  -> -> { ... }
-
-#   85| -> { ... }
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   85| enter -> { ... }
-#-----|  -> x
-
-#   85| exit -> { ... }
-
-#   85| exit -> { ... } (normal)
-#-----|  -> exit -> { ... }
-
-#   85| x
-#-----|  -> x
-
-#   85| x
-#-----|  -> 10
-
-#   85| ... == ...
-#-----|  -> exit -> { ... } (normal)
-
-#   85| 10
-#-----|  -> ... == ...
-
-#   86| in ... then ...
-#-----|  -> foo
-
-#   86| :foo
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   86| foo
-#-----|  -> :foo
-
-#   87| in ... then ...
-#-----|  -> foo bar
-
-#   87| :"foo bar"
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   87| foo bar
-#-----|  -> :"foo bar"
-
-#   88| in ... then ...
-#-----|  -> ... | ...
-
-#   88| - ...
-#-----| match -> case ...
-#-----| no-match -> 10
-
-#   88| ... | ...
-#-----|  -> 5
-
-#   88| 5
-#-----|  -> - ...
-
-#   88| + ...
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   88| 10
-#-----|  -> + ...
-
-#   89| in ... then ...
-#-----|  -> ... | ...
-
-#   89| nil
-#-----| match -> case ...
-#-----| no-match -> self
-
-#   89| ... | ...
-#-----|  -> nil
-
-#   89| self
-#-----| match -> case ...
-#-----| no-match -> true
-
-#   89| true
-#-----| match -> case ...
-#-----| no-match -> false
-
-#   89| false
-#-----| match -> case ...
-#-----| no-match -> __LINE__
-
-#   89| __LINE__
-#-----| match -> case ...
-#-----| no-match -> __FILE__
-
-#   89| __FILE__
-#-----| match -> case ...
-#-----| no-match -> __ENCODING__
-
-#   89| __ENCODING__
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   90| in ... then ...
-#-----|  -> ( ... )
-
-#   90| ( ... )
-#-----|  -> 1
-
-#   90| 1
-#-----|  -> _ .. _
-
-#   90| _ .. _
-#-----| match -> case ...
-#-----| no-match -> in ... then ...
-
-#   91| in ... then ...
-#-----|  -> ( ... )
-
-#   91| ( ... )
-#-----|  -> ... | ...
-
-#   91| 0
-#-----| match -> case ...
-#-----| no-match -> ""
-
-#   91| ... | ...
-#-----|  -> 0
-
-#   91| ""
-#-----| match -> case ...
-#-----| no-match -> [ ..., * ]
-
-#   91| [ ..., * ]
-#-----| match -> case ...
-#-----| no-match -> { ..., ** }
-
-#   91| { ..., ** }
-#-----| raise -> exit case_match_various (abnormal)
-#-----| false, match, true -> case ...
-
-#   95| case_match_guard_no_else
-#-----|  -> exit case.rb (normal)
-
-#   95| enter case_match_guard_no_else
-#-----|  -> value
-
-#   95| exit case_match_guard_no_else
-
-#   95| exit case_match_guard_no_else (abnormal)
-#-----|  -> exit case_match_guard_no_else
-
-#   95| exit case_match_guard_no_else (normal)
-#-----|  -> exit case_match_guard_no_else
-
-#   95| value
-#-----|  -> value
-
-#   96| case ...
-#-----|  -> exit case_match_guard_no_else (normal)
-
-#   96| value
-#-----|  -> in ... then ...
-
-#   97| in ... then ...
-#-----|  -> x
-
-#   97| x
-#-----| match -> x
-
-#   97| x
-#-----|  -> 5
-
-#   97| ... == ...
-#-----| raise -> exit case_match_guard_no_else (abnormal)
-#-----| true -> 6
-
-#   97| 5
-#-----|  -> ... == ...
-
-#   97| then ...
-#-----|  -> case ...
-
-#   97| 6
-#-----|  -> then ...
-
-cfg.html.erb:
-#    5| @title
-#-----|  -> self
-
-#    5| self
-#-----|  -> @title
-
-#    5| enter cfg.html.erb
-#-----|  -> self
-
-#    5| exit cfg.html.erb
-
-#    5| exit cfg.html.erb (normal)
-#-----|  -> exit cfg.html.erb
-
-#    6| call to stylesheet_link_tag
-#-----|  -> self
-
-#    6| self
-#-----|  -> application
-
-#    6| "application"
-#-----|  -> media
-
-#    6| application
-#-----|  -> "application"
-
-#    6| :media
-#-----|  -> all
-
-#    6| media
-#-----|  -> :media
-
-#    6| Pair
-#-----|  -> call to stylesheet_link_tag
-
-#    6| "all"
-#-----|  -> Pair
-
-#    6| all
-#-----|  -> "all"
-
-#   12| call to link_to
-#-----|  -> self
-
-#   12| self
-#-----|  -> A
-
-#   12| "A"
-#-----|  -> self
-
-#   12| A
-#-----|  -> "A"
-
-#   12| call to a
-#-----|  -> id
-
-#   12| self
-#-----|  -> call to a
-
-#   12| :id
-#-----|  -> a
-
-#   12| id
-#-----|  -> :id
-
-#   12| Pair
-#-----|  -> call to link_to
-
-#   12| "a"
-#-----|  -> Pair
-
-#   12| a
-#-----|  -> "a"
-
-#   15| call to link_to
-#-----|  -> self
-
-#   15| self
-#-----|  -> B
-
-#   15| "B"
-#-----|  -> self
-
-#   15| B
-#-----|  -> "B"
-
-#   15| call to a
-#-----|  -> call to link_to
-
-#   15| self
-#-----|  -> call to a
-
-#   16| call to link_to
-#-----|  -> self
-
-#   16| self
-#-----|  -> C
-
-#   16| "C"
-#-----|  -> self
-
-#   16| C
-#-----|  -> "C"
-
-#   16| call to b
-#-----|  -> call to link_to
-
-#   16| self
-#-----|  -> call to b
-
-#   18| if ...
-#-----|  -> self
-
-#   18| call to admin?
-#-----| true -> self
-#-----| false -> self
-
-#   18| self
-#-----|  -> call to admin?
-
-#   18| then ...
-#-----|  -> if ...
-
-#   19| call to link_to
-#-----|  -> then ...
-
-#   19| self
-#-----|  -> D
-
-#   19| "D"
-#-----|  -> self
-
-#   19| D
-#-----|  -> "D"
-
-#   19| call to d
-#-----|  -> call to link_to
-
-#   19| self
-#-----|  -> call to d
-
-#   20| else ...
-#-----|  -> if ...
-
-#   21| call to link_to
-#-----|  -> else ...
-
-#   21| self
-#-----|  -> E
-
-#   21| "E"
-#-----|  -> self
-
-#   21| E
-#-----|  -> "E"
-
-#   21| call to e
-#-----|  -> call to link_to
-
-#   21| self
-#-----|  -> call to e
-
-#   29| call to collection
-#-----|  -> do ... end
-
-#   29| self
-#-----|  -> call to collection
-
-#   29| call to each
-#-----|  -> exit cfg.html.erb (normal)
-
-#   29| do ... end
-#-----|  -> call to each
-
-#   29| enter do ... end
-#-----|  -> key
-
-#   29| exit do ... end
-
-#   29| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#   29| key
-#-----|  -> value
-
-#   29| value
-#-----|  -> key
-
-#   30| key
-#-----|  -> value
-
-#   30| value
-#-----|  -> exit do ... end (normal)
-
-cfg.rb:
-#    1| bar
-#-----|  -> alias ...
-
-#    1| enter cfg.rb
-#-----|  -> self
-
-#    1| exit cfg.rb
-
-#    1| exit cfg.rb (normal)
-#-----|  -> exit cfg.rb
-
-#    3| alias ...
-#-----|  -> foo
-
-#    3| foo
-#-----|  -> bar
-
-#    3| bar
-#-----|  -> b
-
-#    5| b
-#-----|  -> 42
-
-#    5| ... = ...
-#-----|  -> Array
-
-#    5| 42
-#-----|  -> ... = ...
-
-#    7| Array
-#-----|  -> one
-
-#    7| call to []
-#-----|  -> Array
-
-#    7| one
-#-----|  -> b
-
-#    7| :"one#{...}"
-#-----|  -> another
-
-#    7| #{...}
-#-----|  -> :"one#{...}"
-
-#    7| b
-#-----|  -> #{...}
-
-#    7| :"another"
-#-----|  -> call to []
-
-#    7| another
-#-----|  -> :"another"
-
-#    9| Array
-#-----|  -> one
-
-#    9| call to []
-#-----|  -> self
-
-#    9| one
-#-----|  -> b
-
-#    9| "one#{...}"
-#-----|  -> another
-
-#    9| #{...}
-#-----|  -> "one#{...}"
-
-#    9| b
-#-----|  -> #{...}
-
-#    9| "another"
-#-----|  -> call to []
-
-#    9| another
-#-----|  -> "another"
-
-#   12| call to puts
-#-----|  -> END { ... }
-
-#   12| self
-#-----|  -> 4
-
-#   12| 4
-#-----|  -> call to puts
-
-#   15| BEGIN { ... }
-#-----|  -> bar
-
-#   16| call to puts
-#-----|  -> BEGIN { ... }
-
-#   16| self
-#-----|  -> hello
-
-#   16| "hello"
-#-----|  -> call to puts
-
-#   16| hello
-#-----|  -> "hello"
-
-#   19| END { ... }
-#-----|  -> 41
-
-#   23| 41
-#-----|  -> 1
-
-#   23| ... + ...
-#-----|  -> 2
-
-#   23| 1
-#-----|  -> ... + ...
-
-#   25| 2
-#-----|  -> { ... }
-
-#   25| call to times
-#-----|  -> self
-
-#   25| enter { ... }
-#-----|  -> x
-
-#   25| exit { ... }
-
-#   25| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#   25| { ... }
-#-----|  -> call to times
-
-#   25| x
-#-----|  -> self
-
-#   25| call to puts
-#-----|  -> exit { ... } (normal)
-
-#   25| self
-#-----|  -> x
-
-#   25| x
-#-----|  -> call to puts
-
-#   27| call to puts
-#-----|  -> Proc
-
-#   27| self
-#-----|  -> puts
-
-#   27| &...
-#-----|  -> call to puts
-
-#   27| :puts
-#-----|  -> &...
-
-#   27| puts
-#-----|  -> :puts
-
-#   29| Proc
-#-----|  -> { ... }
-
-#   29| call to new
-#-----|  -> true
-
-#   29| enter { ... }
-#-----|  -> x
-
-#   29| exit { ... }
-
-#   29| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#   29| { ... }
-#-----|  -> call to new
-
-#   29| x
-#-----|  -> x
-
-#   29| x
-#-----|  -> call to call
-
-#   29| call to call
-#-----|  -> exit { ... } (normal)
-
-#   31| while ...
-#-----|  -> false
-
-#   31| true
-#-----| true -> 1
-
-#   32| break
-#-----| break -> while ...
-
-#   32| 1
-#-----|  -> break
-
-#   35| if ...
-#-----|  -> self
-
-#   35| false
-#-----| false -> if ...
-
-#   39| self
-#-----|  -> 42
-
-#   39| call to puts
-#-----|  -> 10
-
-#   39| 42
-#-----|  -> call to puts
-
-#   41| case ...
-#-----|  -> b
-
-#   41| 10
-#-----|  -> 1
-
-#   42| [match] when ...
-#-----| match -> self
-
-#   42| [no-match] when ...
-#-----| no-match -> 2
-
-#   42| 1
-#-----| match -> [match] when ...
-#-----| no-match -> [no-match] when ...
-
-#   42| then ...
-#-----|  -> case ...
-
-#   42| call to puts
-#-----|  -> then ...
-
-#   42| self
-#-----|  -> one
-
-#   42| "one"
-#-----|  -> call to puts
-
-#   42| one
-#-----|  -> "one"
-
-#   43| [match] when ...
-#-----| match -> self
-
-#   43| [no-match] when ...
-#-----| no-match -> self
-
-#   43| 2
-#-----| match -> [match] when ...
-#-----| no-match -> 3
-
-#   43| 3
-#-----| match -> [match] when ...
-#-----| no-match -> 4
-
-#   43| 4
-#-----| match -> [match] when ...
-#-----| no-match -> [no-match] when ...
-
-#   43| then ...
-#-----|  -> case ...
-
-#   43| call to puts
-#-----|  -> then ...
-
-#   43| self
-#-----|  -> some
-
-#   43| "some"
-#-----|  -> call to puts
-
-#   43| some
-#-----|  -> "some"
-
-#   44| else ...
-#-----|  -> case ...
-
-#   44| call to puts
-#-----|  -> else ...
-
-#   44| self
-#-----|  -> many
-
-#   44| "many"
-#-----|  -> call to puts
-
-#   44| many
-#-----|  -> "many"
-
-#   47| case ...
-#-----|  -> chained
-
-#   48| [false] when ...
-#-----| false -> b
-
-#   48| [true] when ...
-#-----| true -> self
-
-#   48| b
-#-----|  -> 1
-
-#   48| ... == ...
-#-----| false -> [false] when ...
-#-----| true -> [true] when ...
-
-#   48| 1
-#-----|  -> ... == ...
-
-#   48| then ...
-#-----|  -> case ...
-
-#   48| call to puts
-#-----|  -> then ...
-
-#   48| self
-#-----|  -> one
-
-#   48| "one"
-#-----|  -> call to puts
-
-#   48| one
-#-----|  -> "one"
-
-#   49| [false] when ...
-#-----| false -> case ...
-
-#   49| [true] when ...
-#-----| true -> self
-
-#   49| b
-#-----|  -> 0
-
-#   49| ... == ...
-#-----| true -> [true] when ...
-#-----| false -> b
-
-#   49| 0
-#-----|  -> ... == ...
-
-#   49| b
-#-----|  -> 1
-
-#   49| ... > ...
-#-----| false -> [false] when ...
-#-----| true -> [true] when ...
-
-#   49| 1
-#-----|  -> ... > ...
-
-#   49| then ...
-#-----|  -> case ...
-
-#   49| call to puts
-#-----|  -> then ...
-
-#   49| self
-#-----|  -> some
-
-#   49| "some"
-#-----|  -> call to puts
-
-#   49| some
-#-----|  -> "some"
-
-#   52| chained
-#-----|  -> a
-
-#   52| ... = ...
-#-----|  -> character
-
-#   52| "a"
-#-----|  -> chained
-
-#   52| "..." "..."
-#-----|  -> ... = ...
-
-#   52| a
-#-----|  -> "a"
-
-#   52| "#{...}"
-#-----|  -> string
-
-#   52| #{...}
-#-----|  -> "#{...}"
-
-#   52| chained
-#-----|  -> #{...}
-
-#   52| "string"
-#-----|  -> "..." "..."
-
-#   52| string
-#-----|  -> "string"
-
-#   54| character
-#-----|  -> ?\x40
-
-#   54| ... = ...
-#-----|  -> Silly
-
-#   54| ?\x40
-#-----|  -> ... = ...
-
-#   58| Silly
-#-----|  -> Object
-
-#   58| Object
-#-----|  -> complex
-
-#   59| complex
-#-----|  -> 10
-
-#   59| ... = ...
-#-----|  -> conditional
-
-#   59| 10
-#-----|  -> 2i
-
-#   59| ... - ...
-#-----|  -> ... = ...
-
-#   59| 2i
-#-----|  -> ... - ...
-
-#   60| conditional
-#-----|  -> self
-
-#   60| ... = ...
-#-----|  -> C
-
-#   60| call to b
-#-----|  -> 10
-
-#   60| self
-#-----|  -> call to b
-
-#   60| ... < ...
-#-----| true -> hello
-#-----| false -> bye
-
-#   60| ... ? ... : ...
-#-----|  -> ... = ...
-
-#   60| 10
-#-----|  -> ... < ...
-
-#   60| "hello"
-#-----|  -> ... ? ... : ...
-
-#   60| hello
-#-----|  -> "hello"
-
-#   60| "bye"
-#-----|  -> ... ? ... : ...
-
-#   60| bye
-#-----|  -> "bye"
-
-#   61| C
-#-----|  -> constant
-
-#   61| ... = ...
-#-----|  -> __synth__2
-
-#   61| "constant"
-#-----|  -> ... = ...
-
-#   61| constant
-#-----|  -> "constant"
-
-#   62| ...
-#-----|  -> pattern
-
-#   62| ... = ...
-#-----|  -> __synth__2__1
-
-#   62| 0
-#-----|  -> call to []
-
-#   62| __synth__2
-#-----|  -> 0
-
-#   62| call to []
-#-----|  -> ... = ...
-
-#   62| x
-#-----|  -> __synth__2
-
-#   62| * ...
-#-----|  -> ... = ...
-
-#   62| ...
-#-----|  -> ...
-
-#   62| ... = ...
-#-----|  -> y
-
-#   62| 1
-#-----|  -> call to []
-
-#   62| __synth__2
-#-----|  -> 1
-
-#   62| __synth__2__1
-#-----|  -> __synth__2
-
-#   62| call to []
-#-----|  -> * ...
-
-#   62| ... = ...
-#-----|  -> z
-
-#   62| 0
-#-----|  -> call to []
-
-#   62| __synth__2__1
-#-----|  -> 0
-
-#   62| call to []
-#-----|  -> ... = ...
-
-#   62| y
-#-----|  -> __synth__2__1
-
-#   62| ... = ...
-#-----|  -> ...
-
-#   62| 1
-#-----|  -> call to []
-
-#   62| __synth__2__1
-#-----|  -> 1
-
-#   62| call to []
-#-----|  -> ... = ...
-
-#   62| z
-#-----|  -> __synth__2__1
-
-#   62| * ...
-#-----|  -> ... = ...
-
-#   62| ... = ...
-#-----|  -> x
-
-#   62| Array
-#-----|  -> 1
-
-#   62| __synth__2
-#-----|  -> Array
-
-#   62| call to []
-#-----|  -> * ...
-
-#   62| 1
-#-----|  -> Array
-
-#   62| Array
-#-----|  -> 2
-
-#   62| call to []
-#-----|  -> call to []
-
-#   62| 2
-#-----|  -> 3
-
-#   62| 3
-#-----|  -> call to []
-
-#   63| enter pattern
-#-----|  -> a
-
-#   63| exit pattern
-
-#   63| exit pattern (normal)
-#-----|  -> exit pattern
-
-#   63| pattern
-#-----|  -> items
-
-#   63| (..., ...)
-#-----|  -> self
-
-#   63| a
-#-----|  -> b
-
-#   63| b
-#-----|  -> (..., ...)
-
-#   64| call to puts
-#-----|  -> self
-
-#   64| self
-#-----|  -> a
-
-#   64| a
-#-----|  -> call to puts
-
-#   65| call to puts
-#-----|  -> exit pattern (normal)
-
-#   65| self
-#-----|  -> b
-
-#   65| b
-#-----|  -> call to puts
-
-#   67| items
-#-----|  -> Array
-
-#   67| ... = ...
-#-----|  -> self
-
-#   67| Array
-#-----|  -> 1
-
-#   67| call to []
-#-----|  -> ... = ...
-
-#   67| 1
-#-----|  -> 2
-
-#   67| 2
-#-----|  -> 3
-
-#   67| 3
-#-----|  -> call to []
-
-#   68| call to puts
-#-----|  -> print
-
-#   68| self
-#-----|  -> items
-
-#   68| items
-#-----|  -> 2
-
-#   68| ...[...]
-#-----|  -> call to puts
-
-#   68| 2
-#-----|  -> ...[...]
-
-#   69| enter print
-#-----|  -> self
-
-#   69| exit print
-
-#   69| exit print (normal)
-#-----|  -> exit print
-
-#   69| print
-#-----|  -> x
-
-#   70| call to puts
-#-----|  -> exit print (normal)
-
-#   70| self
-#-----|  -> silly
-
-#   70| "silly"
-#-----|  -> call to puts
-
-#   70| silly
-#-----|  -> "silly"
-
-#   74| x
-#-----|  -> 42
-
-#   74| ... = ...
-#-----|  -> x
-
-#   74| 42
-#-----|  -> ... = ...
-
-#   75| if ...
-#-----|  -> ;
-
-#   75| x
-#-----|  -> 0
-
-#   75| ... < ...
-#-----| true -> 0
-#-----| false -> x
-
-#   75| 0
-#-----|  -> ... < ...
-
-#   75| then ...
-#-----|  -> if ...
-
-#   75| 0
-#-----|  -> then ...
-
-#   75| elsif ...
-#-----|  -> if ...
-
-#   75| x
-#-----|  -> 10
-
-#   75| ... > ...
-#-----| true -> 10
-#-----| false -> x
-
-#   75| 10
-#-----|  -> ... > ...
-
-#   75| then ...
-#-----|  -> elsif ...
-
-#   75| 10
-#-----|  -> then ...
-
-#   75| else ...
-#-----|  -> elsif ...
-
-#   75| x
-#-----|  -> else ...
-
-#   78| ;
-#-----|  -> self
-
-#   82| else ...
-#-----|  -> self
-
-#   83| call to puts
-#-----|  -> else ...
-
-#   83| self
-#-----|  -> ok
-
-#   83| "ok"
-#-----|  -> call to puts
-
-#   83| ok
-#-----|  -> "ok"
-
-#   84| ensure ...
-#-----|  -> escape
-
-#   85| call to puts
-#-----|  -> ensure ...
-
-#   85| self
-#-----|  -> end
-
-#   85| "end"
-#-----|  -> call to puts
-
-#   85| end
-#-----|  -> "end"
-
-#   88| escape
-#-----|  -> \u1234
-
-#   88| ... = ...
-#-----|  -> x
-
-#   88| "\u1234#{...}\n"
-#-----|  -> ... = ...
-
-#   88| \u1234
-#-----|  -> x
-
-#   88| #{...}
-#-----|  -> \n
-
-#   88| x
-#-----|  -> #{...}
-
-#   88| \n
-#-----|  -> "\u1234#{...}\n"
-
-#   90| ...
-#-----|  -> $global
-
-#   90| ... = ...
-#-----|  -> x
-
-#   90| __synth__0__1
-#-----|  -> x
-
-#   90| __synth__0__1
-#-----|  -> ... = ...
-
-#   90| call to each
-#-----|  -> ...
-
-#   90| enter { ... }
-#-----|  -> __synth__0__1
-
-#   90| exit { ... }
-
-#   90| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#   90| { ... }
-#-----|  -> call to each
-
-#   90| ... = ...
-#-----|  -> if ...
-
-#   90| [false] ! ...
-#-----| false -> if ...
-
-#   90| [true] ! ...
-#-----| true -> x
-
-#   90| defined? ...
-#-----| false -> [true] ! ...
-#-----| true -> [false] ! ...
-
-#   90| if ...
-#-----|  -> Array
-
-#   90| nil
-#-----|  -> ... = ...
-
-#   90| x
-#-----|  -> nil
-
-#   90| x
-#-----|  -> defined? ...
-
-#   90| x
-#-----|  -> __synth__0__1
-
-#   90| Array
-#-----|  -> 1.4
-
-#   90| call to []
-#-----|  -> { ... }
-
-#   90| 1.4
-#-----|  -> 2.5
-
-#   90| 2.5
-#-----|  -> 3.4e5
-
-#   90| 3.4e5
-#-----|  -> call to []
-
-#   91| if ...
-#-----|  -> self
-
-#   91| x
-#-----|  -> 3
-
-#   91| ... > ...
-#-----| false -> if ...
-#-----| true -> next
-
-#   91| 3
-#-----|  -> ... > ...
-
-#   91| next
-#-----| next -> exit { ... } (normal)
-
-#   92| call to puts
-#-----|  -> exit { ... } (normal)
-
-#   92| self
-#-----|  -> x
-
-#   92| x
-#-----|  -> call to puts
-
-#   95| $global
-#-----|  -> 42
-
-#   95| ... = ...
-#-----|  -> map1
-
-#   95| 42
-#-----|  -> ... = ...
-
-#   97| map1
-#-----|  -> Hash
-
-#   97| ... = ...
-#-----|  -> map2
-
-#   97| Hash
-#-----|  -> a
-
-#   97| call to []
-#-----|  -> ... = ...
-
-#   97| "a"
-#-----|  -> b
-
-#   97| Pair
-#-----|  -> c
-
-#   97| a
-#-----|  -> "a"
-
-#   97| "b"
-#-----|  -> Pair
-
-#   97| b
-#-----|  -> "b"
-
-#   97| "c"
-#-----|  -> d
-
-#   97| Pair
-#-----|  -> e
-
-#   97| c
-#-----|  -> "c"
-
-#   97| "d"
-#-----|  -> Pair
-
-#   97| d
-#-----|  -> "d"
-
-#   97| :e
-#-----|  -> f
-
-#   97| e
-#-----|  -> :e
-
-#   97| Pair
-#-----|  -> call to []
-
-#   97| "f"
-#-----|  -> Pair
-
-#   97| f
-#-----|  -> "f"
-
-#   98| map2
-#-----|  -> Hash
-
-#   98| ... = ...
-#-----|  -> parameters
-
-#   98| Hash
-#-----|  -> map1
-
-#   98| call to []
-#-----|  -> ... = ...
-
-#   98| ** ...
-#-----|  -> x
-
-#   98| map1
-#-----|  -> ** ...
-
-#   98| "x"
-#-----|  -> y
-
-#   98| Pair
-#-----|  -> map1
-
-#   98| x
-#-----|  -> "x"
-
-#   98| "y"
-#-----|  -> Pair
-
-#   98| y
-#-----|  -> "y"
-
-#   98| ** ...
-#-----|  -> call to []
-
-#   98| map1
-#-----|  -> ** ...
-
-#  101| enter parameters
-#-----|  -> value
-
-#  101| exit parameters
-
-#  101| exit parameters (normal)
-#-----|  -> exit parameters
-
-#  101| parameters
-#-----|  -> type
-
-#  101| value
-#-----| false, no-match, true -> 42
-#-----| match -> key
-
-#  101| 42
-#-----|  -> key
-
-#  101| key
-#-----|  -> kwargs
-
-#  101| kwargs
-#-----|  -> self
-
-#  102| call to puts
-#-----|  -> kwargs
-
-#  102| self
-#-----|  -> value
-
-#  102| value
-#-----|  -> call to puts
-
-#  103| return
-#-----| return -> exit parameters (normal)
-
-#  103| kwargs
-#-----|  -> key
-
-#  103| ...[...]
-#-----|  -> return
-
-#  103| key
-#-----|  -> ...[...]
-
-#  106| type
-#-----|  -> healthy
-
-#  106| ... = ...
-#-----|  -> table
-
-#  106| "healthy"
-#-----|  -> ... = ...
-
-#  106| healthy
-#-----|  -> "healthy"
-
-#  107| table
-#-----|  -> food
-
-#  107| ... = ...
-#-----|  -> self
-
-#  107| "food"
-#-----|  -> ... = ...
-
-#  107| food
-#-----|  -> "food"
-
-#  108| call to puts
-#-----|  -> b
-
-#  108| self
-#-----|  -> 
-#-----| SELECT * FROM 
-
-#  108| ( ... )
-#-----|  -> call to puts
-
-#  108| <<SQL
-#-----|  -> ( ... )
-
-#  108| 
-#  108| SELECT * FROM 
-#-----|  -> table
-
-#  109| #{...}
-#-----|  ->  
-
-#  109| table
-#-----|  -> #{...}
-
-#  109|  
-#-----|  -> \n
-
-#  109| \n
-#-----|  -> 
-#-----| WHERE 
-
-#  109| 
-#  109| WHERE 
-#-----|  -> type
-
-#  110| #{...}
-#-----|  ->  = true 
-
-#  110| type
-#-----|  -> #{...}
-
-#  110|  = true 
-#-----|  -> \n
-
-#  110| \n
-#-----|  -> 
-#-----| 
-
-#  110| 
-#  110| 
-#-----|  -> <<SQL
-
-#  113| call to puts
-#-----|  -> ... if ...
-
-#  113| self
-#-----|  -> hi
-
-#  113| ... if ...
-#-----|  -> C
-
-#  113| "hi"
-#-----|  -> call to puts
-
-#  113| hi
-#-----|  -> "hi"
-
-#  113| b
-#-----|  -> 10
-
-#  113| ... > ...
-#-----| true -> self
-#-----| false -> ... if ...
-
-#  113| 10
-#-----|  -> ... > ...
-
-#  115| C
-#-----|  -> self
-
-#  116| @field
-#-----|  -> 42
-
-#  116| self
-#-----|  -> @field
-
-#  116| ... = ...
-#-----|  -> @@static_field
-
-#  116| 42
-#-----|  -> ... = ...
-
-#  117| @@static_field
-#-----|  -> 10
-
-#  117| ... = ...
-#-----|  -> swap
-
-#  117| 10
-#-----|  -> ... = ...
-
-#  120| swap
-#-----|  -> -> { ... }
-
-#  120| ... = ...
-#-----|  -> M
-
-#  120| -> { ... }
-#-----|  -> ... = ...
-
-#  120| enter -> { ... }
-#-----|  -> x
-
-#  120| exit -> { ... }
-
-#  120| exit -> { ... } (normal)
-#-----|  -> exit -> { ... }
-
-#  120| (..., ...)
-#-----|  -> Array
-
-#  120| x
-#-----|  -> y
-
-#  120| y
-#-----|  -> (..., ...)
-
-#  120| Array
-#-----|  -> y
-
-#  120| call to []
-#-----|  -> exit -> { ... } (normal)
-
-#  120| y
-#-----|  -> x
-
-#  120| x
-#-----|  -> call to []
-
-#  122| M
-#-----|  -> nothing
-
-#  123| nothing
-#-----|  -> nil
-
-#  123| ... = ...
-#-----|  -> some
-
-#  123| nil
-#-----|  -> ... = ...
-
-#  124| some
-#-----|  -> 2
-
-#  124| ... = ...
-#-----|  -> some
-
-#  124| 2
-#-----|  -> ... = ...
-
-#  125| some
-#-----|  -> some
-
-#  125| some
-#-----|  -> 10
-
-#  125| ... = ...
-#-----|  -> last
-
-#  125| ... + ...
-#-----|  -> ... = ...
-
-#  125| 10
-#-----|  -> ... + ...
-
-#  126| last
-#-----|  -> 2
-
-#  126| ... = ...
-#-----|  -> range
-
-#  126| ( ... )
-#-----|  -> ... = ...
-
-#  126| 2
-#-----|  -> 4
-
-#  126| 4
-#-----|  -> 7
-
-#  126| 7
-#-----|  -> ( ... )
-
-#  127| range
-#-----|  -> 0
-
-#  127| ... = ...
-#-----|  -> half
-
-#  127| 0
-#-----|  -> 9
-
-#  127| _ .. _
-#-----|  -> ... = ...
-
-#  127| 9
-#-----|  -> _ .. _
-
-#  128| half
-#-----|  -> 1
-
-#  128| ... = ...
-#-----|  -> regex
-
-#  128| 1
-#-----|  -> 3r
-
-#  128| ... / ...
-#-----|  -> 1
-
-#  128| ... + ...
-#-----|  -> ... = ...
-
-#  128| 3r
-#-----|  -> ... / ...
-
-#  128| 1
-#-----|  -> 6r
-
-#  128| ... / ...
-#-----|  -> ... + ...
-
-#  128| 6r
-#-----|  -> ... / ...
-
-#  129| regex
-#-----|  -> hello
-
-#  129| ... = ...
-#-----|  -> Constant
-
-#  129| /hello\s+[#{...}]/
-#-----|  -> ... = ...
-
-#  129| hello
-#-----|  -> \s
-
-#  129| \s
-#-----|  -> +[
-
-#  129| +[
-#-----|  -> range
-
-#  129| #{...}
-#-----|  -> ]
-
-#  129| range
-#-----|  -> #{...}
-
-#  129| ]
-#-----|  -> /hello\s+[#{...}]/
-
-#  130| Constant
-#-----|  -> 5
-
-#  130| ... = ...
-#-----|  -> EmptyClass
-
-#  130| 5
-#-----|  -> ... = ...
-
-#  133| EmptyClass
-#-----|  -> EmptyModule
-
-#  134| EmptyModule
-#-----|  -> 1
-
-#  136| 1
-#-----|  -> 0
-
-#  136| ... / ...
-#-----|  -> ... rescue ...
-#-----| raise -> self
-
-#  136| ... rescue ...
-#-----|  -> __synth__2
-
-#  136| 0
-#-----|  -> ... / ...
-
-#  136| call to puts
-#-----|  -> ... rescue ...
-
-#  136| self
-#-----|  -> div by zero
-
-#  136| "div by zero"
-#-----|  -> call to puts
-
-#  136| div by zero
-#-----|  -> "div by zero"
-
-#  138| ...
-#-----|  -> M
-
-#  138| -2
-#-----|  -> _ .. _
-
-#  138| ... = ...
-#-----|  -> last
-
-#  138| 0
-#-----|  -> -2
-
-#  138| _ .. _
-#-----|  -> call to []
-
-#  138| __synth__2
-#-----|  -> 0
-
-#  138| call to []
-#-----|  -> ... = ...
-
-#  138| init
-#-----|  -> __synth__2
-
-#  138| -1
-#-----|  -> call to []
-
-#  138| ... = ...
-#-----|  -> ...
-
-#  138| __synth__2
-#-----|  -> -1
-
-#  138| call to []
-#-----|  -> ... = ...
-
-#  138| last
-#-----|  -> __synth__2
-
-#  138| 1
-#-----|  -> 2
-
-#  138| * ...
-#-----|  -> ... = ...
-
-#  138| ... = ...
-#-----|  -> init
-
-#  138| ..., ...
-#-----|  -> * ...
-
-#  138| __synth__2
-#-----|  -> 1
-
-#  138| 2
-#-----|  -> 3
-
-#  138| 3
-#-----|  -> ..., ...
-
-#  140| M
-#-----|  -> Constant
-
-#  140| Constant
-#-----|  -> M
-
-#  141| M
-#-----|  -> call to itself
-
-#  141| call to itself
-#-----|  -> Constant
-
-#  141| Constant
-#-----|  -> Silly
-
-#  143| class << ...
-#-----|  -> silly
-
-#  143| Silly
-#-----|  -> call to itself
-
-#  143| call to itself
-#-----|  -> setter=
-
-#  144| setter=
-#-----|  -> print
-
-#  145| enter print
-#-----|  -> self
-
-#  145| exit print
-
-#  145| exit print (normal)
-#-----|  -> exit print
-
-#  145| print
-#-----|  -> class << ...
-
-#  146| call to puts
-#-----|  -> self
-
-#  146| self
-#-----|  -> singleton
-
-#  146| "singleton"
-#-----|  -> call to puts
-
-#  146| singleton
-#-----|  -> "singleton"
-
-#  147| call to puts
-#-----|  -> exit print (normal)
-
-#  147| self
-#-----|  -> super call to print
-
-#  147| super call to print
-#-----|  -> call to print
-
-#  147| call to print
-#-----|  -> call to puts
-
-#  151| silly
-#-----|  -> Silly
-
-#  151| ... = ...
-#-----|  -> silly
-
-#  151| Silly
-#-----|  -> call to new
-
-#  151| call to new
-#-----|  -> ... = ...
-
-#  152| enter method
-#-----|  -> x
-
-#  152| exit method
-
-#  152| exit method (normal)
-#-----|  -> exit method
-
-#  152| method
-#-----|  -> two_parameters
-
-#  152| silly
-#-----|  -> method
-
-#  152| x
-#-----|  -> self
-
-#  153| call to puts
-#-----|  -> exit method (normal)
-
-#  153| self
-#-----|  -> x
-
-#  153| x
-#-----|  -> call to puts
-
-#  156| enter two_parameters
-#-----|  -> a
-
-#  156| exit two_parameters
-
-#  156| exit two_parameters (normal)
-#-----|  -> exit two_parameters
-
-#  156| two_parameters
-#-----|  -> self
-
-#  156| a
-#-----|  -> b
-
-#  156| b
-#-----|  -> exit two_parameters (normal)
-
-#  158| call to two_parameters
-#-----|  -> scriptfile
-
-#  158| self
-#-----|  -> Array
-
-#  158| * ...
-#-----|  -> call to two_parameters
-
-#  158| Array
-#-----|  -> 1
-
-#  158| call to []
-#-----|  -> * ...
-
-#  158| 1
-#-----|  -> 2
-
-#  158| 2
-#-----|  -> call to []
-
-#  160| scriptfile
-#-----|  -> cat "
-
-#  160| ... = ...
-#-----|  -> symbol
-
-#  160| `cat "#{...}"`
-#-----|  -> ... = ...
-
-#  160| cat "
-#-----|  -> self
-
-#  160| #{...}
-#-----|  -> "
-
-#  160| call to __FILE__
-#-----|  -> #{...}
-
-#  160| self
-#-----|  -> call to __FILE__
-
-#  160| "
-#-----|  -> `cat "#{...}"`
-
-#  162| symbol
-#-----|  -> hello
-
-#  162| ... = ...
-#-----|  -> delimited_symbol
-
-#  162| :hello
-#-----|  -> ... = ...
-
-#  162| hello
-#-----|  -> :hello
-
-#  164| delimited_symbol
-#-----|  -> goodbye-
-
-#  164| ... = ...
-#-----|  -> x
-
-#  164| :"goodbye-#{...}"
-#-----|  -> ... = ...
-
-#  164| goodbye-
-#-----|  -> 12
-
-#  164| #{...}
-#-----|  -> :"goodbye-#{...}"
-
-#  164| 12
-#-----|  -> 13
-
-#  164| ... + ...
-#-----|  -> #{...}
-
-#  164| 13
-#-----|  -> ... + ...
-
-#  166| x
-#-----|  -> true
-
-#  166| ... = ...
-#-----|  -> x
-
-#  166| true
-#-----|  -> ... = ...
-
-#  167| x
-#-----|  -> true
-
-#  167| ... = ...
-#-----|  -> x
-
-#  167| ! ...
-#-----|  -> ... = ...
-
-#  167| true
-#-----|  -> ! ...
-
-#  168| x
-#-----|  -> 42
-
-#  168| ... = ...
-#-----|  -> undef ...
-
-#  168| - ...
-#-----|  -> ... = ...
-
-#  168| 42
-#-----|  -> - ...
-
-#  170| undef ...
-#-----|  -> two_parameters
-
-#  170| two_parameters
-#-----|  -> x
-
-#  172| unless ...
-#-----|  -> x
-
-#  172| x
-#-----|  -> 10
-
-#  172| ... == ...
-#-----| false -> self
-#-----| true -> self
-
-#  172| 10
-#-----|  -> ... == ...
-
-#  172| then ...
-#-----|  -> unless ...
-
-#  172| call to puts
-#-----|  -> then ...
-
-#  172| self
-#-----|  -> hi
-
-#  172| "hi"
-#-----|  -> call to puts
-
-#  172| hi
-#-----|  -> "hi"
-
-#  172| else ...
-#-----|  -> unless ...
-
-#  172| call to puts
-#-----|  -> else ...
-
-#  172| self
-#-----|  -> bye
-
-#  172| "bye"
-#-----|  -> call to puts
-
-#  172| bye
-#-----|  -> "bye"
-
-#  174| call to puts
-#-----|  -> ... unless ...
-
-#  174| self
-#-----|  -> hi
-
-#  174| ... unless ...
-#-----|  -> x
-
-#  174| "hi"
-#-----|  -> call to puts
-
-#  174| hi
-#-----|  -> "hi"
-
-#  174| x
-#-----|  -> 0
-
-#  174| ... == ...
-#-----| false -> self
-#-----| true -> ... unless ...
-
-#  174| 0
-#-----|  -> ... == ...
-
-#  176| until ...
-#-----|  -> i
-
-#  176| x
-#-----|  -> 10
-
-#  176| ... > ...
-#-----| true -> until ...
-#-----| false -> x
-
-#  176| 10
-#-----|  -> ... > ...
-
-#  176| do ...
-#-----|  -> x
-
-#  176| x
-#-----|  -> x
-
-#  176| x
-#-----|  -> 10
-
-#  176| ... = ...
-#-----|  -> self
-
-#  176| ... + ...
-#-----|  -> ... = ...
-
-#  176| 10
-#-----|  -> ... + ...
-
-#  176| call to puts
-#-----|  -> do ...
-
-#  176| self
-#-----|  -> hello
-
-#  176| "hello"
-#-----|  -> call to puts
-
-#  176| hello
-#-----|  -> "hello"
-
-#  178| i
-#-----|  -> 0
-
-#  178| ... = ...
-#-----|  -> i
-
-#  178| 0
-#-----|  -> ... = ...
-
-#  179| ( ... )
-#-----|  -> i
-
-#  179| ... until ...
-#-----|  -> x
-
-#  179| call to puts
-#-----|  -> i
-
-#  179| self
-#-----|  -> hello
-
-#  179| "hello"
-#-----|  -> call to puts
-
-#  179| hello
-#-----|  -> "hello"
-
-#  179| i
-#-----|  -> i
-
-#  179| i
-#-----|  -> 1
-
-#  179| ... = ...
-#-----|  -> ( ... )
-
-#  179| ... + ...
-#-----|  -> ... = ...
-
-#  179| 1
-#-----|  -> ... + ...
-
-#  179| i
-#-----|  -> 10
-
-#  179| ... == ...
-#-----| true -> ... until ...
-#-----| false -> self
-
-#  179| 10
-#-----|  -> ... == ...
-
-#  181| x
-#-----|  -> 0
-
-#  181| ... = ...
-#-----|  -> x
-
-#  181| 0
-#-----|  -> ... = ...
-
-#  182| while ...
-#-----|  -> i
-
-#  182| x
-#-----|  -> 10
-
-#  182| ... < ...
-#-----| false -> while ...
-#-----| true -> x
-
-#  182| 10
-#-----|  -> ... < ...
-
-#  182| do ...
-#-----|  -> x
-
-#  183| x
-#-----|  -> x
-
-#  183| x
-#-----|  -> 1
-
-#  183| ... = ...
-#-----|  -> x
-
-#  183| ... + ...
-#-----|  -> ... = ...
-
-#  183| 1
-#-----|  -> ... + ...
-
-#  184| if ...
-#-----|  -> self
-
-#  184| x
-#-----|  -> 5
-
-#  184| ... == ...
-#-----| false -> if ...
-#-----| true -> redo
-
-#  184| 5
-#-----|  -> ... == ...
-
-#  184| redo
-#-----| redo -> x
-
-#  185| call to puts
-#-----|  -> do ...
-
-#  185| self
-#-----|  -> x
-
-#  185| x
-#-----|  -> call to puts
-
-#  188| ( ... )
-#-----|  -> i
-
-#  188| ... while ...
-#-----|  -> run_block
-
-#  188| call to puts
-#-----|  -> i
-
-#  188| self
-#-----|  -> hello
-
-#  188| "hello"
-#-----|  -> call to puts
-
-#  188| hello
-#-----|  -> "hello"
-
-#  188| i
-#-----|  -> i
-
-#  188| i
-#-----|  -> 1
-
-#  188| ... = ...
-#-----|  -> ( ... )
-
-#  188| ... - ...
-#-----|  -> ... = ...
-
-#  188| 1
-#-----|  -> ... - ...
-
-#  188| i
-#-----|  -> 0
-
-#  188| ... != ...
-#-----| false -> ... while ...
-#-----| true -> self
-
-#  188| 0
-#-----|  -> ... != ...
-
-#  190| enter run_block
-#-----|  -> 42
-
-#  190| exit run_block
-
-#  190| exit run_block (normal)
-#-----|  -> exit run_block
-
-#  190| run_block
-#-----|  -> self
-
-#  191| yield ...
-#-----|  -> exit run_block (normal)
-
-#  191| 42
-#-----|  -> yield ...
-
-#  194| call to run_block
-#-----|  -> forward_param
-
-#  194| self
-#-----|  -> { ... }
-
-#  194| enter { ... }
-#-----|  -> x
-
-#  194| exit { ... }
-
-#  194| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  194| { ... }
-#-----|  -> call to run_block
-
-#  194| x
-#-----|  -> self
-
-#  194| call to puts
-#-----|  -> exit { ... } (normal)
-
-#  194| self
-#-----|  -> x
-
-#  194| x
-#-----|  -> call to puts
-
-#  196| enter forward_param
-#-----|  -> a
-
-#  196| exit forward_param
-
-#  196| exit forward_param (normal)
-#-----|  -> exit forward_param
-
-#  196| forward_param
-#-----|  -> 1
-
-#  196| a
-#-----|  -> b
-
-#  196| b
-#-----|  -> ...
-
-#  196| ...
-#-----|  -> self
-
-#  197| call to bar
-#-----|  -> exit forward_param (normal)
-
-#  197| self
-#-----|  -> b
-
-#  197| b
-#-----|  -> ...
-
-#  197| ...
-#-----|  -> call to bar
-
-#  200| 1
-#-----|  -> { ... }
-
-#  200| call to times
-#-----|  -> 2
-
-#  200| enter { ... }
-#-----|  -> a
-
-#  200| exit { ... }
-
-#  200| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  200| { ... }
-#-----|  -> call to times
-
-#  200| a
-#-----|  -> b
-
-#  200| b
-#-----|  -> Kernel
-
-#  200| Kernel
-#-----|  -> a
-
-#  200| call to puts
-#-----|  -> exit { ... } (normal)
-
-#  200| a
-#-----|  -> call to puts
-
-#  202| 2
-#-----|  -> do ... end
-
-#  202| call to times
-#-----|  -> __synth__0__1
-
-#  202| do ... end
-#-----|  -> call to times
-
-#  202| enter do ... end
-#-----|  -> c
-
-#  202| exit do ... end
-
-#  202| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#  202| c
-#-----|  -> d
-
-#  202| d
-#-----|  -> Kernel
-
-#  202| Kernel
-#-----|  -> c
-
-#  202| call to puts
-#-----|  -> exit do ... end (normal)
-
-#  202| c
-#-----|  -> call to puts
-
-#  205| ... = ...
-#-----|  -> nil
-
-#  205| __synth__0__1
-#-----|  -> self
-
-#  205| __synth__0__1
-#-----|  -> call to ==
-
-#  205| __synth__0__1
-#-----|  -> 1
-
-#  205| call to foo
-#-----|  -> ... = ...
-
-#  205| nil
-#-----|  -> if ...
-
-#  205| self
-#-----|  -> call to foo
-
-#  205| ...
-#-----|  -> filter_nil
-
-#  205| call to bar
-#-----|  -> if ...
-
-#  205| call to ==
-#-----| false -> __synth__0__1
-#-----| true -> nil
-
-#  205| if ...
-#-----|  -> ...
-
-#  205| nil
-#-----|  -> __synth__0__1
-
-#  205| 1
-#-----|  -> 2
-
-#  205| 2
-#-----|  -> { ... }
-
-#  205| enter { ... }
-#-----|  -> x
-
-#  205| exit { ... }
-
-#  205| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  205| { ... }
-#-----|  -> call to bar
-
-#  205| x
-#-----|  -> x
-
-#  205| x
-#-----|  -> exit { ... } (normal)
-
-#  207| enter filter_nil
-#-----|  -> list
-
-#  207| exit filter_nil
-
-#  207| exit filter_nil (normal)
-#-----|  -> exit filter_nil
-
-#  207| filter_nil
-#-----|  -> self
-
-#  207| list
-#-----|  -> list
-
-#  208| list
-#-----|  -> do ... end
-
-#  208| call to reject
-#-----|  -> exit filter_nil (normal)
-
-#  208| do ... end
-#-----|  -> call to reject
-
-#  208| enter do ... end
-#-----|  -> elem
-
-#  208| exit do ... end
-
-#  208| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#  208| elem
-#-----|  -> __synth__0
-
-#  208| __synth__0
-#-----|  -> __synth__0
-
-#  208| __synth__0
-#-----|  -> elem
-
-#  209| elem
-#-----|  -> call to nil?
-
-#  209| call to nil?
-#-----|  -> exit do ... end (normal)
-
-#  213| call to do_something
-#-----|  -> exit cfg.rb (normal)
-
-#  213| self
-#-----|  -> do ... end
-
-#  213| do ... end
-#-----|  -> call to do_something
-
-#  213| enter do ... end
-#-----|  -> self
-
-#  213| exit do ... end
-
-#  213| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#  214| self
-#-----|  -> call to something
-
-#  214| call to something
-#-----|  -> self
-
-#  215| call to something_else
-#-----|  -> exit do ... end (normal)
-
-#  215| self
-#-----|  -> call to something_else
-
-constant_compound_assign.rb:
-#    1| Foo
-#-----|  -> foo_before
-
-#    1| enter constant_compound_assign.rb
-#-----|  -> Foo
-
-#    1| exit constant_compound_assign.rb
-
-#    1| exit constant_compound_assign.rb (normal)
-#-----|  -> exit constant_compound_assign.rb
-
-#    2| foo_before
-#-----|  -> FOO_CONSTANT
-
-#    5| FOO_CONSTANT
-#-----|  -> FOO_CONSTANT
-
-#    5| FOO_CONSTANT
-#-----| true -> ... || ...
-#-----| false -> 123
-
-#    5| ... = ...
-#-----|  -> foo_after
-
-#    5| ... || ...
-#-----|  -> ... = ...
-
-#    5| 123
-#-----|  -> ... || ...
-
-#    7| foo_after
-#-----|  -> top_before
-
-#   11| top_before
-#-----|  -> TOP_CONSTANT
-
-#   14| TOP_CONSTANT
-#-----|  -> TOP_CONSTANT
-
-#   14| TOP_CONSTANT
-#-----| true -> ... || ...
-#-----| false -> 123
-
-#   14| ... = ...
-#-----|  -> top_after
-
-#   14| ... || ...
-#-----|  -> ... = ...
-
-#   14| 123
-#-----|  -> ... || ...
-
-#   16| top_after
-#-----|  -> TOP_CONSTANT2
-
-#   19| TOP_CONSTANT2
-#-----|  -> TOP_CONSTANT2
-
-#   19| TOP_CONSTANT2
-#-----| true -> ... || ...
-#-----| false -> 123
-
-#   19| ... = ...
-#-----|  -> top_after2
-
-#   19| ... || ...
-#-----|  -> ... = ...
-
-#   19| 123
-#-----|  -> ... || ...
-
-#   21| top_after2
-#-----|  -> exit constant_compound_assign.rb (normal)
-
-desugar.rb:
-#    1| enter m1
-#-----|  -> x
-
-#    1| exit m1
-
-#    1| exit m1 (normal)
-#-----|  -> exit m1
-
-#    1| m1
-#-----|  -> m2
-
-#    1| enter desugar.rb
-#-----|  -> m1
-
-#    1| exit desugar.rb
-
-#    1| exit desugar.rb (normal)
-#-----|  -> exit desugar.rb
-
-#    1| x
-#-----|  -> x
-
-#    2| x
-#-----|  -> x
-
-#    2| x
-#-----|  -> 1
-
-#    2| ... = ...
-#-----|  -> exit m1 (normal)
-
-#    2| ... + ...
-#-----|  -> ... = ...
-
-#    2| 1
-#-----|  -> ... + ...
-
-#    5| enter m2
-#-----|  -> x
-
-#    5| exit m2
-
-#    5| exit m2 (normal)
-#-----|  -> exit m2
-
-#    5| m2
-#-----|  -> m3
-
-#    5| x
-#-----|  -> x
-
-#    6| x
-#-----|  -> call to foo
-
-#    6| call to foo
-#-----|  -> __synth__0
-
-#    6| __synth__0
-#-----|  -> ...
-
-#    6| call to count=
-#-----|  -> __synth__0
-
-#    6| ...
-#-----|  -> exit m2 (normal)
-
-#    6| ... = ...
-#-----|  -> call to count=
-
-#    6| 1
-#-----|  -> ... = ...
-
-#    6| __synth__0
-#-----|  -> 1
-
-#    9| enter m3
-#-----|  -> x
-
-#    9| exit m3
-
-#    9| exit m3 (normal)
-#-----|  -> exit m3
-
-#    9| m3
-#-----|  -> m4
-
-#    9| x
-#-----|  -> x
-
-#   10| x
-#-----|  -> call to foo
-
-#   10| call to foo
-#-----|  -> 0
-
-#   10| __synth__0
-#-----|  -> ...
-
-#   10| call to []=
-#-----|  -> __synth__0
-
-#   10| ...
-#-----|  -> exit m3 (normal)
-
-#   10| 0
-#-----|  -> __synth__0
-
-#   10| ... = ...
-#-----|  -> call to []=
-
-#   10| 1
-#-----|  -> ... = ...
-
-#   10| __synth__0
-#-----|  -> 1
-
-#   13| enter m4
-#-----|  -> x
-
-#   13| exit m4
-
-#   13| exit m4 (normal)
-#-----|  -> exit m4
-
-#   13| m4
-#-----|  -> m5
-
-#   13| x
-#-----|  -> __synth__0
-
-#   14| x
-#-----|  -> call to foo
-
-#   14| ... = ...
-#-----|  -> __synth__1
-
-#   14| __synth__0
-#-----|  -> x
-
-#   14| __synth__0
-#-----|  -> __synth__1
-
-#   14| __synth__0
-#-----|  -> call to count
-
-#   14| call to foo
-#-----|  -> ... = ...
-
-#   14| __synth__1
-#-----|  -> call to count=
-
-#   14| call to count
-#-----|  -> 1
-
-#   14| call to count=
-#-----|  -> __synth__1
-
-#   14| ...
-#-----|  -> exit m4 (normal)
-
-#   14| ... + ...
-#-----|  -> ... = ...
-
-#   14| ... = ...
-#-----|  -> __synth__0
-
-#   14| __synth__1
-#-----|  -> ...
-
-#   14| __synth__1
-#-----|  -> __synth__0
-
-#   14| 1
-#-----|  -> ... + ...
-
-#   17| enter m5
-#-----|  -> x
-
-#   17| exit m5
-
-#   17| exit m5 (normal)
-#-----|  -> exit m5
-
-#   17| m5
-#-----|  -> m6
-
-#   17| x
-#-----|  -> y
-
-#   17| y
-#-----|  -> __synth__0
-
-#   18| x
-#-----|  -> call to foo
-
-#   18| ... = ...
-#-----|  -> __synth__1
-
-#   18| __synth__0
-#-----|  -> x
-
-#   18| __synth__0
-#-----|  -> __synth__1
-
-#   18| __synth__0
-#-----|  -> __synth__1
-
-#   18| call to foo
-#-----|  -> ... = ...
-
-#   18| __synth__4
-#-----|  -> call to []=
-
-#   18| call to []
-#-----|  -> 1
-
-#   18| call to []=
-#-----|  -> __synth__4
-
-#   18| ...
-#-----|  -> exit m5 (normal)
-
-#   18| ... = ...
-#-----|  -> __synth__2
-
-#   18| 0
-#-----|  -> ... = ...
-
-#   18| __synth__1
-#-----|  -> 0
-
-#   18| __synth__1
-#-----|  -> __synth__2
-
-#   18| __synth__1
-#-----|  -> __synth__2
-
-#   18| y
-#-----|  -> call to bar
-
-#   18| ... = ...
-#-----|  -> __synth__3
-
-#   18| __synth__2
-#-----|  -> y
-
-#   18| __synth__2
-#-----|  -> __synth__3
-
-#   18| __synth__2
-#-----|  -> __synth__3
-
-#   18| call to bar
-#-----|  -> ... = ...
-
-#   18| x
-#-----|  -> call to baz
-
-#   18| call to baz
-#-----|  -> 3
-
-#   18| ... + ...
-#-----|  -> ... = ...
-
-#   18| ... = ...
-#-----|  -> __synth__4
-
-#   18| __synth__3
-#-----|  -> x
-
-#   18| __synth__3
-#-----|  -> __synth__4
-
-#   18| __synth__3
-#-----|  -> call to []
-
-#   18| 3
-#-----|  -> ... + ...
-
-#   18| ... + ...
-#-----|  -> ... = ...
-
-#   18| ... = ...
-#-----|  -> __synth__0
-
-#   18| __synth__4
-#-----|  -> ...
-
-#   18| __synth__4
-#-----|  -> __synth__0
-
-#   18| 1
-#-----|  -> ... + ...
-
-#   21| enter m6
-#-----|  -> __synth__2
-
-#   21| exit m6
-
-#   21| exit m6 (normal)
-#-----|  -> exit m6
-
-#   21| m6
-#-----|  -> m7
-
-#   22| ... = ...
-#-----|  -> y
-
-#   22| 0
-#-----|  -> call to []
-
-#   22| __synth__3
-#-----|  -> 0
-
-#   22| call to []
-#-----|  -> ... = ...
-
-#   22| x
-#-----|  -> __synth__3
-
-#   22| ...
-#-----|  -> exit m6 (normal)
-
-#   22| -2
-#-----|  -> _ .. _
-
-#   22| ... = ...
-#-----|  -> __synth__2
-
-#   22| 1
-#-----|  -> -2
-
-#   22| _ .. _
-#-----|  -> call to []
-
-#   22| __synth__3
-#-----|  -> 1
-
-#   22| call to []
-#-----|  -> ... = ...
-
-#   22| y
-#-----|  -> __synth__3
-
-#   22| ... = ...
-#-----|  -> __synth__3
-
-#   22| __synth__2
-#-----|  -> self
-
-#   22| call to z
-#-----|  -> ... = ...
-
-#   22| self
-#-----|  -> call to z
-
-#   22| -1
-#-----|  -> call to []
-
-#   22| ...
-#-----|  -> ...
-
-#   22| ... = ...
-#-----|  -> call to bar=
-
-#   22| __synth__0__1
-#-----|  -> ...
-
-#   22| __synth__0__1
-#-----|  -> __synth__3
-
-#   22| __synth__2
-#-----|  -> __synth__0__1
-
-#   22| __synth__3
-#-----|  -> -1
-
-#   22| call to []
-#-----|  -> ... = ...
-
-#   22| call to bar=
-#-----|  -> __synth__0__1
-
-#   22| * ...
-#-----|  -> ... = ...
-
-#   22| ... = ...
-#-----|  -> x
-
-#   22| Array
-#-----|  -> 1
-
-#   22| __synth__3
-#-----|  -> Array
-
-#   22| call to []
-#-----|  -> * ...
-
-#   22| 1
-#-----|  -> 2
-
-#   22| 2
-#-----|  -> 3
-
-#   22| 3
-#-----|  -> 4
-
-#   22| 4
-#-----|  -> call to []
-
-#   25| enter m7
-#-----|  -> __synth__2
-
-#   25| exit m7
-
-#   25| exit m7 (normal)
-#-----|  -> exit m7
-
-#   25| m7
-#-----|  -> X
-
-#   26| ... = ...
-#-----|  -> __synth__2__1
-
-#   26| 0
-#-----|  -> call to []
-
-#   26| __synth__2
-#-----|  -> 0
-
-#   26| call to []
-#-----|  -> ... = ...
-
-#   26| x
-#-----|  -> __synth__2
-
-#   26| ...
-#-----|  -> exit m7 (normal)
-
-#   26| * ...
-#-----|  -> ... = ...
-
-#   26| ...
-#-----|  -> ...
-
-#   26| ... = ...
-#-----|  -> y
-
-#   26| 1
-#-----|  -> call to []
-
-#   26| __synth__2
-#-----|  -> 1
-
-#   26| __synth__2__1
-#-----|  -> __synth__2
-
-#   26| call to []
-#-----|  -> * ...
-
-#   26| ... = ...
-#-----|  -> z
-
-#   26| 0
-#-----|  -> call to []
-
-#   26| __synth__2__1
-#-----|  -> 0
-
-#   26| call to []
-#-----|  -> ... = ...
-
-#   26| y
-#-----|  -> __synth__2__1
-
-#   26| ... = ...
-#-----|  -> ...
-
-#   26| 1
-#-----|  -> call to []
-
-#   26| __synth__2__1
-#-----|  -> 1
-
-#   26| call to []
-#-----|  -> ... = ...
-
-#   26| z
-#-----|  -> __synth__2__1
-
-#   26| * ...
-#-----|  -> ... = ...
-
-#   26| ... = ...
-#-----|  -> x
-
-#   26| Array
-#-----|  -> 1
-
-#   26| __synth__2
-#-----|  -> Array
-
-#   26| call to []
-#-----|  -> * ...
-
-#   26| 1
-#-----|  -> Array
-
-#   26| Array
-#-----|  -> 2
-
-#   26| call to []
-#-----|  -> call to []
-
-#   26| 2
-#-----|  -> 3
-
-#   26| 3
-#-----|  -> call to []
-
-#   29| X
-#-----|  -> self
-
-#   30| @x
-#-----|  -> 1
-
-#   30| self
-#-----|  -> @x
-
-#   30| ... = ...
-#-----|  -> self
-
-#   30| 1
-#-----|  -> ... = ...
-
-#   31| @x
-#-----|  -> self
-
-#   31| @x
-#-----|  -> 2
-
-#   31| self
-#-----|  -> @x
-
-#   31| self
-#-----|  -> @x
-
-#   31| ... = ...
-#-----|  -> @@y
-
-#   31| ... + ...
-#-----|  -> ... = ...
-
-#   31| 2
-#-----|  -> ... + ...
-
-#   33| @@y
-#-----|  -> 3
-
-#   33| ... = ...
-#-----|  -> @@y
-
-#   33| 3
-#-----|  -> ... = ...
-
-#   34| @@y
-#-----|  -> @@y
-
-#   34| @@y
-#-----|  -> 4
-
-#   34| ... = ...
-#-----|  -> $global_var
-
-#   34| ... / ...
-#-----|  -> ... = ...
-
-#   34| 4
-#-----|  -> ... / ...
-
-#   37| $global_var
-#-----|  -> 5
-
-#   37| ... = ...
-#-----|  -> $global_var
-
-#   37| 5
-#-----|  -> ... = ...
-
-#   38| $global_var
-#-----|  -> $global_var
-
-#   38| $global_var
-#-----|  -> 6
-
-#   38| ... = ...
-#-----|  -> exit desugar.rb (normal)
-
-#   38| ... * ...
-#-----|  -> ... = ...
-
-#   38| 6
-#-----|  -> ... * ...
-
-exit.rb:
-#    1| enter m1
-#-----|  -> x
-
-#    1| exit m1
-
-#    1| exit m1 (abnormal)
-#-----|  -> exit m1
-
-#    1| exit m1 (normal)
-#-----|  -> exit m1
-
-#    1| m1
-#-----|  -> m2
-
-#    1| enter exit.rb
-#-----|  -> m1
-
-#    1| exit exit.rb
-
-#    1| exit exit.rb (normal)
-#-----|  -> exit exit.rb
-
-#    1| x
-#-----|  -> x
-
-#    2| if ...
-#-----|  -> self
-
-#    2| x
-#-----|  -> 2
-
-#    2| ... > ...
-#-----| false -> if ...
-#-----| true -> self
-
-#    2| 2
-#-----|  -> ... > ...
-
-#    3| call to exit
-#-----| exit -> exit m1 (abnormal)
-
-#    3| self
-#-----|  -> 1
-
-#    3| 1
-#-----|  -> call to exit
-
-#    5| call to puts
-#-----|  -> exit m1 (normal)
-
-#    5| self
-#-----|  -> x <= 2
-
-#    5| "x <= 2"
-#-----|  -> call to puts
-
-#    5| x <= 2
-#-----|  -> "x <= 2"
-
-#    8| enter m2
-#-----|  -> x
-
-#    8| exit m2
-
-#    8| exit m2 (abnormal)
-#-----|  -> exit m2
-
-#    8| exit m2 (normal)
-#-----|  -> exit m2
-
-#    8| m2
-#-----|  -> exit exit.rb (normal)
-
-#    8| x
-#-----|  -> x
-
-#    9| if ...
-#-----|  -> self
-
-#    9| x
-#-----|  -> 2
-
-#    9| ... > ...
-#-----| false -> if ...
-#-----| true -> self
-
-#    9| 2
-#-----|  -> ... > ...
-
-#   10| call to abort
-#-----| exit -> exit m2 (abnormal)
-
-#   10| self
-#-----|  -> abort!
-
-#   10| "abort!"
-#-----|  -> call to abort
-
-#   10| abort!
-#-----|  -> "abort!"
-
-#   12| call to puts
-#-----|  -> exit m2 (normal)
-
-#   12| self
-#-----|  -> x <= 2
-
-#   12| "x <= 2"
-#-----|  -> call to puts
-
-#   12| x <= 2
-#-----|  -> "x <= 2"
-
-heredoc.rb:
-#    1| double_heredoc
-#-----|  -> exit heredoc.rb (normal)
-
-#    1| enter double_heredoc
-#-----|  -> self
-
-#    1| exit double_heredoc
-
-#    1| exit double_heredoc (normal)
-#-----|  -> exit double_heredoc
-
-#    1| enter heredoc.rb
-#-----|  -> double_heredoc
-
-#    1| exit heredoc.rb
-
-#    1| exit heredoc.rb (normal)
-#-----|  -> exit heredoc.rb
-
-#    2| call to puts
-#-----|  -> exit double_heredoc (normal)
-
-#    2| self
-#-----|  -> 
-#-----|     hello
-#-----| 
-
-#    2| <<A
-#-----|  -> 
-#-----|    world
-#-----| 
-
-#    2| <<A
-#-----|  -> call to puts
-
-#    2| 
-#    2|     hello
-#    2| 
-#-----|  -> <<A
-
-#    4| 
-#    4|    world
-#    4| 
-#-----|  -> <<A
-
-ifs.rb:
-#    1| enter m1
-#-----|  -> x
-
-#    1| exit m1
-
-#    1| exit m1 (normal)
-#-----|  -> exit m1
-
-#    1| m1
-#-----|  -> m2
-
-#    1| enter ifs.rb
-#-----|  -> m1
-
-#    1| exit ifs.rb
-
-#    1| exit ifs.rb (normal)
-#-----|  -> exit ifs.rb
-
-#    1| x
-#-----|  -> x
-
-#    2| if ...
-#-----|  -> exit m1 (normal)
-
-#    2| x
-#-----|  -> 2
-
-#    2| ... > ...
-#-----| true -> self
-#-----| false -> x
-
-#    2| 2
-#-----|  -> ... > ...
-
-#    2| then ...
-#-----|  -> if ...
-
-#    3| call to puts
-#-----|  -> then ...
-
-#    3| self
-#-----|  -> x is greater than 2
-
-#    3| "x is greater than 2"
-#-----|  -> call to puts
-
-#    3| x is greater than 2
-#-----|  -> "x is greater than 2"
-
-#    4| elsif ...
-#-----|  -> if ...
-
-#    4| x
-#-----|  -> 2
-
-#    4| ... <= ...
-#-----| false -> [false] ... and ...
-#-----| true -> x
-
-#    4| [false] ... and ...
-#-----| false -> [false] ... and ...
-
-#    4| [true] ... and ...
-#-----| true -> x
-
-#    4| [false] ... and ...
-#-----| false -> self
-
-#    4| [true] ... and ...
-#-----| true -> self
-
-#    4| 2
-#-----|  -> ... <= ...
-
-#    4| x
-#-----|  -> 0
-
-#    4| ... > ...
-#-----| false -> [false] ... and ...
-#-----| true -> [true] ... and ...
-
-#    4| 0
-#-----|  -> ... > ...
-
-#    4| [false] ! ...
-#-----| false -> [false] ... and ...
-
-#    4| [true] ! ...
-#-----| true -> [true] ... and ...
-
-#    4| [false] ( ... )
-#-----| false -> [true] ! ...
-
-#    4| [true] ( ... )
-#-----| true -> [false] ! ...
-
-#    4| x
-#-----|  -> 5
-
-#    4| ... == ...
-#-----| false -> [false] ( ... )
-#-----| true -> [true] ( ... )
-
-#    4| 5
-#-----|  -> ... == ...
-
-#    4| then ...
-#-----|  -> elsif ...
-
-#    5| call to puts
-#-----|  -> then ...
-
-#    5| self
-#-----|  -> x is 1
-
-#    5| "x is 1"
-#-----|  -> call to puts
-
-#    5| x is 1
-#-----|  -> "x is 1"
-
-#    6| else ...
-#-----|  -> elsif ...
-
-#    7| call to puts
-#-----|  -> else ...
-
-#    7| self
-#-----|  -> I can't guess the number
-
-#    7| "I can't guess the number"
-#-----|  -> call to puts
-
-#    7| I can't guess the number
-#-----|  -> "I can't guess the number"
-
-#   11| enter m2
-#-----|  -> b
-
-#   11| exit m2
-
-#   11| exit m2 (normal)
-#-----|  -> exit m2
-
-#   11| m2
-#-----|  -> m3
-
-#   11| b
-#-----|  -> b
-
-#   12| if ...
-#-----|  -> 1
-
-#   12| b
-#-----| false -> if ...
-#-----| true -> 0
-
-#   13| return
-#-----| return -> exit m2 (normal)
-
-#   13| 0
-#-----|  -> return
-
-#   15| return
-#-----| return -> exit m2 (normal)
-
-#   15| 1
-#-----|  -> return
-
-#   18| enter m3
-#-----|  -> x
-
-#   18| exit m3
-
-#   18| exit m3 (normal)
-#-----|  -> exit m3
-
-#   18| m3
-#-----|  -> m4
-
-#   18| x
-#-----|  -> x
-
-#   19| if ...
-#-----|  -> self
-
-#   19| x
-#-----|  -> 0
-
-#   19| ... < ...
-#-----| false -> if ...
-#-----| true -> x
-
-#   19| 0
-#-----|  -> ... < ...
-
-#   19| then ...
-#-----|  -> if ...
-
-#   20| x
-#-----|  -> x
-
-#   20| ... = ...
-#-----|  -> x
-
-#   20| - ...
-#-----|  -> ... = ...
-
-#   20| x
-#-----|  -> - ...
-
-#   21| if ...
-#-----|  -> then ...
-
-#   21| x
-#-----|  -> 10
-
-#   21| ... > ...
-#-----| false -> if ...
-#-----| true -> x
-
-#   21| 10
-#-----|  -> ... > ...
-
-#   21| then ...
-#-----|  -> if ...
-
-#   22| x
-#-----|  -> x
-
-#   22| ... = ...
-#-----|  -> then ...
-
-#   22| x
-#-----|  -> 1
-
-#   22| ... - ...
-#-----|  -> ... = ...
-
-#   22| 1
-#-----|  -> ... - ...
-
-#   25| call to puts
-#-----|  -> exit m3 (normal)
-
-#   25| self
-#-----|  -> x
-
-#   25| x
-#-----|  -> call to puts
-
-#   28| enter m4
-#-----|  -> b1
-
-#   28| exit m4
-
-#   28| exit m4 (normal)
-#-----|  -> exit m4
-
-#   28| m4
-#-----|  -> m5
-
-#   28| b1
-#-----|  -> b2
-
-#   28| b2
-#-----|  -> b3
-
-#   28| b3
-#-----|  -> b1
-
-#   29| return
-#-----| return -> exit m4 (normal)
-
-#   29| [false] ( ... )
-#-----| false -> !b2 || !b3
-
-#   29| [true] ( ... )
-#-----| true -> b2 || b3
-
-#   29| ... ? ... : ...
-#-----|  -> return
-
-#   29| b1
-#-----| true -> b2
-#-----| false -> b3
-
-#   29| [false] ... ? ... : ...
-#-----| false -> [false] ( ... )
-
-#   29| [true] ... ? ... : ...
-#-----| true -> [true] ( ... )
-
-#   29| b2
-#-----| false -> [false] ... ? ... : ...
-#-----| true -> [true] ... ? ... : ...
-
-#   29| b3
-#-----| false -> [false] ... ? ... : ...
-#-----| true -> [true] ... ? ... : ...
-
-#   29| "b2 || b3"
-#-----|  -> ... ? ... : ...
-
-#   29| b2 || b3
-#-----|  -> "b2 || b3"
-
-#   29| "!b2 || !b3"
-#-----|  -> ... ? ... : ...
-
-#   29| !b2 || !b3
-#-----|  -> "!b2 || !b3"
-
-#   32| enter m5
-#-----|  -> b1
-
-#   32| exit m5
-
-#   32| exit m5 (normal)
-#-----|  -> exit m5
-
-#   32| m5
-#-----|  -> 1
-
-#   32| b1
-#-----|  -> b2
-
-#   32| b2
-#-----|  -> b3
-
-#   32| b3
-#-----|  -> b4
-
-#   32| b4
-#-----|  -> b5
-
-#   32| b5
-#-----|  -> b1
-
-#   33| if ...
-#-----|  -> exit m5 (normal)
-
-#   33| [false] ( ... )
-#-----| false -> !b2 || !b4 || !b5
-
-#   33| [true] ( ... )
-#-----| true -> b2 || b4 || b5
-
-#   33| [false] if ...
-#-----| false -> [false] ( ... )
-
-#   33| [true] if ...
-#-----| true -> [true] ( ... )
-
-#   33| b1
-#-----| true -> b2
-#-----| false -> b3
-
-#   33| [false] then ...
-#-----| false -> [false] if ...
-
-#   33| [true] then ...
-#-----| true -> [true] if ...
-
-#   33| b2
-#-----| false -> [false] then ...
-#-----| true -> [true] then ...
-
-#   33| [false] elsif ...
-#-----| false -> [false] if ...
-
-#   33| [true] elsif ...
-#-----| true -> [true] if ...
-
-#   33| b3
-#-----| true -> b4
-#-----| false -> b5
-
-#   33| [false] then ...
-#-----| false -> [false] elsif ...
-
-#   33| [true] then ...
-#-----| true -> [true] elsif ...
-
-#   33| b4
-#-----| false -> [false] then ...
-#-----| true -> [true] then ...
-
-#   33| [false] else ...
-#-----| false -> [false] elsif ...
-
-#   33| [true] else ...
-#-----| true -> [true] elsif ...
-
-#   33| b5
-#-----| false -> [false] else ...
-#-----| true -> [true] else ...
-
-#   33| then ...
-#-----|  -> if ...
-
-#   33| "b2 || b4 || b5"
-#-----|  -> then ...
-
-#   33| b2 || b4 || b5
-#-----|  -> "b2 || b4 || b5"
-
-#   33| else ...
-#-----|  -> if ...
-
-#   33| "!b2 || !b4 || !b5"
-#-----|  -> else ...
-
-#   33| !b2 || !b4 || !b5
-#-----|  -> "!b2 || !b4 || !b5"
-
-#   36| conditional_method_def
-#-----|  -> ... unless ...
-
-#   36| enter conditional_method_def
-#-----|  -> self
-
-#   36| exit conditional_method_def
-
-#   36| exit conditional_method_def (normal)
-#-----|  -> exit conditional_method_def
-
-#   36| ... unless ...
-#-----|  -> constant_condition
-
-#   37| call to puts
-#-----|  -> exit conditional_method_def (normal)
-
-#   37| self
-#-----|  -> bla
-
-#   37| "bla"
-#-----|  -> call to puts
-
-#   37| bla
-#-----|  -> "bla"
-
-#   38| 1
-#-----|  -> 2
-
-#   38| ... == ...
-#-----| false -> conditional_method_def
-#-----| true -> ... unless ...
-
-#   38| 2
-#-----|  -> ... == ...
-
-#   40| constant_condition
-#-----|  -> empty_else
-
-#   40| enter constant_condition
-#-----|  -> true
-
-#   40| exit constant_condition
-
-#   40| exit constant_condition (normal)
-#-----|  -> exit constant_condition
-
-#   41| if ...
-#-----|  -> exit constant_condition (normal)
-
-#   41| [false] ! ...
-#-----| false -> if ...
-
-#   41| true
-#-----| true -> [false] ! ...
-
-#   46| empty_else
-#-----|  -> disjunct
-
-#   46| enter empty_else
-#-----|  -> b
-
-#   46| exit empty_else
-
-#   46| exit empty_else (normal)
-#-----|  -> exit empty_else
-
-#   46| b
-#-----|  -> b
-
-#   47| if ...
-#-----|  -> self
-
-#   47| b
-#-----| true -> self
-#-----| false -> else ...
-
-#   47| then ...
-#-----|  -> if ...
-
-#   48| call to puts
-#-----|  -> then ...
-
-#   48| self
-#-----|  -> true
-
-#   48| "true"
-#-----|  -> call to puts
-
-#   48| true
-#-----|  -> "true"
-
-#   49| else ...
-#-----|  -> if ...
-
-#   51| call to puts
-#-----|  -> exit empty_else (normal)
-
-#   51| self
-#-----|  -> done
-
-#   51| "done"
-#-----|  -> call to puts
-
-#   51| done
-#-----|  -> "done"
-
-#   54| disjunct
-#-----|  -> exit ifs.rb (normal)
-
-#   54| enter disjunct
-#-----|  -> b1
-
-#   54| exit disjunct
-
-#   54| exit disjunct (normal)
-#-----|  -> exit disjunct
-
-#   54| b1
-#-----|  -> b2
-
-#   54| b2
-#-----|  -> b1
-
-#   55| if ...
-#-----|  -> exit disjunct (normal)
-
-#   55| [false] ( ... )
-#-----| false -> if ...
-
-#   55| [true] ( ... )
-#-----| true -> self
-
-#   55| b1
-#-----| true -> [true] ... || ...
-#-----| false -> b2
-
-#   55| [false] ... || ...
-#-----| false -> [false] ( ... )
-
-#   55| [true] ... || ...
-#-----| true -> [true] ( ... )
-
-#   55| b2
-#-----| false -> [false] ... || ...
-#-----| true -> [true] ... || ...
-
-#   55| then ...
-#-----|  -> if ...
-
-#   56| call to puts
-#-----|  -> then ...
-
-#   56| self
-#-----|  -> b1 or b2
-
-#   56| "b1 or b2"
-#-----|  -> call to puts
-
-#   56| b1 or b2
-#-----|  -> "b1 or b2"
-
-loops.rb:
-#    1| enter m1
-#-----|  -> x
-
-#    1| exit m1
-
-#    1| exit m1 (normal)
-#-----|  -> exit m1
-
-#    1| m1
-#-----|  -> m2
-
-#    1| enter loops.rb
-#-----|  -> m1
-
-#    1| exit loops.rb
-
-#    1| exit loops.rb (normal)
-#-----|  -> exit loops.rb
-
-#    1| x
-#-----|  -> x
-
-#    2| while ...
-#-----|  -> exit m1 (normal)
-
-#    2| x
-#-----|  -> 0
-
-#    2| ... >= ...
-#-----| false -> while ...
-#-----| true -> self
-
-#    2| 0
-#-----|  -> ... >= ...
-
-#    2| do ...
-#-----|  -> x
-
-#    3| call to puts
-#-----|  -> x
-
-#    3| self
-#-----|  -> x
-
-#    3| x
-#-----|  -> call to puts
-
-#    4| x
-#-----|  -> x
-
-#    4| x
-#-----|  -> 1
-
-#    4| ... = ...
-#-----|  -> do ...
-
-#    4| ... - ...
-#-----|  -> ... = ...
-
-#    4| 1
-#-----|  -> ... - ...
-
-#    8| enter m2
-#-----|  -> x
-
-#    8| exit m2
-
-#    8| exit m2 (normal)
-#-----|  -> exit m2
-
-#    8| m2
-#-----|  -> m3
-
-#    8| x
-#-----|  -> x
-
-#    9| while ...
-#-----|  -> self
-
-#    9| x
-#-----|  -> 0
-
-#    9| ... >= ...
-#-----| false -> while ...
-#-----| true -> self
-
-#    9| 0
-#-----|  -> ... >= ...
-
-#    9| do ...
-#-----|  -> x
-
-#   10| call to puts
-#-----|  -> x
-
-#   10| self
-#-----|  -> x
-
-#   10| x
-#-----|  -> call to puts
-
-#   11| x
-#-----|  -> x
-
-#   11| x
-#-----|  -> 1
-
-#   11| ... = ...
-#-----|  -> x
-
-#   11| ... - ...
-#-----|  -> ... = ...
-
-#   11| 1
-#-----|  -> ... - ...
-
-#   12| if ...
-#-----|  -> self
-
-#   12| x
-#-----|  -> 100
-
-#   12| ... > ...
-#-----| true -> break
-#-----| false -> x
-
-#   12| 100
-#-----|  -> ... > ...
-
-#   13| break
-#-----| break -> while ...
-
-#   14| elsif ...
-#-----|  -> if ...
-
-#   14| x
-#-----|  -> 50
-
-#   14| ... > ...
-#-----| true -> next
-#-----| false -> x
-
-#   14| 50
-#-----|  -> ... > ...
-
-#   15| next
-#-----| next -> x
-
-#   16| elsif ...
-#-----|  -> elsif ...
-
-#   16| x
-#-----|  -> 10
-
-#   16| ... > ...
-#-----| false -> elsif ...
-#-----| true -> redo
-
-#   16| 10
-#-----|  -> ... > ...
-
-#   17| redo
-#-----| redo -> self
-
-#   19| call to puts
-#-----|  -> do ...
-
-#   19| self
-#-----|  -> Iter
-
-#   19| "Iter"
-#-----|  -> call to puts
-
-#   19| Iter
-#-----|  -> "Iter"
-
-#   21| call to puts
-#-----|  -> exit m2 (normal)
-
-#   21| self
-#-----|  -> Done
-
-#   21| "Done"
-#-----|  -> call to puts
-
-#   21| Done
-#-----|  -> "Done"
-
-#   24| enter m3
-#-----|  -> Array
-
-#   24| exit m3
-
-#   24| exit m3 (normal)
-#-----|  -> exit m3
-
-#   24| m3
-#-----|  -> m4
-
-#   25| Array
-#-----|  -> 1
-
-#   25| call to []
-#-----|  -> do ... end
-
-#   25| call to each
-#-----|  -> exit m3 (normal)
-
-#   25| 1
-#-----|  -> 2
-
-#   25| 2
-#-----|  -> 3
-
-#   25| 3
-#-----|  -> call to []
-
-#   25| do ... end
-#-----|  -> call to each
-
-#   25| enter do ... end
-#-----|  -> x
-
-#   25| exit do ... end
-
-#   25| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#   25| x
-#-----|  -> self
-
-#   26| call to puts
-#-----|  -> exit do ... end (normal)
-
-#   26| self
-#-----|  -> x
-
-#   26| x
-#-----|  -> call to puts
-
-#   30| enter m4
-#-----|  -> x
-
-#   30| exit m4
-
-#   30| exit m4 (normal)
-#-----|  -> exit m4
-
-#   30| m4
-#-----|  -> exit loops.rb (normal)
-
-#   30| x
-#-----|  -> y
-
-#   30| y
-#-----|  -> x
-
-#   31| while ...
-#-----|  -> exit m4 (normal)
-
-#   31| x
-#-----|  -> y
-
-#   31| ... < ...
-#-----| false -> while ...
-#-----| true -> do ...
-
-#   31| y
-#-----|  -> ... < ...
-
-#   31| do ...
-#-----|  -> x
-
-raise.rb:
-#    1| ExceptionA
-#-----|  -> Exception
-
-#    1| enter raise.rb
-#-----|  -> ExceptionA
-
-#    1| exit raise.rb
-
-#    1| exit raise.rb (normal)
-#-----|  -> exit raise.rb
-
-#    1| Exception
-#-----|  -> ExceptionB
-
-#    4| ExceptionB
-#-----|  -> Exception
-
-#    4| Exception
-#-----|  -> m1
-
-#    7| enter m1
-#-----|  -> x
-
-#    7| exit m1
-
-#    7| exit m1 (abnormal)
-#-----|  -> exit m1
-
-#    7| exit m1 (normal)
-#-----|  -> exit m1
-
-#    7| m1
-#-----|  -> m2
-
-#    7| x
-#-----|  -> x
-
-#    8| if ...
-#-----|  -> self
-
-#    8| x
-#-----|  -> 2
-
-#    8| ... > ...
-#-----| false -> if ...
-#-----| true -> self
-
-#    8| 2
-#-----|  -> ... > ...
-
-#    9| call to raise
-#-----| raise -> exit m1 (abnormal)
-
-#    9| self
-#-----|  -> x > 2
-
-#    9| "x > 2"
-#-----|  -> call to raise
-
-#    9| x > 2
-#-----|  -> "x > 2"
-
-#   11| call to puts
-#-----|  -> exit m1 (normal)
-
-#   11| self
-#-----|  -> x <= 2
-
-#   11| "x <= 2"
-#-----|  -> call to puts
-
-#   11| x <= 2
-#-----|  -> "x <= 2"
-
-#   14| enter m2
-#-----|  -> b
-
-#   14| exit m2
-
-#   14| exit m2 (abnormal)
-#-----|  -> exit m2
-
-#   14| exit m2 (normal)
-#-----|  -> exit m2
-
-#   14| m2
-#-----|  -> m3
-
-#   14| b
-#-----|  -> b
-
-#   16| if ...
-#-----|  -> self
-
-#   16| b
-#-----| false -> if ...
-#-----| true -> self
-
-#   17| call to raise
-#-----| raise -> ExceptionA
-
-#   17| self
-#-----|  -> ExceptionA
-
-#   17| ExceptionA
-#-----|  -> call to raise
-
-#   19| rescue ...
-#-----|  -> self
-
-#   19| ExceptionA
-#-----| raise -> exit m2 (abnormal)
-#-----| match -> self
-
-#   19| then ...
-#-----|  -> rescue ...
-
-#   20| call to puts
-#-----|  -> then ...
-
-#   20| self
-#-----|  -> Rescued
-
-#   20| "Rescued"
-#-----|  -> call to puts
-
-#   20| Rescued
-#-----|  -> "Rescued"
-
-#   22| call to puts
-#-----|  -> exit m2 (normal)
-
-#   22| self
-#-----|  -> End m2
-
-#   22| "End m2"
-#-----|  -> call to puts
-
-#   22| End m2
-#-----|  -> "End m2"
-
-#   25| enter m3
-#-----|  -> b
-
-#   25| exit m3
-
-#   25| exit m3 (normal)
-#-----|  -> exit m3
-
-#   25| m3
-#-----|  -> m4
-
-#   25| b
-#-----|  -> b
-
-#   27| if ...
-#-----|  -> self
-
-#   27| b
-#-----| false -> if ...
-#-----| true -> self
-
-#   28| call to raise
-#-----| raise -> self
-
-#   28| self
-#-----|  -> ExceptionA
-
-#   28| ExceptionA
-#-----|  -> call to raise
-
-#   30| rescue ...
-#-----|  -> self
-
-#   30| then ...
-#-----|  -> rescue ...
-
-#   31| call to puts
-#-----|  -> then ...
-
-#   31| self
-#-----|  -> Rescued
-
-#   31| "Rescued"
-#-----|  -> call to puts
-
-#   31| Rescued
-#-----|  -> "Rescued"
-
-#   33| call to puts
-#-----|  -> exit m3 (normal)
-
-#   33| self
-#-----|  -> End m3
-
-#   33| "End m3"
-#-----|  -> call to puts
-
-#   33| End m3
-#-----|  -> "End m3"
-
-#   36| enter m4
-#-----|  -> b
-
-#   36| exit m4
-
-#   36| exit m4 (normal)
-#-----|  -> exit m4
-
-#   36| m4
-#-----|  -> m5
-
-#   36| b
-#-----|  -> b
-
-#   38| if ...
-#-----|  -> self
-
-#   38| b
-#-----| false -> if ...
-#-----| true -> self
-
-#   39| call to raise
-#-----| raise -> e
-
-#   39| self
-#-----|  -> ExceptionA
-
-#   39| ExceptionA
-#-----|  -> call to raise
-
-#   41| rescue ...
-#-----|  -> self
-
-#   41| e
-#-----|  -> self
-
-#   41| then ...
-#-----|  -> rescue ...
-
-#   42| call to puts
-#-----|  -> then ...
-
-#   42| self
-#-----|  -> Rescued {e}
-
-#   42| "Rescued {e}"
-#-----|  -> call to puts
-
-#   42| Rescued {e}
-#-----|  -> "Rescued {e}"
-
-#   44| call to puts
-#-----|  -> exit m4 (normal)
-
-#   44| self
-#-----|  -> End m4
-
-#   44| "End m4"
-#-----|  -> call to puts
-
-#   44| End m4
-#-----|  -> "End m4"
-
-#   47| enter m5
-#-----|  -> b
-
-#   47| exit m5
-
-#   47| exit m5 (normal)
-#-----|  -> exit m5
-
-#   47| m5
-#-----|  -> m6
-
-#   47| b
-#-----|  -> b
-
-#   49| if ...
-#-----|  -> self
-
-#   49| b
-#-----| false -> if ...
-#-----| true -> self
-
-#   50| call to raise
-#-----| raise -> e
-
-#   50| self
-#-----|  -> ExceptionA
-
-#   50| ExceptionA
-#-----|  -> call to raise
-
-#   52| rescue ...
-#-----|  -> self
-
-#   52| e
-#-----|  -> rescue ...
-
-#   54| call to puts
-#-----|  -> exit m5 (normal)
-
-#   54| self
-#-----|  -> End m5
-
-#   54| "End m5"
-#-----|  -> call to puts
-
-#   54| End m5
-#-----|  -> "End m5"
-
-#   57| enter m6
-#-----|  -> b
-
-#   57| exit m6
-
-#   57| exit m6 (abnormal)
-#-----|  -> exit m6
-
-#   57| exit m6 (normal)
-#-----|  -> exit m6
-
-#   57| m6
-#-----|  -> m7
-
-#   57| b
-#-----|  -> b
-
-#   59| if ...
-#-----|  -> self
-
-#   59| b
-#-----| false -> if ...
-#-----| true -> self
-
-#   60| call to raise
-#-----| raise -> ExceptionA
-
-#   60| self
-#-----|  -> ExceptionA
-
-#   60| ExceptionA
-#-----|  -> call to raise
-
-#   62| rescue ...
-#-----|  -> self
-
-#   62| ExceptionA
-#-----| no-match -> ExceptionB
-#-----| match -> e
-
-#   62| ExceptionB
-#-----| raise -> exit m6 (abnormal)
-#-----| match -> e
-
-#   62| e
-#-----|  -> self
-
-#   62| then ...
-#-----|  -> rescue ...
-
-#   63| call to puts
-#-----|  -> then ...
-
-#   63| self
-#-----|  -> Rescued {e}
-
-#   63| "Rescued {e}"
-#-----|  -> call to puts
-
-#   63| Rescued {e}
-#-----|  -> "Rescued {e}"
-
-#   65| call to puts
-#-----|  -> exit m6 (normal)
-
-#   65| self
-#-----|  -> End m6
-
-#   65| "End m6"
-#-----|  -> call to puts
-
-#   65| End m6
-#-----|  -> "End m6"
-
-#   68| enter m7
-#-----|  -> x
-
-#   68| exit m7
-
-#   68| exit m7 (abnormal)
-#-----|  -> exit m7
-
-#   68| exit m7 (normal)
-#-----|  -> exit m7
-
-#   68| m7
-#-----|  -> m8
-
-#   68| x
-#-----|  -> x
-
-#   69| if ...
-#-----|  -> self
-
-#   69| x
-#-----|  -> 2
-
-#   69| ... > ...
-#-----| true -> self
-#-----| false -> x
-#-----| raise -> [ensure: raise] self
-
-#   69| 2
-#-----|  -> ... > ...
-
-#   70| call to raise
-#-----| raise -> [ensure: raise] self
-
-#   70| self
-#-----|  -> x > 2
-
-#   70| "x > 2"
-#-----|  -> call to raise
-
-#   70| x > 2
-#-----|  -> "x > 2"
-
-#   71| elsif ...
-#-----|  -> if ...
-
-#   71| x
-#-----|  -> 0
-
-#   71| ... < ...
-#-----| false -> elsif ...
-#-----| true -> x < 0
-#-----| raise -> [ensure: raise] self
-
-#   71| 0
-#-----|  -> ... < ...
-
-#   72| return
-#-----| return -> [ensure: return] self
-
-#   72| "x < 0"
-#-----|  -> return
-
-#   72| x < 0
-#-----|  -> "x < 0"
-
-#   74| call to puts
-#-----| raise -> [ensure: raise] self
-#-----|  -> self
-
-#   74| self
-#-----|  -> 0 <= x <= 2
-
-#   74| "0 <= x <= 2"
-#-----|  -> call to puts
-
-#   74| 0 <= x <= 2
-#-----|  -> "0 <= x <= 2"
-
-#   75| [ensure: raise] ensure ...
-#-----| raise -> exit m7 (abnormal)
-
-#   75| [ensure: return] ensure ...
-#-----| return -> exit m7 (normal)
-
-#   75| ensure ...
-#-----|  -> exit m7 (normal)
-
-#   76| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] ensure ...
-
-#   76| [ensure: raise] self
-#-----|  -> [ensure: raise] ensure
-
-#   76| [ensure: return] call to puts
-#-----|  -> [ensure: return] ensure ...
-
-#   76| [ensure: return] self
-#-----|  -> [ensure: return] ensure
-
-#   76| call to puts
-#-----|  -> ensure ...
-
-#   76| self
-#-----|  -> ensure
-
-#   76| "ensure"
-#-----|  -> call to puts
-
-#   76| [ensure: raise] "ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#   76| [ensure: return] "ensure"
-#-----|  -> [ensure: return] call to puts
-
-#   76| [ensure: raise] ensure
-#-----|  -> [ensure: raise] "ensure"
-
-#   76| [ensure: return] ensure
-#-----|  -> [ensure: return] "ensure"
-
-#   76| ensure
-#-----|  -> "ensure"
-
-#   79| enter m8
-#-----|  -> x
-
-#   79| exit m8
-
-#   79| exit m8 (abnormal)
-#-----|  -> exit m8
-
-#   79| exit m8 (normal)
-#-----|  -> exit m8
-
-#   79| m8
-#-----|  -> m9
-
-#   79| x
-#-----|  -> self
-
-#   80| call to puts
-#-----|  -> x
-
-#   80| self
-#-----|  -> Begin m8
-
-#   80| "Begin m8"
-#-----|  -> call to puts
-
-#   80| Begin m8
-#-----|  -> "Begin m8"
-
-#   82| if ...
-#-----|  -> self
-
-#   82| x
-#-----|  -> 2
-
-#   82| ... > ...
-#-----| true -> self
-#-----| false -> x
-#-----| raise -> [ensure: raise] self
-
-#   82| 2
-#-----|  -> ... > ...
-
-#   83| call to raise
-#-----| raise -> [ensure: raise] self
-
-#   83| self
-#-----|  -> x > 2
-
-#   83| "x > 2"
-#-----|  -> call to raise
-
-#   83| x > 2
-#-----|  -> "x > 2"
-
-#   84| elsif ...
-#-----|  -> if ...
-
-#   84| x
-#-----|  -> 0
-
-#   84| ... < ...
-#-----| false -> elsif ...
-#-----| true -> x < 0
-#-----| raise -> [ensure: raise] self
-
-#   84| 0
-#-----|  -> ... < ...
-
-#   85| return
-#-----| return -> [ensure: return] self
-
-#   85| "x < 0"
-#-----|  -> return
-
-#   85| x < 0
-#-----|  -> "x < 0"
-
-#   87| call to puts
-#-----| raise -> [ensure: raise] self
-#-----|  -> self
-
-#   87| self
-#-----|  -> 0 <= x <= 2
-
-#   87| "0 <= x <= 2"
-#-----|  -> call to puts
-
-#   87| 0 <= x <= 2
-#-----|  -> "0 <= x <= 2"
-
-#   88| [ensure: raise] ensure ...
-#-----| raise -> exit m8 (abnormal)
-
-#   88| [ensure: return] ensure ...
-#-----| return -> exit m8 (normal)
-
-#   88| ensure ...
-#-----|  -> self
-
-#   89| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] ensure ...
-
-#   89| [ensure: raise] self
-#-----|  -> [ensure: raise] ensure
-
-#   89| [ensure: return] call to puts
-#-----|  -> [ensure: return] ensure ...
-
-#   89| [ensure: return] self
-#-----|  -> [ensure: return] ensure
-
-#   89| call to puts
-#-----|  -> ensure ...
-
-#   89| self
-#-----|  -> ensure
-
-#   89| "ensure"
-#-----|  -> call to puts
-
-#   89| [ensure: raise] "ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#   89| [ensure: return] "ensure"
-#-----|  -> [ensure: return] call to puts
-
-#   89| [ensure: raise] ensure
-#-----|  -> [ensure: raise] "ensure"
-
-#   89| [ensure: return] ensure
-#-----|  -> [ensure: return] "ensure"
-
-#   89| ensure
-#-----|  -> "ensure"
-
-#   91| call to puts
-#-----|  -> exit m8 (normal)
-
-#   91| self
-#-----|  -> End m8
-
-#   91| "End m8"
-#-----|  -> call to puts
-
-#   91| End m8
-#-----|  -> "End m8"
-
-#   94| enter m9
-#-----|  -> x
-
-#   94| exit m9
-
-#   94| exit m9 (abnormal)
-#-----|  -> exit m9
-
-#   94| exit m9 (normal)
-#-----|  -> exit m9
-
-#   94| m9
-#-----|  -> m10
-
-#   94| x
-#-----|  -> b1
-
-#   94| b1
-#-----|  -> b2
-
-#   94| b2
-#-----|  -> self
-
-#   95| call to puts
-#-----|  -> x
-#-----| raise -> [ensure: raise] self
-
-#   95| self
-#-----|  -> Begin m9
-
-#   95| "Begin m9"
-#-----|  -> call to puts
-
-#   95| Begin m9
-#-----|  -> "Begin m9"
-
-#   97| if ...
-#-----|  -> self
-
-#   97| x
-#-----|  -> 2
-
-#   97| ... > ...
-#-----| true -> self
-#-----| false -> x
-#-----| raise -> [ensure: raise] self
-
-#   97| 2
-#-----|  -> ... > ...
-
-#   98| call to raise
-#-----| raise -> [ensure: raise] self
-
-#   98| self
-#-----|  -> x > 2
-
-#   98| "x > 2"
-#-----|  -> call to raise
-
-#   98| x > 2
-#-----|  -> "x > 2"
-
-#   99| elsif ...
-#-----|  -> if ...
-
-#   99| x
-#-----|  -> 0
-
-#   99| ... < ...
-#-----| false -> elsif ...
-#-----| true -> x < 0
-#-----| raise -> [ensure: raise] self
-
-#   99| 0
-#-----|  -> ... < ...
-
-#  100| return
-#-----| return -> [ensure: return] self
-
-#  100| "x < 0"
-#-----|  -> return
-
-#  100| x < 0
-#-----|  -> "x < 0"
-
-#  102| call to puts
-#-----| raise -> [ensure: raise] self
-#-----|  -> self
-
-#  102| self
-#-----|  -> 0 <= x <= 2
-
-#  102| "0 <= x <= 2"
-#-----|  -> call to puts
-
-#  102| 0 <= x <= 2
-#-----|  -> "0 <= x <= 2"
-
-#  103| [ensure: raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  103| [ensure: return] ensure ...
-#-----| return -> [ensure: return] self
-
-#  103| ensure ...
-#-----|  -> self
-
-#  104| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] b1
-#-----| raise -> [ensure: raise] self
-
-#  104| [ensure: raise] self
-#-----|  -> [ensure: raise] outer ensure
-
-#  104| [ensure: return] call to puts
-#-----|  -> [ensure: return] b1
-#-----| raise -> [ensure: raise] self
-
-#  104| [ensure: return] self
-#-----|  -> [ensure: return] outer ensure
-
-#  104| call to puts
-#-----|  -> b1
-#-----| raise -> [ensure: raise] self
-
-#  104| self
-#-----|  -> outer ensure
-
-#  104| "outer ensure"
-#-----|  -> call to puts
-
-#  104| [ensure: raise] "outer ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#  104| [ensure: return] "outer ensure"
-#-----|  -> [ensure: return] call to puts
-
-#  104| [ensure: raise] outer ensure
-#-----|  -> [ensure: raise] "outer ensure"
-
-#  104| [ensure: return] outer ensure
-#-----|  -> [ensure: return] "outer ensure"
-
-#  104| outer ensure
-#-----|  -> "outer ensure"
-
-#  106| [ensure: raise] if ...
-#-----|  -> [ensure: raise] self
-
-#  106| [ensure: return] if ...
-#-----|  -> [ensure: return] self
-
-#  106| if ...
-#-----|  -> self
-
-#  106| [ensure: raise] b1
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] self
-
-#  106| [ensure: return] b1
-#-----| false -> [ensure: return] if ...
-#-----| true -> [ensure: return] self
-
-#  106| b1
-#-----| false -> if ...
-#-----| true -> self
-
-#  107| [ensure: raise] call to raise
-#-----| raise -> [ensure: raise, ensure(1): raise] self
-
-#  107| [ensure: raise] self
-#-----|  -> [ensure: raise] b1 is true
-
-#  107| [ensure: return] call to raise
-#-----| raise -> [ensure: return, ensure(1): raise] self
-
-#  107| [ensure: return] self
-#-----|  -> [ensure: return] b1 is true
-
-#  107| call to raise
-#-----| raise -> [ensure(1): raise] self
-
-#  107| self
-#-----|  -> b1 is true
-
-#  107| "b1 is true"
-#-----|  -> call to raise
-
-#  107| [ensure: raise] "b1 is true"
-#-----|  -> [ensure: raise] call to raise
-
-#  107| [ensure: return] "b1 is true"
-#-----|  -> [ensure: return] call to raise
-
-#  107| [ensure: raise] b1 is true
-#-----|  -> [ensure: raise] "b1 is true"
-
-#  107| [ensure: return] b1 is true
-#-----|  -> [ensure: return] "b1 is true"
-
-#  107| b1 is true
-#-----|  -> "b1 is true"
-
-#  109| [ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  109| [ensure: raise, ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  109| [ensure: raise] ensure ...
-#-----|  -> [ensure: raise] ensure ...
-
-#  109| [ensure: return, ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  109| [ensure: return] ensure ...
-#-----|  -> [ensure: return] ensure ...
-
-#  109| ensure ...
-#-----|  -> ensure ...
-
-#  110| [ensure(1): raise] call to puts
-#-----|  -> [ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| [ensure(1): raise] self
-#-----|  -> [ensure(1): raise] inner ensure
-
-#  110| [ensure: raise, ensure(1): raise] call to puts
-#-----|  -> [ensure: raise, ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| [ensure: raise, ensure(1): raise] self
-#-----|  -> [ensure: raise, ensure(1): raise] inner ensure
-
-#  110| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| [ensure: raise] self
-#-----|  -> [ensure: raise] inner ensure
-
-#  110| [ensure: return, ensure(1): raise] call to puts
-#-----|  -> [ensure: return, ensure(1): raise] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| [ensure: return, ensure(1): raise] self
-#-----|  -> [ensure: return, ensure(1): raise] inner ensure
-
-#  110| [ensure: return] call to puts
-#-----|  -> [ensure: return] ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| [ensure: return] self
-#-----|  -> [ensure: return] inner ensure
-
-#  110| call to puts
-#-----|  -> ensure ...
-#-----| raise -> [ensure: raise] self
-
-#  110| self
-#-----|  -> inner ensure
-
-#  110| "inner ensure"
-#-----|  -> call to puts
-
-#  110| [ensure(1): raise] "inner ensure"
-#-----|  -> [ensure(1): raise] call to puts
-
-#  110| [ensure: raise, ensure(1): raise] "inner ensure"
-#-----|  -> [ensure: raise, ensure(1): raise] call to puts
-
-#  110| [ensure: raise] "inner ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#  110| [ensure: return, ensure(1): raise] "inner ensure"
-#-----|  -> [ensure: return, ensure(1): raise] call to puts
-
-#  110| [ensure: return] "inner ensure"
-#-----|  -> [ensure: return] call to puts
-
-#  110| [ensure(1): raise] inner ensure
-#-----|  -> [ensure(1): raise] "inner ensure"
-
-#  110| [ensure: raise, ensure(1): raise] inner ensure
-#-----|  -> [ensure: raise, ensure(1): raise] "inner ensure"
-
-#  110| [ensure: raise] inner ensure
-#-----|  -> [ensure: raise] "inner ensure"
-
-#  110| [ensure: return, ensure(1): raise] inner ensure
-#-----|  -> [ensure: return, ensure(1): raise] "inner ensure"
-
-#  110| [ensure: return] inner ensure
-#-----|  -> [ensure: return] "inner ensure"
-
-#  110| inner ensure
-#-----|  -> "inner ensure"
-
-#  113| call to puts
-#-----| raise -> [ensure: raise] self
-#-----|  -> self
-
-#  113| self
-#-----|  -> End m9
-
-#  113| "End m9"
-#-----|  -> call to puts
-
-#  113| End m9
-#-----|  -> "End m9"
-
-#  114| [ensure: raise] ensure ...
-#-----| raise -> exit m9 (abnormal)
-
-#  114| [ensure: return] ensure ...
-#-----| return -> exit m9 (normal)
-
-#  114| ensure ...
-#-----|  -> exit m9 (normal)
-
-#  115| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] b2
-
-#  115| [ensure: raise] self
-#-----|  -> [ensure: raise] method ensure
-
-#  115| [ensure: return] call to puts
-#-----|  -> [ensure: return] b2
-
-#  115| [ensure: return] self
-#-----|  -> [ensure: return] method ensure
-
-#  115| call to puts
-#-----|  -> b2
-
-#  115| self
-#-----|  -> method ensure
-
-#  115| "method ensure"
-#-----|  -> call to puts
-
-#  115| [ensure: raise] "method ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#  115| [ensure: return] "method ensure"
-#-----|  -> [ensure: return] call to puts
-
-#  115| [ensure: raise] method ensure
-#-----|  -> [ensure: raise] "method ensure"
-
-#  115| [ensure: return] method ensure
-#-----|  -> [ensure: return] "method ensure"
-
-#  115| method ensure
-#-----|  -> "method ensure"
-
-#  116| [ensure: raise] if ...
-#-----|  -> [ensure: raise] ensure ...
-
-#  116| [ensure: return] if ...
-#-----|  -> [ensure: return] ensure ...
-
-#  116| if ...
-#-----|  -> ensure ...
-
-#  116| [ensure: raise] b2
-#-----| false -> [ensure: raise] if ...
-#-----| true -> [ensure: raise] self
-
-#  116| [ensure: return] b2
-#-----| false -> [ensure: return] if ...
-#-----| true -> [ensure: return] self
-
-#  116| b2
-#-----| false -> if ...
-#-----| true -> self
-
-#  117| [ensure: raise] call to raise
-#-----| raise -> exit m9 (abnormal)
-
-#  117| [ensure: raise] self
-#-----|  -> [ensure: raise] b2 is true
-
-#  117| [ensure: return] call to raise
-#-----| raise -> exit m9 (abnormal)
-
-#  117| [ensure: return] self
-#-----|  -> [ensure: return] b2 is true
-
-#  117| call to raise
-#-----| raise -> exit m9 (abnormal)
-
-#  117| self
-#-----|  -> b2 is true
-
-#  117| "b2 is true"
-#-----|  -> call to raise
-
-#  117| [ensure: raise] "b2 is true"
-#-----|  -> [ensure: raise] call to raise
-
-#  117| [ensure: return] "b2 is true"
-#-----|  -> [ensure: return] call to raise
-
-#  117| [ensure: raise] b2 is true
-#-----|  -> [ensure: raise] "b2 is true"
-
-#  117| [ensure: return] b2 is true
-#-----|  -> [ensure: return] "b2 is true"
-
-#  117| b2 is true
-#-----|  -> "b2 is true"
-
-#  121| enter m10
-#-----|  -> p
-
-#  121| exit m10
-
-#  121| exit m10 (abnormal)
-#-----|  -> exit m10
-
-#  121| exit m10 (normal)
-#-----|  -> exit m10
-
-#  121| m10
-#-----|  -> m11
-
-#  121| p
-#-----| false, no-match, true -> self
-#-----| match -> self
-
-#  121| call to raise
-#-----| raise -> exit m10 (abnormal)
-
-#  121| self
-#-----|  -> Exception
-
-#  121| "Exception"
-#-----|  -> call to raise
-
-#  121| Exception
-#-----|  -> "Exception"
-
-#  124| ensure ...
-#-----|  -> exit m10 (normal)
-
-#  125| call to puts
-#-----|  -> ensure ...
-
-#  125| self
-#-----|  -> Will not get executed if p is not supplied
-
-#  125| "Will not get executed if p is..."
-#-----|  -> call to puts
-
-#  125| Will not get executed if p is not supplied
-#-----|  -> "Will not get executed if p is..."
-
-#  128| enter m11
-#-----|  -> b
-
-#  128| exit m11
-
-#  128| exit m11 (abnormal)
-#-----|  -> exit m11
-
-#  128| exit m11 (normal)
-#-----|  -> exit m11
-
-#  128| m11
-#-----|  -> m12
-
-#  128| b
-#-----|  -> b
-
-#  130| if ...
-#-----|  -> self
-
-#  130| b
-#-----| false -> if ...
-#-----| true -> self
-
-#  131| call to raise
-#-----| raise -> ExceptionA
-
-#  131| self
-#-----|  -> ExceptionA
-
-#  131| ExceptionA
-#-----|  -> call to raise
-
-#  133| rescue ...
-#-----|  -> self
-
-#  133| ExceptionA
-#-----| match -> rescue ...
-#-----| no-match -> ExceptionB
-
-#  134| rescue ...
-#-----|  -> self
-
-#  134| ExceptionB
-#-----| match -> self
-#-----| raise -> [ensure: raise] self
-
-#  134| then ...
-#-----|  -> rescue ...
-
-#  135| call to puts
-#-----|  -> then ...
-
-#  135| self
-#-----|  -> ExceptionB
-
-#  135| "ExceptionB"
-#-----|  -> call to puts
-
-#  135| ExceptionB
-#-----|  -> "ExceptionB"
-
-#  136| [ensure: raise] ensure ...
-#-----| raise -> exit m11 (abnormal)
-
-#  136| ensure ...
-#-----|  -> self
-
-#  137| [ensure: raise] call to puts
-#-----|  -> [ensure: raise] ensure ...
-
-#  137| [ensure: raise] self
-#-----|  -> [ensure: raise] Ensure
-
-#  137| call to puts
-#-----|  -> ensure ...
-
-#  137| self
-#-----|  -> Ensure
-
-#  137| "Ensure"
-#-----|  -> call to puts
-
-#  137| [ensure: raise] "Ensure"
-#-----|  -> [ensure: raise] call to puts
-
-#  137| Ensure
-#-----|  -> "Ensure"
-
-#  137| [ensure: raise] Ensure
-#-----|  -> [ensure: raise] "Ensure"
-
-#  139| call to puts
-#-----|  -> exit m11 (normal)
-
-#  139| self
-#-----|  -> End m11
-
-#  139| "End m11"
-#-----|  -> call to puts
-
-#  139| End m11
-#-----|  -> "End m11"
-
-#  142| enter m12
-#-----|  -> b
-
-#  142| exit m12
-
-#  142| exit m12 (normal)
-#-----|  -> exit m12
-
-#  142| m12
-#-----|  -> m13
-
-#  142| b
-#-----|  -> b
-
-#  143| if ...
-#-----|  -> 3
-
-#  143| b
-#-----| false -> if ...
-#-----| true -> self
-
-#  144| call to raise
-#-----| raise -> [ensure: raise] 3
-
-#  144| self
-#-----|  -> ""
-
-#  144| ""
-#-----|  -> call to raise
-
-#  147| [ensure: raise] return
-#-----| return -> exit m12 (normal)
-
-#  147| return
-#-----| return -> exit m12 (normal)
-
-#  147| 3
-#-----|  -> return
-
-#  147| [ensure: raise] 3
-#-----|  -> [ensure: raise] return
-
-#  150| enter m13
-#-----|  -> ensure ...
-
-#  150| exit m13
-
-#  150| exit m13 (normal)
-#-----|  -> exit m13
-
-#  150| m13
-#-----|  -> m14
-
-#  151| ensure ...
-#-----|  -> exit m13 (normal)
-
-#  154| enter m14
-#-----|  -> element
-
-#  154| exit m14
-
-#  154| exit m14 (normal)
-#-----|  -> exit m14
-
-#  154| m14
-#-----|  -> m15
-
-#  154| element
-#-----|  -> element
-
-#  155| element
-#-----|  -> { ... }
-
-#  155| call to each
-#-----|  -> exit m14 (normal)
-
-#  155| enter { ... }
-#-----|  -> elem
-
-#  155| exit { ... }
-
-#  155| exit { ... } (abnormal)
-#-----|  -> exit { ... }
-
-#  155| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  155| { ... }
-#-----|  -> call to each
-
-#  155| elem
-#-----|  -> element
-
-#  155| call to raise
-#-----| raise -> exit { ... } (abnormal)
-
-#  155| self
-#-----|  -> ""
-
-#  155| ... if ...
-#-----|  -> exit { ... } (normal)
-
-#  155| ""
-#-----|  -> call to raise
-
-#  155| element
-#-----|  -> call to nil?
-
-#  155| call to nil?
-#-----| true -> self
-#-----| false -> ... if ...
-
-#  158| enter m15
-#-----|  -> self
-
-#  158| exit m15
-
-#  158| exit m15 (normal)
-#-----|  -> exit m15
-
-#  158| m15
-#-----|  -> C
-
-#  159| call to foo
-#-----|  -> exit m15 (normal)
-
-#  159| self
-#-----|  -> do ... end
-
-#  159| do ... end
-#-----|  -> call to foo
-
-#  159| enter do ... end
-#-----|  -> self
-
-#  159| exit do ... end
-
-#  159| exit do ... end (normal)
-#-----|  -> exit do ... end
-
-#  160| call to bar
-#-----|  -> exit do ... end (normal)
-
-#  160| self
-#-----|  -> -> { ... }
-
-#  160| -> { ... }
-#-----|  -> call to bar
-
-#  160| enter -> { ... }
-#-----|  -> x
-
-#  160| exit -> { ... }
-
-#  160| exit -> { ... } (abnormal)
-#-----|  -> exit -> { ... }
-
-#  160| exit -> { ... } (normal)
-#-----|  -> exit -> { ... }
-
-#  160| x
-#-----|  -> x
-
-#  161| call to raise
-#-----| raise -> exit -> { ... } (abnormal)
-
-#  161| self
-#-----|  -> ""
-
-#  161| ... unless ...
-#-----|  -> exit -> { ... } (normal)
-
-#  161| ""
-#-----|  -> call to raise
-
-#  161| x
-#-----| false -> self
-#-----| true -> ... unless ...
-
-#  166| C
-#-----|  -> self
-
-#  167| enter m
-#-----|  -> self
-
-#  167| exit m
-
-#  167| exit m (abnormal)
-#-----|  -> exit m
-
-#  167| m
-#-----|  -> m16
-
-#  167| self
-#-----|  -> m
-
-#  168| call to raise
-#-----| raise -> exit m (abnormal)
-
-#  168| self
-#-----|  -> ""
-
-#  168| ""
-#-----|  -> call to raise
-
-#  172| enter m16
-#-----|  -> b1
-
-#  172| exit m16
-
-#  172| exit m16 (abnormal)
-#-----|  -> exit m16
-
-#  172| exit m16 (normal)
-#-----|  -> exit m16
-
-#  172| m16
-#-----|  -> exit raise.rb (normal)
-
-#  172| b1
-#-----|  -> b2
-
-#  172| b2
-#-----|  -> b1
-
-#  174| b1
-#-----| true -> [true] ... || ...
-#-----| false -> b2
-
-#  174| [false] ... || ...
-#-----| false -> 2
-#-----| raise -> ExceptionA
-
-#  174| [true] ... || ...
-#-----| true -> 1
-#-----| raise -> ExceptionA
-
-#  174| b2
-#-----|  -> true
-
-#  174| ... == ...
-#-----| false -> [false] ... || ...
-#-----| true -> [true] ... || ...
-#-----| raise -> ExceptionA
-
-#  174| true
-#-----|  -> ... == ...
-
-#  175| return
-#-----| return -> exit m16 (normal)
-
-#  175| 1
-#-----|  -> return
-
-#  177| return
-#-----| return -> exit m16 (normal)
-
-#  177| 2
-#-----|  -> return
-
-#  179| ExceptionA
-#-----| raise -> exit m16 (abnormal)
-#-----| match -> 3
-
-#  180| return
-#-----| return -> exit m16 (normal)
-
-#  180| 3
-#-----|  -> return
+| break_ensure.rb:1:1:11:3 | enter m1 | break_ensure.rb:1:8:1:8 | x |  |
+| break_ensure.rb:1:1:11:3 | exit m1 (abnormal) | break_ensure.rb:1:1:11:3 | exit m1 |  |
+| break_ensure.rb:1:1:11:3 | exit m1 (normal) | break_ensure.rb:1:1:11:3 | exit m1 |  |
+| break_ensure.rb:1:1:11:3 | m1 | break_ensure.rb:13:1:25:3 | m2 |  |
+| break_ensure.rb:1:1:56:4 | enter break_ensure.rb | break_ensure.rb:1:1:11:3 | m1 |  |
+| break_ensure.rb:1:1:56:4 | exit break_ensure.rb (normal) | break_ensure.rb:1:1:56:4 | exit break_ensure.rb |  |
+| break_ensure.rb:1:8:1:8 | x | break_ensure.rb:2:9:2:9 | x |  |
+| break_ensure.rb:2:3:6:5 | while ... | break_ensure.rb:8:6:8:13 | self |  |
+| break_ensure.rb:2:9:2:9 | x | break_ensure.rb:2:13:2:13 | 0 |  |
+| break_ensure.rb:2:9:2:13 | ... < ... | break_ensure.rb:2:3:6:5 | while ... | false |
+| break_ensure.rb:2:9:2:13 | ... < ... | break_ensure.rb:3:8:3:8 | x | true |
+| break_ensure.rb:2:9:2:13 | ... < ... | break_ensure.rb:8:6:8:13 | [ensure: raise] self | raise |
+| break_ensure.rb:2:13:2:13 | 0 | break_ensure.rb:2:9:2:13 | ... < ... |  |
+| break_ensure.rb:2:14:6:5 | do ... | break_ensure.rb:2:9:2:9 | x |  |
+| break_ensure.rb:3:5:5:7 | if ... | break_ensure.rb:2:14:6:5 | do ... |  |
+| break_ensure.rb:3:8:3:8 | x | break_ensure.rb:3:12:3:12 | 0 |  |
+| break_ensure.rb:3:8:3:12 | ... > ... | break_ensure.rb:2:3:6:5 | while ... | raise |
+| break_ensure.rb:3:8:3:12 | ... > ... | break_ensure.rb:3:5:5:7 | if ... | false |
+| break_ensure.rb:3:8:3:12 | ... > ... | break_ensure.rb:4:7:4:11 | break | true |
+| break_ensure.rb:3:12:3:12 | 0 | break_ensure.rb:3:8:3:12 | ... > ... |  |
+| break_ensure.rb:4:7:4:11 | break | break_ensure.rb:2:3:6:5 | while ... | break |
+| break_ensure.rb:7:1:10:5 | [ensure: raise] ensure ... | break_ensure.rb:1:1:11:3 | exit m1 (abnormal) | raise |
+| break_ensure.rb:7:1:10:5 | ensure ... | break_ensure.rb:1:1:11:3 | exit m1 (normal) |  |
+| break_ensure.rb:8:3:10:5 | [ensure: raise] if ... | break_ensure.rb:7:1:10:5 | [ensure: raise] ensure ... |  |
+| break_ensure.rb:8:3:10:5 | if ... | break_ensure.rb:7:1:10:5 | ensure ... |  |
+| break_ensure.rb:8:6:8:13 | [ensure: raise] call to elements | break_ensure.rb:8:6:8:18 | [ensure: raise] call to nil? |  |
+| break_ensure.rb:8:6:8:13 | [ensure: raise] self | break_ensure.rb:8:6:8:13 | [ensure: raise] call to elements |  |
+| break_ensure.rb:8:6:8:13 | call to elements | break_ensure.rb:8:6:8:18 | call to nil? |  |
+| break_ensure.rb:8:6:8:13 | self | break_ensure.rb:8:6:8:13 | call to elements |  |
+| break_ensure.rb:8:6:8:18 | [ensure: raise] call to nil? | break_ensure.rb:8:3:10:5 | [ensure: raise] if ... | false |
+| break_ensure.rb:8:6:8:18 | [ensure: raise] call to nil? | break_ensure.rb:9:5:9:23 | [ensure: raise] self | true |
+| break_ensure.rb:8:6:8:18 | call to nil? | break_ensure.rb:8:3:10:5 | if ... | false |
+| break_ensure.rb:8:6:8:18 | call to nil? | break_ensure.rb:9:5:9:23 | self | true |
+| break_ensure.rb:8:20:9:23 | [ensure: raise] then ... | break_ensure.rb:8:3:10:5 | [ensure: raise] if ... |  |
+| break_ensure.rb:8:20:9:23 | then ... | break_ensure.rb:8:3:10:5 | if ... |  |
+| break_ensure.rb:9:5:9:23 | [ensure: raise] call to puts | break_ensure.rb:8:20:9:23 | [ensure: raise] then ... |  |
+| break_ensure.rb:9:5:9:23 | [ensure: raise] self | break_ensure.rb:9:11:9:22 | [ensure: raise] elements nil |  |
+| break_ensure.rb:9:5:9:23 | call to puts | break_ensure.rb:8:20:9:23 | then ... |  |
+| break_ensure.rb:9:5:9:23 | self | break_ensure.rb:9:11:9:22 | elements nil |  |
+| break_ensure.rb:9:10:9:23 | "elements nil" | break_ensure.rb:9:5:9:23 | call to puts |  |
+| break_ensure.rb:9:10:9:23 | [ensure: raise] "elements nil" | break_ensure.rb:9:5:9:23 | [ensure: raise] call to puts |  |
+| break_ensure.rb:9:11:9:22 | [ensure: raise] elements nil | break_ensure.rb:9:10:9:23 | [ensure: raise] "elements nil" |  |
+| break_ensure.rb:9:11:9:22 | elements nil | break_ensure.rb:9:10:9:23 | "elements nil" |  |
+| break_ensure.rb:13:1:25:3 | enter m2 | break_ensure.rb:13:8:13:8 | x |  |
+| break_ensure.rb:13:1:25:3 | exit m2 (normal) | break_ensure.rb:13:1:25:3 | exit m2 |  |
+| break_ensure.rb:13:1:25:3 | m2 | break_ensure.rb:27:1:42:3 | m3 |  |
+| break_ensure.rb:13:8:13:8 | x | break_ensure.rb:13:11:13:11 | y |  |
+| break_ensure.rb:13:11:13:11 | y | break_ensure.rb:14:9:14:9 | x |  |
+| break_ensure.rb:14:3:24:5 | while ... | break_ensure.rb:13:1:25:3 | exit m2 (normal) |  |
+| break_ensure.rb:14:9:14:9 | x | break_ensure.rb:14:13:14:13 | 0 |  |
+| break_ensure.rb:14:9:14:13 | ... < ... | break_ensure.rb:14:3:24:5 | while ... | false |
+| break_ensure.rb:14:9:14:13 | ... < ... | break_ensure.rb:16:10:16:10 | x | true |
+| break_ensure.rb:14:13:14:13 | 0 | break_ensure.rb:14:9:14:13 | ... < ... |  |
+| break_ensure.rb:14:14:24:5 | do ... | break_ensure.rb:14:9:14:9 | x |  |
+| break_ensure.rb:16:7:18:9 | if ... | break_ensure.rb:20:10:20:10 | y |  |
+| break_ensure.rb:16:10:16:10 | x | break_ensure.rb:16:14:16:14 | 0 |  |
+| break_ensure.rb:16:10:16:14 | ... > ... | break_ensure.rb:16:7:18:9 | if ... | false |
+| break_ensure.rb:16:10:16:14 | ... > ... | break_ensure.rb:17:9:17:13 | break | true |
+| break_ensure.rb:16:10:16:14 | ... > ... | break_ensure.rb:20:10:20:10 | [ensure: raise] y | raise |
+| break_ensure.rb:16:14:16:14 | 0 | break_ensure.rb:16:10:16:14 | ... > ... |  |
+| break_ensure.rb:17:9:17:13 | break | break_ensure.rb:20:10:20:10 | [ensure: break] y | break |
+| break_ensure.rb:19:5:22:9 | [ensure: break] ensure ... | break_ensure.rb:14:3:24:5 | while ... | break |
+| break_ensure.rb:19:5:22:9 | [ensure: raise] ensure ... | break_ensure.rb:14:3:24:5 | while ... | raise |
+| break_ensure.rb:19:5:22:9 | ensure ... | break_ensure.rb:14:14:24:5 | do ... |  |
+| break_ensure.rb:20:7:22:9 | [ensure: break] if ... | break_ensure.rb:19:5:22:9 | [ensure: break] ensure ... |  |
+| break_ensure.rb:20:7:22:9 | [ensure: raise] if ... | break_ensure.rb:19:5:22:9 | [ensure: raise] ensure ... |  |
+| break_ensure.rb:20:7:22:9 | if ... | break_ensure.rb:19:5:22:9 | ensure ... |  |
+| break_ensure.rb:20:10:20:10 | [ensure: break] y | break_ensure.rb:20:10:20:15 | [ensure: break] call to nil? |  |
+| break_ensure.rb:20:10:20:10 | [ensure: raise] y | break_ensure.rb:20:10:20:15 | [ensure: raise] call to nil? |  |
+| break_ensure.rb:20:10:20:10 | y | break_ensure.rb:20:10:20:15 | call to nil? |  |
+| break_ensure.rb:20:10:20:15 | [ensure: break] call to nil? | break_ensure.rb:20:7:22:9 | [ensure: break] if ... | false |
+| break_ensure.rb:20:10:20:15 | [ensure: break] call to nil? | break_ensure.rb:21:9:21:20 | [ensure: break] self | true |
+| break_ensure.rb:20:10:20:15 | [ensure: raise] call to nil? | break_ensure.rb:20:7:22:9 | [ensure: raise] if ... | false |
+| break_ensure.rb:20:10:20:15 | [ensure: raise] call to nil? | break_ensure.rb:21:9:21:20 | [ensure: raise] self | true |
+| break_ensure.rb:20:10:20:15 | call to nil? | break_ensure.rb:20:7:22:9 | if ... | false |
+| break_ensure.rb:20:10:20:15 | call to nil? | break_ensure.rb:21:9:21:20 | self | true |
+| break_ensure.rb:20:17:21:20 | [ensure: break] then ... | break_ensure.rb:20:7:22:9 | [ensure: break] if ... |  |
+| break_ensure.rb:20:17:21:20 | [ensure: raise] then ... | break_ensure.rb:20:7:22:9 | [ensure: raise] if ... |  |
+| break_ensure.rb:20:17:21:20 | then ... | break_ensure.rb:20:7:22:9 | if ... |  |
+| break_ensure.rb:21:9:21:20 | [ensure: break] call to puts | break_ensure.rb:20:17:21:20 | [ensure: break] then ... |  |
+| break_ensure.rb:21:9:21:20 | [ensure: break] self | break_ensure.rb:21:15:21:19 | [ensure: break] y nil |  |
+| break_ensure.rb:21:9:21:20 | [ensure: raise] call to puts | break_ensure.rb:20:17:21:20 | [ensure: raise] then ... |  |
+| break_ensure.rb:21:9:21:20 | [ensure: raise] self | break_ensure.rb:21:15:21:19 | [ensure: raise] y nil |  |
+| break_ensure.rb:21:9:21:20 | call to puts | break_ensure.rb:20:17:21:20 | then ... |  |
+| break_ensure.rb:21:9:21:20 | self | break_ensure.rb:21:15:21:19 | y nil |  |
+| break_ensure.rb:21:14:21:20 | "y nil" | break_ensure.rb:21:9:21:20 | call to puts |  |
+| break_ensure.rb:21:14:21:20 | [ensure: break] "y nil" | break_ensure.rb:21:9:21:20 | [ensure: break] call to puts |  |
+| break_ensure.rb:21:14:21:20 | [ensure: raise] "y nil" | break_ensure.rb:21:9:21:20 | [ensure: raise] call to puts |  |
+| break_ensure.rb:21:15:21:19 | [ensure: break] y nil | break_ensure.rb:21:14:21:20 | [ensure: break] "y nil" |  |
+| break_ensure.rb:21:15:21:19 | [ensure: raise] y nil | break_ensure.rb:21:14:21:20 | [ensure: raise] "y nil" |  |
+| break_ensure.rb:21:15:21:19 | y nil | break_ensure.rb:21:14:21:20 | "y nil" |  |
+| break_ensure.rb:27:1:42:3 | enter m3 | break_ensure.rb:27:8:27:8 | x |  |
+| break_ensure.rb:27:1:42:3 | exit m3 (abnormal) | break_ensure.rb:27:1:42:3 | exit m3 |  |
+| break_ensure.rb:27:1:42:3 | exit m3 (normal) | break_ensure.rb:27:1:42:3 | exit m3 |  |
+| break_ensure.rb:27:1:42:3 | m3 | break_ensure.rb:44:1:56:3 | m4 |  |
+| break_ensure.rb:27:8:27:8 | x | break_ensure.rb:27:10:27:10 | y |  |
+| break_ensure.rb:27:10:27:10 | y | break_ensure.rb:29:8:29:8 | x |  |
+| break_ensure.rb:29:5:31:7 | if ... | break_ensure.rb:33:11:33:11 | y |  |
+| break_ensure.rb:29:8:29:8 | x | break_ensure.rb:29:8:29:13 | call to nil? |  |
+| break_ensure.rb:29:8:29:13 | call to nil? | break_ensure.rb:29:5:31:7 | if ... | false |
+| break_ensure.rb:29:8:29:13 | call to nil? | break_ensure.rb:30:7:30:12 | return | true |
+| break_ensure.rb:29:8:29:13 | call to nil? | break_ensure.rb:33:11:33:11 | [ensure: raise] y | raise |
+| break_ensure.rb:30:7:30:12 | return | break_ensure.rb:33:11:33:11 | [ensure: return] y | return |
+| break_ensure.rb:32:3:39:7 | [ensure: raise] ensure ... | break_ensure.rb:27:1:42:3 | exit m3 (abnormal) | raise |
+| break_ensure.rb:32:3:39:7 | [ensure: return] ensure ... | break_ensure.rb:27:1:42:3 | exit m3 (normal) | return |
+| break_ensure.rb:32:3:39:7 | ensure ... | break_ensure.rb:41:3:41:13 | self |  |
+| break_ensure.rb:33:5:39:7 | [ensure: raise] while ... | break_ensure.rb:32:3:39:7 | [ensure: raise] ensure ... |  |
+| break_ensure.rb:33:5:39:7 | [ensure: return] while ... | break_ensure.rb:32:3:39:7 | [ensure: return] ensure ... |  |
+| break_ensure.rb:33:5:39:7 | while ... | break_ensure.rb:32:3:39:7 | ensure ... |  |
+| break_ensure.rb:33:11:33:11 | [ensure: raise] y | break_ensure.rb:33:15:33:15 | [ensure: raise] 0 |  |
+| break_ensure.rb:33:11:33:11 | [ensure: return] y | break_ensure.rb:33:15:33:15 | [ensure: return] 0 |  |
+| break_ensure.rb:33:11:33:11 | y | break_ensure.rb:33:15:33:15 | 0 |  |
+| break_ensure.rb:33:11:33:15 | ... < ... | break_ensure.rb:33:5:39:7 | while ... | false |
+| break_ensure.rb:33:11:33:15 | ... < ... | break_ensure.rb:35:12:35:12 | x | true |
+| break_ensure.rb:33:11:33:15 | [ensure: raise] ... < ... | break_ensure.rb:33:5:39:7 | [ensure: raise] while ... | false |
+| break_ensure.rb:33:11:33:15 | [ensure: raise] ... < ... | break_ensure.rb:35:12:35:12 | [ensure: raise] x | true |
+| break_ensure.rb:33:11:33:15 | [ensure: return] ... < ... | break_ensure.rb:33:5:39:7 | [ensure: return] while ... | false |
+| break_ensure.rb:33:11:33:15 | [ensure: return] ... < ... | break_ensure.rb:35:12:35:12 | [ensure: return] x | true |
+| break_ensure.rb:33:15:33:15 | 0 | break_ensure.rb:33:11:33:15 | ... < ... |  |
+| break_ensure.rb:33:15:33:15 | [ensure: raise] 0 | break_ensure.rb:33:11:33:15 | [ensure: raise] ... < ... |  |
+| break_ensure.rb:33:15:33:15 | [ensure: return] 0 | break_ensure.rb:33:11:33:15 | [ensure: return] ... < ... |  |
+| break_ensure.rb:33:16:39:7 | [ensure: raise] do ... | break_ensure.rb:33:11:33:11 | [ensure: raise] y |  |
+| break_ensure.rb:33:16:39:7 | [ensure: return] do ... | break_ensure.rb:33:11:33:11 | [ensure: return] y |  |
+| break_ensure.rb:33:16:39:7 | do ... | break_ensure.rb:33:11:33:11 | y |  |
+| break_ensure.rb:35:9:37:11 | [ensure: raise] if ... | break_ensure.rb:33:16:39:7 | [ensure: raise] do ... |  |
+| break_ensure.rb:35:9:37:11 | [ensure: return] if ... | break_ensure.rb:33:16:39:7 | [ensure: return] do ... |  |
+| break_ensure.rb:35:9:37:11 | if ... | break_ensure.rb:33:16:39:7 | do ... |  |
+| break_ensure.rb:35:12:35:12 | [ensure: raise] x | break_ensure.rb:35:16:35:16 | [ensure: raise] 0 |  |
+| break_ensure.rb:35:12:35:12 | [ensure: return] x | break_ensure.rb:35:16:35:16 | [ensure: return] 0 |  |
+| break_ensure.rb:35:12:35:12 | x | break_ensure.rb:35:16:35:16 | 0 |  |
+| break_ensure.rb:35:12:35:16 | ... > ... | break_ensure.rb:35:9:37:11 | if ... | false |
+| break_ensure.rb:35:12:35:16 | ... > ... | break_ensure.rb:36:11:36:15 | break | true |
+| break_ensure.rb:35:12:35:16 | [ensure: raise] ... > ... | break_ensure.rb:35:9:37:11 | [ensure: raise] if ... | false |
+| break_ensure.rb:35:12:35:16 | [ensure: raise] ... > ... | break_ensure.rb:36:11:36:15 | [ensure: raise] break | true |
+| break_ensure.rb:35:12:35:16 | [ensure: return] ... > ... | break_ensure.rb:35:9:37:11 | [ensure: return] if ... | false |
+| break_ensure.rb:35:12:35:16 | [ensure: return] ... > ... | break_ensure.rb:36:11:36:15 | [ensure: return] break | true |
+| break_ensure.rb:35:16:35:16 | 0 | break_ensure.rb:35:12:35:16 | ... > ... |  |
+| break_ensure.rb:35:16:35:16 | [ensure: raise] 0 | break_ensure.rb:35:12:35:16 | [ensure: raise] ... > ... |  |
+| break_ensure.rb:35:16:35:16 | [ensure: return] 0 | break_ensure.rb:35:12:35:16 | [ensure: return] ... > ... |  |
+| break_ensure.rb:36:11:36:15 | [ensure: raise] break | break_ensure.rb:33:5:39:7 | [ensure: raise] while ... | break |
+| break_ensure.rb:36:11:36:15 | [ensure: return] break | break_ensure.rb:33:5:39:7 | [ensure: return] while ... | break |
+| break_ensure.rb:36:11:36:15 | break | break_ensure.rb:33:5:39:7 | while ... | break |
+| break_ensure.rb:41:3:41:13 | call to puts | break_ensure.rb:27:1:42:3 | exit m3 (normal) |  |
+| break_ensure.rb:41:3:41:13 | self | break_ensure.rb:41:9:41:12 | Done |  |
+| break_ensure.rb:41:8:41:13 | "Done" | break_ensure.rb:41:3:41:13 | call to puts |  |
+| break_ensure.rb:41:9:41:12 | Done | break_ensure.rb:41:8:41:13 | "Done" |  |
+| break_ensure.rb:44:1:56:3 | enter m4 | break_ensure.rb:44:8:44:8 | x |  |
+| break_ensure.rb:44:1:56:3 | exit m4 (normal) | break_ensure.rb:44:1:56:3 | exit m4 |  |
+| break_ensure.rb:44:1:56:3 | m4 | break_ensure.rb:1:1:56:4 | exit break_ensure.rb (normal) |  |
+| break_ensure.rb:44:8:44:8 | x | break_ensure.rb:45:9:45:9 | x |  |
+| break_ensure.rb:45:3:55:5 | while ... | break_ensure.rb:44:1:56:3 | exit m4 (normal) |  |
+| break_ensure.rb:45:9:45:9 | x | break_ensure.rb:45:13:45:13 | 0 |  |
+| break_ensure.rb:45:9:45:13 | ... < ... | break_ensure.rb:45:3:55:5 | while ... | false |
+| break_ensure.rb:45:9:45:13 | ... < ... | break_ensure.rb:47:10:47:10 | x | true |
+| break_ensure.rb:45:13:45:13 | 0 | break_ensure.rb:45:9:45:13 | ... < ... |  |
+| break_ensure.rb:45:14:55:5 | do ... | break_ensure.rb:45:9:45:9 | x |  |
+| break_ensure.rb:47:7:49:9 | if ... | break_ensure.rb:51:10:51:10 | x |  |
+| break_ensure.rb:47:10:47:10 | x | break_ensure.rb:47:14:47:14 | 1 |  |
+| break_ensure.rb:47:10:47:14 | ... > ... | break_ensure.rb:47:7:49:9 | if ... | false |
+| break_ensure.rb:47:10:47:14 | ... > ... | break_ensure.rb:48:9:48:16 | self | true |
+| break_ensure.rb:47:10:47:14 | ... > ... | break_ensure.rb:51:10:51:10 | [ensure: raise] x | raise |
+| break_ensure.rb:47:14:47:14 | 1 | break_ensure.rb:47:10:47:14 | ... > ... |  |
+| break_ensure.rb:48:9:48:16 | call to raise | break_ensure.rb:51:10:51:10 | [ensure: raise] x | raise |
+| break_ensure.rb:48:9:48:16 | self | break_ensure.rb:48:15:48:16 | "" |  |
+| break_ensure.rb:48:15:48:16 | "" | break_ensure.rb:48:9:48:16 | call to raise |  |
+| break_ensure.rb:50:5:53:9 | [ensure: raise] ensure ... | break_ensure.rb:45:3:55:5 | while ... | raise |
+| break_ensure.rb:50:5:53:9 | ensure ... | break_ensure.rb:45:14:55:5 | do ... |  |
+| break_ensure.rb:51:7:53:9 | [ensure: raise] if ... | break_ensure.rb:50:5:53:9 | [ensure: raise] ensure ... |  |
+| break_ensure.rb:51:7:53:9 | if ... | break_ensure.rb:50:5:53:9 | ensure ... |  |
+| break_ensure.rb:51:10:51:10 | [ensure: raise] x | break_ensure.rb:51:14:51:14 | [ensure: raise] 0 |  |
+| break_ensure.rb:51:10:51:10 | x | break_ensure.rb:51:14:51:14 | 0 |  |
+| break_ensure.rb:51:10:51:14 | ... > ... | break_ensure.rb:51:7:53:9 | if ... | false |
+| break_ensure.rb:51:10:51:14 | ... > ... | break_ensure.rb:52:15:52:16 | 10 | true |
+| break_ensure.rb:51:10:51:14 | [ensure: raise] ... > ... | break_ensure.rb:51:7:53:9 | [ensure: raise] if ... | false |
+| break_ensure.rb:51:10:51:14 | [ensure: raise] ... > ... | break_ensure.rb:52:15:52:16 | [ensure: raise] 10 | true |
+| break_ensure.rb:51:14:51:14 | 0 | break_ensure.rb:51:10:51:14 | ... > ... |  |
+| break_ensure.rb:51:14:51:14 | [ensure: raise] 0 | break_ensure.rb:51:10:51:14 | [ensure: raise] ... > ... |  |
+| break_ensure.rb:52:9:52:16 | [ensure: raise] break | break_ensure.rb:45:3:55:5 | while ... | break |
+| break_ensure.rb:52:9:52:16 | break | break_ensure.rb:45:3:55:5 | while ... | break |
+| break_ensure.rb:52:15:52:16 | 10 | break_ensure.rb:52:9:52:16 | break |  |
+| break_ensure.rb:52:15:52:16 | [ensure: raise] 10 | break_ensure.rb:52:9:52:16 | [ensure: raise] break |  |
+| case.rb:1:1:6:3 | enter if_in_case | case.rb:2:8:2:9 | self |  |
+| case.rb:1:1:6:3 | exit if_in_case (normal) | case.rb:1:1:6:3 | exit if_in_case |  |
+| case.rb:1:1:6:3 | if_in_case | case.rb:8:1:18:3 | case_match |  |
+| case.rb:1:1:99:4 | enter case.rb | case.rb:1:1:6:3 | if_in_case |  |
+| case.rb:1:1:99:4 | exit case.rb (normal) | case.rb:1:1:99:4 | exit case.rb |  |
+| case.rb:2:3:5:5 | case ... | case.rb:1:1:6:3 | exit if_in_case (normal) |  |
+| case.rb:2:8:2:9 | call to x1 | case.rb:3:10:3:10 | 1 |  |
+| case.rb:2:8:2:9 | self | case.rb:2:8:2:9 | call to x1 |  |
+| case.rb:3:5:3:42 | [match] when ... | case.rb:3:21:3:22 | self | match |
+| case.rb:3:5:3:42 | [no-match] when ... | case.rb:4:10:4:10 | 2 | no-match |
+| case.rb:3:10:3:10 | 1 | case.rb:3:5:3:42 | [match] when ... | match |
+| case.rb:3:10:3:10 | 1 | case.rb:3:5:3:42 | [no-match] when ... | no-match |
+| case.rb:3:12:3:42 | then ... | case.rb:2:3:5:5 | case ... |  |
+| case.rb:3:17:3:42 | ( ... ) | case.rb:3:12:3:42 | then ... |  |
+| case.rb:3:18:3:41 | if ... | case.rb:3:17:3:42 | ( ... ) |  |
+| case.rb:3:21:3:22 | call to x2 | case.rb:3:18:3:41 | if ... | false |
+| case.rb:3:21:3:22 | call to x2 | case.rb:3:29:3:37 | self | true |
+| case.rb:3:21:3:22 | self | case.rb:3:21:3:22 | call to x2 |  |
+| case.rb:3:24:3:37 | then ... | case.rb:3:18:3:41 | if ... |  |
+| case.rb:3:29:3:37 | call to puts | case.rb:3:24:3:37 | then ... |  |
+| case.rb:3:29:3:37 | self | case.rb:3:35:3:36 | x2 |  |
+| case.rb:3:34:3:37 | "x2" | case.rb:3:29:3:37 | call to puts |  |
+| case.rb:3:35:3:36 | x2 | case.rb:3:34:3:37 | "x2" |  |
+| case.rb:4:5:4:24 | [match] when ... | case.rb:4:17:4:24 | self | match |
+| case.rb:4:5:4:24 | [no-match] when ... | case.rb:2:3:5:5 | case ... | no-match |
+| case.rb:4:10:4:10 | 2 | case.rb:4:5:4:24 | [match] when ... | match |
+| case.rb:4:10:4:10 | 2 | case.rb:4:5:4:24 | [no-match] when ... | no-match |
+| case.rb:4:12:4:24 | then ... | case.rb:2:3:5:5 | case ... |  |
+| case.rb:4:17:4:24 | call to puts | case.rb:4:12:4:24 | then ... |  |
+| case.rb:4:17:4:24 | self | case.rb:4:23:4:23 | 2 |  |
+| case.rb:4:22:4:24 | "2" | case.rb:4:17:4:24 | call to puts |  |
+| case.rb:4:23:4:23 | 2 | case.rb:4:22:4:24 | "2" |  |
+| case.rb:8:1:18:3 | case_match | case.rb:20:1:24:3 | case_match_no_match |  |
+| case.rb:8:1:18:3 | enter case_match | case.rb:8:16:8:20 | value |  |
+| case.rb:8:1:18:3 | exit case_match (normal) | case.rb:8:1:18:3 | exit case_match |  |
+| case.rb:8:16:8:20 | value | case.rb:9:8:9:12 | value |  |
+| case.rb:9:3:17:5 | case ... | case.rb:8:1:18:3 | exit case_match (normal) |  |
+| case.rb:9:8:9:12 | value | case.rb:10:5:10:9 | in ... then ... |  |
+| case.rb:10:5:10:9 | in ... then ... | case.rb:10:8:10:8 | 0 |  |
+| case.rb:10:8:10:8 | 0 | case.rb:9:3:17:5 | case ... | match |
+| case.rb:10:8:10:8 | 0 | case.rb:11:5:11:15 | in ... then ... | no-match |
+| case.rb:11:5:11:15 | in ... then ... | case.rb:11:8:11:8 | 1 |  |
+| case.rb:11:8:11:8 | 1 | case.rb:11:15:11:15 | 3 | match |
+| case.rb:11:8:11:8 | 1 | case.rb:12:5:13:7 | in ... then ... | no-match |
+| case.rb:11:10:11:15 | then ... | case.rb:9:3:17:5 | case ... |  |
+| case.rb:11:15:11:15 | 3 | case.rb:11:10:11:15 | then ... |  |
+| case.rb:12:5:13:7 | in ... then ... | case.rb:12:8:12:8 | 2 |  |
+| case.rb:12:8:12:8 | 2 | case.rb:13:7:13:7 | 4 | match |
+| case.rb:12:8:12:8 | 2 | case.rb:14:5:14:25 | in ... then ... | no-match |
+| case.rb:12:9:13:7 | then ... | case.rb:9:3:17:5 | case ... |  |
+| case.rb:13:7:13:7 | 4 | case.rb:12:9:13:7 | then ... |  |
+| case.rb:14:5:14:25 | in ... then ... | case.rb:14:8:14:8 | x |  |
+| case.rb:14:8:14:8 | x | case.rb:14:13:14:13 | x | match |
+| case.rb:14:13:14:13 | x | case.rb:14:18:14:18 | 5 |  |
+| case.rb:14:13:14:18 | ... == ... | case.rb:14:25:14:25 | 6 | true |
+| case.rb:14:13:14:18 | ... == ... | case.rb:15:5:15:28 | in ... then ... | false |
+| case.rb:14:18:14:18 | 5 | case.rb:14:13:14:18 | ... == ... |  |
+| case.rb:14:20:14:25 | then ... | case.rb:9:3:17:5 | case ... |  |
+| case.rb:14:25:14:25 | 6 | case.rb:14:20:14:25 | then ... |  |
+| case.rb:15:5:15:28 | in ... then ... | case.rb:15:8:15:8 | x |  |
+| case.rb:15:8:15:8 | x | case.rb:15:17:15:17 | x | match |
+| case.rb:15:17:15:17 | x | case.rb:15:21:15:21 | 0 |  |
+| case.rb:15:17:15:21 | ... < ... | case.rb:15:28:15:28 | 7 | false |
+| case.rb:15:17:15:21 | ... < ... | case.rb:16:10:16:10 | 8 | true |
+| case.rb:15:21:15:21 | 0 | case.rb:15:17:15:21 | ... < ... |  |
+| case.rb:15:23:15:28 | then ... | case.rb:9:3:17:5 | case ... |  |
+| case.rb:15:28:15:28 | 7 | case.rb:15:23:15:28 | then ... |  |
+| case.rb:16:5:16:10 | else ... | case.rb:9:3:17:5 | case ... |  |
+| case.rb:16:10:16:10 | 8 | case.rb:16:5:16:10 | else ... |  |
+| case.rb:20:1:24:3 | case_match_no_match | case.rb:26:1:30:3 | case_match_raise |  |
+| case.rb:20:1:24:3 | enter case_match_no_match | case.rb:20:25:20:29 | value |  |
+| case.rb:20:1:24:3 | exit case_match_no_match (abnormal) | case.rb:20:1:24:3 | exit case_match_no_match |  |
+| case.rb:20:1:24:3 | exit case_match_no_match (normal) | case.rb:20:1:24:3 | exit case_match_no_match |  |
+| case.rb:20:25:20:29 | value | case.rb:21:8:21:12 | value |  |
+| case.rb:21:3:23:5 | case ... | case.rb:20:1:24:3 | exit case_match_no_match (normal) |  |
+| case.rb:21:8:21:12 | value | case.rb:22:5:22:8 | in ... then ... |  |
+| case.rb:22:5:22:8 | in ... then ... | case.rb:22:8:22:8 | 1 |  |
+| case.rb:22:8:22:8 | 1 | case.rb:20:1:24:3 | exit case_match_no_match (abnormal) | raise |
+| case.rb:22:8:22:8 | 1 | case.rb:21:3:23:5 | case ... | match |
+| case.rb:26:1:30:3 | case_match_raise | case.rb:32:1:39:3 | case_match_array |  |
+| case.rb:26:1:30:3 | enter case_match_raise | case.rb:26:22:26:26 | value |  |
+| case.rb:26:1:30:3 | exit case_match_raise (abnormal) | case.rb:26:1:30:3 | exit case_match_raise |  |
+| case.rb:26:1:30:3 | exit case_match_raise (normal) | case.rb:26:1:30:3 | exit case_match_raise |  |
+| case.rb:26:22:26:26 | value | case.rb:27:8:27:12 | value |  |
+| case.rb:27:3:29:5 | case ... | case.rb:26:1:30:3 | exit case_match_raise (normal) |  |
+| case.rb:27:8:27:12 | value | case.rb:28:4:28:28 | in ... then ... |  |
+| case.rb:28:4:28:28 | in ... then ... | case.rb:28:7:28:28 | -> { ... } |  |
+| case.rb:28:7:28:28 | -> { ... } | case.rb:26:1:30:3 | exit case_match_raise (abnormal) | raise |
+| case.rb:28:7:28:28 | -> { ... } | case.rb:27:3:29:5 | case ... | match |
+| case.rb:28:7:28:28 | enter -> { ... } | case.rb:28:10:28:10 | x |  |
+| case.rb:28:7:28:28 | exit -> { ... } (abnormal) | case.rb:28:7:28:28 | exit -> { ... } |  |
+| case.rb:28:10:28:10 | x | case.rb:28:14:28:25 | self |  |
+| case.rb:28:14:28:25 | call to raise | case.rb:28:7:28:28 | exit -> { ... } (abnormal) | raise |
+| case.rb:28:14:28:25 | self | case.rb:28:21:28:24 | oops |  |
+| case.rb:28:20:28:25 | "oops" | case.rb:28:14:28:25 | call to raise |  |
+| case.rb:28:21:28:24 | oops | case.rb:28:20:28:25 | "oops" |  |
+| case.rb:32:1:39:3 | case_match_array | case.rb:41:1:45:3 | case_match_find |  |
+| case.rb:32:1:39:3 | enter case_match_array | case.rb:32:22:32:26 | value |  |
+| case.rb:32:1:39:3 | exit case_match_array (abnormal) | case.rb:32:1:39:3 | exit case_match_array |  |
+| case.rb:32:1:39:3 | exit case_match_array (normal) | case.rb:32:1:39:3 | exit case_match_array |  |
+| case.rb:32:22:32:26 | value | case.rb:33:8:33:12 | value |  |
+| case.rb:33:3:38:5 | case ... | case.rb:32:1:39:3 | exit case_match_array (normal) |  |
+| case.rb:33:8:33:12 | value | case.rb:34:5:34:10 | in ... then ... |  |
+| case.rb:34:5:34:10 | in ... then ... | case.rb:34:8:34:9 | [ ..., * ] |  |
+| case.rb:34:8:34:9 | [ ..., * ] | case.rb:33:3:38:5 | case ... | match |
+| case.rb:34:8:34:9 | [ ..., * ] | case.rb:35:5:35:11 | in ... then ... | no-match |
+| case.rb:35:5:35:11 | in ... then ... | case.rb:35:8:35:10 | [ ..., * ] |  |
+| case.rb:35:8:35:10 | [ ..., * ] | case.rb:35:9:35:9 | x | false, match, true |
+| case.rb:35:8:35:10 | [ ..., * ] | case.rb:36:5:36:13 | in ... then ... | no-match |
+| case.rb:35:9:35:9 | x | case.rb:33:3:38:5 | case ... | match |
+| case.rb:36:5:36:13 | in ... then ... | case.rb:36:8:36:12 | [ ..., * ] |  |
+| case.rb:36:8:36:12 | [ ..., * ] | case.rb:36:9:36:9 | x | false, match, true |
+| case.rb:36:8:36:12 | [ ..., * ] | case.rb:37:5:37:27 | in ... then ... | no-match |
+| case.rb:36:9:36:9 | x | case.rb:33:3:38:5 | case ... | match |
+| case.rb:37:5:37:27 | in ... then ... | case.rb:37:8:37:10 | Bar |  |
+| case.rb:37:8:37:10 | Bar | case.rb:32:1:39:3 | exit case_match_array (abnormal) | raise |
+| case.rb:37:8:37:10 | Bar | case.rb:37:8:37:26 | [ ..., * ] | match |
+| case.rb:37:8:37:26 | [ ..., * ] | case.rb:32:1:39:3 | exit case_match_array (abnormal) | raise |
+| case.rb:37:8:37:26 | [ ..., * ] | case.rb:37:12:37:12 | a | false, match, true |
+| case.rb:37:12:37:12 | a | case.rb:37:15:37:15 | b | match |
+| case.rb:37:15:37:15 | b | case.rb:37:19:37:19 | c | match |
+| case.rb:37:19:37:19 | c | case.rb:37:22:37:22 | d |  |
+| case.rb:37:22:37:22 | d | case.rb:37:25:37:25 | e | match |
+| case.rb:37:25:37:25 | e | case.rb:33:3:38:5 | case ... | match |
+| case.rb:41:1:45:3 | case_match_find | case.rb:47:1:53:3 | case_match_hash |  |
+| case.rb:41:1:45:3 | enter case_match_find | case.rb:41:21:41:25 | value |  |
+| case.rb:41:1:45:3 | exit case_match_find (abnormal) | case.rb:41:1:45:3 | exit case_match_find |  |
+| case.rb:41:1:45:3 | exit case_match_find (normal) | case.rb:41:1:45:3 | exit case_match_find |  |
+| case.rb:41:21:41:25 | value | case.rb:42:8:42:12 | value |  |
+| case.rb:42:3:44:5 | case ... | case.rb:41:1:45:3 | exit case_match_find (normal) |  |
+| case.rb:42:8:42:12 | value | case.rb:43:5:43:22 | in ... then ... |  |
+| case.rb:43:5:43:22 | in ... then ... | case.rb:43:8:43:21 | [ *,...,* ] |  |
+| case.rb:43:8:43:21 | [ *,...,* ] | case.rb:41:1:45:3 | exit case_match_find (abnormal) | raise |
+| case.rb:43:8:43:21 | [ *,...,* ] | case.rb:43:10:43:10 | x | false, match, true |
+| case.rb:43:10:43:10 | x | case.rb:43:13:43:13 | 1 |  |
+| case.rb:43:13:43:13 | 1 | case.rb:41:1:45:3 | exit case_match_find (abnormal) | raise |
+| case.rb:43:13:43:13 | 1 | case.rb:43:16:43:16 | 2 | match |
+| case.rb:43:16:43:16 | 2 | case.rb:41:1:45:3 | exit case_match_find (abnormal) | raise |
+| case.rb:43:16:43:16 | 2 | case.rb:43:20:43:20 | y | match |
+| case.rb:43:20:43:20 | y | case.rb:42:3:44:5 | case ... |  |
+| case.rb:47:1:53:3 | case_match_hash | case.rb:55:1:61:3 | case_match_variable |  |
+| case.rb:47:1:53:3 | enter case_match_hash | case.rb:47:21:47:25 | value |  |
+| case.rb:47:1:53:3 | exit case_match_hash (abnormal) | case.rb:47:1:53:3 | exit case_match_hash |  |
+| case.rb:47:1:53:3 | exit case_match_hash (normal) | case.rb:47:1:53:3 | exit case_match_hash |  |
+| case.rb:47:21:47:25 | value | case.rb:48:8:48:12 | value |  |
+| case.rb:48:3:52:5 | case ... | case.rb:47:1:53:3 | exit case_match_hash (normal) |  |
+| case.rb:48:8:48:12 | value | case.rb:49:5:49:35 | in ... then ... |  |
+| case.rb:49:5:49:35 | in ... then ... | case.rb:49:8:49:10 | Foo |  |
+| case.rb:49:8:49:10 | Foo | case.rb:49:8:49:15 | Bar |  |
+| case.rb:49:8:49:15 | Bar | case.rb:49:8:49:34 | { ..., ** } | match |
+| case.rb:49:8:49:15 | Bar | case.rb:50:5:50:25 | in ... then ... | no-match |
+| case.rb:49:8:49:34 | { ..., ** } | case.rb:49:20:49:20 | 1 | false, match, true |
+| case.rb:49:8:49:34 | { ..., ** } | case.rb:50:5:50:25 | in ... then ... | no-match |
+| case.rb:49:20:49:20 | 1 | case.rb:49:23:49:23 | a | match |
+| case.rb:49:20:49:20 | 1 | case.rb:50:5:50:25 | in ... then ... | no-match |
+| case.rb:49:23:49:23 | a | case.rb:49:29:49:32 | rest | match |
+| case.rb:49:29:49:32 | rest | case.rb:48:3:52:5 | case ... |  |
+| case.rb:50:5:50:25 | in ... then ... | case.rb:50:8:50:10 | Bar |  |
+| case.rb:50:8:50:10 | Bar | case.rb:50:8:50:24 | { ..., ** } | match |
+| case.rb:50:8:50:10 | Bar | case.rb:51:5:51:17 | in ... then ... | no-match |
+| case.rb:50:8:50:24 | { ..., ** } | case.rb:50:16:50:16 | 1 | false, match, true |
+| case.rb:50:8:50:24 | { ..., ** } | case.rb:51:5:51:17 | in ... then ... | no-match |
+| case.rb:50:16:50:16 | 1 | case.rb:48:3:52:5 | case ... | match |
+| case.rb:50:16:50:16 | 1 | case.rb:51:5:51:17 | in ... then ... | no-match |
+| case.rb:51:5:51:17 | in ... then ... | case.rb:51:8:51:10 | Bar |  |
+| case.rb:51:8:51:10 | Bar | case.rb:47:1:53:3 | exit case_match_hash (abnormal) | raise |
+| case.rb:51:8:51:10 | Bar | case.rb:51:8:51:16 | { ..., ** } | match |
+| case.rb:51:8:51:16 | { ..., ** } | case.rb:47:1:53:3 | exit case_match_hash (abnormal) | raise |
+| case.rb:51:8:51:16 | { ..., ** } | case.rb:48:3:52:5 | case ... | false, match, true |
+| case.rb:55:1:61:3 | case_match_variable | case.rb:63:1:67:3 | case_match_underscore |  |
+| case.rb:55:1:61:3 | enter case_match_variable | case.rb:55:25:55:29 | value |  |
+| case.rb:55:1:61:3 | exit case_match_variable (normal) | case.rb:55:1:61:3 | exit case_match_variable |  |
+| case.rb:55:25:55:29 | value | case.rb:56:8:56:12 | value |  |
+| case.rb:56:3:60:5 | case ... | case.rb:55:1:61:3 | exit case_match_variable (normal) |  |
+| case.rb:56:8:56:12 | value | case.rb:57:5:57:8 | in ... then ... |  |
+| case.rb:57:5:57:8 | in ... then ... | case.rb:57:8:57:8 | 5 |  |
+| case.rb:57:8:57:8 | 5 | case.rb:56:3:60:5 | case ... | match |
+| case.rb:57:8:57:8 | 5 | case.rb:58:5:58:10 | in ... then ... | no-match |
+| case.rb:58:5:58:10 | in ... then ... | case.rb:58:8:58:10 | var |  |
+| case.rb:58:8:58:10 | var | case.rb:56:3:60:5 | case ... | match |
+| case.rb:63:1:67:3 | case_match_underscore | case.rb:69:1:93:3 | case_match_various |  |
+| case.rb:63:1:67:3 | enter case_match_underscore | case.rb:63:27:63:31 | value |  |
+| case.rb:63:1:67:3 | exit case_match_underscore (normal) | case.rb:63:1:67:3 | exit case_match_underscore |  |
+| case.rb:63:27:63:31 | value | case.rb:64:8:64:12 | value |  |
+| case.rb:64:3:66:5 | case ... | case.rb:63:1:67:3 | exit case_match_underscore (normal) |  |
+| case.rb:64:8:64:12 | value | case.rb:65:5:65:28 | in ... then ... |  |
+| case.rb:65:5:65:28 | in ... then ... | case.rb:65:8:65:28 | ... \| ... |  |
+| case.rb:65:8:65:8 | 5 | case.rb:64:3:66:5 | case ... | match |
+| case.rb:65:8:65:8 | 5 | case.rb:65:12:65:12 | _ | no-match |
+| case.rb:65:8:65:28 | ... \| ... | case.rb:65:8:65:8 | 5 |  |
+| case.rb:65:12:65:12 | _ | case.rb:64:3:66:5 | case ... | match |
+| case.rb:69:1:93:3 | case_match_various | case.rb:95:1:99:3 | case_match_guard_no_else |  |
+| case.rb:69:1:93:3 | enter case_match_various | case.rb:69:24:69:28 | value |  |
+| case.rb:69:1:93:3 | exit case_match_various (abnormal) | case.rb:69:1:93:3 | exit case_match_various |  |
+| case.rb:69:1:93:3 | exit case_match_various (normal) | case.rb:69:1:93:3 | exit case_match_various |  |
+| case.rb:69:24:69:28 | value | case.rb:70:3:70:5 | foo |  |
+| case.rb:70:3:70:5 | foo | case.rb:70:9:70:10 | 42 |  |
+| case.rb:70:3:70:10 | ... = ... | case.rb:72:8:72:12 | value |  |
+| case.rb:70:9:70:10 | 42 | case.rb:70:3:70:10 | ... = ... |  |
+| case.rb:72:3:92:5 | case ... | case.rb:69:1:93:3 | exit case_match_various (normal) |  |
+| case.rb:72:8:72:12 | value | case.rb:73:5:73:8 | in ... then ... |  |
+| case.rb:73:5:73:8 | in ... then ... | case.rb:73:8:73:8 | 5 |  |
+| case.rb:73:8:73:8 | 5 | case.rb:72:3:92:5 | case ... | match |
+| case.rb:73:8:73:8 | 5 | case.rb:74:5:74:11 | in ... then ... | no-match |
+| case.rb:74:5:74:11 | in ... then ... | case.rb:74:8:74:11 | ^... |  |
+| case.rb:74:8:74:11 | ^... | case.rb:74:9:74:11 | foo |  |
+| case.rb:74:9:74:11 | foo | case.rb:72:3:92:5 | case ... | match |
+| case.rb:74:9:74:11 | foo | case.rb:75:5:75:15 | in ... then ... | no-match |
+| case.rb:75:5:75:15 | in ... then ... | case.rb:75:9:75:14 | string |  |
+| case.rb:75:8:75:15 | "string" | case.rb:72:3:92:5 | case ... | match |
+| case.rb:75:8:75:15 | "string" | case.rb:76:5:76:18 | in ... then ... | no-match |
+| case.rb:75:9:75:14 | string | case.rb:75:8:75:15 | "string" |  |
+| case.rb:76:5:76:18 | in ... then ... | case.rb:76:8:76:18 | Array |  |
+| case.rb:76:8:76:18 | Array | case.rb:76:11:76:13 | foo |  |
+| case.rb:76:8:76:18 | call to [] | case.rb:72:3:92:5 | case ... | match |
+| case.rb:76:8:76:18 | call to [] | case.rb:77:5:77:18 | in ... then ... | no-match |
+| case.rb:76:11:76:13 | "foo" | case.rb:76:15:76:17 | bar |  |
+| case.rb:76:11:76:13 | foo | case.rb:76:11:76:13 | "foo" |  |
+| case.rb:76:15:76:17 | "bar" | case.rb:76:8:76:18 | call to [] |  |
+| case.rb:76:15:76:17 | bar | case.rb:76:15:76:17 | "bar" |  |
+| case.rb:77:5:77:18 | in ... then ... | case.rb:77:8:77:18 | Array |  |
+| case.rb:77:8:77:18 | Array | case.rb:77:11:77:13 | foo |  |
+| case.rb:77:8:77:18 | call to [] | case.rb:72:3:92:5 | case ... | match |
+| case.rb:77:8:77:18 | call to [] | case.rb:78:5:78:19 | in ... then ... | no-match |
+| case.rb:77:11:77:13 | :"foo" | case.rb:77:15:77:17 | bar |  |
+| case.rb:77:11:77:13 | foo | case.rb:77:11:77:13 | :"foo" |  |
+| case.rb:77:15:77:17 | :"bar" | case.rb:77:8:77:18 | call to [] |  |
+| case.rb:77:15:77:17 | bar | case.rb:77:15:77:17 | :"bar" |  |
+| case.rb:78:5:78:19 | in ... then ... | case.rb:78:9:78:18 | .*abc[0-9] |  |
+| case.rb:78:8:78:19 | /.*abc[0-9]/ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:78:8:78:19 | /.*abc[0-9]/ | case.rb:79:5:79:14 | in ... then ... | no-match |
+| case.rb:78:9:78:18 | .*abc[0-9] | case.rb:78:8:78:19 | /.*abc[0-9]/ |  |
+| case.rb:79:5:79:14 | in ... then ... | case.rb:79:8:79:8 | 5 |  |
+| case.rb:79:8:79:8 | 5 | case.rb:79:13:79:14 | 10 |  |
+| case.rb:79:8:79:14 | _ .. _ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:79:8:79:14 | _ .. _ | case.rb:80:5:80:12 | in ... then ... | no-match |
+| case.rb:79:13:79:14 | 10 | case.rb:79:8:79:14 | _ .. _ |  |
+| case.rb:80:5:80:12 | in ... then ... | case.rb:80:11:80:12 | 10 |  |
+| case.rb:80:8:80:12 | _ .. _ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:80:8:80:12 | _ .. _ | case.rb:81:5:81:11 | in ... then ... | no-match |
+| case.rb:80:11:80:12 | 10 | case.rb:80:8:80:12 | _ .. _ |  |
+| case.rb:81:5:81:11 | in ... then ... | case.rb:81:8:81:8 | 5 |  |
+| case.rb:81:8:81:8 | 5 | case.rb:81:8:81:11 | _ .. _ |  |
+| case.rb:81:8:81:11 | _ .. _ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:81:8:81:11 | _ .. _ | case.rb:82:5:82:20 | in ... then ... | no-match |
+| case.rb:82:5:82:20 | in ... then ... | case.rb:82:8:82:13 | ... => ... |  |
+| case.rb:82:8:82:8 | 5 | case.rb:82:13:82:13 | x | match |
+| case.rb:82:8:82:8 | 5 | case.rb:83:5:83:26 | in ... then ... | no-match |
+| case.rb:82:8:82:13 | ... => ... | case.rb:82:8:82:8 | 5 |  |
+| case.rb:82:13:82:13 | x | case.rb:82:20:82:20 | 1 | match |
+| case.rb:82:15:82:20 | then ... | case.rb:72:3:92:5 | case ... |  |
+| case.rb:82:20:82:20 | 1 | case.rb:82:15:82:20 | then ... |  |
+| case.rb:83:5:83:26 | in ... then ... | case.rb:83:8:83:26 | ... \| ... |  |
+| case.rb:83:8:83:8 | 5 | case.rb:72:3:92:5 | case ... | match |
+| case.rb:83:8:83:8 | 5 | case.rb:83:12:83:15 | ^... | no-match |
+| case.rb:83:8:83:26 | ... \| ... | case.rb:83:8:83:8 | 5 |  |
+| case.rb:83:12:83:15 | ^... | case.rb:83:13:83:15 | foo |  |
+| case.rb:83:13:83:15 | foo | case.rb:72:3:92:5 | case ... | match |
+| case.rb:83:13:83:15 | foo | case.rb:83:20:83:25 | string | no-match |
+| case.rb:83:19:83:26 | "string" | case.rb:72:3:92:5 | case ... | match |
+| case.rb:83:19:83:26 | "string" | case.rb:84:5:84:17 | in ... then ... | no-match |
+| case.rb:83:20:83:25 | string | case.rb:83:19:83:26 | "string" |  |
+| case.rb:84:5:84:17 | in ... then ... | case.rb:84:8:84:12 | Foo |  |
+| case.rb:84:8:84:12 | Foo | case.rb:84:8:84:17 | Bar |  |
+| case.rb:84:8:84:17 | Bar | case.rb:72:3:92:5 | case ... | match |
+| case.rb:84:8:84:17 | Bar | case.rb:85:5:85:23 | in ... then ... | no-match |
+| case.rb:85:5:85:23 | in ... then ... | case.rb:85:8:85:23 | -> { ... } |  |
+| case.rb:85:8:85:23 | -> { ... } | case.rb:72:3:92:5 | case ... | match |
+| case.rb:85:8:85:23 | -> { ... } | case.rb:86:5:86:11 | in ... then ... | no-match |
+| case.rb:85:8:85:23 | enter -> { ... } | case.rb:85:11:85:11 | x |  |
+| case.rb:85:8:85:23 | exit -> { ... } (normal) | case.rb:85:8:85:23 | exit -> { ... } |  |
+| case.rb:85:11:85:11 | x | case.rb:85:15:85:15 | x |  |
+| case.rb:85:15:85:15 | x | case.rb:85:20:85:21 | 10 |  |
+| case.rb:85:15:85:21 | ... == ... | case.rb:85:8:85:23 | exit -> { ... } (normal) |  |
+| case.rb:85:20:85:21 | 10 | case.rb:85:15:85:21 | ... == ... |  |
+| case.rb:86:5:86:11 | in ... then ... | case.rb:86:8:86:11 | foo |  |
+| case.rb:86:8:86:11 | :foo | case.rb:72:3:92:5 | case ... | match |
+| case.rb:86:8:86:11 | :foo | case.rb:87:5:87:17 | in ... then ... | no-match |
+| case.rb:86:8:86:11 | foo | case.rb:86:8:86:11 | :foo |  |
+| case.rb:87:5:87:17 | in ... then ... | case.rb:87:10:87:16 | foo bar |  |
+| case.rb:87:8:87:17 | :"foo bar" | case.rb:72:3:92:5 | case ... | match |
+| case.rb:87:8:87:17 | :"foo bar" | case.rb:88:5:88:15 | in ... then ... | no-match |
+| case.rb:87:10:87:16 | foo bar | case.rb:87:8:87:17 | :"foo bar" |  |
+| case.rb:88:5:88:15 | in ... then ... | case.rb:88:8:88:15 | ... \| ... |  |
+| case.rb:88:8:88:9 | - ... | case.rb:72:3:92:5 | case ... | match |
+| case.rb:88:8:88:9 | - ... | case.rb:88:14:88:15 | 10 | no-match |
+| case.rb:88:8:88:15 | ... \| ... | case.rb:88:9:88:9 | 5 |  |
+| case.rb:88:9:88:9 | 5 | case.rb:88:8:88:9 | - ... |  |
+| case.rb:88:13:88:15 | + ... | case.rb:72:3:92:5 | case ... | match |
+| case.rb:88:13:88:15 | + ... | case.rb:89:5:89:69 | in ... then ... | no-match |
+| case.rb:88:14:88:15 | 10 | case.rb:88:13:88:15 | + ... |  |
+| case.rb:89:5:89:69 | in ... then ... | case.rb:89:8:89:69 | ... \| ... |  |
+| case.rb:89:8:89:10 | nil | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:8:89:10 | nil | case.rb:89:14:89:17 | self | no-match |
+| case.rb:89:8:89:69 | ... \| ... | case.rb:89:8:89:10 | nil |  |
+| case.rb:89:14:89:17 | self | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:14:89:17 | self | case.rb:89:21:89:24 | true | no-match |
+| case.rb:89:21:89:24 | true | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:21:89:24 | true | case.rb:89:28:89:32 | false | no-match |
+| case.rb:89:28:89:32 | false | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:28:89:32 | false | case.rb:89:36:89:43 | __LINE__ | no-match |
+| case.rb:89:36:89:43 | __LINE__ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:36:89:43 | __LINE__ | case.rb:89:47:89:54 | __FILE__ | no-match |
+| case.rb:89:47:89:54 | __FILE__ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:47:89:54 | __FILE__ | case.rb:89:58:89:69 | __ENCODING__ | no-match |
+| case.rb:89:58:89:69 | __ENCODING__ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:89:58:89:69 | __ENCODING__ | case.rb:90:5:90:13 | in ... then ... | no-match |
+| case.rb:90:5:90:13 | in ... then ... | case.rb:90:8:90:13 | ( ... ) |  |
+| case.rb:90:8:90:13 | ( ... ) | case.rb:90:9:90:9 | 1 |  |
+| case.rb:90:9:90:9 | 1 | case.rb:90:9:90:12 | _ .. _ |  |
+| case.rb:90:9:90:12 | _ .. _ | case.rb:72:3:92:5 | case ... | match |
+| case.rb:90:9:90:12 | _ .. _ | case.rb:91:5:91:25 | in ... then ... | no-match |
+| case.rb:91:5:91:25 | in ... then ... | case.rb:91:8:91:25 | ( ... ) |  |
+| case.rb:91:8:91:25 | ( ... ) | case.rb:91:9:91:24 | ... \| ... |  |
+| case.rb:91:9:91:9 | 0 | case.rb:72:3:92:5 | case ... | match |
+| case.rb:91:9:91:9 | 0 | case.rb:91:13:91:14 | "" | no-match |
+| case.rb:91:9:91:24 | ... \| ... | case.rb:91:9:91:9 | 0 |  |
+| case.rb:91:13:91:14 | "" | case.rb:72:3:92:5 | case ... | match |
+| case.rb:91:13:91:14 | "" | case.rb:91:18:91:19 | [ ..., * ] | no-match |
+| case.rb:91:18:91:19 | [ ..., * ] | case.rb:72:3:92:5 | case ... | match |
+| case.rb:91:18:91:19 | [ ..., * ] | case.rb:91:23:91:24 | { ..., ** } | no-match |
+| case.rb:91:23:91:24 | { ..., ** } | case.rb:69:1:93:3 | exit case_match_various (abnormal) | raise |
+| case.rb:91:23:91:24 | { ..., ** } | case.rb:72:3:92:5 | case ... | false, match, true |
+| case.rb:95:1:99:3 | case_match_guard_no_else | case.rb:1:1:99:4 | exit case.rb (normal) |  |
+| case.rb:95:1:99:3 | enter case_match_guard_no_else | case.rb:95:30:95:34 | value |  |
+| case.rb:95:1:99:3 | exit case_match_guard_no_else (abnormal) | case.rb:95:1:99:3 | exit case_match_guard_no_else |  |
+| case.rb:95:1:99:3 | exit case_match_guard_no_else (normal) | case.rb:95:1:99:3 | exit case_match_guard_no_else |  |
+| case.rb:95:30:95:34 | value | case.rb:96:8:96:12 | value |  |
+| case.rb:96:3:98:5 | case ... | case.rb:95:1:99:3 | exit case_match_guard_no_else (normal) |  |
+| case.rb:96:8:96:12 | value | case.rb:97:5:97:25 | in ... then ... |  |
+| case.rb:97:5:97:25 | in ... then ... | case.rb:97:8:97:8 | x |  |
+| case.rb:97:8:97:8 | x | case.rb:97:13:97:13 | x | match |
+| case.rb:97:13:97:13 | x | case.rb:97:18:97:18 | 5 |  |
+| case.rb:97:13:97:18 | ... == ... | case.rb:95:1:99:3 | exit case_match_guard_no_else (abnormal) | raise |
+| case.rb:97:13:97:18 | ... == ... | case.rb:97:25:97:25 | 6 | true |
+| case.rb:97:18:97:18 | 5 | case.rb:97:13:97:18 | ... == ... |  |
+| case.rb:97:20:97:25 | then ... | case.rb:96:3:98:5 | case ... |  |
+| case.rb:97:25:97:25 | 6 | case.rb:97:20:97:25 | then ... |  |
+| cfg.html.erb:5:16:5:21 | @title | cfg.html.erb:6:9:6:58 | self |  |
+| cfg.html.erb:5:16:5:21 | self | cfg.html.erb:5:16:5:21 | @title |  |
+| cfg.html.erb:5:16:31:12 | enter cfg.html.erb | cfg.html.erb:5:16:5:21 | self |  |
+| cfg.html.erb:5:16:31:12 | exit cfg.html.erb (normal) | cfg.html.erb:5:16:31:12 | exit cfg.html.erb |  |
+| cfg.html.erb:6:9:6:58 | call to stylesheet_link_tag | cfg.html.erb:12:11:12:33 | self |  |
+| cfg.html.erb:6:9:6:58 | self | cfg.html.erb:6:30:6:40 | application |  |
+| cfg.html.erb:6:29:6:41 | "application" | cfg.html.erb:6:44:6:49 | media |  |
+| cfg.html.erb:6:30:6:40 | application | cfg.html.erb:6:29:6:41 | "application" |  |
+| cfg.html.erb:6:44:6:49 | :media | cfg.html.erb:6:55:6:57 | all |  |
+| cfg.html.erb:6:44:6:49 | media | cfg.html.erb:6:44:6:49 | :media |  |
+| cfg.html.erb:6:44:6:58 | Pair | cfg.html.erb:6:9:6:58 | call to stylesheet_link_tag |  |
+| cfg.html.erb:6:54:6:58 | "all" | cfg.html.erb:6:44:6:58 | Pair |  |
+| cfg.html.erb:6:55:6:57 | all | cfg.html.erb:6:54:6:58 | "all" |  |
+| cfg.html.erb:12:11:12:33 | call to link_to | cfg.html.erb:15:19:15:32 | self |  |
+| cfg.html.erb:12:11:12:33 | self | cfg.html.erb:12:20:12:20 | A |  |
+| cfg.html.erb:12:19:12:21 | "A" | cfg.html.erb:12:24:12:24 | self |  |
+| cfg.html.erb:12:20:12:20 | A | cfg.html.erb:12:19:12:21 | "A" |  |
+| cfg.html.erb:12:24:12:24 | call to a | cfg.html.erb:12:27:12:28 | id |  |
+| cfg.html.erb:12:24:12:24 | self | cfg.html.erb:12:24:12:24 | call to a |  |
+| cfg.html.erb:12:27:12:28 | :id | cfg.html.erb:12:32:12:32 | a |  |
+| cfg.html.erb:12:27:12:28 | id | cfg.html.erb:12:27:12:28 | :id |  |
+| cfg.html.erb:12:27:12:33 | Pair | cfg.html.erb:12:11:12:33 | call to link_to |  |
+| cfg.html.erb:12:31:12:33 | "a" | cfg.html.erb:12:27:12:33 | Pair |  |
+| cfg.html.erb:12:32:12:32 | a | cfg.html.erb:12:31:12:33 | "a" |  |
+| cfg.html.erb:15:19:15:32 | call to link_to | cfg.html.erb:16:19:16:32 | self |  |
+| cfg.html.erb:15:19:15:32 | self | cfg.html.erb:15:28:15:28 | B |  |
+| cfg.html.erb:15:27:15:29 | "B" | cfg.html.erb:15:32:15:32 | self |  |
+| cfg.html.erb:15:28:15:28 | B | cfg.html.erb:15:27:15:29 | "B" |  |
+| cfg.html.erb:15:32:15:32 | call to a | cfg.html.erb:15:19:15:32 | call to link_to |  |
+| cfg.html.erb:15:32:15:32 | self | cfg.html.erb:15:32:15:32 | call to a |  |
+| cfg.html.erb:16:19:16:32 | call to link_to | cfg.html.erb:18:17:18:22 | self |  |
+| cfg.html.erb:16:19:16:32 | self | cfg.html.erb:16:28:16:28 | C |  |
+| cfg.html.erb:16:27:16:29 | "C" | cfg.html.erb:16:32:16:32 | self |  |
+| cfg.html.erb:16:28:16:28 | C | cfg.html.erb:16:27:16:29 | "C" |  |
+| cfg.html.erb:16:32:16:32 | call to b | cfg.html.erb:16:19:16:32 | call to link_to |  |
+| cfg.html.erb:16:32:16:32 | self | cfg.html.erb:16:32:16:32 | call to b |  |
+| cfg.html.erb:18:14:22:16 | if ... | cfg.html.erb:29:8:29:17 | self |  |
+| cfg.html.erb:18:17:18:22 | call to admin? | cfg.html.erb:19:19:19:32 | self | true |
+| cfg.html.erb:18:17:18:22 | call to admin? | cfg.html.erb:21:19:21:32 | self | false |
+| cfg.html.erb:18:17:18:22 | self | cfg.html.erb:18:17:18:22 | call to admin? |  |
+| cfg.html.erb:18:24:19:34 | then ... | cfg.html.erb:18:14:22:16 | if ... |  |
+| cfg.html.erb:19:19:19:32 | call to link_to | cfg.html.erb:18:24:19:34 | then ... |  |
+| cfg.html.erb:19:19:19:32 | self | cfg.html.erb:19:28:19:28 | D |  |
+| cfg.html.erb:19:27:19:29 | "D" | cfg.html.erb:19:32:19:32 | self |  |
+| cfg.html.erb:19:28:19:28 | D | cfg.html.erb:19:27:19:29 | "D" |  |
+| cfg.html.erb:19:32:19:32 | call to d | cfg.html.erb:19:19:19:32 | call to link_to |  |
+| cfg.html.erb:19:32:19:32 | self | cfg.html.erb:19:32:19:32 | call to d |  |
+| cfg.html.erb:20:14:21:34 | else ... | cfg.html.erb:18:14:22:16 | if ... |  |
+| cfg.html.erb:21:19:21:32 | call to link_to | cfg.html.erb:20:14:21:34 | else ... |  |
+| cfg.html.erb:21:19:21:32 | self | cfg.html.erb:21:28:21:28 | E |  |
+| cfg.html.erb:21:27:21:29 | "E" | cfg.html.erb:21:32:21:32 | self |  |
+| cfg.html.erb:21:28:21:28 | E | cfg.html.erb:21:27:21:29 | "E" |  |
+| cfg.html.erb:21:32:21:32 | call to e | cfg.html.erb:21:19:21:32 | call to link_to |  |
+| cfg.html.erb:21:32:21:32 | self | cfg.html.erb:21:32:21:32 | call to e |  |
+| cfg.html.erb:29:8:29:17 | call to collection | cfg.html.erb:29:24:31:10 | do ... end |  |
+| cfg.html.erb:29:8:29:17 | self | cfg.html.erb:29:8:29:17 | call to collection |  |
+| cfg.html.erb:29:8:31:10 | call to each | cfg.html.erb:5:16:31:12 | exit cfg.html.erb (normal) |  |
+| cfg.html.erb:29:24:31:10 | do ... end | cfg.html.erb:29:8:31:10 | call to each |  |
+| cfg.html.erb:29:24:31:10 | enter do ... end | cfg.html.erb:29:28:29:30 | key |  |
+| cfg.html.erb:29:24:31:10 | exit do ... end (normal) | cfg.html.erb:29:24:31:10 | exit do ... end |  |
+| cfg.html.erb:29:28:29:30 | key | cfg.html.erb:29:33:29:37 | value |  |
+| cfg.html.erb:29:33:29:37 | value | cfg.html.erb:30:23:30:25 | key |  |
+| cfg.html.erb:30:23:30:25 | key | cfg.html.erb:30:35:30:39 | value |  |
+| cfg.html.erb:30:35:30:39 | value | cfg.html.erb:29:24:31:10 | exit do ... end (normal) |  |
+| cfg.rb:1:1:1:12 | bar | cfg.rb:3:1:3:13 | alias ... |  |
+| cfg.rb:1:1:221:1 | enter cfg.rb | cfg.rb:16:3:16:14 | self |  |
+| cfg.rb:1:1:221:1 | exit cfg.rb (normal) | cfg.rb:1:1:221:1 | exit cfg.rb |  |
+| cfg.rb:3:1:3:13 | alias ... | cfg.rb:3:7:3:9 | foo |  |
+| cfg.rb:3:7:3:9 | foo | cfg.rb:3:11:3:13 | bar |  |
+| cfg.rb:3:11:3:13 | bar | cfg.rb:5:1:5:1 | b |  |
+| cfg.rb:5:1:5:1 | b | cfg.rb:5:5:5:6 | 42 |  |
+| cfg.rb:5:1:5:6 | ... = ... | cfg.rb:7:1:7:21 | Array |  |
+| cfg.rb:5:5:5:6 | 42 | cfg.rb:5:1:5:6 | ... = ... |  |
+| cfg.rb:7:1:7:21 | Array | cfg.rb:7:4:7:6 | one |  |
+| cfg.rb:7:1:7:21 | call to [] | cfg.rb:9:1:9:21 | Array |  |
+| cfg.rb:7:4:7:6 | one | cfg.rb:7:10:7:10 | b |  |
+| cfg.rb:7:4:7:12 | :"one#{...}" | cfg.rb:7:14:7:20 | another |  |
+| cfg.rb:7:7:7:12 | #{...} | cfg.rb:7:4:7:12 | :"one#{...}" |  |
+| cfg.rb:7:10:7:10 | b | cfg.rb:7:7:7:12 | #{...} |  |
+| cfg.rb:7:14:7:20 | :"another" | cfg.rb:7:1:7:21 | call to [] |  |
+| cfg.rb:7:14:7:20 | another | cfg.rb:7:14:7:20 | :"another" |  |
+| cfg.rb:9:1:9:21 | Array | cfg.rb:9:4:9:6 | one |  |
+| cfg.rb:9:1:9:21 | call to [] | cfg.rb:12:3:12:8 | self |  |
+| cfg.rb:9:4:9:6 | one | cfg.rb:9:10:9:10 | b |  |
+| cfg.rb:9:4:9:12 | "one#{...}" | cfg.rb:9:14:9:20 | another |  |
+| cfg.rb:9:7:9:12 | #{...} | cfg.rb:9:4:9:12 | "one#{...}" |  |
+| cfg.rb:9:10:9:10 | b | cfg.rb:9:7:9:12 | #{...} |  |
+| cfg.rb:9:14:9:20 | "another" | cfg.rb:9:1:9:21 | call to [] |  |
+| cfg.rb:9:14:9:20 | another | cfg.rb:9:14:9:20 | "another" |  |
+| cfg.rb:12:3:12:8 | call to puts | cfg.rb:19:1:21:1 | END { ... } |  |
+| cfg.rb:12:3:12:8 | self | cfg.rb:12:8:12:8 | 4 |  |
+| cfg.rb:12:8:12:8 | 4 | cfg.rb:12:3:12:8 | call to puts |  |
+| cfg.rb:15:1:17:1 | BEGIN { ... } | cfg.rb:1:1:1:12 | bar |  |
+| cfg.rb:16:3:16:14 | call to puts | cfg.rb:15:1:17:1 | BEGIN { ... } |  |
+| cfg.rb:16:3:16:14 | self | cfg.rb:16:9:16:13 | hello |  |
+| cfg.rb:16:8:16:14 | "hello" | cfg.rb:16:3:16:14 | call to puts |  |
+| cfg.rb:16:9:16:13 | hello | cfg.rb:16:8:16:14 | "hello" |  |
+| cfg.rb:19:1:21:1 | END { ... } | cfg.rb:23:1:23:2 | 41 |  |
+| cfg.rb:23:1:23:2 | 41 | cfg.rb:23:6:23:6 | 1 |  |
+| cfg.rb:23:1:23:6 | ... + ... | cfg.rb:25:1:25:1 | 2 |  |
+| cfg.rb:23:6:23:6 | 1 | cfg.rb:23:1:23:6 | ... + ... |  |
+| cfg.rb:25:1:25:1 | 2 | cfg.rb:25:9:25:22 | { ... } |  |
+| cfg.rb:25:1:25:22 | call to times | cfg.rb:27:1:27:11 | self |  |
+| cfg.rb:25:9:25:22 | enter { ... } | cfg.rb:25:12:25:12 | x |  |
+| cfg.rb:25:9:25:22 | exit { ... } (normal) | cfg.rb:25:9:25:22 | exit { ... } |  |
+| cfg.rb:25:9:25:22 | { ... } | cfg.rb:25:1:25:22 | call to times |  |
+| cfg.rb:25:12:25:12 | x | cfg.rb:25:15:25:20 | self |  |
+| cfg.rb:25:15:25:20 | call to puts | cfg.rb:25:9:25:22 | exit { ... } (normal) |  |
+| cfg.rb:25:15:25:20 | self | cfg.rb:25:20:25:20 | x |  |
+| cfg.rb:25:20:25:20 | x | cfg.rb:25:15:25:20 | call to puts |  |
+| cfg.rb:27:1:27:11 | call to puts | cfg.rb:29:1:29:4 | Proc |  |
+| cfg.rb:27:1:27:11 | self | cfg.rb:27:7:27:11 | puts |  |
+| cfg.rb:27:6:27:11 | &... | cfg.rb:27:1:27:11 | call to puts |  |
+| cfg.rb:27:7:27:11 | :puts | cfg.rb:27:6:27:11 | &... |  |
+| cfg.rb:27:7:27:11 | puts | cfg.rb:27:7:27:11 | :puts |  |
+| cfg.rb:29:1:29:4 | Proc | cfg.rb:29:10:29:24 | { ... } |  |
+| cfg.rb:29:1:29:24 | call to new | cfg.rb:31:7:31:10 | true |  |
+| cfg.rb:29:10:29:24 | enter { ... } | cfg.rb:29:14:29:14 | x |  |
+| cfg.rb:29:10:29:24 | exit { ... } (normal) | cfg.rb:29:10:29:24 | exit { ... } |  |
+| cfg.rb:29:10:29:24 | { ... } | cfg.rb:29:1:29:24 | call to new |  |
+| cfg.rb:29:14:29:14 | x | cfg.rb:29:17:29:17 | x |  |
+| cfg.rb:29:17:29:17 | x | cfg.rb:29:17:29:22 | call to call |  |
+| cfg.rb:29:17:29:22 | call to call | cfg.rb:29:10:29:24 | exit { ... } (normal) |  |
+| cfg.rb:31:1:33:3 | while ... | cfg.rb:35:4:35:8 | false |  |
+| cfg.rb:31:7:31:10 | true | cfg.rb:32:9:32:9 | 1 | true |
+| cfg.rb:32:3:32:9 | break | cfg.rb:31:1:33:3 | while ... | break |
+| cfg.rb:32:9:32:9 | 1 | cfg.rb:32:3:32:9 | break |  |
+| cfg.rb:35:1:37:3 | if ... | cfg.rb:39:1:39:4 | self |  |
+| cfg.rb:35:4:35:8 | false | cfg.rb:35:1:37:3 | if ... | false |
+| cfg.rb:39:1:39:4 | self | cfg.rb:39:11:39:12 | 42 |  |
+| cfg.rb:39:1:39:12 | call to puts | cfg.rb:41:6:41:7 | 10 |  |
+| cfg.rb:39:11:39:12 | 42 | cfg.rb:39:1:39:12 | call to puts |  |
+| cfg.rb:41:1:45:3 | case ... | cfg.rb:48:8:48:8 | b |  |
+| cfg.rb:41:6:41:7 | 10 | cfg.rb:42:8:42:8 | 1 |  |
+| cfg.rb:42:3:42:24 | [match] when ... | cfg.rb:42:15:42:24 | self | match |
+| cfg.rb:42:3:42:24 | [no-match] when ... | cfg.rb:43:8:43:8 | 2 | no-match |
+| cfg.rb:42:8:42:8 | 1 | cfg.rb:42:3:42:24 | [match] when ... | match |
+| cfg.rb:42:8:42:8 | 1 | cfg.rb:42:3:42:24 | [no-match] when ... | no-match |
+| cfg.rb:42:10:42:24 | then ... | cfg.rb:41:1:45:3 | case ... |  |
+| cfg.rb:42:15:42:24 | call to puts | cfg.rb:42:10:42:24 | then ... |  |
+| cfg.rb:42:15:42:24 | self | cfg.rb:42:21:42:23 | one |  |
+| cfg.rb:42:20:42:24 | "one" | cfg.rb:42:15:42:24 | call to puts |  |
+| cfg.rb:42:21:42:23 | one | cfg.rb:42:20:42:24 | "one" |  |
+| cfg.rb:43:3:43:31 | [match] when ... | cfg.rb:43:21:43:31 | self | match |
+| cfg.rb:43:3:43:31 | [no-match] when ... | cfg.rb:44:8:44:18 | self | no-match |
+| cfg.rb:43:8:43:8 | 2 | cfg.rb:43:3:43:31 | [match] when ... | match |
+| cfg.rb:43:8:43:8 | 2 | cfg.rb:43:11:43:11 | 3 | no-match |
+| cfg.rb:43:11:43:11 | 3 | cfg.rb:43:3:43:31 | [match] when ... | match |
+| cfg.rb:43:11:43:11 | 3 | cfg.rb:43:14:43:14 | 4 | no-match |
+| cfg.rb:43:14:43:14 | 4 | cfg.rb:43:3:43:31 | [match] when ... | match |
+| cfg.rb:43:14:43:14 | 4 | cfg.rb:43:3:43:31 | [no-match] when ... | no-match |
+| cfg.rb:43:16:43:31 | then ... | cfg.rb:41:1:45:3 | case ... |  |
+| cfg.rb:43:21:43:31 | call to puts | cfg.rb:43:16:43:31 | then ... |  |
+| cfg.rb:43:21:43:31 | self | cfg.rb:43:27:43:30 | some |  |
+| cfg.rb:43:26:43:31 | "some" | cfg.rb:43:21:43:31 | call to puts |  |
+| cfg.rb:43:27:43:30 | some | cfg.rb:43:26:43:31 | "some" |  |
+| cfg.rb:44:3:44:18 | else ... | cfg.rb:41:1:45:3 | case ... |  |
+| cfg.rb:44:8:44:18 | call to puts | cfg.rb:44:3:44:18 | else ... |  |
+| cfg.rb:44:8:44:18 | self | cfg.rb:44:14:44:17 | many |  |
+| cfg.rb:44:13:44:18 | "many" | cfg.rb:44:8:44:18 | call to puts |  |
+| cfg.rb:44:14:44:17 | many | cfg.rb:44:13:44:18 | "many" |  |
+| cfg.rb:47:1:50:3 | case ... | cfg.rb:52:1:52:7 | chained |  |
+| cfg.rb:48:3:48:29 | [false] when ... | cfg.rb:49:8:49:8 | b | false |
+| cfg.rb:48:3:48:29 | [true] when ... | cfg.rb:48:20:48:29 | self | true |
+| cfg.rb:48:8:48:8 | b | cfg.rb:48:13:48:13 | 1 |  |
+| cfg.rb:48:8:48:13 | ... == ... | cfg.rb:48:3:48:29 | [false] when ... | false |
+| cfg.rb:48:8:48:13 | ... == ... | cfg.rb:48:3:48:29 | [true] when ... | true |
+| cfg.rb:48:13:48:13 | 1 | cfg.rb:48:8:48:13 | ... == ... |  |
+| cfg.rb:48:15:48:29 | then ... | cfg.rb:47:1:50:3 | case ... |  |
+| cfg.rb:48:20:48:29 | call to puts | cfg.rb:48:15:48:29 | then ... |  |
+| cfg.rb:48:20:48:29 | self | cfg.rb:48:26:48:28 | one |  |
+| cfg.rb:48:25:48:29 | "one" | cfg.rb:48:20:48:29 | call to puts |  |
+| cfg.rb:48:26:48:28 | one | cfg.rb:48:25:48:29 | "one" |  |
+| cfg.rb:49:3:49:37 | [false] when ... | cfg.rb:47:1:50:3 | case ... | false |
+| cfg.rb:49:3:49:37 | [true] when ... | cfg.rb:49:27:49:37 | self | true |
+| cfg.rb:49:8:49:8 | b | cfg.rb:49:13:49:13 | 0 |  |
+| cfg.rb:49:8:49:13 | ... == ... | cfg.rb:49:3:49:37 | [true] when ... | true |
+| cfg.rb:49:8:49:13 | ... == ... | cfg.rb:49:16:49:16 | b | false |
+| cfg.rb:49:13:49:13 | 0 | cfg.rb:49:8:49:13 | ... == ... |  |
+| cfg.rb:49:16:49:16 | b | cfg.rb:49:20:49:20 | 1 |  |
+| cfg.rb:49:16:49:20 | ... > ... | cfg.rb:49:3:49:37 | [false] when ... | false |
+| cfg.rb:49:16:49:20 | ... > ... | cfg.rb:49:3:49:37 | [true] when ... | true |
+| cfg.rb:49:20:49:20 | 1 | cfg.rb:49:16:49:20 | ... > ... |  |
+| cfg.rb:49:22:49:37 | then ... | cfg.rb:47:1:50:3 | case ... |  |
+| cfg.rb:49:27:49:37 | call to puts | cfg.rb:49:22:49:37 | then ... |  |
+| cfg.rb:49:27:49:37 | self | cfg.rb:49:33:49:36 | some |  |
+| cfg.rb:49:32:49:37 | "some" | cfg.rb:49:27:49:37 | call to puts |  |
+| cfg.rb:49:33:49:36 | some | cfg.rb:49:32:49:37 | "some" |  |
+| cfg.rb:52:1:52:7 | chained | cfg.rb:52:12:52:12 | a |  |
+| cfg.rb:52:1:52:35 | ... = ... | cfg.rb:54:1:54:9 | character |  |
+| cfg.rb:52:11:52:13 | "a" | cfg.rb:52:18:52:24 | chained |  |
+| cfg.rb:52:11:52:35 | "..." "..." | cfg.rb:52:1:52:35 | ... = ... |  |
+| cfg.rb:52:12:52:12 | a | cfg.rb:52:11:52:13 | "a" |  |
+| cfg.rb:52:15:52:26 | "#{...}" | cfg.rb:52:29:52:34 | string |  |
+| cfg.rb:52:16:52:25 | #{...} | cfg.rb:52:15:52:26 | "#{...}" |  |
+| cfg.rb:52:18:52:24 | chained | cfg.rb:52:16:52:25 | #{...} |  |
+| cfg.rb:52:28:52:35 | "string" | cfg.rb:52:11:52:35 | "..." "..." |  |
+| cfg.rb:52:29:52:34 | string | cfg.rb:52:28:52:35 | "string" |  |
+| cfg.rb:54:1:54:9 | character | cfg.rb:54:13:54:17 | ?\\x40 |  |
+| cfg.rb:54:1:54:17 | ... = ... | cfg.rb:58:1:72:3 | Silly |  |
+| cfg.rb:54:13:54:17 | ?\\x40 | cfg.rb:54:1:54:17 | ... = ... |  |
+| cfg.rb:58:1:72:3 | Silly | cfg.rb:58:15:58:20 | Object |  |
+| cfg.rb:58:15:58:20 | Object | cfg.rb:59:3:59:9 | complex |  |
+| cfg.rb:59:3:59:9 | complex | cfg.rb:59:13:59:14 | 10 |  |
+| cfg.rb:59:3:59:17 | ... = ... | cfg.rb:60:3:60:13 | conditional |  |
+| cfg.rb:59:13:59:14 | 10 | cfg.rb:59:16:59:17 | 2i |  |
+| cfg.rb:59:13:59:17 | ... - ... | cfg.rb:59:3:59:17 | ... = ... |  |
+| cfg.rb:59:16:59:17 | 2i | cfg.rb:59:13:59:17 | ... - ... |  |
+| cfg.rb:60:3:60:13 | conditional | cfg.rb:60:17:60:17 | self |  |
+| cfg.rb:60:3:60:40 | ... = ... | cfg.rb:61:3:61:3 | C |  |
+| cfg.rb:60:17:60:17 | call to b | cfg.rb:60:21:60:22 | 10 |  |
+| cfg.rb:60:17:60:17 | self | cfg.rb:60:17:60:17 | call to b |  |
+| cfg.rb:60:17:60:22 | ... < ... | cfg.rb:60:27:60:31 | hello | true |
+| cfg.rb:60:17:60:22 | ... < ... | cfg.rb:60:37:60:39 | bye | false |
+| cfg.rb:60:17:60:40 | ... ? ... : ... | cfg.rb:60:3:60:40 | ... = ... |  |
+| cfg.rb:60:21:60:22 | 10 | cfg.rb:60:17:60:22 | ... < ... |  |
+| cfg.rb:60:26:60:32 | "hello" | cfg.rb:60:17:60:40 | ... ? ... : ... |  |
+| cfg.rb:60:27:60:31 | hello | cfg.rb:60:26:60:32 | "hello" |  |
+| cfg.rb:60:36:60:40 | "bye" | cfg.rb:60:17:60:40 | ... ? ... : ... |  |
+| cfg.rb:60:37:60:39 | bye | cfg.rb:60:36:60:40 | "bye" |  |
+| cfg.rb:61:3:61:3 | C | cfg.rb:61:8:61:15 | constant |  |
+| cfg.rb:61:3:61:16 | ... = ... | cfg.rb:62:17:62:27 | __synth__2 |  |
+| cfg.rb:61:7:61:16 | "constant" | cfg.rb:61:3:61:16 | ... = ... |  |
+| cfg.rb:61:8:61:15 | constant | cfg.rb:61:7:61:16 | "constant" |  |
+| cfg.rb:62:3:62:27 | ... | cfg.rb:63:3:66:5 | pattern |  |
+| cfg.rb:62:4:62:4 | 0 | cfg.rb:62:4:62:4 | call to [] |  |
+| cfg.rb:62:4:62:4 | ... = ... | cfg.rb:62:7:62:12 | __synth__2__1 |  |
+| cfg.rb:62:4:62:4 | __synth__2 | cfg.rb:62:4:62:4 | 0 |  |
+| cfg.rb:62:4:62:4 | call to [] | cfg.rb:62:4:62:4 | ... = ... |  |
+| cfg.rb:62:4:62:4 | x | cfg.rb:62:4:62:4 | __synth__2 |  |
+| cfg.rb:62:7:62:12 | 1 | cfg.rb:62:7:62:12 | call to [] |  |
+| cfg.rb:62:7:62:12 | * ... | cfg.rb:62:7:62:12 | ... = ... |  |
+| cfg.rb:62:7:62:12 | ... | cfg.rb:62:3:62:27 | ... |  |
+| cfg.rb:62:7:62:12 | ... = ... | cfg.rb:62:8:62:8 | y |  |
+| cfg.rb:62:7:62:12 | __synth__2 | cfg.rb:62:7:62:12 | 1 |  |
+| cfg.rb:62:7:62:12 | __synth__2__1 | cfg.rb:62:7:62:12 | __synth__2 |  |
+| cfg.rb:62:7:62:12 | call to [] | cfg.rb:62:7:62:12 | * ... |  |
+| cfg.rb:62:8:62:8 | 0 | cfg.rb:62:8:62:8 | call to [] |  |
+| cfg.rb:62:8:62:8 | ... = ... | cfg.rb:62:11:62:11 | z |  |
+| cfg.rb:62:8:62:8 | __synth__2__1 | cfg.rb:62:8:62:8 | 0 |  |
+| cfg.rb:62:8:62:8 | call to [] | cfg.rb:62:8:62:8 | ... = ... |  |
+| cfg.rb:62:8:62:8 | y | cfg.rb:62:8:62:8 | __synth__2__1 |  |
+| cfg.rb:62:11:62:11 | 1 | cfg.rb:62:11:62:11 | call to [] |  |
+| cfg.rb:62:11:62:11 | ... = ... | cfg.rb:62:7:62:12 | ... |  |
+| cfg.rb:62:11:62:11 | __synth__2__1 | cfg.rb:62:11:62:11 | 1 |  |
+| cfg.rb:62:11:62:11 | call to [] | cfg.rb:62:11:62:11 | ... = ... |  |
+| cfg.rb:62:11:62:11 | z | cfg.rb:62:11:62:11 | __synth__2__1 |  |
+| cfg.rb:62:17:62:27 | * ... | cfg.rb:62:17:62:27 | ... = ... |  |
+| cfg.rb:62:17:62:27 | ... = ... | cfg.rb:62:4:62:4 | x |  |
+| cfg.rb:62:17:62:27 | Array | cfg.rb:62:18:62:18 | 1 |  |
+| cfg.rb:62:17:62:27 | __synth__2 | cfg.rb:62:17:62:27 | Array |  |
+| cfg.rb:62:17:62:27 | call to [] | cfg.rb:62:17:62:27 | * ... |  |
+| cfg.rb:62:18:62:18 | 1 | cfg.rb:62:21:62:26 | Array |  |
+| cfg.rb:62:21:62:26 | Array | cfg.rb:62:22:62:22 | 2 |  |
+| cfg.rb:62:21:62:26 | call to [] | cfg.rb:62:17:62:27 | call to [] |  |
+| cfg.rb:62:22:62:22 | 2 | cfg.rb:62:25:62:25 | 3 |  |
+| cfg.rb:62:25:62:25 | 3 | cfg.rb:62:21:62:26 | call to [] |  |
+| cfg.rb:63:3:66:5 | enter pattern | cfg.rb:63:17:63:17 | a |  |
+| cfg.rb:63:3:66:5 | exit pattern (normal) | cfg.rb:63:3:66:5 | exit pattern |  |
+| cfg.rb:63:3:66:5 | pattern | cfg.rb:67:3:67:7 | items |  |
+| cfg.rb:63:16:63:20 | (..., ...) | cfg.rb:64:5:64:10 | self |  |
+| cfg.rb:63:17:63:17 | a | cfg.rb:63:19:63:19 | b |  |
+| cfg.rb:63:19:63:19 | b | cfg.rb:63:16:63:20 | (..., ...) |  |
+| cfg.rb:64:5:64:10 | call to puts | cfg.rb:65:5:65:10 | self |  |
+| cfg.rb:64:5:64:10 | self | cfg.rb:64:10:64:10 | a |  |
+| cfg.rb:64:10:64:10 | a | cfg.rb:64:5:64:10 | call to puts |  |
+| cfg.rb:65:5:65:10 | call to puts | cfg.rb:63:3:66:5 | exit pattern (normal) |  |
+| cfg.rb:65:5:65:10 | self | cfg.rb:65:10:65:10 | b |  |
+| cfg.rb:65:10:65:10 | b | cfg.rb:65:5:65:10 | call to puts |  |
+| cfg.rb:67:3:67:7 | items | cfg.rb:67:11:67:19 | Array |  |
+| cfg.rb:67:3:67:19 | ... = ... | cfg.rb:68:3:68:15 | self |  |
+| cfg.rb:67:11:67:19 | Array | cfg.rb:67:12:67:12 | 1 |  |
+| cfg.rb:67:11:67:19 | call to [] | cfg.rb:67:3:67:19 | ... = ... |  |
+| cfg.rb:67:12:67:12 | 1 | cfg.rb:67:15:67:15 | 2 |  |
+| cfg.rb:67:15:67:15 | 2 | cfg.rb:67:18:67:18 | 3 |  |
+| cfg.rb:67:18:67:18 | 3 | cfg.rb:67:11:67:19 | call to [] |  |
+| cfg.rb:68:3:68:15 | call to puts | cfg.rb:69:3:71:5 | print |  |
+| cfg.rb:68:3:68:15 | self | cfg.rb:68:8:68:12 | items |  |
+| cfg.rb:68:8:68:12 | items | cfg.rb:68:14:68:14 | 2 |  |
+| cfg.rb:68:8:68:15 | ...[...] | cfg.rb:68:3:68:15 | call to puts |  |
+| cfg.rb:68:14:68:14 | 2 | cfg.rb:68:8:68:15 | ...[...] |  |
+| cfg.rb:69:3:71:5 | enter print | cfg.rb:70:5:70:16 | self |  |
+| cfg.rb:69:3:71:5 | exit print (normal) | cfg.rb:69:3:71:5 | exit print |  |
+| cfg.rb:69:3:71:5 | print | cfg.rb:74:1:74:1 | x |  |
+| cfg.rb:70:5:70:16 | call to puts | cfg.rb:69:3:71:5 | exit print (normal) |  |
+| cfg.rb:70:5:70:16 | self | cfg.rb:70:11:70:15 | silly |  |
+| cfg.rb:70:10:70:16 | "silly" | cfg.rb:70:5:70:16 | call to puts |  |
+| cfg.rb:70:11:70:15 | silly | cfg.rb:70:10:70:16 | "silly" |  |
+| cfg.rb:74:1:74:1 | x | cfg.rb:74:5:74:6 | 42 |  |
+| cfg.rb:74:1:74:6 | ... = ... | cfg.rb:75:4:75:4 | x |  |
+| cfg.rb:74:5:74:6 | 42 | cfg.rb:74:1:74:6 | ... = ... |  |
+| cfg.rb:75:1:75:47 | if ... | cfg.rb:78:3:78:3 | ; |  |
+| cfg.rb:75:4:75:4 | x | cfg.rb:75:8:75:8 | 0 |  |
+| cfg.rb:75:4:75:8 | ... < ... | cfg.rb:75:15:75:15 | 0 | true |
+| cfg.rb:75:4:75:8 | ... < ... | cfg.rb:75:23:75:23 | x | false |
+| cfg.rb:75:8:75:8 | 0 | cfg.rb:75:4:75:8 | ... < ... |  |
+| cfg.rb:75:10:75:15 | then ... | cfg.rb:75:1:75:47 | if ... |  |
+| cfg.rb:75:15:75:15 | 0 | cfg.rb:75:10:75:15 | then ... |  |
+| cfg.rb:75:17:75:43 | elsif ... | cfg.rb:75:1:75:47 | if ... |  |
+| cfg.rb:75:23:75:23 | x | cfg.rb:75:27:75:28 | 10 |  |
+| cfg.rb:75:23:75:28 | ... > ... | cfg.rb:75:35:75:36 | 10 | true |
+| cfg.rb:75:23:75:28 | ... > ... | cfg.rb:75:43:75:43 | x | false |
+| cfg.rb:75:27:75:28 | 10 | cfg.rb:75:23:75:28 | ... > ... |  |
+| cfg.rb:75:30:75:36 | then ... | cfg.rb:75:17:75:43 | elsif ... |  |
+| cfg.rb:75:35:75:36 | 10 | cfg.rb:75:30:75:36 | then ... |  |
+| cfg.rb:75:38:75:43 | else ... | cfg.rb:75:17:75:43 | elsif ... |  |
+| cfg.rb:75:43:75:43 | x | cfg.rb:75:38:75:43 | else ... |  |
+| cfg.rb:78:3:78:3 | ; | cfg.rb:83:3:83:11 | self |  |
+| cfg.rb:82:1:83:11 | else ... | cfg.rb:85:3:85:12 | self |  |
+| cfg.rb:83:3:83:11 | call to puts | cfg.rb:82:1:83:11 | else ... |  |
+| cfg.rb:83:3:83:11 | self | cfg.rb:83:9:83:10 | ok |  |
+| cfg.rb:83:8:83:11 | "ok" | cfg.rb:83:3:83:11 | call to puts |  |
+| cfg.rb:83:9:83:10 | ok | cfg.rb:83:8:83:11 | "ok" |  |
+| cfg.rb:84:1:85:12 | ensure ... | cfg.rb:88:1:88:6 | escape |  |
+| cfg.rb:85:3:85:12 | call to puts | cfg.rb:84:1:85:12 | ensure ... |  |
+| cfg.rb:85:3:85:12 | self | cfg.rb:85:9:85:11 | end |  |
+| cfg.rb:85:8:85:12 | "end" | cfg.rb:85:3:85:12 | call to puts |  |
+| cfg.rb:85:9:85:11 | end | cfg.rb:85:8:85:12 | "end" |  |
+| cfg.rb:88:1:88:6 | escape | cfg.rb:88:11:88:16 | \\u1234 |  |
+| cfg.rb:88:1:88:23 | ... = ... | cfg.rb:90:5:90:5 | x |  |
+| cfg.rb:88:10:88:23 | "\\u1234#{...}\\n" | cfg.rb:88:1:88:23 | ... = ... |  |
+| cfg.rb:88:11:88:16 | \\u1234 | cfg.rb:88:19:88:19 | x |  |
+| cfg.rb:88:17:88:20 | #{...} | cfg.rb:88:21:88:22 | \\n |  |
+| cfg.rb:88:19:88:19 | x | cfg.rb:88:17:88:20 | #{...} |  |
+| cfg.rb:88:21:88:22 | \\n | cfg.rb:88:10:88:23 | "\\u1234#{...}\\n" |  |
+| cfg.rb:90:1:93:3 | ... | cfg.rb:95:1:95:7 | $global |  |
+| cfg.rb:90:1:93:3 | ... = ... | cfg.rb:91:6:91:6 | x |  |
+| cfg.rb:90:1:93:3 | __synth__0__1 | cfg.rb:90:1:93:3 | ... = ... |  |
+| cfg.rb:90:1:93:3 | __synth__0__1 | cfg.rb:90:5:90:5 | x |  |
+| cfg.rb:90:1:93:3 | call to each | cfg.rb:90:1:93:3 | ... |  |
+| cfg.rb:90:1:93:3 | enter { ... } | cfg.rb:90:1:93:3 | __synth__0__1 |  |
+| cfg.rb:90:1:93:3 | exit { ... } (normal) | cfg.rb:90:1:93:3 | exit { ... } |  |
+| cfg.rb:90:1:93:3 | { ... } | cfg.rb:90:1:93:3 | call to each |  |
+| cfg.rb:90:5:90:5 | ... = ... | cfg.rb:90:5:90:5 | if ... |  |
+| cfg.rb:90:5:90:5 | [false] ! ... | cfg.rb:90:5:90:5 | if ... | false |
+| cfg.rb:90:5:90:5 | [true] ! ... | cfg.rb:90:5:90:5 | x | true |
+| cfg.rb:90:5:90:5 | defined? ... | cfg.rb:90:5:90:5 | [false] ! ... | true |
+| cfg.rb:90:5:90:5 | defined? ... | cfg.rb:90:5:90:5 | [true] ! ... | false |
+| cfg.rb:90:5:90:5 | if ... | cfg.rb:90:10:90:26 | Array |  |
+| cfg.rb:90:5:90:5 | nil | cfg.rb:90:5:90:5 | ... = ... |  |
+| cfg.rb:90:5:90:5 | x | cfg.rb:90:1:93:3 | __synth__0__1 |  |
+| cfg.rb:90:5:90:5 | x | cfg.rb:90:5:90:5 | defined? ... |  |
+| cfg.rb:90:5:90:5 | x | cfg.rb:90:5:90:5 | nil |  |
+| cfg.rb:90:10:90:26 | Array | cfg.rb:90:11:90:13 | 1.4 |  |
+| cfg.rb:90:10:90:26 | call to [] | cfg.rb:90:1:93:3 | { ... } |  |
+| cfg.rb:90:11:90:13 | 1.4 | cfg.rb:90:16:90:18 | 2.5 |  |
+| cfg.rb:90:16:90:18 | 2.5 | cfg.rb:90:21:90:25 | 3.4e5 |  |
+| cfg.rb:90:21:90:25 | 3.4e5 | cfg.rb:90:10:90:26 | call to [] |  |
+| cfg.rb:91:3:91:24 | if ... | cfg.rb:92:3:92:8 | self |  |
+| cfg.rb:91:6:91:6 | x | cfg.rb:91:10:91:10 | 3 |  |
+| cfg.rb:91:6:91:10 | ... > ... | cfg.rb:91:3:91:24 | if ... | false |
+| cfg.rb:91:6:91:10 | ... > ... | cfg.rb:91:17:91:20 | next | true |
+| cfg.rb:91:10:91:10 | 3 | cfg.rb:91:6:91:10 | ... > ... |  |
+| cfg.rb:91:17:91:20 | next | cfg.rb:90:1:93:3 | exit { ... } (normal) | next |
+| cfg.rb:92:3:92:8 | call to puts | cfg.rb:90:1:93:3 | exit { ... } (normal) |  |
+| cfg.rb:92:3:92:8 | self | cfg.rb:92:8:92:8 | x |  |
+| cfg.rb:92:8:92:8 | x | cfg.rb:92:3:92:8 | call to puts |  |
+| cfg.rb:95:1:95:7 | $global | cfg.rb:95:11:95:12 | 42 |  |
+| cfg.rb:95:1:95:12 | ... = ... | cfg.rb:97:1:97:4 | map1 |  |
+| cfg.rb:95:11:95:12 | 42 | cfg.rb:95:1:95:12 | ... = ... |  |
+| cfg.rb:97:1:97:4 | map1 | cfg.rb:97:8:97:39 | Hash |  |
+| cfg.rb:97:1:97:39 | ... = ... | cfg.rb:98:1:98:4 | map2 |  |
+| cfg.rb:97:8:97:39 | Hash | cfg.rb:97:11:97:11 | a |  |
+| cfg.rb:97:8:97:39 | call to [] | cfg.rb:97:1:97:39 | ... = ... |  |
+| cfg.rb:97:10:97:12 | "a" | cfg.rb:97:18:97:18 | b |  |
+| cfg.rb:97:10:97:19 | Pair | cfg.rb:97:23:97:23 | c |  |
+| cfg.rb:97:11:97:11 | a | cfg.rb:97:10:97:12 | "a" |  |
+| cfg.rb:97:17:97:19 | "b" | cfg.rb:97:10:97:19 | Pair |  |
+| cfg.rb:97:18:97:18 | b | cfg.rb:97:17:97:19 | "b" |  |
+| cfg.rb:97:22:97:24 | "c" | cfg.rb:97:28:97:28 | d |  |
+| cfg.rb:97:22:97:29 | Pair | cfg.rb:97:32:97:32 | e |  |
+| cfg.rb:97:23:97:23 | c | cfg.rb:97:22:97:24 | "c" |  |
+| cfg.rb:97:27:97:29 | "d" | cfg.rb:97:22:97:29 | Pair |  |
+| cfg.rb:97:28:97:28 | d | cfg.rb:97:27:97:29 | "d" |  |
+| cfg.rb:97:32:97:32 | :e | cfg.rb:97:36:97:36 | f |  |
+| cfg.rb:97:32:97:32 | e | cfg.rb:97:32:97:32 | :e |  |
+| cfg.rb:97:32:97:37 | Pair | cfg.rb:97:8:97:39 | call to [] |  |
+| cfg.rb:97:35:97:37 | "f" | cfg.rb:97:32:97:37 | Pair |  |
+| cfg.rb:97:36:97:36 | f | cfg.rb:97:35:97:37 | "f" |  |
+| cfg.rb:98:1:98:4 | map2 | cfg.rb:98:8:98:36 | Hash |  |
+| cfg.rb:98:1:98:36 | ... = ... | cfg.rb:101:1:104:3 | parameters |  |
+| cfg.rb:98:8:98:36 | Hash | cfg.rb:98:12:98:15 | map1 |  |
+| cfg.rb:98:8:98:36 | call to [] | cfg.rb:98:1:98:36 | ... = ... |  |
+| cfg.rb:98:10:98:15 | ** ... | cfg.rb:98:19:98:19 | x |  |
+| cfg.rb:98:12:98:15 | map1 | cfg.rb:98:10:98:15 | ** ... |  |
+| cfg.rb:98:18:98:20 | "x" | cfg.rb:98:26:98:26 | y |  |
+| cfg.rb:98:18:98:27 | Pair | cfg.rb:98:32:98:35 | map1 |  |
+| cfg.rb:98:19:98:19 | x | cfg.rb:98:18:98:20 | "x" |  |
+| cfg.rb:98:25:98:27 | "y" | cfg.rb:98:18:98:27 | Pair |  |
+| cfg.rb:98:26:98:26 | y | cfg.rb:98:25:98:27 | "y" |  |
+| cfg.rb:98:30:98:35 | ** ... | cfg.rb:98:8:98:36 | call to [] |  |
+| cfg.rb:98:32:98:35 | map1 | cfg.rb:98:30:98:35 | ** ... |  |
+| cfg.rb:101:1:104:3 | enter parameters | cfg.rb:101:16:101:20 | value |  |
+| cfg.rb:101:1:104:3 | exit parameters (normal) | cfg.rb:101:1:104:3 | exit parameters |  |
+| cfg.rb:101:1:104:3 | parameters | cfg.rb:106:1:106:4 | type |  |
+| cfg.rb:101:16:101:20 | value | cfg.rb:101:24:101:25 | 42 | false, no-match, true |
+| cfg.rb:101:16:101:20 | value | cfg.rb:101:28:101:30 | key | match |
+| cfg.rb:101:24:101:25 | 42 | cfg.rb:101:28:101:30 | key |  |
+| cfg.rb:101:28:101:30 | key | cfg.rb:101:36:101:41 | kwargs |  |
+| cfg.rb:101:36:101:41 | kwargs | cfg.rb:102:3:102:12 | self |  |
+| cfg.rb:102:3:102:12 | call to puts | cfg.rb:103:10:103:15 | kwargs |  |
+| cfg.rb:102:3:102:12 | self | cfg.rb:102:8:102:12 | value |  |
+| cfg.rb:102:8:102:12 | value | cfg.rb:102:3:102:12 | call to puts |  |
+| cfg.rb:103:3:103:20 | return | cfg.rb:101:1:104:3 | exit parameters (normal) | return |
+| cfg.rb:103:10:103:15 | kwargs | cfg.rb:103:17:103:19 | key |  |
+| cfg.rb:103:10:103:20 | ...[...] | cfg.rb:103:3:103:20 | return |  |
+| cfg.rb:103:17:103:19 | key | cfg.rb:103:10:103:20 | ...[...] |  |
+| cfg.rb:106:1:106:4 | type | cfg.rb:106:10:106:16 | healthy |  |
+| cfg.rb:106:1:106:17 | ... = ... | cfg.rb:107:1:107:5 | table |  |
+| cfg.rb:106:9:106:17 | "healthy" | cfg.rb:106:1:106:17 | ... = ... |  |
+| cfg.rb:106:10:106:16 | healthy | cfg.rb:106:9:106:17 | "healthy" |  |
+| cfg.rb:107:1:107:5 | table | cfg.rb:107:10:107:13 | food |  |
+| cfg.rb:107:1:107:14 | ... = ... | cfg.rb:108:1:108:12 | self |  |
+| cfg.rb:107:9:107:14 | "food" | cfg.rb:107:1:107:14 | ... = ... |  |
+| cfg.rb:107:10:107:13 | food | cfg.rb:107:9:107:14 | "food" |  |
+| cfg.rb:108:1:108:12 | call to puts | cfg.rb:113:14:113:14 | b |  |
+| cfg.rb:108:1:108:12 | self | cfg.rb:108:13:109:14 | \nSELECT * FROM  |  |
+| cfg.rb:108:6:108:12 | ( ... ) | cfg.rb:108:1:108:12 | call to puts |  |
+| cfg.rb:108:7:108:11 | <<SQL | cfg.rb:108:6:108:12 | ( ... ) |  |
+| cfg.rb:108:13:109:14 | \nSELECT * FROM  | cfg.rb:109:17:109:21 | table |  |
+| cfg.rb:109:15:109:22 | #{...} | cfg.rb:109:23:109:23 |   |  |
+| cfg.rb:109:17:109:21 | table | cfg.rb:109:15:109:22 | #{...} |  |
+| cfg.rb:109:23:109:23 |   | cfg.rb:109:24:109:25 | \\n |  |
+| cfg.rb:109:24:109:25 | \\n | cfg.rb:109:26:110:6 | \nWHERE  |  |
+| cfg.rb:109:26:110:6 | \nWHERE  | cfg.rb:110:9:110:12 | type |  |
+| cfg.rb:110:7:110:13 | #{...} | cfg.rb:110:14:110:21 |  = true  |  |
+| cfg.rb:110:9:110:12 | type | cfg.rb:110:7:110:13 | #{...} |  |
+| cfg.rb:110:14:110:21 |  = true  | cfg.rb:110:22:110:23 | \\n |  |
+| cfg.rb:110:22:110:23 | \\n | cfg.rb:110:24:110:24 | \n |  |
+| cfg.rb:110:24:110:24 | \n | cfg.rb:108:7:108:11 | <<SQL |  |
+| cfg.rb:113:1:113:9 | call to puts | cfg.rb:113:1:113:19 | ... if ... |  |
+| cfg.rb:113:1:113:9 | self | cfg.rb:113:7:113:8 | hi |  |
+| cfg.rb:113:1:113:19 | ... if ... | cfg.rb:115:1:118:3 | C |  |
+| cfg.rb:113:6:113:9 | "hi" | cfg.rb:113:1:113:9 | call to puts |  |
+| cfg.rb:113:7:113:8 | hi | cfg.rb:113:6:113:9 | "hi" |  |
+| cfg.rb:113:14:113:14 | b | cfg.rb:113:18:113:19 | 10 |  |
+| cfg.rb:113:14:113:19 | ... > ... | cfg.rb:113:1:113:9 | self | true |
+| cfg.rb:113:14:113:19 | ... > ... | cfg.rb:113:1:113:19 | ... if ... | false |
+| cfg.rb:113:18:113:19 | 10 | cfg.rb:113:14:113:19 | ... > ... |  |
+| cfg.rb:115:1:118:3 | C | cfg.rb:116:3:116:8 | self |  |
+| cfg.rb:116:3:116:8 | @field | cfg.rb:116:12:116:13 | 42 |  |
+| cfg.rb:116:3:116:8 | self | cfg.rb:116:3:116:8 | @field |  |
+| cfg.rb:116:3:116:13 | ... = ... | cfg.rb:117:3:117:16 | @@static_field |  |
+| cfg.rb:116:12:116:13 | 42 | cfg.rb:116:3:116:13 | ... = ... |  |
+| cfg.rb:117:3:117:16 | @@static_field | cfg.rb:117:20:117:21 | 10 |  |
+| cfg.rb:117:3:117:21 | ... = ... | cfg.rb:120:1:120:4 | swap |  |
+| cfg.rb:117:20:117:21 | 10 | cfg.rb:117:3:117:21 | ... = ... |  |
+| cfg.rb:120:1:120:4 | swap | cfg.rb:120:8:120:28 | -> { ... } |  |
+| cfg.rb:120:1:120:28 | ... = ... | cfg.rb:122:1:131:3 | M |  |
+| cfg.rb:120:8:120:28 | -> { ... } | cfg.rb:120:1:120:28 | ... = ... |  |
+| cfg.rb:120:8:120:28 | enter -> { ... } | cfg.rb:120:12:120:12 | x |  |
+| cfg.rb:120:8:120:28 | exit -> { ... } (normal) | cfg.rb:120:8:120:28 | exit -> { ... } |  |
+| cfg.rb:120:11:120:16 | (..., ...) | cfg.rb:120:21:120:26 | Array |  |
+| cfg.rb:120:12:120:12 | x | cfg.rb:120:15:120:15 | y |  |
+| cfg.rb:120:15:120:15 | y | cfg.rb:120:11:120:16 | (..., ...) |  |
+| cfg.rb:120:21:120:26 | Array | cfg.rb:120:22:120:22 | y |  |
+| cfg.rb:120:21:120:26 | call to [] | cfg.rb:120:8:120:28 | exit -> { ... } (normal) |  |
+| cfg.rb:120:22:120:22 | y | cfg.rb:120:25:120:25 | x |  |
+| cfg.rb:120:25:120:25 | x | cfg.rb:120:21:120:26 | call to [] |  |
+| cfg.rb:122:1:131:3 | M | cfg.rb:123:2:123:8 | nothing |  |
+| cfg.rb:123:2:123:8 | nothing | cfg.rb:123:12:123:14 | nil |  |
+| cfg.rb:123:2:123:14 | ... = ... | cfg.rb:124:2:124:5 | some |  |
+| cfg.rb:123:12:123:14 | nil | cfg.rb:123:2:123:14 | ... = ... |  |
+| cfg.rb:124:2:124:5 | some | cfg.rb:124:9:124:9 | 2 |  |
+| cfg.rb:124:2:124:9 | ... = ... | cfg.rb:125:2:125:5 | some |  |
+| cfg.rb:124:9:124:9 | 2 | cfg.rb:124:2:124:9 | ... = ... |  |
+| cfg.rb:125:2:125:5 | some | cfg.rb:125:2:125:5 | some |  |
+| cfg.rb:125:2:125:5 | some | cfg.rb:125:10:125:11 | 10 |  |
+| cfg.rb:125:2:125:11 | ... = ... | cfg.rb:126:2:126:5 | last |  |
+| cfg.rb:125:7:125:8 | ... + ... | cfg.rb:125:2:125:11 | ... = ... |  |
+| cfg.rb:125:10:125:11 | 10 | cfg.rb:125:7:125:8 | ... + ... |  |
+| cfg.rb:126:2:126:5 | last | cfg.rb:126:10:126:10 | 2 |  |
+| cfg.rb:126:2:126:17 | ... = ... | cfg.rb:127:2:127:6 | range |  |
+| cfg.rb:126:9:126:17 | ( ... ) | cfg.rb:126:2:126:17 | ... = ... |  |
+| cfg.rb:126:10:126:10 | 2 | cfg.rb:126:13:126:13 | 4 |  |
+| cfg.rb:126:13:126:13 | 4 | cfg.rb:126:16:126:16 | 7 |  |
+| cfg.rb:126:16:126:16 | 7 | cfg.rb:126:9:126:17 | ( ... ) |  |
+| cfg.rb:127:2:127:6 | range | cfg.rb:127:10:127:10 | 0 |  |
+| cfg.rb:127:2:127:13 | ... = ... | cfg.rb:128:2:128:5 | half |  |
+| cfg.rb:127:10:127:10 | 0 | cfg.rb:127:13:127:13 | 9 |  |
+| cfg.rb:127:10:127:13 | _ .. _ | cfg.rb:127:2:127:13 | ... = ... |  |
+| cfg.rb:127:13:127:13 | 9 | cfg.rb:127:10:127:13 | _ .. _ |  |
+| cfg.rb:128:2:128:5 | half | cfg.rb:128:9:128:9 | 1 |  |
+| cfg.rb:128:2:128:19 | ... = ... | cfg.rb:129:2:129:6 | regex |  |
+| cfg.rb:128:9:128:9 | 1 | cfg.rb:128:11:128:12 | 3r |  |
+| cfg.rb:128:9:128:12 | ... / ... | cfg.rb:128:16:128:16 | 1 |  |
+| cfg.rb:128:9:128:19 | ... + ... | cfg.rb:128:2:128:19 | ... = ... |  |
+| cfg.rb:128:11:128:12 | 3r | cfg.rb:128:9:128:12 | ... / ... |  |
+| cfg.rb:128:16:128:16 | 1 | cfg.rb:128:18:128:19 | 6r |  |
+| cfg.rb:128:16:128:19 | ... / ... | cfg.rb:128:9:128:19 | ... + ... |  |
+| cfg.rb:128:18:128:19 | 6r | cfg.rb:128:16:128:19 | ... / ... |  |
+| cfg.rb:129:2:129:6 | regex | cfg.rb:129:11:129:15 | hello |  |
+| cfg.rb:129:2:129:29 | ... = ... | cfg.rb:130:2:130:9 | Constant |  |
+| cfg.rb:129:10:129:29 | /hello\\s+[#{...}]/ | cfg.rb:129:2:129:29 | ... = ... |  |
+| cfg.rb:129:11:129:15 | hello | cfg.rb:129:16:129:17 | \\s |  |
+| cfg.rb:129:16:129:17 | \\s | cfg.rb:129:18:129:19 | +[ |  |
+| cfg.rb:129:18:129:19 | +[ | cfg.rb:129:22:129:26 | range |  |
+| cfg.rb:129:20:129:27 | #{...} | cfg.rb:129:28:129:28 | ] |  |
+| cfg.rb:129:22:129:26 | range | cfg.rb:129:20:129:27 | #{...} |  |
+| cfg.rb:129:28:129:28 | ] | cfg.rb:129:10:129:29 | /hello\\s+[#{...}]/ |  |
+| cfg.rb:130:2:130:9 | Constant | cfg.rb:130:13:130:13 | 5 |  |
+| cfg.rb:130:2:130:13 | ... = ... | cfg.rb:133:1:133:21 | EmptyClass |  |
+| cfg.rb:130:13:130:13 | 5 | cfg.rb:130:2:130:13 | ... = ... |  |
+| cfg.rb:133:1:133:21 | EmptyClass | cfg.rb:134:1:134:23 | EmptyModule |  |
+| cfg.rb:134:1:134:23 | EmptyModule | cfg.rb:136:1:136:1 | 1 |  |
+| cfg.rb:136:1:136:1 | 1 | cfg.rb:136:3:136:3 | 0 |  |
+| cfg.rb:136:1:136:3 | ... / ... | cfg.rb:136:1:136:29 | ... rescue ... |  |
+| cfg.rb:136:1:136:3 | ... / ... | cfg.rb:136:12:136:29 | self | raise |
+| cfg.rb:136:1:136:29 | ... rescue ... | cfg.rb:138:17:138:23 | __synth__2 |  |
+| cfg.rb:136:3:136:3 | 0 | cfg.rb:136:1:136:3 | ... / ... |  |
+| cfg.rb:136:12:136:29 | call to puts | cfg.rb:136:1:136:29 | ... rescue ... |  |
+| cfg.rb:136:12:136:29 | self | cfg.rb:136:18:136:28 | div by zero |  |
+| cfg.rb:136:17:136:29 | "div by zero" | cfg.rb:136:12:136:29 | call to puts |  |
+| cfg.rb:136:18:136:28 | div by zero | cfg.rb:136:17:136:29 | "div by zero" |  |
+| cfg.rb:138:1:138:23 | ... | cfg.rb:140:1:140:1 | M |  |
+| cfg.rb:138:3:138:6 | 0 | cfg.rb:138:3:138:6 | -2 |  |
+| cfg.rb:138:3:138:6 | -2 | cfg.rb:138:3:138:6 | _ .. _ |  |
+| cfg.rb:138:3:138:6 | ... = ... | cfg.rb:138:9:138:12 | last |  |
+| cfg.rb:138:3:138:6 | _ .. _ | cfg.rb:138:3:138:6 | call to [] |  |
+| cfg.rb:138:3:138:6 | __synth__2 | cfg.rb:138:3:138:6 | 0 |  |
+| cfg.rb:138:3:138:6 | call to [] | cfg.rb:138:3:138:6 | ... = ... |  |
+| cfg.rb:138:3:138:6 | init | cfg.rb:138:3:138:6 | __synth__2 |  |
+| cfg.rb:138:9:138:12 | -1 | cfg.rb:138:9:138:12 | call to [] |  |
+| cfg.rb:138:9:138:12 | ... = ... | cfg.rb:138:1:138:23 | ... |  |
+| cfg.rb:138:9:138:12 | __synth__2 | cfg.rb:138:9:138:12 | -1 |  |
+| cfg.rb:138:9:138:12 | call to [] | cfg.rb:138:9:138:12 | ... = ... |  |
+| cfg.rb:138:9:138:12 | last | cfg.rb:138:9:138:12 | __synth__2 |  |
+| cfg.rb:138:17:138:17 | 1 | cfg.rb:138:20:138:20 | 2 |  |
+| cfg.rb:138:17:138:23 | * ... | cfg.rb:138:17:138:23 | ... = ... |  |
+| cfg.rb:138:17:138:23 | ... = ... | cfg.rb:138:3:138:6 | init |  |
+| cfg.rb:138:17:138:23 | ..., ... | cfg.rb:138:17:138:23 | * ... |  |
+| cfg.rb:138:17:138:23 | __synth__2 | cfg.rb:138:17:138:17 | 1 |  |
+| cfg.rb:138:20:138:20 | 2 | cfg.rb:138:23:138:23 | 3 |  |
+| cfg.rb:138:23:138:23 | 3 | cfg.rb:138:17:138:23 | ..., ... |  |
+| cfg.rb:140:1:140:1 | M | cfg.rb:140:1:140:11 | Constant |  |
+| cfg.rb:140:1:140:11 | Constant | cfg.rb:141:1:141:1 | M |  |
+| cfg.rb:141:1:141:1 | M | cfg.rb:141:1:141:8 | call to itself |  |
+| cfg.rb:141:1:141:8 | call to itself | cfg.rb:141:1:141:18 | Constant |  |
+| cfg.rb:141:1:141:18 | Constant | cfg.rb:143:10:143:14 | Silly |  |
+| cfg.rb:143:1:149:3 | class << ... | cfg.rb:151:1:151:5 | silly |  |
+| cfg.rb:143:10:143:14 | Silly | cfg.rb:143:10:143:21 | call to itself |  |
+| cfg.rb:143:10:143:21 | call to itself | cfg.rb:144:3:144:19 | setter= |  |
+| cfg.rb:144:3:144:19 | setter= | cfg.rb:145:3:148:5 | print |  |
+| cfg.rb:145:3:148:5 | enter print | cfg.rb:146:5:146:20 | self |  |
+| cfg.rb:145:3:148:5 | exit print (normal) | cfg.rb:145:3:148:5 | exit print |  |
+| cfg.rb:145:3:148:5 | print | cfg.rb:143:1:149:3 | class << ... |  |
+| cfg.rb:146:5:146:20 | call to puts | cfg.rb:147:5:147:22 | self |  |
+| cfg.rb:146:5:146:20 | self | cfg.rb:146:11:146:19 | singleton |  |
+| cfg.rb:146:10:146:20 | "singleton" | cfg.rb:146:5:146:20 | call to puts |  |
+| cfg.rb:146:11:146:19 | singleton | cfg.rb:146:10:146:20 | "singleton" |  |
+| cfg.rb:147:5:147:22 | call to puts | cfg.rb:145:3:148:5 | exit print (normal) |  |
+| cfg.rb:147:5:147:22 | self | cfg.rb:147:10:147:14 | super call to print |  |
+| cfg.rb:147:10:147:14 | super call to print | cfg.rb:147:10:147:22 | call to print |  |
+| cfg.rb:147:10:147:22 | call to print | cfg.rb:147:5:147:22 | call to puts |  |
+| cfg.rb:151:1:151:5 | silly | cfg.rb:151:9:151:13 | Silly |  |
+| cfg.rb:151:1:151:17 | ... = ... | cfg.rb:152:5:152:9 | silly |  |
+| cfg.rb:151:9:151:13 | Silly | cfg.rb:151:9:151:17 | call to new |  |
+| cfg.rb:151:9:151:17 | call to new | cfg.rb:151:1:151:17 | ... = ... |  |
+| cfg.rb:152:1:154:3 | enter method | cfg.rb:152:19:152:19 | x |  |
+| cfg.rb:152:1:154:3 | exit method (normal) | cfg.rb:152:1:154:3 | exit method |  |
+| cfg.rb:152:1:154:3 | method | cfg.rb:156:1:156:28 | two_parameters |  |
+| cfg.rb:152:5:152:9 | silly | cfg.rb:152:1:154:3 | method |  |
+| cfg.rb:152:19:152:19 | x | cfg.rb:153:3:153:8 | self |  |
+| cfg.rb:153:3:153:8 | call to puts | cfg.rb:152:1:154:3 | exit method (normal) |  |
+| cfg.rb:153:3:153:8 | self | cfg.rb:153:8:153:8 | x |  |
+| cfg.rb:153:8:153:8 | x | cfg.rb:153:3:153:8 | call to puts |  |
+| cfg.rb:156:1:156:28 | enter two_parameters | cfg.rb:156:21:156:21 | a |  |
+| cfg.rb:156:1:156:28 | exit two_parameters (normal) | cfg.rb:156:1:156:28 | exit two_parameters |  |
+| cfg.rb:156:1:156:28 | two_parameters | cfg.rb:158:1:158:22 | self |  |
+| cfg.rb:156:21:156:21 | a | cfg.rb:156:23:156:23 | b |  |
+| cfg.rb:156:23:156:23 | b | cfg.rb:156:1:156:28 | exit two_parameters (normal) |  |
+| cfg.rb:158:1:158:22 | call to two_parameters | cfg.rb:160:1:160:10 | scriptfile |  |
+| cfg.rb:158:1:158:22 | self | cfg.rb:158:17:158:21 | Array |  |
+| cfg.rb:158:16:158:21 | * ... | cfg.rb:158:1:158:22 | call to two_parameters |  |
+| cfg.rb:158:17:158:21 | Array | cfg.rb:158:18:158:18 | 1 |  |
+| cfg.rb:158:17:158:21 | call to [] | cfg.rb:158:16:158:21 | * ... |  |
+| cfg.rb:158:18:158:18 | 1 | cfg.rb:158:20:158:20 | 2 |  |
+| cfg.rb:158:20:158:20 | 2 | cfg.rb:158:17:158:21 | call to [] |  |
+| cfg.rb:160:1:160:10 | scriptfile | cfg.rb:160:15:160:19 | cat " |  |
+| cfg.rb:160:1:160:32 | ... = ... | cfg.rb:162:1:162:6 | symbol |  |
+| cfg.rb:160:14:160:32 | `cat "#{...}"` | cfg.rb:160:1:160:32 | ... = ... |  |
+| cfg.rb:160:15:160:19 | cat " | cfg.rb:160:22:160:29 | self |  |
+| cfg.rb:160:20:160:30 | #{...} | cfg.rb:160:31:160:31 | " |  |
+| cfg.rb:160:22:160:29 | call to __FILE__ | cfg.rb:160:20:160:30 | #{...} |  |
+| cfg.rb:160:22:160:29 | self | cfg.rb:160:22:160:29 | call to __FILE__ |  |
+| cfg.rb:160:31:160:31 | " | cfg.rb:160:14:160:32 | `cat "#{...}"` |  |
+| cfg.rb:162:1:162:6 | symbol | cfg.rb:162:10:162:15 | hello |  |
+| cfg.rb:162:1:162:15 | ... = ... | cfg.rb:164:1:164:16 | delimited_symbol |  |
+| cfg.rb:162:10:162:15 | :hello | cfg.rb:162:1:162:15 | ... = ... |  |
+| cfg.rb:162:10:162:15 | hello | cfg.rb:162:10:162:15 | :hello |  |
+| cfg.rb:164:1:164:16 | delimited_symbol | cfg.rb:164:22:164:29 | goodbye- |  |
+| cfg.rb:164:1:164:42 | ... = ... | cfg.rb:166:1:166:1 | x |  |
+| cfg.rb:164:20:164:42 | :"goodbye-#{...}" | cfg.rb:164:1:164:42 | ... = ... |  |
+| cfg.rb:164:22:164:29 | goodbye- | cfg.rb:164:33:164:34 | 12 |  |
+| cfg.rb:164:30:164:41 | #{...} | cfg.rb:164:20:164:42 | :"goodbye-#{...}" |  |
+| cfg.rb:164:33:164:34 | 12 | cfg.rb:164:38:164:39 | 13 |  |
+| cfg.rb:164:33:164:39 | ... + ... | cfg.rb:164:30:164:41 | #{...} |  |
+| cfg.rb:164:38:164:39 | 13 | cfg.rb:164:33:164:39 | ... + ... |  |
+| cfg.rb:166:1:166:1 | x | cfg.rb:166:5:166:8 | true |  |
+| cfg.rb:166:1:166:8 | ... = ... | cfg.rb:167:1:167:1 | x |  |
+| cfg.rb:166:5:166:8 | true | cfg.rb:166:1:166:8 | ... = ... |  |
+| cfg.rb:167:1:167:1 | x | cfg.rb:167:7:167:10 | true |  |
+| cfg.rb:167:1:167:10 | ... = ... | cfg.rb:168:1:168:1 | x |  |
+| cfg.rb:167:5:167:10 | ! ... | cfg.rb:167:1:167:10 | ... = ... |  |
+| cfg.rb:167:7:167:10 | true | cfg.rb:167:5:167:10 | ! ... |  |
+| cfg.rb:168:1:168:1 | x | cfg.rb:168:7:168:8 | 42 |  |
+| cfg.rb:168:1:168:8 | ... = ... | cfg.rb:170:1:170:20 | undef ... |  |
+| cfg.rb:168:5:168:8 | - ... | cfg.rb:168:1:168:8 | ... = ... |  |
+| cfg.rb:168:7:168:8 | 42 | cfg.rb:168:5:168:8 | - ... |  |
+| cfg.rb:170:1:170:20 | undef ... | cfg.rb:170:7:170:20 | two_parameters |  |
+| cfg.rb:170:7:170:20 | two_parameters | cfg.rb:172:8:172:8 | x |  |
+| cfg.rb:172:1:172:49 | unless ... | cfg.rb:174:18:174:18 | x |  |
+| cfg.rb:172:8:172:8 | x | cfg.rb:172:13:172:14 | 10 |  |
+| cfg.rb:172:8:172:14 | ... == ... | cfg.rb:172:21:172:29 | self | false |
+| cfg.rb:172:8:172:14 | ... == ... | cfg.rb:172:36:172:45 | self | true |
+| cfg.rb:172:13:172:14 | 10 | cfg.rb:172:8:172:14 | ... == ... |  |
+| cfg.rb:172:16:172:29 | then ... | cfg.rb:172:1:172:49 | unless ... |  |
+| cfg.rb:172:21:172:29 | call to puts | cfg.rb:172:16:172:29 | then ... |  |
+| cfg.rb:172:21:172:29 | self | cfg.rb:172:27:172:28 | hi |  |
+| cfg.rb:172:26:172:29 | "hi" | cfg.rb:172:21:172:29 | call to puts |  |
+| cfg.rb:172:27:172:28 | hi | cfg.rb:172:26:172:29 | "hi" |  |
+| cfg.rb:172:31:172:45 | else ... | cfg.rb:172:1:172:49 | unless ... |  |
+| cfg.rb:172:36:172:45 | call to puts | cfg.rb:172:31:172:45 | else ... |  |
+| cfg.rb:172:36:172:45 | self | cfg.rb:172:42:172:44 | bye |  |
+| cfg.rb:172:41:172:45 | "bye" | cfg.rb:172:36:172:45 | call to puts |  |
+| cfg.rb:172:42:172:44 | bye | cfg.rb:172:41:172:45 | "bye" |  |
+| cfg.rb:174:1:174:9 | call to puts | cfg.rb:174:1:174:23 | ... unless ... |  |
+| cfg.rb:174:1:174:9 | self | cfg.rb:174:7:174:8 | hi |  |
+| cfg.rb:174:1:174:23 | ... unless ... | cfg.rb:176:7:176:7 | x |  |
+| cfg.rb:174:6:174:9 | "hi" | cfg.rb:174:1:174:9 | call to puts |  |
+| cfg.rb:174:7:174:8 | hi | cfg.rb:174:6:174:9 | "hi" |  |
+| cfg.rb:174:18:174:18 | x | cfg.rb:174:23:174:23 | 0 |  |
+| cfg.rb:174:18:174:23 | ... == ... | cfg.rb:174:1:174:9 | self | false |
+| cfg.rb:174:18:174:23 | ... == ... | cfg.rb:174:1:174:23 | ... unless ... | true |
+| cfg.rb:174:23:174:23 | 0 | cfg.rb:174:18:174:23 | ... == ... |  |
+| cfg.rb:176:1:176:41 | until ... | cfg.rb:178:1:178:1 | i |  |
+| cfg.rb:176:7:176:7 | x | cfg.rb:176:11:176:12 | 10 |  |
+| cfg.rb:176:7:176:12 | ... > ... | cfg.rb:176:1:176:41 | until ... | true |
+| cfg.rb:176:7:176:12 | ... > ... | cfg.rb:176:17:176:17 | x | false |
+| cfg.rb:176:11:176:12 | 10 | cfg.rb:176:7:176:12 | ... > ... |  |
+| cfg.rb:176:14:176:41 | do ... | cfg.rb:176:7:176:7 | x |  |
+| cfg.rb:176:17:176:17 | x | cfg.rb:176:17:176:17 | x |  |
+| cfg.rb:176:17:176:17 | x | cfg.rb:176:22:176:23 | 10 |  |
+| cfg.rb:176:17:176:23 | ... = ... | cfg.rb:176:26:176:37 | self |  |
+| cfg.rb:176:19:176:20 | ... + ... | cfg.rb:176:17:176:23 | ... = ... |  |
+| cfg.rb:176:22:176:23 | 10 | cfg.rb:176:19:176:20 | ... + ... |  |
+| cfg.rb:176:26:176:37 | call to puts | cfg.rb:176:14:176:41 | do ... |  |
+| cfg.rb:176:26:176:37 | self | cfg.rb:176:32:176:36 | hello |  |
+| cfg.rb:176:31:176:37 | "hello" | cfg.rb:176:26:176:37 | call to puts |  |
+| cfg.rb:176:32:176:36 | hello | cfg.rb:176:31:176:37 | "hello" |  |
+| cfg.rb:178:1:178:1 | i | cfg.rb:178:5:178:5 | 0 |  |
+| cfg.rb:178:1:178:5 | ... = ... | cfg.rb:179:30:179:30 | i |  |
+| cfg.rb:178:5:178:5 | 0 | cfg.rb:178:1:178:5 | ... = ... |  |
+| cfg.rb:179:1:179:22 | ( ... ) | cfg.rb:179:30:179:30 | i |  |
+| cfg.rb:179:1:179:36 | ... until ... | cfg.rb:181:1:181:1 | x |  |
+| cfg.rb:179:2:179:13 | call to puts | cfg.rb:179:16:179:16 | i |  |
+| cfg.rb:179:2:179:13 | self | cfg.rb:179:8:179:12 | hello |  |
+| cfg.rb:179:7:179:13 | "hello" | cfg.rb:179:2:179:13 | call to puts |  |
+| cfg.rb:179:8:179:12 | hello | cfg.rb:179:7:179:13 | "hello" |  |
+| cfg.rb:179:16:179:16 | i | cfg.rb:179:16:179:16 | i |  |
+| cfg.rb:179:16:179:16 | i | cfg.rb:179:21:179:21 | 1 |  |
+| cfg.rb:179:16:179:21 | ... = ... | cfg.rb:179:1:179:22 | ( ... ) |  |
+| cfg.rb:179:18:179:19 | ... + ... | cfg.rb:179:16:179:21 | ... = ... |  |
+| cfg.rb:179:21:179:21 | 1 | cfg.rb:179:18:179:19 | ... + ... |  |
+| cfg.rb:179:30:179:30 | i | cfg.rb:179:35:179:36 | 10 |  |
+| cfg.rb:179:30:179:36 | ... == ... | cfg.rb:179:1:179:36 | ... until ... | true |
+| cfg.rb:179:30:179:36 | ... == ... | cfg.rb:179:2:179:13 | self | false |
+| cfg.rb:179:35:179:36 | 10 | cfg.rb:179:30:179:36 | ... == ... |  |
+| cfg.rb:181:1:181:1 | x | cfg.rb:181:5:181:5 | 0 |  |
+| cfg.rb:181:1:181:5 | ... = ... | cfg.rb:182:7:182:7 | x |  |
+| cfg.rb:181:5:181:5 | 0 | cfg.rb:181:1:181:5 | ... = ... |  |
+| cfg.rb:182:1:186:3 | while ... | cfg.rb:188:30:188:30 | i |  |
+| cfg.rb:182:7:182:7 | x | cfg.rb:182:11:182:12 | 10 |  |
+| cfg.rb:182:7:182:12 | ... < ... | cfg.rb:182:1:186:3 | while ... | false |
+| cfg.rb:182:7:182:12 | ... < ... | cfg.rb:183:3:183:3 | x | true |
+| cfg.rb:182:11:182:12 | 10 | cfg.rb:182:7:182:12 | ... < ... |  |
+| cfg.rb:182:14:186:3 | do ... | cfg.rb:182:7:182:7 | x |  |
+| cfg.rb:183:3:183:3 | x | cfg.rb:183:3:183:3 | x |  |
+| cfg.rb:183:3:183:3 | x | cfg.rb:183:8:183:8 | 1 |  |
+| cfg.rb:183:3:183:8 | ... = ... | cfg.rb:184:6:184:6 | x |  |
+| cfg.rb:183:5:183:6 | ... + ... | cfg.rb:183:3:183:8 | ... = ... |  |
+| cfg.rb:183:8:183:8 | 1 | cfg.rb:183:5:183:6 | ... + ... |  |
+| cfg.rb:184:3:184:25 | if ... | cfg.rb:185:3:185:8 | self |  |
+| cfg.rb:184:6:184:6 | x | cfg.rb:184:11:184:11 | 5 |  |
+| cfg.rb:184:6:184:11 | ... == ... | cfg.rb:184:3:184:25 | if ... | false |
+| cfg.rb:184:6:184:11 | ... == ... | cfg.rb:184:18:184:21 | redo | true |
+| cfg.rb:184:11:184:11 | 5 | cfg.rb:184:6:184:11 | ... == ... |  |
+| cfg.rb:184:18:184:21 | redo | cfg.rb:183:3:183:3 | x | redo |
+| cfg.rb:185:3:185:8 | call to puts | cfg.rb:182:14:186:3 | do ... |  |
+| cfg.rb:185:3:185:8 | self | cfg.rb:185:8:185:8 | x |  |
+| cfg.rb:185:8:185:8 | x | cfg.rb:185:3:185:8 | call to puts |  |
+| cfg.rb:188:1:188:22 | ( ... ) | cfg.rb:188:30:188:30 | i |  |
+| cfg.rb:188:1:188:35 | ... while ... | cfg.rb:190:1:192:3 | run_block |  |
+| cfg.rb:188:2:188:13 | call to puts | cfg.rb:188:16:188:16 | i |  |
+| cfg.rb:188:2:188:13 | self | cfg.rb:188:8:188:12 | hello |  |
+| cfg.rb:188:7:188:13 | "hello" | cfg.rb:188:2:188:13 | call to puts |  |
+| cfg.rb:188:8:188:12 | hello | cfg.rb:188:7:188:13 | "hello" |  |
+| cfg.rb:188:16:188:16 | i | cfg.rb:188:16:188:16 | i |  |
+| cfg.rb:188:16:188:16 | i | cfg.rb:188:21:188:21 | 1 |  |
+| cfg.rb:188:16:188:21 | ... = ... | cfg.rb:188:1:188:22 | ( ... ) |  |
+| cfg.rb:188:18:188:19 | ... - ... | cfg.rb:188:16:188:21 | ... = ... |  |
+| cfg.rb:188:21:188:21 | 1 | cfg.rb:188:18:188:19 | ... - ... |  |
+| cfg.rb:188:30:188:30 | i | cfg.rb:188:35:188:35 | 0 |  |
+| cfg.rb:188:30:188:35 | ... != ... | cfg.rb:188:1:188:35 | ... while ... | false |
+| cfg.rb:188:30:188:35 | ... != ... | cfg.rb:188:2:188:13 | self | true |
+| cfg.rb:188:35:188:35 | 0 | cfg.rb:188:30:188:35 | ... != ... |  |
+| cfg.rb:190:1:192:3 | enter run_block | cfg.rb:191:9:191:10 | 42 |  |
+| cfg.rb:190:1:192:3 | exit run_block (normal) | cfg.rb:190:1:192:3 | exit run_block |  |
+| cfg.rb:190:1:192:3 | run_block | cfg.rb:194:1:194:23 | self |  |
+| cfg.rb:191:3:191:10 | yield ... | cfg.rb:190:1:192:3 | exit run_block (normal) |  |
+| cfg.rb:191:9:191:10 | 42 | cfg.rb:191:3:191:10 | yield ... |  |
+| cfg.rb:194:1:194:23 | call to run_block | cfg.rb:196:1:198:3 | forward_param |  |
+| cfg.rb:194:1:194:23 | self | cfg.rb:194:11:194:23 | { ... } |  |
+| cfg.rb:194:11:194:23 | enter { ... } | cfg.rb:194:14:194:14 | x |  |
+| cfg.rb:194:11:194:23 | exit { ... } (normal) | cfg.rb:194:11:194:23 | exit { ... } |  |
+| cfg.rb:194:11:194:23 | { ... } | cfg.rb:194:1:194:23 | call to run_block |  |
+| cfg.rb:194:14:194:14 | x | cfg.rb:194:16:194:21 | self |  |
+| cfg.rb:194:16:194:21 | call to puts | cfg.rb:194:11:194:23 | exit { ... } (normal) |  |
+| cfg.rb:194:16:194:21 | self | cfg.rb:194:21:194:21 | x |  |
+| cfg.rb:194:21:194:21 | x | cfg.rb:194:16:194:21 | call to puts |  |
+| cfg.rb:196:1:198:3 | enter forward_param | cfg.rb:196:19:196:19 | a |  |
+| cfg.rb:196:1:198:3 | exit forward_param (normal) | cfg.rb:196:1:198:3 | exit forward_param |  |
+| cfg.rb:196:1:198:3 | forward_param | cfg.rb:200:1:200:1 | 1 |  |
+| cfg.rb:196:19:196:19 | a | cfg.rb:196:22:196:22 | b |  |
+| cfg.rb:196:22:196:22 | b | cfg.rb:196:25:196:27 | ... |  |
+| cfg.rb:196:25:196:27 | ... | cfg.rb:197:3:197:13 | self |  |
+| cfg.rb:197:3:197:13 | call to bar | cfg.rb:196:1:198:3 | exit forward_param (normal) |  |
+| cfg.rb:197:3:197:13 | self | cfg.rb:197:7:197:7 | b |  |
+| cfg.rb:197:7:197:7 | b | cfg.rb:197:10:197:12 | ... |  |
+| cfg.rb:197:10:197:12 | ... | cfg.rb:197:3:197:13 | call to bar |  |
+| cfg.rb:200:1:200:1 | 1 | cfg.rb:200:9:200:32 | { ... } |  |
+| cfg.rb:200:1:200:32 | call to times | cfg.rb:202:1:202:1 | 2 |  |
+| cfg.rb:200:9:200:32 | enter { ... } | cfg.rb:200:12:200:12 | a |  |
+| cfg.rb:200:9:200:32 | exit { ... } (normal) | cfg.rb:200:9:200:32 | exit { ... } |  |
+| cfg.rb:200:9:200:32 | { ... } | cfg.rb:200:1:200:32 | call to times |  |
+| cfg.rb:200:12:200:12 | a | cfg.rb:200:15:200:15 | b |  |
+| cfg.rb:200:15:200:15 | b | cfg.rb:200:18:200:23 | Kernel |  |
+| cfg.rb:200:18:200:23 | Kernel | cfg.rb:200:30:200:30 | a |  |
+| cfg.rb:200:18:200:30 | call to puts | cfg.rb:200:9:200:32 | exit { ... } (normal) |  |
+| cfg.rb:200:30:200:30 | a | cfg.rb:200:18:200:30 | call to puts |  |
+| cfg.rb:202:1:202:1 | 2 | cfg.rb:202:9:202:35 | do ... end |  |
+| cfg.rb:202:1:202:35 | call to times | cfg.rb:205:1:205:3 | __synth__0__1 |  |
+| cfg.rb:202:9:202:35 | do ... end | cfg.rb:202:1:202:35 | call to times |  |
+| cfg.rb:202:9:202:35 | enter do ... end | cfg.rb:202:13:202:13 | c |  |
+| cfg.rb:202:9:202:35 | exit do ... end (normal) | cfg.rb:202:9:202:35 | exit do ... end |  |
+| cfg.rb:202:13:202:13 | c | cfg.rb:202:16:202:16 | d |  |
+| cfg.rb:202:16:202:16 | d | cfg.rb:202:19:202:24 | Kernel |  |
+| cfg.rb:202:19:202:24 | Kernel | cfg.rb:202:31:202:31 | c |  |
+| cfg.rb:202:19:202:31 | call to puts | cfg.rb:202:9:202:35 | exit do ... end (normal) |  |
+| cfg.rb:202:31:202:31 | c | cfg.rb:202:19:202:31 | call to puts |  |
+| cfg.rb:205:1:205:3 | ... = ... | cfg.rb:205:4:205:5 | nil |  |
+| cfg.rb:205:1:205:3 | __synth__0__1 | cfg.rb:205:1:205:3 | self |  |
+| cfg.rb:205:1:205:3 | __synth__0__1 | cfg.rb:205:4:205:5 | call to == |  |
+| cfg.rb:205:1:205:3 | __synth__0__1 | cfg.rb:205:10:205:10 | 1 |  |
+| cfg.rb:205:1:205:3 | call to foo | cfg.rb:205:1:205:3 | ... = ... |  |
+| cfg.rb:205:1:205:3 | nil | cfg.rb:205:4:205:5 | if ... |  |
+| cfg.rb:205:1:205:3 | self | cfg.rb:205:1:205:3 | call to foo |  |
+| cfg.rb:205:1:205:23 | ... | cfg.rb:207:1:211:3 | filter_nil |  |
+| cfg.rb:205:1:205:23 | call to bar | cfg.rb:205:4:205:5 | if ... |  |
+| cfg.rb:205:4:205:5 | call to == | cfg.rb:205:1:205:3 | __synth__0__1 | false |
+| cfg.rb:205:4:205:5 | call to == | cfg.rb:205:1:205:3 | nil | true |
+| cfg.rb:205:4:205:5 | if ... | cfg.rb:205:1:205:23 | ... |  |
+| cfg.rb:205:4:205:5 | nil | cfg.rb:205:1:205:3 | __synth__0__1 |  |
+| cfg.rb:205:10:205:10 | 1 | cfg.rb:205:12:205:12 | 2 |  |
+| cfg.rb:205:12:205:12 | 2 | cfg.rb:205:15:205:23 | { ... } |  |
+| cfg.rb:205:15:205:23 | enter { ... } | cfg.rb:205:18:205:18 | x |  |
+| cfg.rb:205:15:205:23 | exit { ... } (normal) | cfg.rb:205:15:205:23 | exit { ... } |  |
+| cfg.rb:205:15:205:23 | { ... } | cfg.rb:205:1:205:23 | call to bar |  |
+| cfg.rb:205:18:205:18 | x | cfg.rb:205:21:205:21 | x |  |
+| cfg.rb:205:21:205:21 | x | cfg.rb:205:15:205:23 | exit { ... } (normal) |  |
+| cfg.rb:207:1:211:3 | enter filter_nil | cfg.rb:207:16:207:19 | list |  |
+| cfg.rb:207:1:211:3 | exit filter_nil (normal) | cfg.rb:207:1:211:3 | exit filter_nil |  |
+| cfg.rb:207:1:211:3 | filter_nil | cfg.rb:213:1:216:3 | self |  |
+| cfg.rb:207:16:207:19 | list | cfg.rb:208:3:208:6 | list |  |
+| cfg.rb:208:3:208:6 | list | cfg.rb:208:15:210:5 | do ... end |  |
+| cfg.rb:208:3:210:5 | call to reject | cfg.rb:207:1:211:3 | exit filter_nil (normal) |  |
+| cfg.rb:208:15:210:5 | do ... end | cfg.rb:208:3:210:5 | call to reject |  |
+| cfg.rb:208:15:210:5 | enter do ... end | cfg.rb:208:19:208:22 | elem |  |
+| cfg.rb:208:15:210:5 | exit do ... end (normal) | cfg.rb:208:15:210:5 | exit do ... end |  |
+| cfg.rb:208:19:208:22 | elem | cfg.rb:208:25:208:25 | __synth__0 |  |
+| cfg.rb:208:25:208:25 | __synth__0 | cfg.rb:208:28:208:29 | __synth__0 |  |
+| cfg.rb:208:28:208:29 | __synth__0 | cfg.rb:209:5:209:8 | elem |  |
+| cfg.rb:209:5:209:8 | elem | cfg.rb:209:5:209:13 | call to nil? |  |
+| cfg.rb:209:5:209:13 | call to nil? | cfg.rb:208:15:210:5 | exit do ... end (normal) |  |
+| cfg.rb:213:1:216:3 | call to do_something | cfg.rb:1:1:221:1 | exit cfg.rb (normal) |  |
+| cfg.rb:213:1:216:3 | self | cfg.rb:213:14:216:3 | do ... end |  |
+| cfg.rb:213:14:216:3 | do ... end | cfg.rb:213:1:216:3 | call to do_something |  |
+| cfg.rb:213:14:216:3 | enter do ... end | cfg.rb:214:3:214:6 | self |  |
+| cfg.rb:213:14:216:3 | exit do ... end (normal) | cfg.rb:213:14:216:3 | exit do ... end |  |
+| cfg.rb:214:3:214:6 | self | cfg.rb:214:3:214:16 | call to something |  |
+| cfg.rb:214:3:214:16 | call to something | cfg.rb:215:3:215:16 | self |  |
+| cfg.rb:215:3:215:16 | call to something_else | cfg.rb:213:14:216:3 | exit do ... end (normal) |  |
+| cfg.rb:215:3:215:16 | self | cfg.rb:215:3:215:16 | call to something_else |  |
+| constant_compound_assign.rb:1:1:9:3 | Foo | constant_compound_assign.rb:2:5:3:7 | foo_before |  |
+| constant_compound_assign.rb:1:1:22:4 | enter constant_compound_assign.rb | constant_compound_assign.rb:1:1:9:3 | Foo |  |
+| constant_compound_assign.rb:1:1:22:4 | exit constant_compound_assign.rb (normal) | constant_compound_assign.rb:1:1:22:4 | exit constant_compound_assign.rb |  |
+| constant_compound_assign.rb:2:5:3:7 | foo_before | constant_compound_assign.rb:5:5:5:16 | FOO_CONSTANT |  |
+| constant_compound_assign.rb:5:5:5:16 | FOO_CONSTANT | constant_compound_assign.rb:5:5:5:16 | FOO_CONSTANT |  |
+| constant_compound_assign.rb:5:5:5:16 | FOO_CONSTANT | constant_compound_assign.rb:5:18:5:20 | ... \|\| ... | true |
+| constant_compound_assign.rb:5:5:5:16 | FOO_CONSTANT | constant_compound_assign.rb:5:22:5:24 | 123 | false |
+| constant_compound_assign.rb:5:5:5:24 | ... = ... | constant_compound_assign.rb:7:5:8:7 | foo_after |  |
+| constant_compound_assign.rb:5:18:5:20 | ... \|\| ... | constant_compound_assign.rb:5:5:5:24 | ... = ... |  |
+| constant_compound_assign.rb:5:22:5:24 | 123 | constant_compound_assign.rb:5:18:5:20 | ... \|\| ... |  |
+| constant_compound_assign.rb:7:5:8:7 | foo_after | constant_compound_assign.rb:11:1:12:3 | top_before |  |
+| constant_compound_assign.rb:11:1:12:3 | top_before | constant_compound_assign.rb:14:1:14:12 | TOP_CONSTANT |  |
+| constant_compound_assign.rb:14:1:14:12 | TOP_CONSTANT | constant_compound_assign.rb:14:1:14:12 | TOP_CONSTANT |  |
+| constant_compound_assign.rb:14:1:14:12 | TOP_CONSTANT | constant_compound_assign.rb:14:14:14:16 | ... \|\| ... | true |
+| constant_compound_assign.rb:14:1:14:12 | TOP_CONSTANT | constant_compound_assign.rb:14:18:14:20 | 123 | false |
+| constant_compound_assign.rb:14:1:14:20 | ... = ... | constant_compound_assign.rb:16:1:17:3 | top_after |  |
+| constant_compound_assign.rb:14:14:14:16 | ... \|\| ... | constant_compound_assign.rb:14:1:14:20 | ... = ... |  |
+| constant_compound_assign.rb:14:18:14:20 | 123 | constant_compound_assign.rb:14:14:14:16 | ... \|\| ... |  |
+| constant_compound_assign.rb:16:1:17:3 | top_after | constant_compound_assign.rb:19:1:19:15 | TOP_CONSTANT2 |  |
+| constant_compound_assign.rb:19:1:19:15 | TOP_CONSTANT2 | constant_compound_assign.rb:19:1:19:15 | TOP_CONSTANT2 |  |
+| constant_compound_assign.rb:19:1:19:15 | TOP_CONSTANT2 | constant_compound_assign.rb:19:17:19:19 | ... \|\| ... | true |
+| constant_compound_assign.rb:19:1:19:15 | TOP_CONSTANT2 | constant_compound_assign.rb:19:21:19:23 | 123 | false |
+| constant_compound_assign.rb:19:1:19:23 | ... = ... | constant_compound_assign.rb:21:1:22:3 | top_after2 |  |
+| constant_compound_assign.rb:19:17:19:19 | ... \|\| ... | constant_compound_assign.rb:19:1:19:23 | ... = ... |  |
+| constant_compound_assign.rb:19:21:19:23 | 123 | constant_compound_assign.rb:19:17:19:19 | ... \|\| ... |  |
+| constant_compound_assign.rb:21:1:22:3 | top_after2 | constant_compound_assign.rb:1:1:22:4 | exit constant_compound_assign.rb (normal) |  |
+| desugar.rb:1:1:3:3 | enter m1 | desugar.rb:1:8:1:8 | x |  |
+| desugar.rb:1:1:3:3 | exit m1 (normal) | desugar.rb:1:1:3:3 | exit m1 |  |
+| desugar.rb:1:1:3:3 | m1 | desugar.rb:5:1:7:3 | m2 |  |
+| desugar.rb:1:1:38:17 | enter desugar.rb | desugar.rb:1:1:3:3 | m1 |  |
+| desugar.rb:1:1:38:17 | exit desugar.rb (normal) | desugar.rb:1:1:38:17 | exit desugar.rb |  |
+| desugar.rb:1:8:1:8 | x | desugar.rb:2:3:2:3 | x |  |
+| desugar.rb:2:3:2:3 | x | desugar.rb:2:3:2:3 | x |  |
+| desugar.rb:2:3:2:3 | x | desugar.rb:2:8:2:8 | 1 |  |
+| desugar.rb:2:3:2:8 | ... = ... | desugar.rb:1:1:3:3 | exit m1 (normal) |  |
+| desugar.rb:2:5:2:6 | ... + ... | desugar.rb:2:3:2:8 | ... = ... |  |
+| desugar.rb:2:8:2:8 | 1 | desugar.rb:2:5:2:6 | ... + ... |  |
+| desugar.rb:5:1:7:3 | enter m2 | desugar.rb:5:8:5:8 | x |  |
+| desugar.rb:5:1:7:3 | exit m2 (normal) | desugar.rb:5:1:7:3 | exit m2 |  |
+| desugar.rb:5:1:7:3 | m2 | desugar.rb:9:1:11:3 | m3 |  |
+| desugar.rb:5:8:5:8 | x | desugar.rb:6:3:6:3 | x |  |
+| desugar.rb:6:3:6:3 | x | desugar.rb:6:3:6:7 | call to foo |  |
+| desugar.rb:6:3:6:7 | call to foo | desugar.rb:6:17:6:17 | __synth__0 |  |
+| desugar.rb:6:3:6:13 | __synth__0 | desugar.rb:6:3:6:17 | ... |  |
+| desugar.rb:6:3:6:13 | call to count= | desugar.rb:6:3:6:13 | __synth__0 |  |
+| desugar.rb:6:3:6:17 | ... | desugar.rb:5:1:7:3 | exit m2 (normal) |  |
+| desugar.rb:6:17:6:17 | 1 | desugar.rb:6:17:6:17 | ... = ... |  |
+| desugar.rb:6:17:6:17 | ... = ... | desugar.rb:6:3:6:13 | call to count= |  |
+| desugar.rb:6:17:6:17 | __synth__0 | desugar.rb:6:17:6:17 | 1 |  |
+| desugar.rb:9:1:11:3 | enter m3 | desugar.rb:9:8:9:8 | x |  |
+| desugar.rb:9:1:11:3 | exit m3 (normal) | desugar.rb:9:1:11:3 | exit m3 |  |
+| desugar.rb:9:1:11:3 | m3 | desugar.rb:13:1:15:3 | m4 |  |
+| desugar.rb:9:8:9:8 | x | desugar.rb:10:3:10:3 | x |  |
+| desugar.rb:10:3:10:3 | x | desugar.rb:10:3:10:7 | call to foo |  |
+| desugar.rb:10:3:10:7 | call to foo | desugar.rb:10:9:10:9 | 0 |  |
+| desugar.rb:10:3:10:10 | __synth__0 | desugar.rb:10:3:10:14 | ... |  |
+| desugar.rb:10:3:10:10 | call to []= | desugar.rb:10:3:10:10 | __synth__0 |  |
+| desugar.rb:10:3:10:14 | ... | desugar.rb:9:1:11:3 | exit m3 (normal) |  |
+| desugar.rb:10:9:10:9 | 0 | desugar.rb:10:14:10:14 | __synth__0 |  |
+| desugar.rb:10:14:10:14 | 1 | desugar.rb:10:14:10:14 | ... = ... |  |
+| desugar.rb:10:14:10:14 | ... = ... | desugar.rb:10:3:10:10 | call to []= |  |
+| desugar.rb:10:14:10:14 | __synth__0 | desugar.rb:10:14:10:14 | 1 |  |
+| desugar.rb:13:1:15:3 | enter m4 | desugar.rb:13:8:13:8 | x |  |
+| desugar.rb:13:1:15:3 | exit m4 (normal) | desugar.rb:13:1:15:3 | exit m4 |  |
+| desugar.rb:13:1:15:3 | m4 | desugar.rb:17:1:19:3 | m5 |  |
+| desugar.rb:13:8:13:8 | x | desugar.rb:14:3:14:7 | __synth__0 |  |
+| desugar.rb:14:3:14:3 | x | desugar.rb:14:3:14:7 | call to foo |  |
+| desugar.rb:14:3:14:7 | ... = ... | desugar.rb:14:15:14:16 | __synth__1 |  |
+| desugar.rb:14:3:14:7 | __synth__0 | desugar.rb:14:3:14:3 | x |  |
+| desugar.rb:14:3:14:7 | __synth__0 | desugar.rb:14:3:14:13 | __synth__1 |  |
+| desugar.rb:14:3:14:7 | __synth__0 | desugar.rb:14:3:14:13 | call to count |  |
+| desugar.rb:14:3:14:7 | call to foo | desugar.rb:14:3:14:7 | ... = ... |  |
+| desugar.rb:14:3:14:13 | __synth__1 | desugar.rb:14:3:14:13 | call to count= |  |
+| desugar.rb:14:3:14:13 | call to count | desugar.rb:14:18:14:18 | 1 |  |
+| desugar.rb:14:3:14:13 | call to count= | desugar.rb:14:15:14:16 | __synth__1 |  |
+| desugar.rb:14:3:14:18 | ... | desugar.rb:13:1:15:3 | exit m4 (normal) |  |
+| desugar.rb:14:15:14:16 | ... + ... | desugar.rb:14:15:14:16 | ... = ... |  |
+| desugar.rb:14:15:14:16 | ... = ... | desugar.rb:14:3:14:7 | __synth__0 |  |
+| desugar.rb:14:15:14:16 | __synth__1 | desugar.rb:14:3:14:7 | __synth__0 |  |
+| desugar.rb:14:15:14:16 | __synth__1 | desugar.rb:14:3:14:18 | ... |  |
+| desugar.rb:14:18:14:18 | 1 | desugar.rb:14:15:14:16 | ... + ... |  |
+| desugar.rb:17:1:19:3 | enter m5 | desugar.rb:17:8:17:8 | x |  |
+| desugar.rb:17:1:19:3 | exit m5 (normal) | desugar.rb:17:1:19:3 | exit m5 |  |
+| desugar.rb:17:1:19:3 | m5 | desugar.rb:21:1:23:3 | m6 |  |
+| desugar.rb:17:8:17:8 | x | desugar.rb:17:11:17:11 | y |  |
+| desugar.rb:17:11:17:11 | y | desugar.rb:18:3:18:7 | __synth__0 |  |
+| desugar.rb:18:3:18:3 | x | desugar.rb:18:3:18:7 | call to foo |  |
+| desugar.rb:18:3:18:7 | ... = ... | desugar.rb:18:9:18:9 | __synth__1 |  |
+| desugar.rb:18:3:18:7 | __synth__0 | desugar.rb:18:3:18:3 | x |  |
+| desugar.rb:18:3:18:7 | __synth__0 | desugar.rb:18:9:18:9 | __synth__1 |  |
+| desugar.rb:18:3:18:7 | __synth__0 | desugar.rb:18:9:18:9 | __synth__1 |  |
+| desugar.rb:18:3:18:7 | call to foo | desugar.rb:18:3:18:7 | ... = ... |  |
+| desugar.rb:18:3:18:28 | __synth__4 | desugar.rb:18:3:18:28 | call to []= |  |
+| desugar.rb:18:3:18:28 | call to [] | desugar.rb:18:33:18:33 | 1 |  |
+| desugar.rb:18:3:18:28 | call to []= | desugar.rb:18:30:18:31 | __synth__4 |  |
+| desugar.rb:18:3:18:33 | ... | desugar.rb:17:1:19:3 | exit m5 (normal) |  |
+| desugar.rb:18:9:18:9 | 0 | desugar.rb:18:9:18:9 | ... = ... |  |
+| desugar.rb:18:9:18:9 | ... = ... | desugar.rb:18:12:18:16 | __synth__2 |  |
+| desugar.rb:18:9:18:9 | __synth__1 | desugar.rb:18:9:18:9 | 0 |  |
+| desugar.rb:18:9:18:9 | __synth__1 | desugar.rb:18:12:18:16 | __synth__2 |  |
+| desugar.rb:18:9:18:9 | __synth__1 | desugar.rb:18:12:18:16 | __synth__2 |  |
+| desugar.rb:18:12:18:12 | y | desugar.rb:18:12:18:16 | call to bar |  |
+| desugar.rb:18:12:18:16 | ... = ... | desugar.rb:18:19:18:27 | __synth__3 |  |
+| desugar.rb:18:12:18:16 | __synth__2 | desugar.rb:18:12:18:12 | y |  |
+| desugar.rb:18:12:18:16 | __synth__2 | desugar.rb:18:19:18:27 | __synth__3 |  |
+| desugar.rb:18:12:18:16 | __synth__2 | desugar.rb:18:19:18:27 | __synth__3 |  |
+| desugar.rb:18:12:18:16 | call to bar | desugar.rb:18:12:18:16 | ... = ... |  |
+| desugar.rb:18:19:18:19 | x | desugar.rb:18:19:18:23 | call to baz |  |
+| desugar.rb:18:19:18:23 | call to baz | desugar.rb:18:27:18:27 | 3 |  |
+| desugar.rb:18:19:18:27 | ... + ... | desugar.rb:18:19:18:27 | ... = ... |  |
+| desugar.rb:18:19:18:27 | ... = ... | desugar.rb:18:30:18:31 | __synth__4 |  |
+| desugar.rb:18:19:18:27 | __synth__3 | desugar.rb:18:3:18:28 | __synth__4 |  |
+| desugar.rb:18:19:18:27 | __synth__3 | desugar.rb:18:3:18:28 | call to [] |  |
+| desugar.rb:18:19:18:27 | __synth__3 | desugar.rb:18:19:18:19 | x |  |
+| desugar.rb:18:27:18:27 | 3 | desugar.rb:18:19:18:27 | ... + ... |  |
+| desugar.rb:18:30:18:31 | ... + ... | desugar.rb:18:30:18:31 | ... = ... |  |
+| desugar.rb:18:30:18:31 | ... = ... | desugar.rb:18:3:18:7 | __synth__0 |  |
+| desugar.rb:18:30:18:31 | __synth__4 | desugar.rb:18:3:18:7 | __synth__0 |  |
+| desugar.rb:18:30:18:31 | __synth__4 | desugar.rb:18:3:18:33 | ... |  |
+| desugar.rb:18:33:18:33 | 1 | desugar.rb:18:30:18:31 | ... + ... |  |
+| desugar.rb:21:1:23:3 | enter m6 | desugar.rb:22:10:22:10 | __synth__2 |  |
+| desugar.rb:21:1:23:3 | exit m6 (normal) | desugar.rb:21:1:23:3 | exit m6 |  |
+| desugar.rb:21:1:23:3 | m6 | desugar.rb:25:1:27:3 | m7 |  |
+| desugar.rb:22:3:22:3 | 0 | desugar.rb:22:3:22:3 | call to [] |  |
+| desugar.rb:22:3:22:3 | ... = ... | desugar.rb:22:7:22:7 | y |  |
+| desugar.rb:22:3:22:3 | __synth__3 | desugar.rb:22:3:22:3 | 0 |  |
+| desugar.rb:22:3:22:3 | call to [] | desugar.rb:22:3:22:3 | ... = ... |  |
+| desugar.rb:22:3:22:3 | x | desugar.rb:22:3:22:3 | __synth__3 |  |
+| desugar.rb:22:3:22:29 | ... | desugar.rb:21:1:23:3 | exit m6 (normal) |  |
+| desugar.rb:22:7:22:7 | 1 | desugar.rb:22:7:22:7 | -2 |  |
+| desugar.rb:22:7:22:7 | -2 | desugar.rb:22:7:22:7 | _ .. _ |  |
+| desugar.rb:22:7:22:7 | ... = ... | desugar.rb:22:10:22:14 | __synth__2 |  |
+| desugar.rb:22:7:22:7 | _ .. _ | desugar.rb:22:7:22:7 | call to [] |  |
+| desugar.rb:22:7:22:7 | __synth__3 | desugar.rb:22:7:22:7 | 1 |  |
+| desugar.rb:22:7:22:7 | call to [] | desugar.rb:22:7:22:7 | ... = ... |  |
+| desugar.rb:22:7:22:7 | y | desugar.rb:22:7:22:7 | __synth__3 |  |
+| desugar.rb:22:10:22:10 | ... = ... | desugar.rb:22:18:22:29 | __synth__3 |  |
+| desugar.rb:22:10:22:10 | __synth__2 | desugar.rb:22:10:22:10 | self |  |
+| desugar.rb:22:10:22:10 | call to z | desugar.rb:22:10:22:10 | ... = ... |  |
+| desugar.rb:22:10:22:10 | self | desugar.rb:22:10:22:10 | call to z |  |
+| desugar.rb:22:10:22:14 | -1 | desugar.rb:22:10:22:14 | call to [] |  |
+| desugar.rb:22:10:22:14 | ... | desugar.rb:22:3:22:29 | ... |  |
+| desugar.rb:22:10:22:14 | ... = ... | desugar.rb:22:10:22:14 | call to bar= |  |
+| desugar.rb:22:10:22:14 | __synth__0__1 | desugar.rb:22:10:22:14 | ... |  |
+| desugar.rb:22:10:22:14 | __synth__0__1 | desugar.rb:22:10:22:14 | __synth__3 |  |
+| desugar.rb:22:10:22:14 | __synth__2 | desugar.rb:22:10:22:14 | __synth__0__1 |  |
+| desugar.rb:22:10:22:14 | __synth__3 | desugar.rb:22:10:22:14 | -1 |  |
+| desugar.rb:22:10:22:14 | call to [] | desugar.rb:22:10:22:14 | ... = ... |  |
+| desugar.rb:22:10:22:14 | call to bar= | desugar.rb:22:10:22:14 | __synth__0__1 |  |
+| desugar.rb:22:18:22:29 | * ... | desugar.rb:22:18:22:29 | ... = ... |  |
+| desugar.rb:22:18:22:29 | ... = ... | desugar.rb:22:3:22:3 | x |  |
+| desugar.rb:22:18:22:29 | Array | desugar.rb:22:19:22:19 | 1 |  |
+| desugar.rb:22:18:22:29 | __synth__3 | desugar.rb:22:18:22:29 | Array |  |
+| desugar.rb:22:18:22:29 | call to [] | desugar.rb:22:18:22:29 | * ... |  |
+| desugar.rb:22:19:22:19 | 1 | desugar.rb:22:22:22:22 | 2 |  |
+| desugar.rb:22:22:22:22 | 2 | desugar.rb:22:25:22:25 | 3 |  |
+| desugar.rb:22:25:22:25 | 3 | desugar.rb:22:28:22:28 | 4 |  |
+| desugar.rb:22:28:22:28 | 4 | desugar.rb:22:18:22:29 | call to [] |  |
+| desugar.rb:25:1:27:3 | enter m7 | desugar.rb:26:15:26:25 | __synth__2 |  |
+| desugar.rb:25:1:27:3 | exit m7 (normal) | desugar.rb:25:1:27:3 | exit m7 |  |
+| desugar.rb:25:1:27:3 | m7 | desugar.rb:29:1:35:3 | X |  |
+| desugar.rb:26:3:26:3 | 0 | desugar.rb:26:3:26:3 | call to [] |  |
+| desugar.rb:26:3:26:3 | ... = ... | desugar.rb:26:6:26:11 | __synth__2__1 |  |
+| desugar.rb:26:3:26:3 | __synth__2 | desugar.rb:26:3:26:3 | 0 |  |
+| desugar.rb:26:3:26:3 | call to [] | desugar.rb:26:3:26:3 | ... = ... |  |
+| desugar.rb:26:3:26:3 | x | desugar.rb:26:3:26:3 | __synth__2 |  |
+| desugar.rb:26:3:26:25 | ... | desugar.rb:25:1:27:3 | exit m7 (normal) |  |
+| desugar.rb:26:6:26:11 | 1 | desugar.rb:26:6:26:11 | call to [] |  |
+| desugar.rb:26:6:26:11 | * ... | desugar.rb:26:6:26:11 | ... = ... |  |
+| desugar.rb:26:6:26:11 | ... | desugar.rb:26:3:26:25 | ... |  |
+| desugar.rb:26:6:26:11 | ... = ... | desugar.rb:26:7:26:7 | y |  |
+| desugar.rb:26:6:26:11 | __synth__2 | desugar.rb:26:6:26:11 | 1 |  |
+| desugar.rb:26:6:26:11 | __synth__2__1 | desugar.rb:26:6:26:11 | __synth__2 |  |
+| desugar.rb:26:6:26:11 | call to [] | desugar.rb:26:6:26:11 | * ... |  |
+| desugar.rb:26:7:26:7 | 0 | desugar.rb:26:7:26:7 | call to [] |  |
+| desugar.rb:26:7:26:7 | ... = ... | desugar.rb:26:10:26:10 | z |  |
+| desugar.rb:26:7:26:7 | __synth__2__1 | desugar.rb:26:7:26:7 | 0 |  |
+| desugar.rb:26:7:26:7 | call to [] | desugar.rb:26:7:26:7 | ... = ... |  |
+| desugar.rb:26:7:26:7 | y | desugar.rb:26:7:26:7 | __synth__2__1 |  |
+| desugar.rb:26:10:26:10 | 1 | desugar.rb:26:10:26:10 | call to [] |  |
+| desugar.rb:26:10:26:10 | ... = ... | desugar.rb:26:6:26:11 | ... |  |
+| desugar.rb:26:10:26:10 | __synth__2__1 | desugar.rb:26:10:26:10 | 1 |  |
+| desugar.rb:26:10:26:10 | call to [] | desugar.rb:26:10:26:10 | ... = ... |  |
+| desugar.rb:26:10:26:10 | z | desugar.rb:26:10:26:10 | __synth__2__1 |  |
+| desugar.rb:26:15:26:25 | * ... | desugar.rb:26:15:26:25 | ... = ... |  |
+| desugar.rb:26:15:26:25 | ... = ... | desugar.rb:26:3:26:3 | x |  |
+| desugar.rb:26:15:26:25 | Array | desugar.rb:26:16:26:16 | 1 |  |
+| desugar.rb:26:15:26:25 | __synth__2 | desugar.rb:26:15:26:25 | Array |  |
+| desugar.rb:26:15:26:25 | call to [] | desugar.rb:26:15:26:25 | * ... |  |
+| desugar.rb:26:16:26:16 | 1 | desugar.rb:26:19:26:24 | Array |  |
+| desugar.rb:26:19:26:24 | Array | desugar.rb:26:20:26:20 | 2 |  |
+| desugar.rb:26:19:26:24 | call to [] | desugar.rb:26:15:26:25 | call to [] |  |
+| desugar.rb:26:20:26:20 | 2 | desugar.rb:26:23:26:23 | 3 |  |
+| desugar.rb:26:23:26:23 | 3 | desugar.rb:26:19:26:24 | call to [] |  |
+| desugar.rb:29:1:35:3 | X | desugar.rb:30:3:30:4 | self |  |
+| desugar.rb:30:3:30:4 | @x | desugar.rb:30:8:30:8 | 1 |  |
+| desugar.rb:30:3:30:4 | self | desugar.rb:30:3:30:4 | @x |  |
+| desugar.rb:30:3:30:8 | ... = ... | desugar.rb:31:3:31:4 | self |  |
+| desugar.rb:30:8:30:8 | 1 | desugar.rb:30:3:30:8 | ... = ... |  |
+| desugar.rb:31:3:31:4 | @x | desugar.rb:31:3:31:4 | self |  |
+| desugar.rb:31:3:31:4 | @x | desugar.rb:31:9:31:9 | 2 |  |
+| desugar.rb:31:3:31:4 | self | desugar.rb:31:3:31:4 | @x |  |
+| desugar.rb:31:3:31:4 | self | desugar.rb:31:3:31:4 | @x |  |
+| desugar.rb:31:3:31:9 | ... = ... | desugar.rb:33:3:33:5 | @@y |  |
+| desugar.rb:31:6:31:7 | ... + ... | desugar.rb:31:3:31:9 | ... = ... |  |
+| desugar.rb:31:9:31:9 | 2 | desugar.rb:31:6:31:7 | ... + ... |  |
+| desugar.rb:33:3:33:5 | @@y | desugar.rb:33:9:33:9 | 3 |  |
+| desugar.rb:33:3:33:9 | ... = ... | desugar.rb:34:3:34:5 | @@y |  |
+| desugar.rb:33:9:33:9 | 3 | desugar.rb:33:3:33:9 | ... = ... |  |
+| desugar.rb:34:3:34:5 | @@y | desugar.rb:34:3:34:5 | @@y |  |
+| desugar.rb:34:3:34:5 | @@y | desugar.rb:34:10:34:10 | 4 |  |
+| desugar.rb:34:3:34:10 | ... = ... | desugar.rb:37:1:37:11 | $global_var |  |
+| desugar.rb:34:7:34:8 | ... / ... | desugar.rb:34:3:34:10 | ... = ... |  |
+| desugar.rb:34:10:34:10 | 4 | desugar.rb:34:7:34:8 | ... / ... |  |
+| desugar.rb:37:1:37:11 | $global_var | desugar.rb:37:15:37:15 | 5 |  |
+| desugar.rb:37:1:37:15 | ... = ... | desugar.rb:38:1:38:11 | $global_var |  |
+| desugar.rb:37:15:37:15 | 5 | desugar.rb:37:1:37:15 | ... = ... |  |
+| desugar.rb:38:1:38:11 | $global_var | desugar.rb:38:1:38:11 | $global_var |  |
+| desugar.rb:38:1:38:11 | $global_var | desugar.rb:38:16:38:16 | 6 |  |
+| desugar.rb:38:1:38:16 | ... = ... | desugar.rb:1:1:38:17 | exit desugar.rb (normal) |  |
+| desugar.rb:38:13:38:14 | ... * ... | desugar.rb:38:1:38:16 | ... = ... |  |
+| desugar.rb:38:16:38:16 | 6 | desugar.rb:38:13:38:14 | ... * ... |  |
+| exit.rb:1:1:6:3 | enter m1 | exit.rb:1:8:1:8 | x |  |
+| exit.rb:1:1:6:3 | exit m1 (abnormal) | exit.rb:1:1:6:3 | exit m1 |  |
+| exit.rb:1:1:6:3 | exit m1 (normal) | exit.rb:1:1:6:3 | exit m1 |  |
+| exit.rb:1:1:6:3 | m1 | exit.rb:8:1:13:3 | m2 |  |
+| exit.rb:1:1:13:4 | enter exit.rb | exit.rb:1:1:6:3 | m1 |  |
+| exit.rb:1:1:13:4 | exit exit.rb (normal) | exit.rb:1:1:13:4 | exit exit.rb |  |
+| exit.rb:1:8:1:8 | x | exit.rb:2:6:2:6 | x |  |
+| exit.rb:2:3:4:5 | if ... | exit.rb:5:3:5:15 | self |  |
+| exit.rb:2:6:2:6 | x | exit.rb:2:10:2:10 | 2 |  |
+| exit.rb:2:6:2:10 | ... > ... | exit.rb:2:3:4:5 | if ... | false |
+| exit.rb:2:6:2:10 | ... > ... | exit.rb:3:5:3:10 | self | true |
+| exit.rb:2:10:2:10 | 2 | exit.rb:2:6:2:10 | ... > ... |  |
+| exit.rb:3:5:3:10 | call to exit | exit.rb:1:1:6:3 | exit m1 (abnormal) | exit |
+| exit.rb:3:5:3:10 | self | exit.rb:3:10:3:10 | 1 |  |
+| exit.rb:3:10:3:10 | 1 | exit.rb:3:5:3:10 | call to exit |  |
+| exit.rb:5:3:5:15 | call to puts | exit.rb:1:1:6:3 | exit m1 (normal) |  |
+| exit.rb:5:3:5:15 | self | exit.rb:5:9:5:14 | x <= 2 |  |
+| exit.rb:5:8:5:15 | "x <= 2" | exit.rb:5:3:5:15 | call to puts |  |
+| exit.rb:5:9:5:14 | x <= 2 | exit.rb:5:8:5:15 | "x <= 2" |  |
+| exit.rb:8:1:13:3 | enter m2 | exit.rb:8:8:8:8 | x |  |
+| exit.rb:8:1:13:3 | exit m2 (abnormal) | exit.rb:8:1:13:3 | exit m2 |  |
+| exit.rb:8:1:13:3 | exit m2 (normal) | exit.rb:8:1:13:3 | exit m2 |  |
+| exit.rb:8:1:13:3 | m2 | exit.rb:1:1:13:4 | exit exit.rb (normal) |  |
+| exit.rb:8:8:8:8 | x | exit.rb:9:6:9:6 | x |  |
+| exit.rb:9:3:11:5 | if ... | exit.rb:12:3:12:15 | self |  |
+| exit.rb:9:6:9:6 | x | exit.rb:9:10:9:10 | 2 |  |
+| exit.rb:9:6:9:10 | ... > ... | exit.rb:9:3:11:5 | if ... | false |
+| exit.rb:9:6:9:10 | ... > ... | exit.rb:10:5:10:18 | self | true |
+| exit.rb:9:10:9:10 | 2 | exit.rb:9:6:9:10 | ... > ... |  |
+| exit.rb:10:5:10:18 | call to abort | exit.rb:8:1:13:3 | exit m2 (abnormal) | exit |
+| exit.rb:10:5:10:18 | self | exit.rb:10:12:10:17 | abort! |  |
+| exit.rb:10:11:10:18 | "abort!" | exit.rb:10:5:10:18 | call to abort |  |
+| exit.rb:10:12:10:17 | abort! | exit.rb:10:11:10:18 | "abort!" |  |
+| exit.rb:12:3:12:15 | call to puts | exit.rb:8:1:13:3 | exit m2 (normal) |  |
+| exit.rb:12:3:12:15 | self | exit.rb:12:9:12:14 | x <= 2 |  |
+| exit.rb:12:8:12:15 | "x <= 2" | exit.rb:12:3:12:15 | call to puts |  |
+| exit.rb:12:9:12:14 | x <= 2 | exit.rb:12:8:12:15 | "x <= 2" |  |
+| heredoc.rb:1:1:7:3 | double_heredoc | heredoc.rb:1:1:7:4 | exit heredoc.rb (normal) |  |
+| heredoc.rb:1:1:7:3 | enter double_heredoc | heredoc.rb:2:3:2:16 | self |  |
+| heredoc.rb:1:1:7:3 | exit double_heredoc (normal) | heredoc.rb:1:1:7:3 | exit double_heredoc |  |
+| heredoc.rb:1:1:7:4 | enter heredoc.rb | heredoc.rb:1:1:7:3 | double_heredoc |  |
+| heredoc.rb:1:1:7:4 | exit heredoc.rb (normal) | heredoc.rb:1:1:7:4 | exit heredoc.rb |  |
+| heredoc.rb:2:3:2:16 | call to puts | heredoc.rb:1:1:7:3 | exit double_heredoc (normal) |  |
+| heredoc.rb:2:3:2:16 | self | heredoc.rb:2:17:3:10 | \n    hello\n |  |
+| heredoc.rb:2:8:2:10 | <<A | heredoc.rb:4:2:5:9 | \n   world\n |  |
+| heredoc.rb:2:13:2:15 | <<A | heredoc.rb:2:3:2:16 | call to puts |  |
+| heredoc.rb:2:17:3:10 | \n    hello\n | heredoc.rb:2:8:2:10 | <<A |  |
+| heredoc.rb:4:2:5:9 | \n   world\n | heredoc.rb:2:13:2:15 | <<A |  |
+| ifs.rb:1:1:9:3 | enter m1 | ifs.rb:1:8:1:8 | x |  |
+| ifs.rb:1:1:9:3 | exit m1 (normal) | ifs.rb:1:1:9:3 | exit m1 |  |
+| ifs.rb:1:1:9:3 | m1 | ifs.rb:11:1:16:3 | m2 |  |
+| ifs.rb:1:1:58:4 | enter ifs.rb | ifs.rb:1:1:9:3 | m1 |  |
+| ifs.rb:1:1:58:4 | exit ifs.rb (normal) | ifs.rb:1:1:58:4 | exit ifs.rb |  |
+| ifs.rb:1:8:1:8 | x | ifs.rb:2:6:2:6 | x |  |
+| ifs.rb:2:3:8:5 | if ... | ifs.rb:1:1:9:3 | exit m1 (normal) |  |
+| ifs.rb:2:6:2:6 | x | ifs.rb:2:10:2:10 | 2 |  |
+| ifs.rb:2:6:2:10 | ... > ... | ifs.rb:3:5:3:30 | self | true |
+| ifs.rb:2:6:2:10 | ... > ... | ifs.rb:4:9:4:9 | x | false |
+| ifs.rb:2:10:2:10 | 2 | ifs.rb:2:6:2:10 | ... > ... |  |
+| ifs.rb:2:11:3:30 | then ... | ifs.rb:2:3:8:5 | if ... |  |
+| ifs.rb:3:5:3:30 | call to puts | ifs.rb:2:11:3:30 | then ... |  |
+| ifs.rb:3:5:3:30 | self | ifs.rb:3:11:3:29 | x is greater than 2 |  |
+| ifs.rb:3:10:3:30 | "x is greater than 2" | ifs.rb:3:5:3:30 | call to puts |  |
+| ifs.rb:3:11:3:29 | x is greater than 2 | ifs.rb:3:10:3:30 | "x is greater than 2" |  |
+| ifs.rb:4:3:7:35 | elsif ... | ifs.rb:2:3:8:5 | if ... |  |
+| ifs.rb:4:9:4:9 | x | ifs.rb:4:14:4:14 | 2 |  |
+| ifs.rb:4:9:4:14 | ... <= ... | ifs.rb:4:9:4:24 | [false] ... and ... | false |
+| ifs.rb:4:9:4:14 | ... <= ... | ifs.rb:4:20:4:20 | x | true |
+| ifs.rb:4:9:4:24 | [false] ... and ... | ifs.rb:4:9:4:38 | [false] ... and ... | false |
+| ifs.rb:4:9:4:24 | [true] ... and ... | ifs.rb:4:32:4:32 | x | true |
+| ifs.rb:4:9:4:38 | [false] ... and ... | ifs.rb:7:5:7:35 | self | false |
+| ifs.rb:4:9:4:38 | [true] ... and ... | ifs.rb:5:5:5:17 | self | true |
+| ifs.rb:4:14:4:14 | 2 | ifs.rb:4:9:4:14 | ... <= ... |  |
+| ifs.rb:4:20:4:20 | x | ifs.rb:4:24:4:24 | 0 |  |
+| ifs.rb:4:20:4:24 | ... > ... | ifs.rb:4:9:4:24 | [false] ... and ... | false |
+| ifs.rb:4:20:4:24 | ... > ... | ifs.rb:4:9:4:24 | [true] ... and ... | true |
+| ifs.rb:4:24:4:24 | 0 | ifs.rb:4:20:4:24 | ... > ... |  |
+| ifs.rb:4:30:4:38 | [false] ! ... | ifs.rb:4:9:4:38 | [false] ... and ... | false |
+| ifs.rb:4:30:4:38 | [true] ! ... | ifs.rb:4:9:4:38 | [true] ... and ... | true |
+| ifs.rb:4:31:4:38 | [false] ( ... ) | ifs.rb:4:30:4:38 | [true] ! ... | false |
+| ifs.rb:4:31:4:38 | [true] ( ... ) | ifs.rb:4:30:4:38 | [false] ! ... | true |
+| ifs.rb:4:32:4:32 | x | ifs.rb:4:37:4:37 | 5 |  |
+| ifs.rb:4:32:4:37 | ... == ... | ifs.rb:4:31:4:38 | [false] ( ... ) | false |
+| ifs.rb:4:32:4:37 | ... == ... | ifs.rb:4:31:4:38 | [true] ( ... ) | true |
+| ifs.rb:4:37:4:37 | 5 | ifs.rb:4:32:4:37 | ... == ... |  |
+| ifs.rb:4:39:5:17 | then ... | ifs.rb:4:3:7:35 | elsif ... |  |
+| ifs.rb:5:5:5:17 | call to puts | ifs.rb:4:39:5:17 | then ... |  |
+| ifs.rb:5:5:5:17 | self | ifs.rb:5:11:5:16 | x is 1 |  |
+| ifs.rb:5:10:5:17 | "x is 1" | ifs.rb:5:5:5:17 | call to puts |  |
+| ifs.rb:5:11:5:16 | x is 1 | ifs.rb:5:10:5:17 | "x is 1" |  |
+| ifs.rb:6:3:7:35 | else ... | ifs.rb:4:3:7:35 | elsif ... |  |
+| ifs.rb:7:5:7:35 | call to puts | ifs.rb:6:3:7:35 | else ... |  |
+| ifs.rb:7:5:7:35 | self | ifs.rb:7:11:7:34 | I can't guess the number |  |
+| ifs.rb:7:10:7:35 | "I can't guess the number" | ifs.rb:7:5:7:35 | call to puts |  |
+| ifs.rb:7:11:7:34 | I can't guess the number | ifs.rb:7:10:7:35 | "I can't guess the number" |  |
+| ifs.rb:11:1:16:3 | enter m2 | ifs.rb:11:8:11:8 | b |  |
+| ifs.rb:11:1:16:3 | exit m2 (normal) | ifs.rb:11:1:16:3 | exit m2 |  |
+| ifs.rb:11:1:16:3 | m2 | ifs.rb:18:1:26:3 | m3 |  |
+| ifs.rb:11:8:11:8 | b | ifs.rb:12:6:12:6 | b |  |
+| ifs.rb:12:3:14:5 | if ... | ifs.rb:15:10:15:10 | 1 |  |
+| ifs.rb:12:6:12:6 | b | ifs.rb:12:3:14:5 | if ... | false |
+| ifs.rb:12:6:12:6 | b | ifs.rb:13:12:13:12 | 0 | true |
+| ifs.rb:13:5:13:12 | return | ifs.rb:11:1:16:3 | exit m2 (normal) | return |
+| ifs.rb:13:12:13:12 | 0 | ifs.rb:13:5:13:12 | return |  |
+| ifs.rb:15:3:15:10 | return | ifs.rb:11:1:16:3 | exit m2 (normal) | return |
+| ifs.rb:15:10:15:10 | 1 | ifs.rb:15:3:15:10 | return |  |
+| ifs.rb:18:1:26:3 | enter m3 | ifs.rb:18:8:18:8 | x |  |
+| ifs.rb:18:1:26:3 | exit m3 (normal) | ifs.rb:18:1:26:3 | exit m3 |  |
+| ifs.rb:18:1:26:3 | m3 | ifs.rb:28:1:30:3 | m4 |  |
+| ifs.rb:18:8:18:8 | x | ifs.rb:19:6:19:6 | x |  |
+| ifs.rb:19:3:24:5 | if ... | ifs.rb:25:3:25:8 | self |  |
+| ifs.rb:19:6:19:6 | x | ifs.rb:19:10:19:10 | 0 |  |
+| ifs.rb:19:6:19:10 | ... < ... | ifs.rb:19:3:24:5 | if ... | false |
+| ifs.rb:19:6:19:10 | ... < ... | ifs.rb:20:5:20:5 | x | true |
+| ifs.rb:19:10:19:10 | 0 | ifs.rb:19:6:19:10 | ... < ... |  |
+| ifs.rb:19:11:23:7 | then ... | ifs.rb:19:3:24:5 | if ... |  |
+| ifs.rb:20:5:20:5 | x | ifs.rb:20:10:20:10 | x |  |
+| ifs.rb:20:5:20:10 | ... = ... | ifs.rb:21:8:21:8 | x |  |
+| ifs.rb:20:9:20:10 | - ... | ifs.rb:20:5:20:10 | ... = ... |  |
+| ifs.rb:20:10:20:10 | x | ifs.rb:20:9:20:10 | - ... |  |
+| ifs.rb:21:5:23:7 | if ... | ifs.rb:19:11:23:7 | then ... |  |
+| ifs.rb:21:8:21:8 | x | ifs.rb:21:12:21:13 | 10 |  |
+| ifs.rb:21:8:21:13 | ... > ... | ifs.rb:21:5:23:7 | if ... | false |
+| ifs.rb:21:8:21:13 | ... > ... | ifs.rb:22:7:22:7 | x | true |
+| ifs.rb:21:12:21:13 | 10 | ifs.rb:21:8:21:13 | ... > ... |  |
+| ifs.rb:21:14:22:15 | then ... | ifs.rb:21:5:23:7 | if ... |  |
+| ifs.rb:22:7:22:7 | x | ifs.rb:22:11:22:11 | x |  |
+| ifs.rb:22:7:22:15 | ... = ... | ifs.rb:21:14:22:15 | then ... |  |
+| ifs.rb:22:11:22:11 | x | ifs.rb:22:15:22:15 | 1 |  |
+| ifs.rb:22:11:22:15 | ... - ... | ifs.rb:22:7:22:15 | ... = ... |  |
+| ifs.rb:22:15:22:15 | 1 | ifs.rb:22:11:22:15 | ... - ... |  |
+| ifs.rb:25:3:25:8 | call to puts | ifs.rb:18:1:26:3 | exit m3 (normal) |  |
+| ifs.rb:25:3:25:8 | self | ifs.rb:25:8:25:8 | x |  |
+| ifs.rb:25:8:25:8 | x | ifs.rb:25:3:25:8 | call to puts |  |
+| ifs.rb:28:1:30:3 | enter m4 | ifs.rb:28:9:28:10 | b1 |  |
+| ifs.rb:28:1:30:3 | exit m4 (normal) | ifs.rb:28:1:30:3 | exit m4 |  |
+| ifs.rb:28:1:30:3 | m4 | ifs.rb:32:1:34:3 | m5 |  |
+| ifs.rb:28:9:28:10 | b1 | ifs.rb:28:13:28:14 | b2 |  |
+| ifs.rb:28:13:28:14 | b2 | ifs.rb:28:17:28:18 | b3 |  |
+| ifs.rb:28:17:28:18 | b3 | ifs.rb:29:11:29:12 | b1 |  |
+| ifs.rb:29:3:29:51 | return | ifs.rb:28:1:30:3 | exit m4 (normal) | return |
+| ifs.rb:29:10:29:23 | [false] ( ... ) | ifs.rb:29:41:29:50 | !b2 \|\| !b3 | false |
+| ifs.rb:29:10:29:23 | [true] ( ... ) | ifs.rb:29:28:29:35 | b2 \|\| b3 | true |
+| ifs.rb:29:10:29:51 | ... ? ... : ... | ifs.rb:29:3:29:51 | return |  |
+| ifs.rb:29:11:29:12 | b1 | ifs.rb:29:16:29:17 | b2 | true |
+| ifs.rb:29:11:29:12 | b1 | ifs.rb:29:21:29:22 | b3 | false |
+| ifs.rb:29:11:29:22 | [false] ... ? ... : ... | ifs.rb:29:10:29:23 | [false] ( ... ) | false |
+| ifs.rb:29:11:29:22 | [true] ... ? ... : ... | ifs.rb:29:10:29:23 | [true] ( ... ) | true |
+| ifs.rb:29:16:29:17 | b2 | ifs.rb:29:11:29:22 | [false] ... ? ... : ... | false |
+| ifs.rb:29:16:29:17 | b2 | ifs.rb:29:11:29:22 | [true] ... ? ... : ... | true |
+| ifs.rb:29:21:29:22 | b3 | ifs.rb:29:11:29:22 | [false] ... ? ... : ... | false |
+| ifs.rb:29:21:29:22 | b3 | ifs.rb:29:11:29:22 | [true] ... ? ... : ... | true |
+| ifs.rb:29:27:29:36 | "b2 \|\| b3" | ifs.rb:29:10:29:51 | ... ? ... : ... |  |
+| ifs.rb:29:28:29:35 | b2 \|\| b3 | ifs.rb:29:27:29:36 | "b2 \|\| b3" |  |
+| ifs.rb:29:40:29:51 | "!b2 \|\| !b3" | ifs.rb:29:10:29:51 | ... ? ... : ... |  |
+| ifs.rb:29:41:29:50 | !b2 \|\| !b3 | ifs.rb:29:40:29:51 | "!b2 \|\| !b3" |  |
+| ifs.rb:32:1:34:3 | enter m5 | ifs.rb:32:9:32:10 | b1 |  |
+| ifs.rb:32:1:34:3 | exit m5 (normal) | ifs.rb:32:1:34:3 | exit m5 |  |
+| ifs.rb:32:1:34:3 | m5 | ifs.rb:38:12:38:12 | 1 |  |
+| ifs.rb:32:9:32:10 | b1 | ifs.rb:32:13:32:14 | b2 |  |
+| ifs.rb:32:13:32:14 | b2 | ifs.rb:32:17:32:18 | b3 |  |
+| ifs.rb:32:17:32:18 | b3 | ifs.rb:32:21:32:22 | b4 |  |
+| ifs.rb:32:21:32:22 | b4 | ifs.rb:32:25:32:26 | b5 |  |
+| ifs.rb:32:25:32:26 | b5 | ifs.rb:33:10:33:11 | b1 |  |
+| ifs.rb:33:3:33:100 | if ... | ifs.rb:32:1:34:3 | exit m5 (normal) |  |
+| ifs.rb:33:6:33:49 | [false] ( ... ) | ifs.rb:33:79:33:95 | !b2 \|\| !b4 \|\| !b5 | false |
+| ifs.rb:33:6:33:49 | [true] ( ... ) | ifs.rb:33:57:33:70 | b2 \|\| b4 \|\| b5 | true |
+| ifs.rb:33:7:33:48 | [false] if ... | ifs.rb:33:6:33:49 | [false] ( ... ) | false |
+| ifs.rb:33:7:33:48 | [true] if ... | ifs.rb:33:6:33:49 | [true] ( ... ) | true |
+| ifs.rb:33:10:33:11 | b1 | ifs.rb:33:18:33:19 | b2 | true |
+| ifs.rb:33:10:33:11 | b1 | ifs.rb:33:27:33:28 | b3 | false |
+| ifs.rb:33:13:33:19 | [false] then ... | ifs.rb:33:7:33:48 | [false] if ... | false |
+| ifs.rb:33:13:33:19 | [true] then ... | ifs.rb:33:7:33:48 | [true] if ... | true |
+| ifs.rb:33:18:33:19 | b2 | ifs.rb:33:13:33:19 | [false] then ... | false |
+| ifs.rb:33:18:33:19 | b2 | ifs.rb:33:13:33:19 | [true] then ... | true |
+| ifs.rb:33:21:33:44 | [false] elsif ... | ifs.rb:33:7:33:48 | [false] if ... | false |
+| ifs.rb:33:21:33:44 | [true] elsif ... | ifs.rb:33:7:33:48 | [true] if ... | true |
+| ifs.rb:33:27:33:28 | b3 | ifs.rb:33:35:33:36 | b4 | true |
+| ifs.rb:33:27:33:28 | b3 | ifs.rb:33:43:33:44 | b5 | false |
+| ifs.rb:33:30:33:36 | [false] then ... | ifs.rb:33:21:33:44 | [false] elsif ... | false |
+| ifs.rb:33:30:33:36 | [true] then ... | ifs.rb:33:21:33:44 | [true] elsif ... | true |
+| ifs.rb:33:35:33:36 | b4 | ifs.rb:33:30:33:36 | [false] then ... | false |
+| ifs.rb:33:35:33:36 | b4 | ifs.rb:33:30:33:36 | [true] then ... | true |
+| ifs.rb:33:38:33:44 | [false] else ... | ifs.rb:33:21:33:44 | [false] elsif ... | false |
+| ifs.rb:33:38:33:44 | [true] else ... | ifs.rb:33:21:33:44 | [true] elsif ... | true |
+| ifs.rb:33:43:33:44 | b5 | ifs.rb:33:38:33:44 | [false] else ... | false |
+| ifs.rb:33:43:33:44 | b5 | ifs.rb:33:38:33:44 | [true] else ... | true |
+| ifs.rb:33:51:33:71 | then ... | ifs.rb:33:3:33:100 | if ... |  |
+| ifs.rb:33:56:33:71 | "b2 \|\| b4 \|\| b5" | ifs.rb:33:51:33:71 | then ... |  |
+| ifs.rb:33:57:33:70 | b2 \|\| b4 \|\| b5 | ifs.rb:33:56:33:71 | "b2 \|\| b4 \|\| b5" |  |
+| ifs.rb:33:73:33:96 | else ... | ifs.rb:33:3:33:100 | if ... |  |
+| ifs.rb:33:78:33:96 | "!b2 \|\| !b4 \|\| !b5" | ifs.rb:33:73:33:96 | else ... |  |
+| ifs.rb:33:79:33:95 | !b2 \|\| !b4 \|\| !b5 | ifs.rb:33:78:33:96 | "!b2 \|\| !b4 \|\| !b5" |  |
+| ifs.rb:36:1:38:3 | conditional_method_def | ifs.rb:36:1:38:17 | ... unless ... |  |
+| ifs.rb:36:1:38:3 | enter conditional_method_def | ifs.rb:37:3:37:12 | self |  |
+| ifs.rb:36:1:38:3 | exit conditional_method_def (normal) | ifs.rb:36:1:38:3 | exit conditional_method_def |  |
+| ifs.rb:36:1:38:17 | ... unless ... | ifs.rb:40:1:44:3 | constant_condition |  |
+| ifs.rb:37:3:37:12 | call to puts | ifs.rb:36:1:38:3 | exit conditional_method_def (normal) |  |
+| ifs.rb:37:3:37:12 | self | ifs.rb:37:9:37:11 | bla |  |
+| ifs.rb:37:8:37:12 | "bla" | ifs.rb:37:3:37:12 | call to puts |  |
+| ifs.rb:37:9:37:11 | bla | ifs.rb:37:8:37:12 | "bla" |  |
+| ifs.rb:38:12:38:12 | 1 | ifs.rb:38:17:38:17 | 2 |  |
+| ifs.rb:38:12:38:17 | ... == ... | ifs.rb:36:1:38:3 | conditional_method_def | false |
+| ifs.rb:38:12:38:17 | ... == ... | ifs.rb:36:1:38:17 | ... unless ... | true |
+| ifs.rb:38:17:38:17 | 2 | ifs.rb:38:12:38:17 | ... == ... |  |
+| ifs.rb:40:1:44:3 | constant_condition | ifs.rb:46:1:52:3 | empty_else |  |
+| ifs.rb:40:1:44:3 | enter constant_condition | ifs.rb:41:7:41:10 | true |  |
+| ifs.rb:40:1:44:3 | exit constant_condition (normal) | ifs.rb:40:1:44:3 | exit constant_condition |  |
+| ifs.rb:41:3:43:5 | if ... | ifs.rb:40:1:44:3 | exit constant_condition (normal) |  |
+| ifs.rb:41:6:41:10 | [false] ! ... | ifs.rb:41:3:43:5 | if ... | false |
+| ifs.rb:41:7:41:10 | true | ifs.rb:41:6:41:10 | [false] ! ... | true |
+| ifs.rb:46:1:52:3 | empty_else | ifs.rb:54:1:58:3 | disjunct |  |
+| ifs.rb:46:1:52:3 | enter empty_else | ifs.rb:46:16:46:16 | b |  |
+| ifs.rb:46:1:52:3 | exit empty_else (normal) | ifs.rb:46:1:52:3 | exit empty_else |  |
+| ifs.rb:46:16:46:16 | b | ifs.rb:47:6:47:6 | b |  |
+| ifs.rb:47:3:50:5 | if ... | ifs.rb:51:3:51:13 | self |  |
+| ifs.rb:47:6:47:6 | b | ifs.rb:48:5:48:15 | self | true |
+| ifs.rb:47:6:47:6 | b | ifs.rb:49:3:49:6 | else ... | false |
+| ifs.rb:47:8:48:15 | then ... | ifs.rb:47:3:50:5 | if ... |  |
+| ifs.rb:48:5:48:15 | call to puts | ifs.rb:47:8:48:15 | then ... |  |
+| ifs.rb:48:5:48:15 | self | ifs.rb:48:11:48:14 | true |  |
+| ifs.rb:48:10:48:15 | "true" | ifs.rb:48:5:48:15 | call to puts |  |
+| ifs.rb:48:11:48:14 | true | ifs.rb:48:10:48:15 | "true" |  |
+| ifs.rb:49:3:49:6 | else ... | ifs.rb:47:3:50:5 | if ... |  |
+| ifs.rb:51:3:51:13 | call to puts | ifs.rb:46:1:52:3 | exit empty_else (normal) |  |
+| ifs.rb:51:3:51:13 | self | ifs.rb:51:9:51:12 | done |  |
+| ifs.rb:51:8:51:13 | "done" | ifs.rb:51:3:51:13 | call to puts |  |
+| ifs.rb:51:9:51:12 | done | ifs.rb:51:8:51:13 | "done" |  |
+| ifs.rb:54:1:58:3 | disjunct | ifs.rb:1:1:58:4 | exit ifs.rb (normal) |  |
+| ifs.rb:54:1:58:3 | enter disjunct | ifs.rb:54:15:54:16 | b1 |  |
+| ifs.rb:54:1:58:3 | exit disjunct (normal) | ifs.rb:54:1:58:3 | exit disjunct |  |
+| ifs.rb:54:15:54:16 | b1 | ifs.rb:54:19:54:20 | b2 |  |
+| ifs.rb:54:19:54:20 | b2 | ifs.rb:55:7:55:8 | b1 |  |
+| ifs.rb:55:3:57:5 | if ... | ifs.rb:54:1:58:3 | exit disjunct (normal) |  |
+| ifs.rb:55:6:55:15 | [false] ( ... ) | ifs.rb:55:3:57:5 | if ... | false |
+| ifs.rb:55:6:55:15 | [true] ( ... ) | ifs.rb:56:5:56:19 | self | true |
+| ifs.rb:55:7:55:8 | b1 | ifs.rb:55:7:55:14 | [true] ... \|\| ... | true |
+| ifs.rb:55:7:55:8 | b1 | ifs.rb:55:13:55:14 | b2 | false |
+| ifs.rb:55:7:55:14 | [false] ... \|\| ... | ifs.rb:55:6:55:15 | [false] ( ... ) | false |
+| ifs.rb:55:7:55:14 | [true] ... \|\| ... | ifs.rb:55:6:55:15 | [true] ( ... ) | true |
+| ifs.rb:55:13:55:14 | b2 | ifs.rb:55:7:55:14 | [false] ... \|\| ... | false |
+| ifs.rb:55:13:55:14 | b2 | ifs.rb:55:7:55:14 | [true] ... \|\| ... | true |
+| ifs.rb:55:17:56:19 | then ... | ifs.rb:55:3:57:5 | if ... |  |
+| ifs.rb:56:5:56:19 | call to puts | ifs.rb:55:17:56:19 | then ... |  |
+| ifs.rb:56:5:56:19 | self | ifs.rb:56:11:56:18 | b1 or b2 |  |
+| ifs.rb:56:10:56:19 | "b1 or b2" | ifs.rb:56:5:56:19 | call to puts |  |
+| ifs.rb:56:11:56:18 | b1 or b2 | ifs.rb:56:10:56:19 | "b1 or b2" |  |
+| loops.rb:1:1:6:3 | enter m1 | loops.rb:1:8:1:8 | x |  |
+| loops.rb:1:1:6:3 | exit m1 (normal) | loops.rb:1:1:6:3 | exit m1 |  |
+| loops.rb:1:1:6:3 | m1 | loops.rb:8:1:22:3 | m2 |  |
+| loops.rb:1:1:33:4 | enter loops.rb | loops.rb:1:1:6:3 | m1 |  |
+| loops.rb:1:1:33:4 | exit loops.rb (normal) | loops.rb:1:1:33:4 | exit loops.rb |  |
+| loops.rb:1:8:1:8 | x | loops.rb:2:9:2:9 | x |  |
+| loops.rb:2:3:5:5 | while ... | loops.rb:1:1:6:3 | exit m1 (normal) |  |
+| loops.rb:2:9:2:9 | x | loops.rb:2:14:2:14 | 0 |  |
+| loops.rb:2:9:2:14 | ... >= ... | loops.rb:2:3:5:5 | while ... | false |
+| loops.rb:2:9:2:14 | ... >= ... | loops.rb:3:5:3:10 | self | true |
+| loops.rb:2:14:2:14 | 0 | loops.rb:2:9:2:14 | ... >= ... |  |
+| loops.rb:2:15:5:5 | do ... | loops.rb:2:9:2:9 | x |  |
+| loops.rb:3:5:3:10 | call to puts | loops.rb:4:5:4:5 | x |  |
+| loops.rb:3:5:3:10 | self | loops.rb:3:10:3:10 | x |  |
+| loops.rb:3:10:3:10 | x | loops.rb:3:5:3:10 | call to puts |  |
+| loops.rb:4:5:4:5 | x | loops.rb:4:5:4:5 | x |  |
+| loops.rb:4:5:4:5 | x | loops.rb:4:10:4:10 | 1 |  |
+| loops.rb:4:5:4:10 | ... = ... | loops.rb:2:15:5:5 | do ... |  |
+| loops.rb:4:7:4:8 | ... - ... | loops.rb:4:5:4:10 | ... = ... |  |
+| loops.rb:4:10:4:10 | 1 | loops.rb:4:7:4:8 | ... - ... |  |
+| loops.rb:8:1:22:3 | enter m2 | loops.rb:8:8:8:8 | x |  |
+| loops.rb:8:1:22:3 | exit m2 (normal) | loops.rb:8:1:22:3 | exit m2 |  |
+| loops.rb:8:1:22:3 | m2 | loops.rb:24:1:28:3 | m3 |  |
+| loops.rb:8:8:8:8 | x | loops.rb:9:9:9:9 | x |  |
+| loops.rb:9:3:20:5 | while ... | loops.rb:21:3:21:13 | self |  |
+| loops.rb:9:9:9:9 | x | loops.rb:9:14:9:14 | 0 |  |
+| loops.rb:9:9:9:14 | ... >= ... | loops.rb:9:3:20:5 | while ... | false |
+| loops.rb:9:9:9:14 | ... >= ... | loops.rb:10:5:10:10 | self | true |
+| loops.rb:9:14:9:14 | 0 | loops.rb:9:9:9:14 | ... >= ... |  |
+| loops.rb:9:15:20:5 | do ... | loops.rb:9:9:9:9 | x |  |
+| loops.rb:10:5:10:10 | call to puts | loops.rb:11:5:11:5 | x |  |
+| loops.rb:10:5:10:10 | self | loops.rb:10:10:10:10 | x |  |
+| loops.rb:10:10:10:10 | x | loops.rb:10:5:10:10 | call to puts |  |
+| loops.rb:11:5:11:5 | x | loops.rb:11:5:11:5 | x |  |
+| loops.rb:11:5:11:5 | x | loops.rb:11:10:11:10 | 1 |  |
+| loops.rb:11:5:11:10 | ... = ... | loops.rb:12:8:12:8 | x |  |
+| loops.rb:11:7:11:8 | ... - ... | loops.rb:11:5:11:10 | ... = ... |  |
+| loops.rb:11:10:11:10 | 1 | loops.rb:11:7:11:8 | ... - ... |  |
+| loops.rb:12:5:18:7 | if ... | loops.rb:19:5:19:15 | self |  |
+| loops.rb:12:8:12:8 | x | loops.rb:12:12:12:14 | 100 |  |
+| loops.rb:12:8:12:14 | ... > ... | loops.rb:13:7:13:11 | break | true |
+| loops.rb:12:8:12:14 | ... > ... | loops.rb:14:11:14:11 | x | false |
+| loops.rb:12:12:12:14 | 100 | loops.rb:12:8:12:14 | ... > ... |  |
+| loops.rb:13:7:13:11 | break | loops.rb:9:3:20:5 | while ... | break |
+| loops.rb:14:5:17:10 | elsif ... | loops.rb:12:5:18:7 | if ... |  |
+| loops.rb:14:11:14:11 | x | loops.rb:14:15:14:16 | 50 |  |
+| loops.rb:14:11:14:16 | ... > ... | loops.rb:15:7:15:10 | next | true |
+| loops.rb:14:11:14:16 | ... > ... | loops.rb:16:11:16:11 | x | false |
+| loops.rb:14:15:14:16 | 50 | loops.rb:14:11:14:16 | ... > ... |  |
+| loops.rb:15:7:15:10 | next | loops.rb:9:9:9:9 | x | next |
+| loops.rb:16:5:17:10 | elsif ... | loops.rb:14:5:17:10 | elsif ... |  |
+| loops.rb:16:11:16:11 | x | loops.rb:16:15:16:16 | 10 |  |
+| loops.rb:16:11:16:16 | ... > ... | loops.rb:16:5:17:10 | elsif ... | false |
+| loops.rb:16:11:16:16 | ... > ... | loops.rb:17:7:17:10 | redo | true |
+| loops.rb:16:15:16:16 | 10 | loops.rb:16:11:16:16 | ... > ... |  |
+| loops.rb:17:7:17:10 | redo | loops.rb:10:5:10:10 | self | redo |
+| loops.rb:19:5:19:15 | call to puts | loops.rb:9:15:20:5 | do ... |  |
+| loops.rb:19:5:19:15 | self | loops.rb:19:11:19:14 | Iter |  |
+| loops.rb:19:10:19:15 | "Iter" | loops.rb:19:5:19:15 | call to puts |  |
+| loops.rb:19:11:19:14 | Iter | loops.rb:19:10:19:15 | "Iter" |  |
+| loops.rb:21:3:21:13 | call to puts | loops.rb:8:1:22:3 | exit m2 (normal) |  |
+| loops.rb:21:3:21:13 | self | loops.rb:21:9:21:12 | Done |  |
+| loops.rb:21:8:21:13 | "Done" | loops.rb:21:3:21:13 | call to puts |  |
+| loops.rb:21:9:21:12 | Done | loops.rb:21:8:21:13 | "Done" |  |
+| loops.rb:24:1:28:3 | enter m3 | loops.rb:25:3:25:9 | Array |  |
+| loops.rb:24:1:28:3 | exit m3 (normal) | loops.rb:24:1:28:3 | exit m3 |  |
+| loops.rb:24:1:28:3 | m3 | loops.rb:30:1:33:3 | m4 |  |
+| loops.rb:25:3:25:9 | Array | loops.rb:25:4:25:4 | 1 |  |
+| loops.rb:25:3:25:9 | call to [] | loops.rb:25:16:27:5 | do ... end |  |
+| loops.rb:25:3:27:5 | call to each | loops.rb:24:1:28:3 | exit m3 (normal) |  |
+| loops.rb:25:4:25:4 | 1 | loops.rb:25:6:25:6 | 2 |  |
+| loops.rb:25:6:25:6 | 2 | loops.rb:25:8:25:8 | 3 |  |
+| loops.rb:25:8:25:8 | 3 | loops.rb:25:3:25:9 | call to [] |  |
+| loops.rb:25:16:27:5 | do ... end | loops.rb:25:3:27:5 | call to each |  |
+| loops.rb:25:16:27:5 | enter do ... end | loops.rb:25:20:25:20 | x |  |
+| loops.rb:25:16:27:5 | exit do ... end (normal) | loops.rb:25:16:27:5 | exit do ... end |  |
+| loops.rb:25:20:25:20 | x | loops.rb:26:5:26:10 | self |  |
+| loops.rb:26:5:26:10 | call to puts | loops.rb:25:16:27:5 | exit do ... end (normal) |  |
+| loops.rb:26:5:26:10 | self | loops.rb:26:10:26:10 | x |  |
+| loops.rb:26:10:26:10 | x | loops.rb:26:5:26:10 | call to puts |  |
+| loops.rb:30:1:33:3 | enter m4 | loops.rb:30:8:30:8 | x |  |
+| loops.rb:30:1:33:3 | exit m4 (normal) | loops.rb:30:1:33:3 | exit m4 |  |
+| loops.rb:30:1:33:3 | m4 | loops.rb:1:1:33:4 | exit loops.rb (normal) |  |
+| loops.rb:30:8:30:8 | x | loops.rb:30:11:30:11 | y |  |
+| loops.rb:30:11:30:11 | y | loops.rb:31:9:31:9 | x |  |
+| loops.rb:31:3:32:5 | while ... | loops.rb:30:1:33:3 | exit m4 (normal) |  |
+| loops.rb:31:9:31:9 | x | loops.rb:31:13:31:13 | y |  |
+| loops.rb:31:9:31:13 | ... < ... | loops.rb:31:3:32:5 | while ... | false |
+| loops.rb:31:9:31:13 | ... < ... | loops.rb:31:15:32:5 | do ... | true |
+| loops.rb:31:13:31:13 | y | loops.rb:31:9:31:13 | ... < ... |  |
+| loops.rb:31:15:32:5 | do ... | loops.rb:31:9:31:9 | x |  |
+| raise.rb:1:1:2:3 | ExceptionA | raise.rb:1:20:1:28 | Exception |  |
+| raise.rb:1:1:182:4 | enter raise.rb | raise.rb:1:1:2:3 | ExceptionA |  |
+| raise.rb:1:1:182:4 | exit raise.rb (normal) | raise.rb:1:1:182:4 | exit raise.rb |  |
+| raise.rb:1:20:1:28 | Exception | raise.rb:4:1:5:3 | ExceptionB |  |
+| raise.rb:4:1:5:3 | ExceptionB | raise.rb:4:20:4:28 | Exception |  |
+| raise.rb:4:20:4:28 | Exception | raise.rb:7:1:12:3 | m1 |  |
+| raise.rb:7:1:12:3 | enter m1 | raise.rb:7:8:7:8 | x |  |
+| raise.rb:7:1:12:3 | exit m1 (abnormal) | raise.rb:7:1:12:3 | exit m1 |  |
+| raise.rb:7:1:12:3 | exit m1 (normal) | raise.rb:7:1:12:3 | exit m1 |  |
+| raise.rb:7:1:12:3 | m1 | raise.rb:14:1:23:3 | m2 |  |
+| raise.rb:7:8:7:8 | x | raise.rb:8:6:8:6 | x |  |
+| raise.rb:8:3:10:5 | if ... | raise.rb:11:3:11:15 | self |  |
+| raise.rb:8:6:8:6 | x | raise.rb:8:10:8:10 | 2 |  |
+| raise.rb:8:6:8:10 | ... > ... | raise.rb:8:3:10:5 | if ... | false |
+| raise.rb:8:6:8:10 | ... > ... | raise.rb:9:5:9:17 | self | true |
+| raise.rb:8:10:8:10 | 2 | raise.rb:8:6:8:10 | ... > ... |  |
+| raise.rb:9:5:9:17 | call to raise | raise.rb:7:1:12:3 | exit m1 (abnormal) | raise |
+| raise.rb:9:5:9:17 | self | raise.rb:9:12:9:16 | x > 2 |  |
+| raise.rb:9:11:9:17 | "x > 2" | raise.rb:9:5:9:17 | call to raise |  |
+| raise.rb:9:12:9:16 | x > 2 | raise.rb:9:11:9:17 | "x > 2" |  |
+| raise.rb:11:3:11:15 | call to puts | raise.rb:7:1:12:3 | exit m1 (normal) |  |
+| raise.rb:11:3:11:15 | self | raise.rb:11:9:11:14 | x <= 2 |  |
+| raise.rb:11:8:11:15 | "x <= 2" | raise.rb:11:3:11:15 | call to puts |  |
+| raise.rb:11:9:11:14 | x <= 2 | raise.rb:11:8:11:15 | "x <= 2" |  |
+| raise.rb:14:1:23:3 | enter m2 | raise.rb:14:8:14:8 | b |  |
+| raise.rb:14:1:23:3 | exit m2 (abnormal) | raise.rb:14:1:23:3 | exit m2 |  |
+| raise.rb:14:1:23:3 | exit m2 (normal) | raise.rb:14:1:23:3 | exit m2 |  |
+| raise.rb:14:1:23:3 | m2 | raise.rb:25:1:34:3 | m3 |  |
+| raise.rb:14:8:14:8 | b | raise.rb:16:8:16:8 | b |  |
+| raise.rb:16:5:18:7 | if ... | raise.rb:22:3:22:15 | self |  |
+| raise.rb:16:8:16:8 | b | raise.rb:16:5:18:7 | if ... | false |
+| raise.rb:16:8:16:8 | b | raise.rb:17:7:17:22 | self | true |
+| raise.rb:17:7:17:22 | call to raise | raise.rb:19:10:19:19 | ExceptionA | raise |
+| raise.rb:17:7:17:22 | self | raise.rb:17:13:17:22 | ExceptionA |  |
+| raise.rb:17:13:17:22 | ExceptionA | raise.rb:17:7:17:22 | call to raise |  |
+| raise.rb:19:3:20:18 | rescue ... | raise.rb:22:3:22:15 | self |  |
+| raise.rb:19:10:19:19 | ExceptionA | raise.rb:14:1:23:3 | exit m2 (abnormal) | raise |
+| raise.rb:19:10:19:19 | ExceptionA | raise.rb:20:5:20:18 | self | match |
+| raise.rb:19:20:20:18 | then ... | raise.rb:19:3:20:18 | rescue ... |  |
+| raise.rb:20:5:20:18 | call to puts | raise.rb:19:20:20:18 | then ... |  |
+| raise.rb:20:5:20:18 | self | raise.rb:20:11:20:17 | Rescued |  |
+| raise.rb:20:10:20:18 | "Rescued" | raise.rb:20:5:20:18 | call to puts |  |
+| raise.rb:20:11:20:17 | Rescued | raise.rb:20:10:20:18 | "Rescued" |  |
+| raise.rb:22:3:22:15 | call to puts | raise.rb:14:1:23:3 | exit m2 (normal) |  |
+| raise.rb:22:3:22:15 | self | raise.rb:22:9:22:14 | End m2 |  |
+| raise.rb:22:8:22:15 | "End m2" | raise.rb:22:3:22:15 | call to puts |  |
+| raise.rb:22:9:22:14 | End m2 | raise.rb:22:8:22:15 | "End m2" |  |
+| raise.rb:25:1:34:3 | enter m3 | raise.rb:25:8:25:8 | b |  |
+| raise.rb:25:1:34:3 | exit m3 (normal) | raise.rb:25:1:34:3 | exit m3 |  |
+| raise.rb:25:1:34:3 | m3 | raise.rb:36:1:45:3 | m4 |  |
+| raise.rb:25:8:25:8 | b | raise.rb:27:8:27:8 | b |  |
+| raise.rb:27:5:29:7 | if ... | raise.rb:33:3:33:15 | self |  |
+| raise.rb:27:8:27:8 | b | raise.rb:27:5:29:7 | if ... | false |
+| raise.rb:27:8:27:8 | b | raise.rb:28:7:28:22 | self | true |
+| raise.rb:28:7:28:22 | call to raise | raise.rb:31:5:31:18 | self | raise |
+| raise.rb:28:7:28:22 | self | raise.rb:28:13:28:22 | ExceptionA |  |
+| raise.rb:28:13:28:22 | ExceptionA | raise.rb:28:7:28:22 | call to raise |  |
+| raise.rb:30:3:31:18 | rescue ... | raise.rb:33:3:33:15 | self |  |
+| raise.rb:30:9:31:18 | then ... | raise.rb:30:3:31:18 | rescue ... |  |
+| raise.rb:31:5:31:18 | call to puts | raise.rb:30:9:31:18 | then ... |  |
+| raise.rb:31:5:31:18 | self | raise.rb:31:11:31:17 | Rescued |  |
+| raise.rb:31:10:31:18 | "Rescued" | raise.rb:31:5:31:18 | call to puts |  |
+| raise.rb:31:11:31:17 | Rescued | raise.rb:31:10:31:18 | "Rescued" |  |
+| raise.rb:33:3:33:15 | call to puts | raise.rb:25:1:34:3 | exit m3 (normal) |  |
+| raise.rb:33:3:33:15 | self | raise.rb:33:9:33:14 | End m3 |  |
+| raise.rb:33:8:33:15 | "End m3" | raise.rb:33:3:33:15 | call to puts |  |
+| raise.rb:33:9:33:14 | End m3 | raise.rb:33:8:33:15 | "End m3" |  |
+| raise.rb:36:1:45:3 | enter m4 | raise.rb:36:8:36:8 | b |  |
+| raise.rb:36:1:45:3 | exit m4 (normal) | raise.rb:36:1:45:3 | exit m4 |  |
+| raise.rb:36:1:45:3 | m4 | raise.rb:47:1:55:3 | m5 |  |
+| raise.rb:36:8:36:8 | b | raise.rb:38:8:38:8 | b |  |
+| raise.rb:38:5:40:7 | if ... | raise.rb:44:3:44:15 | self |  |
+| raise.rb:38:8:38:8 | b | raise.rb:38:5:40:7 | if ... | false |
+| raise.rb:38:8:38:8 | b | raise.rb:39:7:39:22 | self | true |
+| raise.rb:39:7:39:22 | call to raise | raise.rb:41:13:41:13 | e | raise |
+| raise.rb:39:7:39:22 | self | raise.rb:39:13:39:22 | ExceptionA |  |
+| raise.rb:39:13:39:22 | ExceptionA | raise.rb:39:7:39:22 | call to raise |  |
+| raise.rb:41:3:42:22 | rescue ... | raise.rb:44:3:44:15 | self |  |
+| raise.rb:41:13:41:13 | e | raise.rb:42:5:42:22 | self |  |
+| raise.rb:41:14:42:22 | then ... | raise.rb:41:3:42:22 | rescue ... |  |
+| raise.rb:42:5:42:22 | call to puts | raise.rb:41:14:42:22 | then ... |  |
+| raise.rb:42:5:42:22 | self | raise.rb:42:11:42:21 | Rescued {e} |  |
+| raise.rb:42:10:42:22 | "Rescued {e}" | raise.rb:42:5:42:22 | call to puts |  |
+| raise.rb:42:11:42:21 | Rescued {e} | raise.rb:42:10:42:22 | "Rescued {e}" |  |
+| raise.rb:44:3:44:15 | call to puts | raise.rb:36:1:45:3 | exit m4 (normal) |  |
+| raise.rb:44:3:44:15 | self | raise.rb:44:9:44:14 | End m4 |  |
+| raise.rb:44:8:44:15 | "End m4" | raise.rb:44:3:44:15 | call to puts |  |
+| raise.rb:44:9:44:14 | End m4 | raise.rb:44:8:44:15 | "End m4" |  |
+| raise.rb:47:1:55:3 | enter m5 | raise.rb:47:8:47:8 | b |  |
+| raise.rb:47:1:55:3 | exit m5 (normal) | raise.rb:47:1:55:3 | exit m5 |  |
+| raise.rb:47:1:55:3 | m5 | raise.rb:57:1:66:3 | m6 |  |
+| raise.rb:47:8:47:8 | b | raise.rb:49:8:49:8 | b |  |
+| raise.rb:49:5:51:7 | if ... | raise.rb:54:3:54:15 | self |  |
+| raise.rb:49:8:49:8 | b | raise.rb:49:5:51:7 | if ... | false |
+| raise.rb:49:8:49:8 | b | raise.rb:50:7:50:22 | self | true |
+| raise.rb:50:7:50:22 | call to raise | raise.rb:52:13:52:13 | e | raise |
+| raise.rb:50:7:50:22 | self | raise.rb:50:13:50:22 | ExceptionA |  |
+| raise.rb:50:13:50:22 | ExceptionA | raise.rb:50:7:50:22 | call to raise |  |
+| raise.rb:52:3:52:13 | rescue ... | raise.rb:54:3:54:15 | self |  |
+| raise.rb:52:13:52:13 | e | raise.rb:52:3:52:13 | rescue ... |  |
+| raise.rb:54:3:54:15 | call to puts | raise.rb:47:1:55:3 | exit m5 (normal) |  |
+| raise.rb:54:3:54:15 | self | raise.rb:54:9:54:14 | End m5 |  |
+| raise.rb:54:8:54:15 | "End m5" | raise.rb:54:3:54:15 | call to puts |  |
+| raise.rb:54:9:54:14 | End m5 | raise.rb:54:8:54:15 | "End m5" |  |
+| raise.rb:57:1:66:3 | enter m6 | raise.rb:57:8:57:8 | b |  |
+| raise.rb:57:1:66:3 | exit m6 (abnormal) | raise.rb:57:1:66:3 | exit m6 |  |
+| raise.rb:57:1:66:3 | exit m6 (normal) | raise.rb:57:1:66:3 | exit m6 |  |
+| raise.rb:57:1:66:3 | m6 | raise.rb:68:1:77:3 | m7 |  |
+| raise.rb:57:8:57:8 | b | raise.rb:59:8:59:8 | b |  |
+| raise.rb:59:5:61:7 | if ... | raise.rb:65:3:65:15 | self |  |
+| raise.rb:59:8:59:8 | b | raise.rb:59:5:61:7 | if ... | false |
+| raise.rb:59:8:59:8 | b | raise.rb:60:7:60:22 | self | true |
+| raise.rb:60:7:60:22 | call to raise | raise.rb:62:10:62:19 | ExceptionA | raise |
+| raise.rb:60:7:60:22 | self | raise.rb:60:13:60:22 | ExceptionA |  |
+| raise.rb:60:13:60:22 | ExceptionA | raise.rb:60:7:60:22 | call to raise |  |
+| raise.rb:62:3:63:22 | rescue ... | raise.rb:65:3:65:15 | self |  |
+| raise.rb:62:10:62:19 | ExceptionA | raise.rb:62:22:62:31 | ExceptionB | no-match |
+| raise.rb:62:10:62:19 | ExceptionA | raise.rb:62:36:62:36 | e | match |
+| raise.rb:62:22:62:31 | ExceptionB | raise.rb:57:1:66:3 | exit m6 (abnormal) | raise |
+| raise.rb:62:22:62:31 | ExceptionB | raise.rb:62:36:62:36 | e | match |
+| raise.rb:62:36:62:36 | e | raise.rb:63:5:63:22 | self |  |
+| raise.rb:62:37:63:22 | then ... | raise.rb:62:3:63:22 | rescue ... |  |
+| raise.rb:63:5:63:22 | call to puts | raise.rb:62:37:63:22 | then ... |  |
+| raise.rb:63:5:63:22 | self | raise.rb:63:11:63:21 | Rescued {e} |  |
+| raise.rb:63:10:63:22 | "Rescued {e}" | raise.rb:63:5:63:22 | call to puts |  |
+| raise.rb:63:11:63:21 | Rescued {e} | raise.rb:63:10:63:22 | "Rescued {e}" |  |
+| raise.rb:65:3:65:15 | call to puts | raise.rb:57:1:66:3 | exit m6 (normal) |  |
+| raise.rb:65:3:65:15 | self | raise.rb:65:9:65:14 | End m6 |  |
+| raise.rb:65:8:65:15 | "End m6" | raise.rb:65:3:65:15 | call to puts |  |
+| raise.rb:65:9:65:14 | End m6 | raise.rb:65:8:65:15 | "End m6" |  |
+| raise.rb:68:1:77:3 | enter m7 | raise.rb:68:8:68:8 | x |  |
+| raise.rb:68:1:77:3 | exit m7 (abnormal) | raise.rb:68:1:77:3 | exit m7 |  |
+| raise.rb:68:1:77:3 | exit m7 (normal) | raise.rb:68:1:77:3 | exit m7 |  |
+| raise.rb:68:1:77:3 | m7 | raise.rb:79:1:92:3 | m8 |  |
+| raise.rb:68:8:68:8 | x | raise.rb:69:6:69:6 | x |  |
+| raise.rb:69:3:73:5 | if ... | raise.rb:74:3:74:20 | self |  |
+| raise.rb:69:6:69:6 | x | raise.rb:69:10:69:10 | 2 |  |
+| raise.rb:69:6:69:10 | ... > ... | raise.rb:70:5:70:17 | self | true |
+| raise.rb:69:6:69:10 | ... > ... | raise.rb:71:9:71:9 | x | false |
+| raise.rb:69:6:69:10 | ... > ... | raise.rb:76:3:76:15 | [ensure: raise] self | raise |
+| raise.rb:69:10:69:10 | 2 | raise.rb:69:6:69:10 | ... > ... |  |
+| raise.rb:70:5:70:17 | call to raise | raise.rb:76:3:76:15 | [ensure: raise] self | raise |
+| raise.rb:70:5:70:17 | self | raise.rb:70:12:70:16 | x > 2 |  |
+| raise.rb:70:11:70:17 | "x > 2" | raise.rb:70:5:70:17 | call to raise |  |
+| raise.rb:70:12:70:16 | x > 2 | raise.rb:70:11:70:17 | "x > 2" |  |
+| raise.rb:71:3:72:18 | elsif ... | raise.rb:69:3:73:5 | if ... |  |
+| raise.rb:71:9:71:9 | x | raise.rb:71:13:71:13 | 0 |  |
+| raise.rb:71:9:71:13 | ... < ... | raise.rb:71:3:72:18 | elsif ... | false |
+| raise.rb:71:9:71:13 | ... < ... | raise.rb:72:13:72:17 | x < 0 | true |
+| raise.rb:71:9:71:13 | ... < ... | raise.rb:76:3:76:15 | [ensure: raise] self | raise |
+| raise.rb:71:13:71:13 | 0 | raise.rb:71:9:71:13 | ... < ... |  |
+| raise.rb:72:5:72:18 | return | raise.rb:76:3:76:15 | [ensure: return] self | return |
+| raise.rb:72:12:72:18 | "x < 0" | raise.rb:72:5:72:18 | return |  |
+| raise.rb:72:13:72:17 | x < 0 | raise.rb:72:12:72:18 | "x < 0" |  |
+| raise.rb:74:3:74:20 | call to puts | raise.rb:76:3:76:15 | [ensure: raise] self | raise |
+| raise.rb:74:3:74:20 | call to puts | raise.rb:76:3:76:15 | self |  |
+| raise.rb:74:3:74:20 | self | raise.rb:74:9:74:19 | 0 <= x <= 2 |  |
+| raise.rb:74:8:74:20 | "0 <= x <= 2" | raise.rb:74:3:74:20 | call to puts |  |
+| raise.rb:74:9:74:19 | 0 <= x <= 2 | raise.rb:74:8:74:20 | "0 <= x <= 2" |  |
+| raise.rb:75:1:76:15 | [ensure: raise] ensure ... | raise.rb:68:1:77:3 | exit m7 (abnormal) | raise |
+| raise.rb:75:1:76:15 | [ensure: return] ensure ... | raise.rb:68:1:77:3 | exit m7 (normal) | return |
+| raise.rb:75:1:76:15 | ensure ... | raise.rb:68:1:77:3 | exit m7 (normal) |  |
+| raise.rb:76:3:76:15 | [ensure: raise] call to puts | raise.rb:75:1:76:15 | [ensure: raise] ensure ... |  |
+| raise.rb:76:3:76:15 | [ensure: raise] self | raise.rb:76:9:76:14 | [ensure: raise] ensure |  |
+| raise.rb:76:3:76:15 | [ensure: return] call to puts | raise.rb:75:1:76:15 | [ensure: return] ensure ... |  |
+| raise.rb:76:3:76:15 | [ensure: return] self | raise.rb:76:9:76:14 | [ensure: return] ensure |  |
+| raise.rb:76:3:76:15 | call to puts | raise.rb:75:1:76:15 | ensure ... |  |
+| raise.rb:76:3:76:15 | self | raise.rb:76:9:76:14 | ensure |  |
+| raise.rb:76:8:76:15 | "ensure" | raise.rb:76:3:76:15 | call to puts |  |
+| raise.rb:76:8:76:15 | [ensure: raise] "ensure" | raise.rb:76:3:76:15 | [ensure: raise] call to puts |  |
+| raise.rb:76:8:76:15 | [ensure: return] "ensure" | raise.rb:76:3:76:15 | [ensure: return] call to puts |  |
+| raise.rb:76:9:76:14 | [ensure: raise] ensure | raise.rb:76:8:76:15 | [ensure: raise] "ensure" |  |
+| raise.rb:76:9:76:14 | [ensure: return] ensure | raise.rb:76:8:76:15 | [ensure: return] "ensure" |  |
+| raise.rb:76:9:76:14 | ensure | raise.rb:76:8:76:15 | "ensure" |  |
+| raise.rb:79:1:92:3 | enter m8 | raise.rb:79:8:79:8 | x |  |
+| raise.rb:79:1:92:3 | exit m8 (abnormal) | raise.rb:79:1:92:3 | exit m8 |  |
+| raise.rb:79:1:92:3 | exit m8 (normal) | raise.rb:79:1:92:3 | exit m8 |  |
+| raise.rb:79:1:92:3 | m8 | raise.rb:94:1:119:3 | m9 |  |
+| raise.rb:79:8:79:8 | x | raise.rb:80:3:80:17 | self |  |
+| raise.rb:80:3:80:17 | call to puts | raise.rb:82:8:82:8 | x |  |
+| raise.rb:80:3:80:17 | self | raise.rb:80:9:80:16 | Begin m8 |  |
+| raise.rb:80:8:80:17 | "Begin m8" | raise.rb:80:3:80:17 | call to puts |  |
+| raise.rb:80:9:80:16 | Begin m8 | raise.rb:80:8:80:17 | "Begin m8" |  |
+| raise.rb:82:5:86:7 | if ... | raise.rb:87:5:87:22 | self |  |
+| raise.rb:82:8:82:8 | x | raise.rb:82:12:82:12 | 2 |  |
+| raise.rb:82:8:82:12 | ... > ... | raise.rb:83:7:83:19 | self | true |
+| raise.rb:82:8:82:12 | ... > ... | raise.rb:84:11:84:11 | x | false |
+| raise.rb:82:8:82:12 | ... > ... | raise.rb:89:5:89:17 | [ensure: raise] self | raise |
+| raise.rb:82:12:82:12 | 2 | raise.rb:82:8:82:12 | ... > ... |  |
+| raise.rb:83:7:83:19 | call to raise | raise.rb:89:5:89:17 | [ensure: raise] self | raise |
+| raise.rb:83:7:83:19 | self | raise.rb:83:14:83:18 | x > 2 |  |
+| raise.rb:83:13:83:19 | "x > 2" | raise.rb:83:7:83:19 | call to raise |  |
+| raise.rb:83:14:83:18 | x > 2 | raise.rb:83:13:83:19 | "x > 2" |  |
+| raise.rb:84:5:85:20 | elsif ... | raise.rb:82:5:86:7 | if ... |  |
+| raise.rb:84:11:84:11 | x | raise.rb:84:15:84:15 | 0 |  |
+| raise.rb:84:11:84:15 | ... < ... | raise.rb:84:5:85:20 | elsif ... | false |
+| raise.rb:84:11:84:15 | ... < ... | raise.rb:85:15:85:19 | x < 0 | true |
+| raise.rb:84:11:84:15 | ... < ... | raise.rb:89:5:89:17 | [ensure: raise] self | raise |
+| raise.rb:84:15:84:15 | 0 | raise.rb:84:11:84:15 | ... < ... |  |
+| raise.rb:85:7:85:20 | return | raise.rb:89:5:89:17 | [ensure: return] self | return |
+| raise.rb:85:14:85:20 | "x < 0" | raise.rb:85:7:85:20 | return |  |
+| raise.rb:85:15:85:19 | x < 0 | raise.rb:85:14:85:20 | "x < 0" |  |
+| raise.rb:87:5:87:22 | call to puts | raise.rb:89:5:89:17 | [ensure: raise] self | raise |
+| raise.rb:87:5:87:22 | call to puts | raise.rb:89:5:89:17 | self |  |
+| raise.rb:87:5:87:22 | self | raise.rb:87:11:87:21 | 0 <= x <= 2 |  |
+| raise.rb:87:10:87:22 | "0 <= x <= 2" | raise.rb:87:5:87:22 | call to puts |  |
+| raise.rb:87:11:87:21 | 0 <= x <= 2 | raise.rb:87:10:87:22 | "0 <= x <= 2" |  |
+| raise.rb:88:3:89:17 | [ensure: raise] ensure ... | raise.rb:79:1:92:3 | exit m8 (abnormal) | raise |
+| raise.rb:88:3:89:17 | [ensure: return] ensure ... | raise.rb:79:1:92:3 | exit m8 (normal) | return |
+| raise.rb:88:3:89:17 | ensure ... | raise.rb:91:3:91:15 | self |  |
+| raise.rb:89:5:89:17 | [ensure: raise] call to puts | raise.rb:88:3:89:17 | [ensure: raise] ensure ... |  |
+| raise.rb:89:5:89:17 | [ensure: raise] self | raise.rb:89:11:89:16 | [ensure: raise] ensure |  |
+| raise.rb:89:5:89:17 | [ensure: return] call to puts | raise.rb:88:3:89:17 | [ensure: return] ensure ... |  |
+| raise.rb:89:5:89:17 | [ensure: return] self | raise.rb:89:11:89:16 | [ensure: return] ensure |  |
+| raise.rb:89:5:89:17 | call to puts | raise.rb:88:3:89:17 | ensure ... |  |
+| raise.rb:89:5:89:17 | self | raise.rb:89:11:89:16 | ensure |  |
+| raise.rb:89:10:89:17 | "ensure" | raise.rb:89:5:89:17 | call to puts |  |
+| raise.rb:89:10:89:17 | [ensure: raise] "ensure" | raise.rb:89:5:89:17 | [ensure: raise] call to puts |  |
+| raise.rb:89:10:89:17 | [ensure: return] "ensure" | raise.rb:89:5:89:17 | [ensure: return] call to puts |  |
+| raise.rb:89:11:89:16 | [ensure: raise] ensure | raise.rb:89:10:89:17 | [ensure: raise] "ensure" |  |
+| raise.rb:89:11:89:16 | [ensure: return] ensure | raise.rb:89:10:89:17 | [ensure: return] "ensure" |  |
+| raise.rb:89:11:89:16 | ensure | raise.rb:89:10:89:17 | "ensure" |  |
+| raise.rb:91:3:91:15 | call to puts | raise.rb:79:1:92:3 | exit m8 (normal) |  |
+| raise.rb:91:3:91:15 | self | raise.rb:91:9:91:14 | End m8 |  |
+| raise.rb:91:8:91:15 | "End m8" | raise.rb:91:3:91:15 | call to puts |  |
+| raise.rb:91:9:91:14 | End m8 | raise.rb:91:8:91:15 | "End m8" |  |
+| raise.rb:94:1:119:3 | enter m9 | raise.rb:94:8:94:8 | x |  |
+| raise.rb:94:1:119:3 | exit m9 (abnormal) | raise.rb:94:1:119:3 | exit m9 |  |
+| raise.rb:94:1:119:3 | exit m9 (normal) | raise.rb:94:1:119:3 | exit m9 |  |
+| raise.rb:94:1:119:3 | m9 | raise.rb:121:1:126:3 | m10 |  |
+| raise.rb:94:8:94:8 | x | raise.rb:94:11:94:12 | b1 |  |
+| raise.rb:94:11:94:12 | b1 | raise.rb:94:15:94:16 | b2 |  |
+| raise.rb:94:15:94:16 | b2 | raise.rb:95:3:95:17 | self |  |
+| raise.rb:95:3:95:17 | call to puts | raise.rb:97:8:97:8 | x |  |
+| raise.rb:95:3:95:17 | call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:95:3:95:17 | self | raise.rb:95:9:95:16 | Begin m9 |  |
+| raise.rb:95:8:95:17 | "Begin m9" | raise.rb:95:3:95:17 | call to puts |  |
+| raise.rb:95:9:95:16 | Begin m9 | raise.rb:95:8:95:17 | "Begin m9" |  |
+| raise.rb:97:5:101:7 | if ... | raise.rb:102:5:102:22 | self |  |
+| raise.rb:97:8:97:8 | x | raise.rb:97:12:97:12 | 2 |  |
+| raise.rb:97:8:97:12 | ... > ... | raise.rb:98:7:98:19 | self | true |
+| raise.rb:97:8:97:12 | ... > ... | raise.rb:99:11:99:11 | x | false |
+| raise.rb:97:8:97:12 | ... > ... | raise.rb:104:5:104:23 | [ensure: raise] self | raise |
+| raise.rb:97:12:97:12 | 2 | raise.rb:97:8:97:12 | ... > ... |  |
+| raise.rb:98:7:98:19 | call to raise | raise.rb:104:5:104:23 | [ensure: raise] self | raise |
+| raise.rb:98:7:98:19 | self | raise.rb:98:14:98:18 | x > 2 |  |
+| raise.rb:98:13:98:19 | "x > 2" | raise.rb:98:7:98:19 | call to raise |  |
+| raise.rb:98:14:98:18 | x > 2 | raise.rb:98:13:98:19 | "x > 2" |  |
+| raise.rb:99:5:100:20 | elsif ... | raise.rb:97:5:101:7 | if ... |  |
+| raise.rb:99:11:99:11 | x | raise.rb:99:15:99:15 | 0 |  |
+| raise.rb:99:11:99:15 | ... < ... | raise.rb:99:5:100:20 | elsif ... | false |
+| raise.rb:99:11:99:15 | ... < ... | raise.rb:100:15:100:19 | x < 0 | true |
+| raise.rb:99:11:99:15 | ... < ... | raise.rb:104:5:104:23 | [ensure: raise] self | raise |
+| raise.rb:99:15:99:15 | 0 | raise.rb:99:11:99:15 | ... < ... |  |
+| raise.rb:100:7:100:20 | return | raise.rb:104:5:104:23 | [ensure: return] self | return |
+| raise.rb:100:14:100:20 | "x < 0" | raise.rb:100:7:100:20 | return |  |
+| raise.rb:100:15:100:19 | x < 0 | raise.rb:100:14:100:20 | "x < 0" |  |
+| raise.rb:102:5:102:22 | call to puts | raise.rb:104:5:104:23 | [ensure: raise] self | raise |
+| raise.rb:102:5:102:22 | call to puts | raise.rb:104:5:104:23 | self |  |
+| raise.rb:102:5:102:22 | self | raise.rb:102:11:102:21 | 0 <= x <= 2 |  |
+| raise.rb:102:10:102:22 | "0 <= x <= 2" | raise.rb:102:5:102:22 | call to puts |  |
+| raise.rb:102:11:102:21 | 0 <= x <= 2 | raise.rb:102:10:102:22 | "0 <= x <= 2" |  |
+| raise.rb:103:3:111:7 | [ensure: raise] ensure ... | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:103:3:111:7 | [ensure: return] ensure ... | raise.rb:115:3:115:22 | [ensure: return] self | return |
+| raise.rb:103:3:111:7 | ensure ... | raise.rb:113:3:113:15 | self |  |
+| raise.rb:104:5:104:23 | [ensure: raise] call to puts | raise.rb:106:10:106:11 | [ensure: raise] b1 |  |
+| raise.rb:104:5:104:23 | [ensure: raise] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:104:5:104:23 | [ensure: raise] self | raise.rb:104:11:104:22 | [ensure: raise] outer ensure |  |
+| raise.rb:104:5:104:23 | [ensure: return] call to puts | raise.rb:106:10:106:11 | [ensure: return] b1 |  |
+| raise.rb:104:5:104:23 | [ensure: return] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:104:5:104:23 | [ensure: return] self | raise.rb:104:11:104:22 | [ensure: return] outer ensure |  |
+| raise.rb:104:5:104:23 | call to puts | raise.rb:106:10:106:11 | b1 |  |
+| raise.rb:104:5:104:23 | call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:104:5:104:23 | self | raise.rb:104:11:104:22 | outer ensure |  |
+| raise.rb:104:10:104:23 | "outer ensure" | raise.rb:104:5:104:23 | call to puts |  |
+| raise.rb:104:10:104:23 | [ensure: raise] "outer ensure" | raise.rb:104:5:104:23 | [ensure: raise] call to puts |  |
+| raise.rb:104:10:104:23 | [ensure: return] "outer ensure" | raise.rb:104:5:104:23 | [ensure: return] call to puts |  |
+| raise.rb:104:11:104:22 | [ensure: raise] outer ensure | raise.rb:104:10:104:23 | [ensure: raise] "outer ensure" |  |
+| raise.rb:104:11:104:22 | [ensure: return] outer ensure | raise.rb:104:10:104:23 | [ensure: return] "outer ensure" |  |
+| raise.rb:104:11:104:22 | outer ensure | raise.rb:104:10:104:23 | "outer ensure" |  |
+| raise.rb:106:7:108:9 | [ensure: raise] if ... | raise.rb:110:7:110:25 | [ensure: raise] self |  |
+| raise.rb:106:7:108:9 | [ensure: return] if ... | raise.rb:110:7:110:25 | [ensure: return] self |  |
+| raise.rb:106:7:108:9 | if ... | raise.rb:110:7:110:25 | self |  |
+| raise.rb:106:10:106:11 | [ensure: raise] b1 | raise.rb:106:7:108:9 | [ensure: raise] if ... | false |
+| raise.rb:106:10:106:11 | [ensure: raise] b1 | raise.rb:107:9:107:26 | [ensure: raise] self | true |
+| raise.rb:106:10:106:11 | [ensure: return] b1 | raise.rb:106:7:108:9 | [ensure: return] if ... | false |
+| raise.rb:106:10:106:11 | [ensure: return] b1 | raise.rb:107:9:107:26 | [ensure: return] self | true |
+| raise.rb:106:10:106:11 | b1 | raise.rb:106:7:108:9 | if ... | false |
+| raise.rb:106:10:106:11 | b1 | raise.rb:107:9:107:26 | self | true |
+| raise.rb:107:9:107:26 | [ensure: raise] call to raise | raise.rb:110:7:110:25 | [ensure: raise, ensure(1): raise] self | raise |
+| raise.rb:107:9:107:26 | [ensure: raise] self | raise.rb:107:16:107:25 | [ensure: raise] b1 is true |  |
+| raise.rb:107:9:107:26 | [ensure: return] call to raise | raise.rb:110:7:110:25 | [ensure: return, ensure(1): raise] self | raise |
+| raise.rb:107:9:107:26 | [ensure: return] self | raise.rb:107:16:107:25 | [ensure: return] b1 is true |  |
+| raise.rb:107:9:107:26 | call to raise | raise.rb:110:7:110:25 | [ensure(1): raise] self | raise |
+| raise.rb:107:9:107:26 | self | raise.rb:107:16:107:25 | b1 is true |  |
+| raise.rb:107:15:107:26 | "b1 is true" | raise.rb:107:9:107:26 | call to raise |  |
+| raise.rb:107:15:107:26 | [ensure: raise] "b1 is true" | raise.rb:107:9:107:26 | [ensure: raise] call to raise |  |
+| raise.rb:107:15:107:26 | [ensure: return] "b1 is true" | raise.rb:107:9:107:26 | [ensure: return] call to raise |  |
+| raise.rb:107:16:107:25 | [ensure: raise] b1 is true | raise.rb:107:15:107:26 | [ensure: raise] "b1 is true" |  |
+| raise.rb:107:16:107:25 | [ensure: return] b1 is true | raise.rb:107:15:107:26 | [ensure: return] "b1 is true" |  |
+| raise.rb:107:16:107:25 | b1 is true | raise.rb:107:15:107:26 | "b1 is true" |  |
+| raise.rb:109:5:110:25 | [ensure(1): raise] ensure ... | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:109:5:110:25 | [ensure: raise, ensure(1): raise] ensure ... | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:109:5:110:25 | [ensure: raise] ensure ... | raise.rb:103:3:111:7 | [ensure: raise] ensure ... |  |
+| raise.rb:109:5:110:25 | [ensure: return, ensure(1): raise] ensure ... | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:109:5:110:25 | [ensure: return] ensure ... | raise.rb:103:3:111:7 | [ensure: return] ensure ... |  |
+| raise.rb:109:5:110:25 | ensure ... | raise.rb:103:3:111:7 | ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure(1): raise] call to puts | raise.rb:109:5:110:25 | [ensure(1): raise] ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure(1): raise] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | [ensure(1): raise] self | raise.rb:110:13:110:24 | [ensure(1): raise] inner ensure |  |
+| raise.rb:110:7:110:25 | [ensure: raise, ensure(1): raise] call to puts | raise.rb:109:5:110:25 | [ensure: raise, ensure(1): raise] ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure: raise, ensure(1): raise] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | [ensure: raise, ensure(1): raise] self | raise.rb:110:13:110:24 | [ensure: raise, ensure(1): raise] inner ensure |  |
+| raise.rb:110:7:110:25 | [ensure: raise] call to puts | raise.rb:109:5:110:25 | [ensure: raise] ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure: raise] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | [ensure: raise] self | raise.rb:110:13:110:24 | [ensure: raise] inner ensure |  |
+| raise.rb:110:7:110:25 | [ensure: return, ensure(1): raise] call to puts | raise.rb:109:5:110:25 | [ensure: return, ensure(1): raise] ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure: return, ensure(1): raise] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | [ensure: return, ensure(1): raise] self | raise.rb:110:13:110:24 | [ensure: return, ensure(1): raise] inner ensure |  |
+| raise.rb:110:7:110:25 | [ensure: return] call to puts | raise.rb:109:5:110:25 | [ensure: return] ensure ... |  |
+| raise.rb:110:7:110:25 | [ensure: return] call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | [ensure: return] self | raise.rb:110:13:110:24 | [ensure: return] inner ensure |  |
+| raise.rb:110:7:110:25 | call to puts | raise.rb:109:5:110:25 | ensure ... |  |
+| raise.rb:110:7:110:25 | call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:110:7:110:25 | self | raise.rb:110:13:110:24 | inner ensure |  |
+| raise.rb:110:12:110:25 | "inner ensure" | raise.rb:110:7:110:25 | call to puts |  |
+| raise.rb:110:12:110:25 | [ensure(1): raise] "inner ensure" | raise.rb:110:7:110:25 | [ensure(1): raise] call to puts |  |
+| raise.rb:110:12:110:25 | [ensure: raise, ensure(1): raise] "inner ensure" | raise.rb:110:7:110:25 | [ensure: raise, ensure(1): raise] call to puts |  |
+| raise.rb:110:12:110:25 | [ensure: raise] "inner ensure" | raise.rb:110:7:110:25 | [ensure: raise] call to puts |  |
+| raise.rb:110:12:110:25 | [ensure: return, ensure(1): raise] "inner ensure" | raise.rb:110:7:110:25 | [ensure: return, ensure(1): raise] call to puts |  |
+| raise.rb:110:12:110:25 | [ensure: return] "inner ensure" | raise.rb:110:7:110:25 | [ensure: return] call to puts |  |
+| raise.rb:110:13:110:24 | [ensure(1): raise] inner ensure | raise.rb:110:12:110:25 | [ensure(1): raise] "inner ensure" |  |
+| raise.rb:110:13:110:24 | [ensure: raise, ensure(1): raise] inner ensure | raise.rb:110:12:110:25 | [ensure: raise, ensure(1): raise] "inner ensure" |  |
+| raise.rb:110:13:110:24 | [ensure: raise] inner ensure | raise.rb:110:12:110:25 | [ensure: raise] "inner ensure" |  |
+| raise.rb:110:13:110:24 | [ensure: return, ensure(1): raise] inner ensure | raise.rb:110:12:110:25 | [ensure: return, ensure(1): raise] "inner ensure" |  |
+| raise.rb:110:13:110:24 | [ensure: return] inner ensure | raise.rb:110:12:110:25 | [ensure: return] "inner ensure" |  |
+| raise.rb:110:13:110:24 | inner ensure | raise.rb:110:12:110:25 | "inner ensure" |  |
+| raise.rb:113:3:113:15 | call to puts | raise.rb:115:3:115:22 | [ensure: raise] self | raise |
+| raise.rb:113:3:113:15 | call to puts | raise.rb:115:3:115:22 | self |  |
+| raise.rb:113:3:113:15 | self | raise.rb:113:9:113:14 | End m9 |  |
+| raise.rb:113:8:113:15 | "End m9" | raise.rb:113:3:113:15 | call to puts |  |
+| raise.rb:113:9:113:14 | End m9 | raise.rb:113:8:113:15 | "End m9" |  |
+| raise.rb:114:1:118:5 | [ensure: raise] ensure ... | raise.rb:94:1:119:3 | exit m9 (abnormal) | raise |
+| raise.rb:114:1:118:5 | [ensure: return] ensure ... | raise.rb:94:1:119:3 | exit m9 (normal) | return |
+| raise.rb:114:1:118:5 | ensure ... | raise.rb:94:1:119:3 | exit m9 (normal) |  |
+| raise.rb:115:3:115:22 | [ensure: raise] call to puts | raise.rb:116:6:116:7 | [ensure: raise] b2 |  |
+| raise.rb:115:3:115:22 | [ensure: raise] self | raise.rb:115:9:115:21 | [ensure: raise] method ensure |  |
+| raise.rb:115:3:115:22 | [ensure: return] call to puts | raise.rb:116:6:116:7 | [ensure: return] b2 |  |
+| raise.rb:115:3:115:22 | [ensure: return] self | raise.rb:115:9:115:21 | [ensure: return] method ensure |  |
+| raise.rb:115:3:115:22 | call to puts | raise.rb:116:6:116:7 | b2 |  |
+| raise.rb:115:3:115:22 | self | raise.rb:115:9:115:21 | method ensure |  |
+| raise.rb:115:8:115:22 | "method ensure" | raise.rb:115:3:115:22 | call to puts |  |
+| raise.rb:115:8:115:22 | [ensure: raise] "method ensure" | raise.rb:115:3:115:22 | [ensure: raise] call to puts |  |
+| raise.rb:115:8:115:22 | [ensure: return] "method ensure" | raise.rb:115:3:115:22 | [ensure: return] call to puts |  |
+| raise.rb:115:9:115:21 | [ensure: raise] method ensure | raise.rb:115:8:115:22 | [ensure: raise] "method ensure" |  |
+| raise.rb:115:9:115:21 | [ensure: return] method ensure | raise.rb:115:8:115:22 | [ensure: return] "method ensure" |  |
+| raise.rb:115:9:115:21 | method ensure | raise.rb:115:8:115:22 | "method ensure" |  |
+| raise.rb:116:3:118:5 | [ensure: raise] if ... | raise.rb:114:1:118:5 | [ensure: raise] ensure ... |  |
+| raise.rb:116:3:118:5 | [ensure: return] if ... | raise.rb:114:1:118:5 | [ensure: return] ensure ... |  |
+| raise.rb:116:3:118:5 | if ... | raise.rb:114:1:118:5 | ensure ... |  |
+| raise.rb:116:6:116:7 | [ensure: raise] b2 | raise.rb:116:3:118:5 | [ensure: raise] if ... | false |
+| raise.rb:116:6:116:7 | [ensure: raise] b2 | raise.rb:117:5:117:22 | [ensure: raise] self | true |
+| raise.rb:116:6:116:7 | [ensure: return] b2 | raise.rb:116:3:118:5 | [ensure: return] if ... | false |
+| raise.rb:116:6:116:7 | [ensure: return] b2 | raise.rb:117:5:117:22 | [ensure: return] self | true |
+| raise.rb:116:6:116:7 | b2 | raise.rb:116:3:118:5 | if ... | false |
+| raise.rb:116:6:116:7 | b2 | raise.rb:117:5:117:22 | self | true |
+| raise.rb:117:5:117:22 | [ensure: raise] call to raise | raise.rb:94:1:119:3 | exit m9 (abnormal) | raise |
+| raise.rb:117:5:117:22 | [ensure: raise] self | raise.rb:117:12:117:21 | [ensure: raise] b2 is true |  |
+| raise.rb:117:5:117:22 | [ensure: return] call to raise | raise.rb:94:1:119:3 | exit m9 (abnormal) | raise |
+| raise.rb:117:5:117:22 | [ensure: return] self | raise.rb:117:12:117:21 | [ensure: return] b2 is true |  |
+| raise.rb:117:5:117:22 | call to raise | raise.rb:94:1:119:3 | exit m9 (abnormal) | raise |
+| raise.rb:117:5:117:22 | self | raise.rb:117:12:117:21 | b2 is true |  |
+| raise.rb:117:11:117:22 | "b2 is true" | raise.rb:117:5:117:22 | call to raise |  |
+| raise.rb:117:11:117:22 | [ensure: raise] "b2 is true" | raise.rb:117:5:117:22 | [ensure: raise] call to raise |  |
+| raise.rb:117:11:117:22 | [ensure: return] "b2 is true" | raise.rb:117:5:117:22 | [ensure: return] call to raise |  |
+| raise.rb:117:12:117:21 | [ensure: raise] b2 is true | raise.rb:117:11:117:22 | [ensure: raise] "b2 is true" |  |
+| raise.rb:117:12:117:21 | [ensure: return] b2 is true | raise.rb:117:11:117:22 | [ensure: return] "b2 is true" |  |
+| raise.rb:117:12:117:21 | b2 is true | raise.rb:117:11:117:22 | "b2 is true" |  |
+| raise.rb:121:1:126:3 | enter m10 | raise.rb:121:9:121:9 | p |  |
+| raise.rb:121:1:126:3 | exit m10 (abnormal) | raise.rb:121:1:126:3 | exit m10 |  |
+| raise.rb:121:1:126:3 | exit m10 (normal) | raise.rb:121:1:126:3 | exit m10 |  |
+| raise.rb:121:1:126:3 | m10 | raise.rb:128:1:140:3 | m11 |  |
+| raise.rb:121:9:121:9 | p | raise.rb:121:14:121:30 | self | false, no-match, true |
+| raise.rb:121:9:121:9 | p | raise.rb:125:3:125:51 | self | match |
+| raise.rb:121:14:121:30 | call to raise | raise.rb:121:1:126:3 | exit m10 (abnormal) | raise |
+| raise.rb:121:14:121:30 | self | raise.rb:121:21:121:29 | Exception |  |
+| raise.rb:121:20:121:30 | "Exception" | raise.rb:121:14:121:30 | call to raise |  |
+| raise.rb:121:21:121:29 | Exception | raise.rb:121:20:121:30 | "Exception" |  |
+| raise.rb:124:1:125:51 | ensure ... | raise.rb:121:1:126:3 | exit m10 (normal) |  |
+| raise.rb:125:3:125:51 | call to puts | raise.rb:124:1:125:51 | ensure ... |  |
+| raise.rb:125:3:125:51 | self | raise.rb:125:9:125:50 | Will not get executed if p is not supplied |  |
+| raise.rb:125:8:125:51 | "Will not get executed if p is..." | raise.rb:125:3:125:51 | call to puts |  |
+| raise.rb:125:9:125:50 | Will not get executed if p is not supplied | raise.rb:125:8:125:51 | "Will not get executed if p is..." |  |
+| raise.rb:128:1:140:3 | enter m11 | raise.rb:128:9:128:9 | b |  |
+| raise.rb:128:1:140:3 | exit m11 (abnormal) | raise.rb:128:1:140:3 | exit m11 |  |
+| raise.rb:128:1:140:3 | exit m11 (normal) | raise.rb:128:1:140:3 | exit m11 |  |
+| raise.rb:128:1:140:3 | m11 | raise.rb:142:1:148:3 | m12 |  |
+| raise.rb:128:9:128:9 | b | raise.rb:130:8:130:8 | b |  |
+| raise.rb:130:5:132:7 | if ... | raise.rb:137:5:137:17 | self |  |
+| raise.rb:130:8:130:8 | b | raise.rb:130:5:132:7 | if ... | false |
+| raise.rb:130:8:130:8 | b | raise.rb:131:7:131:22 | self | true |
+| raise.rb:131:7:131:22 | call to raise | raise.rb:133:10:133:19 | ExceptionA | raise |
+| raise.rb:131:7:131:22 | self | raise.rb:131:13:131:22 | ExceptionA |  |
+| raise.rb:131:13:131:22 | ExceptionA | raise.rb:131:7:131:22 | call to raise |  |
+| raise.rb:133:3:133:19 | rescue ... | raise.rb:137:5:137:17 | self |  |
+| raise.rb:133:10:133:19 | ExceptionA | raise.rb:133:3:133:19 | rescue ... | match |
+| raise.rb:133:10:133:19 | ExceptionA | raise.rb:134:10:134:19 | ExceptionB | no-match |
+| raise.rb:134:3:135:21 | rescue ... | raise.rb:137:5:137:17 | self |  |
+| raise.rb:134:10:134:19 | ExceptionB | raise.rb:135:5:135:21 | self | match |
+| raise.rb:134:10:134:19 | ExceptionB | raise.rb:137:5:137:17 | [ensure: raise] self | raise |
+| raise.rb:134:20:135:21 | then ... | raise.rb:134:3:135:21 | rescue ... |  |
+| raise.rb:135:5:135:21 | call to puts | raise.rb:134:20:135:21 | then ... |  |
+| raise.rb:135:5:135:21 | self | raise.rb:135:11:135:20 | ExceptionB |  |
+| raise.rb:135:10:135:21 | "ExceptionB" | raise.rb:135:5:135:21 | call to puts |  |
+| raise.rb:135:11:135:20 | ExceptionB | raise.rb:135:10:135:21 | "ExceptionB" |  |
+| raise.rb:136:3:137:17 | [ensure: raise] ensure ... | raise.rb:128:1:140:3 | exit m11 (abnormal) | raise |
+| raise.rb:136:3:137:17 | ensure ... | raise.rb:139:3:139:16 | self |  |
+| raise.rb:137:5:137:17 | [ensure: raise] call to puts | raise.rb:136:3:137:17 | [ensure: raise] ensure ... |  |
+| raise.rb:137:5:137:17 | [ensure: raise] self | raise.rb:137:11:137:16 | [ensure: raise] Ensure |  |
+| raise.rb:137:5:137:17 | call to puts | raise.rb:136:3:137:17 | ensure ... |  |
+| raise.rb:137:5:137:17 | self | raise.rb:137:11:137:16 | Ensure |  |
+| raise.rb:137:10:137:17 | "Ensure" | raise.rb:137:5:137:17 | call to puts |  |
+| raise.rb:137:10:137:17 | [ensure: raise] "Ensure" | raise.rb:137:5:137:17 | [ensure: raise] call to puts |  |
+| raise.rb:137:11:137:16 | Ensure | raise.rb:137:10:137:17 | "Ensure" |  |
+| raise.rb:137:11:137:16 | [ensure: raise] Ensure | raise.rb:137:10:137:17 | [ensure: raise] "Ensure" |  |
+| raise.rb:139:3:139:16 | call to puts | raise.rb:128:1:140:3 | exit m11 (normal) |  |
+| raise.rb:139:3:139:16 | self | raise.rb:139:9:139:15 | End m11 |  |
+| raise.rb:139:8:139:16 | "End m11" | raise.rb:139:3:139:16 | call to puts |  |
+| raise.rb:139:9:139:15 | End m11 | raise.rb:139:8:139:16 | "End m11" |  |
+| raise.rb:142:1:148:3 | enter m12 | raise.rb:142:9:142:9 | b |  |
+| raise.rb:142:1:148:3 | exit m12 (normal) | raise.rb:142:1:148:3 | exit m12 |  |
+| raise.rb:142:1:148:3 | m12 | raise.rb:150:1:152:3 | m13 |  |
+| raise.rb:142:9:142:9 | b | raise.rb:143:6:143:6 | b |  |
+| raise.rb:143:3:145:5 | if ... | raise.rb:147:10:147:10 | 3 |  |
+| raise.rb:143:6:143:6 | b | raise.rb:143:3:145:5 | if ... | false |
+| raise.rb:143:6:143:6 | b | raise.rb:144:5:144:12 | self | true |
+| raise.rb:144:5:144:12 | call to raise | raise.rb:147:10:147:10 | [ensure: raise] 3 | raise |
+| raise.rb:144:5:144:12 | self | raise.rb:144:11:144:12 | "" |  |
+| raise.rb:144:11:144:12 | "" | raise.rb:144:5:144:12 | call to raise |  |
+| raise.rb:147:3:147:10 | [ensure: raise] return | raise.rb:142:1:148:3 | exit m12 (normal) | return |
+| raise.rb:147:3:147:10 | return | raise.rb:142:1:148:3 | exit m12 (normal) | return |
+| raise.rb:147:10:147:10 | 3 | raise.rb:147:3:147:10 | return |  |
+| raise.rb:147:10:147:10 | [ensure: raise] 3 | raise.rb:147:3:147:10 | [ensure: raise] return |  |
+| raise.rb:150:1:152:3 | enter m13 | raise.rb:151:1:151:6 | ensure ... |  |
+| raise.rb:150:1:152:3 | exit m13 (normal) | raise.rb:150:1:152:3 | exit m13 |  |
+| raise.rb:150:1:152:3 | m13 | raise.rb:154:1:156:3 | m14 |  |
+| raise.rb:151:1:151:6 | ensure ... | raise.rb:150:1:152:3 | exit m13 (normal) |  |
+| raise.rb:154:1:156:3 | enter m14 | raise.rb:154:9:154:15 | element |  |
+| raise.rb:154:1:156:3 | exit m14 (normal) | raise.rb:154:1:156:3 | exit m14 |  |
+| raise.rb:154:1:156:3 | m14 | raise.rb:158:1:164:3 | m15 |  |
+| raise.rb:154:9:154:15 | element | raise.rb:155:3:155:9 | element |  |
+| raise.rb:155:3:155:9 | element | raise.rb:155:16:155:50 | { ... } |  |
+| raise.rb:155:3:155:50 | call to each | raise.rb:154:1:156:3 | exit m14 (normal) |  |
+| raise.rb:155:16:155:50 | enter { ... } | raise.rb:155:19:155:22 | elem |  |
+| raise.rb:155:16:155:50 | exit { ... } (abnormal) | raise.rb:155:16:155:50 | exit { ... } |  |
+| raise.rb:155:16:155:50 | exit { ... } (normal) | raise.rb:155:16:155:50 | exit { ... } |  |
+| raise.rb:155:16:155:50 | { ... } | raise.rb:155:3:155:50 | call to each |  |
+| raise.rb:155:19:155:22 | elem | raise.rb:155:37:155:43 | element |  |
+| raise.rb:155:25:155:32 | call to raise | raise.rb:155:16:155:50 | exit { ... } (abnormal) | raise |
+| raise.rb:155:25:155:32 | self | raise.rb:155:31:155:32 | "" |  |
+| raise.rb:155:25:155:48 | ... if ... | raise.rb:155:16:155:50 | exit { ... } (normal) |  |
+| raise.rb:155:31:155:32 | "" | raise.rb:155:25:155:32 | call to raise |  |
+| raise.rb:155:37:155:43 | element | raise.rb:155:37:155:48 | call to nil? |  |
+| raise.rb:155:37:155:48 | call to nil? | raise.rb:155:25:155:32 | self | true |
+| raise.rb:155:37:155:48 | call to nil? | raise.rb:155:25:155:48 | ... if ... | false |
+| raise.rb:158:1:164:3 | enter m15 | raise.rb:159:3:163:5 | self |  |
+| raise.rb:158:1:164:3 | exit m15 (normal) | raise.rb:158:1:164:3 | exit m15 |  |
+| raise.rb:158:1:164:3 | m15 | raise.rb:166:1:170:3 | C |  |
+| raise.rb:159:3:163:5 | call to foo | raise.rb:158:1:164:3 | exit m15 (normal) |  |
+| raise.rb:159:3:163:5 | self | raise.rb:159:7:163:5 | do ... end |  |
+| raise.rb:159:7:163:5 | do ... end | raise.rb:159:3:163:5 | call to foo |  |
+| raise.rb:159:7:163:5 | enter do ... end | raise.rb:160:5:162:7 | self |  |
+| raise.rb:159:7:163:5 | exit do ... end (normal) | raise.rb:159:7:163:5 | exit do ... end |  |
+| raise.rb:160:5:162:7 | call to bar | raise.rb:159:7:163:5 | exit do ... end (normal) |  |
+| raise.rb:160:5:162:7 | self | raise.rb:160:9:162:7 | -> { ... } |  |
+| raise.rb:160:9:162:7 | -> { ... } | raise.rb:160:5:162:7 | call to bar |  |
+| raise.rb:160:9:162:7 | enter -> { ... } | raise.rb:160:12:160:12 | x |  |
+| raise.rb:160:9:162:7 | exit -> { ... } (abnormal) | raise.rb:160:9:162:7 | exit -> { ... } |  |
+| raise.rb:160:9:162:7 | exit -> { ... } (normal) | raise.rb:160:9:162:7 | exit -> { ... } |  |
+| raise.rb:160:12:160:12 | x | raise.rb:161:23:161:23 | x |  |
+| raise.rb:161:7:161:14 | call to raise | raise.rb:160:9:162:7 | exit -> { ... } (abnormal) | raise |
+| raise.rb:161:7:161:14 | self | raise.rb:161:13:161:14 | "" |  |
+| raise.rb:161:7:161:23 | ... unless ... | raise.rb:160:9:162:7 | exit -> { ... } (normal) |  |
+| raise.rb:161:13:161:14 | "" | raise.rb:161:7:161:14 | call to raise |  |
+| raise.rb:161:23:161:23 | x | raise.rb:161:7:161:14 | self | false |
+| raise.rb:161:23:161:23 | x | raise.rb:161:7:161:23 | ... unless ... | true |
+| raise.rb:166:1:170:3 | C | raise.rb:167:7:167:10 | self |  |
+| raise.rb:167:3:169:5 | enter m | raise.rb:168:5:168:12 | self |  |
+| raise.rb:167:3:169:5 | exit m (abnormal) | raise.rb:167:3:169:5 | exit m |  |
+| raise.rb:167:3:169:5 | m | raise.rb:172:1:182:3 | m16 |  |
+| raise.rb:167:7:167:10 | self | raise.rb:167:3:169:5 | m |  |
+| raise.rb:168:5:168:12 | call to raise | raise.rb:167:3:169:5 | exit m (abnormal) | raise |
+| raise.rb:168:5:168:12 | self | raise.rb:168:11:168:12 | "" |  |
+| raise.rb:168:11:168:12 | "" | raise.rb:168:5:168:12 | call to raise |  |
+| raise.rb:172:1:182:3 | enter m16 | raise.rb:172:9:172:10 | b1 |  |
+| raise.rb:172:1:182:3 | exit m16 (abnormal) | raise.rb:172:1:182:3 | exit m16 |  |
+| raise.rb:172:1:182:3 | exit m16 (normal) | raise.rb:172:1:182:3 | exit m16 |  |
+| raise.rb:172:1:182:3 | m16 | raise.rb:1:1:182:4 | exit raise.rb (normal) |  |
+| raise.rb:172:9:172:10 | b1 | raise.rb:172:13:172:14 | b2 |  |
+| raise.rb:172:13:172:14 | b2 | raise.rb:174:8:174:9 | b1 |  |
+| raise.rb:174:8:174:9 | b1 | raise.rb:174:8:174:23 | [true] ... \|\| ... | true |
+| raise.rb:174:8:174:9 | b1 | raise.rb:174:14:174:15 | b2 | false |
+| raise.rb:174:8:174:23 | [false] ... \|\| ... | raise.rb:177:14:177:14 | 2 | false |
+| raise.rb:174:8:174:23 | [false] ... \|\| ... | raise.rb:179:10:179:19 | ExceptionA | raise |
+| raise.rb:174:8:174:23 | [true] ... \|\| ... | raise.rb:175:14:175:14 | 1 | true |
+| raise.rb:174:8:174:23 | [true] ... \|\| ... | raise.rb:179:10:179:19 | ExceptionA | raise |
+| raise.rb:174:14:174:15 | b2 | raise.rb:174:20:174:23 | true |  |
+| raise.rb:174:14:174:23 | ... == ... | raise.rb:174:8:174:23 | [false] ... \|\| ... | false |
+| raise.rb:174:14:174:23 | ... == ... | raise.rb:174:8:174:23 | [true] ... \|\| ... | true |
+| raise.rb:174:14:174:23 | ... == ... | raise.rb:179:10:179:19 | ExceptionA | raise |
+| raise.rb:174:20:174:23 | true | raise.rb:174:14:174:23 | ... == ... |  |
+| raise.rb:175:7:175:14 | return | raise.rb:172:1:182:3 | exit m16 (normal) | return |
+| raise.rb:175:14:175:14 | 1 | raise.rb:175:7:175:14 | return |  |
+| raise.rb:177:7:177:14 | return | raise.rb:172:1:182:3 | exit m16 (normal) | return |
+| raise.rb:177:14:177:14 | 2 | raise.rb:177:7:177:14 | return |  |
+| raise.rb:179:10:179:19 | ExceptionA | raise.rb:172:1:182:3 | exit m16 (abnormal) | raise |
+| raise.rb:179:10:179:19 | ExceptionA | raise.rb:180:12:180:12 | 3 | match |
+| raise.rb:180:5:180:12 | return | raise.rb:172:1:182:3 | exit m16 (normal) | return |
+| raise.rb:180:12:180:12 | 3 | raise.rb:180:5:180:12 | return |  |

--- a/ruby/ql/test/library-tests/controlflow/graph/Cfg.ql
+++ b/ruby/ql/test/library-tests/controlflow/graph/Cfg.ql
@@ -1,11 +1,2 @@
-/**
- * @kind graph
- */
-
 import codeql.ruby.CFG
-
-class MyRelevantNode extends CfgNode {
-  string getOrderDisambiguation() { result = "" }
-}
-
-import codeql.ruby.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>
+import codeql.ruby.controlflow.internal.ControlFlowGraphImpl::TestOutput<CfgNode>

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -1,650 +1,216 @@
-nodes
-| test.rs:1:1:4:1 | enter test_call | semmle.order | 1 |
-| test.rs:1:1:4:1 | exit test_call | semmle.order | 2 |
-| test.rs:1:1:4:1 | exit test_call (normal) | semmle.order | 3 |
-| test.rs:1:24:4:1 | BlockExpr | semmle.order | 4 |
-| test.rs:2:5:2:21 | PathExpr | semmle.order | 5 |
-| test.rs:2:5:2:40 | CallExpr | semmle.order | 6 |
-| test.rs:2:5:2:41 | ExprStmt | semmle.order | 7 |
-| test.rs:2:23:2:26 | LiteralExpr | semmle.order | 8 |
-| test.rs:2:29:2:33 | LiteralExpr | semmle.order | 9 |
-| test.rs:2:36:2:39 | LiteralExpr | semmle.order | 10 |
-| test.rs:3:5:3:19 | PathExpr | semmle.order | 11 |
-| test.rs:3:5:3:23 | CallExpr | semmle.order | 12 |
-| test.rs:3:5:3:24 | ExprStmt | semmle.order | 13 |
-| test.rs:3:21:3:22 | LiteralExpr | semmle.order | 14 |
-| test.rs:8:5:24:5 | enter test_break_and_continue | semmle.order | 15 |
-| test.rs:8:5:24:5 | exit test_break_and_continue | semmle.order | 16 |
-| test.rs:8:5:24:5 | exit test_break_and_continue (normal) | semmle.order | 17 |
-| test.rs:9:9:9:22 | LetStmt | semmle.order | 18 |
-| test.rs:9:13:9:17 | IdentPat | semmle.order | 19 |
-| test.rs:9:21:9:21 | PathExpr | semmle.order | 20 |
-| test.rs:10:9:22:9 | ExprStmt | semmle.order | 21 |
-| test.rs:10:9:22:9 | LoopExpr | semmle.order | 22 |
-| test.rs:10:14:22:9 | BlockExpr | semmle.order | 23 |
-| test.rs:11:13:11:13 | PathExpr | semmle.order | 24 |
-| test.rs:11:13:11:23 | BinaryExpr | semmle.order | 25 |
-| test.rs:11:13:11:24 | ExprStmt | semmle.order | 26 |
-| test.rs:11:17:11:20 | PathExpr | semmle.order | 27 |
-| test.rs:11:17:11:23 | CallExpr | semmle.order | 28 |
-| test.rs:11:22:11:22 | PathExpr | semmle.order | 29 |
-| test.rs:12:13:14:13 | ExprStmt | semmle.order | 30 |
-| test.rs:12:13:14:13 | IfExpr | semmle.order | 31 |
-| test.rs:12:16:12:16 | PathExpr | semmle.order | 32 |
-| test.rs:12:16:12:24 | BinaryExpr | semmle.order | 33 |
-| test.rs:12:20:12:24 | LiteralExpr | semmle.order | 34 |
-| test.rs:13:17:13:28 | ReturnExpr | semmle.order | 35 |
-| test.rs:13:17:13:29 | ExprStmt | semmle.order | 36 |
-| test.rs:13:24:13:28 | LiteralExpr | semmle.order | 37 |
-| test.rs:15:13:17:13 | ExprStmt | semmle.order | 38 |
-| test.rs:15:13:17:13 | IfExpr | semmle.order | 39 |
-| test.rs:15:16:15:16 | PathExpr | semmle.order | 40 |
-| test.rs:15:16:15:21 | BinaryExpr | semmle.order | 41 |
-| test.rs:15:21:15:21 | LiteralExpr | semmle.order | 42 |
-| test.rs:16:17:16:21 | BreakExpr | semmle.order | 43 |
-| test.rs:16:17:16:22 | ExprStmt | semmle.order | 44 |
-| test.rs:18:13:20:13 | ExprStmt | semmle.order | 45 |
-| test.rs:18:13:20:13 | IfExpr | semmle.order | 46 |
-| test.rs:18:16:18:16 | PathExpr | semmle.order | 47 |
-| test.rs:18:16:18:20 | BinaryExpr | semmle.order | 48 |
-| test.rs:18:16:18:25 | BinaryExpr | semmle.order | 49 |
-| test.rs:18:20:18:20 | LiteralExpr | semmle.order | 50 |
-| test.rs:18:25:18:25 | LiteralExpr | semmle.order | 51 |
-| test.rs:19:17:19:24 | ContinueExpr | semmle.order | 52 |
-| test.rs:19:17:19:25 | ExprStmt | semmle.order | 53 |
-| test.rs:21:13:21:13 | PathExpr | semmle.order | 54 |
-| test.rs:21:13:21:21 | BinaryExpr | semmle.order | 55 |
-| test.rs:21:17:21:17 | PathExpr | semmle.order | 56 |
-| test.rs:21:17:21:21 | BinaryExpr | semmle.order | 57 |
-| test.rs:21:21:21:21 | LiteralExpr | semmle.order | 58 |
-| test.rs:23:9:23:19 | ReturnExpr | semmle.order | 59 |
-| test.rs:23:9:23:20 | ExprStmt | semmle.order | 60 |
-| test.rs:23:16:23:19 | LiteralExpr | semmle.order | 61 |
-| test.rs:26:5:38:5 | enter test_break_with_labels | semmle.order | 62 |
-| test.rs:26:5:38:5 | exit test_break_with_labels | semmle.order | 63 |
-| test.rs:26:5:38:5 | exit test_break_with_labels (normal) | semmle.order | 64 |
-| test.rs:26:41:38:5 | BlockExpr | semmle.order | 65 |
-| test.rs:27:9:36:9 | ExprStmt | semmle.order | 66 |
-| test.rs:27:9:36:9 | LoopExpr | semmle.order | 67 |
-| test.rs:27:22:36:9 | BlockExpr | semmle.order | 68 |
-| test.rs:28:13:35:13 | LoopExpr | semmle.order | 69 |
-| test.rs:29:17:33:17 | ExprStmt | semmle.order | 70 |
-| test.rs:29:17:33:17 | IfExpr | semmle.order | 71 |
-| test.rs:29:20:29:24 | LiteralExpr | semmle.order | 72 |
-| test.rs:30:21:30:25 | BreakExpr | semmle.order | 73 |
-| test.rs:30:21:30:26 | ExprStmt | semmle.order | 74 |
-| test.rs:31:24:33:17 | IfExpr | semmle.order | 75 |
-| test.rs:31:27:31:30 | LiteralExpr | semmle.order | 76 |
-| test.rs:32:21:32:32 | BreakExpr | semmle.order | 77 |
-| test.rs:32:21:32:33 | ExprStmt | semmle.order | 78 |
-| test.rs:34:17:34:28 | BreakExpr | semmle.order | 79 |
-| test.rs:34:17:34:29 | ExprStmt | semmle.order | 80 |
-| test.rs:37:9:37:12 | LiteralExpr | semmle.order | 81 |
-| test.rs:40:5:52:5 | enter test_continue_with_labels | semmle.order | 82 |
-| test.rs:42:13:42:13 | LiteralExpr | semmle.order | 83 |
-| test.rs:42:13:42:14 | ExprStmt | semmle.order | 84 |
-| test.rs:44:17:48:17 | ExprStmt | semmle.order | 85 |
-| test.rs:44:17:48:17 | IfExpr | semmle.order | 86 |
-| test.rs:44:20:44:24 | LiteralExpr | semmle.order | 87 |
-| test.rs:45:21:45:28 | ContinueExpr | semmle.order | 88 |
-| test.rs:45:21:45:29 | ExprStmt | semmle.order | 89 |
-| test.rs:46:24:48:17 | IfExpr | semmle.order | 90 |
-| test.rs:46:27:46:30 | LiteralExpr | semmle.order | 91 |
-| test.rs:47:21:47:35 | ContinueExpr | semmle.order | 92 |
-| test.rs:47:21:47:36 | ExprStmt | semmle.order | 93 |
-| test.rs:49:17:49:31 | ContinueExpr | semmle.order | 94 |
-| test.rs:49:17:49:32 | ExprStmt | semmle.order | 95 |
-| test.rs:55:1:58:1 | enter test_nested_function | semmle.order | 96 |
-| test.rs:55:1:58:1 | exit test_nested_function | semmle.order | 97 |
-| test.rs:55:1:58:1 | exit test_nested_function (normal) | semmle.order | 98 |
-| test.rs:55:40:58:1 | BlockExpr | semmle.order | 99 |
-| test.rs:56:5:56:28 | LetStmt | semmle.order | 100 |
-| test.rs:56:9:56:15 | IdentPat | semmle.order | 101 |
-| test.rs:56:19:56:27 | ClosureExpr | semmle.order | 102 |
-| test.rs:56:19:56:27 | enter ClosureExpr | semmle.order | 103 |
-| test.rs:56:19:56:27 | exit ClosureExpr | semmle.order | 104 |
-| test.rs:56:19:56:27 | exit ClosureExpr (normal) | semmle.order | 105 |
-| test.rs:56:23:56:23 | PathExpr | semmle.order | 106 |
-| test.rs:56:23:56:27 | BinaryExpr | semmle.order | 107 |
-| test.rs:56:27:56:27 | LiteralExpr | semmle.order | 108 |
-| test.rs:57:5:57:11 | PathExpr | semmle.order | 109 |
-| test.rs:57:5:57:23 | CallExpr | semmle.order | 110 |
-| test.rs:57:13:57:19 | PathExpr | semmle.order | 111 |
-| test.rs:57:13:57:22 | CallExpr | semmle.order | 112 |
-| test.rs:57:21:57:21 | PathExpr | semmle.order | 113 |
-| test.rs:62:5:68:5 | enter test_if_else | semmle.order | 114 |
-| test.rs:62:5:68:5 | exit test_if_else | semmle.order | 115 |
-| test.rs:62:5:68:5 | exit test_if_else (normal) | semmle.order | 116 |
-| test.rs:62:36:68:5 | BlockExpr | semmle.order | 117 |
-| test.rs:63:9:67:9 | IfExpr | semmle.order | 118 |
-| test.rs:63:12:63:12 | PathExpr | semmle.order | 119 |
-| test.rs:63:12:63:17 | BinaryExpr | semmle.order | 120 |
-| test.rs:63:17:63:17 | LiteralExpr | semmle.order | 121 |
-| test.rs:63:19:65:9 | BlockExpr | semmle.order | 122 |
-| test.rs:64:13:64:13 | LiteralExpr | semmle.order | 123 |
-| test.rs:65:16:67:9 | BlockExpr | semmle.order | 124 |
-| test.rs:66:13:66:13 | PathExpr | semmle.order | 125 |
-| test.rs:66:13:66:17 | BinaryExpr | semmle.order | 126 |
-| test.rs:66:17:66:17 | LiteralExpr | semmle.order | 127 |
-| test.rs:70:5:76:5 | enter test_if_let_else | semmle.order | 128 |
-| test.rs:70:5:76:5 | exit test_if_let_else | semmle.order | 129 |
-| test.rs:70:5:76:5 | exit test_if_let_else (normal) | semmle.order | 130 |
-| test.rs:70:48:76:5 | BlockExpr | semmle.order | 131 |
-| test.rs:71:9:75:9 | IfExpr | semmle.order | 132 |
-| test.rs:71:12:71:26 | LetExpr | semmle.order | 133 |
-| test.rs:71:16:71:22 | TupleStructPat | semmle.order | 134 |
-| test.rs:71:28:73:9 | BlockExpr | semmle.order | 135 |
-| test.rs:72:13:72:13 | PathExpr | semmle.order | 136 |
-| test.rs:73:16:75:9 | BlockExpr | semmle.order | 137 |
-| test.rs:74:13:74:13 | LiteralExpr | semmle.order | 138 |
-| test.rs:78:5:83:5 | enter test_if_let | semmle.order | 139 |
-| test.rs:78:5:83:5 | exit test_if_let | semmle.order | 140 |
-| test.rs:78:5:83:5 | exit test_if_let (normal) | semmle.order | 141 |
-| test.rs:78:43:83:5 | BlockExpr | semmle.order | 142 |
-| test.rs:79:9:81:9 | ExprStmt | semmle.order | 143 |
-| test.rs:79:9:81:9 | IfExpr | semmle.order | 144 |
-| test.rs:79:12:79:26 | LetExpr | semmle.order | 145 |
-| test.rs:79:16:79:22 | TupleStructPat | semmle.order | 146 |
-| test.rs:79:28:81:9 | BlockExpr | semmle.order | 147 |
-| test.rs:80:13:80:13 | PathExpr | semmle.order | 148 |
-| test.rs:82:9:82:9 | LiteralExpr | semmle.order | 149 |
-| test.rs:105:5:108:5 | enter test_and_operator | semmle.order | 150 |
-| test.rs:105:5:108:5 | exit test_and_operator | semmle.order | 151 |
-| test.rs:105:5:108:5 | exit test_and_operator (normal) | semmle.order | 152 |
-| test.rs:105:61:108:5 | BlockExpr | semmle.order | 153 |
-| test.rs:106:9:106:28 | LetStmt | semmle.order | 154 |
-| test.rs:106:13:106:13 | IdentPat | semmle.order | 155 |
-| test.rs:106:17:106:17 | PathExpr | semmle.order | 156 |
-| test.rs:106:17:106:22 | BinaryExpr | semmle.order | 157 |
-| test.rs:106:17:106:27 | BinaryExpr | semmle.order | 158 |
-| test.rs:106:22:106:22 | PathExpr | semmle.order | 159 |
-| test.rs:106:27:106:27 | PathExpr | semmle.order | 160 |
-| test.rs:107:9:107:9 | PathExpr | semmle.order | 161 |
-| test.rs:110:5:113:5 | enter test_or_operator | semmle.order | 162 |
-| test.rs:110:5:113:5 | exit test_or_operator | semmle.order | 163 |
-| test.rs:110:5:113:5 | exit test_or_operator (normal) | semmle.order | 164 |
-| test.rs:110:60:113:5 | BlockExpr | semmle.order | 165 |
-| test.rs:111:9:111:28 | LetStmt | semmle.order | 166 |
-| test.rs:111:13:111:13 | IdentPat | semmle.order | 167 |
-| test.rs:111:17:111:17 | PathExpr | semmle.order | 168 |
-| test.rs:111:17:111:22 | BinaryExpr | semmle.order | 169 |
-| test.rs:111:17:111:27 | BinaryExpr | semmle.order | 170 |
-| test.rs:111:22:111:22 | PathExpr | semmle.order | 171 |
-| test.rs:111:27:111:27 | PathExpr | semmle.order | 172 |
-| test.rs:112:9:112:9 | PathExpr | semmle.order | 173 |
-| test.rs:115:5:118:5 | enter test_or_operator_2 | semmle.order | 174 |
-| test.rs:115:5:118:5 | exit test_or_operator_2 | semmle.order | 175 |
-| test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | semmle.order | 176 |
-| test.rs:115:61:118:5 | BlockExpr | semmle.order | 177 |
-| test.rs:116:9:116:36 | LetStmt | semmle.order | 178 |
-| test.rs:116:13:116:13 | IdentPat | semmle.order | 179 |
-| test.rs:116:17:116:17 | PathExpr | semmle.order | 180 |
-| test.rs:116:17:116:30 | BinaryExpr | semmle.order | 181 |
-| test.rs:116:17:116:35 | BinaryExpr | semmle.order | 182 |
-| test.rs:117:9:117:9 | PathExpr | semmle.order | 183 |
-| test.rs:122:1:128:1 | enter test_match | semmle.order | 184 |
-| test.rs:122:1:128:1 | exit test_match | semmle.order | 185 |
-| test.rs:122:1:128:1 | exit test_match (normal) | semmle.order | 186 |
-| test.rs:122:44:128:1 | BlockExpr | semmle.order | 187 |
-| test.rs:123:5:127:5 | MatchExpr | semmle.order | 188 |
-| test.rs:123:11:123:21 | PathExpr | semmle.order | 189 |
-| test.rs:124:9:124:23 | TupleStructPat | semmle.order | 190 |
-| test.rs:124:28:124:28 | PathExpr | semmle.order | 191 |
-| test.rs:124:28:124:33 | BinaryExpr | semmle.order | 192 |
-| test.rs:124:32:124:33 | LiteralExpr | semmle.order | 193 |
-| test.rs:125:9:125:23 | TupleStructPat | semmle.order | 194 |
-| test.rs:125:28:125:28 | PathExpr | semmle.order | 195 |
-| test.rs:126:9:126:20 | PathPat | semmle.order | 196 |
-| test.rs:126:25:126:25 | LiteralExpr | semmle.order | 197 |
-| test.rs:131:5:136:5 | enter test_infinite_loop | semmle.order | 198 |
-| test.rs:132:9:134:9 | ExprStmt | semmle.order | 199 |
-| test.rs:132:14:134:9 | BlockExpr | semmle.order | 200 |
-| test.rs:133:13:133:13 | LiteralExpr | semmle.order | 201 |
-| test.rs:138:5:143:5 | enter test_let_match | semmle.order | 202 |
-| test.rs:138:5:143:5 | exit test_let_match | semmle.order | 203 |
-| test.rs:138:5:143:5 | exit test_let_match (normal) | semmle.order | 204 |
-| test.rs:138:39:143:5 | BlockExpr | semmle.order | 205 |
-| test.rs:139:9:141:10 | LetStmt | semmle.order | 206 |
-| test.rs:139:13:139:19 | TupleStructPat | semmle.order | 207 |
-| test.rs:139:23:139:23 | PathExpr | semmle.order | 208 |
-| test.rs:139:30:141:9 | BlockExpr | semmle.order | 209 |
-| test.rs:140:13:140:27 | LiteralExpr | semmle.order | 210 |
-| test.rs:142:9:142:9 | PathExpr | semmle.order | 211 |
-edges
-| test.rs:1:1:4:1 | enter test_call | test.rs:2:5:2:41 | ExprStmt | semmle.label |  |
-| test.rs:1:1:4:1 | enter test_call | test.rs:2:5:2:41 | ExprStmt | semmle.order | 1 |
-| test.rs:1:1:4:1 | exit test_call (normal) | test.rs:1:1:4:1 | exit test_call | semmle.label |  |
-| test.rs:1:1:4:1 | exit test_call (normal) | test.rs:1:1:4:1 | exit test_call | semmle.order | 1 |
-| test.rs:1:24:4:1 | BlockExpr | test.rs:1:1:4:1 | exit test_call (normal) | semmle.label |  |
-| test.rs:1:24:4:1 | BlockExpr | test.rs:1:1:4:1 | exit test_call (normal) | semmle.order | 1 |
-| test.rs:2:5:2:21 | PathExpr | test.rs:2:23:2:26 | LiteralExpr | semmle.label |  |
-| test.rs:2:5:2:21 | PathExpr | test.rs:2:23:2:26 | LiteralExpr | semmle.order | 1 |
-| test.rs:2:5:2:40 | CallExpr | test.rs:3:5:3:24 | ExprStmt | semmle.label |  |
-| test.rs:2:5:2:40 | CallExpr | test.rs:3:5:3:24 | ExprStmt | semmle.order | 1 |
-| test.rs:2:5:2:41 | ExprStmt | test.rs:2:5:2:21 | PathExpr | semmle.label |  |
-| test.rs:2:5:2:41 | ExprStmt | test.rs:2:5:2:21 | PathExpr | semmle.order | 1 |
-| test.rs:2:23:2:26 | LiteralExpr | test.rs:2:29:2:33 | LiteralExpr | semmle.label |  |
-| test.rs:2:23:2:26 | LiteralExpr | test.rs:2:29:2:33 | LiteralExpr | semmle.order | 1 |
-| test.rs:2:29:2:33 | LiteralExpr | test.rs:2:36:2:39 | LiteralExpr | semmle.label |  |
-| test.rs:2:29:2:33 | LiteralExpr | test.rs:2:36:2:39 | LiteralExpr | semmle.order | 1 |
-| test.rs:2:36:2:39 | LiteralExpr | test.rs:2:5:2:40 | CallExpr | semmle.label |  |
-| test.rs:2:36:2:39 | LiteralExpr | test.rs:2:5:2:40 | CallExpr | semmle.order | 1 |
-| test.rs:3:5:3:19 | PathExpr | test.rs:3:21:3:22 | LiteralExpr | semmle.label |  |
-| test.rs:3:5:3:19 | PathExpr | test.rs:3:21:3:22 | LiteralExpr | semmle.order | 1 |
-| test.rs:3:5:3:23 | CallExpr | test.rs:1:24:4:1 | BlockExpr | semmle.label |  |
-| test.rs:3:5:3:23 | CallExpr | test.rs:1:24:4:1 | BlockExpr | semmle.order | 1 |
-| test.rs:3:5:3:24 | ExprStmt | test.rs:3:5:3:19 | PathExpr | semmle.label |  |
-| test.rs:3:5:3:24 | ExprStmt | test.rs:3:5:3:19 | PathExpr | semmle.order | 1 |
-| test.rs:3:21:3:22 | LiteralExpr | test.rs:3:5:3:23 | CallExpr | semmle.label |  |
-| test.rs:3:21:3:22 | LiteralExpr | test.rs:3:5:3:23 | CallExpr | semmle.order | 1 |
-| test.rs:8:5:24:5 | enter test_break_and_continue | test.rs:9:9:9:22 | LetStmt | semmle.label |  |
-| test.rs:8:5:24:5 | enter test_break_and_continue | test.rs:9:9:9:22 | LetStmt | semmle.order | 1 |
-| test.rs:8:5:24:5 | exit test_break_and_continue (normal) | test.rs:8:5:24:5 | exit test_break_and_continue | semmle.label |  |
-| test.rs:8:5:24:5 | exit test_break_and_continue (normal) | test.rs:8:5:24:5 | exit test_break_and_continue | semmle.order | 1 |
-| test.rs:9:9:9:22 | LetStmt | test.rs:9:21:9:21 | PathExpr | semmle.label |  |
-| test.rs:9:9:9:22 | LetStmt | test.rs:9:21:9:21 | PathExpr | semmle.order | 1 |
-| test.rs:9:13:9:17 | IdentPat | test.rs:10:9:22:9 | ExprStmt | semmle.label | match, no-match |
-| test.rs:9:13:9:17 | IdentPat | test.rs:10:9:22:9 | ExprStmt | semmle.order | 1 |
-| test.rs:9:13:9:17 | IdentPat | test.rs:10:9:22:9 | ExprStmt | semmle.order | 2 |
-| test.rs:9:21:9:21 | PathExpr | test.rs:9:13:9:17 | IdentPat | semmle.label |  |
-| test.rs:9:21:9:21 | PathExpr | test.rs:9:13:9:17 | IdentPat | semmle.order | 1 |
-| test.rs:10:9:22:9 | ExprStmt | test.rs:11:13:11:24 | ExprStmt | semmle.label |  |
-| test.rs:10:9:22:9 | ExprStmt | test.rs:11:13:11:24 | ExprStmt | semmle.order | 1 |
-| test.rs:10:9:22:9 | LoopExpr | test.rs:23:9:23:20 | ExprStmt | semmle.label |  |
-| test.rs:10:9:22:9 | LoopExpr | test.rs:23:9:23:20 | ExprStmt | semmle.order | 1 |
-| test.rs:10:14:22:9 | BlockExpr | test.rs:11:13:11:24 | ExprStmt | semmle.label |  |
-| test.rs:10:14:22:9 | BlockExpr | test.rs:11:13:11:24 | ExprStmt | semmle.order | 1 |
-| test.rs:11:13:11:13 | PathExpr | test.rs:11:17:11:20 | PathExpr | semmle.label |  |
-| test.rs:11:13:11:13 | PathExpr | test.rs:11:17:11:20 | PathExpr | semmle.order | 1 |
-| test.rs:11:13:11:23 | BinaryExpr | test.rs:12:13:14:13 | ExprStmt | semmle.label |  |
-| test.rs:11:13:11:23 | BinaryExpr | test.rs:12:13:14:13 | ExprStmt | semmle.order | 1 |
-| test.rs:11:13:11:24 | ExprStmt | test.rs:11:13:11:13 | PathExpr | semmle.label |  |
-| test.rs:11:13:11:24 | ExprStmt | test.rs:11:13:11:13 | PathExpr | semmle.order | 1 |
-| test.rs:11:17:11:20 | PathExpr | test.rs:11:22:11:22 | PathExpr | semmle.label |  |
-| test.rs:11:17:11:20 | PathExpr | test.rs:11:22:11:22 | PathExpr | semmle.order | 1 |
-| test.rs:11:17:11:23 | CallExpr | test.rs:11:13:11:23 | BinaryExpr | semmle.label |  |
-| test.rs:11:17:11:23 | CallExpr | test.rs:11:13:11:23 | BinaryExpr | semmle.order | 1 |
-| test.rs:11:22:11:22 | PathExpr | test.rs:11:17:11:23 | CallExpr | semmle.label |  |
-| test.rs:11:22:11:22 | PathExpr | test.rs:11:17:11:23 | CallExpr | semmle.order | 1 |
-| test.rs:12:13:14:13 | ExprStmt | test.rs:12:16:12:16 | PathExpr | semmle.label |  |
-| test.rs:12:13:14:13 | ExprStmt | test.rs:12:16:12:16 | PathExpr | semmle.order | 1 |
-| test.rs:12:13:14:13 | IfExpr | test.rs:15:13:17:13 | ExprStmt | semmle.label |  |
-| test.rs:12:13:14:13 | IfExpr | test.rs:15:13:17:13 | ExprStmt | semmle.order | 1 |
-| test.rs:12:16:12:16 | PathExpr | test.rs:12:20:12:24 | LiteralExpr | semmle.label |  |
-| test.rs:12:16:12:16 | PathExpr | test.rs:12:20:12:24 | LiteralExpr | semmle.order | 1 |
-| test.rs:12:16:12:24 | BinaryExpr | test.rs:12:13:14:13 | IfExpr | semmle.label | false |
-| test.rs:12:16:12:24 | BinaryExpr | test.rs:12:13:14:13 | IfExpr | semmle.order | 1 |
-| test.rs:12:16:12:24 | BinaryExpr | test.rs:13:17:13:29 | ExprStmt | semmle.label | true |
-| test.rs:12:16:12:24 | BinaryExpr | test.rs:13:17:13:29 | ExprStmt | semmle.order | 2 |
-| test.rs:12:20:12:24 | LiteralExpr | test.rs:12:16:12:24 | BinaryExpr | semmle.label |  |
-| test.rs:12:20:12:24 | LiteralExpr | test.rs:12:16:12:24 | BinaryExpr | semmle.order | 1 |
-| test.rs:13:17:13:28 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | semmle.label | return |
-| test.rs:13:17:13:28 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | semmle.order | 1 |
-| test.rs:13:17:13:29 | ExprStmt | test.rs:13:24:13:28 | LiteralExpr | semmle.label |  |
-| test.rs:13:17:13:29 | ExprStmt | test.rs:13:24:13:28 | LiteralExpr | semmle.order | 1 |
-| test.rs:13:24:13:28 | LiteralExpr | test.rs:13:17:13:28 | ReturnExpr | semmle.label |  |
-| test.rs:13:24:13:28 | LiteralExpr | test.rs:13:17:13:28 | ReturnExpr | semmle.order | 1 |
-| test.rs:15:13:17:13 | ExprStmt | test.rs:15:16:15:16 | PathExpr | semmle.label |  |
-| test.rs:15:13:17:13 | ExprStmt | test.rs:15:16:15:16 | PathExpr | semmle.order | 1 |
-| test.rs:15:13:17:13 | IfExpr | test.rs:18:13:20:13 | ExprStmt | semmle.label |  |
-| test.rs:15:13:17:13 | IfExpr | test.rs:18:13:20:13 | ExprStmt | semmle.order | 1 |
-| test.rs:15:16:15:16 | PathExpr | test.rs:15:21:15:21 | LiteralExpr | semmle.label |  |
-| test.rs:15:16:15:16 | PathExpr | test.rs:15:21:15:21 | LiteralExpr | semmle.order | 1 |
-| test.rs:15:16:15:21 | BinaryExpr | test.rs:15:13:17:13 | IfExpr | semmle.label | false |
-| test.rs:15:16:15:21 | BinaryExpr | test.rs:15:13:17:13 | IfExpr | semmle.order | 1 |
-| test.rs:15:16:15:21 | BinaryExpr | test.rs:16:17:16:22 | ExprStmt | semmle.label | true |
-| test.rs:15:16:15:21 | BinaryExpr | test.rs:16:17:16:22 | ExprStmt | semmle.order | 2 |
-| test.rs:15:21:15:21 | LiteralExpr | test.rs:15:16:15:21 | BinaryExpr | semmle.label |  |
-| test.rs:15:21:15:21 | LiteralExpr | test.rs:15:16:15:21 | BinaryExpr | semmle.order | 1 |
-| test.rs:16:17:16:21 | BreakExpr | test.rs:10:9:22:9 | LoopExpr | semmle.label | break |
-| test.rs:16:17:16:21 | BreakExpr | test.rs:10:9:22:9 | LoopExpr | semmle.order | 1 |
-| test.rs:16:17:16:22 | ExprStmt | test.rs:16:17:16:21 | BreakExpr | semmle.label |  |
-| test.rs:16:17:16:22 | ExprStmt | test.rs:16:17:16:21 | BreakExpr | semmle.order | 1 |
-| test.rs:18:13:20:13 | ExprStmt | test.rs:18:16:18:16 | PathExpr | semmle.label |  |
-| test.rs:18:13:20:13 | ExprStmt | test.rs:18:16:18:16 | PathExpr | semmle.order | 1 |
-| test.rs:18:13:20:13 | IfExpr | test.rs:21:13:21:13 | PathExpr | semmle.label |  |
-| test.rs:18:13:20:13 | IfExpr | test.rs:21:13:21:13 | PathExpr | semmle.order | 1 |
-| test.rs:18:16:18:16 | PathExpr | test.rs:18:20:18:20 | LiteralExpr | semmle.label |  |
-| test.rs:18:16:18:16 | PathExpr | test.rs:18:20:18:20 | LiteralExpr | semmle.order | 1 |
-| test.rs:18:16:18:20 | BinaryExpr | test.rs:18:25:18:25 | LiteralExpr | semmle.label |  |
-| test.rs:18:16:18:20 | BinaryExpr | test.rs:18:25:18:25 | LiteralExpr | semmle.order | 1 |
-| test.rs:18:16:18:25 | BinaryExpr | test.rs:18:13:20:13 | IfExpr | semmle.label | false |
-| test.rs:18:16:18:25 | BinaryExpr | test.rs:18:13:20:13 | IfExpr | semmle.order | 1 |
-| test.rs:18:16:18:25 | BinaryExpr | test.rs:19:17:19:25 | ExprStmt | semmle.label | true |
-| test.rs:18:16:18:25 | BinaryExpr | test.rs:19:17:19:25 | ExprStmt | semmle.order | 2 |
-| test.rs:18:20:18:20 | LiteralExpr | test.rs:18:16:18:20 | BinaryExpr | semmle.label |  |
-| test.rs:18:20:18:20 | LiteralExpr | test.rs:18:16:18:20 | BinaryExpr | semmle.order | 1 |
-| test.rs:18:25:18:25 | LiteralExpr | test.rs:18:16:18:25 | BinaryExpr | semmle.label |  |
-| test.rs:18:25:18:25 | LiteralExpr | test.rs:18:16:18:25 | BinaryExpr | semmle.order | 1 |
-| test.rs:19:17:19:24 | ContinueExpr | test.rs:11:13:11:24 | ExprStmt | semmle.label | continue |
-| test.rs:19:17:19:24 | ContinueExpr | test.rs:11:13:11:24 | ExprStmt | semmle.order | 1 |
-| test.rs:19:17:19:25 | ExprStmt | test.rs:19:17:19:24 | ContinueExpr | semmle.label |  |
-| test.rs:19:17:19:25 | ExprStmt | test.rs:19:17:19:24 | ContinueExpr | semmle.order | 1 |
-| test.rs:21:13:21:13 | PathExpr | test.rs:21:17:21:17 | PathExpr | semmle.label |  |
-| test.rs:21:13:21:13 | PathExpr | test.rs:21:17:21:17 | PathExpr | semmle.order | 1 |
-| test.rs:21:13:21:21 | BinaryExpr | test.rs:10:14:22:9 | BlockExpr | semmle.label |  |
-| test.rs:21:13:21:21 | BinaryExpr | test.rs:10:14:22:9 | BlockExpr | semmle.order | 1 |
-| test.rs:21:17:21:17 | PathExpr | test.rs:21:21:21:21 | LiteralExpr | semmle.label |  |
-| test.rs:21:17:21:17 | PathExpr | test.rs:21:21:21:21 | LiteralExpr | semmle.order | 1 |
-| test.rs:21:17:21:21 | BinaryExpr | test.rs:21:13:21:21 | BinaryExpr | semmle.label |  |
-| test.rs:21:17:21:21 | BinaryExpr | test.rs:21:13:21:21 | BinaryExpr | semmle.order | 1 |
-| test.rs:21:21:21:21 | LiteralExpr | test.rs:21:17:21:21 | BinaryExpr | semmle.label |  |
-| test.rs:21:21:21:21 | LiteralExpr | test.rs:21:17:21:21 | BinaryExpr | semmle.order | 1 |
-| test.rs:23:9:23:19 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | semmle.label | return |
-| test.rs:23:9:23:19 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | semmle.order | 1 |
-| test.rs:23:9:23:20 | ExprStmt | test.rs:23:16:23:19 | LiteralExpr | semmle.label |  |
-| test.rs:23:9:23:20 | ExprStmt | test.rs:23:16:23:19 | LiteralExpr | semmle.order | 1 |
-| test.rs:23:16:23:19 | LiteralExpr | test.rs:23:9:23:19 | ReturnExpr | semmle.label |  |
-| test.rs:23:16:23:19 | LiteralExpr | test.rs:23:9:23:19 | ReturnExpr | semmle.order | 1 |
-| test.rs:26:5:38:5 | enter test_break_with_labels | test.rs:27:9:36:9 | ExprStmt | semmle.label |  |
-| test.rs:26:5:38:5 | enter test_break_with_labels | test.rs:27:9:36:9 | ExprStmt | semmle.order | 1 |
-| test.rs:26:5:38:5 | exit test_break_with_labels (normal) | test.rs:26:5:38:5 | exit test_break_with_labels | semmle.label |  |
-| test.rs:26:5:38:5 | exit test_break_with_labels (normal) | test.rs:26:5:38:5 | exit test_break_with_labels | semmle.order | 1 |
-| test.rs:26:41:38:5 | BlockExpr | test.rs:26:5:38:5 | exit test_break_with_labels (normal) | semmle.label |  |
-| test.rs:26:41:38:5 | BlockExpr | test.rs:26:5:38:5 | exit test_break_with_labels (normal) | semmle.order | 1 |
-| test.rs:27:9:36:9 | ExprStmt | test.rs:29:17:33:17 | ExprStmt | semmle.label |  |
-| test.rs:27:9:36:9 | ExprStmt | test.rs:29:17:33:17 | ExprStmt | semmle.order | 1 |
-| test.rs:27:9:36:9 | LoopExpr | test.rs:37:9:37:12 | LiteralExpr | semmle.label |  |
-| test.rs:27:9:36:9 | LoopExpr | test.rs:37:9:37:12 | LiteralExpr | semmle.order | 1 |
-| test.rs:27:22:36:9 | BlockExpr | test.rs:29:17:33:17 | ExprStmt | semmle.label |  |
-| test.rs:27:22:36:9 | BlockExpr | test.rs:29:17:33:17 | ExprStmt | semmle.order | 1 |
-| test.rs:28:13:35:13 | LoopExpr | test.rs:27:22:36:9 | BlockExpr | semmle.label |  |
-| test.rs:28:13:35:13 | LoopExpr | test.rs:27:22:36:9 | BlockExpr | semmle.order | 1 |
-| test.rs:29:17:33:17 | ExprStmt | test.rs:29:20:29:24 | LiteralExpr | semmle.label |  |
-| test.rs:29:17:33:17 | ExprStmt | test.rs:29:20:29:24 | LiteralExpr | semmle.order | 1 |
-| test.rs:29:17:33:17 | IfExpr | test.rs:34:17:34:29 | ExprStmt | semmle.label |  |
-| test.rs:29:17:33:17 | IfExpr | test.rs:34:17:34:29 | ExprStmt | semmle.order | 1 |
-| test.rs:29:20:29:24 | LiteralExpr | test.rs:30:21:30:26 | ExprStmt | semmle.label | true |
-| test.rs:29:20:29:24 | LiteralExpr | test.rs:30:21:30:26 | ExprStmt | semmle.order | 1 |
-| test.rs:29:20:29:24 | LiteralExpr | test.rs:31:27:31:30 | LiteralExpr | semmle.label | false |
-| test.rs:29:20:29:24 | LiteralExpr | test.rs:31:27:31:30 | LiteralExpr | semmle.order | 2 |
-| test.rs:30:21:30:25 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | semmle.label | break |
-| test.rs:30:21:30:25 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | semmle.order | 1 |
-| test.rs:30:21:30:26 | ExprStmt | test.rs:30:21:30:25 | BreakExpr | semmle.label |  |
-| test.rs:30:21:30:26 | ExprStmt | test.rs:30:21:30:25 | BreakExpr | semmle.order | 1 |
-| test.rs:31:24:33:17 | IfExpr | test.rs:29:17:33:17 | IfExpr | semmle.label |  |
-| test.rs:31:24:33:17 | IfExpr | test.rs:29:17:33:17 | IfExpr | semmle.order | 1 |
-| test.rs:31:27:31:30 | LiteralExpr | test.rs:31:24:33:17 | IfExpr | semmle.label | false |
-| test.rs:31:27:31:30 | LiteralExpr | test.rs:31:24:33:17 | IfExpr | semmle.order | 1 |
-| test.rs:31:27:31:30 | LiteralExpr | test.rs:32:21:32:33 | ExprStmt | semmle.label | true |
-| test.rs:31:27:31:30 | LiteralExpr | test.rs:32:21:32:33 | ExprStmt | semmle.order | 2 |
-| test.rs:32:21:32:32 | BreakExpr | test.rs:27:9:36:9 | LoopExpr | semmle.label | break('outer) |
-| test.rs:32:21:32:32 | BreakExpr | test.rs:27:9:36:9 | LoopExpr | semmle.order | 1 |
-| test.rs:32:21:32:33 | ExprStmt | test.rs:32:21:32:32 | BreakExpr | semmle.label |  |
-| test.rs:32:21:32:33 | ExprStmt | test.rs:32:21:32:32 | BreakExpr | semmle.order | 1 |
-| test.rs:34:17:34:28 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | semmle.label | break('inner) |
-| test.rs:34:17:34:28 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | semmle.order | 1 |
-| test.rs:34:17:34:29 | ExprStmt | test.rs:34:17:34:28 | BreakExpr | semmle.label |  |
-| test.rs:34:17:34:29 | ExprStmt | test.rs:34:17:34:28 | BreakExpr | semmle.order | 1 |
-| test.rs:37:9:37:12 | LiteralExpr | test.rs:26:41:38:5 | BlockExpr | semmle.label |  |
-| test.rs:37:9:37:12 | LiteralExpr | test.rs:26:41:38:5 | BlockExpr | semmle.order | 1 |
-| test.rs:40:5:52:5 | enter test_continue_with_labels | test.rs:42:13:42:14 | ExprStmt | semmle.label |  |
-| test.rs:40:5:52:5 | enter test_continue_with_labels | test.rs:42:13:42:14 | ExprStmt | semmle.order | 1 |
-| test.rs:42:13:42:13 | LiteralExpr | test.rs:44:17:48:17 | ExprStmt | semmle.label |  |
-| test.rs:42:13:42:13 | LiteralExpr | test.rs:44:17:48:17 | ExprStmt | semmle.order | 1 |
-| test.rs:42:13:42:14 | ExprStmt | test.rs:42:13:42:13 | LiteralExpr | semmle.label |  |
-| test.rs:42:13:42:14 | ExprStmt | test.rs:42:13:42:13 | LiteralExpr | semmle.order | 1 |
-| test.rs:44:17:48:17 | ExprStmt | test.rs:44:20:44:24 | LiteralExpr | semmle.label |  |
-| test.rs:44:17:48:17 | ExprStmt | test.rs:44:20:44:24 | LiteralExpr | semmle.order | 1 |
-| test.rs:44:17:48:17 | IfExpr | test.rs:49:17:49:32 | ExprStmt | semmle.label |  |
-| test.rs:44:17:48:17 | IfExpr | test.rs:49:17:49:32 | ExprStmt | semmle.order | 1 |
-| test.rs:44:20:44:24 | LiteralExpr | test.rs:45:21:45:29 | ExprStmt | semmle.label | true |
-| test.rs:44:20:44:24 | LiteralExpr | test.rs:45:21:45:29 | ExprStmt | semmle.order | 1 |
-| test.rs:44:20:44:24 | LiteralExpr | test.rs:46:27:46:30 | LiteralExpr | semmle.label | false |
-| test.rs:44:20:44:24 | LiteralExpr | test.rs:46:27:46:30 | LiteralExpr | semmle.order | 2 |
-| test.rs:45:21:45:28 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | semmle.label | continue |
-| test.rs:45:21:45:28 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | semmle.order | 1 |
-| test.rs:45:21:45:29 | ExprStmt | test.rs:45:21:45:28 | ContinueExpr | semmle.label |  |
-| test.rs:45:21:45:29 | ExprStmt | test.rs:45:21:45:28 | ContinueExpr | semmle.order | 1 |
-| test.rs:46:24:48:17 | IfExpr | test.rs:44:17:48:17 | IfExpr | semmle.label |  |
-| test.rs:46:24:48:17 | IfExpr | test.rs:44:17:48:17 | IfExpr | semmle.order | 1 |
-| test.rs:46:27:46:30 | LiteralExpr | test.rs:46:24:48:17 | IfExpr | semmle.label | false |
-| test.rs:46:27:46:30 | LiteralExpr | test.rs:46:24:48:17 | IfExpr | semmle.order | 1 |
-| test.rs:46:27:46:30 | LiteralExpr | test.rs:47:21:47:36 | ExprStmt | semmle.label | true |
-| test.rs:46:27:46:30 | LiteralExpr | test.rs:47:21:47:36 | ExprStmt | semmle.order | 2 |
-| test.rs:47:21:47:35 | ContinueExpr | test.rs:42:13:42:14 | ExprStmt | semmle.label | continue('outer) |
-| test.rs:47:21:47:35 | ContinueExpr | test.rs:42:13:42:14 | ExprStmt | semmle.order | 1 |
-| test.rs:47:21:47:36 | ExprStmt | test.rs:47:21:47:35 | ContinueExpr | semmle.label |  |
-| test.rs:47:21:47:36 | ExprStmt | test.rs:47:21:47:35 | ContinueExpr | semmle.order | 1 |
-| test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | semmle.label | continue('inner) |
-| test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | semmle.order | 1 |
-| test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr | semmle.label |  |
-| test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr | semmle.order | 1 |
-| test.rs:55:1:58:1 | enter test_nested_function | test.rs:56:5:56:28 | LetStmt | semmle.label |  |
-| test.rs:55:1:58:1 | enter test_nested_function | test.rs:56:5:56:28 | LetStmt | semmle.order | 1 |
-| test.rs:55:1:58:1 | exit test_nested_function (normal) | test.rs:55:1:58:1 | exit test_nested_function | semmle.label |  |
-| test.rs:55:1:58:1 | exit test_nested_function (normal) | test.rs:55:1:58:1 | exit test_nested_function | semmle.order | 1 |
-| test.rs:55:40:58:1 | BlockExpr | test.rs:55:1:58:1 | exit test_nested_function (normal) | semmle.label |  |
-| test.rs:55:40:58:1 | BlockExpr | test.rs:55:1:58:1 | exit test_nested_function (normal) | semmle.order | 1 |
-| test.rs:56:5:56:28 | LetStmt | test.rs:56:19:56:27 | ClosureExpr | semmle.label |  |
-| test.rs:56:5:56:28 | LetStmt | test.rs:56:19:56:27 | ClosureExpr | semmle.order | 1 |
-| test.rs:56:9:56:15 | IdentPat | test.rs:57:5:57:11 | PathExpr | semmle.label | match, no-match |
-| test.rs:56:9:56:15 | IdentPat | test.rs:57:5:57:11 | PathExpr | semmle.order | 1 |
-| test.rs:56:9:56:15 | IdentPat | test.rs:57:5:57:11 | PathExpr | semmle.order | 2 |
-| test.rs:56:19:56:27 | ClosureExpr | test.rs:56:9:56:15 | IdentPat | semmle.label |  |
-| test.rs:56:19:56:27 | ClosureExpr | test.rs:56:9:56:15 | IdentPat | semmle.order | 1 |
-| test.rs:56:19:56:27 | enter ClosureExpr | test.rs:56:23:56:23 | PathExpr | semmle.label |  |
-| test.rs:56:19:56:27 | enter ClosureExpr | test.rs:56:23:56:23 | PathExpr | semmle.order | 1 |
-| test.rs:56:19:56:27 | exit ClosureExpr (normal) | test.rs:56:19:56:27 | exit ClosureExpr | semmle.label |  |
-| test.rs:56:19:56:27 | exit ClosureExpr (normal) | test.rs:56:19:56:27 | exit ClosureExpr | semmle.order | 1 |
-| test.rs:56:23:56:23 | PathExpr | test.rs:56:27:56:27 | LiteralExpr | semmle.label |  |
-| test.rs:56:23:56:23 | PathExpr | test.rs:56:27:56:27 | LiteralExpr | semmle.order | 1 |
-| test.rs:56:23:56:27 | BinaryExpr | test.rs:56:19:56:27 | exit ClosureExpr (normal) | semmle.label |  |
-| test.rs:56:23:56:27 | BinaryExpr | test.rs:56:19:56:27 | exit ClosureExpr (normal) | semmle.order | 1 |
-| test.rs:56:27:56:27 | LiteralExpr | test.rs:56:23:56:27 | BinaryExpr | semmle.label |  |
-| test.rs:56:27:56:27 | LiteralExpr | test.rs:56:23:56:27 | BinaryExpr | semmle.order | 1 |
-| test.rs:57:5:57:11 | PathExpr | test.rs:57:13:57:19 | PathExpr | semmle.label |  |
-| test.rs:57:5:57:11 | PathExpr | test.rs:57:13:57:19 | PathExpr | semmle.order | 1 |
-| test.rs:57:5:57:23 | CallExpr | test.rs:55:40:58:1 | BlockExpr | semmle.label |  |
-| test.rs:57:5:57:23 | CallExpr | test.rs:55:40:58:1 | BlockExpr | semmle.order | 1 |
-| test.rs:57:13:57:19 | PathExpr | test.rs:57:21:57:21 | PathExpr | semmle.label |  |
-| test.rs:57:13:57:19 | PathExpr | test.rs:57:21:57:21 | PathExpr | semmle.order | 1 |
-| test.rs:57:13:57:22 | CallExpr | test.rs:57:5:57:23 | CallExpr | semmle.label |  |
-| test.rs:57:13:57:22 | CallExpr | test.rs:57:5:57:23 | CallExpr | semmle.order | 1 |
-| test.rs:57:21:57:21 | PathExpr | test.rs:57:13:57:22 | CallExpr | semmle.label |  |
-| test.rs:57:21:57:21 | PathExpr | test.rs:57:13:57:22 | CallExpr | semmle.order | 1 |
-| test.rs:62:5:68:5 | enter test_if_else | test.rs:63:12:63:12 | PathExpr | semmle.label |  |
-| test.rs:62:5:68:5 | enter test_if_else | test.rs:63:12:63:12 | PathExpr | semmle.order | 1 |
-| test.rs:62:5:68:5 | exit test_if_else (normal) | test.rs:62:5:68:5 | exit test_if_else | semmle.label |  |
-| test.rs:62:5:68:5 | exit test_if_else (normal) | test.rs:62:5:68:5 | exit test_if_else | semmle.order | 1 |
-| test.rs:62:36:68:5 | BlockExpr | test.rs:62:5:68:5 | exit test_if_else (normal) | semmle.label |  |
-| test.rs:62:36:68:5 | BlockExpr | test.rs:62:5:68:5 | exit test_if_else (normal) | semmle.order | 1 |
-| test.rs:63:9:67:9 | IfExpr | test.rs:62:36:68:5 | BlockExpr | semmle.label |  |
-| test.rs:63:9:67:9 | IfExpr | test.rs:62:36:68:5 | BlockExpr | semmle.order | 1 |
-| test.rs:63:12:63:12 | PathExpr | test.rs:63:17:63:17 | LiteralExpr | semmle.label |  |
-| test.rs:63:12:63:12 | PathExpr | test.rs:63:17:63:17 | LiteralExpr | semmle.order | 1 |
-| test.rs:63:12:63:17 | BinaryExpr | test.rs:64:13:64:13 | LiteralExpr | semmle.label | true |
-| test.rs:63:12:63:17 | BinaryExpr | test.rs:64:13:64:13 | LiteralExpr | semmle.order | 1 |
-| test.rs:63:12:63:17 | BinaryExpr | test.rs:66:13:66:13 | PathExpr | semmle.label | false |
-| test.rs:63:12:63:17 | BinaryExpr | test.rs:66:13:66:13 | PathExpr | semmle.order | 2 |
-| test.rs:63:17:63:17 | LiteralExpr | test.rs:63:12:63:17 | BinaryExpr | semmle.label |  |
-| test.rs:63:17:63:17 | LiteralExpr | test.rs:63:12:63:17 | BinaryExpr | semmle.order | 1 |
-| test.rs:63:19:65:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr | semmle.label |  |
-| test.rs:63:19:65:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr | semmle.order | 1 |
-| test.rs:64:13:64:13 | LiteralExpr | test.rs:63:19:65:9 | BlockExpr | semmle.label |  |
-| test.rs:64:13:64:13 | LiteralExpr | test.rs:63:19:65:9 | BlockExpr | semmle.order | 1 |
-| test.rs:65:16:67:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr | semmle.label |  |
-| test.rs:65:16:67:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr | semmle.order | 1 |
-| test.rs:66:13:66:13 | PathExpr | test.rs:66:17:66:17 | LiteralExpr | semmle.label |  |
-| test.rs:66:13:66:13 | PathExpr | test.rs:66:17:66:17 | LiteralExpr | semmle.order | 1 |
-| test.rs:66:13:66:17 | BinaryExpr | test.rs:65:16:67:9 | BlockExpr | semmle.label |  |
-| test.rs:66:13:66:17 | BinaryExpr | test.rs:65:16:67:9 | BlockExpr | semmle.order | 1 |
-| test.rs:66:17:66:17 | LiteralExpr | test.rs:66:13:66:17 | BinaryExpr | semmle.label |  |
-| test.rs:66:17:66:17 | LiteralExpr | test.rs:66:13:66:17 | BinaryExpr | semmle.order | 1 |
-| test.rs:70:5:76:5 | enter test_if_let_else | test.rs:71:12:71:26 | LetExpr | semmle.label |  |
-| test.rs:70:5:76:5 | enter test_if_let_else | test.rs:71:12:71:26 | LetExpr | semmle.order | 1 |
-| test.rs:70:5:76:5 | exit test_if_let_else (normal) | test.rs:70:5:76:5 | exit test_if_let_else | semmle.label |  |
-| test.rs:70:5:76:5 | exit test_if_let_else (normal) | test.rs:70:5:76:5 | exit test_if_let_else | semmle.order | 1 |
-| test.rs:70:48:76:5 | BlockExpr | test.rs:70:5:76:5 | exit test_if_let_else (normal) | semmle.label |  |
-| test.rs:70:48:76:5 | BlockExpr | test.rs:70:5:76:5 | exit test_if_let_else (normal) | semmle.order | 1 |
-| test.rs:71:9:75:9 | IfExpr | test.rs:70:48:76:5 | BlockExpr | semmle.label |  |
-| test.rs:71:9:75:9 | IfExpr | test.rs:70:48:76:5 | BlockExpr | semmle.order | 1 |
-| test.rs:71:12:71:26 | LetExpr | test.rs:71:16:71:22 | TupleStructPat | semmle.label |  |
-| test.rs:71:12:71:26 | LetExpr | test.rs:71:16:71:22 | TupleStructPat | semmle.order | 1 |
-| test.rs:71:16:71:22 | TupleStructPat | test.rs:72:13:72:13 | PathExpr | semmle.label | match |
-| test.rs:71:16:71:22 | TupleStructPat | test.rs:72:13:72:13 | PathExpr | semmle.order | 1 |
-| test.rs:71:16:71:22 | TupleStructPat | test.rs:74:13:74:13 | LiteralExpr | semmle.label | no-match |
-| test.rs:71:16:71:22 | TupleStructPat | test.rs:74:13:74:13 | LiteralExpr | semmle.order | 2 |
-| test.rs:71:28:73:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr | semmle.label |  |
-| test.rs:71:28:73:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr | semmle.order | 1 |
-| test.rs:72:13:72:13 | PathExpr | test.rs:71:28:73:9 | BlockExpr | semmle.label |  |
-| test.rs:72:13:72:13 | PathExpr | test.rs:71:28:73:9 | BlockExpr | semmle.order | 1 |
-| test.rs:73:16:75:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr | semmle.label |  |
-| test.rs:73:16:75:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr | semmle.order | 1 |
-| test.rs:74:13:74:13 | LiteralExpr | test.rs:73:16:75:9 | BlockExpr | semmle.label |  |
-| test.rs:74:13:74:13 | LiteralExpr | test.rs:73:16:75:9 | BlockExpr | semmle.order | 1 |
-| test.rs:78:5:83:5 | enter test_if_let | test.rs:79:9:81:9 | ExprStmt | semmle.label |  |
-| test.rs:78:5:83:5 | enter test_if_let | test.rs:79:9:81:9 | ExprStmt | semmle.order | 1 |
-| test.rs:78:5:83:5 | exit test_if_let (normal) | test.rs:78:5:83:5 | exit test_if_let | semmle.label |  |
-| test.rs:78:5:83:5 | exit test_if_let (normal) | test.rs:78:5:83:5 | exit test_if_let | semmle.order | 1 |
-| test.rs:78:43:83:5 | BlockExpr | test.rs:78:5:83:5 | exit test_if_let (normal) | semmle.label |  |
-| test.rs:78:43:83:5 | BlockExpr | test.rs:78:5:83:5 | exit test_if_let (normal) | semmle.order | 1 |
-| test.rs:79:9:81:9 | ExprStmt | test.rs:79:12:79:26 | LetExpr | semmle.label |  |
-| test.rs:79:9:81:9 | ExprStmt | test.rs:79:12:79:26 | LetExpr | semmle.order | 1 |
-| test.rs:79:9:81:9 | IfExpr | test.rs:82:9:82:9 | LiteralExpr | semmle.label |  |
-| test.rs:79:9:81:9 | IfExpr | test.rs:82:9:82:9 | LiteralExpr | semmle.order | 1 |
-| test.rs:79:12:79:26 | LetExpr | test.rs:79:16:79:22 | TupleStructPat | semmle.label |  |
-| test.rs:79:12:79:26 | LetExpr | test.rs:79:16:79:22 | TupleStructPat | semmle.order | 1 |
-| test.rs:79:16:79:22 | TupleStructPat | test.rs:79:9:81:9 | IfExpr | semmle.label | no-match |
-| test.rs:79:16:79:22 | TupleStructPat | test.rs:79:9:81:9 | IfExpr | semmle.order | 1 |
-| test.rs:79:16:79:22 | TupleStructPat | test.rs:80:13:80:13 | PathExpr | semmle.label | match |
-| test.rs:79:16:79:22 | TupleStructPat | test.rs:80:13:80:13 | PathExpr | semmle.order | 2 |
-| test.rs:79:28:81:9 | BlockExpr | test.rs:79:9:81:9 | IfExpr | semmle.label |  |
-| test.rs:79:28:81:9 | BlockExpr | test.rs:79:9:81:9 | IfExpr | semmle.order | 1 |
-| test.rs:80:13:80:13 | PathExpr | test.rs:79:28:81:9 | BlockExpr | semmle.label |  |
-| test.rs:80:13:80:13 | PathExpr | test.rs:79:28:81:9 | BlockExpr | semmle.order | 1 |
-| test.rs:82:9:82:9 | LiteralExpr | test.rs:78:43:83:5 | BlockExpr | semmle.label |  |
-| test.rs:82:9:82:9 | LiteralExpr | test.rs:78:43:83:5 | BlockExpr | semmle.order | 1 |
-| test.rs:105:5:108:5 | enter test_and_operator | test.rs:106:9:106:28 | LetStmt | semmle.label |  |
-| test.rs:105:5:108:5 | enter test_and_operator | test.rs:106:9:106:28 | LetStmt | semmle.order | 1 |
-| test.rs:105:5:108:5 | exit test_and_operator (normal) | test.rs:105:5:108:5 | exit test_and_operator | semmle.label |  |
-| test.rs:105:5:108:5 | exit test_and_operator (normal) | test.rs:105:5:108:5 | exit test_and_operator | semmle.order | 1 |
-| test.rs:105:61:108:5 | BlockExpr | test.rs:105:5:108:5 | exit test_and_operator (normal) | semmle.label |  |
-| test.rs:105:61:108:5 | BlockExpr | test.rs:105:5:108:5 | exit test_and_operator (normal) | semmle.order | 1 |
-| test.rs:106:9:106:28 | LetStmt | test.rs:106:17:106:27 | BinaryExpr | semmle.label |  |
-| test.rs:106:9:106:28 | LetStmt | test.rs:106:17:106:27 | BinaryExpr | semmle.order | 1 |
-| test.rs:106:13:106:13 | IdentPat | test.rs:107:9:107:9 | PathExpr | semmle.label | match, no-match |
-| test.rs:106:13:106:13 | IdentPat | test.rs:107:9:107:9 | PathExpr | semmle.order | 1 |
-| test.rs:106:13:106:13 | IdentPat | test.rs:107:9:107:9 | PathExpr | semmle.order | 2 |
-| test.rs:106:17:106:17 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.label | false |
-| test.rs:106:17:106:17 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.order | 1 |
-| test.rs:106:17:106:17 | PathExpr | test.rs:106:22:106:22 | PathExpr | semmle.label | true |
-| test.rs:106:17:106:17 | PathExpr | test.rs:106:22:106:22 | PathExpr | semmle.order | 2 |
-| test.rs:106:17:106:22 | BinaryExpr | test.rs:106:17:106:17 | PathExpr | semmle.label |  |
-| test.rs:106:17:106:22 | BinaryExpr | test.rs:106:17:106:17 | PathExpr | semmle.order | 1 |
-| test.rs:106:17:106:27 | BinaryExpr | test.rs:106:17:106:22 | BinaryExpr | semmle.label |  |
-| test.rs:106:17:106:27 | BinaryExpr | test.rs:106:17:106:22 | BinaryExpr | semmle.order | 1 |
-| test.rs:106:22:106:22 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.label | false |
-| test.rs:106:22:106:22 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.order | 1 |
-| test.rs:106:22:106:22 | PathExpr | test.rs:106:27:106:27 | PathExpr | semmle.label | true |
-| test.rs:106:22:106:22 | PathExpr | test.rs:106:27:106:27 | PathExpr | semmle.order | 2 |
-| test.rs:106:27:106:27 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.label |  |
-| test.rs:106:27:106:27 | PathExpr | test.rs:106:13:106:13 | IdentPat | semmle.order | 1 |
-| test.rs:107:9:107:9 | PathExpr | test.rs:105:61:108:5 | BlockExpr | semmle.label |  |
-| test.rs:107:9:107:9 | PathExpr | test.rs:105:61:108:5 | BlockExpr | semmle.order | 1 |
-| test.rs:110:5:113:5 | enter test_or_operator | test.rs:111:9:111:28 | LetStmt | semmle.label |  |
-| test.rs:110:5:113:5 | enter test_or_operator | test.rs:111:9:111:28 | LetStmt | semmle.order | 1 |
-| test.rs:110:5:113:5 | exit test_or_operator (normal) | test.rs:110:5:113:5 | exit test_or_operator | semmle.label |  |
-| test.rs:110:5:113:5 | exit test_or_operator (normal) | test.rs:110:5:113:5 | exit test_or_operator | semmle.order | 1 |
-| test.rs:110:60:113:5 | BlockExpr | test.rs:110:5:113:5 | exit test_or_operator (normal) | semmle.label |  |
-| test.rs:110:60:113:5 | BlockExpr | test.rs:110:5:113:5 | exit test_or_operator (normal) | semmle.order | 1 |
-| test.rs:111:9:111:28 | LetStmt | test.rs:111:17:111:27 | BinaryExpr | semmle.label |  |
-| test.rs:111:9:111:28 | LetStmt | test.rs:111:17:111:27 | BinaryExpr | semmle.order | 1 |
-| test.rs:111:13:111:13 | IdentPat | test.rs:112:9:112:9 | PathExpr | semmle.label | match, no-match |
-| test.rs:111:13:111:13 | IdentPat | test.rs:112:9:112:9 | PathExpr | semmle.order | 1 |
-| test.rs:111:13:111:13 | IdentPat | test.rs:112:9:112:9 | PathExpr | semmle.order | 2 |
-| test.rs:111:17:111:17 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.label | true |
-| test.rs:111:17:111:17 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.order | 1 |
-| test.rs:111:17:111:17 | PathExpr | test.rs:111:22:111:22 | PathExpr | semmle.label | false |
-| test.rs:111:17:111:17 | PathExpr | test.rs:111:22:111:22 | PathExpr | semmle.order | 2 |
-| test.rs:111:17:111:22 | BinaryExpr | test.rs:111:17:111:17 | PathExpr | semmle.label |  |
-| test.rs:111:17:111:22 | BinaryExpr | test.rs:111:17:111:17 | PathExpr | semmle.order | 1 |
-| test.rs:111:17:111:27 | BinaryExpr | test.rs:111:17:111:22 | BinaryExpr | semmle.label |  |
-| test.rs:111:17:111:27 | BinaryExpr | test.rs:111:17:111:22 | BinaryExpr | semmle.order | 1 |
-| test.rs:111:22:111:22 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.label | true |
-| test.rs:111:22:111:22 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.order | 1 |
-| test.rs:111:22:111:22 | PathExpr | test.rs:111:27:111:27 | PathExpr | semmle.label | false |
-| test.rs:111:22:111:22 | PathExpr | test.rs:111:27:111:27 | PathExpr | semmle.order | 2 |
-| test.rs:111:27:111:27 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.label |  |
-| test.rs:111:27:111:27 | PathExpr | test.rs:111:13:111:13 | IdentPat | semmle.order | 1 |
-| test.rs:112:9:112:9 | PathExpr | test.rs:110:60:113:5 | BlockExpr | semmle.label |  |
-| test.rs:112:9:112:9 | PathExpr | test.rs:110:60:113:5 | BlockExpr | semmle.order | 1 |
-| test.rs:115:5:118:5 | enter test_or_operator_2 | test.rs:116:9:116:36 | LetStmt | semmle.label |  |
-| test.rs:115:5:118:5 | enter test_or_operator_2 | test.rs:116:9:116:36 | LetStmt | semmle.order | 1 |
-| test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | test.rs:115:5:118:5 | exit test_or_operator_2 | semmle.label |  |
-| test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | test.rs:115:5:118:5 | exit test_or_operator_2 | semmle.order | 1 |
-| test.rs:115:61:118:5 | BlockExpr | test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | semmle.label |  |
-| test.rs:115:61:118:5 | BlockExpr | test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | semmle.order | 1 |
-| test.rs:116:9:116:36 | LetStmt | test.rs:116:17:116:35 | BinaryExpr | semmle.label |  |
-| test.rs:116:9:116:36 | LetStmt | test.rs:116:17:116:35 | BinaryExpr | semmle.order | 1 |
-| test.rs:116:13:116:13 | IdentPat | test.rs:117:9:117:9 | PathExpr | semmle.label | match, no-match |
-| test.rs:116:13:116:13 | IdentPat | test.rs:117:9:117:9 | PathExpr | semmle.order | 1 |
-| test.rs:116:13:116:13 | IdentPat | test.rs:117:9:117:9 | PathExpr | semmle.order | 2 |
-| test.rs:116:17:116:17 | PathExpr | test.rs:116:13:116:13 | IdentPat | semmle.label | true |
-| test.rs:116:17:116:17 | PathExpr | test.rs:116:13:116:13 | IdentPat | semmle.order | 1 |
-| test.rs:116:17:116:30 | BinaryExpr | test.rs:116:17:116:17 | PathExpr | semmle.label |  |
-| test.rs:116:17:116:30 | BinaryExpr | test.rs:116:17:116:17 | PathExpr | semmle.order | 1 |
-| test.rs:116:17:116:35 | BinaryExpr | test.rs:116:17:116:30 | BinaryExpr | semmle.label |  |
-| test.rs:116:17:116:35 | BinaryExpr | test.rs:116:17:116:30 | BinaryExpr | semmle.order | 1 |
-| test.rs:117:9:117:9 | PathExpr | test.rs:115:61:118:5 | BlockExpr | semmle.label |  |
-| test.rs:117:9:117:9 | PathExpr | test.rs:115:61:118:5 | BlockExpr | semmle.order | 1 |
-| test.rs:122:1:128:1 | enter test_match | test.rs:123:11:123:21 | PathExpr | semmle.label |  |
-| test.rs:122:1:128:1 | enter test_match | test.rs:123:11:123:21 | PathExpr | semmle.order | 1 |
-| test.rs:122:1:128:1 | exit test_match (normal) | test.rs:122:1:128:1 | exit test_match | semmle.label |  |
-| test.rs:122:1:128:1 | exit test_match (normal) | test.rs:122:1:128:1 | exit test_match | semmle.order | 1 |
-| test.rs:122:44:128:1 | BlockExpr | test.rs:122:1:128:1 | exit test_match (normal) | semmle.label |  |
-| test.rs:122:44:128:1 | BlockExpr | test.rs:122:1:128:1 | exit test_match (normal) | semmle.order | 1 |
-| test.rs:123:5:127:5 | MatchExpr | test.rs:122:44:128:1 | BlockExpr | semmle.label |  |
-| test.rs:123:5:127:5 | MatchExpr | test.rs:122:44:128:1 | BlockExpr | semmle.order | 1 |
-| test.rs:123:11:123:21 | PathExpr | test.rs:124:9:124:23 | TupleStructPat | semmle.label |  |
-| test.rs:123:11:123:21 | PathExpr | test.rs:124:9:124:23 | TupleStructPat | semmle.order | 1 |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | semmle.label | no-match |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | semmle.order | 1 |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:124:28:124:28 | PathExpr | semmle.label | match |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:124:28:124:28 | PathExpr | semmle.order | 2 |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:125:9:125:23 | TupleStructPat | semmle.label | no-match |
-| test.rs:124:9:124:23 | TupleStructPat | test.rs:125:9:125:23 | TupleStructPat | semmle.order | 3 |
-| test.rs:124:28:124:28 | PathExpr | test.rs:124:32:124:33 | LiteralExpr | semmle.label |  |
-| test.rs:124:28:124:28 | PathExpr | test.rs:124:32:124:33 | LiteralExpr | semmle.order | 1 |
-| test.rs:124:32:124:33 | LiteralExpr | test.rs:124:28:124:33 | BinaryExpr | semmle.label |  |
-| test.rs:124:32:124:33 | LiteralExpr | test.rs:124:28:124:33 | BinaryExpr | semmle.order | 1 |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | semmle.label | no-match |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | semmle.order | 1 |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:125:28:125:28 | PathExpr | semmle.label | match |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:125:28:125:28 | PathExpr | semmle.order | 2 |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:126:9:126:20 | PathPat | semmle.label | no-match |
-| test.rs:125:9:125:23 | TupleStructPat | test.rs:126:9:126:20 | PathPat | semmle.order | 3 |
-| test.rs:125:28:125:28 | PathExpr | test.rs:123:5:127:5 | MatchExpr | semmle.label |  |
-| test.rs:125:28:125:28 | PathExpr | test.rs:123:5:127:5 | MatchExpr | semmle.order | 1 |
-| test.rs:126:9:126:20 | PathPat | test.rs:123:5:127:5 | MatchExpr | semmle.label | no-match |
-| test.rs:126:9:126:20 | PathPat | test.rs:123:5:127:5 | MatchExpr | semmle.order | 1 |
-| test.rs:126:9:126:20 | PathPat | test.rs:126:25:126:25 | LiteralExpr | semmle.label | match |
-| test.rs:126:9:126:20 | PathPat | test.rs:126:25:126:25 | LiteralExpr | semmle.order | 2 |
-| test.rs:126:25:126:25 | LiteralExpr | test.rs:123:5:127:5 | MatchExpr | semmle.label |  |
-| test.rs:126:25:126:25 | LiteralExpr | test.rs:123:5:127:5 | MatchExpr | semmle.order | 1 |
-| test.rs:131:5:136:5 | enter test_infinite_loop | test.rs:132:9:134:9 | ExprStmt | semmle.label |  |
-| test.rs:131:5:136:5 | enter test_infinite_loop | test.rs:132:9:134:9 | ExprStmt | semmle.order | 1 |
-| test.rs:132:9:134:9 | ExprStmt | test.rs:133:13:133:13 | LiteralExpr | semmle.label |  |
-| test.rs:132:9:134:9 | ExprStmt | test.rs:133:13:133:13 | LiteralExpr | semmle.order | 1 |
-| test.rs:132:14:134:9 | BlockExpr | test.rs:133:13:133:13 | LiteralExpr | semmle.label |  |
-| test.rs:132:14:134:9 | BlockExpr | test.rs:133:13:133:13 | LiteralExpr | semmle.order | 1 |
-| test.rs:133:13:133:13 | LiteralExpr | test.rs:132:14:134:9 | BlockExpr | semmle.label |  |
-| test.rs:133:13:133:13 | LiteralExpr | test.rs:132:14:134:9 | BlockExpr | semmle.order | 1 |
-| test.rs:138:5:143:5 | enter test_let_match | test.rs:139:9:141:10 | LetStmt | semmle.label |  |
-| test.rs:138:5:143:5 | enter test_let_match | test.rs:139:9:141:10 | LetStmt | semmle.order | 1 |
-| test.rs:138:5:143:5 | exit test_let_match (normal) | test.rs:138:5:143:5 | exit test_let_match | semmle.label |  |
-| test.rs:138:5:143:5 | exit test_let_match (normal) | test.rs:138:5:143:5 | exit test_let_match | semmle.order | 1 |
-| test.rs:138:39:143:5 | BlockExpr | test.rs:138:5:143:5 | exit test_let_match (normal) | semmle.label |  |
-| test.rs:138:39:143:5 | BlockExpr | test.rs:138:5:143:5 | exit test_let_match (normal) | semmle.order | 1 |
-| test.rs:139:9:141:10 | LetStmt | test.rs:139:23:139:23 | PathExpr | semmle.label |  |
-| test.rs:139:9:141:10 | LetStmt | test.rs:139:23:139:23 | PathExpr | semmle.order | 1 |
-| test.rs:139:13:139:19 | TupleStructPat | test.rs:140:13:140:27 | LiteralExpr | semmle.label | no-match |
-| test.rs:139:13:139:19 | TupleStructPat | test.rs:140:13:140:27 | LiteralExpr | semmle.order | 1 |
-| test.rs:139:13:139:19 | TupleStructPat | test.rs:142:9:142:9 | PathExpr | semmle.label | match |
-| test.rs:139:13:139:19 | TupleStructPat | test.rs:142:9:142:9 | PathExpr | semmle.order | 2 |
-| test.rs:139:23:139:23 | PathExpr | test.rs:139:13:139:19 | TupleStructPat | semmle.label |  |
-| test.rs:139:23:139:23 | PathExpr | test.rs:139:13:139:19 | TupleStructPat | semmle.order | 1 |
-| test.rs:140:13:140:27 | LiteralExpr | test.rs:139:30:141:9 | BlockExpr | semmle.label |  |
-| test.rs:140:13:140:27 | LiteralExpr | test.rs:139:30:141:9 | BlockExpr | semmle.order | 1 |
-| test.rs:142:9:142:9 | PathExpr | test.rs:138:39:143:5 | BlockExpr | semmle.label |  |
-| test.rs:142:9:142:9 | PathExpr | test.rs:138:39:143:5 | BlockExpr | semmle.order | 1 |
+| test.rs:1:1:4:1 | enter test_call | test.rs:2:5:2:41 | ExprStmt |  |
+| test.rs:1:1:4:1 | exit test_call (normal) | test.rs:1:1:4:1 | exit test_call |  |
+| test.rs:1:24:4:1 | BlockExpr | test.rs:1:1:4:1 | exit test_call (normal) |  |
+| test.rs:2:5:2:21 | PathExpr | test.rs:2:23:2:26 | LiteralExpr |  |
+| test.rs:2:5:2:40 | CallExpr | test.rs:3:5:3:24 | ExprStmt |  |
+| test.rs:2:5:2:41 | ExprStmt | test.rs:2:5:2:21 | PathExpr |  |
+| test.rs:2:23:2:26 | LiteralExpr | test.rs:2:29:2:33 | LiteralExpr |  |
+| test.rs:2:29:2:33 | LiteralExpr | test.rs:2:36:2:39 | LiteralExpr |  |
+| test.rs:2:36:2:39 | LiteralExpr | test.rs:2:5:2:40 | CallExpr |  |
+| test.rs:3:5:3:19 | PathExpr | test.rs:3:21:3:22 | LiteralExpr |  |
+| test.rs:3:5:3:23 | CallExpr | test.rs:1:24:4:1 | BlockExpr |  |
+| test.rs:3:5:3:24 | ExprStmt | test.rs:3:5:3:19 | PathExpr |  |
+| test.rs:3:21:3:22 | LiteralExpr | test.rs:3:5:3:23 | CallExpr |  |
+| test.rs:8:5:24:5 | enter test_break_and_continue | test.rs:9:9:9:22 | LetStmt |  |
+| test.rs:8:5:24:5 | exit test_break_and_continue (normal) | test.rs:8:5:24:5 | exit test_break_and_continue |  |
+| test.rs:9:9:9:22 | LetStmt | test.rs:9:21:9:21 | PathExpr |  |
+| test.rs:9:13:9:17 | IdentPat | test.rs:10:9:22:9 | ExprStmt | match, no-match |
+| test.rs:9:21:9:21 | PathExpr | test.rs:9:13:9:17 | IdentPat |  |
+| test.rs:10:9:22:9 | ExprStmt | test.rs:11:13:11:24 | ExprStmt |  |
+| test.rs:10:9:22:9 | LoopExpr | test.rs:23:9:23:20 | ExprStmt |  |
+| test.rs:10:14:22:9 | BlockExpr | test.rs:11:13:11:24 | ExprStmt |  |
+| test.rs:11:13:11:13 | PathExpr | test.rs:11:17:11:20 | PathExpr |  |
+| test.rs:11:13:11:23 | BinaryExpr | test.rs:12:13:14:13 | ExprStmt |  |
+| test.rs:11:13:11:24 | ExprStmt | test.rs:11:13:11:13 | PathExpr |  |
+| test.rs:11:17:11:20 | PathExpr | test.rs:11:22:11:22 | PathExpr |  |
+| test.rs:11:17:11:23 | CallExpr | test.rs:11:13:11:23 | BinaryExpr |  |
+| test.rs:11:22:11:22 | PathExpr | test.rs:11:17:11:23 | CallExpr |  |
+| test.rs:12:13:14:13 | ExprStmt | test.rs:12:16:12:16 | PathExpr |  |
+| test.rs:12:13:14:13 | IfExpr | test.rs:15:13:17:13 | ExprStmt |  |
+| test.rs:12:16:12:16 | PathExpr | test.rs:12:20:12:24 | LiteralExpr |  |
+| test.rs:12:16:12:24 | BinaryExpr | test.rs:12:13:14:13 | IfExpr | false |
+| test.rs:12:16:12:24 | BinaryExpr | test.rs:13:17:13:29 | ExprStmt | true |
+| test.rs:12:20:12:24 | LiteralExpr | test.rs:12:16:12:24 | BinaryExpr |  |
+| test.rs:13:17:13:28 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | return |
+| test.rs:13:17:13:29 | ExprStmt | test.rs:13:24:13:28 | LiteralExpr |  |
+| test.rs:13:24:13:28 | LiteralExpr | test.rs:13:17:13:28 | ReturnExpr |  |
+| test.rs:15:13:17:13 | ExprStmt | test.rs:15:16:15:16 | PathExpr |  |
+| test.rs:15:13:17:13 | IfExpr | test.rs:18:13:20:13 | ExprStmt |  |
+| test.rs:15:16:15:16 | PathExpr | test.rs:15:21:15:21 | LiteralExpr |  |
+| test.rs:15:16:15:21 | BinaryExpr | test.rs:15:13:17:13 | IfExpr | false |
+| test.rs:15:16:15:21 | BinaryExpr | test.rs:16:17:16:22 | ExprStmt | true |
+| test.rs:15:21:15:21 | LiteralExpr | test.rs:15:16:15:21 | BinaryExpr |  |
+| test.rs:16:17:16:21 | BreakExpr | test.rs:10:9:22:9 | LoopExpr | break |
+| test.rs:16:17:16:22 | ExprStmt | test.rs:16:17:16:21 | BreakExpr |  |
+| test.rs:18:13:20:13 | ExprStmt | test.rs:18:16:18:16 | PathExpr |  |
+| test.rs:18:13:20:13 | IfExpr | test.rs:21:13:21:13 | PathExpr |  |
+| test.rs:18:16:18:16 | PathExpr | test.rs:18:20:18:20 | LiteralExpr |  |
+| test.rs:18:16:18:20 | BinaryExpr | test.rs:18:25:18:25 | LiteralExpr |  |
+| test.rs:18:16:18:25 | BinaryExpr | test.rs:18:13:20:13 | IfExpr | false |
+| test.rs:18:16:18:25 | BinaryExpr | test.rs:19:17:19:25 | ExprStmt | true |
+| test.rs:18:20:18:20 | LiteralExpr | test.rs:18:16:18:20 | BinaryExpr |  |
+| test.rs:18:25:18:25 | LiteralExpr | test.rs:18:16:18:25 | BinaryExpr |  |
+| test.rs:19:17:19:24 | ContinueExpr | test.rs:11:13:11:24 | ExprStmt | continue |
+| test.rs:19:17:19:25 | ExprStmt | test.rs:19:17:19:24 | ContinueExpr |  |
+| test.rs:21:13:21:13 | PathExpr | test.rs:21:17:21:17 | PathExpr |  |
+| test.rs:21:13:21:21 | BinaryExpr | test.rs:10:14:22:9 | BlockExpr |  |
+| test.rs:21:17:21:17 | PathExpr | test.rs:21:21:21:21 | LiteralExpr |  |
+| test.rs:21:17:21:21 | BinaryExpr | test.rs:21:13:21:21 | BinaryExpr |  |
+| test.rs:21:21:21:21 | LiteralExpr | test.rs:21:17:21:21 | BinaryExpr |  |
+| test.rs:23:9:23:19 | ReturnExpr | test.rs:8:5:24:5 | exit test_break_and_continue (normal) | return |
+| test.rs:23:9:23:20 | ExprStmt | test.rs:23:16:23:19 | LiteralExpr |  |
+| test.rs:23:16:23:19 | LiteralExpr | test.rs:23:9:23:19 | ReturnExpr |  |
+| test.rs:26:5:38:5 | enter test_break_with_labels | test.rs:27:9:36:9 | ExprStmt |  |
+| test.rs:26:5:38:5 | exit test_break_with_labels (normal) | test.rs:26:5:38:5 | exit test_break_with_labels |  |
+| test.rs:26:41:38:5 | BlockExpr | test.rs:26:5:38:5 | exit test_break_with_labels (normal) |  |
+| test.rs:27:9:36:9 | ExprStmt | test.rs:29:17:33:17 | ExprStmt |  |
+| test.rs:27:9:36:9 | LoopExpr | test.rs:37:9:37:12 | LiteralExpr |  |
+| test.rs:27:22:36:9 | BlockExpr | test.rs:29:17:33:17 | ExprStmt |  |
+| test.rs:28:13:35:13 | LoopExpr | test.rs:27:22:36:9 | BlockExpr |  |
+| test.rs:29:17:33:17 | ExprStmt | test.rs:29:20:29:24 | LiteralExpr |  |
+| test.rs:29:17:33:17 | IfExpr | test.rs:34:17:34:29 | ExprStmt |  |
+| test.rs:29:20:29:24 | LiteralExpr | test.rs:30:21:30:26 | ExprStmt | true |
+| test.rs:29:20:29:24 | LiteralExpr | test.rs:31:27:31:30 | LiteralExpr | false |
+| test.rs:30:21:30:25 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | break |
+| test.rs:30:21:30:26 | ExprStmt | test.rs:30:21:30:25 | BreakExpr |  |
+| test.rs:31:24:33:17 | IfExpr | test.rs:29:17:33:17 | IfExpr |  |
+| test.rs:31:27:31:30 | LiteralExpr | test.rs:31:24:33:17 | IfExpr | false |
+| test.rs:31:27:31:30 | LiteralExpr | test.rs:32:21:32:33 | ExprStmt | true |
+| test.rs:32:21:32:32 | BreakExpr | test.rs:27:9:36:9 | LoopExpr | break('outer) |
+| test.rs:32:21:32:33 | ExprStmt | test.rs:32:21:32:32 | BreakExpr |  |
+| test.rs:34:17:34:28 | BreakExpr | test.rs:28:13:35:13 | LoopExpr | break('inner) |
+| test.rs:34:17:34:29 | ExprStmt | test.rs:34:17:34:28 | BreakExpr |  |
+| test.rs:37:9:37:12 | LiteralExpr | test.rs:26:41:38:5 | BlockExpr |  |
+| test.rs:40:5:52:5 | enter test_continue_with_labels | test.rs:42:13:42:14 | ExprStmt |  |
+| test.rs:42:13:42:13 | LiteralExpr | test.rs:44:17:48:17 | ExprStmt |  |
+| test.rs:42:13:42:14 | ExprStmt | test.rs:42:13:42:13 | LiteralExpr |  |
+| test.rs:44:17:48:17 | ExprStmt | test.rs:44:20:44:24 | LiteralExpr |  |
+| test.rs:44:17:48:17 | IfExpr | test.rs:49:17:49:32 | ExprStmt |  |
+| test.rs:44:20:44:24 | LiteralExpr | test.rs:45:21:45:29 | ExprStmt | true |
+| test.rs:44:20:44:24 | LiteralExpr | test.rs:46:27:46:30 | LiteralExpr | false |
+| test.rs:45:21:45:28 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | continue |
+| test.rs:45:21:45:29 | ExprStmt | test.rs:45:21:45:28 | ContinueExpr |  |
+| test.rs:46:24:48:17 | IfExpr | test.rs:44:17:48:17 | IfExpr |  |
+| test.rs:46:27:46:30 | LiteralExpr | test.rs:46:24:48:17 | IfExpr | false |
+| test.rs:46:27:46:30 | LiteralExpr | test.rs:47:21:47:36 | ExprStmt | true |
+| test.rs:47:21:47:35 | ContinueExpr | test.rs:42:13:42:14 | ExprStmt | continue('outer) |
+| test.rs:47:21:47:36 | ExprStmt | test.rs:47:21:47:35 | ContinueExpr |  |
+| test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | continue('inner) |
+| test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr |  |
+| test.rs:55:1:58:1 | enter test_nested_function | test.rs:56:5:56:28 | LetStmt |  |
+| test.rs:55:1:58:1 | exit test_nested_function (normal) | test.rs:55:1:58:1 | exit test_nested_function |  |
+| test.rs:55:40:58:1 | BlockExpr | test.rs:55:1:58:1 | exit test_nested_function (normal) |  |
+| test.rs:56:5:56:28 | LetStmt | test.rs:56:19:56:27 | ClosureExpr |  |
+| test.rs:56:9:56:15 | IdentPat | test.rs:57:5:57:11 | PathExpr | match, no-match |
+| test.rs:56:19:56:27 | ClosureExpr | test.rs:56:9:56:15 | IdentPat |  |
+| test.rs:56:19:56:27 | enter ClosureExpr | test.rs:56:23:56:23 | PathExpr |  |
+| test.rs:56:19:56:27 | exit ClosureExpr (normal) | test.rs:56:19:56:27 | exit ClosureExpr |  |
+| test.rs:56:23:56:23 | PathExpr | test.rs:56:27:56:27 | LiteralExpr |  |
+| test.rs:56:23:56:27 | BinaryExpr | test.rs:56:19:56:27 | exit ClosureExpr (normal) |  |
+| test.rs:56:27:56:27 | LiteralExpr | test.rs:56:23:56:27 | BinaryExpr |  |
+| test.rs:57:5:57:11 | PathExpr | test.rs:57:13:57:19 | PathExpr |  |
+| test.rs:57:5:57:23 | CallExpr | test.rs:55:40:58:1 | BlockExpr |  |
+| test.rs:57:13:57:19 | PathExpr | test.rs:57:21:57:21 | PathExpr |  |
+| test.rs:57:13:57:22 | CallExpr | test.rs:57:5:57:23 | CallExpr |  |
+| test.rs:57:21:57:21 | PathExpr | test.rs:57:13:57:22 | CallExpr |  |
+| test.rs:62:5:68:5 | enter test_if_else | test.rs:63:12:63:12 | PathExpr |  |
+| test.rs:62:5:68:5 | exit test_if_else (normal) | test.rs:62:5:68:5 | exit test_if_else |  |
+| test.rs:62:36:68:5 | BlockExpr | test.rs:62:5:68:5 | exit test_if_else (normal) |  |
+| test.rs:63:9:67:9 | IfExpr | test.rs:62:36:68:5 | BlockExpr |  |
+| test.rs:63:12:63:12 | PathExpr | test.rs:63:17:63:17 | LiteralExpr |  |
+| test.rs:63:12:63:17 | BinaryExpr | test.rs:64:13:64:13 | LiteralExpr | true |
+| test.rs:63:12:63:17 | BinaryExpr | test.rs:66:13:66:13 | PathExpr | false |
+| test.rs:63:17:63:17 | LiteralExpr | test.rs:63:12:63:17 | BinaryExpr |  |
+| test.rs:63:19:65:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr |  |
+| test.rs:64:13:64:13 | LiteralExpr | test.rs:63:19:65:9 | BlockExpr |  |
+| test.rs:65:16:67:9 | BlockExpr | test.rs:63:9:67:9 | IfExpr |  |
+| test.rs:66:13:66:13 | PathExpr | test.rs:66:17:66:17 | LiteralExpr |  |
+| test.rs:66:13:66:17 | BinaryExpr | test.rs:65:16:67:9 | BlockExpr |  |
+| test.rs:66:17:66:17 | LiteralExpr | test.rs:66:13:66:17 | BinaryExpr |  |
+| test.rs:70:5:76:5 | enter test_if_let_else | test.rs:71:12:71:26 | LetExpr |  |
+| test.rs:70:5:76:5 | exit test_if_let_else (normal) | test.rs:70:5:76:5 | exit test_if_let_else |  |
+| test.rs:70:48:76:5 | BlockExpr | test.rs:70:5:76:5 | exit test_if_let_else (normal) |  |
+| test.rs:71:9:75:9 | IfExpr | test.rs:70:48:76:5 | BlockExpr |  |
+| test.rs:71:12:71:26 | LetExpr | test.rs:71:16:71:22 | TupleStructPat |  |
+| test.rs:71:16:71:22 | TupleStructPat | test.rs:72:13:72:13 | PathExpr | match |
+| test.rs:71:16:71:22 | TupleStructPat | test.rs:74:13:74:13 | LiteralExpr | no-match |
+| test.rs:71:28:73:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr |  |
+| test.rs:72:13:72:13 | PathExpr | test.rs:71:28:73:9 | BlockExpr |  |
+| test.rs:73:16:75:9 | BlockExpr | test.rs:71:9:75:9 | IfExpr |  |
+| test.rs:74:13:74:13 | LiteralExpr | test.rs:73:16:75:9 | BlockExpr |  |
+| test.rs:78:5:83:5 | enter test_if_let | test.rs:79:9:81:9 | ExprStmt |  |
+| test.rs:78:5:83:5 | exit test_if_let (normal) | test.rs:78:5:83:5 | exit test_if_let |  |
+| test.rs:78:43:83:5 | BlockExpr | test.rs:78:5:83:5 | exit test_if_let (normal) |  |
+| test.rs:79:9:81:9 | ExprStmt | test.rs:79:12:79:26 | LetExpr |  |
+| test.rs:79:9:81:9 | IfExpr | test.rs:82:9:82:9 | LiteralExpr |  |
+| test.rs:79:12:79:26 | LetExpr | test.rs:79:16:79:22 | TupleStructPat |  |
+| test.rs:79:16:79:22 | TupleStructPat | test.rs:79:9:81:9 | IfExpr | no-match |
+| test.rs:79:16:79:22 | TupleStructPat | test.rs:80:13:80:13 | PathExpr | match |
+| test.rs:79:28:81:9 | BlockExpr | test.rs:79:9:81:9 | IfExpr |  |
+| test.rs:80:13:80:13 | PathExpr | test.rs:79:28:81:9 | BlockExpr |  |
+| test.rs:82:9:82:9 | LiteralExpr | test.rs:78:43:83:5 | BlockExpr |  |
+| test.rs:105:5:108:5 | enter test_and_operator | test.rs:106:9:106:28 | LetStmt |  |
+| test.rs:105:5:108:5 | exit test_and_operator (normal) | test.rs:105:5:108:5 | exit test_and_operator |  |
+| test.rs:105:61:108:5 | BlockExpr | test.rs:105:5:108:5 | exit test_and_operator (normal) |  |
+| test.rs:106:9:106:28 | LetStmt | test.rs:106:17:106:27 | BinaryExpr |  |
+| test.rs:106:13:106:13 | IdentPat | test.rs:107:9:107:9 | PathExpr | match, no-match |
+| test.rs:106:17:106:17 | PathExpr | test.rs:106:13:106:13 | IdentPat | false |
+| test.rs:106:17:106:17 | PathExpr | test.rs:106:22:106:22 | PathExpr | true |
+| test.rs:106:17:106:22 | BinaryExpr | test.rs:106:17:106:17 | PathExpr |  |
+| test.rs:106:17:106:27 | BinaryExpr | test.rs:106:17:106:22 | BinaryExpr |  |
+| test.rs:106:22:106:22 | PathExpr | test.rs:106:13:106:13 | IdentPat | false |
+| test.rs:106:22:106:22 | PathExpr | test.rs:106:27:106:27 | PathExpr | true |
+| test.rs:106:27:106:27 | PathExpr | test.rs:106:13:106:13 | IdentPat |  |
+| test.rs:107:9:107:9 | PathExpr | test.rs:105:61:108:5 | BlockExpr |  |
+| test.rs:110:5:113:5 | enter test_or_operator | test.rs:111:9:111:28 | LetStmt |  |
+| test.rs:110:5:113:5 | exit test_or_operator (normal) | test.rs:110:5:113:5 | exit test_or_operator |  |
+| test.rs:110:60:113:5 | BlockExpr | test.rs:110:5:113:5 | exit test_or_operator (normal) |  |
+| test.rs:111:9:111:28 | LetStmt | test.rs:111:17:111:27 | BinaryExpr |  |
+| test.rs:111:13:111:13 | IdentPat | test.rs:112:9:112:9 | PathExpr | match, no-match |
+| test.rs:111:17:111:17 | PathExpr | test.rs:111:13:111:13 | IdentPat | true |
+| test.rs:111:17:111:17 | PathExpr | test.rs:111:22:111:22 | PathExpr | false |
+| test.rs:111:17:111:22 | BinaryExpr | test.rs:111:17:111:17 | PathExpr |  |
+| test.rs:111:17:111:27 | BinaryExpr | test.rs:111:17:111:22 | BinaryExpr |  |
+| test.rs:111:22:111:22 | PathExpr | test.rs:111:13:111:13 | IdentPat | true |
+| test.rs:111:22:111:22 | PathExpr | test.rs:111:27:111:27 | PathExpr | false |
+| test.rs:111:27:111:27 | PathExpr | test.rs:111:13:111:13 | IdentPat |  |
+| test.rs:112:9:112:9 | PathExpr | test.rs:110:60:113:5 | BlockExpr |  |
+| test.rs:115:5:118:5 | enter test_or_operator_2 | test.rs:116:9:116:36 | LetStmt |  |
+| test.rs:115:5:118:5 | exit test_or_operator_2 (normal) | test.rs:115:5:118:5 | exit test_or_operator_2 |  |
+| test.rs:115:61:118:5 | BlockExpr | test.rs:115:5:118:5 | exit test_or_operator_2 (normal) |  |
+| test.rs:116:9:116:36 | LetStmt | test.rs:116:17:116:35 | BinaryExpr |  |
+| test.rs:116:13:116:13 | IdentPat | test.rs:117:9:117:9 | PathExpr | match, no-match |
+| test.rs:116:17:116:17 | PathExpr | test.rs:116:13:116:13 | IdentPat | true |
+| test.rs:116:17:116:30 | BinaryExpr | test.rs:116:17:116:17 | PathExpr |  |
+| test.rs:116:17:116:35 | BinaryExpr | test.rs:116:17:116:30 | BinaryExpr |  |
+| test.rs:117:9:117:9 | PathExpr | test.rs:115:61:118:5 | BlockExpr |  |
+| test.rs:122:1:128:1 | enter test_match | test.rs:123:11:123:21 | PathExpr |  |
+| test.rs:122:1:128:1 | exit test_match (normal) | test.rs:122:1:128:1 | exit test_match |  |
+| test.rs:122:44:128:1 | BlockExpr | test.rs:122:1:128:1 | exit test_match (normal) |  |
+| test.rs:123:5:127:5 | MatchExpr | test.rs:122:44:128:1 | BlockExpr |  |
+| test.rs:123:11:123:21 | PathExpr | test.rs:124:9:124:23 | TupleStructPat |  |
+| test.rs:124:9:124:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | no-match |
+| test.rs:124:9:124:23 | TupleStructPat | test.rs:124:28:124:28 | PathExpr | match |
+| test.rs:124:9:124:23 | TupleStructPat | test.rs:125:9:125:23 | TupleStructPat | no-match |
+| test.rs:124:28:124:28 | PathExpr | test.rs:124:32:124:33 | LiteralExpr |  |
+| test.rs:124:32:124:33 | LiteralExpr | test.rs:124:28:124:33 | BinaryExpr |  |
+| test.rs:125:9:125:23 | TupleStructPat | test.rs:123:5:127:5 | MatchExpr | no-match |
+| test.rs:125:9:125:23 | TupleStructPat | test.rs:125:28:125:28 | PathExpr | match |
+| test.rs:125:9:125:23 | TupleStructPat | test.rs:126:9:126:20 | PathPat | no-match |
+| test.rs:125:28:125:28 | PathExpr | test.rs:123:5:127:5 | MatchExpr |  |
+| test.rs:126:9:126:20 | PathPat | test.rs:123:5:127:5 | MatchExpr | no-match |
+| test.rs:126:9:126:20 | PathPat | test.rs:126:25:126:25 | LiteralExpr | match |
+| test.rs:126:25:126:25 | LiteralExpr | test.rs:123:5:127:5 | MatchExpr |  |
+| test.rs:131:5:136:5 | enter test_infinite_loop | test.rs:132:9:134:9 | ExprStmt |  |
+| test.rs:132:9:134:9 | ExprStmt | test.rs:133:13:133:13 | LiteralExpr |  |
+| test.rs:132:14:134:9 | BlockExpr | test.rs:133:13:133:13 | LiteralExpr |  |
+| test.rs:133:13:133:13 | LiteralExpr | test.rs:132:14:134:9 | BlockExpr |  |
+| test.rs:138:5:143:5 | enter test_let_match | test.rs:139:9:141:10 | LetStmt |  |
+| test.rs:138:5:143:5 | exit test_let_match (normal) | test.rs:138:5:143:5 | exit test_let_match |  |
+| test.rs:138:39:143:5 | BlockExpr | test.rs:138:5:143:5 | exit test_let_match (normal) |  |
+| test.rs:139:9:141:10 | LetStmt | test.rs:139:23:139:23 | PathExpr |  |
+| test.rs:139:13:139:19 | TupleStructPat | test.rs:140:13:140:27 | LiteralExpr | no-match |
+| test.rs:139:13:139:19 | TupleStructPat | test.rs:142:9:142:9 | PathExpr | match |
+| test.rs:139:23:139:23 | PathExpr | test.rs:139:13:139:19 | TupleStructPat |  |
+| test.rs:140:13:140:27 | LiteralExpr | test.rs:139:30:141:9 | BlockExpr |  |
+| test.rs:142:9:142:9 | PathExpr | test.rs:138:39:143:5 | BlockExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.ql
+++ b/rust/ql/test/library-tests/controlflow/Cfg.ql
@@ -8,8 +8,6 @@ import TestUtils
 
 class MyRelevantNode extends CfgNode {
   MyRelevantNode() { toBeTested(this.getScope()) }
-
-  string getOrderDisambiguation() { result = "" }
 }
 
 import codeql.rust.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.expected
@@ -1,7006 +1,2306 @@
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----|  ... = ...
-#-----|  -> exit set (normal)
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| &...
-#-----|  -> yield ...
-
-#-----| .b
-#-----|  -> return ...
-
-#-----| .b
-#-----|  -> value
-
-#-----| .bs
-#-----|  -> return ...
-
-#-----| .bs
-#-----|  -> value
-
-#-----| .c
-#-----|  -> return ...
-
-#-----| .field
-#-----|  -> return ...
-
-#-----| .field
-#-----|  -> value
-
-#-----| .mayB
-#-----|  -> return ...
-
-#-----| .mayB
-#-----|  -> value
-
-#-----| .myInt
-#-----|  -> return ...
-
-#-----| .x
-#-----|  -> return ...
-
-#-----| .x
-#-----|  -> value
-
-#-----| .x
-#-----|  -> return ...
-
-#-----| .x
-#-----|  -> value
-
-#-----| .x
-#-----|  -> return ...
-
-#-----| .x
-#-----|  -> value
-
-#-----| KeyPathComponent
-#-----|  -> #keyPath(...)
-
-#-----| await ...
-#-----|  -> for ... in ... { ... }
-
-#-----| getter for .b
-#-----|  -> &...
-
-#-----| getter for .bs
-#-----|  -> &...
-
-#-----| getter for .field
-#-----|  -> &...
-
-#-----| getter for .mayB
-#-----|  -> &...
-
-#-----| getter for .x
-#-----|  -> &...
-
-#-----| getter for .x
-#-----|  -> &...
-
-#-----| getter for .x
-#-----|  -> &...
-
-#-----| n
-#-----|  -> _unimplementedInitializer(className:initName:file:line:column:)
-
-#-----| return
-#-----| return -> exit Derived.init(n:) (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| return ...
-#-----| return -> exit get (normal)
-
-#-----| self
-#-----|  -> .myInt
-
-#-----| self
-#-----|  -> .c
-
-#-----| self
-#-----|  -> .field
-
-#-----| self
-#-----|  -> .field
-
-#-----| self
-#-----|  -> getter for .field
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> getter for .x
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> getter for .x
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> .x
-
-#-----| self
-#-----|  -> getter for .x
-
-#-----| self
-#-----|  -> .mayB
-
-#-----| self
-#-----|  -> .mayB
-
-#-----| self
-#-----|  -> getter for .mayB
-
-#-----| self
-#-----|  -> .bs
-
-#-----| self
-#-----|  -> .bs
-
-#-----| self
-#-----|  -> getter for .bs
-
-#-----| self
-#-----|  -> .b
-
-#-----| self
-#-----|  -> .b
-
-#-----| self
-#-----|  -> getter for .b
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| value
-#-----|  ->  ... = ...
-
-#-----| var ... = ...
-#-----|  -> .next()
-
-#-----| var ... = ...
-#-----|  -> .next()
-
-#-----| var ... = ...
-#-----|  -> .next()
-
-cfg.swift:
-#    5| enter returnZero()
-#-----|  -> returnZero()
-
-#    5| exit returnZero()
-
-#    5| exit returnZero() (normal)
-#-----|  -> exit returnZero()
-
-#    5| returnZero()
-#-----|  -> 0
-
-#    5| return ...
-#-----| return -> exit returnZero() (normal)
-
-#    5| 0
-#-----|  -> return ...
-
-#   15| enter isZero(x:)
-#-----|  -> isZero(x:)
-
-#   15| exit isZero(x:)
-
-#   15| exit isZero(x:) (normal)
-#-----|  -> exit isZero(x:)
-
-#   15| isZero(x:)
-#-----|  -> x
-
-#   15| x
-#-----|  -> .==(_:_:)
-
-#   15| return ...
-#-----| return -> exit isZero(x:) (normal)
-
-#   15| x
-#-----|  -> 0
-
-#   15| ... .==(_:_:) ...
-#-----|  -> return ...
-
-#   15| .==(_:_:)
-#-----|  -> Int.Type
-
-#   15| Int.Type
-#-----|  -> x
-
-#   15| 0
-#-----|  -> ... .==(_:_:) ...
-
-#   17| enter mightThrow(x:)
-#-----|  -> mightThrow(x:)
-
-#   17| exit mightThrow(x:)
-
-#   17| exit mightThrow(x:) (abnormal)
-#-----|  -> exit mightThrow(x:)
-
-#   17| exit mightThrow(x:) (normal)
-#-----|  -> exit mightThrow(x:)
-
-#   17| mightThrow(x:)
-#-----|  -> x
-
-#   17| x
-#-----|  -> guard ... else { ... }
-
-#   18| guard ... else { ... }
-#-----|  -> StmtCondition
-
-#   18| x
-#-----|  -> 0
-
-#   18| ... .>=(_:_:) ...
-#-----| false -> .error1
-#-----| true -> guard ... else { ... }
-
-#   18| StmtCondition
-#-----|  -> .>=(_:_:)
-
-#   18| .>=(_:_:)
-#-----|  -> Int.Type
-
-#   18| Int.Type
-#-----|  -> x
-
-#   18| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#   19| throw ...
-#-----| exception -> exit mightThrow(x:) (abnormal)
-
-#   19| MyError.Type
-#-----|  -> (any Error) ...
-
-#   19| (any Error) ...
-#-----|  -> throw ...
-
-#   19| .error1
-#-----|  -> MyError.Type
-
-#   21| guard ... else { ... }
-#-----|  -> StmtCondition
-
-#   21| x
-#-----|  -> 0
-
-#   21| ... .<=(_:_:) ...
-#-----| true -> exit mightThrow(x:) (normal)
-#-----| false -> .error3
-
-#   21| StmtCondition
-#-----|  -> .<=(_:_:)
-
-#   21| .<=(_:_:)
-#-----|  -> Int.Type
-
-#   21| Int.Type
-#-----|  -> x
-
-#   21| 0
-#-----|  -> ... .<=(_:_:) ...
-
-#   22| throw ...
-#-----| exception -> exit mightThrow(x:) (abnormal)
-
-#   22| MyError.Type
-#-----|  -> .+(_:_:)
-
-#   22| .error3
-#-----|  -> MyError.Type
-
-#   22| (any Error) ...
-#-----|  -> throw ...
-
-#   22| call to ...
-#-----|  -> (any Error) ...
-
-#   22| x
-#-----|  -> 1
-
-#   22| ... .+(_:_:) ...
-#-----|  -> call to ...
-
-#   22| .+(_:_:)
-#-----|  -> Int.Type
-
-#   22| Int.Type
-#-----|  -> x
-
-#   22| 1
-#-----|  -> ... .+(_:_:) ...
-
-#   26| enter tryCatch(x:)
-#-----|  -> tryCatch(x:)
-
-#   26| exit tryCatch(x:)
-
-#   26| exit tryCatch(x:) (normal)
-#-----|  -> exit tryCatch(x:)
-
-#   26| tryCatch(x:)
-#-----|  -> x
-
-#   26| x
-#-----|  -> do { ... } catch { ... }
-
-#   27| do { ... } catch { ... }
-#-----|  -> mightThrow(x:)
-
-#   28| try ...
-#-----|  -> print(_:separator:terminator:)
-
-#   28| mightThrow(x:)
-#-----|  -> 0
-
-#   28| call to mightThrow(x:)
-#-----|  -> try ...
-#-----| exception -> case ...
-
-#   28| 0
-#-----|  -> call to mightThrow(x:)
-
-#   29| print(_:separator:terminator:)
-#-----|  -> Did not throw.
-
-#   29| call to print(_:separator:terminator:)
-#-----|  -> mightThrow(x:)
-
-#   29| default separator
-#-----|  -> default terminator
-
-#   29| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#   29| (Any) ...
-#-----|  -> [...]
-
-#   29| Did not throw.
-#-----|  -> (Any) ...
-
-#   29| [...]
-#-----|  -> [...]
-
-#   29| [...]
-#-----|  -> default separator
-
-#   30| try! ...
-#-----|  -> print(_:separator:terminator:)
-
-#   30| mightThrow(x:)
-#-----|  -> 0
-
-#   30| call to mightThrow(x:)
-#-----|  -> try! ...
-#-----| exception -> case ...
-
-#   30| 0
-#-----|  -> call to mightThrow(x:)
-
-#   31| print(_:separator:terminator:)
-#-----|  -> Still did not throw.
-
-#   31| call to print(_:separator:terminator:)
-#-----|  -> 0
-
-#   31| default separator
-#-----|  -> default terminator
-
-#   31| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#   31| (Any) ...
-#-----|  -> [...]
-
-#   31| Still did not throw.
-#-----|  -> (Any) ...
-
-#   31| [...]
-#-----|  -> [...]
-
-#   31| [...]
-#-----|  -> default separator
-
-#   33| case ...
-#-----|  -> ... is ...
-
-#   33| ... is ...
-#-----|  -> .error1
-
-#   33| ... is ...
-#-----| no-match -> ... is ... where ...
-#-----| match -> 0
-
-#   33| .error1
-#-----| match, no-match -> ... is ...
-
-#   33| ... is ...
-#-----| match, no-match -> call to isZero(x:)
-#-----| no-match -> case ...
-
-#   33| .error2
-#-----| match, no-match -> ... is ...
-
-#   33| ... is ... where ...
-#-----|  -> .error2
-
-#   33| call to isZero(x:)
-
-#   34| return ...
-#-----| return -> exit tryCatch(x:) (normal)
-
-#   34| 0
-#-----|  -> return ...
-
-#   35| case ...
-#-----|  -> ... is ...
-
-#   35| ... is ...
-#-----|  -> .error3(...)
-
-#   35| ... is ...
-#-----| match -> withParam
-#-----| no-match -> case ...
-
-#   35| .error3(...)
-#-----| no-match -> ... is ...
-#-----| match -> (...)
-
-#   35| (...)
-#-----|  -> withParam
-
-#   35| let ...
-#-----| match -> ... is ...
-
-#   35| withParam
-#-----| match -> let ...
-
-#   36| return ...
-#-----| return -> exit tryCatch(x:) (normal)
-
-#   36| withParam
-#-----|  -> return ...
-
-#   37| case ...
-#-----|  -> ... is ...
-
-#   37| ... is ...
-#-----|  -> ... is ...
-
-#   37| ... is ...
-#-----| match -> print(_:separator:terminator:)
-#-----| no-match -> case ...
-
-#   38| print(_:separator:terminator:)
-#-----|  -> MyError
-
-#   38| call to print(_:separator:terminator:)
-#-----|  -> 0
-
-#   38| default separator
-#-----|  -> default terminator
-
-#   38| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#   38| (Any) ...
-#-----|  -> [...]
-
-#   38| MyError
-#-----|  -> (Any) ...
-
-#   38| [...]
-#-----|  -> [...]
-
-#   38| [...]
-#-----|  -> default separator
-
-#   39| case ...
-#-----|  -> error
-
-#   39| error
-#-----|  -> error
-
-#   39| error
-#-----| match -> let ...
-
-#   39| let ...
-#-----| match -> print(_:separator:terminator:)
-
-#   40| print(_:separator:terminator:)
-#-----|  -> OpaqueValueExpr
-
-#   40| call to print(_:separator:terminator:)
-#-----|  -> 0
-
-#   40| default separator
-#-----|  -> default terminator
-
-#   40| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#   40| "..."
-#-----|  -> (Any) ...
-
-#   40| (Any) ...
-#-----|  -> [...]
-
-#   40| OpaqueValueExpr
-#-----|  -> .appendLiteral(_:)
-
-#   40| TapExpr
-#-----|  -> "..."
-
-#   40| Unknown error 
-#-----|  -> call to appendLiteral(_:)
-
-#   40| [...]
-#-----|  -> [...]
-
-#   40| [...]
-#-----|  -> default separator
-
-#   40| call to appendLiteral(_:)
-#-----|  -> .appendInterpolation(_:)
-
-#   40| $interpolation
-#-----|  -> &...
-
-#   40| &...
-#-----|  -> Unknown error 
-
-#   40| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#   40| $interpolation
-#-----|  -> &...
-
-#   40| &...
-#-----|  -> error
-
-#   40| .appendInterpolation(_:)
-#-----|  -> $interpolation
-
-#   40| call to appendInterpolation(_:)
-#-----|  -> .appendLiteral(_:)
-
-#   40| error
-#-----|  -> call to appendInterpolation(_:)
-
-#   40| 
-#-----|  -> call to appendLiteral(_:)
-
-#   40| $interpolation
-#-----|  -> &...
-
-#   40| &...
-#-----|  -> 
-
-#   40| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#   40| call to appendLiteral(_:)
-#-----|  -> TapExpr
-
-#   42| return ...
-#-----| return -> exit tryCatch(x:) (normal)
-
-#   42| 0
-#-----|  -> return ...
-
-#   45| createClosure1(s:)
-#-----|  -> s
-
-#   45| enter createClosure1(s:)
-#-----|  -> createClosure1(s:)
-
-#   45| exit createClosure1(s:)
-
-#   45| exit createClosure1(s:) (normal)
-#-----|  -> exit createClosure1(s:)
-
-#   45| s
-#-----|  -> { ... }
-
-#   46| return ...
-#-----| return -> exit createClosure1(s:) (normal)
-
-#   46| enter { ... }
-#-----|  -> { ... }
-
-#   46| exit { ... }
-
-#   46| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#   46| { ... }
-#-----|  -> .+(_:_:)
-
-#   46| { ... }
-#-----|  -> return ...
-
-#   47| return ...
-#-----| return -> exit { ... } (normal)
-
-#   47| s
-#-----|  -> 
-
-#   47| ... .+(_:_:) ...
-#-----|  -> return ...
-
-#   47| .+(_:_:)
-#-----|  -> String.Type
-
-#   47| String.Type
-#-----|  -> s
-
-#   47| 
-#-----|  -> ... .+(_:_:) ...
-
-#   51| createClosure2(x:)
-#-----|  -> x
-
-#   51| enter createClosure2(x:)
-#-----|  -> createClosure2(x:)
-
-#   51| exit createClosure2(x:)
-
-#   51| exit createClosure2(x:) (normal)
-#-----|  -> exit createClosure2(x:)
-
-#   51| x
-#-----|  -> f(y:)
-
-#   52| enter f(y:)
-#-----|  -> f(y:)
-
-#   52| exit f(y:)
-
-#   52| exit f(y:) (normal)
-#-----|  -> exit f(y:)
-
-#   52| f(y:)
-#-----|  -> y
-
-#   52| f(y:)
-#-----|  -> f(y:)
-
-#   52| y
-#-----|  -> .+(_:_:)
-
-#   53| return ...
-#-----| return -> exit f(y:) (normal)
-
-#   53| x
-#-----|  -> y
-
-#   53| ... .+(_:_:) ...
-#-----|  -> return ...
-
-#   53| .+(_:_:)
-#-----|  -> Int.Type
-
-#   53| Int.Type
-#-----|  -> x
-
-#   53| y
-#-----|  -> ... .+(_:_:) ...
-
-#   55| return ...
-#-----| return -> exit createClosure2(x:) (normal)
-
-#   55| f(y:)
-#-----|  -> return ...
-
-#   58| createClosure3(x:)
-#-----|  -> x
-
-#   58| enter createClosure3(x:)
-#-----|  -> createClosure3(x:)
-
-#   58| exit createClosure3(x:)
-
-#   58| exit createClosure3(x:) (normal)
-#-----|  -> exit createClosure3(x:)
-
-#   58| x
-#-----|  -> { ... }
-
-#   59| return ...
-#-----| return -> exit createClosure3(x:) (normal)
-
-#   59| enter { ... }
-#-----|  -> { ... }
-
-#   59| exit { ... }
-
-#   59| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#   59| { ... }
-#-----|  -> y
-
-#   59| { ... }
-#-----|  -> return ...
-
-#   60| y
-#-----|  -> .+(_:_:)
-
-#   60| x
-#-----|  -> y
-
-#   60| ... .+(_:_:) ...
-#-----|  -> return ...
-
-#   60| return ...
-#-----| return -> exit { ... } (normal)
-
-#   60| .+(_:_:)
-#-----|  -> Int.Type
-
-#   60| Int.Type
-#-----|  -> x
-
-#   60| y
-#-----|  -> ... .+(_:_:) ...
-
-#   64| callClosures()
-#-----|  -> x1
-
-#   64| enter callClosures()
-#-----|  -> callClosures()
-
-#   64| exit callClosures()
-
-#   64| exit callClosures() (normal)
-#-----|  -> exit callClosures()
-
-#   65| var ... = ...
-#-----|  -> x2
-
-#   65| x1
-#-----| match -> createClosure1(s:)
-
-#   65| createClosure1(s:)
-#-----|  -> 
-
-#   65| call to createClosure1(s:)
-#-----|  -> call to ...
-
-#   65| call to ...
-#-----|  -> var ... = ...
-
-#   65| 
-#-----|  -> call to createClosure1(s:)
-
-#   66| var ... = ...
-#-----|  -> x3
-
-#   66| x2
-#-----| match -> createClosure2(x:)
-
-#   66| createClosure2(x:)
-#-----|  -> 0
-
-#   66| call to createClosure2(x:)
-#-----|  -> 10
-
-#   66| call to ...
-#-----|  -> var ... = ...
-
-#   66| 0
-#-----|  -> call to createClosure2(x:)
-
-#   66| 10
-#-----|  -> call to ...
-
-#   67| var ... = ...
-#-----|  -> exit callClosures() (normal)
-
-#   67| x3
-#-----| match -> createClosure3(x:)
-
-#   67| createClosure3(x:)
-#-----|  -> 0
-
-#   67| call to createClosure3(x:)
-#-----|  -> 10
-
-#   67| call to ...
-#-----|  -> var ... = ...
-
-#   67| 0
-#-----|  -> call to createClosure3(x:)
-
-#   67| 10
-#-----|  -> call to ...
-
-#   70| enter maybeParseInt(s:)
-#-----|  -> maybeParseInt(s:)
-
-#   70| exit maybeParseInt(s:)
-
-#   70| exit maybeParseInt(s:) (normal)
-#-----|  -> exit maybeParseInt(s:)
-
-#   70| maybeParseInt(s:)
-#-----|  -> s
-
-#   70| s
-#-----|  -> n
-
-#   71| var ... = ...
-#-----|  -> n
-
-#   71| n
-#-----| match -> ... as ...
-
-#   71| ... as ...
-#-----| match -> Self.init(_:)
-
-#   71| Int.Type
-#-----|  -> s
-
-#   71| Self.init(_:)
-#-----|  -> Int.Type
-
-#   71| call to Self.init(_:)
-#-----|  -> var ... = ...
-
-#   71| s
-#-----|  -> call to Self.init(_:)
-
-#   72| return ...
-#-----| return -> exit maybeParseInt(s:) (normal)
-
-#   72| (Int?) ...
-#-----|  -> return ...
-
-#   72| n
-#-----|  -> (Int?) ...
-
-#   75| enter forceAndBackToOptional()
-#-----|  -> forceAndBackToOptional()
-
-#   75| exit forceAndBackToOptional()
-
-#   75| exit forceAndBackToOptional() (normal)
-#-----|  -> exit forceAndBackToOptional()
-
-#   75| forceAndBackToOptional()
-#-----|  -> nBang
-
-#   76| var ... = ...
-#-----|  -> n
-
-#   76| nBang
-#-----| match -> maybeParseInt(s:)
-
-#   76| maybeParseInt(s:)
-#-----|  -> 42
-
-#   76| call to maybeParseInt(s:)
-#-----|  -> ...!
-
-#   76| ...!
-#-----|  -> var ... = ...
-
-#   76| 42
-#-----|  -> call to maybeParseInt(s:)
-
-#   77| var ... = ...
-#-----|  -> .+(_:_:)
-
-#   77| n
-#-----| match -> maybeParseInt(s:)
-
-#   77| maybeParseInt(s:)
-#-----|  -> 42
-
-#   77| call to maybeParseInt(s:)
-#-----|  -> var ... = ...
-
-#   77| 42
-#-----|  -> call to maybeParseInt(s:)
-
-#   78| return ...
-#-----| return -> exit forceAndBackToOptional() (normal)
-
-#   78| (Int) ...
-#-----|  -> n
-
-#   78| nBang
-#-----|  -> (Int) ...
-
-#   78| (Int?) ...
-#-----|  -> return ...
-
-#   78| ... .+(_:_:) ...
-#-----|  -> (Int?) ...
-
-#   78| .+(_:_:)
-#-----|  -> Int.Type
-
-#   78| Int.Type
-#-----|  -> nBang
-
-#   78| (Int?) ...
-#-----|  -> ...!
-
-#   78| n
-#-----|  -> (Int?) ...
-
-#   78| ...!
-#-----|  -> ... .+(_:_:) ...
-
-#   81| enter testInOut()
-#-----|  -> testInOut()
-
-#   81| exit testInOut()
-
-#   81| exit testInOut() (normal)
-#-----|  -> exit testInOut()
-
-#   81| testInOut()
-#-----|  -> temp
-
-#   82| var ... = ...
-#-----|  -> add(a:)
-
-#   82| temp
-#-----| match -> 10
-
-#   82| 10
-#-----|  -> var ... = ...
-
-#   84| add(a:)
-#-----|  -> a
-
-#   84| add(a:)
-#-----|  -> addOptional(a:)
-
-#   84| enter add(a:)
-#-----|  -> add(a:)
-
-#   84| exit add(a:)
-
-#   84| exit add(a:) (normal)
-#-----|  -> exit add(a:)
-
-#   84| a
-#-----|  -> a
-
-#   85| a
-#-----|  -> .+(_:_:)
-
-#   85|  ... = ...
-#-----|  -> exit add(a:) (normal)
-
-#   85| (Int) ...
-#-----|  -> 1
-
-#   85| a
-#-----|  -> (Int) ...
-
-#   85| ... .+(_:_:) ...
-#-----|  ->  ... = ...
-
-#   85| .+(_:_:)
-#-----|  -> Int.Type
-
-#   85| Int.Type
-#-----|  -> a
-
-#   85| 1
-#-----|  -> ... .+(_:_:) ...
-
-#   88| addOptional(a:)
-#-----|  -> a
-
-#   88| addOptional(a:)
-#-----|  -> add(a:)
-
-#   88| enter addOptional(a:)
-#-----|  -> addOptional(a:)
-
-#   88| exit addOptional(a:)
-
-#   88| exit addOptional(a:) (normal)
-#-----|  -> exit addOptional(a:)
-
-#   88| a
-#-----|  -> a
-
-#   89| a
-#-----|  -> nil
-
-#   89|  ... = ...
-#-----|  -> exit addOptional(a:) (normal)
-
-#   89| nil
-#-----|  ->  ... = ...
-
-#   92| add(a:)
-#-----|  -> temp
-
-#   92| call to add(a:)
-#-----|  -> tempOptional
-
-#   92| &...
-#-----|  -> call to add(a:)
-
-#   92| temp
-#-----|  -> &...
-
-#   93| var ... = ...
-#-----|  -> addOptional(a:)
-
-#   93| tempOptional
-#-----| match -> ... as ...
-
-#   93| ... as ...
-#-----| match -> 10
-
-#   93| (Int?) ...
-#-----|  -> var ... = ...
-
-#   93| 10
-#-----|  -> (Int?) ...
-
-#   94| addOptional(a:)
-#-----|  -> tempOptional
-
-#   94| call to addOptional(a:)
-#-----|  -> .+(_:_:)
-
-#   94| &...
-#-----|  -> call to addOptional(a:)
-
-#   94| tempOptional
-#-----|  -> &...
-
-#   95| return ...
-#-----| return -> exit testInOut() (normal)
-
-#   95| (Int) ...
-#-----|  -> tempOptional
-
-#   95| temp
-#-----|  -> (Int) ...
-
-#   95| ... .+(_:_:) ...
-#-----|  -> return ...
-
-#   95| .+(_:_:)
-#-----|  -> Int.Type
-
-#   95| Int.Type
-#-----|  -> temp
-
-#   95| (Int?) ...
-#-----|  -> ...!
-
-#   95| tempOptional
-#-----|  -> (Int?) ...
-
-#   95| ...!
-#-----|  -> ... .+(_:_:) ...
-
-#   98| C.deinit()
-#-----|  -> self
-
-#   98| enter C.deinit()
-#-----|  -> C.deinit()
-
-#   98| exit C.deinit()
-
-#   98| exit C.deinit() (normal)
-#-----|  -> exit C.deinit()
-
-#   98| self
-#-----|  -> { ... }
-
-#   98| { ... }
-#-----|  -> exit C.deinit() (normal)
-
-#   99| enter get
-#-----|  -> get
-
-#   99| exit get
-
-#   99| exit get (normal)
-#-----|  -> exit get
-
-#   99| get
-#-----|  -> self
-
-#   99| self
-#-----|  -> self
-
-#  100| self
-#-----|  -> n
-
-#  100| C.init(n:)
-#-----|  -> self
-
-#  100| enter C.init(n:)
-#-----|  -> C.init(n:)
-
-#  100| exit C.init(n:)
-
-#  100| exit C.init(n:) (normal)
-#-----|  -> exit C.init(n:)
-
-#  100| n
-#-----|  -> self
-
-#  101| .myInt
-#-----|  -> n
-
-#  101| self
-#-----|  -> .myInt
-
-#  101|  ... = ...
-#-----|  -> return
-
-#  101| n
-#-----|  ->  ... = ...
-
-#  102| return
-#-----| return -> exit C.init(n:) (normal)
-
-#  104| enter getMyInt()
-#-----|  -> getMyInt()
-
-#  104| exit getMyInt()
-
-#  104| exit getMyInt() (normal)
-#-----|  -> exit getMyInt()
-
-#  104| getMyInt()
-#-----|  -> self
-
-#  104| self
-#-----|  -> self
-
-#  105| return ...
-#-----| return -> exit getMyInt() (normal)
-
-#  105| getter for .myInt
-#-----|  -> return ...
-
-#  105| self
-#-----|  -> getter for .myInt
-
-#  109| enter testMemberRef(param:inoutParam:opt:)
-#-----|  -> testMemberRef(param:inoutParam:opt:)
-
-#  109| exit testMemberRef(param:inoutParam:opt:)
-
-#  109| exit testMemberRef(param:inoutParam:opt:) (normal)
-#-----|  -> exit testMemberRef(param:inoutParam:opt:)
-
-#  109| testMemberRef(param:inoutParam:opt:)
-#-----|  -> param
-
-#  109| param
-#-----|  -> inoutParam
-
-#  109| inoutParam
-#-----|  -> opt
-
-#  109| opt
-#-----|  -> c
-
-#  110| var ... = ...
-#-----|  -> n1
-
-#  110| c
-#-----| match -> C.init(n:)
-
-#  110| C.Type
-#-----|  -> 42
-
-#  110| C.init(n:)
-#-----|  -> C.Type
-
-#  110| call to C.init(n:)
-#-----|  -> var ... = ...
-
-#  110| 42
-#-----|  -> call to C.init(n:)
-
-#  111| var ... = ...
-#-----|  -> n2
-
-#  111| n1
-#-----| match -> c
-
-#  111| c
-#-----|  -> getter for .myInt
-
-#  111| getter for .myInt
-#-----|  -> var ... = ...
-
-#  112| var ... = ...
-#-----|  -> n3
-
-#  112| n2
-#-----| match -> c
-
-#  112| c
-#-----|  -> .self
-
-#  112| .self
-#-----|  -> getter for .myInt
-
-#  112| getter for .myInt
-#-----|  -> var ... = ...
-
-#  113| var ... = ...
-#-----|  -> n4
-
-#  113| n3
-#-----| match -> .getMyInt()
-
-#  113| c
-#-----|  -> call to getMyInt()
-
-#  113| .getMyInt()
-#-----|  -> c
-
-#  113| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  114| var ... = ...
-#-----|  -> n5
-
-#  114| n4
-#-----| match -> .getMyInt()
-
-#  114| c
-#-----|  -> .self
-
-#  114| .self
-#-----|  -> call to getMyInt()
-
-#  114| .getMyInt()
-#-----|  -> c
-
-#  114| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  116| var ... = ...
-#-----|  -> n6
-
-#  116| n5
-#-----| match -> param
-
-#  116| param
-#-----|  -> getter for .myInt
-
-#  116| getter for .myInt
-#-----|  -> var ... = ...
-
-#  117| var ... = ...
-#-----|  -> n7
-
-#  117| n6
-#-----| match -> param
-
-#  117| param
-#-----|  -> .self
-
-#  117| .self
-#-----|  -> getter for .myInt
-
-#  117| getter for .myInt
-#-----|  -> var ... = ...
-
-#  118| var ... = ...
-#-----|  -> n8
-
-#  118| n7
-#-----| match -> .getMyInt()
-
-#  118| param
-#-----|  -> call to getMyInt()
-
-#  118| .getMyInt()
-#-----|  -> param
-
-#  118| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  119| var ... = ...
-#-----|  -> n9
-
-#  119| n8
-#-----| match -> .getMyInt()
-
-#  119| param
-#-----|  -> .self
-
-#  119| .self
-#-----|  -> call to getMyInt()
-
-#  119| .getMyInt()
-#-----|  -> param
-
-#  119| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  121| var ... = ...
-#-----|  -> n10
-
-#  121| n9
-#-----| match -> inoutParam
-
-#  121| (C) ...
-#-----|  -> getter for .myInt
-
-#  121| inoutParam
-#-----|  -> (C) ...
-
-#  121| getter for .myInt
-#-----|  -> var ... = ...
-
-#  122| var ... = ...
-#-----|  -> n11
-
-#  122| n10
-#-----| match -> inoutParam
-
-#  122| inoutParam
-#-----|  -> .self
-
-#  122| (C) ...
-#-----|  -> getter for .myInt
-
-#  122| .self
-#-----|  -> (C) ...
-
-#  122| getter for .myInt
-#-----|  -> var ... = ...
-
-#  123| var ... = ...
-#-----|  -> n12
-
-#  123| n11
-#-----| match -> .getMyInt()
-
-#  123| (C) ...
-#-----|  -> call to getMyInt()
-
-#  123| inoutParam
-#-----|  -> (C) ...
-
-#  123| .getMyInt()
-#-----|  -> inoutParam
-
-#  123| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  124| var ... = ...
-#-----|  -> n13
-
-#  124| n12
-#-----| match -> .getMyInt()
-
-#  124| inoutParam
-#-----|  -> .self
-
-#  124| (C) ...
-#-----|  -> call to getMyInt()
-
-#  124| .self
-#-----|  -> (C) ...
-
-#  124| .getMyInt()
-#-----|  -> inoutParam
-
-#  124| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  126| var ... = ...
-#-----|  -> n14
-
-#  126| n13
-#-----| match -> opt
-
-#  126| opt
-#-----|  -> ...!
-
-#  126| ...!
-#-----|  -> getter for .myInt
-
-#  126| getter for .myInt
-#-----|  -> var ... = ...
-
-#  127| var ... = ...
-#-----|  -> n15
-
-#  127| n14
-#-----| match -> opt
-
-#  127| opt
-#-----|  -> ...!
-
-#  127| ...!
-#-----|  -> .self
-
-#  127| .self
-#-----|  -> getter for .myInt
-
-#  127| getter for .myInt
-#-----|  -> var ... = ...
-
-#  128| var ... = ...
-#-----|  -> n16
-
-#  128| n15
-#-----| match -> .getMyInt()
-
-#  128| opt
-#-----|  -> ...!
-
-#  128| ...!
-#-----|  -> call to getMyInt()
-
-#  128| .getMyInt()
-#-----|  -> opt
-
-#  128| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  129| var ... = ...
-#-----|  -> n17
-
-#  129| n16
-#-----| match -> .getMyInt()
-
-#  129| opt
-#-----|  -> ...!
-
-#  129| ...!
-#-----|  -> .self
-
-#  129| .self
-#-----|  -> call to getMyInt()
-
-#  129| .getMyInt()
-#-----|  -> opt
-
-#  129| call to getMyInt()
-#-----|  -> var ... = ...
-
-#  131| var ... = ...
-#-----|  -> n18
-
-#  131| n17
-#-----| match -> opt
-
-#  131| opt
-#-----|  -> ...?
-
-#  131| ...?
-#-----|  -> getter for .myInt
-
-#  131| (Int?) ...
-#-----|  -> OptionalEvaluationExpr
-
-#  131| OptionalEvaluationExpr
-#-----|  -> var ... = ...
-
-#  131| getter for .myInt
-#-----|  -> (Int?) ...
-
-#  132| var ... = ...
-#-----|  -> n19
-
-#  132| n18
-#-----| match -> opt
-
-#  132| opt
-#-----|  -> ...?
-
-#  132| ...?
-#-----|  -> .self
-
-#  132| .self
-#-----|  -> getter for .myInt
-
-#  132| (Int?) ...
-#-----|  -> OptionalEvaluationExpr
-
-#  132| OptionalEvaluationExpr
-#-----|  -> var ... = ...
-
-#  132| getter for .myInt
-#-----|  -> (Int?) ...
-
-#  133| var ... = ...
-#-----|  -> n20
-
-#  133| n19
-#-----| match -> .getMyInt()
-
-#  133| opt
-#-----|  -> ...?
-
-#  133| ...?
-#-----|  -> call to getMyInt()
-
-#  133| .getMyInt()
-#-----|  -> opt
-
-#  133| (Int?) ...
-#-----|  -> OptionalEvaluationExpr
-
-#  133| OptionalEvaluationExpr
-#-----|  -> var ... = ...
-
-#  133| call to getMyInt()
-#-----|  -> (Int?) ...
-
-#  134| var ... = ...
-#-----|  -> exit testMemberRef(param:inoutParam:opt:) (normal)
-
-#  134| n20
-#-----| match -> .getMyInt()
-
-#  134| opt
-#-----|  -> ...?
-
-#  134| ...?
-#-----|  -> .self
-
-#  134| .self
-#-----|  -> call to getMyInt()
-
-#  134| .getMyInt()
-#-----|  -> opt
-
-#  134| (Int?) ...
-#-----|  -> OptionalEvaluationExpr
-
-#  134| OptionalEvaluationExpr
-#-----|  -> var ... = ...
-
-#  134| call to getMyInt()
-#-----|  -> (Int?) ...
-
-#  137| enter patterns(x:)
-#-----|  -> patterns(x:)
-
-#  137| exit patterns(x:)
-
-#  137| exit patterns(x:) (normal)
-#-----|  -> exit patterns(x:)
-
-#  137| patterns(x:)
-#-----|  -> x
-
-#  137| x
-#-----|  -> $generator
-
-#  138| $generator
-#-----|  -> &...
-
-#  138| &...
-#-----|  -> call to next()
-
-#  138| .next()
-#-----|  -> $generator
-
-#  138| call to next()
-#-----|  -> for ... in ... { ... }
-
-#  138| for ... in ... { ... }
-#-----| non-empty -> _
-#-----| empty -> switch x { ... }
-
-#  138| _
-#-----| match -> { ... }
-
-#  138| $generator
-#-----| match -> .makeIterator()
-
-#  138| 0
-#-----|  -> 10
-
-#  138| ... ....(_:_:) ...
-#-----|  -> call to makeIterator()
-
-#  138| .makeIterator()
-#-----|  -> ....(_:_:)
-
-#  138| call to makeIterator()
-#-----|  -> var ... = ...
-
-#  138| ....(_:_:)
-#-----|  -> Int.Type
-
-#  138| Int.Type
-#-----|  -> 0
-
-#  138| 10
-#-----|  -> ... ....(_:_:) ...
-
-#  138| { ... }
-#-----|  -> .next()
-
-#  140| switch x { ... }
-#-----|  -> x
-
-#  140| x
-#-----|  -> case ...
-
-#  141| case ...
-#-----|  -> =~ ...
-
-#  141| $match
-#-----|  -> ... ~=(_:_:) ...
-
-#  141| ... ~=(_:_:) ...
-#-----|  -> =~ ...
-
-#  141| 0
-#-----|  -> $match
-
-#  141| =~ ...
-#-----|  -> ~=(_:_:)
-
-#  141| =~ ...
-#-----| no-match -> =~ ...
-#-----| match -> true
-
-#  141| ~=(_:_:)
-#-----|  -> 0
-
-#  141| $match
-#-----|  -> ... ~=(_:_:) ...
-
-#  141| ... ~=(_:_:) ...
-#-----|  -> =~ ...
-
-#  141| 1
-#-----|  -> $match
-
-#  141| =~ ...
-#-----|  -> ~=(_:_:)
-
-#  141| =~ ...
-#-----| match -> true
-#-----| no-match -> case ...
-
-#  141| ~=(_:_:)
-#-----|  -> 1
-
-#  142| return ...
-#-----| return -> exit patterns(x:) (normal)
-
-#  142| true
-#-----|  -> return ...
-
-#  144| case ...
-#-----|  -> =~ ... where ...
-
-#  144| $match
-#-----|  -> ... ~=(_:_:) ...
-
-#  144| ... ~=(_:_:) ...
-#-----|  -> =~ ...
-
-#  144| =~ ...
-#-----| match, no-match -> ... .&&(_:_:) ...
-#-----| no-match -> case ...
-
-#  144| x
-#-----|  -> $match
-
-#  144| ~=(_:_:)
-#-----|  -> x
-
-#  144| =~ ... where ...
-#-----|  -> ~=(_:_:)
-
-#  144| ... .&&(_:_:) ...
-
-#  146| _
-#-----| match -> false
-
-#  146| _
-#-----|  -> _
-
-#  146| case ...
-#-----|  -> _
-
-#  147| return ...
-#-----| return -> exit patterns(x:) (normal)
-
-#  147| false
-#-----|  -> return ...
-
-#  163| enter testDefer(x:)
-#-----|  -> testDefer(x:)
-
-#  163| exit testDefer(x:)
-
-#  163| exit testDefer(x:) (normal)
-#-----|  -> exit testDefer(x:)
-
-#  163| testDefer(x:)
-#-----|  -> x
-
-#  163| x
-#-----|  -> defer { ... }
-
-#  165| defer { ... }
-#-----|  -> defer { ... }
-
-#  166| print(_:separator:terminator:)
-#-----|  -> 4
-
-#  166| call to print(_:separator:terminator:)
-#-----|  -> exit testDefer(x:) (normal)
-
-#  166| default separator
-#-----|  -> default terminator
-
-#  166| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  166| (Any) ...
-#-----|  -> [...]
-
-#  166| 4
-#-----|  -> (Any) ...
-
-#  166| [...]
-#-----|  -> [...]
-
-#  166| [...]
-#-----|  -> default separator
-
-#  169| defer { ... }
-#-----|  -> defer { ... }
-
-#  170| print(_:separator:terminator:)
-#-----|  -> 3
-
-#  170| call to print(_:separator:terminator:)
-#-----|  -> print(_:separator:terminator:)
-
-#  170| default separator
-#-----|  -> default terminator
-
-#  170| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  170| (Any) ...
-#-----|  -> [...]
-
-#  170| 3
-#-----|  -> (Any) ...
-
-#  170| [...]
-#-----|  -> [...]
-
-#  170| [...]
-#-----|  -> default separator
-
-#  173| defer { ... }
-#-----|  -> print(_:separator:terminator:)
-
-#  174| print(_:separator:terminator:)
-#-----|  -> 1
-
-#  174| call to print(_:separator:terminator:)
-#-----|  -> defer { ... }
-
-#  174| default separator
-#-----|  -> default terminator
-
-#  174| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  174| (Any) ...
-#-----|  -> [...]
-
-#  174| 1
-#-----|  -> (Any) ...
-
-#  174| [...]
-#-----|  -> [...]
-
-#  174| [...]
-#-----|  -> default separator
-
-#  175| defer { ... }
-#-----|  -> print(_:separator:terminator:)
-
-#  176| print(_:separator:terminator:)
-#-----|  -> 2
-
-#  176| call to print(_:separator:terminator:)
-#-----|  -> print(_:separator:terminator:)
-
-#  176| default separator
-#-----|  -> default terminator
-
-#  176| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  176| (Any) ...
-#-----|  -> [...]
-
-#  176| 2
-#-----|  -> (Any) ...
-
-#  176| [...]
-#-----|  -> [...]
-
-#  176| [...]
-#-----|  -> default separator
-
-#  181| enter m1(x:)
-#-----|  -> m1(x:)
-
-#  181| exit m1(x:)
-
-#  181| exit m1(x:) (abnormal)
-#-----|  -> exit m1(x:)
-
-#  181| exit m1(x:) (normal)
-#-----|  -> exit m1(x:)
-
-#  181| m1(x:)
-#-----|  -> x
-
-#  181| x
-#-----|  -> if ... then { ... } else { ... }
-
-#  182| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  182| x
-#-----|  -> 2
-
-#  182| ... .>(_:_:) ...
-#-----| true -> print(_:separator:terminator:)
-#-----| false -> if ... then { ... } else { ... }
-
-#  182| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  182| .>(_:_:)
-#-----|  -> Int.Type
-
-#  182| Int.Type
-#-----|  -> x
-
-#  182| 2
-#-----|  -> ... .>(_:_:) ...
-
-#  183| print(_:separator:terminator:)
-#-----|  -> x is greater than 2
-
-#  183| call to print(_:separator:terminator:)
-#-----|  -> exit m1(x:) (normal)
-
-#  183| default separator
-#-----|  -> default terminator
-
-#  183| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  183| (Any) ...
-#-----|  -> [...]
-
-#  183| [...]
-#-----|  -> [...]
-
-#  183| [...]
-#-----|  -> default separator
-
-#  183| x is greater than 2
-#-----|  -> (Any) ...
-
-#  185| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  185| x
-#-----|  -> 2
-
-#  185| ... .<=(_:_:) ...
-#-----| false -> [false] ... .&&(_:_:) ...
-#-----| true -> { ... }
-
-#  185| ... .&&(_:_:) ...
-#-----| exception -> exit m1(x:) (abnormal)
-#-----| false -> [false] ... .&&(_:_:) ...
-#-----| true -> { ... }
-
-#  185| [false] ... .&&(_:_:) ...
-#-----| exception -> exit m1(x:) (abnormal)
-#-----| false -> [false] ... .&&(_:_:) ...
-
-#  185| ... .&&(_:_:) ...
-#-----| exception -> exit m1(x:) (abnormal)
-#-----| true -> print(_:separator:terminator:)
-#-----| false -> print(_:separator:terminator:)
-
-#  185| StmtCondition
-#-----|  -> .<=(_:_:)
-
-#  185| [false] ... .&&(_:_:) ...
-#-----| exception -> exit m1(x:) (abnormal)
-#-----| false -> print(_:separator:terminator:)
-
-#  185| .<=(_:_:)
-#-----|  -> Int.Type
-
-#  185| Int.Type
-#-----|  -> x
-
-#  185| 2
-#-----|  -> ... .<=(_:_:) ...
-
-#  185| x
-#-----|  -> 0
-
-#  185| ... .>(_:_:) ...
-#-----|  -> return ...
-
-#  185| return ...
-#-----|  -> ... .&&(_:_:) ...
-
-#  185| { ... }
-#-----|  -> .>(_:_:)
-
-#  185| .>(_:_:)
-#-----|  -> Int.Type
-
-#  185| Int.Type
-#-----|  -> x
-
-#  185| 0
-#-----|  -> ... .>(_:_:) ...
-
-#  185| call to !(_:)
-#-----|  -> return ...
-
-#  185| return ...
-#-----|  -> ... .&&(_:_:) ...
-
-#  185| { ... }
-#-----|  -> .==(_:_:)
-
-#  185| (...)
-#-----|  -> call to !(_:)
-
-#  185| x
-#-----|  -> 5
-
-#  185| ... .==(_:_:) ...
-#-----|  -> (...)
-
-#  185| .==(_:_:)
-#-----|  -> Int.Type
-
-#  185| Int.Type
-#-----|  -> x
-
-#  185| 5
-#-----|  -> ... .==(_:_:) ...
-
-#  186| print(_:separator:terminator:)
-#-----|  -> x is 1
-
-#  186| call to print(_:separator:terminator:)
-#-----|  -> exit m1(x:) (normal)
-
-#  186| default separator
-#-----|  -> default terminator
-
-#  186| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  186| (Any) ...
-#-----|  -> [...]
-
-#  186| [...]
-#-----|  -> [...]
-
-#  186| [...]
-#-----|  -> default separator
-
-#  186| x is 1
-#-----|  -> (Any) ...
-
-#  189| print(_:separator:terminator:)
-#-----|  -> I can't guess the number
-
-#  189| call to print(_:separator:terminator:)
-#-----|  -> exit m1(x:) (normal)
-
-#  189| default separator
-#-----|  -> default terminator
-
-#  189| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  189| (Any) ...
-#-----|  -> [...]
-
-#  189| I can't guess the number
-#-----|  -> (Any) ...
-
-#  189| [...]
-#-----|  -> [...]
-
-#  189| [...]
-#-----|  -> default separator
-
-#  193| enter m2(b:)
-#-----|  -> m2(b:)
-
-#  193| exit m2(b:)
-
-#  193| exit m2(b:) (normal)
-#-----|  -> exit m2(b:)
-
-#  193| m2(b:)
-#-----|  -> b
-
-#  193| b
-#-----|  -> if ... then { ... }
-
-#  194| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  194| StmtCondition
-#-----|  -> b
-
-#  194| b
-#-----| true -> 0
-#-----| false -> 1
-
-#  195| return ...
-#-----| return -> exit m2(b:) (normal)
-
-#  195| 0
-#-----|  -> return ...
-
-#  197| return ...
-#-----| return -> exit m2(b:) (normal)
-
-#  197| 1
-#-----|  -> return ...
-
-#  200| enter m3(x:)
-#-----|  -> m3(x:)
-
-#  200| exit m3(x:)
-
-#  200| exit m3(x:) (normal)
-#-----|  -> exit m3(x:)
-
-#  200| m3(x:)
-#-----|  -> x
-
-#  200| x
-#-----|  -> if ... then { ... }
-
-#  201| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  201| (Int) ...
-#-----|  -> 0
-
-#  201| x
-#-----|  -> (Int) ...
-
-#  201| ... .<(_:_:) ...
-#-----| true -> x
-#-----| false -> x
-
-#  201| StmtCondition
-#-----|  -> .<(_:_:)
-
-#  201| .<(_:_:)
-#-----|  -> Int.Type
-
-#  201| Int.Type
-#-----|  -> x
-
-#  201| 0
-#-----|  -> ... .<(_:_:) ...
-
-#  202| x
-#-----|  -> .-(_:)
-
-#  202|  ... = ...
-#-----|  -> if ... then { ... }
-
-#  202| .-(_:)
-#-----|  -> Int.Type
-
-#  202| Int.Type
-#-----|  -> x
-
-#  202| call to -(_:)
-#-----|  ->  ... = ...
-
-#  202| (Int) ...
-#-----|  -> call to -(_:)
-
-#  202| x
-#-----|  -> (Int) ...
-
-#  203| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  203| (Int) ...
-#-----|  -> 10
-
-#  203| x
-#-----|  -> (Int) ...
-
-#  203| ... .>(_:_:) ...
-#-----| true -> x
-#-----| false -> x
-
-#  203| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  203| .>(_:_:)
-#-----|  -> Int.Type
-
-#  203| Int.Type
-#-----|  -> x
-
-#  203| 10
-#-----|  -> ... .>(_:_:) ...
-
-#  204| x
-#-----|  -> .-(_:_:)
-
-#  204|  ... = ...
-#-----|  -> x
-
-#  204| (Int) ...
-#-----|  -> 1
-
-#  204| x
-#-----|  -> (Int) ...
-
-#  204| ... .-(_:_:) ...
-#-----|  ->  ... = ...
-
-#  204| .-(_:_:)
-#-----|  -> Int.Type
-
-#  204| Int.Type
-#-----|  -> x
-
-#  204| 1
-#-----|  -> ... .-(_:_:) ...
-
-#  207| return ...
-#-----| return -> exit m3(x:) (normal)
-
-#  207| (Int) ...
-#-----|  -> return ...
-
-#  207| x
-#-----|  -> (Int) ...
-
-#  210| enter m4(b1:b2:b3:)
-#-----|  -> m4(b1:b2:b3:)
-
-#  210| exit m4(b1:b2:b3:)
-
-#  210| exit m4(b1:b2:b3:) (normal)
-#-----|  -> exit m4(b1:b2:b3:)
-
-#  210| m4(b1:b2:b3:)
-#-----|  -> b1
-
-#  210| b1
-#-----|  -> b2
-
-#  210| b2
-#-----|  -> b3
-
-#  210| b3
-#-----|  -> b1
-
-#  211| return ...
-#-----| return -> exit m4(b1:b2:b3:) (normal)
-
-#  211| [false] (...)
-#-----| false -> !b2 || !b3
-
-#  211| [true] (...)
-#-----| true -> b2 || b3
-
-#  211| ... ? ... : ...
-#-----|  -> return ...
-
-#  211| b1
-#-----| true -> b2
-#-----| false -> b3
-
-#  211| [false] ... ? ... : ...
-#-----| false -> [false] (...)
-
-#  211| [true] ... ? ... : ...
-#-----| true -> [true] (...)
-
-#  211| b2
-#-----| false -> [false] ... ? ... : ...
-#-----| true -> [true] ... ? ... : ...
-
-#  211| b3
-#-----| false -> [false] ... ? ... : ...
-#-----| true -> [true] ... ? ... : ...
-
-#  211| b2 || b3
-#-----|  -> ... ? ... : ...
-
-#  211| !b2 || !b3
-#-----|  -> ... ? ... : ...
-
-#  214| conversionsInSplitEntry(b:)
-#-----|  -> b
-
-#  214| enter conversionsInSplitEntry(b:)
-#-----|  -> conversionsInSplitEntry(b:)
-
-#  214| exit conversionsInSplitEntry(b:)
-
-#  214| exit conversionsInSplitEntry(b:) (normal)
-#-----|  -> exit conversionsInSplitEntry(b:)
-
-#  214| b
-#-----|  -> if ... then { ... } else { ... }
-
-#  215| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  215| b
-#-----| true -> true
-#-----| false -> false
-
-#  215| StmtCondition
-#-----|  -> b
-
-#  215| [false] ... ? ... : ...
-#-----| false -> !b
-
-#  215| [true] ... ? ... : ...
-#-----| true -> b
-
-#  215| [true] (...)
-#-----| true -> [true] ... ? ... : ...
-
-#  215| true
-#-----| true -> [true] (...)
-
-#  215| [false] (Bool) ...
-#-----| false -> [false] ... ? ... : ...
-
-#  215| false
-#-----| false -> [false] (Bool) ...
-
-#  216| return ...
-#-----| return -> exit conversionsInSplitEntry(b:) (normal)
-
-#  216| b
-#-----|  -> return ...
-
-#  219| return ...
-#-----| return -> exit conversionsInSplitEntry(b:) (normal)
-
-#  219| !b
-#-----|  -> return ...
-
-#  223| constant_condition()
-#-----|  -> if ... then { ... }
-
-#  223| enter constant_condition()
-#-----|  -> constant_condition()
-
-#  223| exit constant_condition()
-
-#  223| exit constant_condition() (normal)
-#-----|  -> exit constant_condition()
-
-#  224| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  224| StmtCondition
-#-----|  -> true
-
-#  224| [false] call to !(_:)
-#-----| false -> exit constant_condition() (normal)
-
-#  224| true
-#-----| true -> [false] call to !(_:)
-
-#  229| empty_else(b:)
-#-----|  -> b
-
-#  229| enter empty_else(b:)
-#-----|  -> empty_else(b:)
-
-#  229| exit empty_else(b:)
-
-#  229| exit empty_else(b:) (normal)
-#-----|  -> exit empty_else(b:)
-
-#  229| b
-#-----|  -> if ... then { ... } else { ... }
-
-#  230| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  230| StmtCondition
-#-----|  -> b
-
-#  230| b
-#-----| true -> print(_:separator:terminator:)
-#-----| false -> { ... }
-
-#  231| print(_:separator:terminator:)
-#-----|  -> true
-
-#  231| call to print(_:separator:terminator:)
-#-----|  -> print(_:separator:terminator:)
-
-#  231| default separator
-#-----|  -> default terminator
-
-#  231| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  231| (Any) ...
-#-----|  -> [...]
-
-#  231| [...]
-#-----|  -> [...]
-
-#  231| [...]
-#-----|  -> default separator
-
-#  231| true
-#-----|  -> (Any) ...
-
-#  233| { ... }
-#-----|  -> print(_:separator:terminator:)
-
-#  234| print(_:separator:terminator:)
-#-----|  -> done
-
-#  234| call to print(_:separator:terminator:)
-#-----|  -> exit empty_else(b:) (normal)
-
-#  234| default separator
-#-----|  -> default terminator
-
-#  234| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  234| (Any) ...
-#-----|  -> [...]
-
-#  234| [...]
-#-----|  -> [...]
-
-#  234| [...]
-#-----|  -> default separator
-
-#  234| done
-#-----|  -> (Any) ...
-
-#  237| disjunct(b1:b2:)
-#-----|  -> b1
-
-#  237| enter disjunct(b1:b2:)
-#-----|  -> disjunct(b1:b2:)
-
-#  237| exit disjunct(b1:b2:)
-
-#  237| exit disjunct(b1:b2:) (abnormal)
-#-----|  -> exit disjunct(b1:b2:)
-
-#  237| exit disjunct(b1:b2:) (normal)
-#-----|  -> exit disjunct(b1:b2:)
-
-#  237| b1
-#-----|  -> b2
-
-#  237| b2
-#-----|  -> if ... then { ... }
-
-#  238| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  238| StmtCondition
-#-----|  -> b1
-
-#  238| [false] (...)
-#-----| false -> exit disjunct(b1:b2:) (normal)
-
-#  238| [true] (...)
-#-----| true -> print(_:separator:terminator:)
-
-#  238| b1
-#-----| true -> [true] ... .||(_:_:) ...
-#-----| false -> { ... }
-
-#  238| ... .||(_:_:) ...
-#-----| exception -> exit disjunct(b1:b2:) (abnormal)
-#-----| false -> [false] (...)
-#-----| true -> [true] (...)
-
-#  238| [true] ... .||(_:_:) ...
-#-----| exception -> exit disjunct(b1:b2:) (abnormal)
-#-----| true -> [true] (...)
-
-#  238| b2
-#-----|  -> return ...
-
-#  238| return ...
-#-----|  -> ... .||(_:_:) ...
-
-#  238| { ... }
-#-----|  -> b2
-
-#  239| print(_:separator:terminator:)
-#-----|  -> b1 or b2
-
-#  239| call to print(_:separator:terminator:)
-#-----|  -> exit disjunct(b1:b2:) (normal)
-
-#  239| default separator
-#-----|  -> default terminator
-
-#  239| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  239| (Any) ...
-#-----|  -> [...]
-
-#  239| [...]
-#-----|  -> [...]
-
-#  239| [...]
-#-----|  -> default separator
-
-#  239| b1 or b2
-#-----|  -> (Any) ...
-
-#  243| binaryExprs(a:b:)
-#-----|  -> a
-
-#  243| enter binaryExprs(a:b:)
-#-----|  -> binaryExprs(a:b:)
-
-#  243| exit binaryExprs(a:b:)
-
-#  243| exit binaryExprs(a:b:) (normal)
-#-----|  -> exit binaryExprs(a:b:)
-
-#  243| a
-#-----|  -> b
-
-#  243| b
-#-----|  -> c
-
-#  244| var ... = ...
-#-----|  -> d
-
-#  244| c
-#-----| match -> .+(_:_:)
-
-#  244| a
-#-----|  -> b
-
-#  244| ... .+(_:_:) ...
-#-----|  -> var ... = ...
-
-#  244| .+(_:_:)
-#-----|  -> Int.Type
-
-#  244| Int.Type
-#-----|  -> a
-
-#  244| b
-#-----|  -> ... .+(_:_:) ...
-
-#  245| var ... = ...
-#-----|  -> e
-
-#  245| d
-#-----| match -> .-(_:_:)
-
-#  245| a
-#-----|  -> b
-
-#  245| ... .-(_:_:) ...
-#-----|  -> var ... = ...
-
-#  245| .-(_:_:)
-#-----|  -> Int.Type
-
-#  245| Int.Type
-#-----|  -> a
-
-#  245| b
-#-----|  -> ... .-(_:_:) ...
-
-#  246| var ... = ...
-#-----|  -> f
-
-#  246| e
-#-----| match -> .*(_:_:)
-
-#  246| a
-#-----|  -> b
-
-#  246| ... .*(_:_:) ...
-#-----|  -> var ... = ...
-
-#  246| .*(_:_:)
-#-----|  -> Int.Type
-
-#  246| Int.Type
-#-----|  -> a
-
-#  246| b
-#-----|  -> ... .*(_:_:) ...
-
-#  247| var ... = ...
-#-----|  -> g
-
-#  247| f
-#-----| match -> ./(_:_:)
-
-#  247| a
-#-----|  -> b
-
-#  247| ... ./(_:_:) ...
-#-----|  -> var ... = ...
-
-#  247| ./(_:_:)
-#-----|  -> Int.Type
-
-#  247| Int.Type
-#-----|  -> a
-
-#  247| b
-#-----|  -> ... ./(_:_:) ...
-
-#  248| var ... = ...
-#-----|  -> h
-
-#  248| g
-#-----| match -> .%(_:_:)
-
-#  248| a
-#-----|  -> b
-
-#  248| ... .%(_:_:) ...
-#-----|  -> var ... = ...
-
-#  248| .%(_:_:)
-#-----|  -> Int.Type
-
-#  248| Int.Type
-#-----|  -> a
-
-#  248| b
-#-----|  -> ... .%(_:_:) ...
-
-#  249| var ... = ...
-#-----|  -> i
-
-#  249| h
-#-----| match -> .&(_:_:)
-
-#  249| a
-#-----|  -> b
-
-#  249| ... .&(_:_:) ...
-#-----|  -> var ... = ...
-
-#  249| .&(_:_:)
-#-----|  -> Int.Type
-
-#  249| Int.Type
-#-----|  -> a
-
-#  249| b
-#-----|  -> ... .&(_:_:) ...
-
-#  250| var ... = ...
-#-----|  -> j
-
-#  250| i
-#-----| match -> .|(_:_:)
-
-#  250| a
-#-----|  -> b
-
-#  250| ... .|(_:_:) ...
-#-----|  -> var ... = ...
-
-#  250| .|(_:_:)
-#-----|  -> Int.Type
-
-#  250| Int.Type
-#-----|  -> a
-
-#  250| b
-#-----|  -> ... .|(_:_:) ...
-
-#  251| var ... = ...
-#-----|  -> k
-
-#  251| j
-#-----| match -> .^(_:_:)
-
-#  251| a
-#-----|  -> b
-
-#  251| ... .^(_:_:) ...
-#-----|  -> var ... = ...
-
-#  251| .^(_:_:)
-#-----|  -> Int.Type
-
-#  251| Int.Type
-#-----|  -> a
-
-#  251| b
-#-----|  -> ... .^(_:_:) ...
-
-#  252| var ... = ...
-#-----|  -> l
-
-#  252| k
-#-----| match -> .<<(_:_:)
-
-#  252| a
-#-----|  -> b
-
-#  252| ... .<<(_:_:) ...
-#-----|  -> var ... = ...
-
-#  252| .<<(_:_:)
-#-----|  -> Int.Type
-
-#  252| Int.Type
-#-----|  -> a
-
-#  252| b
-#-----|  -> ... .<<(_:_:) ...
-
-#  253| var ... = ...
-#-----|  -> o
-
-#  253| l
-#-----| match -> .>>(_:_:)
-
-#  253| a
-#-----|  -> b
-
-#  253| ... .>>(_:_:) ...
-#-----|  -> var ... = ...
-
-#  253| .>>(_:_:)
-#-----|  -> Int.Type
-
-#  253| Int.Type
-#-----|  -> a
-
-#  253| b
-#-----|  -> ... .>>(_:_:) ...
-
-#  254| var ... = ...
-#-----|  -> p
-
-#  254| o
-#-----| match -> .==(_:_:)
-
-#  254| a
-#-----|  -> b
-
-#  254| ... .==(_:_:) ...
-#-----|  -> var ... = ...
-
-#  254| .==(_:_:)
-#-----|  -> Int.Type
-
-#  254| Int.Type
-#-----|  -> a
-
-#  254| b
-#-----|  -> ... .==(_:_:) ...
-
-#  255| var ... = ...
-#-----|  -> q
-
-#  255| p
-#-----| match -> .!=(_:_:)
-
-#  255| a
-#-----|  -> b
-
-#  255| ... .!=(_:_:) ...
-#-----|  -> var ... = ...
-
-#  255| .!=(_:_:)
-#-----|  -> Int.Type
-
-#  255| Int.Type
-#-----|  -> a
-
-#  255| b
-#-----|  -> ... .!=(_:_:) ...
-
-#  256| var ... = ...
-#-----|  -> r
-
-#  256| q
-#-----| match -> .<(_:_:)
-
-#  256| a
-#-----|  -> b
-
-#  256| ... .<(_:_:) ...
-#-----|  -> var ... = ...
-
-#  256| .<(_:_:)
-#-----|  -> Int.Type
-
-#  256| Int.Type
-#-----|  -> a
-
-#  256| b
-#-----|  -> ... .<(_:_:) ...
-
-#  257| var ... = ...
-#-----|  -> s
-
-#  257| r
-#-----| match -> .<=(_:_:)
-
-#  257| a
-#-----|  -> b
-
-#  257| ... .<=(_:_:) ...
-#-----|  -> var ... = ...
-
-#  257| .<=(_:_:)
-#-----|  -> Int.Type
-
-#  257| Int.Type
-#-----|  -> a
-
-#  257| b
-#-----|  -> ... .<=(_:_:) ...
-
-#  258| var ... = ...
-#-----|  -> t
-
-#  258| s
-#-----| match -> .>(_:_:)
-
-#  258| a
-#-----|  -> b
-
-#  258| ... .>(_:_:) ...
-#-----|  -> var ... = ...
-
-#  258| .>(_:_:)
-#-----|  -> Int.Type
-
-#  258| Int.Type
-#-----|  -> a
-
-#  258| b
-#-----|  -> ... .>(_:_:) ...
-
-#  259| var ... = ...
-#-----|  -> exit binaryExprs(a:b:) (normal)
-
-#  259| t
-#-----| match -> .>=(_:_:)
-
-#  259| a
-#-----|  -> b
-
-#  259| ... .>=(_:_:) ...
-#-----|  -> var ... = ...
-
-#  259| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  259| Int.Type
-#-----|  -> a
-
-#  259| b
-#-----|  -> ... .>=(_:_:) ...
-
-#  262| enter interpolatedString(x:y:)
-#-----|  -> interpolatedString(x:y:)
-
-#  262| exit interpolatedString(x:y:)
-
-#  262| exit interpolatedString(x:y:) (normal)
-#-----|  -> exit interpolatedString(x:y:)
-
-#  262| interpolatedString(x:y:)
-#-----|  -> x
-
-#  262| x
-#-----|  -> y
-
-#  262| y
-#-----|  -> OpaqueValueExpr
-
-#  263| return ...
-#-----| return -> exit interpolatedString(x:y:) (normal)
-
-#  263| 
-#-----|  -> call to appendLiteral(_:)
-
-#  263| "..."
-#-----|  -> return ...
-
-#  263| OpaqueValueExpr
-#-----|  -> .appendLiteral(_:)
-
-#  263| TapExpr
-#-----|  -> "..."
-
-#  263| call to appendLiteral(_:)
-#-----|  -> .appendInterpolation(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> 
-
-#  263| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> x
-
-#  263| .appendInterpolation(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendInterpolation(_:)
-#-----|  -> .appendLiteral(_:)
-
-#  263| x
-#-----|  -> call to appendInterpolation(_:)
-
-#  263|  + 
-#-----|  -> call to appendLiteral(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  ->  + 
-
-#  263| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendLiteral(_:)
-#-----|  -> .appendInterpolation(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> y
-
-#  263| .appendInterpolation(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendInterpolation(_:)
-#-----|  -> .appendLiteral(_:)
-
-#  263| y
-#-----|  -> call to appendInterpolation(_:)
-
-#  263|  is equal to 
-#-----|  -> call to appendLiteral(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  ->  is equal to 
-
-#  263| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendLiteral(_:)
-#-----|  -> .appendInterpolation(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> .+(_:_:)
-
-#  263| .appendInterpolation(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendInterpolation(_:)
-#-----|  -> .appendLiteral(_:)
-
-#  263| x
-#-----|  -> y
-
-#  263| ... .+(_:_:) ...
-#-----|  -> call to appendInterpolation(_:)
-
-#  263| .+(_:_:)
-#-----|  -> Int.Type
-
-#  263| Int.Type
-#-----|  -> x
-
-#  263| y
-#-----|  -> ... .+(_:_:) ...
-
-#  263|  and here is a zero: 
-#-----|  -> call to appendLiteral(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  ->  and here is a zero: 
-
-#  263| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendLiteral(_:)
-#-----|  -> .appendInterpolation(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> returnZero()
-
-#  263| .appendInterpolation(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendInterpolation(_:)
-#-----|  -> .appendLiteral(_:)
-
-#  263| returnZero()
-#-----|  -> call to returnZero()
-
-#  263| call to returnZero()
-#-----|  -> call to appendInterpolation(_:)
-
-#  263| 
-#-----|  -> call to appendLiteral(_:)
-
-#  263| $interpolation
-#-----|  -> &...
-
-#  263| &...
-#-----|  -> 
-
-#  263| .appendLiteral(_:)
-#-----|  -> $interpolation
-
-#  263| call to appendLiteral(_:)
-#-----|  -> TapExpr
-
-#  266| enter testSubscriptExpr()
-#-----|  -> testSubscriptExpr()
-
-#  266| exit testSubscriptExpr()
-
-#  266| exit testSubscriptExpr() (normal)
-#-----|  -> exit testSubscriptExpr()
-
-#  266| testSubscriptExpr()
-#-----|  -> a
-
-#  267| var ... = ...
-#-----|  -> a
-
-#  267| a
-#-----| match -> 0
-
-#  267| [...]
-#-----|  -> var ... = ...
-
-#  267| 0
-#-----|  -> 1
-
-#  267| 1
-#-----|  -> 2
-
-#  267| 2
-#-----|  -> 3
-
-#  267| 3
-#-----|  -> 4
-
-#  267| 4
-#-----|  -> 5
-
-#  267| 5
-#-----|  -> 6
-
-#  267| 6
-#-----|  -> 7
-
-#  267| 7
-#-----|  -> 8
-
-#  267| 8
-#-----|  -> 9
-
-#  267| 9
-#-----|  -> 10
-
-#  267| 10
-#-----|  -> [...]
-
-#  268| &...
-#-----|  -> 0
-
-#  268| a
-#-----|  -> &...
-
-#  268| ...[...]
-#-----|  -> 0
-
-#  268| setter for  ... = ...
-#-----|  -> .+=(_:_:)
-
-#  268| 0
-#-----|  -> ...[...]
-
-#  268| 0
-#-----|  -> setter for  ... = ...
-
-#  269| &...
-#-----|  -> 1
-
-#  269| a
-#-----|  -> &...
-
-#  269| &...
-#-----|  -> 1
-
-#  269| getter for ...[...]
-#-----|  -> &...
-
-#  269| ... .+=(_:_:) ...
-#-----|  -> .-=(_:_:)
-
-#  269| 1
-#-----|  -> getter for ...[...]
-
-#  269| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  269| Int.Type
-#-----|  -> a
-
-#  269| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  270| &...
-#-----|  -> 2
-
-#  270| a
-#-----|  -> &...
-
-#  270| &...
-#-----|  -> 1
-
-#  270| getter for ...[...]
-#-----|  -> &...
-
-#  270| ... .-=(_:_:) ...
-#-----|  -> .*=(_:_:)
-
-#  270| 2
-#-----|  -> getter for ...[...]
-
-#  270| .-=(_:_:)
-#-----|  -> Int.Type
-
-#  270| Int.Type
-#-----|  -> a
-
-#  270| 1
-#-----|  -> ... .-=(_:_:) ...
-
-#  271| &...
-#-----|  -> 3
-
-#  271| a
-#-----|  -> &...
-
-#  271| &...
-#-----|  -> 1
-
-#  271| getter for ...[...]
-#-----|  -> &...
-
-#  271| ... .*=(_:_:) ...
-#-----|  -> ./=(_:_:)
-
-#  271| 3
-#-----|  -> getter for ...[...]
-
-#  271| .*=(_:_:)
-#-----|  -> Int.Type
-
-#  271| Int.Type
-#-----|  -> a
-
-#  271| 1
-#-----|  -> ... .*=(_:_:) ...
-
-#  272| &...
-#-----|  -> 4
-
-#  272| a
-#-----|  -> &...
-
-#  272| &...
-#-----|  -> 1
-
-#  272| getter for ...[...]
-#-----|  -> &...
-
-#  272| ... ./=(_:_:) ...
-#-----|  -> .%=(_:_:)
-
-#  272| 4
-#-----|  -> getter for ...[...]
-
-#  272| ./=(_:_:)
-#-----|  -> Int.Type
-
-#  272| Int.Type
-#-----|  -> a
-
-#  272| 1
-#-----|  -> ... ./=(_:_:) ...
-
-#  273| &...
-#-----|  -> 5
-
-#  273| a
-#-----|  -> &...
-
-#  273| &...
-#-----|  -> 1
-
-#  273| getter for ...[...]
-#-----|  -> &...
-
-#  273| ... .%=(_:_:) ...
-#-----|  -> .&=(_:_:)
-
-#  273| 5
-#-----|  -> getter for ...[...]
-
-#  273| .%=(_:_:)
-#-----|  -> Int.Type
-
-#  273| Int.Type
-#-----|  -> a
-
-#  273| 1
-#-----|  -> ... .%=(_:_:) ...
-
-#  274| &...
-#-----|  -> 6
-
-#  274| a
-#-----|  -> &...
-
-#  274| &...
-#-----|  -> 1
-
-#  274| getter for ...[...]
-#-----|  -> &...
-
-#  274| ... .&=(_:_:) ...
-#-----|  -> .|=(_:_:)
-
-#  274| 6
-#-----|  -> getter for ...[...]
-
-#  274| .&=(_:_:)
-#-----|  -> Int.Type
-
-#  274| Int.Type
-#-----|  -> a
-
-#  274| 1
-#-----|  -> ... .&=(_:_:) ...
-
-#  275| &...
-#-----|  -> 7
-
-#  275| a
-#-----|  -> &...
-
-#  275| &...
-#-----|  -> 1
-
-#  275| getter for ...[...]
-#-----|  -> &...
-
-#  275| ... .|=(_:_:) ...
-#-----|  -> .^=(_:_:)
-
-#  275| 7
-#-----|  -> getter for ...[...]
-
-#  275| .|=(_:_:)
-#-----|  -> Int.Type
-
-#  275| Int.Type
-#-----|  -> a
-
-#  275| 1
-#-----|  -> ... .|=(_:_:) ...
-
-#  276| &...
-#-----|  -> 8
-
-#  276| a
-#-----|  -> &...
-
-#  276| &...
-#-----|  -> 1
-
-#  276| getter for ...[...]
-#-----|  -> &...
-
-#  276| ... .^=(_:_:) ...
-#-----|  -> .<<=(_:_:)
-
-#  276| 8
-#-----|  -> getter for ...[...]
-
-#  276| .^=(_:_:)
-#-----|  -> Int.Type
-
-#  276| Int.Type
-#-----|  -> a
-
-#  276| 1
-#-----|  -> ... .^=(_:_:) ...
-
-#  277| &...
-#-----|  -> 9
-
-#  277| a
-#-----|  -> &...
-
-#  277| &...
-#-----|  -> 1
-
-#  277| getter for ...[...]
-#-----|  -> &...
-
-#  277| ... .<<=(_:_:) ...
-#-----|  -> .>>=(_:_:)
-
-#  277| 9
-#-----|  -> getter for ...[...]
-
-#  277| .<<=(_:_:)
-#-----|  -> Int.Type
-
-#  277| Int.Type
-#-----|  -> a
-
-#  277| 1
-#-----|  -> ... .<<=(_:_:) ...
-
-#  278| &...
-#-----|  -> 10
-
-#  278| a
-#-----|  -> &...
-
-#  278| &...
-#-----|  -> 1
-
-#  278| getter for ...[...]
-#-----|  -> &...
-
-#  278| ... .>>=(_:_:) ...
-#-----|  -> tupleWithA
-
-#  278| 10
-#-----|  -> getter for ...[...]
-
-#  278| .>>=(_:_:)
-#-----|  -> Int.Type
-
-#  278| Int.Type
-#-----|  -> a
-
-#  278| 1
-#-----|  -> ... .>>=(_:_:) ...
-
-#  280| var ... = ...
-#-----|  -> b
-
-#  280| tupleWithA
-#-----| match -> a
-
-#  280| (...)
-#-----|  -> var ... = ...
-
-#  280| &...
-#-----|  -> 0
-
-#  280| a
-#-----|  -> &...
-
-#  280| (Int) ...
-#-----|  -> a
-
-#  280| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  280| 0
-#-----|  -> getter for ...[...]
-
-#  280| &...
-#-----|  -> 1
-
-#  280| a
-#-----|  -> &...
-
-#  280| (Int) ...
-#-----|  -> a
-
-#  280| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  280| 1
-#-----|  -> getter for ...[...]
-
-#  280| &...
-#-----|  -> 2
-
-#  280| a
-#-----|  -> &...
-
-#  280| (Int) ...
-#-----|  -> a
-
-#  280| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  280| 2
-#-----|  -> getter for ...[...]
-
-#  280| &...
-#-----|  -> 3
-
-#  280| a
-#-----|  -> &...
-
-#  280| (Int) ...
-#-----|  -> a
-
-#  280| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  280| 3
-#-----|  -> getter for ...[...]
-
-#  280| &...
-#-----|  -> 4
-
-#  280| a
-#-----|  -> &...
-
-#  280| (Int) ...
-#-----|  -> (...)
-
-#  280| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  280| 4
-#-----|  -> getter for ...[...]
-
-#  282| var ... = ...
-#-----|  -> b
-
-#  282| b
-#-----| match -> 0
-
-#  282| [...]
-#-----|  -> var ... = ...
-
-#  282| 0
-#-----|  -> 1
-
-#  282| 1
-#-----|  -> 2
-
-#  282| 2
-#-----|  -> 3
-
-#  282| 3
-#-----|  -> 4
-
-#  282| 4
-#-----|  -> 5
-
-#  282| 5
-#-----|  -> 6
-
-#  282| 6
-#-----|  -> 7
-
-#  282| 7
-#-----|  -> 8
-
-#  282| 8
-#-----|  -> 9
-
-#  282| 9
-#-----|  -> 10
-
-#  282| 10
-#-----|  -> 11
-
-#  282| 11
-#-----|  -> [...]
-
-#  283| &...
-#-----|  -> 0
-
-#  283| b
-#-----|  -> &...
-
-#  283| ...[...]
-#-----|  -> a
-
-#  283| setter for  ... = ...
-#-----|  -> b
-
-#  283| 0
-#-----|  -> ...[...]
-
-#  283| &...
-#-----|  -> 10
-
-#  283| a
-#-----|  -> &...
-
-#  283| (Int) ...
-#-----|  -> setter for  ... = ...
-
-#  283| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  283| 10
-#-----|  -> getter for ...[...]
-
-#  284| &...
-#-----|  -> 1
-
-#  284| b
-#-----|  -> &...
-
-#  284| ...[...]
-#-----|  -> .+(_:_:)
-
-#  284| setter for  ... = ...
-#-----|  -> b
-
-#  284| 1
-#-----|  -> ...[...]
-
-#  284| &...
-#-----|  -> 0
-
-#  284| b
-#-----|  -> &...
-
-#  284| (Int) ...
-#-----|  -> 1
-
-#  284| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  284| ... .+(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  284| 0
-#-----|  -> getter for ...[...]
-
-#  284| .+(_:_:)
-#-----|  -> Int.Type
-
-#  284| Int.Type
-#-----|  -> b
-
-#  284| 1
-#-----|  -> ... .+(_:_:) ...
-
-#  285| &...
-#-----|  -> 2
-
-#  285| b
-#-----|  -> &...
-
-#  285| ...[...]
-#-----|  -> .-(_:_:)
-
-#  285| setter for  ... = ...
-#-----|  -> b
-
-#  285| 2
-#-----|  -> ...[...]
-
-#  285| &...
-#-----|  -> 1
-
-#  285| b
-#-----|  -> &...
-
-#  285| (Int) ...
-#-----|  -> 1
-
-#  285| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  285| ... .-(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  285| 1
-#-----|  -> getter for ...[...]
-
-#  285| .-(_:_:)
-#-----|  -> Int.Type
-
-#  285| Int.Type
-#-----|  -> b
-
-#  285| 1
-#-----|  -> ... .-(_:_:) ...
-
-#  286| &...
-#-----|  -> 3
-
-#  286| b
-#-----|  -> &...
-
-#  286| ...[...]
-#-----|  -> .*(_:_:)
-
-#  286| setter for  ... = ...
-#-----|  -> b
-
-#  286| 3
-#-----|  -> ...[...]
-
-#  286| &...
-#-----|  -> 2
-
-#  286| b
-#-----|  -> &...
-
-#  286| (Int) ...
-#-----|  -> 1
-
-#  286| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  286| ... .*(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  286| 2
-#-----|  -> getter for ...[...]
-
-#  286| .*(_:_:)
-#-----|  -> Int.Type
-
-#  286| Int.Type
-#-----|  -> b
-
-#  286| 1
-#-----|  -> ... .*(_:_:) ...
-
-#  287| &...
-#-----|  -> 4
-
-#  287| b
-#-----|  -> &...
-
-#  287| ...[...]
-#-----|  -> ./(_:_:)
-
-#  287| setter for  ... = ...
-#-----|  -> b
-
-#  287| 4
-#-----|  -> ...[...]
-
-#  287| &...
-#-----|  -> 3
-
-#  287| b
-#-----|  -> &...
-
-#  287| (Int) ...
-#-----|  -> 1
-
-#  287| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  287| ... ./(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  287| 3
-#-----|  -> getter for ...[...]
-
-#  287| ./(_:_:)
-#-----|  -> Int.Type
-
-#  287| Int.Type
-#-----|  -> b
-
-#  287| 1
-#-----|  -> ... ./(_:_:) ...
-
-#  288| &...
-#-----|  -> 5
-
-#  288| b
-#-----|  -> &...
-
-#  288| ...[...]
-#-----|  -> .%(_:_:)
-
-#  288| setter for  ... = ...
-#-----|  -> b
-
-#  288| 5
-#-----|  -> ...[...]
-
-#  288| &...
-#-----|  -> 4
-
-#  288| b
-#-----|  -> &...
-
-#  288| (Int) ...
-#-----|  -> 1
-
-#  288| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  288| ... .%(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  288| 4
-#-----|  -> getter for ...[...]
-
-#  288| .%(_:_:)
-#-----|  -> Int.Type
-
-#  288| Int.Type
-#-----|  -> b
-
-#  288| 1
-#-----|  -> ... .%(_:_:) ...
-
-#  289| &...
-#-----|  -> 6
-
-#  289| b
-#-----|  -> &...
-
-#  289| ...[...]
-#-----|  -> .&(_:_:)
-
-#  289| setter for  ... = ...
-#-----|  -> b
-
-#  289| 6
-#-----|  -> ...[...]
-
-#  289| &...
-#-----|  -> 5
-
-#  289| b
-#-----|  -> &...
-
-#  289| (Int) ...
-#-----|  -> 1
-
-#  289| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  289| ... .&(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  289| 5
-#-----|  -> getter for ...[...]
-
-#  289| .&(_:_:)
-#-----|  -> Int.Type
-
-#  289| Int.Type
-#-----|  -> b
-
-#  289| 1
-#-----|  -> ... .&(_:_:) ...
-
-#  290| &...
-#-----|  -> 7
-
-#  290| b
-#-----|  -> &...
-
-#  290| ...[...]
-#-----|  -> .|(_:_:)
-
-#  290| setter for  ... = ...
-#-----|  -> b
-
-#  290| 7
-#-----|  -> ...[...]
-
-#  290| &...
-#-----|  -> 6
-
-#  290| b
-#-----|  -> &...
-
-#  290| (Int) ...
-#-----|  -> 1
-
-#  290| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  290| ... .|(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  290| 6
-#-----|  -> getter for ...[...]
-
-#  290| .|(_:_:)
-#-----|  -> Int.Type
-
-#  290| Int.Type
-#-----|  -> b
-
-#  290| 1
-#-----|  -> ... .|(_:_:) ...
-
-#  291| &...
-#-----|  -> 8
-
-#  291| b
-#-----|  -> &...
-
-#  291| ...[...]
-#-----|  -> .^(_:_:)
-
-#  291| setter for  ... = ...
-#-----|  -> b
-
-#  291| 8
-#-----|  -> ...[...]
-
-#  291| &...
-#-----|  -> 7
-
-#  291| b
-#-----|  -> &...
-
-#  291| (Int) ...
-#-----|  -> 1
-
-#  291| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  291| ... .^(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  291| 7
-#-----|  -> getter for ...[...]
-
-#  291| .^(_:_:)
-#-----|  -> Int.Type
-
-#  291| Int.Type
-#-----|  -> b
-
-#  291| 1
-#-----|  -> ... .^(_:_:) ...
-
-#  292| &...
-#-----|  -> 9
-
-#  292| b
-#-----|  -> &...
-
-#  292| ...[...]
-#-----|  -> .<<(_:_:)
-
-#  292| setter for  ... = ...
-#-----|  -> b
-
-#  292| 9
-#-----|  -> ...[...]
-
-#  292| &...
-#-----|  -> 8
-
-#  292| b
-#-----|  -> &...
-
-#  292| (Int) ...
-#-----|  -> 1
-
-#  292| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  292| ... .<<(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  292| 8
-#-----|  -> getter for ...[...]
-
-#  292| .<<(_:_:)
-#-----|  -> Int.Type
-
-#  292| Int.Type
-#-----|  -> b
-
-#  292| 1
-#-----|  -> ... .<<(_:_:) ...
-
-#  293| &...
-#-----|  -> 10
-
-#  293| b
-#-----|  -> &...
-
-#  293| ...[...]
-#-----|  -> .>>(_:_:)
-
-#  293| setter for  ... = ...
-#-----|  -> (...)
-
-#  293| 10
-#-----|  -> ...[...]
-
-#  293| &...
-#-----|  -> 9
-
-#  293| b
-#-----|  -> &...
-
-#  293| (Int) ...
-#-----|  -> 1
-
-#  293| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  293| ... .>>(_:_:) ...
-#-----|  -> setter for  ... = ...
-
-#  293| 9
-#-----|  -> getter for ...[...]
-
-#  293| .>>(_:_:)
-#-----|  -> Int.Type
-
-#  293| Int.Type
-#-----|  -> b
-
-#  293| 1
-#-----|  -> ... .>>(_:_:) ...
-
-#  295| var ... = ...
-#-----|  -> .+(_:_:)
-
-#  295| (...)
-#-----|  -> a1
-
-#  295| a1
-#-----| match -> a2
-
-#  295| a2
-#-----| match -> a3
-
-#  295| a3
-#-----| match -> a4
-
-#  295| a4
-#-----| match -> a5
-
-#  295| a5
-#-----| match -> tupleWithA
-
-#  295| ((Int, Int, Int, Int, Int)) ...
-#-----|  -> var ... = ...
-
-#  295| tupleWithA
-#-----|  -> ((Int, Int, Int, Int, Int)) ...
-
-#  296| return ...
-#-----| return -> exit testSubscriptExpr() (normal)
-
-#  296| (...)
-#-----|  -> return ...
-
-#  296| a1
-#-----|  -> b
-
-#  296| ... .+(_:_:) ...
-#-----|  -> .+(_:_:)
-
-#  296| .+(_:_:)
-#-----|  -> Int.Type
-
-#  296| Int.Type
-#-----|  -> a1
-
-#  296| &...
-#-----|  -> 0
-
-#  296| b
-#-----|  -> &...
-
-#  296| (Int) ...
-#-----|  -> ... .+(_:_:) ...
-
-#  296| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  296| 0
-#-----|  -> getter for ...[...]
-
-#  296| a2
-#-----|  -> b
-
-#  296| ... .+(_:_:) ...
-#-----|  -> .+(_:_:)
-
-#  296| .+(_:_:)
-#-----|  -> Int.Type
-
-#  296| Int.Type
-#-----|  -> a2
-
-#  296| &...
-#-----|  -> 1
-
-#  296| b
-#-----|  -> &...
-
-#  296| (Int) ...
-#-----|  -> ... .+(_:_:) ...
-
-#  296| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  296| 1
-#-----|  -> getter for ...[...]
-
-#  296| a3
-#-----|  -> b
-
-#  296| ... .+(_:_:) ...
-#-----|  -> .+(_:_:)
-
-#  296| .+(_:_:)
-#-----|  -> Int.Type
-
-#  296| Int.Type
-#-----|  -> a3
-
-#  296| &...
-#-----|  -> 2
-
-#  296| b
-#-----|  -> &...
-
-#  296| (Int) ...
-#-----|  -> ... .+(_:_:) ...
-
-#  296| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  296| 2
-#-----|  -> getter for ...[...]
-
-#  296| a4
-#-----|  -> b
-
-#  296| ... .+(_:_:) ...
-#-----|  -> .+(_:_:)
-
-#  296| .+(_:_:)
-#-----|  -> Int.Type
-
-#  296| Int.Type
-#-----|  -> a4
-
-#  296| &...
-#-----|  -> 3
-
-#  296| b
-#-----|  -> &...
-
-#  296| (Int) ...
-#-----|  -> ... .+(_:_:) ...
-
-#  296| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  296| 3
-#-----|  -> getter for ...[...]
-
-#  296| a5
-#-----|  -> b
-
-#  296| ... .+(_:_:) ...
-#-----|  -> (...)
-
-#  296| .+(_:_:)
-#-----|  -> Int.Type
-
-#  296| Int.Type
-#-----|  -> a5
-
-#  296| &...
-#-----|  -> 4
-
-#  296| b
-#-----|  -> &...
-
-#  296| (Int) ...
-#-----|  -> ... .+(_:_:) ...
-
-#  296| getter for ...[...]
-#-----|  -> (Int) ...
-
-#  296| 4
-#-----|  -> getter for ...[...]
-
-#  299| enter loop1(x:)
-#-----|  -> loop1(x:)
-
-#  299| exit loop1(x:)
-
-#  299| exit loop1(x:) (normal)
-#-----|  -> exit loop1(x:)
-
-#  299| loop1(x:)
-#-----|  -> x
-
-#  299| x
-#-----|  -> while ... { ... }
-
-#  300| while ... { ... }
-#-----|  -> StmtCondition
-
-#  300| (Int) ...
-#-----|  -> 0
-
-#  300| x
-#-----|  -> (Int) ...
-
-#  300| ... .>=(_:_:) ...
-#-----| false -> exit loop1(x:) (normal)
-#-----| true -> print(_:separator:terminator:)
-
-#  300| StmtCondition
-#-----|  -> .>=(_:_:)
-
-#  300| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  300| Int.Type
-#-----|  -> x
-
-#  300| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#  301| print(_:separator:terminator:)
-#-----|  -> x
-
-#  301| call to print(_:separator:terminator:)
-#-----|  -> .-=(_:_:)
-
-#  301| default separator
-#-----|  -> default terminator
-
-#  301| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  301| (Any) ...
-#-----|  -> [...]
-
-#  301| (Int) ...
-#-----|  -> (Any) ...
-
-#  301| [...]
-#-----|  -> [...]
-
-#  301| [...]
-#-----|  -> default separator
-
-#  301| x
-#-----|  -> (Int) ...
-
-#  302| &...
-#-----|  -> 1
-
-#  302| x
-#-----|  -> &...
-
-#  302| ... .-=(_:_:) ...
-#-----|  -> StmtCondition
-
-#  302| .-=(_:_:)
-#-----|  -> Int.Type
-
-#  302| Int.Type
-#-----|  -> x
-
-#  302| 1
-#-----|  -> ... .-=(_:_:) ...
-
-#  306| enter loop2(x:)
-#-----|  -> loop2(x:)
-
-#  306| exit loop2(x:)
-
-#  306| exit loop2(x:) (normal)
-#-----|  -> exit loop2(x:)
-
-#  306| loop2(x:)
-#-----|  -> x
-
-#  306| x
-#-----|  -> while ... { ... }
-
-#  307| while ... { ... }
-#-----|  -> StmtCondition
-
-#  307| (Int) ...
-#-----|  -> 0
-
-#  307| x
-#-----|  -> (Int) ...
-
-#  307| ... .>=(_:_:) ...
-#-----| true -> print(_:separator:terminator:)
-#-----| false -> print(_:separator:terminator:)
-
-#  307| StmtCondition
-#-----|  -> .>=(_:_:)
-
-#  307| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  307| Int.Type
-#-----|  -> x
-
-#  307| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#  308| print(_:separator:terminator:)
-#-----|  -> x
-
-#  308| call to print(_:separator:terminator:)
-#-----|  -> .-=(_:_:)
-
-#  308| default separator
-#-----|  -> default terminator
-
-#  308| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  308| (Any) ...
-#-----|  -> [...]
-
-#  308| (Int) ...
-#-----|  -> (Any) ...
-
-#  308| [...]
-#-----|  -> [...]
-
-#  308| [...]
-#-----|  -> default separator
-
-#  308| x
-#-----|  -> (Int) ...
-
-#  309| &...
-#-----|  -> 1
-
-#  309| x
-#-----|  -> &...
-
-#  309| ... .-=(_:_:) ...
-#-----|  -> if ... then { ... } else { ... }
-
-#  309| .-=(_:_:)
-#-----|  -> Int.Type
-
-#  309| Int.Type
-#-----|  -> x
-
-#  309| 1
-#-----|  -> ... .-=(_:_:) ...
-
-#  310| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  310| (Int) ...
-#-----|  -> 100
-
-#  310| x
-#-----|  -> (Int) ...
-
-#  310| ... .>(_:_:) ...
-#-----| true -> break
-#-----| false -> if ... then { ... }
-
-#  310| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  310| .>(_:_:)
-#-----|  -> Int.Type
-
-#  310| Int.Type
-#-----|  -> x
-
-#  310| 100
-#-----|  -> ... .>(_:_:) ...
-
-#  311| break
-#-----|  -> print(_:separator:terminator:)
-
-#  313| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  313| (Int) ...
-#-----|  -> 50
-
-#  313| x
-#-----|  -> (Int) ...
-
-#  313| ... .>(_:_:) ...
-#-----| true -> continue
-#-----| false -> print(_:separator:terminator:)
-
-#  313| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  313| .>(_:_:)
-#-----|  -> Int.Type
-
-#  313| Int.Type
-#-----|  -> x
-
-#  313| 50
-#-----|  -> ... .>(_:_:) ...
-
-#  314| continue
-#-----| continue -> StmtCondition
-
-#  316| print(_:separator:terminator:)
-#-----|  -> Iter
-
-#  316| call to print(_:separator:terminator:)
-#-----|  -> StmtCondition
-
-#  316| default separator
-#-----|  -> default terminator
-
-#  316| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  316| (Any) ...
-#-----|  -> [...]
-
-#  316| Iter
-#-----|  -> (Any) ...
-
-#  316| [...]
-#-----|  -> [...]
-
-#  316| [...]
-#-----|  -> default separator
-
-#  318| print(_:separator:terminator:)
-#-----|  -> Done
-
-#  318| call to print(_:separator:terminator:)
-#-----|  -> exit loop2(x:) (normal)
-
-#  318| default separator
-#-----|  -> default terminator
-
-#  318| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  318| (Any) ...
-#-----|  -> [...]
-
-#  318| Done
-#-----|  -> (Any) ...
-
-#  318| [...]
-#-----|  -> [...]
-
-#  318| [...]
-#-----|  -> default separator
-
-#  321| enter labeledLoop(x:)
-#-----|  -> labeledLoop(x:)
-
-#  321| exit labeledLoop(x:)
-
-#  321| exit labeledLoop(x:) (normal)
-#-----|  -> exit labeledLoop(x:)
-
-#  321| labeledLoop(x:)
-#-----|  -> x
-
-#  321| x
-#-----|  -> while ... { ... }
-
-#  322| while ... { ... }
-#-----|  -> StmtCondition
-
-#  322| (Int) ...
-#-----|  -> 0
-
-#  322| x
-#-----|  -> (Int) ...
-
-#  322| ... .>=(_:_:) ...
-#-----| false -> exit labeledLoop(x:) (normal)
-#-----| true -> while ... { ... }
-
-#  322| StmtCondition
-#-----|  -> .>=(_:_:)
-
-#  322| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  322| Int.Type
-#-----|  -> x
-
-#  322| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#  323| while ... { ... }
-#-----|  -> StmtCondition
-
-#  323| (Int) ...
-#-----|  -> 0
-
-#  323| x
-#-----|  -> (Int) ...
-
-#  323| ... .>=(_:_:) ...
-#-----| true -> print(_:separator:terminator:)
-#-----| false -> print(_:separator:terminator:)
-
-#  323| StmtCondition
-#-----|  -> .>=(_:_:)
-
-#  323| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  323| Int.Type
-#-----|  -> x
-
-#  323| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#  324| print(_:separator:terminator:)
-#-----|  -> x
-
-#  324| call to print(_:separator:terminator:)
-#-----|  -> .-=(_:_:)
-
-#  324| default separator
-#-----|  -> default terminator
-
-#  324| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  324| (Any) ...
-#-----|  -> [...]
-
-#  324| (Int) ...
-#-----|  -> (Any) ...
-
-#  324| [...]
-#-----|  -> [...]
-
-#  324| [...]
-#-----|  -> default separator
-
-#  324| x
-#-----|  -> (Int) ...
-
-#  325| &...
-#-----|  -> 1
-
-#  325| x
-#-----|  -> &...
-
-#  325| ... .-=(_:_:) ...
-#-----|  -> if ... then { ... } else { ... }
-
-#  325| .-=(_:_:)
-#-----|  -> Int.Type
-
-#  325| Int.Type
-#-----|  -> x
-
-#  325| 1
-#-----|  -> ... .-=(_:_:) ...
-
-#  326| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  326| (Int) ...
-#-----|  -> 100
-
-#  326| x
-#-----|  -> (Int) ...
-
-#  326| ... .>(_:_:) ...
-#-----| true -> break outer
-#-----| false -> if ... then { ... }
-
-#  326| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  326| .>(_:_:)
-#-----|  -> Int.Type
-
-#  326| Int.Type
-#-----|  -> x
-
-#  326| 100
-#-----|  -> ... .>(_:_:) ...
-
-#  327| break outer
-#-----|  -> exit labeledLoop(x:) (normal)
-
-#  329| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  329| (Int) ...
-#-----|  -> 50
-
-#  329| x
-#-----|  -> (Int) ...
-
-#  329| ... .>(_:_:) ...
-#-----| true -> continue inner
-#-----| false -> print(_:separator:terminator:)
-
-#  329| StmtCondition
-#-----|  -> .>(_:_:)
-
-#  329| .>(_:_:)
-#-----|  -> Int.Type
-
-#  329| Int.Type
-#-----|  -> x
-
-#  329| 50
-#-----|  -> ... .>(_:_:) ...
-
-#  330| continue inner
-#-----| continue -> StmtCondition
-
-#  332| print(_:separator:terminator:)
-#-----|  -> Iter
-
-#  332| call to print(_:separator:terminator:)
-#-----|  -> StmtCondition
-
-#  332| default separator
-#-----|  -> default terminator
-
-#  332| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  332| (Any) ...
-#-----|  -> [...]
-
-#  332| Iter
-#-----|  -> (Any) ...
-
-#  332| [...]
-#-----|  -> [...]
-
-#  332| [...]
-#-----|  -> default separator
-
-#  334| print(_:separator:terminator:)
-#-----|  -> Done
-
-#  334| call to print(_:separator:terminator:)
-#-----|  -> StmtCondition
-
-#  334| default separator
-#-----|  -> default terminator
-
-#  334| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  334| (Any) ...
-#-----|  -> [...]
-
-#  334| Done
-#-----|  -> (Any) ...
-
-#  334| [...]
-#-----|  -> [...]
-
-#  334| [...]
-#-----|  -> default separator
-
-#  338| enter testRepeat(x:)
-#-----|  -> testRepeat(x:)
-
-#  338| exit testRepeat(x:)
-
-#  338| exit testRepeat(x:) (normal)
-#-----|  -> exit testRepeat(x:)
-
-#  338| testRepeat(x:)
-#-----|  -> x
-
-#  338| x
-#-----|  -> repeat { ... } while ... 
-
-#  339| repeat { ... } while ... 
-#-----|  -> print(_:separator:terminator:)
-
-#  340| print(_:separator:terminator:)
-#-----|  -> x
-
-#  340| call to print(_:separator:terminator:)
-#-----|  -> .-=(_:_:)
-
-#  340| default separator
-#-----|  -> default terminator
-
-#  340| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  340| (Any) ...
-#-----|  -> [...]
-
-#  340| (Int) ...
-#-----|  -> (Any) ...
-
-#  340| [...]
-#-----|  -> [...]
-
-#  340| [...]
-#-----|  -> default separator
-
-#  340| x
-#-----|  -> (Int) ...
-
-#  341| &...
-#-----|  -> 1
-
-#  341| x
-#-----|  -> &...
-
-#  341| ... .-=(_:_:) ...
-#-----|  -> .>=(_:_:)
-
-#  341| .-=(_:_:)
-#-----|  -> Int.Type
-
-#  341| Int.Type
-#-----|  -> x
-
-#  341| 1
-#-----|  -> ... .-=(_:_:) ...
-
-#  342| (Int) ...
-#-----|  -> 0
-
-#  342| x
-#-----|  -> (Int) ...
-
-#  342| ... .>=(_:_:) ...
-#-----| false -> exit testRepeat(x:) (normal)
-#-----| true -> print(_:separator:terminator:)
-
-#  342| .>=(_:_:)
-#-----|  -> Int.Type
-
-#  342| Int.Type
-#-----|  -> x
-
-#  342| 0
-#-----|  -> ... .>=(_:_:) ...
-
-#  345| enter loop_with_identity_expr()
-#-----|  -> loop_with_identity_expr()
-
-#  345| exit loop_with_identity_expr()
-
-#  345| exit loop_with_identity_expr() (normal)
-#-----|  -> exit loop_with_identity_expr()
-
-#  345| loop_with_identity_expr()
-#-----|  -> x
-
-#  346| var ... = ...
-#-----|  -> while ... { ... }
-
-#  346| x
-#-----| match -> 0
-
-#  346| 0
-#-----|  -> var ... = ...
-
-#  347| while ... { ... }
-#-----|  -> StmtCondition
-
-#  347| StmtCondition
-#-----|  -> .<(_:_:)
-
-#  347| [false] (...)
-#-----| false -> exit loop_with_identity_expr() (normal)
-
-#  347| [true] (...)
-#-----| true -> .+=(_:_:)
-
-#  347| (Int) ...
-#-----|  -> 10
-
-#  347| x
-#-----|  -> (Int) ...
-
-#  347| ... .<(_:_:) ...
-#-----| false -> [false] (...)
-#-----| true -> [true] (...)
-
-#  347| .<(_:_:)
-#-----|  -> Int.Type
-
-#  347| Int.Type
-#-----|  -> x
-
-#  347| 10
-#-----|  -> ... .<(_:_:) ...
-
-#  348| &...
-#-----|  -> 1
-
-#  348| x
-#-----|  -> &...
-
-#  348| ... .+=(_:_:) ...
-#-----|  -> StmtCondition
-
-#  348| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  348| Int.Type
-#-----|  -> x
-
-#  348| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  352| OptionalC.deinit()
-#-----|  -> self
-
-#  352| enter OptionalC.deinit()
-#-----|  -> OptionalC.deinit()
-
-#  352| exit OptionalC.deinit()
-
-#  352| exit OptionalC.deinit() (normal)
-#-----|  -> exit OptionalC.deinit()
-
-#  352| self
-#-----|  -> { ... }
-
-#  352| { ... }
-#-----|  -> exit OptionalC.deinit() (normal)
-
-#  353| enter get
-#-----|  -> get
-
-#  353| exit get
-
-#  353| exit get (normal)
-#-----|  -> exit get
-
-#  353| get
-#-----|  -> self
-
-#  353| self
-#-----|  -> self
-
-#  354| self
-#-----|  -> arg
-
-#  354| OptionalC.init(arg:)
-#-----|  -> self
-
-#  354| enter OptionalC.init(arg:)
-#-----|  -> OptionalC.init(arg:)
-
-#  354| exit OptionalC.init(arg:)
-
-#  354| exit OptionalC.init(arg:) (normal)
-#-----|  -> exit OptionalC.init(arg:)
-
-#  354| arg
-#-----|  -> self
-
-#  355| .c
-#-----|  -> arg
-
-#  355| self
-#-----|  -> .c
-
-#  355|  ... = ...
-#-----|  -> return
-
-#  355| arg
-#-----|  ->  ... = ...
-
-#  356| return
-#-----| return -> exit OptionalC.init(arg:) (normal)
-
-#  358| enter getOptional()
-#-----|  -> getOptional()
-
-#  358| exit getOptional()
-
-#  358| exit getOptional() (normal)
-#-----|  -> exit getOptional()
-
-#  358| getOptional()
-#-----|  -> self
-
-#  358| self
-#-----|  -> self
-
-#  359| return ...
-#-----| return -> exit getOptional() (normal)
-
-#  359| getter for .c
-#-----|  -> return ...
-
-#  359| self
-#-----|  -> getter for .c
-
-#  363| enter testOptional(c:)
-#-----|  -> testOptional(c:)
-
-#  363| exit testOptional(c:)
-
-#  363| exit testOptional(c:) (normal)
-#-----|  -> exit testOptional(c:)
-
-#  363| testOptional(c:)
-#-----|  -> c
-
-#  363| c
-#-----|  -> .getMyInt()
-
-#  364| return ...
-#-----| return -> exit testOptional(c:) (normal)
-
-#  364| c
-#-----|  -> ...?
-
-#  364| ...?
-#-----|  -> call to getOptional()
-
-#  364| .getOptional()
-#-----|  -> c
-
-#  364| call to getOptional()
-#-----|  -> ...?
-
-#  364| ...?
-#-----|  -> call to getMyInt()
-
-#  364| .getMyInt()
-#-----|  -> .getOptional()
-
-#  364| (Int?) ...
-#-----|  -> OptionalEvaluationExpr
-
-#  364| OptionalEvaluationExpr
-#-----|  -> return ...
-
-#  364| call to getMyInt()
-#-----|  -> (Int?) ...
-
-#  367| enter testCapture(x:y:)
-#-----|  -> testCapture(x:y:)
-
-#  367| exit testCapture(x:y:)
-
-#  367| exit testCapture(x:y:) (normal)
-#-----|  -> exit testCapture(x:y:)
-
-#  367| testCapture(x:y:)
-#-----|  -> x
-
-#  367| x
-#-----|  -> y
-
-#  367| y
-#-----|  -> z
-
-#  368| return ...
-#-----| return -> exit testCapture(x:y:) (normal)
-
-#  368| enter { ... }
-#-----|  -> { ... }
-
-#  368| exit { ... }
-
-#  368| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  368| { ... }
-#-----|  -> z
-
-#  368| { ... }
-#-----|  -> return ...
-
-#  368| { ... }
-#-----|  -> { ... }
-
-#  368| z
-#-----| match -> .+(_:_:)
-
-#  368| var ... = ...
-#-----|  -> t
-
-#  368| x
-#-----|  -> y
-
-#  368| ... .+(_:_:) ...
-#-----|  -> var ... = ...
-
-#  368| .+(_:_:)
-#-----|  -> Int.Type
-
-#  368| Int.Type
-#-----|  -> x
-
-#  368| y
-#-----|  -> ... .+(_:_:) ...
-
-#  368| t
-#-----| match -> literal
-
-#  368| var ... = ...
-#-----|  -> { ... }
-
-#  368| literal
-#-----|  -> var ... = ...
-
-#  369| return ...
-#-----| return -> exit { ... } (normal)
-
-#  369| z
-#-----|  -> return ...
-
-#  373| enter testTupleElement(t:)
-#-----|  -> testTupleElement(t:)
-
-#  373| exit testTupleElement(t:)
-
-#  373| exit testTupleElement(t:) (normal)
-#-----|  -> exit testTupleElement(t:)
-
-#  373| testTupleElement(t:)
-#-----|  -> t
-
-#  373| t
-#-----|  -> .+(_:_:)
-
-#  374| return ...
-#-----| return -> exit testTupleElement(t:) (normal)
-
-#  374| t
-#-----|  -> .0
-
-#  374| .0
-#-----|  -> t
-
-#  374| ... .+(_:_:) ...
-#-----|  -> t
-
-#  374| ... .+(_:_:) ...
-#-----|  -> 1
-
-#  374| ... .+(_:_:) ...
-#-----|  -> return ...
-
-#  374| .+(_:_:)
-#-----|  -> Int.Type
-
-#  374| Int.Type
-#-----|  -> t
-
-#  374| t
-#-----|  -> .1
-
-#  374| .1
-#-----|  -> ... .+(_:_:) ...
-
-#  374| .+(_:_:)
-#-----|  -> Int.Type
-
-#  374| Int.Type
-#-----|  -> .+(_:_:)
-
-#  374| t
-#-----|  -> .2
-
-#  374| .2
-#-----|  -> ... .+(_:_:) ...
-
-#  374| .+(_:_:)
-#-----|  -> Int.Type
-
-#  374| Int.Type
-#-----|  -> .+(_:_:)
-
-#  374| (...)
-#-----|  -> .0
-
-#  374| .0
-#-----|  -> ... .+(_:_:) ...
-
-#  374| 1
-#-----|  -> 2
-
-#  374| 2
-#-----|  -> 3
-
-#  374| 3
-#-----|  -> (...)
-
-#  377| #...
-#-----|  -> #...
-
-#  377| #...
-#-----|  -> #...
-
-#  377| #...
-#-----|  -> #...
-
-#  377| #...
-#-----|  -> call to _unimplementedInitializer(className:initName:file:line:column:)
-
-#  377| Derived.deinit()
-#-----|  -> self
-
-#  377| _unimplementedInitializer(className:initName:file:line:column:)
-#-----|  -> cfg.Derived
-
-#  377| call to _unimplementedInitializer(className:initName:file:line:column:)
-#-----|  -> return
-
-#  377| cfg.Derived
-#-----|  -> #...
-
-#  377| enter Derived.deinit()
-#-----|  -> Derived.deinit()
-
-#  377| exit Derived.deinit()
-
-#  377| exit Derived.deinit() (normal)
-#-----|  -> exit Derived.deinit()
-
-#  377| self
-#-----|  -> { ... }
-
-#  377| { ... }
-#-----|  -> exit Derived.deinit() (normal)
-
-#  377| Derived.init(n:)
-#-----|  -> self
-
-#  377| enter Derived.init(n:)
-#-----|  -> Derived.init(n:)
-
-#  377| exit Derived.init(n:)
-
-#  377| exit Derived.init(n:) (normal)
-#-----|  -> exit Derived.init(n:)
-
-#  377| self
-#-----|  -> n
-
-#  378| self
-#-----|  -> C.init(n:)
-
-#  378| Derived.init()
-#-----|  -> self
-
-#  378| enter Derived.init()
-#-----|  -> Derived.init()
-
-#  378| exit Derived.init()
-
-#  378| exit Derived.init() (normal)
-#-----|  -> exit Derived.init()
-
-#  379| super
-#-----|  -> 0
-
-#  379| C.init(n:)
-#-----|  -> super
-
-#  379| call to C.init(n:)
-#-----|  -> self = ...
-
-#  379| self = ...
-#-----|  -> return
-
-#  379| 0
-#-----|  -> call to C.init(n:)
-
-#  380| return
-#-----| return -> exit Derived.init() (normal)
-
-#  383| doWithoutCatch(x:)
-#-----|  -> x
-
-#  383| enter doWithoutCatch(x:)
-#-----|  -> doWithoutCatch(x:)
-
-#  383| exit doWithoutCatch(x:)
-
-#  383| exit doWithoutCatch(x:) (abnormal)
-#-----|  -> exit doWithoutCatch(x:)
-
-#  383| exit doWithoutCatch(x:) (normal)
-#-----|  -> exit doWithoutCatch(x:)
-
-#  383| x
-#-----|  -> do { ... }
-
-#  384| do { ... }
-#-----|  -> mightThrow(x:)
-
-#  385| try ...
-#-----|  -> print(_:separator:terminator:)
-
-#  385| mightThrow(x:)
-#-----|  -> 0
-
-#  385| call to mightThrow(x:)
-#-----| exception -> exit doWithoutCatch(x:) (abnormal)
-#-----|  -> try ...
-
-#  385| 0
-#-----|  -> call to mightThrow(x:)
-
-#  386| print(_:separator:terminator:)
-#-----|  -> Did not throw.
-
-#  386| call to print(_:separator:terminator:)
-#-----|  -> mightThrow(x:)
-
-#  386| default separator
-#-----|  -> default terminator
-
-#  386| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  386| (Any) ...
-#-----|  -> [...]
-
-#  386| Did not throw.
-#-----|  -> (Any) ...
-
-#  386| [...]
-#-----|  -> [...]
-
-#  386| [...]
-#-----|  -> default separator
-
-#  387| try! ...
-#-----|  -> print(_:separator:terminator:)
-
-#  387| mightThrow(x:)
-#-----|  -> 0
-
-#  387| call to mightThrow(x:)
-#-----| exception -> exit doWithoutCatch(x:) (abnormal)
-#-----|  -> try! ...
-
-#  387| 0
-#-----|  -> call to mightThrow(x:)
-
-#  388| print(_:separator:terminator:)
-#-----|  -> Still did not throw.
-
-#  388| call to print(_:separator:terminator:)
-#-----|  -> 0
-
-#  388| default separator
-#-----|  -> default terminator
-
-#  388| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  388| (Any) ...
-#-----|  -> [...]
-
-#  388| Still did not throw.
-#-----|  -> (Any) ...
-
-#  388| [...]
-#-----|  -> [...]
-
-#  388| [...]
-#-----|  -> default separator
-
-#  390| return ...
-#-----| return -> exit doWithoutCatch(x:) (normal)
-
-#  390| 0
-#-----|  -> return ...
-
-#  394| _modify
-#-----|  -> self
-
-#  394| enter _modify
-#-----|  -> _modify
-
-#  394| enter get
-#-----|  -> get
-
-#  394| enter set
-#-----|  -> set
-
-#  394| exit _modify
-
-#  394| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  394| exit get
-
-#  394| exit get (normal)
-#-----|  -> exit get
-
-#  394| exit set
-
-#  394| exit set (normal)
-#-----|  -> exit set
-
-#  394| get
-#-----|  -> self
-
-#  394| self
-#-----|  -> self
-
-#  394| self
-#-----|  -> value
-
-#  394| self
-#-----|  -> self
-
-#  394| set
-#-----|  -> self
-
-#  394| value
-#-----|  -> self
-
-#  394| yield ...
-#-----|  -> exit _modify (normal)
-
-#  395| self
-#-----|  -> self
-
-#  395| Structors.init()
-#-----|  -> self
-
-#  395| enter Structors.init()
-#-----|  -> Structors.init()
-
-#  395| exit Structors.init()
-
-#  395| exit Structors.init() (normal)
-#-----|  -> exit Structors.init()
-
-#  396| .field
-#-----|  -> 10
-
-#  396| self
-#-----|  -> .field
-
-#  396|  ... = ...
-#-----|  -> return
-
-#  396| 10
-#-----|  ->  ... = ...
-
-#  397| return
-#-----| return -> exit Structors.init() (normal)
-
-#  399| self
-#-----|  -> self
-
-#  399| Structors.deinit()
-#-----|  -> self
-
-#  399| enter Structors.deinit()
-#-----|  -> Structors.deinit()
-
-#  399| exit Structors.deinit()
-
-#  399| exit Structors.deinit() (normal)
-#-----|  -> exit Structors.deinit()
-
-#  400| .field
-#-----|  -> 0
-
-#  400| self
-#-----|  -> .field
-
-#  400|  ... = ...
-#-----|  -> exit Structors.deinit() (normal)
-
-#  400| 0
-#-----|  ->  ... = ...
-
-#  404| dictionaryLiteral(x:y:)
-#-----|  -> x
-
-#  404| enter dictionaryLiteral(x:y:)
-#-----|  -> dictionaryLiteral(x:y:)
-
-#  404| exit dictionaryLiteral(x:y:)
-
-#  404| exit dictionaryLiteral(x:y:) (normal)
-#-----|  -> exit dictionaryLiteral(x:y:)
-
-#  404| x
-#-----|  -> y
-
-#  404| y
-#-----|  -> x
-
-#  405| return ...
-#-----| return -> exit dictionaryLiteral(x:y:) (normal)
-
-#  405| [...]
-#-----|  -> return ...
-
-#  405| x
-#-----|  -> x
-
-#  405| (...)
-#-----|  -> y
-
-#  405| x
-#-----|  -> (...)
-
-#  405| y
-#-----|  -> y
-
-#  405| (...)
-#-----|  -> [...]
-
-#  405| y
-#-----|  -> (...)
-
-#  408| enter localDeclarations()
-#-----|  -> localDeclarations()
-
-#  408| exit localDeclarations()
-
-#  408| exit localDeclarations() (normal)
-#-----|  -> exit localDeclarations()
-
-#  408| localDeclarations()
-#-----|  -> MyLocalClass
-
-#  409| MyLocalClass
-#-----|  -> MyLocalStruct
-
-#  409| MyLocalClass.deinit()
-#-----|  -> self
-
-#  409| enter MyLocalClass.deinit()
-#-----|  -> MyLocalClass.deinit()
-
-#  409| exit MyLocalClass.deinit()
-
-#  409| exit MyLocalClass.deinit() (normal)
-#-----|  -> exit MyLocalClass.deinit()
-
-#  409| self
-#-----|  -> { ... }
-
-#  409| { ... }
-#-----|  -> exit MyLocalClass.deinit() (normal)
-
-#  410| _modify
-#-----|  -> self
-
-#  410| enter _modify
-#-----|  -> _modify
-
-#  410| enter get
-#-----|  -> get
-
-#  410| enter set
-#-----|  -> set
-
-#  410| exit _modify
-
-#  410| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  410| exit get
-
-#  410| exit get (normal)
-#-----|  -> exit get
-
-#  410| exit set
-
-#  410| exit set (normal)
-#-----|  -> exit set
-
-#  410| get
-#-----|  -> self
-
-#  410| self
-#-----|  -> self
-
-#  410| self
-#-----|  -> value
-
-#  410| self
-#-----|  -> self
-
-#  410| set
-#-----|  -> self
-
-#  410| value
-#-----|  -> self
-
-#  410| yield ...
-#-----|  -> exit _modify (normal)
-
-#  411| self
-#-----|  -> self
-
-#  411| MyLocalClass.init()
-#-----|  -> self
-
-#  411| enter MyLocalClass.init()
-#-----|  -> MyLocalClass.init()
-
-#  411| exit MyLocalClass.init()
-
-#  411| exit MyLocalClass.init() (normal)
-#-----|  -> exit MyLocalClass.init()
-
-#  412| .x
-#-----|  -> 10
-
-#  412| self
-#-----|  -> .x
-
-#  412|  ... = ...
-#-----|  -> return
-
-#  412| 10
-#-----|  ->  ... = ...
-
-#  413| return
-#-----| return -> exit MyLocalClass.init() (normal)
-
-#  416| MyLocalStruct
-#-----|  -> MyLocalEnum
-
-#  417| _modify
-#-----|  -> self
-
-#  417| enter _modify
-#-----|  -> _modify
-
-#  417| enter get
-#-----|  -> get
-
-#  417| enter set
-#-----|  -> set
-
-#  417| exit _modify
-
-#  417| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  417| exit get
-
-#  417| exit get (normal)
-#-----|  -> exit get
-
-#  417| exit set
-
-#  417| exit set (normal)
-#-----|  -> exit set
-
-#  417| get
-#-----|  -> self
-
-#  417| self
-#-----|  -> self
-
-#  417| self
-#-----|  -> value
-
-#  417| self
-#-----|  -> self
-
-#  417| set
-#-----|  -> self
-
-#  417| value
-#-----|  -> self
-
-#  417| yield ...
-#-----|  -> exit _modify (normal)
-
-#  418| self
-#-----|  -> self
-
-#  418| MyLocalStruct.init()
-#-----|  -> self
-
-#  418| enter MyLocalStruct.init()
-#-----|  -> MyLocalStruct.init()
-
-#  418| exit MyLocalStruct.init()
-
-#  418| exit MyLocalStruct.init() (normal)
-#-----|  -> exit MyLocalStruct.init()
-
-#  419| .x
-#-----|  -> 10
-
-#  419| self
-#-----|  -> .x
-
-#  419|  ... = ...
-#-----|  -> return
-
-#  419| 10
-#-----|  ->  ... = ...
-
-#  420| return
-#-----| return -> exit MyLocalStruct.init() (normal)
-
-#  423| MyLocalEnum
-#-----|  -> myLocalVar
-
-#  428| var ... = ...
-#-----|  -> 0
-
-#  428| myLocalVar
-#-----| match -> ... as ...
-
-#  428| ... as ...
-#-----| match -> var ... = ...
-
-#  442| return ...
-#-----| return -> exit localDeclarations() (normal)
-
-#  442| 0
-#-----|  -> return ...
-
-#  446| _modify
-#-----|  -> self
-
-#  446| enter _modify
-#-----|  -> _modify
-
-#  446| enter get
-#-----|  -> get
-
-#  446| enter set
-#-----|  -> set
-
-#  446| exit _modify
-
-#  446| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  446| exit get
-
-#  446| exit get (normal)
-#-----|  -> exit get
-
-#  446| exit set
-
-#  446| exit set (normal)
-#-----|  -> exit set
-
-#  446| get
-#-----|  -> self
-
-#  446| self
-#-----|  -> self
-
-#  446| self
-#-----|  -> value
-
-#  446| self
-#-----|  -> self
-
-#  446| set
-#-----|  -> self
-
-#  446| value
-#-----|  -> self
-
-#  446| yield ...
-#-----|  -> exit _modify (normal)
-
-#  450| _modify
-#-----|  -> self
-
-#  450| enter _modify
-#-----|  -> _modify
-
-#  450| enter get
-#-----|  -> get
-
-#  450| enter set
-#-----|  -> set
-
-#  450| exit _modify
-
-#  450| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  450| exit get
-
-#  450| exit get (normal)
-#-----|  -> exit get
-
-#  450| exit set
-
-#  450| exit set (normal)
-#-----|  -> exit set
-
-#  450| get
-#-----|  -> self
-
-#  450| self
-#-----|  -> self
-
-#  450| self
-#-----|  -> value
-
-#  450| self
-#-----|  -> self
-
-#  450| set
-#-----|  -> self
-
-#  450| value
-#-----|  -> self
-
-#  450| yield ...
-#-----|  -> exit _modify (normal)
-
-#  451| _modify
-#-----|  -> self
-
-#  451| enter _modify
-#-----|  -> _modify
-
-#  451| enter get
-#-----|  -> get
-
-#  451| enter set
-#-----|  -> set
-
-#  451| exit _modify
-
-#  451| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  451| exit get
-
-#  451| exit get (normal)
-#-----|  -> exit get
-
-#  451| exit set
-
-#  451| exit set (normal)
-#-----|  -> exit set
-
-#  451| get
-#-----|  -> self
-
-#  451| self
-#-----|  -> self
-
-#  451| self
-#-----|  -> value
-
-#  451| self
-#-----|  -> self
-
-#  451| set
-#-----|  -> self
-
-#  451| value
-#-----|  -> self
-
-#  451| yield ...
-#-----|  -> exit _modify (normal)
-
-#  452| _modify
-#-----|  -> self
-
-#  452| enter _modify
-#-----|  -> _modify
-
-#  452| enter get
-#-----|  -> get
-
-#  452| enter set
-#-----|  -> set
-
-#  452| exit _modify
-
-#  452| exit _modify (normal)
-#-----|  -> exit _modify
-
-#  452| exit get
-
-#  452| exit get (normal)
-#-----|  -> exit get
-
-#  452| exit set
-
-#  452| exit set (normal)
-#-----|  -> exit set
-
-#  452| get
-#-----|  -> self
-
-#  452| self
-#-----|  -> self
-
-#  452| self
-#-----|  -> value
-
-#  452| self
-#-----|  -> self
-
-#  452| set
-#-----|  -> self
-
-#  452| value
-#-----|  -> self
-
-#  452| yield ...
-#-----|  -> exit _modify (normal)
-
-#  455| enter test(a:)
-#-----|  -> test(a:)
-
-#  455| exit test(a:)
-
-#  455| exit test(a:) (normal)
-#-----|  -> exit test(a:)
-
-#  455| test(a:)
-#-----|  -> a
-
-#  455| a
-#-----|  -> kpGet_b_x
-
-#  456| var ... = ...
-#-----|  -> kpGet_bs_0_x
-
-#  456| kpGet_b_x
-#-----| match -> #keyPath(...)
-
-#  456| #keyPath(...)
-#-----|  -> exit #keyPath(...) (normal)
-
-#  456| #keyPath(...)
-#-----|  -> var ... = ...
-
-#  456| enter #keyPath(...)
-#-----|  -> KeyPathComponent
-
-#  456| exit #keyPath(...)
-
-#  456| exit #keyPath(...) (normal)
-#-----|  -> exit #keyPath(...)
-
-#  456| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  456| KeyPathComponent
-#-----|  -> #keyPath(...)
-
-#  457| var ... = ...
-#-----|  -> kpGet_mayB_force_x
-
-#  457| kpGet_bs_0_x
-#-----| match -> #keyPath(...)
-
-#  457| #keyPath(...)
-#-----|  -> exit #keyPath(...) (normal)
-
-#  457| #keyPath(...)
-#-----|  -> var ... = ...
-
-#  457| enter #keyPath(...)
-#-----|  -> KeyPathComponent
-
-#  457| exit #keyPath(...)
-
-#  457| exit #keyPath(...) (normal)
-#-----|  -> exit #keyPath(...)
-
-#  457| KeyPathComponent
-#-----|  -> 0
-
-#  457| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  457| 0
-#-----|  -> KeyPathComponent
-
-#  457| KeyPathComponent
-#-----|  -> #keyPath(...)
-
-#  458| var ... = ...
-#-----|  -> kpGet_mayB_x
-
-#  458| kpGet_mayB_force_x
-#-----| match -> #keyPath(...)
-
-#  458| #keyPath(...)
-#-----|  -> exit #keyPath(...) (normal)
-
-#  458| #keyPath(...)
-#-----|  -> var ... = ...
-
-#  458| enter #keyPath(...)
-#-----|  -> KeyPathComponent
-
-#  458| exit #keyPath(...)
-
-#  458| exit #keyPath(...) (normal)
-#-----|  -> exit #keyPath(...)
-
-#  458| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  458| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  458| KeyPathComponent
-#-----|  -> #keyPath(...)
-
-#  459| var ... = ...
-#-----|  -> apply_kpGet_b_x
-
-#  459| kpGet_mayB_x
-#-----| match -> #keyPath(...)
-
-#  459| #keyPath(...)
-#-----|  -> exit #keyPath(...) (normal)
-
-#  459| #keyPath(...)
-#-----|  -> var ... = ...
-
-#  459| enter #keyPath(...)
-#-----|  -> KeyPathComponent
-
-#  459| exit #keyPath(...)
-
-#  459| exit #keyPath(...) (normal)
-#-----|  -> exit #keyPath(...)
-
-#  459| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  459| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  459| KeyPathComponent
-#-----|  -> KeyPathComponent
-
-#  461| var ... = ...
-#-----|  -> apply_kpGet_bs_0_x
-
-#  461| apply_kpGet_b_x
-#-----| match -> a
-
-#  461| a
-#-----|  -> kpGet_b_x
-
-#  461| \...[...]
-#-----|  -> var ... = ...
-
-#  461| (WritableKeyPath<A, Int>) ...
-#-----|  -> \...[...]
-
-#  461| kpGet_b_x
-#-----|  -> (WritableKeyPath<A, Int>) ...
-
-#  462| var ... = ...
-#-----|  -> apply_kpGet_mayB_force_x
-
-#  462| apply_kpGet_bs_0_x
-#-----| match -> a
-
-#  462| a
-#-----|  -> kpGet_bs_0_x
-
-#  462| \...[...]
-#-----|  -> var ... = ...
-
-#  462| (WritableKeyPath<A, Int>) ...
-#-----|  -> \...[...]
-
-#  462| kpGet_bs_0_x
-#-----|  -> (WritableKeyPath<A, Int>) ...
-
-#  463| var ... = ...
-#-----|  -> apply_kpGet_mayB_x
-
-#  463| apply_kpGet_mayB_force_x
-#-----| match -> a
-
-#  463| a
-#-----|  -> kpGet_mayB_force_x
-
-#  463| \...[...]
-#-----|  -> var ... = ...
-
-#  463| (WritableKeyPath<A, Int>) ...
-#-----|  -> \...[...]
-
-#  463| kpGet_mayB_force_x
-#-----|  -> (WritableKeyPath<A, Int>) ...
-
-#  464| var ... = ...
-#-----|  -> exit test(a:) (normal)
-
-#  464| apply_kpGet_mayB_x
-#-----| match -> a
-
-#  464| a
-#-----|  -> kpGet_mayB_x
-
-#  464| \...[...]
-#-----|  -> var ... = ...
-
-#  464| (KeyPath<A, Int?>) ...
-#-----|  -> \...[...]
-
-#  464| kpGet_mayB_x
-#-----|  -> (KeyPath<A, Int?>) ...
-
-#  467| enter testIfConfig()
-#-----|  -> testIfConfig()
-
-#  467| exit testIfConfig()
-
-#  467| exit testIfConfig() (normal)
-#-----|  -> exit testIfConfig()
-
-#  467| testIfConfig()
-#-----|  -> #if ...
-
-#  468| #if ...
-#-----|  -> 3
-
-#  472| 3
-#-----|  -> 4
-
-#  473| 4
-#-----|  -> 5
-
-#  476| 5
-#-----|  -> #if ...
-
-#  478| #if ...
-#-----|  -> 8
-
-#  483| 8
-#-----|  -> #if ...
-
-#  485| #if ...
-#-----|  -> 11
-
-#  489| 11
-#-----|  -> 12
-
-#  490| 12
-#-----|  -> 13
-
-#  493| 13
-#-----|  -> exit testIfConfig() (normal)
-
-#  496| enter testAvailable()
-#-----|  -> testAvailable()
-
-#  496| exit testAvailable()
-
-#  496| exit testAvailable() (normal)
-#-----|  -> exit testAvailable()
-
-#  496| testAvailable()
-#-----|  -> x
-
-#  497| var ... = ...
-#-----|  -> if ... then { ... }
-
-#  497| x
-#-----| match -> 0
-
-#  497| 0
-#-----|  -> var ... = ...
-
-#  499| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  499| #available
-#-----| true -> .+=(_:_:)
-#-----| false -> if ... then { ... }
-
-#  499| StmtCondition
-#-----|  -> macOS 10
-
-#  499| macOS 10
-#-----|  -> *
-
-#  499| *
-#-----|  -> #available
-
-#  500| &...
-#-----|  -> 1
-
-#  500| x
-#-----|  -> &...
-
-#  500| ... .+=(_:_:) ...
-#-----|  -> if ... then { ... }
-
-#  500| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  500| Int.Type
-#-----|  -> x
-
-#  500| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  503| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  503| #available
-#-----| true -> .+=(_:_:)
-#-----| false -> if ... then { ... }
-
-#  503| StmtCondition
-#-----|  -> macOS 10.13
-
-#  503| macOS 10.13
-#-----|  -> *
-
-#  503| *
-#-----|  -> #available
-
-#  504| &...
-#-----|  -> 1
-
-#  504| x
-#-----|  -> &...
-
-#  504| ... .+=(_:_:) ...
-#-----|  -> if ... then { ... }
-
-#  504| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  504| Int.Type
-#-----|  -> x
-
-#  504| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  507| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  507| #unavailable
-#-----| true -> .+=(_:_:)
-#-----| false -> guard ... else { ... }
-
-#  507| StmtCondition
-#-----|  -> iOS 10
-
-#  507| iOS 10
-#-----|  -> watchOS 10
-
-#  507| watchOS 10
-#-----|  -> macOS 10
-
-#  507| macOS 10
-#-----|  -> #unavailable
-
-#  508| &...
-#-----|  -> 1
-
-#  508| x
-#-----|  -> &...
-
-#  508| ... .+=(_:_:) ...
-#-----|  -> guard ... else { ... }
-
-#  508| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  508| Int.Type
-#-----|  -> x
-
-#  508| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  511| guard ... else { ... }
-#-----|  -> StmtCondition
-
-#  511| #available
-#-----| false -> .+=(_:_:)
-#-----| true -> if ... then { ... }
-
-#  511| StmtCondition
-#-----|  -> macOS 12
-
-#  511| macOS 12
-#-----|  -> *
-
-#  511| *
-#-----|  -> #available
-
-#  512| &...
-#-----|  -> 1
-
-#  512| x
-#-----|  -> &...
-
-#  512| ... .+=(_:_:) ...
-#-----|  -> if ... then { ... }
-
-#  512| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  512| Int.Type
-#-----|  -> x
-
-#  512| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  515| if ... then { ... }
-#-----|  -> StmtCondition
-
-#  515| #available
-#-----| false, true -> iOS 12
-#-----| false -> x
-
-#  515| StmtCondition
-#-----|  -> macOS 12
-
-#  515| macOS 12
-#-----|  -> *
-
-#  515| *
-#-----|  -> #available
-
-#  515| #available
-#-----| true -> .+=(_:_:)
-#-----| false -> x
-
-#  515| iOS 12
-#-----|  -> *
-
-#  515| *
-#-----|  -> #available
-
-#  516| &...
-#-----|  -> 1
-
-#  516| x
-#-----|  -> &...
-
-#  516| ... .+=(_:_:) ...
-#-----|  -> x
-
-#  516| .+=(_:_:)
-#-----|  -> Int.Type
-
-#  516| Int.Type
-#-----|  -> x
-
-#  516| 1
-#-----|  -> ... .+=(_:_:) ...
-
-#  519| return ...
-#-----| return -> exit testAvailable() (normal)
-
-#  519| (Int) ...
-#-----|  -> return ...
-
-#  519| x
-#-----|  -> (Int) ...
-
-#  522| enter testAsyncFor()
-#-----|  -> testAsyncFor()
-
-#  522| exit testAsyncFor()
-
-#  522| exit testAsyncFor() (normal)
-#-----|  -> exit testAsyncFor()
-
-#  522| testAsyncFor()
-#-----|  -> stream
-
-#  523| var ... = ...
-#-----|  -> $i$generator
-
-#  523| stream
-#-----| match -> AsyncStream<Element>.init(_:bufferingPolicy:_:)
-
-#  523| AsyncStream<Element>.init(_:bufferingPolicy:_:)
-#-----|  -> AsyncStream<Int>.Type
-
-#  523| AsyncStream<Int>.Type
-#-----|  -> Int.Type
-
-#  523| call to AsyncStream<Element>.init(_:bufferingPolicy:_:)
-#-----|  -> var ... = ...
-
-#  523| Int.Type
-#-----|  -> .self
-
-#  523| .self
-#-----|  -> .bufferingNewest
-
-#  523| AsyncStream<Int>.Continuation.BufferingPolicy.Type
-#-----|  -> 5
-
-#  523| .bufferingNewest
-#-----|  -> AsyncStream<Int>.Continuation.BufferingPolicy.Type
-
-#  523| call to ...
-#-----|  -> { ... }
-
-#  523| 5
-#-----|  -> call to ...
-
-#  523| enter { ... }
-#-----|  -> { ... }
-
-#  523| exit { ... }
-
-#  523| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  523| { ... }
-#-----|  -> continuation
-
-#  523| { ... }
-#-----|  -> call to AsyncStream<Element>.init(_:bufferingPolicy:_:)
-
-#  524| continuation
-#-----|  -> .detached(priority:operation:)
-
-#  525| Task<(), Never>.Type
-#-----|  -> default priority
-
-#  525| .detached(priority:operation:)
-#-----|  -> Task<(), Never>.Type
-
-#  525| call to detached(priority:operation:)
-#-----|  -> exit { ... } (normal)
-
-#  525| default priority
-#-----|  -> { ... }
-
-#  525| enter { ... }
-#-----|  -> { ... }
-
-#  525| exit { ... }
-
-#  525| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  525| { ... }
-#-----|  -> $i$generator
-
-#  525| { ... }
-#-----|  -> call to detached(priority:operation:)
-
-#  526| $i$generator
-#-----|  -> &...
-
-#  526| &...
-#-----|  -> call to next()
-
-#  526| .next()
-#-----|  -> $i$generator
-
-#  526| call to next()
-#-----|  -> for ... in ... { ... }
-
-#  526| for ... in ... { ... }
-#-----| non-empty -> i
-#-----| empty -> .finish()
-
-#  526| i
-#-----| match -> .yield(_:)
-
-#  526| $i$generator
-#-----| match -> .makeIterator()
-
-#  526| 1
-#-----|  -> 100
-
-#  526| ... ....(_:_:) ...
-#-----|  -> call to makeIterator()
-
-#  526| .makeIterator()
-#-----|  -> ....(_:_:)
-
-#  526| call to makeIterator()
-#-----|  -> var ... = ...
-
-#  526| ....(_:_:)
-#-----|  -> Int.Type
-
-#  526| Int.Type
-#-----|  -> 1
-
-#  526| 100
-#-----|  -> ... ....(_:_:) ...
-
-#  527| continuation
-#-----|  -> i
-
-#  527| .yield(_:)
-#-----|  -> continuation
-
-#  527| call to yield(_:)
-#-----|  -> .next()
-
-#  527| i
-#-----|  -> call to yield(_:)
-
-#  529| continuation
-#-----|  -> call to finish()
-
-#  529| .finish()
-#-----|  -> continuation
-
-#  529| call to finish()
-#-----|  -> exit { ... } (normal)
-
-#  533| $i$generator
-#-----|  -> &...
-
-#  533| &...
-#-----|  -> call to next()
-
-#  533| .next()
-#-----|  -> $i$generator
-
-#  533| call to next()
-#-----|  -> await ...
-
-#  533| for ... in ... { ... }
-#-----| empty -> exit testAsyncFor() (normal)
-#-----| non-empty -> i
-
-#  533| i
-#-----| match -> print(_:separator:terminator:)
-
-#  533| $i$generator
-#-----| match -> .makeAsyncIterator()
-
-#  533| (AsyncStream<Int>) ...
-#-----|  -> call to makeAsyncIterator()
-
-#  533| .makeAsyncIterator()
-#-----|  -> stream
-
-#  533| call to makeAsyncIterator()
-#-----|  -> var ... = ...
-
-#  533| stream
-#-----|  -> (AsyncStream<Int>) ...
-
-#  534| print(_:separator:terminator:)
-#-----|  -> i
-
-#  534| call to print(_:separator:terminator:)
-#-----|  -> .next()
-
-#  534| default separator
-#-----|  -> default terminator
-
-#  534| default terminator
-#-----|  -> call to print(_:separator:terminator:)
-
-#  534| (Any) ...
-#-----|  -> [...]
-
-#  534| [...]
-#-----|  -> [...]
-
-#  534| [...]
-#-----|  -> default separator
-
-#  534| i
-#-----|  -> (Any) ...
-
-#  538| enter testNilCoalescing(x:)
-#-----|  -> testNilCoalescing(x:)
-
-#  538| exit testNilCoalescing(x:)
-
-#  538| exit testNilCoalescing(x:) (abnormal)
-#-----|  -> exit testNilCoalescing(x:)
-
-#  538| exit testNilCoalescing(x:) (normal)
-#-----|  -> exit testNilCoalescing(x:)
-
-#  538| testNilCoalescing(x:)
-#-----|  -> x
-
-#  538| x
-#-----|  -> x
-
-#  539| return ...
-#-----| return -> exit testNilCoalescing(x:) (normal)
-
-#  539| x
-#-----|  -> emptiness test for ... ??(_:_:) ...
-
-#  539| ... ??(_:_:) ...
-#-----| exception -> exit testNilCoalescing(x:) (abnormal)
-#-----|  -> return ...
-
-#  539| emptiness test for ... ??(_:_:) ...
-#-----| non-empty -> ... ??(_:_:) ...
-#-----| empty -> { ... }
-
-#  539| 0
-#-----|  -> return ...
-
-#  539| return ...
-#-----|  -> ... ??(_:_:) ...
-
-#  539| { ... }
-#-----|  -> 0
-
-#  542| enter testNilCoalescing2(x:)
-#-----|  -> testNilCoalescing2(x:)
-
-#  542| exit testNilCoalescing2(x:)
-
-#  542| exit testNilCoalescing2(x:) (abnormal)
-#-----|  -> exit testNilCoalescing2(x:)
-
-#  542| exit testNilCoalescing2(x:) (normal)
-#-----|  -> exit testNilCoalescing2(x:)
-
-#  542| testNilCoalescing2(x:)
-#-----|  -> x
-
-#  542| x
-#-----|  -> if ... then { ... } else { ... }
-
-#  543| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  543| x
-#-----|  -> emptiness test for ... ??(_:_:) ...
-
-#  543| ... ??(_:_:) ...
-#-----| exception -> exit testNilCoalescing2(x:) (abnormal)
-#-----| true -> 1
-#-----| false -> 0
-
-#  543| StmtCondition
-#-----|  -> x
-
-#  543| emptiness test for ... ??(_:_:) ...
-#-----| non-empty -> ... ??(_:_:) ...
-#-----| empty -> { ... }
-
-#  543| false
-#-----|  -> return ...
-
-#  543| return ...
-#-----|  -> ... ??(_:_:) ...
-
-#  543| { ... }
-#-----|  -> false
-
-#  544| return ...
-#-----| return -> exit testNilCoalescing2(x:) (normal)
-
-#  544| 1
-#-----|  -> return ...
-
-#  546| return ...
-#-----| return -> exit testNilCoalescing2(x:) (normal)
-
-#  546| 0
-#-----|  -> return ...
-
-#  550| enter usesAutoclosure(_:)
-#-----|  -> usesAutoclosure(_:)
-
-#  550| exit usesAutoclosure(_:)
-
-#  550| exit usesAutoclosure(_:) (normal)
-#-----|  -> exit usesAutoclosure(_:)
-
-#  550| usesAutoclosure(_:)
-#-----|  -> expr
-
-#  550| expr
-#-----|  -> expr
-
-#  551| return ...
-#-----| return -> exit usesAutoclosure(_:) (normal)
-
-#  551| expr
-#-----|  -> call to ...
-
-#  551| call to ...
-#-----|  -> return ...
-
-#  554| autoclosureTest()
-#-----|  -> usesAutoclosure(_:)
-
-#  554| enter autoclosureTest()
-#-----|  -> autoclosureTest()
-
-#  554| exit autoclosureTest()
-
-#  554| exit autoclosureTest() (normal)
-#-----|  -> exit autoclosureTest()
-
-#  555| usesAutoclosure(_:)
-#-----|  -> { ... }
-
-#  555| call to usesAutoclosure(_:)
-#-----|  -> exit autoclosureTest() (normal)
-
-#  555| 1
-#-----|  -> return ...
-
-#  555| enter { ... }
-#-----|  -> { ... }
-
-#  555| exit { ... }
-
-#  555| exit { ... } (normal)
-#-----|  -> exit { ... }
-
-#  555| return ...
-#-----|  -> exit { ... } (normal)
-
-#  555| { ... }
-#-----|  -> 1
-
-#  555| { ... }
-#-----|  -> call to usesAutoclosure(_:)
-
-#  564| MyProcotolImpl.deinit()
-#-----|  -> self
-
-#  564| MyProcotolImpl.init()
-#-----|  -> self
-
-#  564| enter MyProcotolImpl.deinit()
-#-----|  -> MyProcotolImpl.deinit()
-
-#  564| enter MyProcotolImpl.init()
-#-----|  -> MyProcotolImpl.init()
-
-#  564| exit MyProcotolImpl.deinit()
-
-#  564| exit MyProcotolImpl.deinit() (normal)
-#-----|  -> exit MyProcotolImpl.deinit()
-
-#  564| exit MyProcotolImpl.init()
-
-#  564| exit MyProcotolImpl.init() (normal)
-#-----|  -> exit MyProcotolImpl.init()
-
-#  564| return
-#-----| return -> exit MyProcotolImpl.init() (normal)
-
-#  564| self
-#-----|  -> { ... }
-
-#  564| self
-#-----|  -> return
-
-#  564| { ... }
-#-----|  -> exit MyProcotolImpl.deinit() (normal)
-
-#  565| enter source()
-#-----|  -> source()
-
-#  565| exit source()
-
-#  565| exit source() (normal)
-#-----|  -> exit source()
-
-#  565| source()
-#-----|  -> self
-
-#  565| self
-#-----|  -> 0
-
-#  565| return ...
-#-----| return -> exit source() (normal)
-
-#  565| 0
-#-----|  -> return ...
-
-#  568| enter getMyProtocol()
-#-----|  -> getMyProtocol()
-
-#  568| exit getMyProtocol()
-
-#  568| exit getMyProtocol() (normal)
-#-----|  -> exit getMyProtocol()
-
-#  568| getMyProtocol()
-#-----|  -> MyProcotolImpl.init()
-
-#  568| return ...
-#-----| return -> exit getMyProtocol() (normal)
-
-#  568| MyProcotolImpl.Type
-#-----|  -> call to MyProcotolImpl.init()
-
-#  568| MyProcotolImpl.init()
-#-----|  -> MyProcotolImpl.Type
-
-#  568| (any MyProtocol) ...
-#-----|  -> return ...
-
-#  568| call to MyProcotolImpl.init()
-#-----|  -> (any MyProtocol) ...
-
-#  569| enter getMyProtocolImpl()
-#-----|  -> getMyProtocolImpl()
-
-#  569| exit getMyProtocolImpl()
-
-#  569| exit getMyProtocolImpl() (normal)
-#-----|  -> exit getMyProtocolImpl()
-
-#  569| getMyProtocolImpl()
-#-----|  -> MyProcotolImpl.init()
-
-#  569| return ...
-#-----| return -> exit getMyProtocolImpl() (normal)
-
-#  569| MyProcotolImpl.Type
-#-----|  -> call to MyProcotolImpl.init()
-
-#  569| MyProcotolImpl.init()
-#-----|  -> MyProcotolImpl.Type
-
-#  569| call to MyProcotolImpl.init()
-#-----|  -> return ...
-
-#  571| enter sink(arg:)
-#-----|  -> sink(arg:)
-
-#  571| exit sink(arg:)
-
-#  571| exit sink(arg:) (normal)
-#-----|  -> exit sink(arg:)
-
-#  571| sink(arg:)
-#-----|  -> arg
-
-#  571| arg
-#-----|  -> { ... }
-
-#  571| { ... }
-#-----|  -> exit sink(arg:) (normal)
-
-#  573| enter testOpenExistentialExpr(x:y:)
-#-----|  -> testOpenExistentialExpr(x:y:)
-
-#  573| exit testOpenExistentialExpr(x:y:)
-
-#  573| exit testOpenExistentialExpr(x:y:) (normal)
-#-----|  -> exit testOpenExistentialExpr(x:y:)
-
-#  573| testOpenExistentialExpr(x:y:)
-#-----|  -> x
-
-#  573| x
-#-----|  -> y
-
-#  573| y
-#-----|  -> sink(arg:)
-
-#  574| sink(arg:)
-#-----|  -> x
-
-#  574| call to sink(arg:)
-#-----|  -> sink(arg:)
-
-#  574| OpaqueValueExpr
-#-----|  -> call to source()
-
-#  574| x
-#-----|  -> .source()
-
-#  574| .source()
-#-----|  -> OpaqueValueExpr
-
-#  574| OpenExistentialExpr
-#-----|  -> call to sink(arg:)
-
-#  574| call to source()
-#-----|  -> OpenExistentialExpr
-
-#  575| sink(arg:)
-#-----|  -> .source()
-
-#  575| call to sink(arg:)
-#-----|  -> sink(arg:)
-
-#  575| y
-#-----|  -> call to source()
-
-#  575| .source()
-#-----|  -> y
-
-#  575| call to source()
-#-----|  -> call to sink(arg:)
-
-#  576| sink(arg:)
-#-----|  -> getMyProtocol()
-
-#  576| call to sink(arg:)
-#-----|  -> sink(arg:)
-
-#  576| getMyProtocol()
-#-----|  -> call to getMyProtocol()
-
-#  576| OpaqueValueExpr
-#-----|  -> call to source()
-
-#  576| call to getMyProtocol()
-#-----|  -> .source()
-
-#  576| .source()
-#-----|  -> OpaqueValueExpr
-
-#  576| OpenExistentialExpr
-#-----|  -> call to sink(arg:)
-
-#  576| call to source()
-#-----|  -> OpenExistentialExpr
-
-#  577| sink(arg:)
-#-----|  -> .source()
-
-#  577| call to sink(arg:)
-#-----|  -> exit testOpenExistentialExpr(x:y:) (normal)
-
-#  577| getMyProtocolImpl()
-#-----|  -> call to getMyProtocolImpl()
-
-#  577| call to getMyProtocolImpl()
-#-----|  -> call to source()
-
-#  577| .source()
-#-----|  -> getMyProtocolImpl()
-
-#  577| call to source()
-#-----|  -> call to sink(arg:)
-
-#  580| enter singleStmtExpr(_:)
-#-----|  -> singleStmtExpr(_:)
-
-#  580| exit singleStmtExpr(_:)
-
-#  580| exit singleStmtExpr(_:) (normal)
-#-----|  -> exit singleStmtExpr(_:)
-
-#  580| singleStmtExpr(_:)
-#-----|  -> x
-
-#  580| x
-#-----|  -> a
-
-#  581| var ... = ...
-#-----|  -> b
-
-#  581| a
-#-----| match -> switch x { ... }
-
-#  581| SingleValueStmtExpr
-#-----|  -> var ... = ...
-
-#  581| switch x { ... }
-#-----|  -> x
-
-#  581| x
-#-----|  -> case ...
-
-#  582| case ...
-#-----|  -> =~ ...
-
-#  582| .~=(_:_:)
-#-----|  -> Range<Int>.Type
-
-#  582| 0
-#-----|  -> 5
-
-#  582| Range<Int>.Type
-#-----|  -> ...<(_:_:)
-
-#  582| ... ...<(_:_:) ...
-#-----|  -> $match
-
-#  582| ... .~=(_:_:) ...
-#-----|  -> =~ ...
-
-#  582| =~ ...
-#-----|  -> .~=(_:_:)
-
-#  582| =~ ...
-#-----| match -> 1
-#-----| no-match -> case ...
-
-#  582| ...<(_:_:)
-#-----|  -> Int.Type
-
-#  582| Int.Type
-#-----|  -> 0
-
-#  582| $match
-#-----|  -> ... .~=(_:_:) ...
-
-#  582| 5
-#-----|  -> ... ...<(_:_:) ...
-
-#  582| 1
-#-----|  -> ThenStmt
-
-#  582| ThenStmt
-#-----|  -> SingleValueStmtExpr
-
-#  583| _
-#-----| match -> 2
-
-#  583| _
-#-----|  -> _
-
-#  583| case ...
-#-----|  -> _
-
-#  583| 2
-#-----|  -> ThenStmt
-
-#  583| ThenStmt
-#-----|  -> SingleValueStmtExpr
-
-#  585| var ... = ...
-#-----|  -> exit singleStmtExpr(_:) (normal)
-
-#  585| b
-#-----| match -> if ... then { ... } else { ... }
-
-#  585| SingleValueStmtExpr
-#-----|  -> var ... = ...
-
-#  585| if ... then { ... } else { ... }
-#-----|  -> StmtCondition
-
-#  585| StmtCondition
-#-----|  -> .<(_:_:)
-
-#  585| [false] (...)
-#-----| false -> 2
-
-#  585| [true] (...)
-#-----| true -> 1
-
-#  585| x
-#-----|  -> 42
-
-#  585| ... .<(_:_:) ...
-#-----| false -> [false] (...)
-#-----| true -> [true] (...)
-
-#  585| .<(_:_:)
-#-----|  -> Int.Type
-
-#  585| Int.Type
-#-----|  -> x
-
-#  585| 42
-#-----|  -> ... .<(_:_:) ...
-
-#  585| 1
-#-----|  -> ThenStmt
-
-#  585| ThenStmt
-#-----|  -> SingleValueStmtExpr
-
-#  585| 2
-#-----|  -> ThenStmt
-
-#  585| ThenStmt
-#-----|  -> SingleValueStmtExpr
+| cfg.swift:5:1:5:37 | enter returnZero() | cfg.swift:5:1:5:37 | returnZero() |  |
+| cfg.swift:5:1:5:37 | exit returnZero() (normal) | cfg.swift:5:1:5:37 | exit returnZero() |  |
+| cfg.swift:5:1:5:37 | returnZero() | cfg.swift:5:35:5:35 | 0 |  |
+| cfg.swift:5:28:5:35 | return ... | cfg.swift:5:1:5:37 | exit returnZero() (normal) | return |
+| cfg.swift:5:35:5:35 | 0 | cfg.swift:5:28:5:35 | return ... |  |
+| cfg.swift:15:1:15:46 | enter isZero(x:) | cfg.swift:15:1:15:46 | isZero(x:) |  |
+| cfg.swift:15:1:15:46 | exit isZero(x:) (normal) | cfg.swift:15:1:15:46 | exit isZero(x:) |  |
+| cfg.swift:15:1:15:46 | isZero(x:) | cfg.swift:15:13:15:17 | x |  |
+| cfg.swift:15:13:15:17 | x | cfg.swift:15:41:15:41 | .==(_:_:) |  |
+| cfg.swift:15:32:15:44 | return ... | cfg.swift:15:1:15:46 | exit isZero(x:) (normal) | return |
+| cfg.swift:15:39:15:39 | x | cfg.swift:15:44:15:44 | 0 |  |
+| cfg.swift:15:39:15:44 | ... .==(_:_:) ... | cfg.swift:15:32:15:44 | return ... |  |
+| cfg.swift:15:41:15:41 | .==(_:_:) | cfg.swift:15:41:15:41 | Int.Type |  |
+| cfg.swift:15:41:15:41 | Int.Type | cfg.swift:15:39:15:39 | x |  |
+| cfg.swift:15:44:15:44 | 0 | cfg.swift:15:39:15:44 | ... .==(_:_:) ... |  |
+| cfg.swift:17:1:24:1 | enter mightThrow(x:) | cfg.swift:17:1:24:1 | mightThrow(x:) |  |
+| cfg.swift:17:1:24:1 | exit mightThrow(x:) (abnormal) | cfg.swift:17:1:24:1 | exit mightThrow(x:) |  |
+| cfg.swift:17:1:24:1 | exit mightThrow(x:) (normal) | cfg.swift:17:1:24:1 | exit mightThrow(x:) |  |
+| cfg.swift:17:1:24:1 | mightThrow(x:) | cfg.swift:17:17:17:21 | x |  |
+| cfg.swift:17:17:17:21 | x | cfg.swift:18:3:20:3 | guard ... else { ... } |  |
+| cfg.swift:18:3:20:3 | guard ... else { ... } | cfg.swift:18:9:18:14 | StmtCondition |  |
+| cfg.swift:18:9:18:9 | x | cfg.swift:18:14:18:14 | 0 |  |
+| cfg.swift:18:9:18:14 | ... .>=(_:_:) ... | cfg.swift:19:11:19:19 | .error1 | false |
+| cfg.swift:18:9:18:14 | ... .>=(_:_:) ... | cfg.swift:21:3:23:3 | guard ... else { ... } | true |
+| cfg.swift:18:9:18:14 | StmtCondition | cfg.swift:18:11:18:11 | .>=(_:_:) |  |
+| cfg.swift:18:11:18:11 | .>=(_:_:) | cfg.swift:18:11:18:11 | Int.Type |  |
+| cfg.swift:18:11:18:11 | Int.Type | cfg.swift:18:9:18:9 | x |  |
+| cfg.swift:18:14:18:14 | 0 | cfg.swift:18:9:18:14 | ... .>=(_:_:) ... |  |
+| cfg.swift:19:5:19:19 | throw ... | cfg.swift:17:1:24:1 | exit mightThrow(x:) (abnormal) | exception |
+| cfg.swift:19:11:19:11 | MyError.Type | cfg.swift:19:11:19:19 | (any Error) ... |  |
+| cfg.swift:19:11:19:19 | (any Error) ... | cfg.swift:19:5:19:19 | throw ... |  |
+| cfg.swift:19:11:19:19 | .error1 | cfg.swift:19:11:19:11 | MyError.Type |  |
+| cfg.swift:21:3:23:3 | guard ... else { ... } | cfg.swift:21:9:21:14 | StmtCondition |  |
+| cfg.swift:21:9:21:9 | x | cfg.swift:21:14:21:14 | 0 |  |
+| cfg.swift:21:9:21:14 | ... .<=(_:_:) ... | cfg.swift:17:1:24:1 | exit mightThrow(x:) (normal) | true |
+| cfg.swift:21:9:21:14 | ... .<=(_:_:) ... | cfg.swift:22:11:22:19 | .error3 | false |
+| cfg.swift:21:9:21:14 | StmtCondition | cfg.swift:21:11:21:11 | .<=(_:_:) |  |
+| cfg.swift:21:11:21:11 | .<=(_:_:) | cfg.swift:21:11:21:11 | Int.Type |  |
+| cfg.swift:21:11:21:11 | Int.Type | cfg.swift:21:9:21:9 | x |  |
+| cfg.swift:21:14:21:14 | 0 | cfg.swift:21:9:21:14 | ... .<=(_:_:) ... |  |
+| cfg.swift:22:5:22:42 | throw ... | cfg.swift:17:1:24:1 | exit mightThrow(x:) (abnormal) | exception |
+| cfg.swift:22:11:22:11 | MyError.Type | cfg.swift:22:39:22:39 | .+(_:_:) |  |
+| cfg.swift:22:11:22:19 | .error3 | cfg.swift:22:11:22:11 | MyError.Type |  |
+| cfg.swift:22:11:22:42 | (any Error) ... | cfg.swift:22:5:22:42 | throw ... |  |
+| cfg.swift:22:11:22:42 | call to ... | cfg.swift:22:11:22:42 | (any Error) ... |  |
+| cfg.swift:22:37:22:37 | x | cfg.swift:22:41:22:41 | 1 |  |
+| cfg.swift:22:37:22:41 | ... .+(_:_:) ... | cfg.swift:22:11:22:42 | call to ... |  |
+| cfg.swift:22:39:22:39 | .+(_:_:) | cfg.swift:22:39:22:39 | Int.Type |  |
+| cfg.swift:22:39:22:39 | Int.Type | cfg.swift:22:37:22:37 | x |  |
+| cfg.swift:22:41:22:41 | 1 | cfg.swift:22:37:22:41 | ... .+(_:_:) ... |  |
+| cfg.swift:26:1:43:1 | enter tryCatch(x:) | cfg.swift:26:1:43:1 | tryCatch(x:) |  |
+| cfg.swift:26:1:43:1 | exit tryCatch(x:) (normal) | cfg.swift:26:1:43:1 | exit tryCatch(x:) |  |
+| cfg.swift:26:1:43:1 | tryCatch(x:) | cfg.swift:26:15:26:19 | x |  |
+| cfg.swift:26:15:26:19 | x | cfg.swift:27:3:41:3 | do { ... } catch { ... } |  |
+| cfg.swift:27:3:41:3 | do { ... } catch { ... } | cfg.swift:28:9:28:9 | mightThrow(x:) |  |
+| cfg.swift:28:5:28:24 | try ... | cfg.swift:29:5:29:5 | print(_:separator:terminator:) |  |
+| cfg.swift:28:9:28:9 | mightThrow(x:) | cfg.swift:28:23:28:23 | 0 |  |
+| cfg.swift:28:9:28:24 | call to mightThrow(x:) | cfg.swift:28:5:28:24 | try ... |  |
+| cfg.swift:28:9:28:24 | call to mightThrow(x:) | cfg.swift:33:5:35:3 | case ... | exception |
+| cfg.swift:28:23:28:23 | 0 | cfg.swift:28:9:28:24 | call to mightThrow(x:) |  |
+| cfg.swift:29:5:29:5 | print(_:separator:terminator:) | cfg.swift:29:11:29:11 | Did not throw. |  |
+| cfg.swift:29:5:29:27 | call to print(_:separator:terminator:) | cfg.swift:30:10:30:10 | mightThrow(x:) |  |
+| cfg.swift:29:10:29:10 | default separator | cfg.swift:29:10:29:10 | default terminator |  |
+| cfg.swift:29:10:29:10 | default terminator | cfg.swift:29:5:29:27 | call to print(_:separator:terminator:) |  |
+| cfg.swift:29:11:29:11 | (Any) ... | cfg.swift:29:11:29:11 | [...] |  |
+| cfg.swift:29:11:29:11 | Did not throw. | cfg.swift:29:11:29:11 | (Any) ... |  |
+| cfg.swift:29:11:29:11 | [...] | cfg.swift:29:10:29:10 | default separator |  |
+| cfg.swift:29:11:29:11 | [...] | cfg.swift:29:11:29:11 | [...] |  |
+| cfg.swift:30:5:30:25 | try! ... | cfg.swift:31:5:31:5 | print(_:separator:terminator:) |  |
+| cfg.swift:30:10:30:10 | mightThrow(x:) | cfg.swift:30:24:30:24 | 0 |  |
+| cfg.swift:30:10:30:25 | call to mightThrow(x:) | cfg.swift:30:5:30:25 | try! ... |  |
+| cfg.swift:30:10:30:25 | call to mightThrow(x:) | cfg.swift:33:5:35:3 | case ... | exception |
+| cfg.swift:30:24:30:24 | 0 | cfg.swift:30:10:30:25 | call to mightThrow(x:) |  |
+| cfg.swift:31:5:31:5 | print(_:separator:terminator:) | cfg.swift:31:11:31:11 | Still did not throw. |  |
+| cfg.swift:31:5:31:33 | call to print(_:separator:terminator:) | cfg.swift:42:10:42:10 | 0 |  |
+| cfg.swift:31:10:31:10 | default separator | cfg.swift:31:10:31:10 | default terminator |  |
+| cfg.swift:31:10:31:10 | default terminator | cfg.swift:31:5:31:33 | call to print(_:separator:terminator:) |  |
+| cfg.swift:31:11:31:11 | (Any) ... | cfg.swift:31:11:31:11 | [...] |  |
+| cfg.swift:31:11:31:11 | Still did not throw. | cfg.swift:31:11:31:11 | (Any) ... |  |
+| cfg.swift:31:11:31:11 | [...] | cfg.swift:31:10:31:10 | default separator |  |
+| cfg.swift:31:11:31:11 | [...] | cfg.swift:31:11:31:11 | [...] |  |
+| cfg.swift:33:5:35:3 | case ... | cfg.swift:33:11:33:11 | ... is ... |  |
+| cfg.swift:33:11:33:11 | ... is ... | cfg.swift:33:11:33:19 | .error1 |  |
+| cfg.swift:33:11:33:11 | ... is ... | cfg.swift:33:28:33:60 | ... is ... where ... | no-match |
+| cfg.swift:33:11:33:11 | ... is ... | cfg.swift:34:12:34:12 | 0 | match |
+| cfg.swift:33:11:33:19 | .error1 | cfg.swift:33:11:33:11 | ... is ... | match, no-match |
+| cfg.swift:33:28:33:28 | ... is ... | cfg.swift:33:49:33:60 | call to isZero(x:) | match, no-match |
+| cfg.swift:33:28:33:28 | ... is ... | cfg.swift:35:5:37:3 | case ... | no-match |
+| cfg.swift:33:28:33:36 | .error2 | cfg.swift:33:28:33:28 | ... is ... | match, no-match |
+| cfg.swift:33:28:33:60 | ... is ... where ... | cfg.swift:33:28:33:36 | .error2 |  |
+| cfg.swift:34:5:34:12 | return ... | cfg.swift:26:1:43:1 | exit tryCatch(x:) (normal) | return |
+| cfg.swift:34:12:34:12 | 0 | cfg.swift:34:5:34:12 | return ... |  |
+| cfg.swift:35:5:37:3 | case ... | cfg.swift:35:11:35:11 | ... is ... |  |
+| cfg.swift:35:11:35:11 | ... is ... | cfg.swift:35:11:35:39 | .error3(...) |  |
+| cfg.swift:35:11:35:11 | ... is ... | cfg.swift:36:12:36:12 | withParam | match |
+| cfg.swift:35:11:35:11 | ... is ... | cfg.swift:37:5:39:3 | case ... | no-match |
+| cfg.swift:35:11:35:39 | .error3(...) | cfg.swift:35:11:35:11 | ... is ... | no-match |
+| cfg.swift:35:11:35:39 | .error3(...) | cfg.swift:35:25:35:39 | (...) | match |
+| cfg.swift:35:25:35:39 | (...) | cfg.swift:35:30:35:30 | withParam |  |
+| cfg.swift:35:26:35:30 | let ... | cfg.swift:35:11:35:11 | ... is ... | match |
+| cfg.swift:35:30:35:30 | withParam | cfg.swift:35:26:35:30 | let ... | match |
+| cfg.swift:36:5:36:12 | return ... | cfg.swift:26:1:43:1 | exit tryCatch(x:) (normal) | return |
+| cfg.swift:36:12:36:12 | withParam | cfg.swift:36:5:36:12 | return ... |  |
+| cfg.swift:37:5:39:3 | case ... | cfg.swift:37:11:37:14 | ... is ... |  |
+| cfg.swift:37:11:37:14 | ... is ... | cfg.swift:37:11:37:14 | ... is ... |  |
+| cfg.swift:37:11:37:14 | ... is ... | cfg.swift:38:5:38:5 | print(_:separator:terminator:) | match |
+| cfg.swift:37:11:37:14 | ... is ... | cfg.swift:39:5:41:3 | case ... | no-match |
+| cfg.swift:38:5:38:5 | print(_:separator:terminator:) | cfg.swift:38:11:38:11 | MyError |  |
+| cfg.swift:38:5:38:20 | call to print(_:separator:terminator:) | cfg.swift:42:10:42:10 | 0 |  |
+| cfg.swift:38:10:38:10 | default separator | cfg.swift:38:10:38:10 | default terminator |  |
+| cfg.swift:38:10:38:10 | default terminator | cfg.swift:38:5:38:20 | call to print(_:separator:terminator:) |  |
+| cfg.swift:38:11:38:11 | (Any) ... | cfg.swift:38:11:38:11 | [...] |  |
+| cfg.swift:38:11:38:11 | MyError | cfg.swift:38:11:38:11 | (Any) ... |  |
+| cfg.swift:38:11:38:11 | [...] | cfg.swift:38:10:38:10 | default separator |  |
+| cfg.swift:38:11:38:11 | [...] | cfg.swift:38:11:38:11 | [...] |  |
+| cfg.swift:39:5:41:3 | case ... | cfg.swift:39:11:39:11 | error |  |
+| cfg.swift:39:11:39:11 | error | cfg.swift:39:11:39:11 | error |  |
+| cfg.swift:39:11:39:11 | error | cfg.swift:39:11:39:11 | let ... | match |
+| cfg.swift:39:11:39:11 | let ... | cfg.swift:40:5:40:5 | print(_:separator:terminator:) | match |
+| cfg.swift:40:5:40:5 | print(_:separator:terminator:) | cfg.swift:40:11:40:11 | OpaqueValueExpr |  |
+| cfg.swift:40:5:40:35 | call to print(_:separator:terminator:) | cfg.swift:42:10:42:10 | 0 |  |
+| cfg.swift:40:10:40:10 | default separator | cfg.swift:40:10:40:10 | default terminator |  |
+| cfg.swift:40:10:40:10 | default terminator | cfg.swift:40:5:40:35 | call to print(_:separator:terminator:) |  |
+| cfg.swift:40:11:40:11 | "..." | cfg.swift:40:11:40:11 | (Any) ... |  |
+| cfg.swift:40:11:40:11 | (Any) ... | cfg.swift:40:11:40:11 | [...] |  |
+| cfg.swift:40:11:40:11 | OpaqueValueExpr | cfg.swift:40:12:40:12 | .appendLiteral(_:) |  |
+| cfg.swift:40:11:40:11 | TapExpr | cfg.swift:40:11:40:11 | "..." |  |
+| cfg.swift:40:11:40:11 | Unknown error  | cfg.swift:40:12:40:11 | call to appendLiteral(_:) |  |
+| cfg.swift:40:11:40:11 | [...] | cfg.swift:40:10:40:10 | default separator |  |
+| cfg.swift:40:11:40:11 | [...] | cfg.swift:40:11:40:11 | [...] |  |
+| cfg.swift:40:12:40:11 | call to appendLiteral(_:) | cfg.swift:40:27:40:27 | .appendInterpolation(_:) |  |
+| cfg.swift:40:12:40:12 | $interpolation | cfg.swift:40:12:40:12 | &... |  |
+| cfg.swift:40:12:40:12 | &... | cfg.swift:40:11:40:11 | Unknown error  |  |
+| cfg.swift:40:12:40:12 | .appendLiteral(_:) | cfg.swift:40:12:40:12 | $interpolation |  |
+| cfg.swift:40:27:40:27 | $interpolation | cfg.swift:40:27:40:27 | &... |  |
+| cfg.swift:40:27:40:27 | &... | cfg.swift:40:28:40:28 | error |  |
+| cfg.swift:40:27:40:27 | .appendInterpolation(_:) | cfg.swift:40:27:40:27 | $interpolation |  |
+| cfg.swift:40:27:40:33 | call to appendInterpolation(_:) | cfg.swift:40:34:40:34 | .appendLiteral(_:) |  |
+| cfg.swift:40:28:40:28 | error | cfg.swift:40:27:40:33 | call to appendInterpolation(_:) |  |
+| cfg.swift:40:34:40:34 |  | cfg.swift:40:34:40:34 | call to appendLiteral(_:) |  |
+| cfg.swift:40:34:40:34 | $interpolation | cfg.swift:40:34:40:34 | &... |  |
+| cfg.swift:40:34:40:34 | &... | cfg.swift:40:34:40:34 |  |  |
+| cfg.swift:40:34:40:34 | .appendLiteral(_:) | cfg.swift:40:34:40:34 | $interpolation |  |
+| cfg.swift:40:34:40:34 | call to appendLiteral(_:) | cfg.swift:40:11:40:11 | TapExpr |  |
+| cfg.swift:42:3:42:10 | return ... | cfg.swift:26:1:43:1 | exit tryCatch(x:) (normal) | return |
+| cfg.swift:42:10:42:10 | 0 | cfg.swift:42:3:42:10 | return ... |  |
+| cfg.swift:45:1:49:1 | createClosure1(s:) | cfg.swift:45:21:45:25 | s |  |
+| cfg.swift:45:1:49:1 | enter createClosure1(s:) | cfg.swift:45:1:49:1 | createClosure1(s:) |  |
+| cfg.swift:45:1:49:1 | exit createClosure1(s:) (normal) | cfg.swift:45:1:49:1 | exit createClosure1(s:) |  |
+| cfg.swift:45:21:45:25 | s | cfg.swift:46:10:48:3 | { ... } |  |
+| cfg.swift:46:3:48:3 | return ... | cfg.swift:45:1:49:1 | exit createClosure1(s:) (normal) | return |
+| cfg.swift:46:10:48:3 | enter { ... } | cfg.swift:46:10:48:3 | { ... } |  |
+| cfg.swift:46:10:48:3 | exit { ... } (normal) | cfg.swift:46:10:48:3 | exit { ... } |  |
+| cfg.swift:46:10:48:3 | { ... } | cfg.swift:46:3:48:3 | return ... |  |
+| cfg.swift:46:10:48:3 | { ... } | cfg.swift:47:14:47:14 | .+(_:_:) |  |
+| cfg.swift:47:5:47:16 | return ... | cfg.swift:46:10:48:3 | exit { ... } (normal) | return |
+| cfg.swift:47:12:47:12 | s | cfg.swift:47:16:47:16 |  |  |
+| cfg.swift:47:12:47:16 | ... .+(_:_:) ... | cfg.swift:47:5:47:16 | return ... |  |
+| cfg.swift:47:14:47:14 | .+(_:_:) | cfg.swift:47:14:47:14 | String.Type |  |
+| cfg.swift:47:14:47:14 | String.Type | cfg.swift:47:12:47:12 | s |  |
+| cfg.swift:47:16:47:16 |  | cfg.swift:47:12:47:16 | ... .+(_:_:) ... |  |
+| cfg.swift:51:1:56:1 | createClosure2(x:) | cfg.swift:51:21:51:25 | x |  |
+| cfg.swift:51:1:56:1 | enter createClosure2(x:) | cfg.swift:51:1:56:1 | createClosure2(x:) |  |
+| cfg.swift:51:1:56:1 | exit createClosure2(x:) (normal) | cfg.swift:51:1:56:1 | exit createClosure2(x:) |  |
+| cfg.swift:51:21:51:25 | x | cfg.swift:52:3:54:3 | f(y:) |  |
+| cfg.swift:52:3:54:3 | enter f(y:) | cfg.swift:52:3:54:3 | f(y:) |  |
+| cfg.swift:52:3:54:3 | exit f(y:) (normal) | cfg.swift:52:3:54:3 | exit f(y:) |  |
+| cfg.swift:52:3:54:3 | f(y:) | cfg.swift:52:10:52:14 | y |  |
+| cfg.swift:52:3:54:3 | f(y:) | cfg.swift:55:10:55:10 | f(y:) |  |
+| cfg.swift:52:10:52:14 | y | cfg.swift:53:14:53:14 | .+(_:_:) |  |
+| cfg.swift:53:5:53:16 | return ... | cfg.swift:52:3:54:3 | exit f(y:) (normal) | return |
+| cfg.swift:53:12:53:12 | x | cfg.swift:53:16:53:16 | y |  |
+| cfg.swift:53:12:53:16 | ... .+(_:_:) ... | cfg.swift:53:5:53:16 | return ... |  |
+| cfg.swift:53:14:53:14 | .+(_:_:) | cfg.swift:53:14:53:14 | Int.Type |  |
+| cfg.swift:53:14:53:14 | Int.Type | cfg.swift:53:12:53:12 | x |  |
+| cfg.swift:53:16:53:16 | y | cfg.swift:53:12:53:16 | ... .+(_:_:) ... |  |
+| cfg.swift:55:3:55:10 | return ... | cfg.swift:51:1:56:1 | exit createClosure2(x:) (normal) | return |
+| cfg.swift:55:10:55:10 | f(y:) | cfg.swift:55:3:55:10 | return ... |  |
+| cfg.swift:58:1:62:1 | createClosure3(x:) | cfg.swift:58:21:58:25 | x |  |
+| cfg.swift:58:1:62:1 | enter createClosure3(x:) | cfg.swift:58:1:62:1 | createClosure3(x:) |  |
+| cfg.swift:58:1:62:1 | exit createClosure3(x:) (normal) | cfg.swift:58:1:62:1 | exit createClosure3(x:) |  |
+| cfg.swift:58:21:58:25 | x | cfg.swift:59:10:61:3 | { ... } |  |
+| cfg.swift:59:3:61:3 | return ... | cfg.swift:58:1:62:1 | exit createClosure3(x:) (normal) | return |
+| cfg.swift:59:10:61:3 | enter { ... } | cfg.swift:59:10:61:3 | { ... } |  |
+| cfg.swift:59:10:61:3 | exit { ... } (normal) | cfg.swift:59:10:61:3 | exit { ... } |  |
+| cfg.swift:59:10:61:3 | { ... } | cfg.swift:59:3:61:3 | return ... |  |
+| cfg.swift:59:10:61:3 | { ... } | cfg.swift:60:6:60:6 | y |  |
+| cfg.swift:60:6:60:6 | y | cfg.swift:60:21:60:21 | .+(_:_:) |  |
+| cfg.swift:60:19:60:19 | x | cfg.swift:60:23:60:23 | y |  |
+| cfg.swift:60:19:60:23 | ... .+(_:_:) ... | cfg.swift:60:19:60:23 | return ... |  |
+| cfg.swift:60:19:60:23 | return ... | cfg.swift:59:10:61:3 | exit { ... } (normal) | return |
+| cfg.swift:60:21:60:21 | .+(_:_:) | cfg.swift:60:21:60:21 | Int.Type |  |
+| cfg.swift:60:21:60:21 | Int.Type | cfg.swift:60:19:60:19 | x |  |
+| cfg.swift:60:23:60:23 | y | cfg.swift:60:19:60:23 | ... .+(_:_:) ... |  |
+| cfg.swift:64:1:68:1 | callClosures() | cfg.swift:65:7:65:7 | x1 |  |
+| cfg.swift:64:1:68:1 | enter callClosures() | cfg.swift:64:1:68:1 | callClosures() |  |
+| cfg.swift:64:1:68:1 | exit callClosures() (normal) | cfg.swift:64:1:68:1 | exit callClosures() |  |
+| cfg.swift:65:3:65:34 | var ... = ... | cfg.swift:66:7:66:7 | x2 |  |
+| cfg.swift:65:7:65:7 | x1 | cfg.swift:65:12:65:12 | createClosure1(s:) | match |
+| cfg.swift:65:12:65:12 | createClosure1(s:) | cfg.swift:65:30:65:30 |  |  |
+| cfg.swift:65:12:65:32 | call to createClosure1(s:) | cfg.swift:65:12:65:34 | call to ... |  |
+| cfg.swift:65:12:65:34 | call to ... | cfg.swift:65:3:65:34 | var ... = ... |  |
+| cfg.swift:65:30:65:30 |  | cfg.swift:65:12:65:32 | call to createClosure1(s:) |  |
+| cfg.swift:66:3:66:35 | var ... = ... | cfg.swift:67:7:67:7 | x3 |  |
+| cfg.swift:66:7:66:7 | x2 | cfg.swift:66:12:66:12 | createClosure2(x:) | match |
+| cfg.swift:66:12:66:12 | createClosure2(x:) | cfg.swift:66:30:66:30 | 0 |  |
+| cfg.swift:66:12:66:31 | call to createClosure2(x:) | cfg.swift:66:33:66:33 | 10 |  |
+| cfg.swift:66:12:66:35 | call to ... | cfg.swift:66:3:66:35 | var ... = ... |  |
+| cfg.swift:66:30:66:30 | 0 | cfg.swift:66:12:66:31 | call to createClosure2(x:) |  |
+| cfg.swift:66:33:66:33 | 10 | cfg.swift:66:12:66:35 | call to ... |  |
+| cfg.swift:67:3:67:35 | var ... = ... | cfg.swift:64:1:68:1 | exit callClosures() (normal) |  |
+| cfg.swift:67:7:67:7 | x3 | cfg.swift:67:12:67:12 | createClosure3(x:) | match |
+| cfg.swift:67:12:67:12 | createClosure3(x:) | cfg.swift:67:30:67:30 | 0 |  |
+| cfg.swift:67:12:67:31 | call to createClosure3(x:) | cfg.swift:67:33:67:33 | 10 |  |
+| cfg.swift:67:12:67:35 | call to ... | cfg.swift:67:3:67:35 | var ... = ... |  |
+| cfg.swift:67:30:67:30 | 0 | cfg.swift:67:12:67:31 | call to createClosure3(x:) |  |
+| cfg.swift:67:33:67:33 | 10 | cfg.swift:67:12:67:35 | call to ... |  |
+| cfg.swift:70:1:73:1 | enter maybeParseInt(s:) | cfg.swift:70:1:73:1 | maybeParseInt(s:) |  |
+| cfg.swift:70:1:73:1 | exit maybeParseInt(s:) (normal) | cfg.swift:70:1:73:1 | exit maybeParseInt(s:) |  |
+| cfg.swift:70:1:73:1 | maybeParseInt(s:) | cfg.swift:70:20:70:24 | s |  |
+| cfg.swift:70:20:70:24 | s | cfg.swift:71:7:71:7 | n |  |
+| cfg.swift:71:3:71:23 | var ... = ... | cfg.swift:72:10:72:10 | n |  |
+| cfg.swift:71:7:71:7 | n | cfg.swift:71:7:71:14 | ... as ... | match |
+| cfg.swift:71:7:71:14 | ... as ... | cfg.swift:71:18:71:18 | Self.init(_:) | match |
+| cfg.swift:71:18:71:18 | Int.Type | cfg.swift:71:22:71:22 | s |  |
+| cfg.swift:71:18:71:18 | Self.init(_:) | cfg.swift:71:18:71:18 | Int.Type |  |
+| cfg.swift:71:18:71:23 | call to Self.init(_:) | cfg.swift:71:3:71:23 | var ... = ... |  |
+| cfg.swift:71:22:71:22 | s | cfg.swift:71:18:71:23 | call to Self.init(_:) |  |
+| cfg.swift:72:3:72:10 | return ... | cfg.swift:70:1:73:1 | exit maybeParseInt(s:) (normal) | return |
+| cfg.swift:72:10:72:10 | (Int?) ... | cfg.swift:72:3:72:10 | return ... |  |
+| cfg.swift:72:10:72:10 | n | cfg.swift:72:10:72:10 | (Int?) ... |  |
+| cfg.swift:75:1:79:1 | enter forceAndBackToOptional() | cfg.swift:75:1:79:1 | forceAndBackToOptional() |  |
+| cfg.swift:75:1:79:1 | exit forceAndBackToOptional() (normal) | cfg.swift:75:1:79:1 | exit forceAndBackToOptional() |  |
+| cfg.swift:75:1:79:1 | forceAndBackToOptional() | cfg.swift:76:7:76:7 | nBang |  |
+| cfg.swift:76:3:76:36 | var ... = ... | cfg.swift:77:7:77:7 | n |  |
+| cfg.swift:76:7:76:7 | nBang | cfg.swift:76:15:76:15 | maybeParseInt(s:) | match |
+| cfg.swift:76:15:76:15 | maybeParseInt(s:) | cfg.swift:76:31:76:31 | 42 |  |
+| cfg.swift:76:15:76:35 | call to maybeParseInt(s:) | cfg.swift:76:15:76:36 | ...! |  |
+| cfg.swift:76:15:76:36 | ...! | cfg.swift:76:3:76:36 | var ... = ... |  |
+| cfg.swift:76:31:76:31 | 42 | cfg.swift:76:15:76:35 | call to maybeParseInt(s:) |  |
+| cfg.swift:77:3:77:31 | var ... = ... | cfg.swift:78:16:78:16 | .+(_:_:) |  |
+| cfg.swift:77:7:77:7 | n | cfg.swift:77:11:77:11 | maybeParseInt(s:) | match |
+| cfg.swift:77:11:77:11 | maybeParseInt(s:) | cfg.swift:77:27:77:27 | 42 |  |
+| cfg.swift:77:11:77:31 | call to maybeParseInt(s:) | cfg.swift:77:3:77:31 | var ... = ... |  |
+| cfg.swift:77:27:77:27 | 42 | cfg.swift:77:11:77:31 | call to maybeParseInt(s:) |  |
+| cfg.swift:78:3:78:19 | return ... | cfg.swift:75:1:79:1 | exit forceAndBackToOptional() (normal) | return |
+| cfg.swift:78:10:78:10 | (Int) ... | cfg.swift:78:18:78:18 | n |  |
+| cfg.swift:78:10:78:10 | nBang | cfg.swift:78:10:78:10 | (Int) ... |  |
+| cfg.swift:78:10:78:19 | (Int?) ... | cfg.swift:78:3:78:19 | return ... |  |
+| cfg.swift:78:10:78:19 | ... .+(_:_:) ... | cfg.swift:78:10:78:19 | (Int?) ... |  |
+| cfg.swift:78:16:78:16 | .+(_:_:) | cfg.swift:78:16:78:16 | Int.Type |  |
+| cfg.swift:78:16:78:16 | Int.Type | cfg.swift:78:10:78:10 | nBang |  |
+| cfg.swift:78:18:78:18 | (Int?) ... | cfg.swift:78:18:78:19 | ...! |  |
+| cfg.swift:78:18:78:18 | n | cfg.swift:78:18:78:18 | (Int?) ... |  |
+| cfg.swift:78:18:78:19 | ...! | cfg.swift:78:10:78:19 | ... .+(_:_:) ... |  |
+| cfg.swift:81:1:96:1 | enter testInOut() | cfg.swift:81:1:96:1 | testInOut() |  |
+| cfg.swift:81:1:96:1 | exit testInOut() (normal) | cfg.swift:81:1:96:1 | exit testInOut() |  |
+| cfg.swift:81:1:96:1 | testInOut() | cfg.swift:82:7:82:7 | temp |  |
+| cfg.swift:82:3:82:14 | var ... = ... | cfg.swift:84:3:86:3 | add(a:) |  |
+| cfg.swift:82:7:82:7 | temp | cfg.swift:82:14:82:14 | 10 | match |
+| cfg.swift:82:14:82:14 | 10 | cfg.swift:82:3:82:14 | var ... = ... |  |
+| cfg.swift:84:3:86:3 | add(a:) | cfg.swift:84:12:84:21 | a |  |
+| cfg.swift:84:3:86:3 | add(a:) | cfg.swift:88:3:90:3 | addOptional(a:) |  |
+| cfg.swift:84:3:86:3 | enter add(a:) | cfg.swift:84:3:86:3 | add(a:) |  |
+| cfg.swift:84:3:86:3 | exit add(a:) (normal) | cfg.swift:84:3:86:3 | exit add(a:) |  |
+| cfg.swift:84:12:84:21 | a | cfg.swift:85:5:85:5 | a |  |
+| cfg.swift:85:5:85:5 | a | cfg.swift:85:11:85:11 | .+(_:_:) |  |
+| cfg.swift:85:5:85:13 |  ... = ... | cfg.swift:84:3:86:3 | exit add(a:) (normal) |  |
+| cfg.swift:85:9:85:9 | (Int) ... | cfg.swift:85:13:85:13 | 1 |  |
+| cfg.swift:85:9:85:9 | a | cfg.swift:85:9:85:9 | (Int) ... |  |
+| cfg.swift:85:9:85:13 | ... .+(_:_:) ... | cfg.swift:85:5:85:13 |  ... = ... |  |
+| cfg.swift:85:11:85:11 | .+(_:_:) | cfg.swift:85:11:85:11 | Int.Type |  |
+| cfg.swift:85:11:85:11 | Int.Type | cfg.swift:85:9:85:9 | a |  |
+| cfg.swift:85:13:85:13 | 1 | cfg.swift:85:9:85:13 | ... .+(_:_:) ... |  |
+| cfg.swift:88:3:90:3 | addOptional(a:) | cfg.swift:88:20:88:32 | a |  |
+| cfg.swift:88:3:90:3 | addOptional(a:) | cfg.swift:92:3:92:3 | add(a:) |  |
+| cfg.swift:88:3:90:3 | enter addOptional(a:) | cfg.swift:88:3:90:3 | addOptional(a:) |  |
+| cfg.swift:88:3:90:3 | exit addOptional(a:) (normal) | cfg.swift:88:3:90:3 | exit addOptional(a:) |  |
+| cfg.swift:88:20:88:32 | a | cfg.swift:89:5:89:5 | a |  |
+| cfg.swift:89:5:89:5 | a | cfg.swift:89:9:89:9 | nil |  |
+| cfg.swift:89:5:89:9 |  ... = ... | cfg.swift:88:3:90:3 | exit addOptional(a:) (normal) |  |
+| cfg.swift:89:9:89:9 | nil | cfg.swift:89:5:89:9 |  ... = ... |  |
+| cfg.swift:92:3:92:3 | add(a:) | cfg.swift:92:10:92:10 | temp |  |
+| cfg.swift:92:3:92:14 | call to add(a:) | cfg.swift:93:7:93:7 | tempOptional |  |
+| cfg.swift:92:9:92:10 | &... | cfg.swift:92:3:92:14 | call to add(a:) |  |
+| cfg.swift:92:10:92:10 | temp | cfg.swift:92:9:92:10 | &... |  |
+| cfg.swift:93:3:93:29 | var ... = ... | cfg.swift:94:3:94:3 | addOptional(a:) |  |
+| cfg.swift:93:7:93:7 | tempOptional | cfg.swift:93:7:93:25 | ... as ... | match |
+| cfg.swift:93:7:93:25 | ... as ... | cfg.swift:93:29:93:29 | 10 | match |
+| cfg.swift:93:29:93:29 | 10 | cfg.swift:93:29:93:29 | (Int?) ... |  |
+| cfg.swift:93:29:93:29 | (Int?) ... | cfg.swift:93:3:93:29 | var ... = ... |  |
+| cfg.swift:94:3:94:3 | addOptional(a:) | cfg.swift:94:18:94:18 | tempOptional |  |
+| cfg.swift:94:3:94:30 | call to addOptional(a:) | cfg.swift:95:15:95:15 | .+(_:_:) |  |
+| cfg.swift:94:17:94:18 | &... | cfg.swift:94:3:94:30 | call to addOptional(a:) |  |
+| cfg.swift:94:18:94:18 | tempOptional | cfg.swift:94:17:94:18 | &... |  |
+| cfg.swift:95:3:95:29 | return ... | cfg.swift:81:1:96:1 | exit testInOut() (normal) | return |
+| cfg.swift:95:10:95:10 | (Int) ... | cfg.swift:95:17:95:17 | tempOptional |  |
+| cfg.swift:95:10:95:10 | temp | cfg.swift:95:10:95:10 | (Int) ... |  |
+| cfg.swift:95:10:95:29 | ... .+(_:_:) ... | cfg.swift:95:3:95:29 | return ... |  |
+| cfg.swift:95:15:95:15 | .+(_:_:) | cfg.swift:95:15:95:15 | Int.Type |  |
+| cfg.swift:95:15:95:15 | Int.Type | cfg.swift:95:10:95:10 | temp |  |
+| cfg.swift:95:17:95:17 | (Int?) ... | cfg.swift:95:17:95:29 | ...! |  |
+| cfg.swift:95:17:95:17 | tempOptional | cfg.swift:95:17:95:17 | (Int?) ... |  |
+| cfg.swift:95:17:95:29 | ...! | cfg.swift:95:10:95:29 | ... .+(_:_:) ... |  |
+| cfg.swift:98:7:98:7 | C.deinit() | cfg.swift:98:7:98:7 | self |  |
+| cfg.swift:98:7:98:7 | enter C.deinit() | cfg.swift:98:7:98:7 | C.deinit() |  |
+| cfg.swift:98:7:98:7 | exit C.deinit() (normal) | cfg.swift:98:7:98:7 | exit C.deinit() |  |
+| cfg.swift:98:7:98:7 | self | cfg.swift:98:7:98:7 | { ... } |  |
+| cfg.swift:98:7:98:7 | { ... } | cfg.swift:98:7:98:7 | exit C.deinit() (normal) |  |
+| cfg.swift:99:7:99:7 | enter get | cfg.swift:99:7:99:7 | get |  |
+| cfg.swift:99:7:99:7 | exit get (normal) | cfg.swift:99:7:99:7 | exit get |  |
+| cfg.swift:99:7:99:7 | get | cfg.swift:99:7:99:7 | self |  |
+| cfg.swift:99:7:99:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:100:3:100:3 | self | cfg.swift:100:8:100:11 | n |  |
+| cfg.swift:100:3:102:3 | C.init(n:) | cfg.swift:100:3:100:3 | self |  |
+| cfg.swift:100:3:102:3 | enter C.init(n:) | cfg.swift:100:3:102:3 | C.init(n:) |  |
+| cfg.swift:100:3:102:3 | exit C.init(n:) (normal) | cfg.swift:100:3:102:3 | exit C.init(n:) |  |
+| cfg.swift:100:8:100:11 | n | cfg.swift:101:5:101:5 | self |  |
+| cfg.swift:101:5:101:5 | .myInt | cfg.swift:101:13:101:13 | n |  |
+| cfg.swift:101:5:101:5 | self | cfg.swift:101:5:101:5 | .myInt |  |
+| cfg.swift:101:5:101:13 |  ... = ... | cfg.swift:102:3:102:3 | return |  |
+| cfg.swift:101:13:101:13 | n | cfg.swift:101:5:101:13 |  ... = ... |  |
+| cfg.swift:102:3:102:3 | return | cfg.swift:100:3:102:3 | exit C.init(n:) (normal) | return |
+| cfg.swift:104:3:106:3 | enter getMyInt() | cfg.swift:104:3:106:3 | getMyInt() |  |
+| cfg.swift:104:3:106:3 | exit getMyInt() (normal) | cfg.swift:104:3:106:3 | exit getMyInt() |  |
+| cfg.swift:104:3:106:3 | getMyInt() | cfg.swift:104:8:104:8 | self |  |
+| cfg.swift:104:8:104:8 | self | cfg.swift:105:12:105:12 | self |  |
+| cfg.swift:105:5:105:12 | return ... | cfg.swift:104:3:106:3 | exit getMyInt() (normal) | return |
+| cfg.swift:105:12:105:12 | getter for .myInt | cfg.swift:105:5:105:12 | return ... |  |
+| cfg.swift:105:12:105:12 | self | cfg.swift:105:12:105:12 | getter for .myInt |  |
+| cfg.swift:109:1:135:1 | enter testMemberRef(param:inoutParam:opt:) | cfg.swift:109:1:135:1 | testMemberRef(param:inoutParam:opt:) |  |
+| cfg.swift:109:1:135:1 | exit testMemberRef(param:inoutParam:opt:) (normal) | cfg.swift:109:1:135:1 | exit testMemberRef(param:inoutParam:opt:) |  |
+| cfg.swift:109:1:135:1 | testMemberRef(param:inoutParam:opt:) | cfg.swift:109:20:109:28 | param |  |
+| cfg.swift:109:20:109:28 | param | cfg.swift:109:31:109:50 | inoutParam |  |
+| cfg.swift:109:31:109:50 | inoutParam | cfg.swift:109:53:109:60 | opt |  |
+| cfg.swift:109:53:109:60 | opt | cfg.swift:110:7:110:7 | c |  |
+| cfg.swift:110:3:110:18 | var ... = ... | cfg.swift:111:7:111:7 | n1 |  |
+| cfg.swift:110:7:110:7 | c | cfg.swift:110:11:110:11 | C.init(n:) | match |
+| cfg.swift:110:11:110:11 | C.Type | cfg.swift:110:16:110:16 | 42 |  |
+| cfg.swift:110:11:110:11 | C.init(n:) | cfg.swift:110:11:110:11 | C.Type |  |
+| cfg.swift:110:11:110:18 | call to C.init(n:) | cfg.swift:110:3:110:18 | var ... = ... |  |
+| cfg.swift:110:16:110:16 | 42 | cfg.swift:110:11:110:18 | call to C.init(n:) |  |
+| cfg.swift:111:3:111:14 | var ... = ... | cfg.swift:112:7:112:7 | n2 |  |
+| cfg.swift:111:7:111:7 | n1 | cfg.swift:111:12:111:12 | c | match |
+| cfg.swift:111:12:111:12 | c | cfg.swift:111:12:111:14 | getter for .myInt |  |
+| cfg.swift:111:12:111:14 | getter for .myInt | cfg.swift:111:3:111:14 | var ... = ... |  |
+| cfg.swift:112:3:112:19 | var ... = ... | cfg.swift:113:7:113:7 | n3 |  |
+| cfg.swift:112:7:112:7 | n2 | cfg.swift:112:12:112:12 | c | match |
+| cfg.swift:112:12:112:12 | c | cfg.swift:112:12:112:14 | .self |  |
+| cfg.swift:112:12:112:14 | .self | cfg.swift:112:12:112:19 | getter for .myInt |  |
+| cfg.swift:112:12:112:19 | getter for .myInt | cfg.swift:112:3:112:19 | var ... = ... |  |
+| cfg.swift:113:3:113:23 | var ... = ... | cfg.swift:114:7:114:7 | n4 |  |
+| cfg.swift:113:7:113:7 | n3 | cfg.swift:113:12:113:14 | .getMyInt() | match |
+| cfg.swift:113:12:113:12 | c | cfg.swift:113:12:113:23 | call to getMyInt() |  |
+| cfg.swift:113:12:113:14 | .getMyInt() | cfg.swift:113:12:113:12 | c |  |
+| cfg.swift:113:12:113:23 | call to getMyInt() | cfg.swift:113:3:113:23 | var ... = ... |  |
+| cfg.swift:114:3:114:28 | var ... = ... | cfg.swift:116:7:116:7 | n5 |  |
+| cfg.swift:114:7:114:7 | n4 | cfg.swift:114:12:114:19 | .getMyInt() | match |
+| cfg.swift:114:12:114:12 | c | cfg.swift:114:12:114:14 | .self |  |
+| cfg.swift:114:12:114:14 | .self | cfg.swift:114:12:114:28 | call to getMyInt() |  |
+| cfg.swift:114:12:114:19 | .getMyInt() | cfg.swift:114:12:114:12 | c |  |
+| cfg.swift:114:12:114:28 | call to getMyInt() | cfg.swift:114:3:114:28 | var ... = ... |  |
+| cfg.swift:116:3:116:18 | var ... = ... | cfg.swift:117:7:117:7 | n6 |  |
+| cfg.swift:116:7:116:7 | n5 | cfg.swift:116:12:116:12 | param | match |
+| cfg.swift:116:12:116:12 | param | cfg.swift:116:12:116:18 | getter for .myInt |  |
+| cfg.swift:116:12:116:18 | getter for .myInt | cfg.swift:116:3:116:18 | var ... = ... |  |
+| cfg.swift:117:3:117:23 | var ... = ... | cfg.swift:118:7:118:7 | n7 |  |
+| cfg.swift:117:7:117:7 | n6 | cfg.swift:117:12:117:12 | param | match |
+| cfg.swift:117:12:117:12 | param | cfg.swift:117:12:117:18 | .self |  |
+| cfg.swift:117:12:117:18 | .self | cfg.swift:117:12:117:23 | getter for .myInt |  |
+| cfg.swift:117:12:117:23 | getter for .myInt | cfg.swift:117:3:117:23 | var ... = ... |  |
+| cfg.swift:118:3:118:27 | var ... = ... | cfg.swift:119:7:119:7 | n8 |  |
+| cfg.swift:118:7:118:7 | n7 | cfg.swift:118:12:118:18 | .getMyInt() | match |
+| cfg.swift:118:12:118:12 | param | cfg.swift:118:12:118:27 | call to getMyInt() |  |
+| cfg.swift:118:12:118:18 | .getMyInt() | cfg.swift:118:12:118:12 | param |  |
+| cfg.swift:118:12:118:27 | call to getMyInt() | cfg.swift:118:3:118:27 | var ... = ... |  |
+| cfg.swift:119:3:119:32 | var ... = ... | cfg.swift:121:7:121:7 | n9 |  |
+| cfg.swift:119:7:119:7 | n8 | cfg.swift:119:12:119:23 | .getMyInt() | match |
+| cfg.swift:119:12:119:12 | param | cfg.swift:119:12:119:18 | .self |  |
+| cfg.swift:119:12:119:18 | .self | cfg.swift:119:12:119:32 | call to getMyInt() |  |
+| cfg.swift:119:12:119:23 | .getMyInt() | cfg.swift:119:12:119:12 | param |  |
+| cfg.swift:119:12:119:32 | call to getMyInt() | cfg.swift:119:3:119:32 | var ... = ... |  |
+| cfg.swift:121:3:121:23 | var ... = ... | cfg.swift:122:7:122:7 | n10 |  |
+| cfg.swift:121:7:121:7 | n9 | cfg.swift:121:12:121:12 | inoutParam | match |
+| cfg.swift:121:12:121:12 | (C) ... | cfg.swift:121:12:121:23 | getter for .myInt |  |
+| cfg.swift:121:12:121:12 | inoutParam | cfg.swift:121:12:121:12 | (C) ... |  |
+| cfg.swift:121:12:121:23 | getter for .myInt | cfg.swift:121:3:121:23 | var ... = ... |  |
+| cfg.swift:122:3:122:29 | var ... = ... | cfg.swift:123:7:123:7 | n11 |  |
+| cfg.swift:122:7:122:7 | n10 | cfg.swift:122:13:122:13 | inoutParam | match |
+| cfg.swift:122:13:122:13 | inoutParam | cfg.swift:122:13:122:24 | .self |  |
+| cfg.swift:122:13:122:24 | (C) ... | cfg.swift:122:13:122:29 | getter for .myInt |  |
+| cfg.swift:122:13:122:24 | .self | cfg.swift:122:13:122:24 | (C) ... |  |
+| cfg.swift:122:13:122:29 | getter for .myInt | cfg.swift:122:3:122:29 | var ... = ... |  |
+| cfg.swift:123:3:123:33 | var ... = ... | cfg.swift:124:7:124:7 | n12 |  |
+| cfg.swift:123:7:123:7 | n11 | cfg.swift:123:13:123:24 | .getMyInt() | match |
+| cfg.swift:123:13:123:13 | (C) ... | cfg.swift:123:13:123:33 | call to getMyInt() |  |
+| cfg.swift:123:13:123:13 | inoutParam | cfg.swift:123:13:123:13 | (C) ... |  |
+| cfg.swift:123:13:123:24 | .getMyInt() | cfg.swift:123:13:123:13 | inoutParam |  |
+| cfg.swift:123:13:123:33 | call to getMyInt() | cfg.swift:123:3:123:33 | var ... = ... |  |
+| cfg.swift:124:3:124:38 | var ... = ... | cfg.swift:126:7:126:7 | n13 |  |
+| cfg.swift:124:7:124:7 | n12 | cfg.swift:124:13:124:29 | .getMyInt() | match |
+| cfg.swift:124:13:124:13 | inoutParam | cfg.swift:124:13:124:24 | .self |  |
+| cfg.swift:124:13:124:24 | (C) ... | cfg.swift:124:13:124:38 | call to getMyInt() |  |
+| cfg.swift:124:13:124:24 | .self | cfg.swift:124:13:124:24 | (C) ... |  |
+| cfg.swift:124:13:124:29 | .getMyInt() | cfg.swift:124:13:124:13 | inoutParam |  |
+| cfg.swift:124:13:124:38 | call to getMyInt() | cfg.swift:124:3:124:38 | var ... = ... |  |
+| cfg.swift:126:3:126:18 | var ... = ... | cfg.swift:127:7:127:7 | n14 |  |
+| cfg.swift:126:7:126:7 | n13 | cfg.swift:126:13:126:13 | opt | match |
+| cfg.swift:126:13:126:13 | opt | cfg.swift:126:13:126:16 | ...! |  |
+| cfg.swift:126:13:126:16 | ...! | cfg.swift:126:13:126:18 | getter for .myInt |  |
+| cfg.swift:126:13:126:18 | getter for .myInt | cfg.swift:126:3:126:18 | var ... = ... |  |
+| cfg.swift:127:3:127:23 | var ... = ... | cfg.swift:128:7:128:7 | n15 |  |
+| cfg.swift:127:7:127:7 | n14 | cfg.swift:127:13:127:13 | opt | match |
+| cfg.swift:127:13:127:13 | opt | cfg.swift:127:13:127:16 | ...! |  |
+| cfg.swift:127:13:127:16 | ...! | cfg.swift:127:13:127:18 | .self |  |
+| cfg.swift:127:13:127:18 | .self | cfg.swift:127:13:127:23 | getter for .myInt |  |
+| cfg.swift:127:13:127:23 | getter for .myInt | cfg.swift:127:3:127:23 | var ... = ... |  |
+| cfg.swift:128:3:128:27 | var ... = ... | cfg.swift:129:7:129:7 | n16 |  |
+| cfg.swift:128:7:128:7 | n15 | cfg.swift:128:13:128:18 | .getMyInt() | match |
+| cfg.swift:128:13:128:13 | opt | cfg.swift:128:13:128:16 | ...! |  |
+| cfg.swift:128:13:128:16 | ...! | cfg.swift:128:13:128:27 | call to getMyInt() |  |
+| cfg.swift:128:13:128:18 | .getMyInt() | cfg.swift:128:13:128:13 | opt |  |
+| cfg.swift:128:13:128:27 | call to getMyInt() | cfg.swift:128:3:128:27 | var ... = ... |  |
+| cfg.swift:129:3:129:32 | var ... = ... | cfg.swift:131:7:131:7 | n17 |  |
+| cfg.swift:129:7:129:7 | n16 | cfg.swift:129:13:129:23 | .getMyInt() | match |
+| cfg.swift:129:13:129:13 | opt | cfg.swift:129:13:129:16 | ...! |  |
+| cfg.swift:129:13:129:16 | ...! | cfg.swift:129:13:129:18 | .self |  |
+| cfg.swift:129:13:129:18 | .self | cfg.swift:129:13:129:32 | call to getMyInt() |  |
+| cfg.swift:129:13:129:23 | .getMyInt() | cfg.swift:129:13:129:13 | opt |  |
+| cfg.swift:129:13:129:32 | call to getMyInt() | cfg.swift:129:3:129:32 | var ... = ... |  |
+| cfg.swift:131:3:131:18 | var ... = ... | cfg.swift:132:7:132:7 | n18 |  |
+| cfg.swift:131:7:131:7 | n17 | cfg.swift:131:13:131:13 | opt | match |
+| cfg.swift:131:13:131:13 | opt | cfg.swift:131:13:131:16 | ...? |  |
+| cfg.swift:131:13:131:16 | ...? | cfg.swift:131:13:131:18 | getter for .myInt |  |
+| cfg.swift:131:13:131:18 | (Int?) ... | cfg.swift:131:13:131:18 | OptionalEvaluationExpr |  |
+| cfg.swift:131:13:131:18 | OptionalEvaluationExpr | cfg.swift:131:3:131:18 | var ... = ... |  |
+| cfg.swift:131:13:131:18 | getter for .myInt | cfg.swift:131:13:131:18 | (Int?) ... |  |
+| cfg.swift:132:3:132:23 | var ... = ... | cfg.swift:133:7:133:7 | n19 |  |
+| cfg.swift:132:7:132:7 | n18 | cfg.swift:132:13:132:13 | opt | match |
+| cfg.swift:132:13:132:13 | opt | cfg.swift:132:13:132:16 | ...? |  |
+| cfg.swift:132:13:132:16 | ...? | cfg.swift:132:13:132:18 | .self |  |
+| cfg.swift:132:13:132:18 | .self | cfg.swift:132:13:132:23 | getter for .myInt |  |
+| cfg.swift:132:13:132:23 | (Int?) ... | cfg.swift:132:13:132:23 | OptionalEvaluationExpr |  |
+| cfg.swift:132:13:132:23 | OptionalEvaluationExpr | cfg.swift:132:3:132:23 | var ... = ... |  |
+| cfg.swift:132:13:132:23 | getter for .myInt | cfg.swift:132:13:132:23 | (Int?) ... |  |
+| cfg.swift:133:3:133:27 | var ... = ... | cfg.swift:134:7:134:7 | n20 |  |
+| cfg.swift:133:7:133:7 | n19 | cfg.swift:133:13:133:18 | .getMyInt() | match |
+| cfg.swift:133:13:133:13 | opt | cfg.swift:133:13:133:16 | ...? |  |
+| cfg.swift:133:13:133:16 | ...? | cfg.swift:133:13:133:27 | call to getMyInt() |  |
+| cfg.swift:133:13:133:18 | .getMyInt() | cfg.swift:133:13:133:13 | opt |  |
+| cfg.swift:133:13:133:27 | (Int?) ... | cfg.swift:133:13:133:27 | OptionalEvaluationExpr |  |
+| cfg.swift:133:13:133:27 | OptionalEvaluationExpr | cfg.swift:133:3:133:27 | var ... = ... |  |
+| cfg.swift:133:13:133:27 | call to getMyInt() | cfg.swift:133:13:133:27 | (Int?) ... |  |
+| cfg.swift:134:3:134:32 | var ... = ... | cfg.swift:109:1:135:1 | exit testMemberRef(param:inoutParam:opt:) (normal) |  |
+| cfg.swift:134:7:134:7 | n20 | cfg.swift:134:13:134:23 | .getMyInt() | match |
+| cfg.swift:134:13:134:13 | opt | cfg.swift:134:13:134:16 | ...? |  |
+| cfg.swift:134:13:134:16 | ...? | cfg.swift:134:13:134:18 | .self |  |
+| cfg.swift:134:13:134:18 | .self | cfg.swift:134:13:134:32 | call to getMyInt() |  |
+| cfg.swift:134:13:134:23 | .getMyInt() | cfg.swift:134:13:134:13 | opt |  |
+| cfg.swift:134:13:134:32 | (Int?) ... | cfg.swift:134:13:134:32 | OptionalEvaluationExpr |  |
+| cfg.swift:134:13:134:32 | OptionalEvaluationExpr | cfg.swift:134:3:134:32 | var ... = ... |  |
+| cfg.swift:134:13:134:32 | call to getMyInt() | cfg.swift:134:13:134:32 | (Int?) ... |  |
+| cfg.swift:137:1:161:1 | enter patterns(x:) | cfg.swift:137:1:161:1 | patterns(x:) |  |
+| cfg.swift:137:1:161:1 | exit patterns(x:) (normal) | cfg.swift:137:1:161:1 | exit patterns(x:) |  |
+| cfg.swift:137:1:161:1 | patterns(x:) | cfg.swift:137:15:137:19 | x |  |
+| cfg.swift:137:15:137:19 | x | cfg.swift:138:12:138:12 | $generator |  |
+| cfg.swift:138:3:138:3 | $generator | cfg.swift:138:3:138:3 | &... |  |
+| cfg.swift:138:3:138:3 | &... | cfg.swift:138:3:138:3 | call to next() |  |
+| cfg.swift:138:3:138:3 | .next() | cfg.swift:138:3:138:3 | $generator |  |
+| cfg.swift:138:3:138:3 | call to next() | cfg.swift:138:3:138:22 | for ... in ... { ... } |  |
+| cfg.swift:138:3:138:22 | for ... in ... { ... } | cfg.swift:138:7:138:7 | _ | non-empty |
+| cfg.swift:138:3:138:22 | for ... in ... { ... } | cfg.swift:140:3:148:3 | switch x { ... } | empty |
+| cfg.swift:138:7:138:7 | _ | cfg.swift:138:19:138:22 | { ... } | match |
+| cfg.swift:138:12:138:12 | 0 | cfg.swift:138:16:138:16 | 10 |  |
+| cfg.swift:138:12:138:12 | $generator | cfg.swift:138:12:138:16 | .makeIterator() | match |
+| cfg.swift:138:12:138:16 | ... ....(_:_:) ... | cfg.swift:138:12:138:16 | call to makeIterator() |  |
+| cfg.swift:138:12:138:16 | .makeIterator() | cfg.swift:138:13:138:13 | ....(_:_:) |  |
+| cfg.swift:138:12:138:16 | call to makeIterator() | file://:0:0:0:0 | var ... = ... |  |
+| cfg.swift:138:13:138:13 | ....(_:_:) | cfg.swift:138:13:138:13 | Int.Type |  |
+| cfg.swift:138:13:138:13 | Int.Type | cfg.swift:138:12:138:12 | 0 |  |
+| cfg.swift:138:16:138:16 | 10 | cfg.swift:138:12:138:16 | ... ....(_:_:) ... |  |
+| cfg.swift:138:19:138:22 | { ... } | cfg.swift:138:3:138:3 | .next() |  |
+| cfg.swift:140:3:148:3 | switch x { ... } | cfg.swift:140:10:140:10 | x |  |
+| cfg.swift:140:10:140:10 | x | cfg.swift:141:5:143:14 | case ... |  |
+| cfg.swift:141:5:143:14 | case ... | cfg.swift:141:10:141:10 | =~ ... |  |
+| cfg.swift:141:10:141:10 | 0 | cfg.swift:141:10:141:10 | $match |  |
+| cfg.swift:141:10:141:10 | $match | cfg.swift:141:10:141:10 | ... ~=(_:_:) ... |  |
+| cfg.swift:141:10:141:10 | ... ~=(_:_:) ... | cfg.swift:141:10:141:10 | =~ ... |  |
+| cfg.swift:141:10:141:10 | =~ ... | cfg.swift:141:10:141:10 | ~=(_:_:) |  |
+| cfg.swift:141:10:141:10 | =~ ... | cfg.swift:141:13:141:13 | =~ ... | no-match |
+| cfg.swift:141:10:141:10 | =~ ... | cfg.swift:142:14:142:14 | true | match |
+| cfg.swift:141:10:141:10 | ~=(_:_:) | cfg.swift:141:10:141:10 | 0 |  |
+| cfg.swift:141:13:141:13 | 1 | cfg.swift:141:13:141:13 | $match |  |
+| cfg.swift:141:13:141:13 | $match | cfg.swift:141:13:141:13 | ... ~=(_:_:) ... |  |
+| cfg.swift:141:13:141:13 | ... ~=(_:_:) ... | cfg.swift:141:13:141:13 | =~ ... |  |
+| cfg.swift:141:13:141:13 | =~ ... | cfg.swift:141:13:141:13 | ~=(_:_:) |  |
+| cfg.swift:141:13:141:13 | =~ ... | cfg.swift:142:14:142:14 | true | match |
+| cfg.swift:141:13:141:13 | =~ ... | cfg.swift:144:5:145:14 | case ... | no-match |
+| cfg.swift:141:13:141:13 | ~=(_:_:) | cfg.swift:141:13:141:13 | 1 |  |
+| cfg.swift:142:7:142:14 | return ... | cfg.swift:137:1:161:1 | exit patterns(x:) (normal) | return |
+| cfg.swift:142:14:142:14 | true | cfg.swift:142:7:142:14 | return ... |  |
+| cfg.swift:144:5:145:14 | case ... | cfg.swift:144:10:144:34 | =~ ... where ... |  |
+| cfg.swift:144:10:144:10 | $match | cfg.swift:144:10:144:10 | ... ~=(_:_:) ... |  |
+| cfg.swift:144:10:144:10 | ... ~=(_:_:) ... | cfg.swift:144:10:144:10 | =~ ... |  |
+| cfg.swift:144:10:144:10 | =~ ... | cfg.swift:144:18:144:34 | ... .&&(_:_:) ... | match, no-match |
+| cfg.swift:144:10:144:10 | =~ ... | cfg.swift:146:5:147:14 | case ... | no-match |
+| cfg.swift:144:10:144:10 | x | cfg.swift:144:10:144:10 | $match |  |
+| cfg.swift:144:10:144:10 | ~=(_:_:) | cfg.swift:144:10:144:10 | x |  |
+| cfg.swift:144:10:144:34 | =~ ... where ... | cfg.swift:144:10:144:10 | ~=(_:_:) |  |
+| cfg.swift:146:5:146:5 | _ | cfg.swift:146:5:146:5 | _ |  |
+| cfg.swift:146:5:146:5 | _ | cfg.swift:147:14:147:14 | false | match |
+| cfg.swift:146:5:147:14 | case ... | cfg.swift:146:5:146:5 | _ |  |
+| cfg.swift:147:7:147:14 | return ... | cfg.swift:137:1:161:1 | exit patterns(x:) (normal) | return |
+| cfg.swift:147:14:147:14 | false | cfg.swift:147:7:147:14 | return ... |  |
+| cfg.swift:163:1:179:1 | enter testDefer(x:) | cfg.swift:163:1:179:1 | testDefer(x:) |  |
+| cfg.swift:163:1:179:1 | exit testDefer(x:) (normal) | cfg.swift:163:1:179:1 | exit testDefer(x:) |  |
+| cfg.swift:163:1:179:1 | testDefer(x:) | cfg.swift:163:16:163:26 | x |  |
+| cfg.swift:163:16:163:26 | x | cfg.swift:165:3:167:3 | defer { ... } |  |
+| cfg.swift:165:3:167:3 | defer { ... } | cfg.swift:169:3:171:3 | defer { ... } |  |
+| cfg.swift:166:5:166:5 | print(_:separator:terminator:) | cfg.swift:166:11:166:11 | 4 |  |
+| cfg.swift:166:5:166:14 | call to print(_:separator:terminator:) | cfg.swift:163:1:179:1 | exit testDefer(x:) (normal) |  |
+| cfg.swift:166:10:166:10 | default separator | cfg.swift:166:10:166:10 | default terminator |  |
+| cfg.swift:166:10:166:10 | default terminator | cfg.swift:166:5:166:14 | call to print(_:separator:terminator:) |  |
+| cfg.swift:166:11:166:11 | 4 | cfg.swift:166:11:166:11 | (Any) ... |  |
+| cfg.swift:166:11:166:11 | (Any) ... | cfg.swift:166:11:166:11 | [...] |  |
+| cfg.swift:166:11:166:11 | [...] | cfg.swift:166:10:166:10 | default separator |  |
+| cfg.swift:166:11:166:11 | [...] | cfg.swift:166:11:166:11 | [...] |  |
+| cfg.swift:169:3:171:3 | defer { ... } | cfg.swift:173:3:178:3 | defer { ... } |  |
+| cfg.swift:170:5:170:5 | print(_:separator:terminator:) | cfg.swift:170:11:170:11 | 3 |  |
+| cfg.swift:170:5:170:14 | call to print(_:separator:terminator:) | cfg.swift:166:5:166:5 | print(_:separator:terminator:) |  |
+| cfg.swift:170:10:170:10 | default separator | cfg.swift:170:10:170:10 | default terminator |  |
+| cfg.swift:170:10:170:10 | default terminator | cfg.swift:170:5:170:14 | call to print(_:separator:terminator:) |  |
+| cfg.swift:170:11:170:11 | 3 | cfg.swift:170:11:170:11 | (Any) ... |  |
+| cfg.swift:170:11:170:11 | (Any) ... | cfg.swift:170:11:170:11 | [...] |  |
+| cfg.swift:170:11:170:11 | [...] | cfg.swift:170:10:170:10 | default separator |  |
+| cfg.swift:170:11:170:11 | [...] | cfg.swift:170:11:170:11 | [...] |  |
+| cfg.swift:173:3:178:3 | defer { ... } | cfg.swift:174:5:174:5 | print(_:separator:terminator:) |  |
+| cfg.swift:174:5:174:5 | print(_:separator:terminator:) | cfg.swift:174:11:174:11 | 1 |  |
+| cfg.swift:174:5:174:14 | call to print(_:separator:terminator:) | cfg.swift:175:6:177:5 | defer { ... } |  |
+| cfg.swift:174:10:174:10 | default separator | cfg.swift:174:10:174:10 | default terminator |  |
+| cfg.swift:174:10:174:10 | default terminator | cfg.swift:174:5:174:14 | call to print(_:separator:terminator:) |  |
+| cfg.swift:174:11:174:11 | 1 | cfg.swift:174:11:174:11 | (Any) ... |  |
+| cfg.swift:174:11:174:11 | (Any) ... | cfg.swift:174:11:174:11 | [...] |  |
+| cfg.swift:174:11:174:11 | [...] | cfg.swift:174:10:174:10 | default separator |  |
+| cfg.swift:174:11:174:11 | [...] | cfg.swift:174:11:174:11 | [...] |  |
+| cfg.swift:175:6:177:5 | defer { ... } | cfg.swift:176:7:176:7 | print(_:separator:terminator:) |  |
+| cfg.swift:176:7:176:7 | print(_:separator:terminator:) | cfg.swift:176:13:176:13 | 2 |  |
+| cfg.swift:176:7:176:16 | call to print(_:separator:terminator:) | cfg.swift:170:5:170:5 | print(_:separator:terminator:) |  |
+| cfg.swift:176:12:176:12 | default separator | cfg.swift:176:12:176:12 | default terminator |  |
+| cfg.swift:176:12:176:12 | default terminator | cfg.swift:176:7:176:16 | call to print(_:separator:terminator:) |  |
+| cfg.swift:176:13:176:13 | 2 | cfg.swift:176:13:176:13 | (Any) ... |  |
+| cfg.swift:176:13:176:13 | (Any) ... | cfg.swift:176:13:176:13 | [...] |  |
+| cfg.swift:176:13:176:13 | [...] | cfg.swift:176:12:176:12 | default separator |  |
+| cfg.swift:176:13:176:13 | [...] | cfg.swift:176:13:176:13 | [...] |  |
+| cfg.swift:181:1:191:1 | enter m1(x:) | cfg.swift:181:1:191:1 | m1(x:) |  |
+| cfg.swift:181:1:191:1 | exit m1(x:) (abnormal) | cfg.swift:181:1:191:1 | exit m1(x:) |  |
+| cfg.swift:181:1:191:1 | exit m1(x:) (normal) | cfg.swift:181:1:191:1 | exit m1(x:) |  |
+| cfg.swift:181:1:191:1 | m1(x:) | cfg.swift:181:9:181:13 | x |  |
+| cfg.swift:181:9:181:13 | x | cfg.swift:182:3:190:3 | if ... then { ... } else { ... } |  |
+| cfg.swift:182:3:190:3 | if ... then { ... } else { ... } | cfg.swift:182:6:182:10 | StmtCondition |  |
+| cfg.swift:182:6:182:6 | x | cfg.swift:182:10:182:10 | 2 |  |
+| cfg.swift:182:6:182:10 | ... .>(_:_:) ... | cfg.swift:183:5:183:5 | print(_:separator:terminator:) | true |
+| cfg.swift:182:6:182:10 | ... .>(_:_:) ... | cfg.swift:185:8:190:3 | if ... then { ... } else { ... } | false |
+| cfg.swift:182:6:182:10 | StmtCondition | cfg.swift:182:8:182:8 | .>(_:_:) |  |
+| cfg.swift:182:8:182:8 | .>(_:_:) | cfg.swift:182:8:182:8 | Int.Type |  |
+| cfg.swift:182:8:182:8 | Int.Type | cfg.swift:182:6:182:6 | x |  |
+| cfg.swift:182:10:182:10 | 2 | cfg.swift:182:6:182:10 | ... .>(_:_:) ... |  |
+| cfg.swift:183:5:183:5 | print(_:separator:terminator:) | cfg.swift:183:11:183:11 | x is greater than 2 |  |
+| cfg.swift:183:5:183:32 | call to print(_:separator:terminator:) | cfg.swift:181:1:191:1 | exit m1(x:) (normal) |  |
+| cfg.swift:183:10:183:10 | default separator | cfg.swift:183:10:183:10 | default terminator |  |
+| cfg.swift:183:10:183:10 | default terminator | cfg.swift:183:5:183:32 | call to print(_:separator:terminator:) |  |
+| cfg.swift:183:11:183:11 | (Any) ... | cfg.swift:183:11:183:11 | [...] |  |
+| cfg.swift:183:11:183:11 | [...] | cfg.swift:183:10:183:10 | default separator |  |
+| cfg.swift:183:11:183:11 | [...] | cfg.swift:183:11:183:11 | [...] |  |
+| cfg.swift:183:11:183:11 | x is greater than 2 | cfg.swift:183:11:183:11 | (Any) ... |  |
+| cfg.swift:185:8:190:3 | if ... then { ... } else { ... } | cfg.swift:185:11:185:38 | StmtCondition |  |
+| cfg.swift:185:11:185:11 | x | cfg.swift:185:16:185:16 | 2 |  |
+| cfg.swift:185:11:185:16 | ... .<=(_:_:) ... | cfg.swift:185:11:185:25 | [false] ... .&&(_:_:) ... | false |
+| cfg.swift:185:11:185:16 | ... .<=(_:_:) ... | cfg.swift:185:21:185:25 | { ... } | true |
+| cfg.swift:185:11:185:25 | ... .&&(_:_:) ... | cfg.swift:181:1:191:1 | exit m1(x:) (abnormal) | exception |
+| cfg.swift:185:11:185:25 | ... .&&(_:_:) ... | cfg.swift:185:11:185:38 | [false] ... .&&(_:_:) ... | false |
+| cfg.swift:185:11:185:25 | ... .&&(_:_:) ... | cfg.swift:185:30:185:38 | { ... } | true |
+| cfg.swift:185:11:185:25 | [false] ... .&&(_:_:) ... | cfg.swift:181:1:191:1 | exit m1(x:) (abnormal) | exception |
+| cfg.swift:185:11:185:25 | [false] ... .&&(_:_:) ... | cfg.swift:185:11:185:38 | [false] ... .&&(_:_:) ... | false |
+| cfg.swift:185:11:185:38 | ... .&&(_:_:) ... | cfg.swift:181:1:191:1 | exit m1(x:) (abnormal) | exception |
+| cfg.swift:185:11:185:38 | ... .&&(_:_:) ... | cfg.swift:186:5:186:5 | print(_:separator:terminator:) | true |
+| cfg.swift:185:11:185:38 | ... .&&(_:_:) ... | cfg.swift:189:5:189:5 | print(_:separator:terminator:) | false |
+| cfg.swift:185:11:185:38 | StmtCondition | cfg.swift:185:13:185:13 | .<=(_:_:) |  |
+| cfg.swift:185:11:185:38 | [false] ... .&&(_:_:) ... | cfg.swift:181:1:191:1 | exit m1(x:) (abnormal) | exception |
+| cfg.swift:185:11:185:38 | [false] ... .&&(_:_:) ... | cfg.swift:189:5:189:5 | print(_:separator:terminator:) | false |
+| cfg.swift:185:13:185:13 | .<=(_:_:) | cfg.swift:185:13:185:13 | Int.Type |  |
+| cfg.swift:185:13:185:13 | Int.Type | cfg.swift:185:11:185:11 | x |  |
+| cfg.swift:185:16:185:16 | 2 | cfg.swift:185:11:185:16 | ... .<=(_:_:) ... |  |
+| cfg.swift:185:21:185:21 | x | cfg.swift:185:25:185:25 | 0 |  |
+| cfg.swift:185:21:185:25 | ... .>(_:_:) ... | cfg.swift:185:21:185:25 | return ... |  |
+| cfg.swift:185:21:185:25 | return ... | cfg.swift:185:11:185:25 | ... .&&(_:_:) ... |  |
+| cfg.swift:185:21:185:25 | { ... } | cfg.swift:185:23:185:23 | .>(_:_:) |  |
+| cfg.swift:185:23:185:23 | .>(_:_:) | cfg.swift:185:23:185:23 | Int.Type |  |
+| cfg.swift:185:23:185:23 | Int.Type | cfg.swift:185:21:185:21 | x |  |
+| cfg.swift:185:25:185:25 | 0 | cfg.swift:185:21:185:25 | ... .>(_:_:) ... |  |
+| cfg.swift:185:30:185:38 | call to !(_:) | cfg.swift:185:30:185:38 | return ... |  |
+| cfg.swift:185:30:185:38 | return ... | cfg.swift:185:11:185:38 | ... .&&(_:_:) ... |  |
+| cfg.swift:185:30:185:38 | { ... } | cfg.swift:185:34:185:34 | .==(_:_:) |  |
+| cfg.swift:185:31:185:38 | (...) | cfg.swift:185:30:185:38 | call to !(_:) |  |
+| cfg.swift:185:32:185:32 | x | cfg.swift:185:37:185:37 | 5 |  |
+| cfg.swift:185:32:185:37 | ... .==(_:_:) ... | cfg.swift:185:31:185:38 | (...) |  |
+| cfg.swift:185:34:185:34 | .==(_:_:) | cfg.swift:185:34:185:34 | Int.Type |  |
+| cfg.swift:185:34:185:34 | Int.Type | cfg.swift:185:32:185:32 | x |  |
+| cfg.swift:185:37:185:37 | 5 | cfg.swift:185:32:185:37 | ... .==(_:_:) ... |  |
+| cfg.swift:186:5:186:5 | print(_:separator:terminator:) | cfg.swift:186:11:186:11 | x is 1 |  |
+| cfg.swift:186:5:186:19 | call to print(_:separator:terminator:) | cfg.swift:181:1:191:1 | exit m1(x:) (normal) |  |
+| cfg.swift:186:10:186:10 | default separator | cfg.swift:186:10:186:10 | default terminator |  |
+| cfg.swift:186:10:186:10 | default terminator | cfg.swift:186:5:186:19 | call to print(_:separator:terminator:) |  |
+| cfg.swift:186:11:186:11 | (Any) ... | cfg.swift:186:11:186:11 | [...] |  |
+| cfg.swift:186:11:186:11 | [...] | cfg.swift:186:10:186:10 | default separator |  |
+| cfg.swift:186:11:186:11 | [...] | cfg.swift:186:11:186:11 | [...] |  |
+| cfg.swift:186:11:186:11 | x is 1 | cfg.swift:186:11:186:11 | (Any) ... |  |
+| cfg.swift:189:5:189:5 | print(_:separator:terminator:) | cfg.swift:189:11:189:11 | I can't guess the number |  |
+| cfg.swift:189:5:189:37 | call to print(_:separator:terminator:) | cfg.swift:181:1:191:1 | exit m1(x:) (normal) |  |
+| cfg.swift:189:10:189:10 | default separator | cfg.swift:189:10:189:10 | default terminator |  |
+| cfg.swift:189:10:189:10 | default terminator | cfg.swift:189:5:189:37 | call to print(_:separator:terminator:) |  |
+| cfg.swift:189:11:189:11 | (Any) ... | cfg.swift:189:11:189:11 | [...] |  |
+| cfg.swift:189:11:189:11 | I can't guess the number | cfg.swift:189:11:189:11 | (Any) ... |  |
+| cfg.swift:189:11:189:11 | [...] | cfg.swift:189:10:189:10 | default separator |  |
+| cfg.swift:189:11:189:11 | [...] | cfg.swift:189:11:189:11 | [...] |  |
+| cfg.swift:193:1:198:1 | enter m2(b:) | cfg.swift:193:1:198:1 | m2(b:) |  |
+| cfg.swift:193:1:198:1 | exit m2(b:) (normal) | cfg.swift:193:1:198:1 | exit m2(b:) |  |
+| cfg.swift:193:1:198:1 | m2(b:) | cfg.swift:193:9:193:13 | b |  |
+| cfg.swift:193:9:193:13 | b | cfg.swift:194:3:196:3 | if ... then { ... } |  |
+| cfg.swift:194:3:196:3 | if ... then { ... } | cfg.swift:194:6:194:6 | StmtCondition |  |
+| cfg.swift:194:6:194:6 | StmtCondition | cfg.swift:194:6:194:6 | b |  |
+| cfg.swift:194:6:194:6 | b | cfg.swift:195:12:195:12 | 0 | true |
+| cfg.swift:194:6:194:6 | b | cfg.swift:197:10:197:10 | 1 | false |
+| cfg.swift:195:5:195:12 | return ... | cfg.swift:193:1:198:1 | exit m2(b:) (normal) | return |
+| cfg.swift:195:12:195:12 | 0 | cfg.swift:195:5:195:12 | return ... |  |
+| cfg.swift:197:3:197:10 | return ... | cfg.swift:193:1:198:1 | exit m2(b:) (normal) | return |
+| cfg.swift:197:10:197:10 | 1 | cfg.swift:197:3:197:10 | return ... |  |
+| cfg.swift:200:1:208:1 | enter m3(x:) | cfg.swift:200:1:208:1 | m3(x:) |  |
+| cfg.swift:200:1:208:1 | exit m3(x:) (normal) | cfg.swift:200:1:208:1 | exit m3(x:) |  |
+| cfg.swift:200:1:208:1 | m3(x:) | cfg.swift:200:9:200:19 | x |  |
+| cfg.swift:200:9:200:19 | x | cfg.swift:201:3:206:3 | if ... then { ... } |  |
+| cfg.swift:201:3:206:3 | if ... then { ... } | cfg.swift:201:6:201:10 | StmtCondition |  |
+| cfg.swift:201:6:201:6 | (Int) ... | cfg.swift:201:10:201:10 | 0 |  |
+| cfg.swift:201:6:201:6 | x | cfg.swift:201:6:201:6 | (Int) ... |  |
+| cfg.swift:201:6:201:10 | ... .<(_:_:) ... | cfg.swift:202:5:202:5 | x | true |
+| cfg.swift:201:6:201:10 | ... .<(_:_:) ... | cfg.swift:207:10:207:10 | x | false |
+| cfg.swift:201:6:201:10 | StmtCondition | cfg.swift:201:8:201:8 | .<(_:_:) |  |
+| cfg.swift:201:8:201:8 | .<(_:_:) | cfg.swift:201:8:201:8 | Int.Type |  |
+| cfg.swift:201:8:201:8 | Int.Type | cfg.swift:201:6:201:6 | x |  |
+| cfg.swift:201:10:201:10 | 0 | cfg.swift:201:6:201:10 | ... .<(_:_:) ... |  |
+| cfg.swift:202:5:202:5 | x | cfg.swift:202:9:202:9 | .-(_:) |  |
+| cfg.swift:202:5:202:10 |  ... = ... | cfg.swift:203:5:205:5 | if ... then { ... } |  |
+| cfg.swift:202:9:202:9 | .-(_:) | cfg.swift:202:9:202:9 | Int.Type |  |
+| cfg.swift:202:9:202:9 | Int.Type | cfg.swift:202:10:202:10 | x |  |
+| cfg.swift:202:9:202:10 | call to -(_:) | cfg.swift:202:5:202:10 |  ... = ... |  |
+| cfg.swift:202:10:202:10 | (Int) ... | cfg.swift:202:9:202:10 | call to -(_:) |  |
+| cfg.swift:202:10:202:10 | x | cfg.swift:202:10:202:10 | (Int) ... |  |
+| cfg.swift:203:5:205:5 | if ... then { ... } | cfg.swift:203:8:203:12 | StmtCondition |  |
+| cfg.swift:203:8:203:8 | (Int) ... | cfg.swift:203:12:203:12 | 10 |  |
+| cfg.swift:203:8:203:8 | x | cfg.swift:203:8:203:8 | (Int) ... |  |
+| cfg.swift:203:8:203:12 | ... .>(_:_:) ... | cfg.swift:204:7:204:7 | x | true |
+| cfg.swift:203:8:203:12 | ... .>(_:_:) ... | cfg.swift:207:10:207:10 | x | false |
+| cfg.swift:203:8:203:12 | StmtCondition | cfg.swift:203:10:203:10 | .>(_:_:) |  |
+| cfg.swift:203:10:203:10 | .>(_:_:) | cfg.swift:203:10:203:10 | Int.Type |  |
+| cfg.swift:203:10:203:10 | Int.Type | cfg.swift:203:8:203:8 | x |  |
+| cfg.swift:203:12:203:12 | 10 | cfg.swift:203:8:203:12 | ... .>(_:_:) ... |  |
+| cfg.swift:204:7:204:7 | x | cfg.swift:204:13:204:13 | .-(_:_:) |  |
+| cfg.swift:204:7:204:15 |  ... = ... | cfg.swift:207:10:207:10 | x |  |
+| cfg.swift:204:11:204:11 | (Int) ... | cfg.swift:204:15:204:15 | 1 |  |
+| cfg.swift:204:11:204:11 | x | cfg.swift:204:11:204:11 | (Int) ... |  |
+| cfg.swift:204:11:204:15 | ... .-(_:_:) ... | cfg.swift:204:7:204:15 |  ... = ... |  |
+| cfg.swift:204:13:204:13 | .-(_:_:) | cfg.swift:204:13:204:13 | Int.Type |  |
+| cfg.swift:204:13:204:13 | Int.Type | cfg.swift:204:11:204:11 | x |  |
+| cfg.swift:204:15:204:15 | 1 | cfg.swift:204:11:204:15 | ... .-(_:_:) ... |  |
+| cfg.swift:207:3:207:10 | return ... | cfg.swift:200:1:208:1 | exit m3(x:) (normal) | return |
+| cfg.swift:207:10:207:10 | (Int) ... | cfg.swift:207:3:207:10 | return ... |  |
+| cfg.swift:207:10:207:10 | x | cfg.swift:207:10:207:10 | (Int) ... |  |
+| cfg.swift:210:1:212:1 | enter m4(b1:b2:b3:) | cfg.swift:210:1:212:1 | m4(b1:b2:b3:) |  |
+| cfg.swift:210:1:212:1 | exit m4(b1:b2:b3:) (normal) | cfg.swift:210:1:212:1 | exit m4(b1:b2:b3:) |  |
+| cfg.swift:210:1:212:1 | m4(b1:b2:b3:) | cfg.swift:210:10:210:15 | b1 |  |
+| cfg.swift:210:10:210:15 | b1 | cfg.swift:210:21:210:26 | b2 |  |
+| cfg.swift:210:21:210:26 | b2 | cfg.swift:210:32:210:37 | b3 |  |
+| cfg.swift:210:32:210:37 | b3 | cfg.swift:211:11:211:11 | b1 |  |
+| cfg.swift:211:3:211:40 | return ... | cfg.swift:210:1:212:1 | exit m4(b1:b2:b3:) (normal) | return |
+| cfg.swift:211:10:211:23 | [false] (...) | cfg.swift:211:40:211:40 | !b2 \|\| !b3 | false |
+| cfg.swift:211:10:211:23 | [true] (...) | cfg.swift:211:27:211:27 | b2 \|\| b3 | true |
+| cfg.swift:211:10:211:40 | ... ? ... : ... | cfg.swift:211:3:211:40 | return ... |  |
+| cfg.swift:211:11:211:11 | b1 | cfg.swift:211:16:211:16 | b2 | true |
+| cfg.swift:211:11:211:11 | b1 | cfg.swift:211:21:211:21 | b3 | false |
+| cfg.swift:211:11:211:21 | [false] ... ? ... : ... | cfg.swift:211:10:211:23 | [false] (...) | false |
+| cfg.swift:211:11:211:21 | [true] ... ? ... : ... | cfg.swift:211:10:211:23 | [true] (...) | true |
+| cfg.swift:211:16:211:16 | b2 | cfg.swift:211:11:211:21 | [false] ... ? ... : ... | false |
+| cfg.swift:211:16:211:16 | b2 | cfg.swift:211:11:211:21 | [true] ... ? ... : ... | true |
+| cfg.swift:211:21:211:21 | b3 | cfg.swift:211:11:211:21 | [false] ... ? ... : ... | false |
+| cfg.swift:211:21:211:21 | b3 | cfg.swift:211:11:211:21 | [true] ... ? ... : ... | true |
+| cfg.swift:211:27:211:27 | b2 \|\| b3 | cfg.swift:211:10:211:40 | ... ? ... : ... |  |
+| cfg.swift:211:40:211:40 | !b2 \|\| !b3 | cfg.swift:211:10:211:40 | ... ? ... : ... |  |
+| cfg.swift:214:1:221:1 | conversionsInSplitEntry(b:) | cfg.swift:214:31:214:35 | b |  |
+| cfg.swift:214:1:221:1 | enter conversionsInSplitEntry(b:) | cfg.swift:214:1:221:1 | conversionsInSplitEntry(b:) |  |
+| cfg.swift:214:1:221:1 | exit conversionsInSplitEntry(b:) (normal) | cfg.swift:214:1:221:1 | exit conversionsInSplitEntry(b:) |  |
+| cfg.swift:214:31:214:35 | b | cfg.swift:215:3:220:3 | if ... then { ... } else { ... } |  |
+| cfg.swift:215:3:220:3 | if ... then { ... } else { ... } | cfg.swift:215:6:215:29 | StmtCondition |  |
+| cfg.swift:215:6:215:6 | b | cfg.swift:215:11:215:11 | true | true |
+| cfg.swift:215:6:215:6 | b | cfg.swift:215:24:215:24 | false | false |
+| cfg.swift:215:6:215:29 | StmtCondition | cfg.swift:215:6:215:6 | b |  |
+| cfg.swift:215:6:215:29 | [false] ... ? ... : ... | cfg.swift:219:12:219:12 | !b | false |
+| cfg.swift:215:6:215:29 | [true] ... ? ... : ... | cfg.swift:216:12:216:12 | b | true |
+| cfg.swift:215:10:215:15 | [true] (...) | cfg.swift:215:6:215:29 | [true] ... ? ... : ... | true |
+| cfg.swift:215:11:215:11 | true | cfg.swift:215:10:215:15 | [true] (...) | true |
+| cfg.swift:215:19:215:29 | [false] (Bool) ... | cfg.swift:215:6:215:29 | [false] ... ? ... : ... | false |
+| cfg.swift:215:24:215:24 | false | cfg.swift:215:19:215:29 | [false] (Bool) ... | false |
+| cfg.swift:216:5:216:12 | return ... | cfg.swift:214:1:221:1 | exit conversionsInSplitEntry(b:) (normal) | return |
+| cfg.swift:216:12:216:12 | b | cfg.swift:216:5:216:12 | return ... |  |
+| cfg.swift:219:5:219:12 | return ... | cfg.swift:214:1:221:1 | exit conversionsInSplitEntry(b:) (normal) | return |
+| cfg.swift:219:12:219:12 | !b | cfg.swift:219:5:219:12 | return ... |  |
+| cfg.swift:223:1:227:1 | constant_condition() | cfg.swift:224:3:226:3 | if ... then { ... } |  |
+| cfg.swift:223:1:227:1 | enter constant_condition() | cfg.swift:223:1:227:1 | constant_condition() |  |
+| cfg.swift:223:1:227:1 | exit constant_condition() (normal) | cfg.swift:223:1:227:1 | exit constant_condition() |  |
+| cfg.swift:224:3:226:3 | if ... then { ... } | cfg.swift:224:6:224:7 | StmtCondition |  |
+| cfg.swift:224:6:224:7 | StmtCondition | cfg.swift:224:7:224:7 | true |  |
+| cfg.swift:224:6:224:7 | [false] call to !(_:) | cfg.swift:223:1:227:1 | exit constant_condition() (normal) | false |
+| cfg.swift:224:7:224:7 | true | cfg.swift:224:6:224:7 | [false] call to !(_:) | true |
+| cfg.swift:229:1:235:1 | empty_else(b:) | cfg.swift:229:17:229:21 | b |  |
+| cfg.swift:229:1:235:1 | enter empty_else(b:) | cfg.swift:229:1:235:1 | empty_else(b:) |  |
+| cfg.swift:229:1:235:1 | exit empty_else(b:) (normal) | cfg.swift:229:1:235:1 | exit empty_else(b:) |  |
+| cfg.swift:229:17:229:21 | b | cfg.swift:230:3:233:9 | if ... then { ... } else { ... } |  |
+| cfg.swift:230:3:233:9 | if ... then { ... } else { ... } | cfg.swift:230:6:230:6 | StmtCondition |  |
+| cfg.swift:230:6:230:6 | StmtCondition | cfg.swift:230:6:230:6 | b |  |
+| cfg.swift:230:6:230:6 | b | cfg.swift:231:5:231:5 | print(_:separator:terminator:) | true |
+| cfg.swift:230:6:230:6 | b | cfg.swift:233:8:233:9 | { ... } | false |
+| cfg.swift:231:5:231:5 | print(_:separator:terminator:) | cfg.swift:231:11:231:11 | true |  |
+| cfg.swift:231:5:231:17 | call to print(_:separator:terminator:) | cfg.swift:234:3:234:3 | print(_:separator:terminator:) |  |
+| cfg.swift:231:10:231:10 | default separator | cfg.swift:231:10:231:10 | default terminator |  |
+| cfg.swift:231:10:231:10 | default terminator | cfg.swift:231:5:231:17 | call to print(_:separator:terminator:) |  |
+| cfg.swift:231:11:231:11 | (Any) ... | cfg.swift:231:11:231:11 | [...] |  |
+| cfg.swift:231:11:231:11 | [...] | cfg.swift:231:10:231:10 | default separator |  |
+| cfg.swift:231:11:231:11 | [...] | cfg.swift:231:11:231:11 | [...] |  |
+| cfg.swift:231:11:231:11 | true | cfg.swift:231:11:231:11 | (Any) ... |  |
+| cfg.swift:233:8:233:9 | { ... } | cfg.swift:234:3:234:3 | print(_:separator:terminator:) |  |
+| cfg.swift:234:3:234:3 | print(_:separator:terminator:) | cfg.swift:234:9:234:9 | done |  |
+| cfg.swift:234:3:234:15 | call to print(_:separator:terminator:) | cfg.swift:229:1:235:1 | exit empty_else(b:) (normal) |  |
+| cfg.swift:234:8:234:8 | default separator | cfg.swift:234:8:234:8 | default terminator |  |
+| cfg.swift:234:8:234:8 | default terminator | cfg.swift:234:3:234:15 | call to print(_:separator:terminator:) |  |
+| cfg.swift:234:9:234:9 | (Any) ... | cfg.swift:234:9:234:9 | [...] |  |
+| cfg.swift:234:9:234:9 | [...] | cfg.swift:234:8:234:8 | default separator |  |
+| cfg.swift:234:9:234:9 | [...] | cfg.swift:234:9:234:9 | [...] |  |
+| cfg.swift:234:9:234:9 | done | cfg.swift:234:9:234:9 | (Any) ... |  |
+| cfg.swift:237:1:241:1 | disjunct(b1:b2:) | cfg.swift:237:16:237:21 | b1 |  |
+| cfg.swift:237:1:241:1 | enter disjunct(b1:b2:) | cfg.swift:237:1:241:1 | disjunct(b1:b2:) |  |
+| cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (abnormal) | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) |  |
+| cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (normal) | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) |  |
+| cfg.swift:237:16:237:21 | b1 | cfg.swift:237:27:237:32 | b2 |  |
+| cfg.swift:237:27:237:32 | b2 | cfg.swift:238:3:240:3 | if ... then { ... } |  |
+| cfg.swift:238:3:240:3 | if ... then { ... } | cfg.swift:238:6:238:15 | StmtCondition |  |
+| cfg.swift:238:6:238:15 | StmtCondition | cfg.swift:238:7:238:7 | b1 |  |
+| cfg.swift:238:6:238:15 | [false] (...) | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (normal) | false |
+| cfg.swift:238:6:238:15 | [true] (...) | cfg.swift:239:5:239:5 | print(_:separator:terminator:) | true |
+| cfg.swift:238:7:238:7 | b1 | cfg.swift:238:7:238:13 | [true] ... .\|\|(_:_:) ... | true |
+| cfg.swift:238:7:238:7 | b1 | cfg.swift:238:13:238:13 | { ... } | false |
+| cfg.swift:238:7:238:13 | ... .\|\|(_:_:) ... | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (abnormal) | exception |
+| cfg.swift:238:7:238:13 | ... .\|\|(_:_:) ... | cfg.swift:238:6:238:15 | [false] (...) | false |
+| cfg.swift:238:7:238:13 | ... .\|\|(_:_:) ... | cfg.swift:238:6:238:15 | [true] (...) | true |
+| cfg.swift:238:7:238:13 | [true] ... .\|\|(_:_:) ... | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (abnormal) | exception |
+| cfg.swift:238:7:238:13 | [true] ... .\|\|(_:_:) ... | cfg.swift:238:6:238:15 | [true] (...) | true |
+| cfg.swift:238:13:238:13 | b2 | cfg.swift:238:13:238:13 | return ... |  |
+| cfg.swift:238:13:238:13 | return ... | cfg.swift:238:7:238:13 | ... .\|\|(_:_:) ... |  |
+| cfg.swift:238:13:238:13 | { ... } | cfg.swift:238:13:238:13 | b2 |  |
+| cfg.swift:239:5:239:5 | print(_:separator:terminator:) | cfg.swift:239:11:239:11 | b1 or b2 |  |
+| cfg.swift:239:5:239:21 | call to print(_:separator:terminator:) | cfg.swift:237:1:241:1 | exit disjunct(b1:b2:) (normal) |  |
+| cfg.swift:239:10:239:10 | default separator | cfg.swift:239:10:239:10 | default terminator |  |
+| cfg.swift:239:10:239:10 | default terminator | cfg.swift:239:5:239:21 | call to print(_:separator:terminator:) |  |
+| cfg.swift:239:11:239:11 | (Any) ... | cfg.swift:239:11:239:11 | [...] |  |
+| cfg.swift:239:11:239:11 | [...] | cfg.swift:239:10:239:10 | default separator |  |
+| cfg.swift:239:11:239:11 | [...] | cfg.swift:239:11:239:11 | [...] |  |
+| cfg.swift:239:11:239:11 | b1 or b2 | cfg.swift:239:11:239:11 | (Any) ... |  |
+| cfg.swift:243:1:260:1 | binaryExprs(a:b:) | cfg.swift:243:18:243:22 | a |  |
+| cfg.swift:243:1:260:1 | enter binaryExprs(a:b:) | cfg.swift:243:1:260:1 | binaryExprs(a:b:) |  |
+| cfg.swift:243:1:260:1 | exit binaryExprs(a:b:) (normal) | cfg.swift:243:1:260:1 | exit binaryExprs(a:b:) |  |
+| cfg.swift:243:18:243:22 | a | cfg.swift:243:27:243:31 | b |  |
+| cfg.swift:243:27:243:31 | b | cfg.swift:244:7:244:7 | c |  |
+| cfg.swift:244:3:244:15 | var ... = ... | cfg.swift:245:7:245:7 | d |  |
+| cfg.swift:244:7:244:7 | c | cfg.swift:244:13:244:13 | .+(_:_:) | match |
+| cfg.swift:244:11:244:11 | a | cfg.swift:244:15:244:15 | b |  |
+| cfg.swift:244:11:244:15 | ... .+(_:_:) ... | cfg.swift:244:3:244:15 | var ... = ... |  |
+| cfg.swift:244:13:244:13 | .+(_:_:) | cfg.swift:244:13:244:13 | Int.Type |  |
+| cfg.swift:244:13:244:13 | Int.Type | cfg.swift:244:11:244:11 | a |  |
+| cfg.swift:244:15:244:15 | b | cfg.swift:244:11:244:15 | ... .+(_:_:) ... |  |
+| cfg.swift:245:3:245:15 | var ... = ... | cfg.swift:246:7:246:7 | e |  |
+| cfg.swift:245:7:245:7 | d | cfg.swift:245:13:245:13 | .-(_:_:) | match |
+| cfg.swift:245:11:245:11 | a | cfg.swift:245:15:245:15 | b |  |
+| cfg.swift:245:11:245:15 | ... .-(_:_:) ... | cfg.swift:245:3:245:15 | var ... = ... |  |
+| cfg.swift:245:13:245:13 | .-(_:_:) | cfg.swift:245:13:245:13 | Int.Type |  |
+| cfg.swift:245:13:245:13 | Int.Type | cfg.swift:245:11:245:11 | a |  |
+| cfg.swift:245:15:245:15 | b | cfg.swift:245:11:245:15 | ... .-(_:_:) ... |  |
+| cfg.swift:246:3:246:15 | var ... = ... | cfg.swift:247:7:247:7 | f |  |
+| cfg.swift:246:7:246:7 | e | cfg.swift:246:13:246:13 | .*(_:_:) | match |
+| cfg.swift:246:11:246:11 | a | cfg.swift:246:15:246:15 | b |  |
+| cfg.swift:246:11:246:15 | ... .*(_:_:) ... | cfg.swift:246:3:246:15 | var ... = ... |  |
+| cfg.swift:246:13:246:13 | .*(_:_:) | cfg.swift:246:13:246:13 | Int.Type |  |
+| cfg.swift:246:13:246:13 | Int.Type | cfg.swift:246:11:246:11 | a |  |
+| cfg.swift:246:15:246:15 | b | cfg.swift:246:11:246:15 | ... .*(_:_:) ... |  |
+| cfg.swift:247:3:247:15 | var ... = ... | cfg.swift:248:7:248:7 | g |  |
+| cfg.swift:247:7:247:7 | f | cfg.swift:247:13:247:13 | ./(_:_:) | match |
+| cfg.swift:247:11:247:11 | a | cfg.swift:247:15:247:15 | b |  |
+| cfg.swift:247:11:247:15 | ... ./(_:_:) ... | cfg.swift:247:3:247:15 | var ... = ... |  |
+| cfg.swift:247:13:247:13 | ./(_:_:) | cfg.swift:247:13:247:13 | Int.Type |  |
+| cfg.swift:247:13:247:13 | Int.Type | cfg.swift:247:11:247:11 | a |  |
+| cfg.swift:247:15:247:15 | b | cfg.swift:247:11:247:15 | ... ./(_:_:) ... |  |
+| cfg.swift:248:3:248:15 | var ... = ... | cfg.swift:249:7:249:7 | h |  |
+| cfg.swift:248:7:248:7 | g | cfg.swift:248:13:248:13 | .%(_:_:) | match |
+| cfg.swift:248:11:248:11 | a | cfg.swift:248:15:248:15 | b |  |
+| cfg.swift:248:11:248:15 | ... .%(_:_:) ... | cfg.swift:248:3:248:15 | var ... = ... |  |
+| cfg.swift:248:13:248:13 | .%(_:_:) | cfg.swift:248:13:248:13 | Int.Type |  |
+| cfg.swift:248:13:248:13 | Int.Type | cfg.swift:248:11:248:11 | a |  |
+| cfg.swift:248:15:248:15 | b | cfg.swift:248:11:248:15 | ... .%(_:_:) ... |  |
+| cfg.swift:249:3:249:15 | var ... = ... | cfg.swift:250:7:250:7 | i |  |
+| cfg.swift:249:7:249:7 | h | cfg.swift:249:13:249:13 | .&(_:_:) | match |
+| cfg.swift:249:11:249:11 | a | cfg.swift:249:15:249:15 | b |  |
+| cfg.swift:249:11:249:15 | ... .&(_:_:) ... | cfg.swift:249:3:249:15 | var ... = ... |  |
+| cfg.swift:249:13:249:13 | .&(_:_:) | cfg.swift:249:13:249:13 | Int.Type |  |
+| cfg.swift:249:13:249:13 | Int.Type | cfg.swift:249:11:249:11 | a |  |
+| cfg.swift:249:15:249:15 | b | cfg.swift:249:11:249:15 | ... .&(_:_:) ... |  |
+| cfg.swift:250:3:250:15 | var ... = ... | cfg.swift:251:7:251:7 | j |  |
+| cfg.swift:250:7:250:7 | i | cfg.swift:250:13:250:13 | .\|(_:_:) | match |
+| cfg.swift:250:11:250:11 | a | cfg.swift:250:15:250:15 | b |  |
+| cfg.swift:250:11:250:15 | ... .\|(_:_:) ... | cfg.swift:250:3:250:15 | var ... = ... |  |
+| cfg.swift:250:13:250:13 | .\|(_:_:) | cfg.swift:250:13:250:13 | Int.Type |  |
+| cfg.swift:250:13:250:13 | Int.Type | cfg.swift:250:11:250:11 | a |  |
+| cfg.swift:250:15:250:15 | b | cfg.swift:250:11:250:15 | ... .\|(_:_:) ... |  |
+| cfg.swift:251:3:251:15 | var ... = ... | cfg.swift:252:7:252:7 | k |  |
+| cfg.swift:251:7:251:7 | j | cfg.swift:251:13:251:13 | .^(_:_:) | match |
+| cfg.swift:251:11:251:11 | a | cfg.swift:251:15:251:15 | b |  |
+| cfg.swift:251:11:251:15 | ... .^(_:_:) ... | cfg.swift:251:3:251:15 | var ... = ... |  |
+| cfg.swift:251:13:251:13 | .^(_:_:) | cfg.swift:251:13:251:13 | Int.Type |  |
+| cfg.swift:251:13:251:13 | Int.Type | cfg.swift:251:11:251:11 | a |  |
+| cfg.swift:251:15:251:15 | b | cfg.swift:251:11:251:15 | ... .^(_:_:) ... |  |
+| cfg.swift:252:3:252:16 | var ... = ... | cfg.swift:253:7:253:7 | l |  |
+| cfg.swift:252:7:252:7 | k | cfg.swift:252:13:252:13 | .<<(_:_:) | match |
+| cfg.swift:252:11:252:11 | a | cfg.swift:252:16:252:16 | b |  |
+| cfg.swift:252:11:252:16 | ... .<<(_:_:) ... | cfg.swift:252:3:252:16 | var ... = ... |  |
+| cfg.swift:252:13:252:13 | .<<(_:_:) | cfg.swift:252:13:252:13 | Int.Type |  |
+| cfg.swift:252:13:252:13 | Int.Type | cfg.swift:252:11:252:11 | a |  |
+| cfg.swift:252:16:252:16 | b | cfg.swift:252:11:252:16 | ... .<<(_:_:) ... |  |
+| cfg.swift:253:3:253:16 | var ... = ... | cfg.swift:254:7:254:7 | o |  |
+| cfg.swift:253:7:253:7 | l | cfg.swift:253:13:253:13 | .>>(_:_:) | match |
+| cfg.swift:253:11:253:11 | a | cfg.swift:253:16:253:16 | b |  |
+| cfg.swift:253:11:253:16 | ... .>>(_:_:) ... | cfg.swift:253:3:253:16 | var ... = ... |  |
+| cfg.swift:253:13:253:13 | .>>(_:_:) | cfg.swift:253:13:253:13 | Int.Type |  |
+| cfg.swift:253:13:253:13 | Int.Type | cfg.swift:253:11:253:11 | a |  |
+| cfg.swift:253:16:253:16 | b | cfg.swift:253:11:253:16 | ... .>>(_:_:) ... |  |
+| cfg.swift:254:3:254:16 | var ... = ... | cfg.swift:255:7:255:7 | p |  |
+| cfg.swift:254:7:254:7 | o | cfg.swift:254:13:254:13 | .==(_:_:) | match |
+| cfg.swift:254:11:254:11 | a | cfg.swift:254:16:254:16 | b |  |
+| cfg.swift:254:11:254:16 | ... .==(_:_:) ... | cfg.swift:254:3:254:16 | var ... = ... |  |
+| cfg.swift:254:13:254:13 | .==(_:_:) | cfg.swift:254:13:254:13 | Int.Type |  |
+| cfg.swift:254:13:254:13 | Int.Type | cfg.swift:254:11:254:11 | a |  |
+| cfg.swift:254:16:254:16 | b | cfg.swift:254:11:254:16 | ... .==(_:_:) ... |  |
+| cfg.swift:255:3:255:16 | var ... = ... | cfg.swift:256:7:256:7 | q |  |
+| cfg.swift:255:7:255:7 | p | cfg.swift:255:13:255:13 | .!=(_:_:) | match |
+| cfg.swift:255:11:255:11 | a | cfg.swift:255:16:255:16 | b |  |
+| cfg.swift:255:11:255:16 | ... .!=(_:_:) ... | cfg.swift:255:3:255:16 | var ... = ... |  |
+| cfg.swift:255:13:255:13 | .!=(_:_:) | cfg.swift:255:13:255:13 | Int.Type |  |
+| cfg.swift:255:13:255:13 | Int.Type | cfg.swift:255:11:255:11 | a |  |
+| cfg.swift:255:16:255:16 | b | cfg.swift:255:11:255:16 | ... .!=(_:_:) ... |  |
+| cfg.swift:256:3:256:15 | var ... = ... | cfg.swift:257:7:257:7 | r |  |
+| cfg.swift:256:7:256:7 | q | cfg.swift:256:13:256:13 | .<(_:_:) | match |
+| cfg.swift:256:11:256:11 | a | cfg.swift:256:15:256:15 | b |  |
+| cfg.swift:256:11:256:15 | ... .<(_:_:) ... | cfg.swift:256:3:256:15 | var ... = ... |  |
+| cfg.swift:256:13:256:13 | .<(_:_:) | cfg.swift:256:13:256:13 | Int.Type |  |
+| cfg.swift:256:13:256:13 | Int.Type | cfg.swift:256:11:256:11 | a |  |
+| cfg.swift:256:15:256:15 | b | cfg.swift:256:11:256:15 | ... .<(_:_:) ... |  |
+| cfg.swift:257:3:257:16 | var ... = ... | cfg.swift:258:7:258:7 | s |  |
+| cfg.swift:257:7:257:7 | r | cfg.swift:257:13:257:13 | .<=(_:_:) | match |
+| cfg.swift:257:11:257:11 | a | cfg.swift:257:16:257:16 | b |  |
+| cfg.swift:257:11:257:16 | ... .<=(_:_:) ... | cfg.swift:257:3:257:16 | var ... = ... |  |
+| cfg.swift:257:13:257:13 | .<=(_:_:) | cfg.swift:257:13:257:13 | Int.Type |  |
+| cfg.swift:257:13:257:13 | Int.Type | cfg.swift:257:11:257:11 | a |  |
+| cfg.swift:257:16:257:16 | b | cfg.swift:257:11:257:16 | ... .<=(_:_:) ... |  |
+| cfg.swift:258:3:258:15 | var ... = ... | cfg.swift:259:7:259:7 | t |  |
+| cfg.swift:258:7:258:7 | s | cfg.swift:258:13:258:13 | .>(_:_:) | match |
+| cfg.swift:258:11:258:11 | a | cfg.swift:258:15:258:15 | b |  |
+| cfg.swift:258:11:258:15 | ... .>(_:_:) ... | cfg.swift:258:3:258:15 | var ... = ... |  |
+| cfg.swift:258:13:258:13 | .>(_:_:) | cfg.swift:258:13:258:13 | Int.Type |  |
+| cfg.swift:258:13:258:13 | Int.Type | cfg.swift:258:11:258:11 | a |  |
+| cfg.swift:258:15:258:15 | b | cfg.swift:258:11:258:15 | ... .>(_:_:) ... |  |
+| cfg.swift:259:3:259:16 | var ... = ... | cfg.swift:243:1:260:1 | exit binaryExprs(a:b:) (normal) |  |
+| cfg.swift:259:7:259:7 | t | cfg.swift:259:13:259:13 | .>=(_:_:) | match |
+| cfg.swift:259:11:259:11 | a | cfg.swift:259:16:259:16 | b |  |
+| cfg.swift:259:11:259:16 | ... .>=(_:_:) ... | cfg.swift:259:3:259:16 | var ... = ... |  |
+| cfg.swift:259:13:259:13 | .>=(_:_:) | cfg.swift:259:13:259:13 | Int.Type |  |
+| cfg.swift:259:13:259:13 | Int.Type | cfg.swift:259:11:259:11 | a |  |
+| cfg.swift:259:16:259:16 | b | cfg.swift:259:11:259:16 | ... .>=(_:_:) ... |  |
+| cfg.swift:262:1:264:1 | enter interpolatedString(x:y:) | cfg.swift:262:1:264:1 | interpolatedString(x:y:) |  |
+| cfg.swift:262:1:264:1 | exit interpolatedString(x:y:) (normal) | cfg.swift:262:1:264:1 | exit interpolatedString(x:y:) |  |
+| cfg.swift:262:1:264:1 | interpolatedString(x:y:) | cfg.swift:262:25:262:29 | x |  |
+| cfg.swift:262:25:262:29 | x | cfg.swift:262:34:262:38 | y |  |
+| cfg.swift:262:34:262:38 | y | cfg.swift:263:10:263:10 | OpaqueValueExpr |  |
+| cfg.swift:263:3:263:10 | return ... | cfg.swift:262:1:264:1 | exit interpolatedString(x:y:) (normal) | return |
+| cfg.swift:263:10:263:10 |  | cfg.swift:263:11:263:10 | call to appendLiteral(_:) |  |
+| cfg.swift:263:10:263:10 | "..." | cfg.swift:263:3:263:10 | return ... |  |
+| cfg.swift:263:10:263:10 | OpaqueValueExpr | cfg.swift:263:11:263:11 | .appendLiteral(_:) |  |
+| cfg.swift:263:10:263:10 | TapExpr | cfg.swift:263:10:263:10 | "..." |  |
+| cfg.swift:263:11:263:10 | call to appendLiteral(_:) | cfg.swift:263:12:263:12 | .appendInterpolation(_:) |  |
+| cfg.swift:263:11:263:11 | $interpolation | cfg.swift:263:11:263:11 | &... |  |
+| cfg.swift:263:11:263:11 | &... | cfg.swift:263:10:263:10 |  |  |
+| cfg.swift:263:11:263:11 | .appendLiteral(_:) | cfg.swift:263:11:263:11 | $interpolation |  |
+| cfg.swift:263:12:263:12 | $interpolation | cfg.swift:263:12:263:12 | &... |  |
+| cfg.swift:263:12:263:12 | &... | cfg.swift:263:13:263:13 | x |  |
+| cfg.swift:263:12:263:12 | .appendInterpolation(_:) | cfg.swift:263:12:263:12 | $interpolation |  |
+| cfg.swift:263:12:263:14 | call to appendInterpolation(_:) | cfg.swift:263:15:263:15 | .appendLiteral(_:) |  |
+| cfg.swift:263:13:263:13 | x | cfg.swift:263:12:263:14 | call to appendInterpolation(_:) |  |
+| cfg.swift:263:15:263:15 |  +  | cfg.swift:263:15:263:15 | call to appendLiteral(_:) |  |
+| cfg.swift:263:15:263:15 | $interpolation | cfg.swift:263:15:263:15 | &... |  |
+| cfg.swift:263:15:263:15 | &... | cfg.swift:263:15:263:15 |  +  |  |
+| cfg.swift:263:15:263:15 | .appendLiteral(_:) | cfg.swift:263:15:263:15 | $interpolation |  |
+| cfg.swift:263:15:263:15 | call to appendLiteral(_:) | cfg.swift:263:19:263:19 | .appendInterpolation(_:) |  |
+| cfg.swift:263:19:263:19 | $interpolation | cfg.swift:263:19:263:19 | &... |  |
+| cfg.swift:263:19:263:19 | &... | cfg.swift:263:20:263:20 | y |  |
+| cfg.swift:263:19:263:19 | .appendInterpolation(_:) | cfg.swift:263:19:263:19 | $interpolation |  |
+| cfg.swift:263:19:263:21 | call to appendInterpolation(_:) | cfg.swift:263:22:263:22 | .appendLiteral(_:) |  |
+| cfg.swift:263:20:263:20 | y | cfg.swift:263:19:263:21 | call to appendInterpolation(_:) |  |
+| cfg.swift:263:22:263:22 |  is equal to  | cfg.swift:263:22:263:22 | call to appendLiteral(_:) |  |
+| cfg.swift:263:22:263:22 | $interpolation | cfg.swift:263:22:263:22 | &... |  |
+| cfg.swift:263:22:263:22 | &... | cfg.swift:263:22:263:22 |  is equal to  |  |
+| cfg.swift:263:22:263:22 | .appendLiteral(_:) | cfg.swift:263:22:263:22 | $interpolation |  |
+| cfg.swift:263:22:263:22 | call to appendLiteral(_:) | cfg.swift:263:36:263:36 | .appendInterpolation(_:) |  |
+| cfg.swift:263:36:263:36 | $interpolation | cfg.swift:263:36:263:36 | &... |  |
+| cfg.swift:263:36:263:36 | &... | cfg.swift:263:39:263:39 | .+(_:_:) |  |
+| cfg.swift:263:36:263:36 | .appendInterpolation(_:) | cfg.swift:263:36:263:36 | $interpolation |  |
+| cfg.swift:263:36:263:42 | call to appendInterpolation(_:) | cfg.swift:263:43:263:43 | .appendLiteral(_:) |  |
+| cfg.swift:263:37:263:37 | x | cfg.swift:263:41:263:41 | y |  |
+| cfg.swift:263:37:263:41 | ... .+(_:_:) ... | cfg.swift:263:36:263:42 | call to appendInterpolation(_:) |  |
+| cfg.swift:263:39:263:39 | .+(_:_:) | cfg.swift:263:39:263:39 | Int.Type |  |
+| cfg.swift:263:39:263:39 | Int.Type | cfg.swift:263:37:263:37 | x |  |
+| cfg.swift:263:41:263:41 | y | cfg.swift:263:37:263:41 | ... .+(_:_:) ... |  |
+| cfg.swift:263:43:263:43 |  and here is a zero:  | cfg.swift:263:43:263:43 | call to appendLiteral(_:) |  |
+| cfg.swift:263:43:263:43 | $interpolation | cfg.swift:263:43:263:43 | &... |  |
+| cfg.swift:263:43:263:43 | &... | cfg.swift:263:43:263:43 |  and here is a zero:  |  |
+| cfg.swift:263:43:263:43 | .appendLiteral(_:) | cfg.swift:263:43:263:43 | $interpolation |  |
+| cfg.swift:263:43:263:43 | call to appendLiteral(_:) | cfg.swift:263:65:263:65 | .appendInterpolation(_:) |  |
+| cfg.swift:263:65:263:65 | $interpolation | cfg.swift:263:65:263:65 | &... |  |
+| cfg.swift:263:65:263:65 | &... | cfg.swift:263:66:263:66 | returnZero() |  |
+| cfg.swift:263:65:263:65 | .appendInterpolation(_:) | cfg.swift:263:65:263:65 | $interpolation |  |
+| cfg.swift:263:65:263:78 | call to appendInterpolation(_:) | cfg.swift:263:79:263:79 | .appendLiteral(_:) |  |
+| cfg.swift:263:66:263:66 | returnZero() | cfg.swift:263:66:263:77 | call to returnZero() |  |
+| cfg.swift:263:66:263:77 | call to returnZero() | cfg.swift:263:65:263:78 | call to appendInterpolation(_:) |  |
+| cfg.swift:263:79:263:79 |  | cfg.swift:263:79:263:79 | call to appendLiteral(_:) |  |
+| cfg.swift:263:79:263:79 | $interpolation | cfg.swift:263:79:263:79 | &... |  |
+| cfg.swift:263:79:263:79 | &... | cfg.swift:263:79:263:79 |  |  |
+| cfg.swift:263:79:263:79 | .appendLiteral(_:) | cfg.swift:263:79:263:79 | $interpolation |  |
+| cfg.swift:263:79:263:79 | call to appendLiteral(_:) | cfg.swift:263:10:263:10 | TapExpr |  |
+| cfg.swift:266:1:297:1 | enter testSubscriptExpr() | cfg.swift:266:1:297:1 | testSubscriptExpr() |  |
+| cfg.swift:266:1:297:1 | exit testSubscriptExpr() (normal) | cfg.swift:266:1:297:1 | exit testSubscriptExpr() |  |
+| cfg.swift:266:1:297:1 | testSubscriptExpr() | cfg.swift:267:7:267:7 | a |  |
+| cfg.swift:267:3:267:44 | var ... = ... | cfg.swift:268:3:268:3 | a |  |
+| cfg.swift:267:7:267:7 | a | cfg.swift:267:12:267:12 | 0 | match |
+| cfg.swift:267:11:267:44 | [...] | cfg.swift:267:3:267:44 | var ... = ... |  |
+| cfg.swift:267:12:267:12 | 0 | cfg.swift:267:15:267:15 | 1 |  |
+| cfg.swift:267:15:267:15 | 1 | cfg.swift:267:18:267:18 | 2 |  |
+| cfg.swift:267:18:267:18 | 2 | cfg.swift:267:21:267:21 | 3 |  |
+| cfg.swift:267:21:267:21 | 3 | cfg.swift:267:24:267:24 | 4 |  |
+| cfg.swift:267:24:267:24 | 4 | cfg.swift:267:27:267:27 | 5 |  |
+| cfg.swift:267:27:267:27 | 5 | cfg.swift:267:30:267:30 | 6 |  |
+| cfg.swift:267:30:267:30 | 6 | cfg.swift:267:33:267:33 | 7 |  |
+| cfg.swift:267:33:267:33 | 7 | cfg.swift:267:36:267:36 | 8 |  |
+| cfg.swift:267:36:267:36 | 8 | cfg.swift:267:39:267:39 | 9 |  |
+| cfg.swift:267:39:267:39 | 9 | cfg.swift:267:42:267:42 | 10 |  |
+| cfg.swift:267:42:267:42 | 10 | cfg.swift:267:11:267:44 | [...] |  |
+| cfg.swift:268:3:268:3 | &... | cfg.swift:268:5:268:5 | 0 |  |
+| cfg.swift:268:3:268:3 | a | cfg.swift:268:3:268:3 | &... |  |
+| cfg.swift:268:3:268:6 | ...[...] | cfg.swift:268:10:268:10 | 0 |  |
+| cfg.swift:268:3:268:10 | setter for  ... = ... | cfg.swift:269:8:269:8 | .+=(_:_:) |  |
+| cfg.swift:268:5:268:5 | 0 | cfg.swift:268:3:268:6 | ...[...] |  |
+| cfg.swift:268:10:268:10 | 0 | cfg.swift:268:3:268:10 | setter for  ... = ... |  |
+| cfg.swift:269:3:269:3 | &... | cfg.swift:269:5:269:5 | 1 |  |
+| cfg.swift:269:3:269:3 | a | cfg.swift:269:3:269:3 | &... |  |
+| cfg.swift:269:3:269:6 | &... | cfg.swift:269:11:269:11 | 1 |  |
+| cfg.swift:269:3:269:6 | getter for ...[...] | cfg.swift:269:3:269:6 | &... |  |
+| cfg.swift:269:3:269:11 | ... .+=(_:_:) ... | cfg.swift:270:8:270:8 | .-=(_:_:) |  |
+| cfg.swift:269:5:269:5 | 1 | cfg.swift:269:3:269:6 | getter for ...[...] |  |
+| cfg.swift:269:8:269:8 | .+=(_:_:) | cfg.swift:269:8:269:8 | Int.Type |  |
+| cfg.swift:269:8:269:8 | Int.Type | cfg.swift:269:3:269:3 | a |  |
+| cfg.swift:269:11:269:11 | 1 | cfg.swift:269:3:269:11 | ... .+=(_:_:) ... |  |
+| cfg.swift:270:3:270:3 | &... | cfg.swift:270:5:270:5 | 2 |  |
+| cfg.swift:270:3:270:3 | a | cfg.swift:270:3:270:3 | &... |  |
+| cfg.swift:270:3:270:6 | &... | cfg.swift:270:11:270:11 | 1 |  |
+| cfg.swift:270:3:270:6 | getter for ...[...] | cfg.swift:270:3:270:6 | &... |  |
+| cfg.swift:270:3:270:11 | ... .-=(_:_:) ... | cfg.swift:271:8:271:8 | .*=(_:_:) |  |
+| cfg.swift:270:5:270:5 | 2 | cfg.swift:270:3:270:6 | getter for ...[...] |  |
+| cfg.swift:270:8:270:8 | .-=(_:_:) | cfg.swift:270:8:270:8 | Int.Type |  |
+| cfg.swift:270:8:270:8 | Int.Type | cfg.swift:270:3:270:3 | a |  |
+| cfg.swift:270:11:270:11 | 1 | cfg.swift:270:3:270:11 | ... .-=(_:_:) ... |  |
+| cfg.swift:271:3:271:3 | &... | cfg.swift:271:5:271:5 | 3 |  |
+| cfg.swift:271:3:271:3 | a | cfg.swift:271:3:271:3 | &... |  |
+| cfg.swift:271:3:271:6 | &... | cfg.swift:271:11:271:11 | 1 |  |
+| cfg.swift:271:3:271:6 | getter for ...[...] | cfg.swift:271:3:271:6 | &... |  |
+| cfg.swift:271:3:271:11 | ... .*=(_:_:) ... | cfg.swift:272:8:272:8 | ./=(_:_:) |  |
+| cfg.swift:271:5:271:5 | 3 | cfg.swift:271:3:271:6 | getter for ...[...] |  |
+| cfg.swift:271:8:271:8 | .*=(_:_:) | cfg.swift:271:8:271:8 | Int.Type |  |
+| cfg.swift:271:8:271:8 | Int.Type | cfg.swift:271:3:271:3 | a |  |
+| cfg.swift:271:11:271:11 | 1 | cfg.swift:271:3:271:11 | ... .*=(_:_:) ... |  |
+| cfg.swift:272:3:272:3 | &... | cfg.swift:272:5:272:5 | 4 |  |
+| cfg.swift:272:3:272:3 | a | cfg.swift:272:3:272:3 | &... |  |
+| cfg.swift:272:3:272:6 | &... | cfg.swift:272:11:272:11 | 1 |  |
+| cfg.swift:272:3:272:6 | getter for ...[...] | cfg.swift:272:3:272:6 | &... |  |
+| cfg.swift:272:3:272:11 | ... ./=(_:_:) ... | cfg.swift:273:8:273:8 | .%=(_:_:) |  |
+| cfg.swift:272:5:272:5 | 4 | cfg.swift:272:3:272:6 | getter for ...[...] |  |
+| cfg.swift:272:8:272:8 | ./=(_:_:) | cfg.swift:272:8:272:8 | Int.Type |  |
+| cfg.swift:272:8:272:8 | Int.Type | cfg.swift:272:3:272:3 | a |  |
+| cfg.swift:272:11:272:11 | 1 | cfg.swift:272:3:272:11 | ... ./=(_:_:) ... |  |
+| cfg.swift:273:3:273:3 | &... | cfg.swift:273:5:273:5 | 5 |  |
+| cfg.swift:273:3:273:3 | a | cfg.swift:273:3:273:3 | &... |  |
+| cfg.swift:273:3:273:6 | &... | cfg.swift:273:11:273:11 | 1 |  |
+| cfg.swift:273:3:273:6 | getter for ...[...] | cfg.swift:273:3:273:6 | &... |  |
+| cfg.swift:273:3:273:11 | ... .%=(_:_:) ... | cfg.swift:274:8:274:8 | .&=(_:_:) |  |
+| cfg.swift:273:5:273:5 | 5 | cfg.swift:273:3:273:6 | getter for ...[...] |  |
+| cfg.swift:273:8:273:8 | .%=(_:_:) | cfg.swift:273:8:273:8 | Int.Type |  |
+| cfg.swift:273:8:273:8 | Int.Type | cfg.swift:273:3:273:3 | a |  |
+| cfg.swift:273:11:273:11 | 1 | cfg.swift:273:3:273:11 | ... .%=(_:_:) ... |  |
+| cfg.swift:274:3:274:3 | &... | cfg.swift:274:5:274:5 | 6 |  |
+| cfg.swift:274:3:274:3 | a | cfg.swift:274:3:274:3 | &... |  |
+| cfg.swift:274:3:274:6 | &... | cfg.swift:274:11:274:11 | 1 |  |
+| cfg.swift:274:3:274:6 | getter for ...[...] | cfg.swift:274:3:274:6 | &... |  |
+| cfg.swift:274:3:274:11 | ... .&=(_:_:) ... | cfg.swift:275:8:275:8 | .\|=(_:_:) |  |
+| cfg.swift:274:5:274:5 | 6 | cfg.swift:274:3:274:6 | getter for ...[...] |  |
+| cfg.swift:274:8:274:8 | .&=(_:_:) | cfg.swift:274:8:274:8 | Int.Type |  |
+| cfg.swift:274:8:274:8 | Int.Type | cfg.swift:274:3:274:3 | a |  |
+| cfg.swift:274:11:274:11 | 1 | cfg.swift:274:3:274:11 | ... .&=(_:_:) ... |  |
+| cfg.swift:275:3:275:3 | &... | cfg.swift:275:5:275:5 | 7 |  |
+| cfg.swift:275:3:275:3 | a | cfg.swift:275:3:275:3 | &... |  |
+| cfg.swift:275:3:275:6 | &... | cfg.swift:275:11:275:11 | 1 |  |
+| cfg.swift:275:3:275:6 | getter for ...[...] | cfg.swift:275:3:275:6 | &... |  |
+| cfg.swift:275:3:275:11 | ... .\|=(_:_:) ... | cfg.swift:276:8:276:8 | .^=(_:_:) |  |
+| cfg.swift:275:5:275:5 | 7 | cfg.swift:275:3:275:6 | getter for ...[...] |  |
+| cfg.swift:275:8:275:8 | .\|=(_:_:) | cfg.swift:275:8:275:8 | Int.Type |  |
+| cfg.swift:275:8:275:8 | Int.Type | cfg.swift:275:3:275:3 | a |  |
+| cfg.swift:275:11:275:11 | 1 | cfg.swift:275:3:275:11 | ... .\|=(_:_:) ... |  |
+| cfg.swift:276:3:276:3 | &... | cfg.swift:276:5:276:5 | 8 |  |
+| cfg.swift:276:3:276:3 | a | cfg.swift:276:3:276:3 | &... |  |
+| cfg.swift:276:3:276:6 | &... | cfg.swift:276:11:276:11 | 1 |  |
+| cfg.swift:276:3:276:6 | getter for ...[...] | cfg.swift:276:3:276:6 | &... |  |
+| cfg.swift:276:3:276:11 | ... .^=(_:_:) ... | cfg.swift:277:8:277:8 | .<<=(_:_:) |  |
+| cfg.swift:276:5:276:5 | 8 | cfg.swift:276:3:276:6 | getter for ...[...] |  |
+| cfg.swift:276:8:276:8 | .^=(_:_:) | cfg.swift:276:8:276:8 | Int.Type |  |
+| cfg.swift:276:8:276:8 | Int.Type | cfg.swift:276:3:276:3 | a |  |
+| cfg.swift:276:11:276:11 | 1 | cfg.swift:276:3:276:11 | ... .^=(_:_:) ... |  |
+| cfg.swift:277:3:277:3 | &... | cfg.swift:277:5:277:5 | 9 |  |
+| cfg.swift:277:3:277:3 | a | cfg.swift:277:3:277:3 | &... |  |
+| cfg.swift:277:3:277:6 | &... | cfg.swift:277:12:277:12 | 1 |  |
+| cfg.swift:277:3:277:6 | getter for ...[...] | cfg.swift:277:3:277:6 | &... |  |
+| cfg.swift:277:3:277:12 | ... .<<=(_:_:) ... | cfg.swift:278:9:278:9 | .>>=(_:_:) |  |
+| cfg.swift:277:5:277:5 | 9 | cfg.swift:277:3:277:6 | getter for ...[...] |  |
+| cfg.swift:277:8:277:8 | .<<=(_:_:) | cfg.swift:277:8:277:8 | Int.Type |  |
+| cfg.swift:277:8:277:8 | Int.Type | cfg.swift:277:3:277:3 | a |  |
+| cfg.swift:277:12:277:12 | 1 | cfg.swift:277:3:277:12 | ... .<<=(_:_:) ... |  |
+| cfg.swift:278:3:278:3 | &... | cfg.swift:278:5:278:5 | 10 |  |
+| cfg.swift:278:3:278:3 | a | cfg.swift:278:3:278:3 | &... |  |
+| cfg.swift:278:3:278:7 | &... | cfg.swift:278:13:278:13 | 1 |  |
+| cfg.swift:278:3:278:7 | getter for ...[...] | cfg.swift:278:3:278:7 | &... |  |
+| cfg.swift:278:3:278:13 | ... .>>=(_:_:) ... | cfg.swift:280:7:280:7 | tupleWithA |  |
+| cfg.swift:278:5:278:5 | 10 | cfg.swift:278:3:278:7 | getter for ...[...] |  |
+| cfg.swift:278:9:278:9 | .>>=(_:_:) | cfg.swift:278:9:278:9 | Int.Type |  |
+| cfg.swift:278:9:278:9 | Int.Type | cfg.swift:278:3:278:3 | a |  |
+| cfg.swift:278:13:278:13 | 1 | cfg.swift:278:3:278:13 | ... .>>=(_:_:) ... |  |
+| cfg.swift:280:3:280:49 | var ... = ... | cfg.swift:282:7:282:7 | b |  |
+| cfg.swift:280:7:280:7 | tupleWithA | cfg.swift:280:21:280:21 | a | match |
+| cfg.swift:280:20:280:49 | (...) | cfg.swift:280:3:280:49 | var ... = ... |  |
+| cfg.swift:280:21:280:21 | &... | cfg.swift:280:23:280:23 | 0 |  |
+| cfg.swift:280:21:280:21 | a | cfg.swift:280:21:280:21 | &... |  |
+| cfg.swift:280:21:280:24 | (Int) ... | cfg.swift:280:27:280:27 | a |  |
+| cfg.swift:280:21:280:24 | getter for ...[...] | cfg.swift:280:21:280:24 | (Int) ... |  |
+| cfg.swift:280:23:280:23 | 0 | cfg.swift:280:21:280:24 | getter for ...[...] |  |
+| cfg.swift:280:27:280:27 | &... | cfg.swift:280:29:280:29 | 1 |  |
+| cfg.swift:280:27:280:27 | a | cfg.swift:280:27:280:27 | &... |  |
+| cfg.swift:280:27:280:30 | (Int) ... | cfg.swift:280:33:280:33 | a |  |
+| cfg.swift:280:27:280:30 | getter for ...[...] | cfg.swift:280:27:280:30 | (Int) ... |  |
+| cfg.swift:280:29:280:29 | 1 | cfg.swift:280:27:280:30 | getter for ...[...] |  |
+| cfg.swift:280:33:280:33 | &... | cfg.swift:280:35:280:35 | 2 |  |
+| cfg.swift:280:33:280:33 | a | cfg.swift:280:33:280:33 | &... |  |
+| cfg.swift:280:33:280:36 | (Int) ... | cfg.swift:280:39:280:39 | a |  |
+| cfg.swift:280:33:280:36 | getter for ...[...] | cfg.swift:280:33:280:36 | (Int) ... |  |
+| cfg.swift:280:35:280:35 | 2 | cfg.swift:280:33:280:36 | getter for ...[...] |  |
+| cfg.swift:280:39:280:39 | &... | cfg.swift:280:41:280:41 | 3 |  |
+| cfg.swift:280:39:280:39 | a | cfg.swift:280:39:280:39 | &... |  |
+| cfg.swift:280:39:280:42 | (Int) ... | cfg.swift:280:45:280:45 | a |  |
+| cfg.swift:280:39:280:42 | getter for ...[...] | cfg.swift:280:39:280:42 | (Int) ... |  |
+| cfg.swift:280:41:280:41 | 3 | cfg.swift:280:39:280:42 | getter for ...[...] |  |
+| cfg.swift:280:45:280:45 | &... | cfg.swift:280:47:280:47 | 4 |  |
+| cfg.swift:280:45:280:45 | a | cfg.swift:280:45:280:45 | &... |  |
+| cfg.swift:280:45:280:48 | (Int) ... | cfg.swift:280:20:280:49 | (...) |  |
+| cfg.swift:280:45:280:48 | getter for ...[...] | cfg.swift:280:45:280:48 | (Int) ... |  |
+| cfg.swift:280:47:280:47 | 4 | cfg.swift:280:45:280:48 | getter for ...[...] |  |
+| cfg.swift:282:3:282:48 | var ... = ... | cfg.swift:283:3:283:3 | b |  |
+| cfg.swift:282:7:282:7 | b | cfg.swift:282:12:282:12 | 0 | match |
+| cfg.swift:282:11:282:48 | [...] | cfg.swift:282:3:282:48 | var ... = ... |  |
+| cfg.swift:282:12:282:12 | 0 | cfg.swift:282:15:282:15 | 1 |  |
+| cfg.swift:282:15:282:15 | 1 | cfg.swift:282:18:282:18 | 2 |  |
+| cfg.swift:282:18:282:18 | 2 | cfg.swift:282:21:282:21 | 3 |  |
+| cfg.swift:282:21:282:21 | 3 | cfg.swift:282:24:282:24 | 4 |  |
+| cfg.swift:282:24:282:24 | 4 | cfg.swift:282:27:282:27 | 5 |  |
+| cfg.swift:282:27:282:27 | 5 | cfg.swift:282:30:282:30 | 6 |  |
+| cfg.swift:282:30:282:30 | 6 | cfg.swift:282:33:282:33 | 7 |  |
+| cfg.swift:282:33:282:33 | 7 | cfg.swift:282:36:282:36 | 8 |  |
+| cfg.swift:282:36:282:36 | 8 | cfg.swift:282:39:282:39 | 9 |  |
+| cfg.swift:282:39:282:39 | 9 | cfg.swift:282:42:282:42 | 10 |  |
+| cfg.swift:282:42:282:42 | 10 | cfg.swift:282:46:282:46 | 11 |  |
+| cfg.swift:282:46:282:46 | 11 | cfg.swift:282:11:282:48 | [...] |  |
+| cfg.swift:283:3:283:3 | &... | cfg.swift:283:5:283:5 | 0 |  |
+| cfg.swift:283:3:283:3 | b | cfg.swift:283:3:283:3 | &... |  |
+| cfg.swift:283:3:283:6 | ...[...] | cfg.swift:283:10:283:10 | a |  |
+| cfg.swift:283:3:283:14 | setter for  ... = ... | cfg.swift:284:3:284:3 | b |  |
+| cfg.swift:283:5:283:5 | 0 | cfg.swift:283:3:283:6 | ...[...] |  |
+| cfg.swift:283:10:283:10 | &... | cfg.swift:283:12:283:12 | 10 |  |
+| cfg.swift:283:10:283:10 | a | cfg.swift:283:10:283:10 | &... |  |
+| cfg.swift:283:10:283:14 | (Int) ... | cfg.swift:283:3:283:14 | setter for  ... = ... |  |
+| cfg.swift:283:10:283:14 | getter for ...[...] | cfg.swift:283:10:283:14 | (Int) ... |  |
+| cfg.swift:283:12:283:12 | 10 | cfg.swift:283:10:283:14 | getter for ...[...] |  |
+| cfg.swift:284:3:284:3 | &... | cfg.swift:284:5:284:5 | 1 |  |
+| cfg.swift:284:3:284:3 | b | cfg.swift:284:3:284:3 | &... |  |
+| cfg.swift:284:3:284:6 | ...[...] | cfg.swift:284:15:284:15 | .+(_:_:) |  |
+| cfg.swift:284:3:284:17 | setter for  ... = ... | cfg.swift:285:3:285:3 | b |  |
+| cfg.swift:284:5:284:5 | 1 | cfg.swift:284:3:284:6 | ...[...] |  |
+| cfg.swift:284:10:284:10 | &... | cfg.swift:284:12:284:12 | 0 |  |
+| cfg.swift:284:10:284:10 | b | cfg.swift:284:10:284:10 | &... |  |
+| cfg.swift:284:10:284:13 | (Int) ... | cfg.swift:284:17:284:17 | 1 |  |
+| cfg.swift:284:10:284:13 | getter for ...[...] | cfg.swift:284:10:284:13 | (Int) ... |  |
+| cfg.swift:284:10:284:17 | ... .+(_:_:) ... | cfg.swift:284:3:284:17 | setter for  ... = ... |  |
+| cfg.swift:284:12:284:12 | 0 | cfg.swift:284:10:284:13 | getter for ...[...] |  |
+| cfg.swift:284:15:284:15 | .+(_:_:) | cfg.swift:284:15:284:15 | Int.Type |  |
+| cfg.swift:284:15:284:15 | Int.Type | cfg.swift:284:10:284:10 | b |  |
+| cfg.swift:284:17:284:17 | 1 | cfg.swift:284:10:284:17 | ... .+(_:_:) ... |  |
+| cfg.swift:285:3:285:3 | &... | cfg.swift:285:5:285:5 | 2 |  |
+| cfg.swift:285:3:285:3 | b | cfg.swift:285:3:285:3 | &... |  |
+| cfg.swift:285:3:285:6 | ...[...] | cfg.swift:285:15:285:15 | .-(_:_:) |  |
+| cfg.swift:285:3:285:17 | setter for  ... = ... | cfg.swift:286:3:286:3 | b |  |
+| cfg.swift:285:5:285:5 | 2 | cfg.swift:285:3:285:6 | ...[...] |  |
+| cfg.swift:285:10:285:10 | &... | cfg.swift:285:12:285:12 | 1 |  |
+| cfg.swift:285:10:285:10 | b | cfg.swift:285:10:285:10 | &... |  |
+| cfg.swift:285:10:285:13 | (Int) ... | cfg.swift:285:17:285:17 | 1 |  |
+| cfg.swift:285:10:285:13 | getter for ...[...] | cfg.swift:285:10:285:13 | (Int) ... |  |
+| cfg.swift:285:10:285:17 | ... .-(_:_:) ... | cfg.swift:285:3:285:17 | setter for  ... = ... |  |
+| cfg.swift:285:12:285:12 | 1 | cfg.swift:285:10:285:13 | getter for ...[...] |  |
+| cfg.swift:285:15:285:15 | .-(_:_:) | cfg.swift:285:15:285:15 | Int.Type |  |
+| cfg.swift:285:15:285:15 | Int.Type | cfg.swift:285:10:285:10 | b |  |
+| cfg.swift:285:17:285:17 | 1 | cfg.swift:285:10:285:17 | ... .-(_:_:) ... |  |
+| cfg.swift:286:3:286:3 | &... | cfg.swift:286:5:286:5 | 3 |  |
+| cfg.swift:286:3:286:3 | b | cfg.swift:286:3:286:3 | &... |  |
+| cfg.swift:286:3:286:6 | ...[...] | cfg.swift:286:15:286:15 | .*(_:_:) |  |
+| cfg.swift:286:3:286:17 | setter for  ... = ... | cfg.swift:287:3:287:3 | b |  |
+| cfg.swift:286:5:286:5 | 3 | cfg.swift:286:3:286:6 | ...[...] |  |
+| cfg.swift:286:10:286:10 | &... | cfg.swift:286:12:286:12 | 2 |  |
+| cfg.swift:286:10:286:10 | b | cfg.swift:286:10:286:10 | &... |  |
+| cfg.swift:286:10:286:13 | (Int) ... | cfg.swift:286:17:286:17 | 1 |  |
+| cfg.swift:286:10:286:13 | getter for ...[...] | cfg.swift:286:10:286:13 | (Int) ... |  |
+| cfg.swift:286:10:286:17 | ... .*(_:_:) ... | cfg.swift:286:3:286:17 | setter for  ... = ... |  |
+| cfg.swift:286:12:286:12 | 2 | cfg.swift:286:10:286:13 | getter for ...[...] |  |
+| cfg.swift:286:15:286:15 | .*(_:_:) | cfg.swift:286:15:286:15 | Int.Type |  |
+| cfg.swift:286:15:286:15 | Int.Type | cfg.swift:286:10:286:10 | b |  |
+| cfg.swift:286:17:286:17 | 1 | cfg.swift:286:10:286:17 | ... .*(_:_:) ... |  |
+| cfg.swift:287:3:287:3 | &... | cfg.swift:287:5:287:5 | 4 |  |
+| cfg.swift:287:3:287:3 | b | cfg.swift:287:3:287:3 | &... |  |
+| cfg.swift:287:3:287:6 | ...[...] | cfg.swift:287:15:287:15 | ./(_:_:) |  |
+| cfg.swift:287:3:287:17 | setter for  ... = ... | cfg.swift:288:3:288:3 | b |  |
+| cfg.swift:287:5:287:5 | 4 | cfg.swift:287:3:287:6 | ...[...] |  |
+| cfg.swift:287:10:287:10 | &... | cfg.swift:287:12:287:12 | 3 |  |
+| cfg.swift:287:10:287:10 | b | cfg.swift:287:10:287:10 | &... |  |
+| cfg.swift:287:10:287:13 | (Int) ... | cfg.swift:287:17:287:17 | 1 |  |
+| cfg.swift:287:10:287:13 | getter for ...[...] | cfg.swift:287:10:287:13 | (Int) ... |  |
+| cfg.swift:287:10:287:17 | ... ./(_:_:) ... | cfg.swift:287:3:287:17 | setter for  ... = ... |  |
+| cfg.swift:287:12:287:12 | 3 | cfg.swift:287:10:287:13 | getter for ...[...] |  |
+| cfg.swift:287:15:287:15 | ./(_:_:) | cfg.swift:287:15:287:15 | Int.Type |  |
+| cfg.swift:287:15:287:15 | Int.Type | cfg.swift:287:10:287:10 | b |  |
+| cfg.swift:287:17:287:17 | 1 | cfg.swift:287:10:287:17 | ... ./(_:_:) ... |  |
+| cfg.swift:288:3:288:3 | &... | cfg.swift:288:5:288:5 | 5 |  |
+| cfg.swift:288:3:288:3 | b | cfg.swift:288:3:288:3 | &... |  |
+| cfg.swift:288:3:288:6 | ...[...] | cfg.swift:288:15:288:15 | .%(_:_:) |  |
+| cfg.swift:288:3:288:17 | setter for  ... = ... | cfg.swift:289:3:289:3 | b |  |
+| cfg.swift:288:5:288:5 | 5 | cfg.swift:288:3:288:6 | ...[...] |  |
+| cfg.swift:288:10:288:10 | &... | cfg.swift:288:12:288:12 | 4 |  |
+| cfg.swift:288:10:288:10 | b | cfg.swift:288:10:288:10 | &... |  |
+| cfg.swift:288:10:288:13 | (Int) ... | cfg.swift:288:17:288:17 | 1 |  |
+| cfg.swift:288:10:288:13 | getter for ...[...] | cfg.swift:288:10:288:13 | (Int) ... |  |
+| cfg.swift:288:10:288:17 | ... .%(_:_:) ... | cfg.swift:288:3:288:17 | setter for  ... = ... |  |
+| cfg.swift:288:12:288:12 | 4 | cfg.swift:288:10:288:13 | getter for ...[...] |  |
+| cfg.swift:288:15:288:15 | .%(_:_:) | cfg.swift:288:15:288:15 | Int.Type |  |
+| cfg.swift:288:15:288:15 | Int.Type | cfg.swift:288:10:288:10 | b |  |
+| cfg.swift:288:17:288:17 | 1 | cfg.swift:288:10:288:17 | ... .%(_:_:) ... |  |
+| cfg.swift:289:3:289:3 | &... | cfg.swift:289:5:289:5 | 6 |  |
+| cfg.swift:289:3:289:3 | b | cfg.swift:289:3:289:3 | &... |  |
+| cfg.swift:289:3:289:6 | ...[...] | cfg.swift:289:15:289:15 | .&(_:_:) |  |
+| cfg.swift:289:3:289:17 | setter for  ... = ... | cfg.swift:290:3:290:3 | b |  |
+| cfg.swift:289:5:289:5 | 6 | cfg.swift:289:3:289:6 | ...[...] |  |
+| cfg.swift:289:10:289:10 | &... | cfg.swift:289:12:289:12 | 5 |  |
+| cfg.swift:289:10:289:10 | b | cfg.swift:289:10:289:10 | &... |  |
+| cfg.swift:289:10:289:13 | (Int) ... | cfg.swift:289:17:289:17 | 1 |  |
+| cfg.swift:289:10:289:13 | getter for ...[...] | cfg.swift:289:10:289:13 | (Int) ... |  |
+| cfg.swift:289:10:289:17 | ... .&(_:_:) ... | cfg.swift:289:3:289:17 | setter for  ... = ... |  |
+| cfg.swift:289:12:289:12 | 5 | cfg.swift:289:10:289:13 | getter for ...[...] |  |
+| cfg.swift:289:15:289:15 | .&(_:_:) | cfg.swift:289:15:289:15 | Int.Type |  |
+| cfg.swift:289:15:289:15 | Int.Type | cfg.swift:289:10:289:10 | b |  |
+| cfg.swift:289:17:289:17 | 1 | cfg.swift:289:10:289:17 | ... .&(_:_:) ... |  |
+| cfg.swift:290:3:290:3 | &... | cfg.swift:290:5:290:5 | 7 |  |
+| cfg.swift:290:3:290:3 | b | cfg.swift:290:3:290:3 | &... |  |
+| cfg.swift:290:3:290:6 | ...[...] | cfg.swift:290:15:290:15 | .\|(_:_:) |  |
+| cfg.swift:290:3:290:17 | setter for  ... = ... | cfg.swift:291:3:291:3 | b |  |
+| cfg.swift:290:5:290:5 | 7 | cfg.swift:290:3:290:6 | ...[...] |  |
+| cfg.swift:290:10:290:10 | &... | cfg.swift:290:12:290:12 | 6 |  |
+| cfg.swift:290:10:290:10 | b | cfg.swift:290:10:290:10 | &... |  |
+| cfg.swift:290:10:290:13 | (Int) ... | cfg.swift:290:17:290:17 | 1 |  |
+| cfg.swift:290:10:290:13 | getter for ...[...] | cfg.swift:290:10:290:13 | (Int) ... |  |
+| cfg.swift:290:10:290:17 | ... .\|(_:_:) ... | cfg.swift:290:3:290:17 | setter for  ... = ... |  |
+| cfg.swift:290:12:290:12 | 6 | cfg.swift:290:10:290:13 | getter for ...[...] |  |
+| cfg.swift:290:15:290:15 | .\|(_:_:) | cfg.swift:290:15:290:15 | Int.Type |  |
+| cfg.swift:290:15:290:15 | Int.Type | cfg.swift:290:10:290:10 | b |  |
+| cfg.swift:290:17:290:17 | 1 | cfg.swift:290:10:290:17 | ... .\|(_:_:) ... |  |
+| cfg.swift:291:3:291:3 | &... | cfg.swift:291:5:291:5 | 8 |  |
+| cfg.swift:291:3:291:3 | b | cfg.swift:291:3:291:3 | &... |  |
+| cfg.swift:291:3:291:6 | ...[...] | cfg.swift:291:15:291:15 | .^(_:_:) |  |
+| cfg.swift:291:3:291:17 | setter for  ... = ... | cfg.swift:292:3:292:3 | b |  |
+| cfg.swift:291:5:291:5 | 8 | cfg.swift:291:3:291:6 | ...[...] |  |
+| cfg.swift:291:10:291:10 | &... | cfg.swift:291:12:291:12 | 7 |  |
+| cfg.swift:291:10:291:10 | b | cfg.swift:291:10:291:10 | &... |  |
+| cfg.swift:291:10:291:13 | (Int) ... | cfg.swift:291:17:291:17 | 1 |  |
+| cfg.swift:291:10:291:13 | getter for ...[...] | cfg.swift:291:10:291:13 | (Int) ... |  |
+| cfg.swift:291:10:291:17 | ... .^(_:_:) ... | cfg.swift:291:3:291:17 | setter for  ... = ... |  |
+| cfg.swift:291:12:291:12 | 7 | cfg.swift:291:10:291:13 | getter for ...[...] |  |
+| cfg.swift:291:15:291:15 | .^(_:_:) | cfg.swift:291:15:291:15 | Int.Type |  |
+| cfg.swift:291:15:291:15 | Int.Type | cfg.swift:291:10:291:10 | b |  |
+| cfg.swift:291:17:291:17 | 1 | cfg.swift:291:10:291:17 | ... .^(_:_:) ... |  |
+| cfg.swift:292:3:292:3 | &... | cfg.swift:292:5:292:5 | 9 |  |
+| cfg.swift:292:3:292:3 | b | cfg.swift:292:3:292:3 | &... |  |
+| cfg.swift:292:3:292:6 | ...[...] | cfg.swift:292:15:292:15 | .<<(_:_:) |  |
+| cfg.swift:292:3:292:18 | setter for  ... = ... | cfg.swift:293:3:293:3 | b |  |
+| cfg.swift:292:5:292:5 | 9 | cfg.swift:292:3:292:6 | ...[...] |  |
+| cfg.swift:292:10:292:10 | &... | cfg.swift:292:12:292:12 | 8 |  |
+| cfg.swift:292:10:292:10 | b | cfg.swift:292:10:292:10 | &... |  |
+| cfg.swift:292:10:292:13 | (Int) ... | cfg.swift:292:18:292:18 | 1 |  |
+| cfg.swift:292:10:292:13 | getter for ...[...] | cfg.swift:292:10:292:13 | (Int) ... |  |
+| cfg.swift:292:10:292:18 | ... .<<(_:_:) ... | cfg.swift:292:3:292:18 | setter for  ... = ... |  |
+| cfg.swift:292:12:292:12 | 8 | cfg.swift:292:10:292:13 | getter for ...[...] |  |
+| cfg.swift:292:15:292:15 | .<<(_:_:) | cfg.swift:292:15:292:15 | Int.Type |  |
+| cfg.swift:292:15:292:15 | Int.Type | cfg.swift:292:10:292:10 | b |  |
+| cfg.swift:292:18:292:18 | 1 | cfg.swift:292:10:292:18 | ... .<<(_:_:) ... |  |
+| cfg.swift:293:3:293:3 | &... | cfg.swift:293:5:293:5 | 10 |  |
+| cfg.swift:293:3:293:3 | b | cfg.swift:293:3:293:3 | &... |  |
+| cfg.swift:293:3:293:7 | ...[...] | cfg.swift:293:16:293:16 | .>>(_:_:) |  |
+| cfg.swift:293:3:293:19 | setter for  ... = ... | cfg.swift:295:7:295:26 | (...) |  |
+| cfg.swift:293:5:293:5 | 10 | cfg.swift:293:3:293:7 | ...[...] |  |
+| cfg.swift:293:11:293:11 | &... | cfg.swift:293:13:293:13 | 9 |  |
+| cfg.swift:293:11:293:11 | b | cfg.swift:293:11:293:11 | &... |  |
+| cfg.swift:293:11:293:14 | (Int) ... | cfg.swift:293:19:293:19 | 1 |  |
+| cfg.swift:293:11:293:14 | getter for ...[...] | cfg.swift:293:11:293:14 | (Int) ... |  |
+| cfg.swift:293:11:293:19 | ... .>>(_:_:) ... | cfg.swift:293:3:293:19 | setter for  ... = ... |  |
+| cfg.swift:293:13:293:13 | 9 | cfg.swift:293:11:293:14 | getter for ...[...] |  |
+| cfg.swift:293:16:293:16 | .>>(_:_:) | cfg.swift:293:16:293:16 | Int.Type |  |
+| cfg.swift:293:16:293:16 | Int.Type | cfg.swift:293:11:293:11 | b |  |
+| cfg.swift:293:19:293:19 | 1 | cfg.swift:293:11:293:19 | ... .>>(_:_:) ... |  |
+| cfg.swift:295:3:295:30 | var ... = ... | cfg.swift:296:14:296:14 | .+(_:_:) |  |
+| cfg.swift:295:7:295:26 | (...) | cfg.swift:295:8:295:8 | a1 |  |
+| cfg.swift:295:8:295:8 | a1 | cfg.swift:295:12:295:12 | a2 | match |
+| cfg.swift:295:12:295:12 | a2 | cfg.swift:295:16:295:16 | a3 | match |
+| cfg.swift:295:16:295:16 | a3 | cfg.swift:295:20:295:20 | a4 | match |
+| cfg.swift:295:20:295:20 | a4 | cfg.swift:295:24:295:24 | a5 | match |
+| cfg.swift:295:24:295:24 | a5 | cfg.swift:295:30:295:30 | tupleWithA | match |
+| cfg.swift:295:30:295:30 | ((Int, Int, Int, Int, Int)) ... | cfg.swift:295:3:295:30 | var ... = ... |  |
+| cfg.swift:295:30:295:30 | tupleWithA | cfg.swift:295:30:295:30 | ((Int, Int, Int, Int, Int)) ... |  |
+| cfg.swift:296:3:296:64 | return ... | cfg.swift:266:1:297:1 | exit testSubscriptExpr() (normal) | return |
+| cfg.swift:296:10:296:64 | (...) | cfg.swift:296:3:296:64 | return ... |  |
+| cfg.swift:296:11:296:11 | a1 | cfg.swift:296:16:296:16 | b |  |
+| cfg.swift:296:11:296:19 | ... .+(_:_:) ... | cfg.swift:296:25:296:25 | .+(_:_:) |  |
+| cfg.swift:296:14:296:14 | .+(_:_:) | cfg.swift:296:14:296:14 | Int.Type |  |
+| cfg.swift:296:14:296:14 | Int.Type | cfg.swift:296:11:296:11 | a1 |  |
+| cfg.swift:296:16:296:16 | &... | cfg.swift:296:18:296:18 | 0 |  |
+| cfg.swift:296:16:296:16 | b | cfg.swift:296:16:296:16 | &... |  |
+| cfg.swift:296:16:296:19 | (Int) ... | cfg.swift:296:11:296:19 | ... .+(_:_:) ... |  |
+| cfg.swift:296:16:296:19 | getter for ...[...] | cfg.swift:296:16:296:19 | (Int) ... |  |
+| cfg.swift:296:18:296:18 | 0 | cfg.swift:296:16:296:19 | getter for ...[...] |  |
+| cfg.swift:296:22:296:22 | a2 | cfg.swift:296:27:296:27 | b |  |
+| cfg.swift:296:22:296:30 | ... .+(_:_:) ... | cfg.swift:296:36:296:36 | .+(_:_:) |  |
+| cfg.swift:296:25:296:25 | .+(_:_:) | cfg.swift:296:25:296:25 | Int.Type |  |
+| cfg.swift:296:25:296:25 | Int.Type | cfg.swift:296:22:296:22 | a2 |  |
+| cfg.swift:296:27:296:27 | &... | cfg.swift:296:29:296:29 | 1 |  |
+| cfg.swift:296:27:296:27 | b | cfg.swift:296:27:296:27 | &... |  |
+| cfg.swift:296:27:296:30 | (Int) ... | cfg.swift:296:22:296:30 | ... .+(_:_:) ... |  |
+| cfg.swift:296:27:296:30 | getter for ...[...] | cfg.swift:296:27:296:30 | (Int) ... |  |
+| cfg.swift:296:29:296:29 | 1 | cfg.swift:296:27:296:30 | getter for ...[...] |  |
+| cfg.swift:296:33:296:33 | a3 | cfg.swift:296:38:296:38 | b |  |
+| cfg.swift:296:33:296:41 | ... .+(_:_:) ... | cfg.swift:296:47:296:47 | .+(_:_:) |  |
+| cfg.swift:296:36:296:36 | .+(_:_:) | cfg.swift:296:36:296:36 | Int.Type |  |
+| cfg.swift:296:36:296:36 | Int.Type | cfg.swift:296:33:296:33 | a3 |  |
+| cfg.swift:296:38:296:38 | &... | cfg.swift:296:40:296:40 | 2 |  |
+| cfg.swift:296:38:296:38 | b | cfg.swift:296:38:296:38 | &... |  |
+| cfg.swift:296:38:296:41 | (Int) ... | cfg.swift:296:33:296:41 | ... .+(_:_:) ... |  |
+| cfg.swift:296:38:296:41 | getter for ...[...] | cfg.swift:296:38:296:41 | (Int) ... |  |
+| cfg.swift:296:40:296:40 | 2 | cfg.swift:296:38:296:41 | getter for ...[...] |  |
+| cfg.swift:296:44:296:44 | a4 | cfg.swift:296:49:296:49 | b |  |
+| cfg.swift:296:44:296:52 | ... .+(_:_:) ... | cfg.swift:296:58:296:58 | .+(_:_:) |  |
+| cfg.swift:296:47:296:47 | .+(_:_:) | cfg.swift:296:47:296:47 | Int.Type |  |
+| cfg.swift:296:47:296:47 | Int.Type | cfg.swift:296:44:296:44 | a4 |  |
+| cfg.swift:296:49:296:49 | &... | cfg.swift:296:51:296:51 | 3 |  |
+| cfg.swift:296:49:296:49 | b | cfg.swift:296:49:296:49 | &... |  |
+| cfg.swift:296:49:296:52 | (Int) ... | cfg.swift:296:44:296:52 | ... .+(_:_:) ... |  |
+| cfg.swift:296:49:296:52 | getter for ...[...] | cfg.swift:296:49:296:52 | (Int) ... |  |
+| cfg.swift:296:51:296:51 | 3 | cfg.swift:296:49:296:52 | getter for ...[...] |  |
+| cfg.swift:296:55:296:55 | a5 | cfg.swift:296:60:296:60 | b |  |
+| cfg.swift:296:55:296:63 | ... .+(_:_:) ... | cfg.swift:296:10:296:64 | (...) |  |
+| cfg.swift:296:58:296:58 | .+(_:_:) | cfg.swift:296:58:296:58 | Int.Type |  |
+| cfg.swift:296:58:296:58 | Int.Type | cfg.swift:296:55:296:55 | a5 |  |
+| cfg.swift:296:60:296:60 | &... | cfg.swift:296:62:296:62 | 4 |  |
+| cfg.swift:296:60:296:60 | b | cfg.swift:296:60:296:60 | &... |  |
+| cfg.swift:296:60:296:63 | (Int) ... | cfg.swift:296:55:296:63 | ... .+(_:_:) ... |  |
+| cfg.swift:296:60:296:63 | getter for ...[...] | cfg.swift:296:60:296:63 | (Int) ... |  |
+| cfg.swift:296:62:296:62 | 4 | cfg.swift:296:60:296:63 | getter for ...[...] |  |
+| cfg.swift:299:1:304:1 | enter loop1(x:) | cfg.swift:299:1:304:1 | loop1(x:) |  |
+| cfg.swift:299:1:304:1 | exit loop1(x:) (normal) | cfg.swift:299:1:304:1 | exit loop1(x:) |  |
+| cfg.swift:299:1:304:1 | loop1(x:) | cfg.swift:299:12:299:22 | x |  |
+| cfg.swift:299:12:299:22 | x | cfg.swift:300:3:303:3 | while ... { ... } |  |
+| cfg.swift:300:3:303:3 | while ... { ... } | cfg.swift:300:9:300:14 | StmtCondition |  |
+| cfg.swift:300:9:300:9 | (Int) ... | cfg.swift:300:14:300:14 | 0 |  |
+| cfg.swift:300:9:300:9 | x | cfg.swift:300:9:300:9 | (Int) ... |  |
+| cfg.swift:300:9:300:14 | ... .>=(_:_:) ... | cfg.swift:299:1:304:1 | exit loop1(x:) (normal) | false |
+| cfg.swift:300:9:300:14 | ... .>=(_:_:) ... | cfg.swift:301:5:301:5 | print(_:separator:terminator:) | true |
+| cfg.swift:300:9:300:14 | StmtCondition | cfg.swift:300:11:300:11 | .>=(_:_:) |  |
+| cfg.swift:300:11:300:11 | .>=(_:_:) | cfg.swift:300:11:300:11 | Int.Type |  |
+| cfg.swift:300:11:300:11 | Int.Type | cfg.swift:300:9:300:9 | x |  |
+| cfg.swift:300:14:300:14 | 0 | cfg.swift:300:9:300:14 | ... .>=(_:_:) ... |  |
+| cfg.swift:301:5:301:5 | print(_:separator:terminator:) | cfg.swift:301:11:301:11 | x |  |
+| cfg.swift:301:5:301:12 | call to print(_:separator:terminator:) | cfg.swift:302:7:302:7 | .-=(_:_:) |  |
+| cfg.swift:301:10:301:10 | default separator | cfg.swift:301:10:301:10 | default terminator |  |
+| cfg.swift:301:10:301:10 | default terminator | cfg.swift:301:5:301:12 | call to print(_:separator:terminator:) |  |
+| cfg.swift:301:11:301:11 | (Any) ... | cfg.swift:301:11:301:11 | [...] |  |
+| cfg.swift:301:11:301:11 | (Int) ... | cfg.swift:301:11:301:11 | (Any) ... |  |
+| cfg.swift:301:11:301:11 | [...] | cfg.swift:301:10:301:10 | default separator |  |
+| cfg.swift:301:11:301:11 | [...] | cfg.swift:301:11:301:11 | [...] |  |
+| cfg.swift:301:11:301:11 | x | cfg.swift:301:11:301:11 | (Int) ... |  |
+| cfg.swift:302:5:302:5 | &... | cfg.swift:302:10:302:10 | 1 |  |
+| cfg.swift:302:5:302:5 | x | cfg.swift:302:5:302:5 | &... |  |
+| cfg.swift:302:5:302:10 | ... .-=(_:_:) ... | cfg.swift:300:9:300:14 | StmtCondition |  |
+| cfg.swift:302:7:302:7 | .-=(_:_:) | cfg.swift:302:7:302:7 | Int.Type |  |
+| cfg.swift:302:7:302:7 | Int.Type | cfg.swift:302:5:302:5 | x |  |
+| cfg.swift:302:10:302:10 | 1 | cfg.swift:302:5:302:10 | ... .-=(_:_:) ... |  |
+| cfg.swift:306:1:319:1 | enter loop2(x:) | cfg.swift:306:1:319:1 | loop2(x:) |  |
+| cfg.swift:306:1:319:1 | exit loop2(x:) (normal) | cfg.swift:306:1:319:1 | exit loop2(x:) |  |
+| cfg.swift:306:1:319:1 | loop2(x:) | cfg.swift:306:12:306:22 | x |  |
+| cfg.swift:306:12:306:22 | x | cfg.swift:307:3:317:3 | while ... { ... } |  |
+| cfg.swift:307:3:317:3 | while ... { ... } | cfg.swift:307:9:307:14 | StmtCondition |  |
+| cfg.swift:307:9:307:9 | (Int) ... | cfg.swift:307:14:307:14 | 0 |  |
+| cfg.swift:307:9:307:9 | x | cfg.swift:307:9:307:9 | (Int) ... |  |
+| cfg.swift:307:9:307:14 | ... .>=(_:_:) ... | cfg.swift:308:5:308:5 | print(_:separator:terminator:) | true |
+| cfg.swift:307:9:307:14 | ... .>=(_:_:) ... | cfg.swift:318:3:318:3 | print(_:separator:terminator:) | false |
+| cfg.swift:307:9:307:14 | StmtCondition | cfg.swift:307:11:307:11 | .>=(_:_:) |  |
+| cfg.swift:307:11:307:11 | .>=(_:_:) | cfg.swift:307:11:307:11 | Int.Type |  |
+| cfg.swift:307:11:307:11 | Int.Type | cfg.swift:307:9:307:9 | x |  |
+| cfg.swift:307:14:307:14 | 0 | cfg.swift:307:9:307:14 | ... .>=(_:_:) ... |  |
+| cfg.swift:308:5:308:5 | print(_:separator:terminator:) | cfg.swift:308:11:308:11 | x |  |
+| cfg.swift:308:5:308:12 | call to print(_:separator:terminator:) | cfg.swift:309:7:309:7 | .-=(_:_:) |  |
+| cfg.swift:308:10:308:10 | default separator | cfg.swift:308:10:308:10 | default terminator |  |
+| cfg.swift:308:10:308:10 | default terminator | cfg.swift:308:5:308:12 | call to print(_:separator:terminator:) |  |
+| cfg.swift:308:11:308:11 | (Any) ... | cfg.swift:308:11:308:11 | [...] |  |
+| cfg.swift:308:11:308:11 | (Int) ... | cfg.swift:308:11:308:11 | (Any) ... |  |
+| cfg.swift:308:11:308:11 | [...] | cfg.swift:308:10:308:10 | default separator |  |
+| cfg.swift:308:11:308:11 | [...] | cfg.swift:308:11:308:11 | [...] |  |
+| cfg.swift:308:11:308:11 | x | cfg.swift:308:11:308:11 | (Int) ... |  |
+| cfg.swift:309:5:309:5 | &... | cfg.swift:309:10:309:10 | 1 |  |
+| cfg.swift:309:5:309:5 | x | cfg.swift:309:5:309:5 | &... |  |
+| cfg.swift:309:5:309:10 | ... .-=(_:_:) ... | cfg.swift:310:5:315:5 | if ... then { ... } else { ... } |  |
+| cfg.swift:309:7:309:7 | .-=(_:_:) | cfg.swift:309:7:309:7 | Int.Type |  |
+| cfg.swift:309:7:309:7 | Int.Type | cfg.swift:309:5:309:5 | x |  |
+| cfg.swift:309:10:309:10 | 1 | cfg.swift:309:5:309:10 | ... .-=(_:_:) ... |  |
+| cfg.swift:310:5:315:5 | if ... then { ... } else { ... } | cfg.swift:310:8:310:12 | StmtCondition |  |
+| cfg.swift:310:8:310:8 | (Int) ... | cfg.swift:310:12:310:12 | 100 |  |
+| cfg.swift:310:8:310:8 | x | cfg.swift:310:8:310:8 | (Int) ... |  |
+| cfg.swift:310:8:310:12 | ... .>(_:_:) ... | cfg.swift:311:7:311:7 | break | true |
+| cfg.swift:310:8:310:12 | ... .>(_:_:) ... | cfg.swift:313:10:315:5 | if ... then { ... } | false |
+| cfg.swift:310:8:310:12 | StmtCondition | cfg.swift:310:10:310:10 | .>(_:_:) |  |
+| cfg.swift:310:10:310:10 | .>(_:_:) | cfg.swift:310:10:310:10 | Int.Type |  |
+| cfg.swift:310:10:310:10 | Int.Type | cfg.swift:310:8:310:8 | x |  |
+| cfg.swift:310:12:310:12 | 100 | cfg.swift:310:8:310:12 | ... .>(_:_:) ... |  |
+| cfg.swift:311:7:311:7 | break | cfg.swift:318:3:318:3 | print(_:separator:terminator:) |  |
+| cfg.swift:313:10:315:5 | if ... then { ... } | cfg.swift:313:13:313:17 | StmtCondition |  |
+| cfg.swift:313:13:313:13 | (Int) ... | cfg.swift:313:17:313:17 | 50 |  |
+| cfg.swift:313:13:313:13 | x | cfg.swift:313:13:313:13 | (Int) ... |  |
+| cfg.swift:313:13:313:17 | ... .>(_:_:) ... | cfg.swift:314:7:314:7 | continue | true |
+| cfg.swift:313:13:313:17 | ... .>(_:_:) ... | cfg.swift:316:5:316:5 | print(_:separator:terminator:) | false |
+| cfg.swift:313:13:313:17 | StmtCondition | cfg.swift:313:15:313:15 | .>(_:_:) |  |
+| cfg.swift:313:15:313:15 | .>(_:_:) | cfg.swift:313:15:313:15 | Int.Type |  |
+| cfg.swift:313:15:313:15 | Int.Type | cfg.swift:313:13:313:13 | x |  |
+| cfg.swift:313:17:313:17 | 50 | cfg.swift:313:13:313:17 | ... .>(_:_:) ... |  |
+| cfg.swift:314:7:314:7 | continue | cfg.swift:307:9:307:14 | StmtCondition | continue |
+| cfg.swift:316:5:316:5 | print(_:separator:terminator:) | cfg.swift:316:11:316:11 | Iter |  |
+| cfg.swift:316:5:316:17 | call to print(_:separator:terminator:) | cfg.swift:307:9:307:14 | StmtCondition |  |
+| cfg.swift:316:10:316:10 | default separator | cfg.swift:316:10:316:10 | default terminator |  |
+| cfg.swift:316:10:316:10 | default terminator | cfg.swift:316:5:316:17 | call to print(_:separator:terminator:) |  |
+| cfg.swift:316:11:316:11 | (Any) ... | cfg.swift:316:11:316:11 | [...] |  |
+| cfg.swift:316:11:316:11 | Iter | cfg.swift:316:11:316:11 | (Any) ... |  |
+| cfg.swift:316:11:316:11 | [...] | cfg.swift:316:10:316:10 | default separator |  |
+| cfg.swift:316:11:316:11 | [...] | cfg.swift:316:11:316:11 | [...] |  |
+| cfg.swift:318:3:318:3 | print(_:separator:terminator:) | cfg.swift:318:9:318:9 | Done |  |
+| cfg.swift:318:3:318:15 | call to print(_:separator:terminator:) | cfg.swift:306:1:319:1 | exit loop2(x:) (normal) |  |
+| cfg.swift:318:8:318:8 | default separator | cfg.swift:318:8:318:8 | default terminator |  |
+| cfg.swift:318:8:318:8 | default terminator | cfg.swift:318:3:318:15 | call to print(_:separator:terminator:) |  |
+| cfg.swift:318:9:318:9 | (Any) ... | cfg.swift:318:9:318:9 | [...] |  |
+| cfg.swift:318:9:318:9 | Done | cfg.swift:318:9:318:9 | (Any) ... |  |
+| cfg.swift:318:9:318:9 | [...] | cfg.swift:318:8:318:8 | default separator |  |
+| cfg.swift:318:9:318:9 | [...] | cfg.swift:318:9:318:9 | [...] |  |
+| cfg.swift:321:1:336:1 | enter labeledLoop(x:) | cfg.swift:321:1:336:1 | labeledLoop(x:) |  |
+| cfg.swift:321:1:336:1 | exit labeledLoop(x:) (normal) | cfg.swift:321:1:336:1 | exit labeledLoop(x:) |  |
+| cfg.swift:321:1:336:1 | labeledLoop(x:) | cfg.swift:321:18:321:28 | x |  |
+| cfg.swift:321:18:321:28 | x | cfg.swift:322:3:335:3 | while ... { ... } |  |
+| cfg.swift:322:3:335:3 | while ... { ... } | cfg.swift:322:16:322:21 | StmtCondition |  |
+| cfg.swift:322:16:322:16 | (Int) ... | cfg.swift:322:21:322:21 | 0 |  |
+| cfg.swift:322:16:322:16 | x | cfg.swift:322:16:322:16 | (Int) ... |  |
+| cfg.swift:322:16:322:21 | ... .>=(_:_:) ... | cfg.swift:321:1:336:1 | exit labeledLoop(x:) (normal) | false |
+| cfg.swift:322:16:322:21 | ... .>=(_:_:) ... | cfg.swift:323:5:333:5 | while ... { ... } | true |
+| cfg.swift:322:16:322:21 | StmtCondition | cfg.swift:322:18:322:18 | .>=(_:_:) |  |
+| cfg.swift:322:18:322:18 | .>=(_:_:) | cfg.swift:322:18:322:18 | Int.Type |  |
+| cfg.swift:322:18:322:18 | Int.Type | cfg.swift:322:16:322:16 | x |  |
+| cfg.swift:322:21:322:21 | 0 | cfg.swift:322:16:322:21 | ... .>=(_:_:) ... |  |
+| cfg.swift:323:5:333:5 | while ... { ... } | cfg.swift:323:18:323:23 | StmtCondition |  |
+| cfg.swift:323:18:323:18 | (Int) ... | cfg.swift:323:23:323:23 | 0 |  |
+| cfg.swift:323:18:323:18 | x | cfg.swift:323:18:323:18 | (Int) ... |  |
+| cfg.swift:323:18:323:23 | ... .>=(_:_:) ... | cfg.swift:324:7:324:7 | print(_:separator:terminator:) | true |
+| cfg.swift:323:18:323:23 | ... .>=(_:_:) ... | cfg.swift:334:5:334:5 | print(_:separator:terminator:) | false |
+| cfg.swift:323:18:323:23 | StmtCondition | cfg.swift:323:20:323:20 | .>=(_:_:) |  |
+| cfg.swift:323:20:323:20 | .>=(_:_:) | cfg.swift:323:20:323:20 | Int.Type |  |
+| cfg.swift:323:20:323:20 | Int.Type | cfg.swift:323:18:323:18 | x |  |
+| cfg.swift:323:23:323:23 | 0 | cfg.swift:323:18:323:23 | ... .>=(_:_:) ... |  |
+| cfg.swift:324:7:324:7 | print(_:separator:terminator:) | cfg.swift:324:13:324:13 | x |  |
+| cfg.swift:324:7:324:14 | call to print(_:separator:terminator:) | cfg.swift:325:9:325:9 | .-=(_:_:) |  |
+| cfg.swift:324:12:324:12 | default separator | cfg.swift:324:12:324:12 | default terminator |  |
+| cfg.swift:324:12:324:12 | default terminator | cfg.swift:324:7:324:14 | call to print(_:separator:terminator:) |  |
+| cfg.swift:324:13:324:13 | (Any) ... | cfg.swift:324:13:324:13 | [...] |  |
+| cfg.swift:324:13:324:13 | (Int) ... | cfg.swift:324:13:324:13 | (Any) ... |  |
+| cfg.swift:324:13:324:13 | [...] | cfg.swift:324:12:324:12 | default separator |  |
+| cfg.swift:324:13:324:13 | [...] | cfg.swift:324:13:324:13 | [...] |  |
+| cfg.swift:324:13:324:13 | x | cfg.swift:324:13:324:13 | (Int) ... |  |
+| cfg.swift:325:7:325:7 | &... | cfg.swift:325:12:325:12 | 1 |  |
+| cfg.swift:325:7:325:7 | x | cfg.swift:325:7:325:7 | &... |  |
+| cfg.swift:325:7:325:12 | ... .-=(_:_:) ... | cfg.swift:326:7:331:7 | if ... then { ... } else { ... } |  |
+| cfg.swift:325:9:325:9 | .-=(_:_:) | cfg.swift:325:9:325:9 | Int.Type |  |
+| cfg.swift:325:9:325:9 | Int.Type | cfg.swift:325:7:325:7 | x |  |
+| cfg.swift:325:12:325:12 | 1 | cfg.swift:325:7:325:12 | ... .-=(_:_:) ... |  |
+| cfg.swift:326:7:331:7 | if ... then { ... } else { ... } | cfg.swift:326:10:326:14 | StmtCondition |  |
+| cfg.swift:326:10:326:10 | (Int) ... | cfg.swift:326:14:326:14 | 100 |  |
+| cfg.swift:326:10:326:10 | x | cfg.swift:326:10:326:10 | (Int) ... |  |
+| cfg.swift:326:10:326:14 | ... .>(_:_:) ... | cfg.swift:327:9:327:15 | break outer | true |
+| cfg.swift:326:10:326:14 | ... .>(_:_:) ... | cfg.swift:329:12:331:7 | if ... then { ... } | false |
+| cfg.swift:326:10:326:14 | StmtCondition | cfg.swift:326:12:326:12 | .>(_:_:) |  |
+| cfg.swift:326:12:326:12 | .>(_:_:) | cfg.swift:326:12:326:12 | Int.Type |  |
+| cfg.swift:326:12:326:12 | Int.Type | cfg.swift:326:10:326:10 | x |  |
+| cfg.swift:326:14:326:14 | 100 | cfg.swift:326:10:326:14 | ... .>(_:_:) ... |  |
+| cfg.swift:327:9:327:15 | break outer | cfg.swift:321:1:336:1 | exit labeledLoop(x:) (normal) |  |
+| cfg.swift:329:12:331:7 | if ... then { ... } | cfg.swift:329:15:329:19 | StmtCondition |  |
+| cfg.swift:329:15:329:15 | (Int) ... | cfg.swift:329:19:329:19 | 50 |  |
+| cfg.swift:329:15:329:15 | x | cfg.swift:329:15:329:15 | (Int) ... |  |
+| cfg.swift:329:15:329:19 | ... .>(_:_:) ... | cfg.swift:330:9:330:18 | continue inner | true |
+| cfg.swift:329:15:329:19 | ... .>(_:_:) ... | cfg.swift:332:7:332:7 | print(_:separator:terminator:) | false |
+| cfg.swift:329:15:329:19 | StmtCondition | cfg.swift:329:17:329:17 | .>(_:_:) |  |
+| cfg.swift:329:17:329:17 | .>(_:_:) | cfg.swift:329:17:329:17 | Int.Type |  |
+| cfg.swift:329:17:329:17 | Int.Type | cfg.swift:329:15:329:15 | x |  |
+| cfg.swift:329:19:329:19 | 50 | cfg.swift:329:15:329:19 | ... .>(_:_:) ... |  |
+| cfg.swift:330:9:330:18 | continue inner | cfg.swift:323:18:323:23 | StmtCondition | continue |
+| cfg.swift:332:7:332:7 | print(_:separator:terminator:) | cfg.swift:332:13:332:13 | Iter |  |
+| cfg.swift:332:7:332:19 | call to print(_:separator:terminator:) | cfg.swift:323:18:323:23 | StmtCondition |  |
+| cfg.swift:332:12:332:12 | default separator | cfg.swift:332:12:332:12 | default terminator |  |
+| cfg.swift:332:12:332:12 | default terminator | cfg.swift:332:7:332:19 | call to print(_:separator:terminator:) |  |
+| cfg.swift:332:13:332:13 | (Any) ... | cfg.swift:332:13:332:13 | [...] |  |
+| cfg.swift:332:13:332:13 | Iter | cfg.swift:332:13:332:13 | (Any) ... |  |
+| cfg.swift:332:13:332:13 | [...] | cfg.swift:332:12:332:12 | default separator |  |
+| cfg.swift:332:13:332:13 | [...] | cfg.swift:332:13:332:13 | [...] |  |
+| cfg.swift:334:5:334:5 | print(_:separator:terminator:) | cfg.swift:334:11:334:11 | Done |  |
+| cfg.swift:334:5:334:17 | call to print(_:separator:terminator:) | cfg.swift:322:16:322:21 | StmtCondition |  |
+| cfg.swift:334:10:334:10 | default separator | cfg.swift:334:10:334:10 | default terminator |  |
+| cfg.swift:334:10:334:10 | default terminator | cfg.swift:334:5:334:17 | call to print(_:separator:terminator:) |  |
+| cfg.swift:334:11:334:11 | (Any) ... | cfg.swift:334:11:334:11 | [...] |  |
+| cfg.swift:334:11:334:11 | Done | cfg.swift:334:11:334:11 | (Any) ... |  |
+| cfg.swift:334:11:334:11 | [...] | cfg.swift:334:10:334:10 | default separator |  |
+| cfg.swift:334:11:334:11 | [...] | cfg.swift:334:11:334:11 | [...] |  |
+| cfg.swift:338:1:343:1 | enter testRepeat(x:) | cfg.swift:338:1:343:1 | testRepeat(x:) |  |
+| cfg.swift:338:1:343:1 | exit testRepeat(x:) (normal) | cfg.swift:338:1:343:1 | exit testRepeat(x:) |  |
+| cfg.swift:338:1:343:1 | testRepeat(x:) | cfg.swift:338:17:338:27 | x |  |
+| cfg.swift:338:17:338:27 | x | cfg.swift:339:3:342:16 | repeat { ... } while ...  |  |
+| cfg.swift:339:3:342:16 | repeat { ... } while ...  | cfg.swift:340:5:340:5 | print(_:separator:terminator:) |  |
+| cfg.swift:340:5:340:5 | print(_:separator:terminator:) | cfg.swift:340:11:340:11 | x |  |
+| cfg.swift:340:5:340:12 | call to print(_:separator:terminator:) | cfg.swift:341:7:341:7 | .-=(_:_:) |  |
+| cfg.swift:340:10:340:10 | default separator | cfg.swift:340:10:340:10 | default terminator |  |
+| cfg.swift:340:10:340:10 | default terminator | cfg.swift:340:5:340:12 | call to print(_:separator:terminator:) |  |
+| cfg.swift:340:11:340:11 | (Any) ... | cfg.swift:340:11:340:11 | [...] |  |
+| cfg.swift:340:11:340:11 | (Int) ... | cfg.swift:340:11:340:11 | (Any) ... |  |
+| cfg.swift:340:11:340:11 | [...] | cfg.swift:340:10:340:10 | default separator |  |
+| cfg.swift:340:11:340:11 | [...] | cfg.swift:340:11:340:11 | [...] |  |
+| cfg.swift:340:11:340:11 | x | cfg.swift:340:11:340:11 | (Int) ... |  |
+| cfg.swift:341:5:341:5 | &... | cfg.swift:341:10:341:10 | 1 |  |
+| cfg.swift:341:5:341:5 | x | cfg.swift:341:5:341:5 | &... |  |
+| cfg.swift:341:5:341:10 | ... .-=(_:_:) ... | cfg.swift:342:13:342:13 | .>=(_:_:) |  |
+| cfg.swift:341:7:341:7 | .-=(_:_:) | cfg.swift:341:7:341:7 | Int.Type |  |
+| cfg.swift:341:7:341:7 | Int.Type | cfg.swift:341:5:341:5 | x |  |
+| cfg.swift:341:10:341:10 | 1 | cfg.swift:341:5:341:10 | ... .-=(_:_:) ... |  |
+| cfg.swift:342:11:342:11 | (Int) ... | cfg.swift:342:16:342:16 | 0 |  |
+| cfg.swift:342:11:342:11 | x | cfg.swift:342:11:342:11 | (Int) ... |  |
+| cfg.swift:342:11:342:16 | ... .>=(_:_:) ... | cfg.swift:338:1:343:1 | exit testRepeat(x:) (normal) | false |
+| cfg.swift:342:11:342:16 | ... .>=(_:_:) ... | cfg.swift:340:5:340:5 | print(_:separator:terminator:) | true |
+| cfg.swift:342:13:342:13 | .>=(_:_:) | cfg.swift:342:13:342:13 | Int.Type |  |
+| cfg.swift:342:13:342:13 | Int.Type | cfg.swift:342:11:342:11 | x |  |
+| cfg.swift:342:16:342:16 | 0 | cfg.swift:342:11:342:16 | ... .>=(_:_:) ... |  |
+| cfg.swift:345:1:350:1 | enter loop_with_identity_expr() | cfg.swift:345:1:350:1 | loop_with_identity_expr() |  |
+| cfg.swift:345:1:350:1 | exit loop_with_identity_expr() (normal) | cfg.swift:345:1:350:1 | exit loop_with_identity_expr() |  |
+| cfg.swift:345:1:350:1 | loop_with_identity_expr() | cfg.swift:346:7:346:7 | x |  |
+| cfg.swift:346:3:346:11 | var ... = ... | cfg.swift:347:3:349:3 | while ... { ... } |  |
+| cfg.swift:346:7:346:7 | x | cfg.swift:346:11:346:11 | 0 | match |
+| cfg.swift:346:11:346:11 | 0 | cfg.swift:346:3:346:11 | var ... = ... |  |
+| cfg.swift:347:3:349:3 | while ... { ... } | cfg.swift:347:8:347:15 | StmtCondition |  |
+| cfg.swift:347:8:347:15 | StmtCondition | cfg.swift:347:11:347:11 | .<(_:_:) |  |
+| cfg.swift:347:8:347:15 | [false] (...) | cfg.swift:345:1:350:1 | exit loop_with_identity_expr() (normal) | false |
+| cfg.swift:347:8:347:15 | [true] (...) | cfg.swift:348:7:348:7 | .+=(_:_:) | true |
+| cfg.swift:347:9:347:9 | (Int) ... | cfg.swift:347:13:347:13 | 10 |  |
+| cfg.swift:347:9:347:9 | x | cfg.swift:347:9:347:9 | (Int) ... |  |
+| cfg.swift:347:9:347:13 | ... .<(_:_:) ... | cfg.swift:347:8:347:15 | [false] (...) | false |
+| cfg.swift:347:9:347:13 | ... .<(_:_:) ... | cfg.swift:347:8:347:15 | [true] (...) | true |
+| cfg.swift:347:11:347:11 | .<(_:_:) | cfg.swift:347:11:347:11 | Int.Type |  |
+| cfg.swift:347:11:347:11 | Int.Type | cfg.swift:347:9:347:9 | x |  |
+| cfg.swift:347:13:347:13 | 10 | cfg.swift:347:9:347:13 | ... .<(_:_:) ... |  |
+| cfg.swift:348:5:348:5 | &... | cfg.swift:348:10:348:10 | 1 |  |
+| cfg.swift:348:5:348:5 | x | cfg.swift:348:5:348:5 | &... |  |
+| cfg.swift:348:5:348:10 | ... .+=(_:_:) ... | cfg.swift:347:8:347:15 | StmtCondition |  |
+| cfg.swift:348:7:348:7 | .+=(_:_:) | cfg.swift:348:7:348:7 | Int.Type |  |
+| cfg.swift:348:7:348:7 | Int.Type | cfg.swift:348:5:348:5 | x |  |
+| cfg.swift:348:10:348:10 | 1 | cfg.swift:348:5:348:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:352:7:352:7 | OptionalC.deinit() | cfg.swift:352:7:352:7 | self |  |
+| cfg.swift:352:7:352:7 | enter OptionalC.deinit() | cfg.swift:352:7:352:7 | OptionalC.deinit() |  |
+| cfg.swift:352:7:352:7 | exit OptionalC.deinit() (normal) | cfg.swift:352:7:352:7 | exit OptionalC.deinit() |  |
+| cfg.swift:352:7:352:7 | self | cfg.swift:352:7:352:7 | { ... } |  |
+| cfg.swift:352:7:352:7 | { ... } | cfg.swift:352:7:352:7 | exit OptionalC.deinit() (normal) |  |
+| cfg.swift:353:7:353:7 | enter get | cfg.swift:353:7:353:7 | get |  |
+| cfg.swift:353:7:353:7 | exit get (normal) | cfg.swift:353:7:353:7 | exit get |  |
+| cfg.swift:353:7:353:7 | get | cfg.swift:353:7:353:7 | self |  |
+| cfg.swift:353:7:353:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:354:3:354:3 | self | cfg.swift:354:8:354:14 | arg |  |
+| cfg.swift:354:3:356:3 | OptionalC.init(arg:) | cfg.swift:354:3:354:3 | self |  |
+| cfg.swift:354:3:356:3 | enter OptionalC.init(arg:) | cfg.swift:354:3:356:3 | OptionalC.init(arg:) |  |
+| cfg.swift:354:3:356:3 | exit OptionalC.init(arg:) (normal) | cfg.swift:354:3:356:3 | exit OptionalC.init(arg:) |  |
+| cfg.swift:354:8:354:14 | arg | cfg.swift:355:5:355:5 | self |  |
+| cfg.swift:355:5:355:5 | .c | cfg.swift:355:9:355:9 | arg |  |
+| cfg.swift:355:5:355:5 | self | cfg.swift:355:5:355:5 | .c |  |
+| cfg.swift:355:5:355:9 |  ... = ... | cfg.swift:356:3:356:3 | return |  |
+| cfg.swift:355:9:355:9 | arg | cfg.swift:355:5:355:9 |  ... = ... |  |
+| cfg.swift:356:3:356:3 | return | cfg.swift:354:3:356:3 | exit OptionalC.init(arg:) (normal) | return |
+| cfg.swift:358:3:360:3 | enter getOptional() | cfg.swift:358:3:360:3 | getOptional() |  |
+| cfg.swift:358:3:360:3 | exit getOptional() (normal) | cfg.swift:358:3:360:3 | exit getOptional() |  |
+| cfg.swift:358:3:360:3 | getOptional() | cfg.swift:358:8:358:8 | self |  |
+| cfg.swift:358:8:358:8 | self | cfg.swift:359:12:359:12 | self |  |
+| cfg.swift:359:5:359:12 | return ... | cfg.swift:358:3:360:3 | exit getOptional() (normal) | return |
+| cfg.swift:359:12:359:12 | getter for .c | cfg.swift:359:5:359:12 | return ... |  |
+| cfg.swift:359:12:359:12 | self | cfg.swift:359:12:359:12 | getter for .c |  |
+| cfg.swift:363:1:365:1 | enter testOptional(c:) | cfg.swift:363:1:365:1 | testOptional(c:) |  |
+| cfg.swift:363:1:365:1 | exit testOptional(c:) (normal) | cfg.swift:363:1:365:1 | exit testOptional(c:) |  |
+| cfg.swift:363:1:365:1 | testOptional(c:) | cfg.swift:363:19:363:32 | c |  |
+| cfg.swift:363:19:363:32 | c | cfg.swift:364:10:364:28 | .getMyInt() |  |
+| cfg.swift:364:3:364:37 | return ... | cfg.swift:363:1:365:1 | exit testOptional(c:) (normal) | return |
+| cfg.swift:364:10:364:10 | c | cfg.swift:364:10:364:11 | ...? |  |
+| cfg.swift:364:10:364:11 | ...? | cfg.swift:364:10:364:25 | call to getOptional() |  |
+| cfg.swift:364:10:364:13 | .getOptional() | cfg.swift:364:10:364:10 | c |  |
+| cfg.swift:364:10:364:25 | call to getOptional() | cfg.swift:364:10:364:26 | ...? |  |
+| cfg.swift:364:10:364:26 | ...? | cfg.swift:364:10:364:37 | call to getMyInt() |  |
+| cfg.swift:364:10:364:28 | .getMyInt() | cfg.swift:364:10:364:13 | .getOptional() |  |
+| cfg.swift:364:10:364:37 | (Int?) ... | cfg.swift:364:10:364:37 | OptionalEvaluationExpr |  |
+| cfg.swift:364:10:364:37 | OptionalEvaluationExpr | cfg.swift:364:3:364:37 | return ... |  |
+| cfg.swift:364:10:364:37 | call to getMyInt() | cfg.swift:364:10:364:37 | (Int?) ... |  |
+| cfg.swift:367:1:371:1 | enter testCapture(x:y:) | cfg.swift:367:1:371:1 | testCapture(x:y:) |  |
+| cfg.swift:367:1:371:1 | exit testCapture(x:y:) (normal) | cfg.swift:367:1:371:1 | exit testCapture(x:y:) |  |
+| cfg.swift:367:1:371:1 | testCapture(x:y:) | cfg.swift:367:18:367:22 | x |  |
+| cfg.swift:367:18:367:22 | x | cfg.swift:367:27:367:31 | y |  |
+| cfg.swift:367:27:367:31 | y | cfg.swift:368:13:368:13 | z |  |
+| cfg.swift:368:3:370:3 | return ... | cfg.swift:367:1:371:1 | exit testCapture(x:y:) (normal) | return |
+| cfg.swift:368:10:370:3 | enter { ... } | cfg.swift:368:10:370:3 | { ... } |  |
+| cfg.swift:368:10:370:3 | exit { ... } (normal) | cfg.swift:368:10:370:3 | exit { ... } |  |
+| cfg.swift:368:10:370:3 | { ... } | cfg.swift:368:3:370:3 | return ... |  |
+| cfg.swift:368:10:370:3 | { ... } | cfg.swift:368:10:370:3 | { ... } |  |
+| cfg.swift:368:10:370:3 | { ... } | cfg.swift:369:12:369:12 | z |  |
+| cfg.swift:368:13:368:13 | z | cfg.swift:368:19:368:19 | .+(_:_:) | match |
+| cfg.swift:368:13:368:21 | var ... = ... | cfg.swift:368:24:368:24 | t |  |
+| cfg.swift:368:17:368:17 | x | cfg.swift:368:21:368:21 | y |  |
+| cfg.swift:368:17:368:21 | ... .+(_:_:) ... | cfg.swift:368:13:368:21 | var ... = ... |  |
+| cfg.swift:368:19:368:19 | .+(_:_:) | cfg.swift:368:19:368:19 | Int.Type |  |
+| cfg.swift:368:19:368:19 | Int.Type | cfg.swift:368:17:368:17 | x |  |
+| cfg.swift:368:21:368:21 | y | cfg.swift:368:17:368:21 | ... .+(_:_:) ... |  |
+| cfg.swift:368:24:368:24 | t | cfg.swift:368:28:368:28 | literal | match |
+| cfg.swift:368:24:368:28 | var ... = ... | cfg.swift:368:10:370:3 | { ... } |  |
+| cfg.swift:368:28:368:28 | literal | cfg.swift:368:24:368:28 | var ... = ... |  |
+| cfg.swift:369:5:369:12 | return ... | cfg.swift:368:10:370:3 | exit { ... } (normal) | return |
+| cfg.swift:369:12:369:12 | z | cfg.swift:369:5:369:12 | return ... |  |
+| cfg.swift:373:1:375:1 | enter testTupleElement(t:) | cfg.swift:373:1:375:1 | testTupleElement(t:) |  |
+| cfg.swift:373:1:375:1 | exit testTupleElement(t:) (normal) | cfg.swift:373:1:375:1 | exit testTupleElement(t:) |  |
+| cfg.swift:373:1:375:1 | testTupleElement(t:) | cfg.swift:373:23:373:47 | t |  |
+| cfg.swift:373:23:373:47 | t | cfg.swift:374:26:374:26 | .+(_:_:) |  |
+| cfg.swift:374:3:374:38 | return ... | cfg.swift:373:1:375:1 | exit testTupleElement(t:) (normal) | return |
+| cfg.swift:374:10:374:10 | t | cfg.swift:374:10:374:12 | .0 |  |
+| cfg.swift:374:10:374:12 | .0 | cfg.swift:374:16:374:16 | t |  |
+| cfg.swift:374:10:374:18 | ... .+(_:_:) ... | cfg.swift:374:22:374:22 | t |  |
+| cfg.swift:374:10:374:24 | ... .+(_:_:) ... | cfg.swift:374:29:374:29 | 1 |  |
+| cfg.swift:374:10:374:38 | ... .+(_:_:) ... | cfg.swift:374:3:374:38 | return ... |  |
+| cfg.swift:374:14:374:14 | .+(_:_:) | cfg.swift:374:14:374:14 | Int.Type |  |
+| cfg.swift:374:14:374:14 | Int.Type | cfg.swift:374:10:374:10 | t |  |
+| cfg.swift:374:16:374:16 | t | cfg.swift:374:16:374:18 | .1 |  |
+| cfg.swift:374:16:374:18 | .1 | cfg.swift:374:10:374:18 | ... .+(_:_:) ... |  |
+| cfg.swift:374:20:374:20 | .+(_:_:) | cfg.swift:374:20:374:20 | Int.Type |  |
+| cfg.swift:374:20:374:20 | Int.Type | cfg.swift:374:14:374:14 | .+(_:_:) |  |
+| cfg.swift:374:22:374:22 | t | cfg.swift:374:22:374:24 | .2 |  |
+| cfg.swift:374:22:374:24 | .2 | cfg.swift:374:10:374:24 | ... .+(_:_:) ... |  |
+| cfg.swift:374:26:374:26 | .+(_:_:) | cfg.swift:374:26:374:26 | Int.Type |  |
+| cfg.swift:374:26:374:26 | Int.Type | cfg.swift:374:20:374:20 | .+(_:_:) |  |
+| cfg.swift:374:28:374:36 | (...) | cfg.swift:374:28:374:38 | .0 |  |
+| cfg.swift:374:28:374:38 | .0 | cfg.swift:374:10:374:38 | ... .+(_:_:) ... |  |
+| cfg.swift:374:29:374:29 | 1 | cfg.swift:374:32:374:32 | 2 |  |
+| cfg.swift:374:32:374:32 | 2 | cfg.swift:374:35:374:35 | 3 |  |
+| cfg.swift:374:35:374:35 | 3 | cfg.swift:374:28:374:36 | (...) |  |
+| cfg.swift:377:7:377:7 | #... | cfg.swift:377:7:377:7 | #... |  |
+| cfg.swift:377:7:377:7 | #... | cfg.swift:377:7:377:7 | #... |  |
+| cfg.swift:377:7:377:7 | #... | cfg.swift:377:7:377:7 | #... |  |
+| cfg.swift:377:7:377:7 | #... | cfg.swift:377:7:377:7 | call to _unimplementedInitializer(className:initName:file:line:column:) |  |
+| cfg.swift:377:7:377:7 | Derived.deinit() | cfg.swift:377:7:377:7 | self |  |
+| cfg.swift:377:7:377:7 | _unimplementedInitializer(className:initName:file:line:column:) | cfg.swift:377:7:377:7 | cfg.Derived |  |
+| cfg.swift:377:7:377:7 | call to _unimplementedInitializer(className:initName:file:line:column:) | file://:0:0:0:0 | return |  |
+| cfg.swift:377:7:377:7 | cfg.Derived | cfg.swift:377:7:377:7 | #... |  |
+| cfg.swift:377:7:377:7 | enter Derived.deinit() | cfg.swift:377:7:377:7 | Derived.deinit() |  |
+| cfg.swift:377:7:377:7 | exit Derived.deinit() (normal) | cfg.swift:377:7:377:7 | exit Derived.deinit() |  |
+| cfg.swift:377:7:377:7 | self | cfg.swift:377:7:377:7 | { ... } |  |
+| cfg.swift:377:7:377:7 | { ... } | cfg.swift:377:7:377:7 | exit Derived.deinit() (normal) |  |
+| cfg.swift:377:19:377:19 | Derived.init(n:) | cfg.swift:377:19:377:19 | self |  |
+| cfg.swift:377:19:377:19 | enter Derived.init(n:) | cfg.swift:377:19:377:19 | Derived.init(n:) |  |
+| cfg.swift:377:19:377:19 | exit Derived.init(n:) (normal) | cfg.swift:377:19:377:19 | exit Derived.init(n:) |  |
+| cfg.swift:377:19:377:19 | self | file://:0:0:0:0 | n |  |
+| cfg.swift:378:3:378:3 | self | cfg.swift:379:5:379:11 | C.init(n:) |  |
+| cfg.swift:378:3:380:3 | Derived.init() | cfg.swift:378:3:378:3 | self |  |
+| cfg.swift:378:3:380:3 | enter Derived.init() | cfg.swift:378:3:380:3 | Derived.init() |  |
+| cfg.swift:378:3:380:3 | exit Derived.init() (normal) | cfg.swift:378:3:380:3 | exit Derived.init() |  |
+| cfg.swift:379:5:379:5 | super | cfg.swift:379:19:379:19 | 0 |  |
+| cfg.swift:379:5:379:11 | C.init(n:) | cfg.swift:379:5:379:5 | super |  |
+| cfg.swift:379:5:379:20 | call to C.init(n:) | cfg.swift:379:5:379:20 | self = ... |  |
+| cfg.swift:379:5:379:20 | self = ... | cfg.swift:380:3:380:3 | return |  |
+| cfg.swift:379:19:379:19 | 0 | cfg.swift:379:5:379:20 | call to C.init(n:) |  |
+| cfg.swift:380:3:380:3 | return | cfg.swift:378:3:380:3 | exit Derived.init() (normal) | return |
+| cfg.swift:383:1:391:1 | doWithoutCatch(x:) | cfg.swift:383:21:383:25 | x |  |
+| cfg.swift:383:1:391:1 | enter doWithoutCatch(x:) | cfg.swift:383:1:391:1 | doWithoutCatch(x:) |  |
+| cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) (abnormal) | cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) |  |
+| cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) (normal) | cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) |  |
+| cfg.swift:383:21:383:25 | x | cfg.swift:384:3:389:3 | do { ... } |  |
+| cfg.swift:384:3:389:3 | do { ... } | cfg.swift:385:9:385:9 | mightThrow(x:) |  |
+| cfg.swift:385:5:385:24 | try ... | cfg.swift:386:5:386:5 | print(_:separator:terminator:) |  |
+| cfg.swift:385:9:385:9 | mightThrow(x:) | cfg.swift:385:23:385:23 | 0 |  |
+| cfg.swift:385:9:385:24 | call to mightThrow(x:) | cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) (abnormal) | exception |
+| cfg.swift:385:9:385:24 | call to mightThrow(x:) | cfg.swift:385:5:385:24 | try ... |  |
+| cfg.swift:385:23:385:23 | 0 | cfg.swift:385:9:385:24 | call to mightThrow(x:) |  |
+| cfg.swift:386:5:386:5 | print(_:separator:terminator:) | cfg.swift:386:11:386:11 | Did not throw. |  |
+| cfg.swift:386:5:386:27 | call to print(_:separator:terminator:) | cfg.swift:387:10:387:10 | mightThrow(x:) |  |
+| cfg.swift:386:10:386:10 | default separator | cfg.swift:386:10:386:10 | default terminator |  |
+| cfg.swift:386:10:386:10 | default terminator | cfg.swift:386:5:386:27 | call to print(_:separator:terminator:) |  |
+| cfg.swift:386:11:386:11 | (Any) ... | cfg.swift:386:11:386:11 | [...] |  |
+| cfg.swift:386:11:386:11 | Did not throw. | cfg.swift:386:11:386:11 | (Any) ... |  |
+| cfg.swift:386:11:386:11 | [...] | cfg.swift:386:10:386:10 | default separator |  |
+| cfg.swift:386:11:386:11 | [...] | cfg.swift:386:11:386:11 | [...] |  |
+| cfg.swift:387:5:387:25 | try! ... | cfg.swift:388:5:388:5 | print(_:separator:terminator:) |  |
+| cfg.swift:387:10:387:10 | mightThrow(x:) | cfg.swift:387:24:387:24 | 0 |  |
+| cfg.swift:387:10:387:25 | call to mightThrow(x:) | cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) (abnormal) | exception |
+| cfg.swift:387:10:387:25 | call to mightThrow(x:) | cfg.swift:387:5:387:25 | try! ... |  |
+| cfg.swift:387:24:387:24 | 0 | cfg.swift:387:10:387:25 | call to mightThrow(x:) |  |
+| cfg.swift:388:5:388:5 | print(_:separator:terminator:) | cfg.swift:388:11:388:11 | Still did not throw. |  |
+| cfg.swift:388:5:388:33 | call to print(_:separator:terminator:) | cfg.swift:390:10:390:10 | 0 |  |
+| cfg.swift:388:10:388:10 | default separator | cfg.swift:388:10:388:10 | default terminator |  |
+| cfg.swift:388:10:388:10 | default terminator | cfg.swift:388:5:388:33 | call to print(_:separator:terminator:) |  |
+| cfg.swift:388:11:388:11 | (Any) ... | cfg.swift:388:11:388:11 | [...] |  |
+| cfg.swift:388:11:388:11 | Still did not throw. | cfg.swift:388:11:388:11 | (Any) ... |  |
+| cfg.swift:388:11:388:11 | [...] | cfg.swift:388:10:388:10 | default separator |  |
+| cfg.swift:388:11:388:11 | [...] | cfg.swift:388:11:388:11 | [...] |  |
+| cfg.swift:390:3:390:10 | return ... | cfg.swift:383:1:391:1 | exit doWithoutCatch(x:) (normal) | return |
+| cfg.swift:390:10:390:10 | 0 | cfg.swift:390:3:390:10 | return ... |  |
+| cfg.swift:394:7:394:7 | _modify | cfg.swift:394:7:394:7 | self |  |
+| cfg.swift:394:7:394:7 | enter _modify | cfg.swift:394:7:394:7 | _modify |  |
+| cfg.swift:394:7:394:7 | enter get | cfg.swift:394:7:394:7 | get |  |
+| cfg.swift:394:7:394:7 | enter set | cfg.swift:394:7:394:7 | set |  |
+| cfg.swift:394:7:394:7 | exit _modify (normal) | cfg.swift:394:7:394:7 | exit _modify |  |
+| cfg.swift:394:7:394:7 | exit get (normal) | cfg.swift:394:7:394:7 | exit get |  |
+| cfg.swift:394:7:394:7 | exit set (normal) | cfg.swift:394:7:394:7 | exit set |  |
+| cfg.swift:394:7:394:7 | get | cfg.swift:394:7:394:7 | self |  |
+| cfg.swift:394:7:394:7 | self | cfg.swift:394:7:394:7 | value |  |
+| cfg.swift:394:7:394:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:394:7:394:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:394:7:394:7 | set | cfg.swift:394:7:394:7 | self |  |
+| cfg.swift:394:7:394:7 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:394:7:394:7 | yield ... | cfg.swift:394:7:394:7 | exit _modify (normal) |  |
+| cfg.swift:395:3:395:3 | self | cfg.swift:396:5:396:5 | self |  |
+| cfg.swift:395:3:397:3 | Structors.init() | cfg.swift:395:3:395:3 | self |  |
+| cfg.swift:395:3:397:3 | enter Structors.init() | cfg.swift:395:3:397:3 | Structors.init() |  |
+| cfg.swift:395:3:397:3 | exit Structors.init() (normal) | cfg.swift:395:3:397:3 | exit Structors.init() |  |
+| cfg.swift:396:5:396:5 | .field | cfg.swift:396:13:396:13 | 10 |  |
+| cfg.swift:396:5:396:5 | self | cfg.swift:396:5:396:5 | .field |  |
+| cfg.swift:396:5:396:13 |  ... = ... | cfg.swift:397:3:397:3 | return |  |
+| cfg.swift:396:13:396:13 | 10 | cfg.swift:396:5:396:13 |  ... = ... |  |
+| cfg.swift:397:3:397:3 | return | cfg.swift:395:3:397:3 | exit Structors.init() (normal) | return |
+| cfg.swift:399:3:399:3 | self | cfg.swift:400:5:400:5 | self |  |
+| cfg.swift:399:3:401:3 | Structors.deinit() | cfg.swift:399:3:399:3 | self |  |
+| cfg.swift:399:3:401:3 | enter Structors.deinit() | cfg.swift:399:3:401:3 | Structors.deinit() |  |
+| cfg.swift:399:3:401:3 | exit Structors.deinit() (normal) | cfg.swift:399:3:401:3 | exit Structors.deinit() |  |
+| cfg.swift:400:5:400:5 | .field | cfg.swift:400:13:400:13 | 0 |  |
+| cfg.swift:400:5:400:5 | self | cfg.swift:400:5:400:5 | .field |  |
+| cfg.swift:400:5:400:13 |  ... = ... | cfg.swift:399:3:401:3 | exit Structors.deinit() (normal) |  |
+| cfg.swift:400:13:400:13 | 0 | cfg.swift:400:5:400:13 |  ... = ... |  |
+| cfg.swift:404:1:406:1 | dictionaryLiteral(x:y:) | cfg.swift:404:24:404:27 | x |  |
+| cfg.swift:404:1:406:1 | enter dictionaryLiteral(x:y:) | cfg.swift:404:1:406:1 | dictionaryLiteral(x:y:) |  |
+| cfg.swift:404:1:406:1 | exit dictionaryLiteral(x:y:) (normal) | cfg.swift:404:1:406:1 | exit dictionaryLiteral(x:y:) |  |
+| cfg.swift:404:24:404:27 | x | cfg.swift:404:32:404:35 | y |  |
+| cfg.swift:404:32:404:35 | y | cfg.swift:405:11:405:11 | x |  |
+| cfg.swift:405:3:405:25 | return ... | cfg.swift:404:1:406:1 | exit dictionaryLiteral(x:y:) (normal) | return |
+| cfg.swift:405:10:405:25 | [...] | cfg.swift:405:3:405:25 | return ... |  |
+| cfg.swift:405:11:405:11 | x | cfg.swift:405:16:405:16 | x |  |
+| cfg.swift:405:11:405:16 | (...) | cfg.swift:405:19:405:19 | y |  |
+| cfg.swift:405:16:405:16 | x | cfg.swift:405:11:405:16 | (...) |  |
+| cfg.swift:405:19:405:19 | y | cfg.swift:405:24:405:24 | y |  |
+| cfg.swift:405:19:405:24 | (...) | cfg.swift:405:10:405:25 | [...] |  |
+| cfg.swift:405:24:405:24 | y | cfg.swift:405:19:405:24 | (...) |  |
+| cfg.swift:408:1:443:1 | enter localDeclarations() | cfg.swift:408:1:443:1 | localDeclarations() |  |
+| cfg.swift:408:1:443:1 | exit localDeclarations() (normal) | cfg.swift:408:1:443:1 | exit localDeclarations() |  |
+| cfg.swift:408:1:443:1 | localDeclarations() | cfg.swift:409:3:414:3 | MyLocalClass |  |
+| cfg.swift:409:3:414:3 | MyLocalClass | cfg.swift:416:3:421:3 | MyLocalStruct |  |
+| cfg.swift:409:9:409:9 | MyLocalClass.deinit() | cfg.swift:409:9:409:9 | self |  |
+| cfg.swift:409:9:409:9 | enter MyLocalClass.deinit() | cfg.swift:409:9:409:9 | MyLocalClass.deinit() |  |
+| cfg.swift:409:9:409:9 | exit MyLocalClass.deinit() (normal) | cfg.swift:409:9:409:9 | exit MyLocalClass.deinit() |  |
+| cfg.swift:409:9:409:9 | self | cfg.swift:409:9:409:9 | { ... } |  |
+| cfg.swift:409:9:409:9 | { ... } | cfg.swift:409:9:409:9 | exit MyLocalClass.deinit() (normal) |  |
+| cfg.swift:410:9:410:9 | _modify | cfg.swift:410:9:410:9 | self |  |
+| cfg.swift:410:9:410:9 | enter _modify | cfg.swift:410:9:410:9 | _modify |  |
+| cfg.swift:410:9:410:9 | enter get | cfg.swift:410:9:410:9 | get |  |
+| cfg.swift:410:9:410:9 | enter set | cfg.swift:410:9:410:9 | set |  |
+| cfg.swift:410:9:410:9 | exit _modify (normal) | cfg.swift:410:9:410:9 | exit _modify |  |
+| cfg.swift:410:9:410:9 | exit get (normal) | cfg.swift:410:9:410:9 | exit get |  |
+| cfg.swift:410:9:410:9 | exit set (normal) | cfg.swift:410:9:410:9 | exit set |  |
+| cfg.swift:410:9:410:9 | get | cfg.swift:410:9:410:9 | self |  |
+| cfg.swift:410:9:410:9 | self | cfg.swift:410:9:410:9 | value |  |
+| cfg.swift:410:9:410:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:410:9:410:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:410:9:410:9 | set | cfg.swift:410:9:410:9 | self |  |
+| cfg.swift:410:9:410:9 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:410:9:410:9 | yield ... | cfg.swift:410:9:410:9 | exit _modify (normal) |  |
+| cfg.swift:411:5:411:5 | self | cfg.swift:412:7:412:7 | self |  |
+| cfg.swift:411:5:413:5 | MyLocalClass.init() | cfg.swift:411:5:411:5 | self |  |
+| cfg.swift:411:5:413:5 | enter MyLocalClass.init() | cfg.swift:411:5:413:5 | MyLocalClass.init() |  |
+| cfg.swift:411:5:413:5 | exit MyLocalClass.init() (normal) | cfg.swift:411:5:413:5 | exit MyLocalClass.init() |  |
+| cfg.swift:412:7:412:7 | .x | cfg.swift:412:11:412:11 | 10 |  |
+| cfg.swift:412:7:412:7 | self | cfg.swift:412:7:412:7 | .x |  |
+| cfg.swift:412:7:412:11 |  ... = ... | cfg.swift:413:5:413:5 | return |  |
+| cfg.swift:412:11:412:11 | 10 | cfg.swift:412:7:412:11 |  ... = ... |  |
+| cfg.swift:413:5:413:5 | return | cfg.swift:411:5:413:5 | exit MyLocalClass.init() (normal) | return |
+| cfg.swift:416:3:421:3 | MyLocalStruct | cfg.swift:423:3:426:3 | MyLocalEnum |  |
+| cfg.swift:417:9:417:9 | _modify | cfg.swift:417:9:417:9 | self |  |
+| cfg.swift:417:9:417:9 | enter _modify | cfg.swift:417:9:417:9 | _modify |  |
+| cfg.swift:417:9:417:9 | enter get | cfg.swift:417:9:417:9 | get |  |
+| cfg.swift:417:9:417:9 | enter set | cfg.swift:417:9:417:9 | set |  |
+| cfg.swift:417:9:417:9 | exit _modify (normal) | cfg.swift:417:9:417:9 | exit _modify |  |
+| cfg.swift:417:9:417:9 | exit get (normal) | cfg.swift:417:9:417:9 | exit get |  |
+| cfg.swift:417:9:417:9 | exit set (normal) | cfg.swift:417:9:417:9 | exit set |  |
+| cfg.swift:417:9:417:9 | get | cfg.swift:417:9:417:9 | self |  |
+| cfg.swift:417:9:417:9 | self | cfg.swift:417:9:417:9 | value |  |
+| cfg.swift:417:9:417:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:417:9:417:9 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:417:9:417:9 | set | cfg.swift:417:9:417:9 | self |  |
+| cfg.swift:417:9:417:9 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:417:9:417:9 | yield ... | cfg.swift:417:9:417:9 | exit _modify (normal) |  |
+| cfg.swift:418:5:418:5 | self | cfg.swift:419:7:419:7 | self |  |
+| cfg.swift:418:5:420:5 | MyLocalStruct.init() | cfg.swift:418:5:418:5 | self |  |
+| cfg.swift:418:5:420:5 | enter MyLocalStruct.init() | cfg.swift:418:5:420:5 | MyLocalStruct.init() |  |
+| cfg.swift:418:5:420:5 | exit MyLocalStruct.init() (normal) | cfg.swift:418:5:420:5 | exit MyLocalStruct.init() |  |
+| cfg.swift:419:7:419:7 | .x | cfg.swift:419:11:419:11 | 10 |  |
+| cfg.swift:419:7:419:7 | self | cfg.swift:419:7:419:7 | .x |  |
+| cfg.swift:419:7:419:11 |  ... = ... | cfg.swift:420:5:420:5 | return |  |
+| cfg.swift:419:11:419:11 | 10 | cfg.swift:419:7:419:11 |  ... = ... |  |
+| cfg.swift:420:5:420:5 | return | cfg.swift:418:5:420:5 | exit MyLocalStruct.init() (normal) | return |
+| cfg.swift:423:3:426:3 | MyLocalEnum | cfg.swift:428:7:428:7 | myLocalVar |  |
+| cfg.swift:428:3:428:20 | var ... = ... | cfg.swift:442:10:442:10 | 0 |  |
+| cfg.swift:428:7:428:7 | myLocalVar | cfg.swift:428:7:428:20 | ... as ... | match |
+| cfg.swift:428:7:428:20 | ... as ... | cfg.swift:428:3:428:20 | var ... = ... | match |
+| cfg.swift:442:3:442:10 | return ... | cfg.swift:408:1:443:1 | exit localDeclarations() (normal) | return |
+| cfg.swift:442:10:442:10 | 0 | cfg.swift:442:3:442:10 | return ... |  |
+| cfg.swift:446:7:446:7 | _modify | cfg.swift:446:7:446:7 | self |  |
+| cfg.swift:446:7:446:7 | enter _modify | cfg.swift:446:7:446:7 | _modify |  |
+| cfg.swift:446:7:446:7 | enter get | cfg.swift:446:7:446:7 | get |  |
+| cfg.swift:446:7:446:7 | enter set | cfg.swift:446:7:446:7 | set |  |
+| cfg.swift:446:7:446:7 | exit _modify (normal) | cfg.swift:446:7:446:7 | exit _modify |  |
+| cfg.swift:446:7:446:7 | exit get (normal) | cfg.swift:446:7:446:7 | exit get |  |
+| cfg.swift:446:7:446:7 | exit set (normal) | cfg.swift:446:7:446:7 | exit set |  |
+| cfg.swift:446:7:446:7 | get | cfg.swift:446:7:446:7 | self |  |
+| cfg.swift:446:7:446:7 | self | cfg.swift:446:7:446:7 | value |  |
+| cfg.swift:446:7:446:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:446:7:446:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:446:7:446:7 | set | cfg.swift:446:7:446:7 | self |  |
+| cfg.swift:446:7:446:7 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:446:7:446:7 | yield ... | cfg.swift:446:7:446:7 | exit _modify (normal) |  |
+| cfg.swift:450:7:450:7 | _modify | cfg.swift:450:7:450:7 | self |  |
+| cfg.swift:450:7:450:7 | enter _modify | cfg.swift:450:7:450:7 | _modify |  |
+| cfg.swift:450:7:450:7 | enter get | cfg.swift:450:7:450:7 | get |  |
+| cfg.swift:450:7:450:7 | enter set | cfg.swift:450:7:450:7 | set |  |
+| cfg.swift:450:7:450:7 | exit _modify (normal) | cfg.swift:450:7:450:7 | exit _modify |  |
+| cfg.swift:450:7:450:7 | exit get (normal) | cfg.swift:450:7:450:7 | exit get |  |
+| cfg.swift:450:7:450:7 | exit set (normal) | cfg.swift:450:7:450:7 | exit set |  |
+| cfg.swift:450:7:450:7 | get | cfg.swift:450:7:450:7 | self |  |
+| cfg.swift:450:7:450:7 | self | cfg.swift:450:7:450:7 | value |  |
+| cfg.swift:450:7:450:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:450:7:450:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:450:7:450:7 | set | cfg.swift:450:7:450:7 | self |  |
+| cfg.swift:450:7:450:7 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:450:7:450:7 | yield ... | cfg.swift:450:7:450:7 | exit _modify (normal) |  |
+| cfg.swift:451:7:451:7 | _modify | cfg.swift:451:7:451:7 | self |  |
+| cfg.swift:451:7:451:7 | enter _modify | cfg.swift:451:7:451:7 | _modify |  |
+| cfg.swift:451:7:451:7 | enter get | cfg.swift:451:7:451:7 | get |  |
+| cfg.swift:451:7:451:7 | enter set | cfg.swift:451:7:451:7 | set |  |
+| cfg.swift:451:7:451:7 | exit _modify (normal) | cfg.swift:451:7:451:7 | exit _modify |  |
+| cfg.swift:451:7:451:7 | exit get (normal) | cfg.swift:451:7:451:7 | exit get |  |
+| cfg.swift:451:7:451:7 | exit set (normal) | cfg.swift:451:7:451:7 | exit set |  |
+| cfg.swift:451:7:451:7 | get | cfg.swift:451:7:451:7 | self |  |
+| cfg.swift:451:7:451:7 | self | cfg.swift:451:7:451:7 | value |  |
+| cfg.swift:451:7:451:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:451:7:451:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:451:7:451:7 | set | cfg.swift:451:7:451:7 | self |  |
+| cfg.swift:451:7:451:7 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:451:7:451:7 | yield ... | cfg.swift:451:7:451:7 | exit _modify (normal) |  |
+| cfg.swift:452:7:452:7 | _modify | cfg.swift:452:7:452:7 | self |  |
+| cfg.swift:452:7:452:7 | enter _modify | cfg.swift:452:7:452:7 | _modify |  |
+| cfg.swift:452:7:452:7 | enter get | cfg.swift:452:7:452:7 | get |  |
+| cfg.swift:452:7:452:7 | enter set | cfg.swift:452:7:452:7 | set |  |
+| cfg.swift:452:7:452:7 | exit _modify (normal) | cfg.swift:452:7:452:7 | exit _modify |  |
+| cfg.swift:452:7:452:7 | exit get (normal) | cfg.swift:452:7:452:7 | exit get |  |
+| cfg.swift:452:7:452:7 | exit set (normal) | cfg.swift:452:7:452:7 | exit set |  |
+| cfg.swift:452:7:452:7 | get | cfg.swift:452:7:452:7 | self |  |
+| cfg.swift:452:7:452:7 | self | cfg.swift:452:7:452:7 | value |  |
+| cfg.swift:452:7:452:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:452:7:452:7 | self | file://:0:0:0:0 | self |  |
+| cfg.swift:452:7:452:7 | set | cfg.swift:452:7:452:7 | self |  |
+| cfg.swift:452:7:452:7 | value | file://:0:0:0:0 | self |  |
+| cfg.swift:452:7:452:7 | yield ... | cfg.swift:452:7:452:7 | exit _modify (normal) |  |
+| cfg.swift:455:1:465:1 | enter test(a:) | cfg.swift:455:1:465:1 | test(a:) |  |
+| cfg.swift:455:1:465:1 | exit test(a:) (normal) | cfg.swift:455:1:465:1 | exit test(a:) |  |
+| cfg.swift:455:1:465:1 | test(a:) | cfg.swift:455:11:455:15 | a |  |
+| cfg.swift:455:11:455:15 | a | cfg.swift:456:7:456:7 | kpGet_b_x |  |
+| cfg.swift:456:3:456:24 | var ... = ... | cfg.swift:457:7:457:7 | kpGet_bs_0_x |  |
+| cfg.swift:456:7:456:7 | kpGet_b_x | cfg.swift:456:19:456:24 | #keyPath(...) | match |
+| cfg.swift:456:19:456:24 | #keyPath(...) | cfg.swift:456:3:456:24 | var ... = ... |  |
+| cfg.swift:456:19:456:24 | #keyPath(...) | cfg.swift:456:19:456:24 | exit #keyPath(...) (normal) |  |
+| cfg.swift:456:19:456:24 | enter #keyPath(...) | cfg.swift:456:22:456:22 | KeyPathComponent |  |
+| cfg.swift:456:19:456:24 | exit #keyPath(...) (normal) | cfg.swift:456:19:456:24 | exit #keyPath(...) |  |
+| cfg.swift:456:22:456:22 | KeyPathComponent | cfg.swift:456:24:456:24 | KeyPathComponent |  |
+| cfg.swift:456:24:456:24 | KeyPathComponent | cfg.swift:456:19:456:24 | #keyPath(...) |  |
+| cfg.swift:457:3:457:31 | var ... = ... | cfg.swift:458:7:458:7 | kpGet_mayB_force_x |  |
+| cfg.swift:457:7:457:7 | kpGet_bs_0_x | cfg.swift:457:22:457:31 | #keyPath(...) | match |
+| cfg.swift:457:22:457:31 | #keyPath(...) | cfg.swift:457:3:457:31 | var ... = ... |  |
+| cfg.swift:457:22:457:31 | #keyPath(...) | cfg.swift:457:22:457:31 | exit #keyPath(...) (normal) |  |
+| cfg.swift:457:22:457:31 | enter #keyPath(...) | cfg.swift:457:25:457:25 | KeyPathComponent |  |
+| cfg.swift:457:22:457:31 | exit #keyPath(...) (normal) | cfg.swift:457:22:457:31 | exit #keyPath(...) |  |
+| cfg.swift:457:25:457:25 | KeyPathComponent | cfg.swift:457:28:457:28 | 0 |  |
+| cfg.swift:457:27:457:29 | KeyPathComponent | cfg.swift:457:31:457:31 | KeyPathComponent |  |
+| cfg.swift:457:28:457:28 | 0 | cfg.swift:457:27:457:29 | KeyPathComponent |  |
+| cfg.swift:457:31:457:31 | KeyPathComponent | cfg.swift:457:22:457:31 | #keyPath(...) |  |
+| cfg.swift:458:3:458:37 | var ... = ... | cfg.swift:459:7:459:7 | kpGet_mayB_x |  |
+| cfg.swift:458:7:458:7 | kpGet_mayB_force_x | cfg.swift:458:28:458:37 | #keyPath(...) | match |
+| cfg.swift:458:28:458:37 | #keyPath(...) | cfg.swift:458:3:458:37 | var ... = ... |  |
+| cfg.swift:458:28:458:37 | #keyPath(...) | cfg.swift:458:28:458:37 | exit #keyPath(...) (normal) |  |
+| cfg.swift:458:28:458:37 | enter #keyPath(...) | cfg.swift:458:31:458:31 | KeyPathComponent |  |
+| cfg.swift:458:28:458:37 | exit #keyPath(...) (normal) | cfg.swift:458:28:458:37 | exit #keyPath(...) |  |
+| cfg.swift:458:31:458:31 | KeyPathComponent | cfg.swift:458:31:458:31 | KeyPathComponent |  |
+| cfg.swift:458:31:458:31 | KeyPathComponent | cfg.swift:458:37:458:37 | KeyPathComponent |  |
+| cfg.swift:458:37:458:37 | KeyPathComponent | cfg.swift:458:28:458:37 | #keyPath(...) |  |
+| cfg.swift:459:3:459:31 | var ... = ... | cfg.swift:461:7:461:7 | apply_kpGet_b_x |  |
+| cfg.swift:459:7:459:7 | kpGet_mayB_x | cfg.swift:459:22:459:31 | #keyPath(...) | match |
+| cfg.swift:459:22:459:31 | #keyPath(...) | cfg.swift:459:3:459:31 | var ... = ... |  |
+| cfg.swift:459:22:459:31 | #keyPath(...) | cfg.swift:459:22:459:31 | exit #keyPath(...) (normal) |  |
+| cfg.swift:459:22:459:31 | enter #keyPath(...) | cfg.swift:459:25:459:25 | KeyPathComponent |  |
+| cfg.swift:459:22:459:31 | exit #keyPath(...) (normal) | cfg.swift:459:22:459:31 | exit #keyPath(...) |  |
+| cfg.swift:459:25:459:25 | KeyPathComponent | cfg.swift:459:29:459:29 | KeyPathComponent |  |
+| cfg.swift:459:29:459:29 | KeyPathComponent | cfg.swift:459:31:459:31 | KeyPathComponent |  |
+| cfg.swift:459:31:459:31 | KeyPathComponent | file://:0:0:0:0 | KeyPathComponent |  |
+| cfg.swift:461:3:461:45 | var ... = ... | cfg.swift:462:7:462:7 | apply_kpGet_bs_0_x |  |
+| cfg.swift:461:7:461:7 | apply_kpGet_b_x | cfg.swift:461:25:461:25 | a | match |
+| cfg.swift:461:25:461:25 | a | cfg.swift:461:36:461:36 | kpGet_b_x |  |
+| cfg.swift:461:25:461:45 | \\...[...] | cfg.swift:461:3:461:45 | var ... = ... |  |
+| cfg.swift:461:36:461:36 | (WritableKeyPath<A, Int>) ... | cfg.swift:461:25:461:45 | \\...[...] |  |
+| cfg.swift:461:36:461:36 | kpGet_b_x | cfg.swift:461:36:461:36 | (WritableKeyPath<A, Int>) ... |  |
+| cfg.swift:462:3:462:51 | var ... = ... | cfg.swift:463:7:463:7 | apply_kpGet_mayB_force_x |  |
+| cfg.swift:462:7:462:7 | apply_kpGet_bs_0_x | cfg.swift:462:28:462:28 | a | match |
+| cfg.swift:462:28:462:28 | a | cfg.swift:462:39:462:39 | kpGet_bs_0_x |  |
+| cfg.swift:462:28:462:51 | \\...[...] | cfg.swift:462:3:462:51 | var ... = ... |  |
+| cfg.swift:462:39:462:39 | (WritableKeyPath<A, Int>) ... | cfg.swift:462:28:462:51 | \\...[...] |  |
+| cfg.swift:462:39:462:39 | kpGet_bs_0_x | cfg.swift:462:39:462:39 | (WritableKeyPath<A, Int>) ... |  |
+| cfg.swift:463:3:463:63 | var ... = ... | cfg.swift:464:7:464:7 | apply_kpGet_mayB_x |  |
+| cfg.swift:463:7:463:7 | apply_kpGet_mayB_force_x | cfg.swift:463:34:463:34 | a | match |
+| cfg.swift:463:34:463:34 | a | cfg.swift:463:45:463:45 | kpGet_mayB_force_x |  |
+| cfg.swift:463:34:463:63 | \\...[...] | cfg.swift:463:3:463:63 | var ... = ... |  |
+| cfg.swift:463:45:463:45 | (WritableKeyPath<A, Int>) ... | cfg.swift:463:34:463:63 | \\...[...] |  |
+| cfg.swift:463:45:463:45 | kpGet_mayB_force_x | cfg.swift:463:45:463:45 | (WritableKeyPath<A, Int>) ... |  |
+| cfg.swift:464:3:464:51 | var ... = ... | cfg.swift:455:1:465:1 | exit test(a:) (normal) |  |
+| cfg.swift:464:7:464:7 | apply_kpGet_mayB_x | cfg.swift:464:28:464:28 | a | match |
+| cfg.swift:464:28:464:28 | a | cfg.swift:464:39:464:39 | kpGet_mayB_x |  |
+| cfg.swift:464:28:464:51 | \\...[...] | cfg.swift:464:3:464:51 | var ... = ... |  |
+| cfg.swift:464:39:464:39 | (KeyPath<A, Int?>) ... | cfg.swift:464:28:464:51 | \\...[...] |  |
+| cfg.swift:464:39:464:39 | kpGet_mayB_x | cfg.swift:464:39:464:39 | (KeyPath<A, Int?>) ... |  |
+| cfg.swift:467:1:494:1 | enter testIfConfig() | cfg.swift:467:1:494:1 | testIfConfig() |  |
+| cfg.swift:467:1:494:1 | exit testIfConfig() (normal) | cfg.swift:467:1:494:1 | exit testIfConfig() |  |
+| cfg.swift:467:1:494:1 | testIfConfig() | cfg.swift:468:1:474:1 | #if ... |  |
+| cfg.swift:468:1:474:1 | #if ... | cfg.swift:472:3:472:3 | 3 |  |
+| cfg.swift:472:3:472:3 | 3 | cfg.swift:473:3:473:3 | 4 |  |
+| cfg.swift:473:3:473:3 | 4 | cfg.swift:476:3:476:3 | 5 |  |
+| cfg.swift:476:3:476:3 | 5 | cfg.swift:478:1:481:1 | #if ... |  |
+| cfg.swift:478:1:481:1 | #if ... | cfg.swift:483:3:483:3 | 8 |  |
+| cfg.swift:483:3:483:3 | 8 | cfg.swift:485:1:491:1 | #if ... |  |
+| cfg.swift:485:1:491:1 | #if ... | cfg.swift:489:3:489:3 | 11 |  |
+| cfg.swift:489:3:489:3 | 11 | cfg.swift:490:3:490:3 | 12 |  |
+| cfg.swift:490:3:490:3 | 12 | cfg.swift:493:3:493:3 | 13 |  |
+| cfg.swift:493:3:493:3 | 13 | cfg.swift:467:1:494:1 | exit testIfConfig() (normal) |  |
+| cfg.swift:496:1:520:1 | enter testAvailable() | cfg.swift:496:1:520:1 | testAvailable() |  |
+| cfg.swift:496:1:520:1 | exit testAvailable() (normal) | cfg.swift:496:1:520:1 | exit testAvailable() |  |
+| cfg.swift:496:1:520:1 | testAvailable() | cfg.swift:497:7:497:7 | x |  |
+| cfg.swift:497:3:497:11 | var ... = ... | cfg.swift:499:3:501:3 | if ... then { ... } |  |
+| cfg.swift:497:7:497:7 | x | cfg.swift:497:11:497:11 | 0 | match |
+| cfg.swift:497:11:497:11 | 0 | cfg.swift:497:3:497:11 | var ... = ... |  |
+| cfg.swift:499:3:501:3 | if ... then { ... } | cfg.swift:499:6:499:28 | StmtCondition |  |
+| cfg.swift:499:6:499:28 | #available | cfg.swift:500:7:500:7 | .+=(_:_:) | true |
+| cfg.swift:499:6:499:28 | #available | cfg.swift:503:3:505:3 | if ... then { ... } | false |
+| cfg.swift:499:6:499:28 | StmtCondition | cfg.swift:499:17:499:23 | macOS 10 |  |
+| cfg.swift:499:17:499:23 | macOS 10 | cfg.swift:499:27:499:27 | * |  |
+| cfg.swift:499:27:499:27 | * | cfg.swift:499:6:499:28 | #available |  |
+| cfg.swift:500:5:500:5 | &... | cfg.swift:500:10:500:10 | 1 |  |
+| cfg.swift:500:5:500:5 | x | cfg.swift:500:5:500:5 | &... |  |
+| cfg.swift:500:5:500:10 | ... .+=(_:_:) ... | cfg.swift:503:3:505:3 | if ... then { ... } |  |
+| cfg.swift:500:7:500:7 | .+=(_:_:) | cfg.swift:500:7:500:7 | Int.Type |  |
+| cfg.swift:500:7:500:7 | Int.Type | cfg.swift:500:5:500:5 | x |  |
+| cfg.swift:500:10:500:10 | 1 | cfg.swift:500:5:500:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:503:3:505:3 | if ... then { ... } | cfg.swift:503:6:503:31 | StmtCondition |  |
+| cfg.swift:503:6:503:31 | #available | cfg.swift:504:7:504:7 | .+=(_:_:) | true |
+| cfg.swift:503:6:503:31 | #available | cfg.swift:507:3:509:3 | if ... then { ... } | false |
+| cfg.swift:503:6:503:31 | StmtCondition | cfg.swift:503:17:503:23 | macOS 10.13 |  |
+| cfg.swift:503:17:503:23 | macOS 10.13 | cfg.swift:503:30:503:30 | * |  |
+| cfg.swift:503:30:503:30 | * | cfg.swift:503:6:503:31 | #available |  |
+| cfg.swift:504:5:504:5 | &... | cfg.swift:504:10:504:10 | 1 |  |
+| cfg.swift:504:5:504:5 | x | cfg.swift:504:5:504:5 | &... |  |
+| cfg.swift:504:5:504:10 | ... .+=(_:_:) ... | cfg.swift:507:3:509:3 | if ... then { ... } |  |
+| cfg.swift:504:7:504:7 | .+=(_:_:) | cfg.swift:504:7:504:7 | Int.Type |  |
+| cfg.swift:504:7:504:7 | Int.Type | cfg.swift:504:5:504:5 | x |  |
+| cfg.swift:504:10:504:10 | 1 | cfg.swift:504:5:504:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:507:3:509:3 | if ... then { ... } | cfg.swift:507:6:507:47 | StmtCondition |  |
+| cfg.swift:507:6:507:47 | #unavailable | cfg.swift:508:7:508:7 | .+=(_:_:) | true |
+| cfg.swift:507:6:507:47 | #unavailable | cfg.swift:511:3:513:3 | guard ... else { ... } | false |
+| cfg.swift:507:6:507:47 | StmtCondition | cfg.swift:507:19:507:23 | iOS 10 |  |
+| cfg.swift:507:19:507:23 | iOS 10 | cfg.swift:507:27:507:35 | watchOS 10 |  |
+| cfg.swift:507:27:507:35 | watchOS 10 | cfg.swift:507:39:507:45 | macOS 10 |  |
+| cfg.swift:507:39:507:45 | macOS 10 | cfg.swift:507:6:507:47 | #unavailable |  |
+| cfg.swift:508:5:508:5 | &... | cfg.swift:508:10:508:10 | 1 |  |
+| cfg.swift:508:5:508:5 | x | cfg.swift:508:5:508:5 | &... |  |
+| cfg.swift:508:5:508:10 | ... .+=(_:_:) ... | cfg.swift:511:3:513:3 | guard ... else { ... } |  |
+| cfg.swift:508:7:508:7 | .+=(_:_:) | cfg.swift:508:7:508:7 | Int.Type |  |
+| cfg.swift:508:7:508:7 | Int.Type | cfg.swift:508:5:508:5 | x |  |
+| cfg.swift:508:10:508:10 | 1 | cfg.swift:508:5:508:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:511:3:513:3 | guard ... else { ... } | cfg.swift:511:9:511:31 | StmtCondition |  |
+| cfg.swift:511:9:511:31 | #available | cfg.swift:512:7:512:7 | .+=(_:_:) | false |
+| cfg.swift:511:9:511:31 | #available | cfg.swift:515:3:517:3 | if ... then { ... } | true |
+| cfg.swift:511:9:511:31 | StmtCondition | cfg.swift:511:20:511:26 | macOS 12 |  |
+| cfg.swift:511:20:511:26 | macOS 12 | cfg.swift:511:30:511:30 | * |  |
+| cfg.swift:511:30:511:30 | * | cfg.swift:511:9:511:31 | #available |  |
+| cfg.swift:512:5:512:5 | &... | cfg.swift:512:10:512:10 | 1 |  |
+| cfg.swift:512:5:512:5 | x | cfg.swift:512:5:512:5 | &... |  |
+| cfg.swift:512:5:512:10 | ... .+=(_:_:) ... | cfg.swift:515:3:517:3 | if ... then { ... } |  |
+| cfg.swift:512:7:512:7 | .+=(_:_:) | cfg.swift:512:7:512:7 | Int.Type |  |
+| cfg.swift:512:7:512:7 | Int.Type | cfg.swift:512:5:512:5 | x |  |
+| cfg.swift:512:10:512:10 | 1 | cfg.swift:512:5:512:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:515:3:517:3 | if ... then { ... } | cfg.swift:515:6:515:51 | StmtCondition |  |
+| cfg.swift:515:6:515:28 | #available | cfg.swift:515:42:515:46 | iOS 12 | false, true |
+| cfg.swift:515:6:515:28 | #available | cfg.swift:519:10:519:10 | x | false |
+| cfg.swift:515:6:515:51 | StmtCondition | cfg.swift:515:17:515:23 | macOS 12 |  |
+| cfg.swift:515:17:515:23 | macOS 12 | cfg.swift:515:27:515:27 | * |  |
+| cfg.swift:515:27:515:27 | * | cfg.swift:515:6:515:28 | #available |  |
+| cfg.swift:515:31:515:51 | #available | cfg.swift:516:7:516:7 | .+=(_:_:) | true |
+| cfg.swift:515:31:515:51 | #available | cfg.swift:519:10:519:10 | x | false |
+| cfg.swift:515:42:515:46 | iOS 12 | cfg.swift:515:50:515:50 | * |  |
+| cfg.swift:515:50:515:50 | * | cfg.swift:515:31:515:51 | #available |  |
+| cfg.swift:516:5:516:5 | &... | cfg.swift:516:10:516:10 | 1 |  |
+| cfg.swift:516:5:516:5 | x | cfg.swift:516:5:516:5 | &... |  |
+| cfg.swift:516:5:516:10 | ... .+=(_:_:) ... | cfg.swift:519:10:519:10 | x |  |
+| cfg.swift:516:7:516:7 | .+=(_:_:) | cfg.swift:516:7:516:7 | Int.Type |  |
+| cfg.swift:516:7:516:7 | Int.Type | cfg.swift:516:5:516:5 | x |  |
+| cfg.swift:516:10:516:10 | 1 | cfg.swift:516:5:516:10 | ... .+=(_:_:) ... |  |
+| cfg.swift:519:3:519:10 | return ... | cfg.swift:496:1:520:1 | exit testAvailable() (normal) | return |
+| cfg.swift:519:10:519:10 | (Int) ... | cfg.swift:519:3:519:10 | return ... |  |
+| cfg.swift:519:10:519:10 | x | cfg.swift:519:10:519:10 | (Int) ... |  |
+| cfg.swift:522:1:536:1 | enter testAsyncFor() | cfg.swift:522:1:536:1 | testAsyncFor() |  |
+| cfg.swift:522:1:536:1 | exit testAsyncFor() (normal) | cfg.swift:522:1:536:1 | exit testAsyncFor() |  |
+| cfg.swift:522:1:536:1 | testAsyncFor() | cfg.swift:523:9:523:9 | stream |  |
+| cfg.swift:523:5:531:6 | var ... = ... | cfg.swift:533:24:533:24 | $i$generator |  |
+| cfg.swift:523:9:523:9 | stream | cfg.swift:523:18:523:18 | AsyncStream<Element>.init(_:bufferingPolicy:_:) | match |
+| cfg.swift:523:18:523:18 | AsyncStream<Element>.init(_:bufferingPolicy:_:) | cfg.swift:523:18:523:18 | AsyncStream<Int>.Type |  |
+| cfg.swift:523:18:523:18 | AsyncStream<Int>.Type | cfg.swift:523:30:523:30 | Int.Type |  |
+| cfg.swift:523:18:531:6 | call to AsyncStream<Element>.init(_:bufferingPolicy:_:) | cfg.swift:523:5:531:6 | var ... = ... |  |
+| cfg.swift:523:30:523:30 | Int.Type | cfg.swift:523:30:523:34 | .self |  |
+| cfg.swift:523:30:523:34 | .self | cfg.swift:523:57:523:58 | .bufferingNewest |  |
+| cfg.swift:523:57:523:57 | AsyncStream<Int>.Continuation.BufferingPolicy.Type | cfg.swift:523:74:523:74 | 5 |  |
+| cfg.swift:523:57:523:58 | .bufferingNewest | cfg.swift:523:57:523:57 | AsyncStream<Int>.Continuation.BufferingPolicy.Type |  |
+| cfg.swift:523:57:523:75 | call to ... | cfg.swift:523:78:531:5 | { ... } |  |
+| cfg.swift:523:74:523:74 | 5 | cfg.swift:523:57:523:75 | call to ... |  |
+| cfg.swift:523:78:531:5 | enter { ... } | cfg.swift:523:78:531:5 | { ... } |  |
+| cfg.swift:523:78:531:5 | exit { ... } (normal) | cfg.swift:523:78:531:5 | exit { ... } |  |
+| cfg.swift:523:78:531:5 | { ... } | cfg.swift:523:18:531:6 | call to AsyncStream<Element>.init(_:bufferingPolicy:_:) |  |
+| cfg.swift:523:78:531:5 | { ... } | cfg.swift:524:9:524:9 | continuation |  |
+| cfg.swift:524:9:524:9 | continuation | cfg.swift:525:13:525:18 | .detached(priority:operation:) |  |
+| cfg.swift:525:13:525:13 | Task<(), Never>.Type | cfg.swift:525:27:525:27 | default priority |  |
+| cfg.swift:525:13:525:18 | .detached(priority:operation:) | cfg.swift:525:13:525:13 | Task<(), Never>.Type |  |
+| cfg.swift:525:13:530:13 | call to detached(priority:operation:) | cfg.swift:523:78:531:5 | exit { ... } (normal) |  |
+| cfg.swift:525:27:525:27 | default priority | cfg.swift:525:27:530:13 | { ... } |  |
+| cfg.swift:525:27:530:13 | enter { ... } | cfg.swift:525:27:530:13 | { ... } |  |
+| cfg.swift:525:27:530:13 | exit { ... } (normal) | cfg.swift:525:27:530:13 | exit { ... } |  |
+| cfg.swift:525:27:530:13 | { ... } | cfg.swift:525:13:530:13 | call to detached(priority:operation:) |  |
+| cfg.swift:525:27:530:13 | { ... } | cfg.swift:526:26:526:26 | $i$generator |  |
+| cfg.swift:526:17:526:17 | $i$generator | cfg.swift:526:17:526:17 | &... |  |
+| cfg.swift:526:17:526:17 | &... | cfg.swift:526:17:526:17 | call to next() |  |
+| cfg.swift:526:17:526:17 | .next() | cfg.swift:526:17:526:17 | $i$generator |  |
+| cfg.swift:526:17:526:17 | call to next() | cfg.swift:526:17:528:17 | for ... in ... { ... } |  |
+| cfg.swift:526:17:528:17 | for ... in ... { ... } | cfg.swift:526:21:526:21 | i | non-empty |
+| cfg.swift:526:17:528:17 | for ... in ... { ... } | cfg.swift:529:17:529:30 | .finish() | empty |
+| cfg.swift:526:21:526:21 | i | cfg.swift:527:21:527:34 | .yield(_:) | match |
+| cfg.swift:526:26:526:26 | 1 | cfg.swift:526:30:526:30 | 100 |  |
+| cfg.swift:526:26:526:26 | $i$generator | cfg.swift:526:26:526:30 | .makeIterator() | match |
+| cfg.swift:526:26:526:30 | ... ....(_:_:) ... | cfg.swift:526:26:526:30 | call to makeIterator() |  |
+| cfg.swift:526:26:526:30 | .makeIterator() | cfg.swift:526:27:526:27 | ....(_:_:) |  |
+| cfg.swift:526:26:526:30 | call to makeIterator() | file://:0:0:0:0 | var ... = ... |  |
+| cfg.swift:526:27:526:27 | ....(_:_:) | cfg.swift:526:27:526:27 | Int.Type |  |
+| cfg.swift:526:27:526:27 | Int.Type | cfg.swift:526:26:526:26 | 1 |  |
+| cfg.swift:526:30:526:30 | 100 | cfg.swift:526:26:526:30 | ... ....(_:_:) ... |  |
+| cfg.swift:527:21:527:21 | continuation | cfg.swift:527:40:527:40 | i |  |
+| cfg.swift:527:21:527:34 | .yield(_:) | cfg.swift:527:21:527:21 | continuation |  |
+| cfg.swift:527:21:527:41 | call to yield(_:) | cfg.swift:526:17:526:17 | .next() |  |
+| cfg.swift:527:40:527:40 | i | cfg.swift:527:21:527:41 | call to yield(_:) |  |
+| cfg.swift:529:17:529:17 | continuation | cfg.swift:529:17:529:37 | call to finish() |  |
+| cfg.swift:529:17:529:30 | .finish() | cfg.swift:529:17:529:17 | continuation |  |
+| cfg.swift:529:17:529:37 | call to finish() | cfg.swift:525:27:530:13 | exit { ... } (normal) |  |
+| cfg.swift:533:5:533:5 | $i$generator | cfg.swift:533:5:533:5 | &... |  |
+| cfg.swift:533:5:533:5 | &... | cfg.swift:533:5:533:5 | call to next() |  |
+| cfg.swift:533:5:533:5 | .next() | cfg.swift:533:5:533:5 | $i$generator |  |
+| cfg.swift:533:5:533:5 | call to next() | file://:0:0:0:0 | await ... |  |
+| cfg.swift:533:5:535:5 | for ... in ... { ... } | cfg.swift:522:1:536:1 | exit testAsyncFor() (normal) | empty |
+| cfg.swift:533:5:535:5 | for ... in ... { ... } | cfg.swift:533:19:533:19 | i | non-empty |
+| cfg.swift:533:19:533:19 | i | cfg.swift:534:9:534:9 | print(_:separator:terminator:) | match |
+| cfg.swift:533:24:533:24 | $i$generator | cfg.swift:533:24:533:24 | .makeAsyncIterator() | match |
+| cfg.swift:533:24:533:24 | (AsyncStream<Int>) ... | cfg.swift:533:24:533:24 | call to makeAsyncIterator() |  |
+| cfg.swift:533:24:533:24 | .makeAsyncIterator() | cfg.swift:533:24:533:24 | stream |  |
+| cfg.swift:533:24:533:24 | call to makeAsyncIterator() | file://:0:0:0:0 | var ... = ... |  |
+| cfg.swift:533:24:533:24 | stream | cfg.swift:533:24:533:24 | (AsyncStream<Int>) ... |  |
+| cfg.swift:534:9:534:9 | print(_:separator:terminator:) | cfg.swift:534:15:534:15 | i |  |
+| cfg.swift:534:9:534:16 | call to print(_:separator:terminator:) | cfg.swift:533:5:533:5 | .next() |  |
+| cfg.swift:534:14:534:14 | default separator | cfg.swift:534:14:534:14 | default terminator |  |
+| cfg.swift:534:14:534:14 | default terminator | cfg.swift:534:9:534:16 | call to print(_:separator:terminator:) |  |
+| cfg.swift:534:15:534:15 | (Any) ... | cfg.swift:534:15:534:15 | [...] |  |
+| cfg.swift:534:15:534:15 | [...] | cfg.swift:534:14:534:14 | default separator |  |
+| cfg.swift:534:15:534:15 | [...] | cfg.swift:534:15:534:15 | [...] |  |
+| cfg.swift:534:15:534:15 | i | cfg.swift:534:15:534:15 | (Any) ... |  |
+| cfg.swift:538:1:540:1 | enter testNilCoalescing(x:) | cfg.swift:538:1:540:1 | testNilCoalescing(x:) |  |
+| cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) (abnormal) | cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) |  |
+| cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) (normal) | cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) |  |
+| cfg.swift:538:1:540:1 | testNilCoalescing(x:) | cfg.swift:538:24:538:30 | x |  |
+| cfg.swift:538:24:538:30 | x | cfg.swift:539:10:539:10 | x |  |
+| cfg.swift:539:3:539:15 | return ... | cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) (normal) | return |
+| cfg.swift:539:10:539:10 | x | cfg.swift:539:10:539:15 | emptiness test for ... ??(_:_:) ... |  |
+| cfg.swift:539:10:539:15 | ... ??(_:_:) ... | cfg.swift:538:1:540:1 | exit testNilCoalescing(x:) (abnormal) | exception |
+| cfg.swift:539:10:539:15 | ... ??(_:_:) ... | cfg.swift:539:3:539:15 | return ... |  |
+| cfg.swift:539:10:539:15 | emptiness test for ... ??(_:_:) ... | cfg.swift:539:10:539:15 | ... ??(_:_:) ... | non-empty |
+| cfg.swift:539:10:539:15 | emptiness test for ... ??(_:_:) ... | cfg.swift:539:15:539:15 | { ... } | empty |
+| cfg.swift:539:15:539:15 | 0 | cfg.swift:539:15:539:15 | return ... |  |
+| cfg.swift:539:15:539:15 | return ... | cfg.swift:539:10:539:15 | ... ??(_:_:) ... |  |
+| cfg.swift:539:15:539:15 | { ... } | cfg.swift:539:15:539:15 | 0 |  |
+| cfg.swift:542:1:548:1 | enter testNilCoalescing2(x:) | cfg.swift:542:1:548:1 | testNilCoalescing2(x:) |  |
+| cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) (abnormal) | cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) |  |
+| cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) (normal) | cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) |  |
+| cfg.swift:542:1:548:1 | testNilCoalescing2(x:) | cfg.swift:542:25:542:32 | x |  |
+| cfg.swift:542:25:542:32 | x | cfg.swift:543:3:547:3 | if ... then { ... } else { ... } |  |
+| cfg.swift:543:3:547:3 | if ... then { ... } else { ... } | cfg.swift:543:6:543:11 | StmtCondition |  |
+| cfg.swift:543:6:543:6 | x | cfg.swift:543:6:543:11 | emptiness test for ... ??(_:_:) ... |  |
+| cfg.swift:543:6:543:11 | ... ??(_:_:) ... | cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) (abnormal) | exception |
+| cfg.swift:543:6:543:11 | ... ??(_:_:) ... | cfg.swift:544:12:544:12 | 1 | true |
+| cfg.swift:543:6:543:11 | ... ??(_:_:) ... | cfg.swift:546:12:546:12 | 0 | false |
+| cfg.swift:543:6:543:11 | StmtCondition | cfg.swift:543:6:543:6 | x |  |
+| cfg.swift:543:6:543:11 | emptiness test for ... ??(_:_:) ... | cfg.swift:543:6:543:11 | ... ??(_:_:) ... | non-empty |
+| cfg.swift:543:6:543:11 | emptiness test for ... ??(_:_:) ... | cfg.swift:543:11:543:11 | { ... } | empty |
+| cfg.swift:543:11:543:11 | false | cfg.swift:543:11:543:11 | return ... |  |
+| cfg.swift:543:11:543:11 | return ... | cfg.swift:543:6:543:11 | ... ??(_:_:) ... |  |
+| cfg.swift:543:11:543:11 | { ... } | cfg.swift:543:11:543:11 | false |  |
+| cfg.swift:544:5:544:12 | return ... | cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) (normal) | return |
+| cfg.swift:544:12:544:12 | 1 | cfg.swift:544:5:544:12 | return ... |  |
+| cfg.swift:546:5:546:12 | return ... | cfg.swift:542:1:548:1 | exit testNilCoalescing2(x:) (normal) | return |
+| cfg.swift:546:12:546:12 | 0 | cfg.swift:546:5:546:12 | return ... |  |
+| cfg.swift:550:1:552:1 | enter usesAutoclosure(_:) | cfg.swift:550:1:552:1 | usesAutoclosure(_:) |  |
+| cfg.swift:550:1:552:1 | exit usesAutoclosure(_:) (normal) | cfg.swift:550:1:552:1 | exit usesAutoclosure(_:) |  |
+| cfg.swift:550:1:552:1 | usesAutoclosure(_:) | cfg.swift:550:22:550:49 | expr |  |
+| cfg.swift:550:22:550:49 | expr | cfg.swift:551:10:551:10 | expr |  |
+| cfg.swift:551:3:551:15 | return ... | cfg.swift:550:1:552:1 | exit usesAutoclosure(_:) (normal) | return |
+| cfg.swift:551:10:551:10 | expr | cfg.swift:551:10:551:15 | call to ... |  |
+| cfg.swift:551:10:551:15 | call to ... | cfg.swift:551:3:551:15 | return ... |  |
+| cfg.swift:554:1:556:1 | autoclosureTest() | cfg.swift:555:3:555:3 | usesAutoclosure(_:) |  |
+| cfg.swift:554:1:556:1 | enter autoclosureTest() | cfg.swift:554:1:556:1 | autoclosureTest() |  |
+| cfg.swift:554:1:556:1 | exit autoclosureTest() (normal) | cfg.swift:554:1:556:1 | exit autoclosureTest() |  |
+| cfg.swift:555:3:555:3 | usesAutoclosure(_:) | cfg.swift:555:19:555:19 | { ... } |  |
+| cfg.swift:555:3:555:20 | call to usesAutoclosure(_:) | cfg.swift:554:1:556:1 | exit autoclosureTest() (normal) |  |
+| cfg.swift:555:19:555:19 | 1 | cfg.swift:555:19:555:19 | return ... |  |
+| cfg.swift:555:19:555:19 | enter { ... } | cfg.swift:555:19:555:19 | { ... } |  |
+| cfg.swift:555:19:555:19 | exit { ... } (normal) | cfg.swift:555:19:555:19 | exit { ... } |  |
+| cfg.swift:555:19:555:19 | return ... | cfg.swift:555:19:555:19 | exit { ... } (normal) |  |
+| cfg.swift:555:19:555:19 | { ... } | cfg.swift:555:3:555:20 | call to usesAutoclosure(_:) |  |
+| cfg.swift:555:19:555:19 | { ... } | cfg.swift:555:19:555:19 | 1 |  |
+| cfg.swift:564:7:564:7 | MyProcotolImpl.deinit() | cfg.swift:564:7:564:7 | self |  |
+| cfg.swift:564:7:564:7 | MyProcotolImpl.init() | cfg.swift:564:7:564:7 | self |  |
+| cfg.swift:564:7:564:7 | enter MyProcotolImpl.deinit() | cfg.swift:564:7:564:7 | MyProcotolImpl.deinit() |  |
+| cfg.swift:564:7:564:7 | enter MyProcotolImpl.init() | cfg.swift:564:7:564:7 | MyProcotolImpl.init() |  |
+| cfg.swift:564:7:564:7 | exit MyProcotolImpl.deinit() (normal) | cfg.swift:564:7:564:7 | exit MyProcotolImpl.deinit() |  |
+| cfg.swift:564:7:564:7 | exit MyProcotolImpl.init() (normal) | cfg.swift:564:7:564:7 | exit MyProcotolImpl.init() |  |
+| cfg.swift:564:7:564:7 | return | cfg.swift:564:7:564:7 | exit MyProcotolImpl.init() (normal) | return |
+| cfg.swift:564:7:564:7 | self | cfg.swift:564:7:564:7 | return |  |
+| cfg.swift:564:7:564:7 | self | cfg.swift:564:7:564:7 | { ... } |  |
+| cfg.swift:564:7:564:7 | { ... } | cfg.swift:564:7:564:7 | exit MyProcotolImpl.deinit() (normal) |  |
+| cfg.swift:565:2:565:34 | enter source() | cfg.swift:565:2:565:34 | source() |  |
+| cfg.swift:565:2:565:34 | exit source() (normal) | cfg.swift:565:2:565:34 | exit source() |  |
+| cfg.swift:565:2:565:34 | source() | cfg.swift:565:7:565:7 | self |  |
+| cfg.swift:565:7:565:7 | self | cfg.swift:565:32:565:32 | 0 |  |
+| cfg.swift:565:25:565:32 | return ... | cfg.swift:565:2:565:34 | exit source() (normal) | return |
+| cfg.swift:565:32:565:32 | 0 | cfg.swift:565:25:565:32 | return ... |  |
+| cfg.swift:568:1:568:62 | enter getMyProtocol() | cfg.swift:568:1:568:62 | getMyProtocol() |  |
+| cfg.swift:568:1:568:62 | exit getMyProtocol() (normal) | cfg.swift:568:1:568:62 | exit getMyProtocol() |  |
+| cfg.swift:568:1:568:62 | getMyProtocol() | cfg.swift:568:45:568:45 | MyProcotolImpl.init() |  |
+| cfg.swift:568:38:568:60 | return ... | cfg.swift:568:1:568:62 | exit getMyProtocol() (normal) | return |
+| cfg.swift:568:45:568:45 | MyProcotolImpl.Type | cfg.swift:568:45:568:60 | call to MyProcotolImpl.init() |  |
+| cfg.swift:568:45:568:45 | MyProcotolImpl.init() | cfg.swift:568:45:568:45 | MyProcotolImpl.Type |  |
+| cfg.swift:568:45:568:60 | (any MyProtocol) ... | cfg.swift:568:38:568:60 | return ... |  |
+| cfg.swift:568:45:568:60 | call to MyProcotolImpl.init() | cfg.swift:568:45:568:60 | (any MyProtocol) ... |  |
+| cfg.swift:569:1:569:70 | enter getMyProtocolImpl() | cfg.swift:569:1:569:70 | getMyProtocolImpl() |  |
+| cfg.swift:569:1:569:70 | exit getMyProtocolImpl() (normal) | cfg.swift:569:1:569:70 | exit getMyProtocolImpl() |  |
+| cfg.swift:569:1:569:70 | getMyProtocolImpl() | cfg.swift:569:53:569:53 | MyProcotolImpl.init() |  |
+| cfg.swift:569:46:569:68 | return ... | cfg.swift:569:1:569:70 | exit getMyProtocolImpl() (normal) | return |
+| cfg.swift:569:53:569:53 | MyProcotolImpl.Type | cfg.swift:569:53:569:68 | call to MyProcotolImpl.init() |  |
+| cfg.swift:569:53:569:53 | MyProcotolImpl.init() | cfg.swift:569:53:569:53 | MyProcotolImpl.Type |  |
+| cfg.swift:569:53:569:68 | call to MyProcotolImpl.init() | cfg.swift:569:46:569:68 | return ... |  |
+| cfg.swift:571:1:571:23 | enter sink(arg:) | cfg.swift:571:1:571:23 | sink(arg:) |  |
+| cfg.swift:571:1:571:23 | exit sink(arg:) (normal) | cfg.swift:571:1:571:23 | exit sink(arg:) |  |
+| cfg.swift:571:1:571:23 | sink(arg:) | cfg.swift:571:11:571:16 | arg |  |
+| cfg.swift:571:11:571:16 | arg | cfg.swift:571:21:571:23 | { ... } |  |
+| cfg.swift:571:21:571:23 | { ... } | cfg.swift:571:1:571:23 | exit sink(arg:) (normal) |  |
+| cfg.swift:573:1:578:1 | enter testOpenExistentialExpr(x:y:) | cfg.swift:573:1:578:1 | testOpenExistentialExpr(x:y:) |  |
+| cfg.swift:573:1:578:1 | exit testOpenExistentialExpr(x:y:) (normal) | cfg.swift:573:1:578:1 | exit testOpenExistentialExpr(x:y:) |  |
+| cfg.swift:573:1:578:1 | testOpenExistentialExpr(x:y:) | cfg.swift:573:30:573:33 | x |  |
+| cfg.swift:573:30:573:33 | x | cfg.swift:573:45:573:48 | y |  |
+| cfg.swift:573:45:573:48 | y | cfg.swift:574:2:574:2 | sink(arg:) |  |
+| cfg.swift:574:2:574:2 | sink(arg:) | cfg.swift:574:12:574:12 | x |  |
+| cfg.swift:574:2:574:22 | call to sink(arg:) | cfg.swift:575:2:575:2 | sink(arg:) |  |
+| cfg.swift:574:12:574:12 | OpaqueValueExpr | cfg.swift:574:12:574:21 | call to source() |  |
+| cfg.swift:574:12:574:12 | x | cfg.swift:574:12:574:14 | .source() |  |
+| cfg.swift:574:12:574:14 | .source() | cfg.swift:574:12:574:12 | OpaqueValueExpr |  |
+| cfg.swift:574:12:574:21 | OpenExistentialExpr | cfg.swift:574:2:574:22 | call to sink(arg:) |  |
+| cfg.swift:574:12:574:21 | call to source() | cfg.swift:574:12:574:21 | OpenExistentialExpr |  |
+| cfg.swift:575:2:575:2 | sink(arg:) | cfg.swift:575:12:575:14 | .source() |  |
+| cfg.swift:575:2:575:22 | call to sink(arg:) | cfg.swift:576:2:576:2 | sink(arg:) |  |
+| cfg.swift:575:12:575:12 | y | cfg.swift:575:12:575:21 | call to source() |  |
+| cfg.swift:575:12:575:14 | .source() | cfg.swift:575:12:575:12 | y |  |
+| cfg.swift:575:12:575:21 | call to source() | cfg.swift:575:2:575:22 | call to sink(arg:) |  |
+| cfg.swift:576:2:576:2 | sink(arg:) | cfg.swift:576:12:576:12 | getMyProtocol() |  |
+| cfg.swift:576:2:576:36 | call to sink(arg:) | cfg.swift:577:2:577:2 | sink(arg:) |  |
+| cfg.swift:576:12:576:12 | getMyProtocol() | cfg.swift:576:12:576:26 | call to getMyProtocol() |  |
+| cfg.swift:576:12:576:26 | OpaqueValueExpr | cfg.swift:576:12:576:35 | call to source() |  |
+| cfg.swift:576:12:576:26 | call to getMyProtocol() | cfg.swift:576:12:576:28 | .source() |  |
+| cfg.swift:576:12:576:28 | .source() | cfg.swift:576:12:576:26 | OpaqueValueExpr |  |
+| cfg.swift:576:12:576:35 | OpenExistentialExpr | cfg.swift:576:2:576:36 | call to sink(arg:) |  |
+| cfg.swift:576:12:576:35 | call to source() | cfg.swift:576:12:576:35 | OpenExistentialExpr |  |
+| cfg.swift:577:2:577:2 | sink(arg:) | cfg.swift:577:12:577:32 | .source() |  |
+| cfg.swift:577:2:577:40 | call to sink(arg:) | cfg.swift:573:1:578:1 | exit testOpenExistentialExpr(x:y:) (normal) |  |
+| cfg.swift:577:12:577:12 | getMyProtocolImpl() | cfg.swift:577:12:577:30 | call to getMyProtocolImpl() |  |
+| cfg.swift:577:12:577:30 | call to getMyProtocolImpl() | cfg.swift:577:12:577:39 | call to source() |  |
+| cfg.swift:577:12:577:32 | .source() | cfg.swift:577:12:577:12 | getMyProtocolImpl() |  |
+| cfg.swift:577:12:577:39 | call to source() | cfg.swift:577:2:577:40 | call to sink(arg:) |  |
+| cfg.swift:580:1:586:1 | enter singleStmtExpr(_:) | cfg.swift:580:1:586:1 | singleStmtExpr(_:) |  |
+| cfg.swift:580:1:586:1 | exit singleStmtExpr(_:) (normal) | cfg.swift:580:1:586:1 | exit singleStmtExpr(_:) |  |
+| cfg.swift:580:1:586:1 | singleStmtExpr(_:) | cfg.swift:580:21:580:26 | x |  |
+| cfg.swift:580:21:580:26 | x | cfg.swift:581:7:581:7 | a |  |
+| cfg.swift:581:3:584:3 | var ... = ... | cfg.swift:585:7:585:7 | b |  |
+| cfg.swift:581:7:581:7 | a | cfg.swift:581:11:584:3 | switch x { ... } | match |
+| cfg.swift:581:11:584:3 | SingleValueStmtExpr | cfg.swift:581:3:584:3 | var ... = ... |  |
+| cfg.swift:581:11:584:3 | switch x { ... } | cfg.swift:581:18:581:18 | x |  |
+| cfg.swift:581:18:581:18 | x | cfg.swift:582:5:582:17 | case ... |  |
+| cfg.swift:582:5:582:17 | case ... | cfg.swift:582:10:582:14 | =~ ... |  |
+| cfg.swift:582:10:582:10 | 0 | cfg.swift:582:14:582:14 | 5 |  |
+| cfg.swift:582:10:582:10 | .~=(_:_:) | cfg.swift:582:10:582:10 | Range<Int>.Type |  |
+| cfg.swift:582:10:582:10 | Range<Int>.Type | cfg.swift:582:11:582:11 | ...<(_:_:) |  |
+| cfg.swift:582:10:582:14 | ... ...<(_:_:) ... | cfg.swift:582:14:582:14 | $match |  |
+| cfg.swift:582:10:582:14 | ... .~=(_:_:) ... | cfg.swift:582:10:582:14 | =~ ... |  |
+| cfg.swift:582:10:582:14 | =~ ... | cfg.swift:582:10:582:10 | .~=(_:_:) |  |
+| cfg.swift:582:10:582:14 | =~ ... | cfg.swift:582:17:582:17 | 1 | match |
+| cfg.swift:582:10:582:14 | =~ ... | cfg.swift:583:5:583:14 | case ... | no-match |
+| cfg.swift:582:11:582:11 | ...<(_:_:) | cfg.swift:582:11:582:11 | Int.Type |  |
+| cfg.swift:582:11:582:11 | Int.Type | cfg.swift:582:10:582:10 | 0 |  |
+| cfg.swift:582:14:582:14 | 5 | cfg.swift:582:10:582:14 | ... ...<(_:_:) ... |  |
+| cfg.swift:582:14:582:14 | $match | cfg.swift:582:10:582:14 | ... .~=(_:_:) ... |  |
+| cfg.swift:582:17:582:17 | 1 | cfg.swift:582:17:582:17 | ThenStmt |  |
+| cfg.swift:582:17:582:17 | ThenStmt | cfg.swift:581:11:584:3 | SingleValueStmtExpr |  |
+| cfg.swift:583:5:583:5 | _ | cfg.swift:583:5:583:5 | _ |  |
+| cfg.swift:583:5:583:5 | _ | cfg.swift:583:14:583:14 | 2 | match |
+| cfg.swift:583:5:583:14 | case ... | cfg.swift:583:5:583:5 | _ |  |
+| cfg.swift:583:14:583:14 | 2 | cfg.swift:583:14:583:14 | ThenStmt |  |
+| cfg.swift:583:14:583:14 | ThenStmt | cfg.swift:581:11:584:3 | SingleValueStmtExpr |  |
+| cfg.swift:585:3:585:38 | var ... = ... | cfg.swift:580:1:586:1 | exit singleStmtExpr(_:) (normal) |  |
+| cfg.swift:585:7:585:7 | b | cfg.swift:585:11:585:38 | if ... then { ... } else { ... } | match |
+| cfg.swift:585:11:585:38 | SingleValueStmtExpr | cfg.swift:585:3:585:38 | var ... = ... |  |
+| cfg.swift:585:11:585:38 | if ... then { ... } else { ... } | cfg.swift:585:14:585:21 | StmtCondition |  |
+| cfg.swift:585:14:585:21 | StmtCondition | cfg.swift:585:17:585:17 | .<(_:_:) |  |
+| cfg.swift:585:14:585:21 | [false] (...) | cfg.swift:585:36:585:36 | 2 | false |
+| cfg.swift:585:14:585:21 | [true] (...) | cfg.swift:585:25:585:25 | 1 | true |
+| cfg.swift:585:15:585:15 | x | cfg.swift:585:19:585:19 | 42 |  |
+| cfg.swift:585:15:585:19 | ... .<(_:_:) ... | cfg.swift:585:14:585:21 | [false] (...) | false |
+| cfg.swift:585:15:585:19 | ... .<(_:_:) ... | cfg.swift:585:14:585:21 | [true] (...) | true |
+| cfg.swift:585:17:585:17 | .<(_:_:) | cfg.swift:585:17:585:17 | Int.Type |  |
+| cfg.swift:585:17:585:17 | Int.Type | cfg.swift:585:15:585:15 | x |  |
+| cfg.swift:585:19:585:19 | 42 | cfg.swift:585:15:585:19 | ... .<(_:_:) ... |  |
+| cfg.swift:585:25:585:25 | 1 | cfg.swift:585:25:585:25 | ThenStmt |  |
+| cfg.swift:585:25:585:25 | ThenStmt | cfg.swift:585:11:585:38 | SingleValueStmtExpr |  |
+| cfg.swift:585:36:585:36 | 2 | cfg.swift:585:36:585:36 | ThenStmt |  |
+| cfg.swift:585:36:585:36 | ThenStmt | cfg.swift:585:11:585:38 | SingleValueStmtExpr |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:394:7:394:7 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:410:9:410:9 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:417:9:417:9 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:446:7:446:7 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:450:7:450:7 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:451:7:451:7 | exit set (normal) |  |
+| file://:0:0:0:0 |  ... = ... | cfg.swift:452:7:452:7 | exit set (normal) |  |
+| file://:0:0:0:0 | &... | cfg.swift:394:7:394:7 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:410:9:410:9 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:417:9:417:9 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:446:7:446:7 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:450:7:450:7 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:451:7:451:7 | yield ... |  |
+| file://:0:0:0:0 | &... | cfg.swift:452:7:452:7 | yield ... |  |
+| file://:0:0:0:0 | .b | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .b | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .bs | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .bs | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .c | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .field | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .field | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .mayB | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .mayB | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .myInt | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | return ... |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | .x | file://:0:0:0:0 | value |  |
+| file://:0:0:0:0 | KeyPathComponent | cfg.swift:459:22:459:31 | #keyPath(...) |  |
+| file://:0:0:0:0 | await ... | cfg.swift:533:5:535:5 | for ... in ... { ... } |  |
+| file://:0:0:0:0 | getter for .b | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .bs | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .field | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .mayB | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | getter for .x | file://:0:0:0:0 | &... |  |
+| file://:0:0:0:0 | n | cfg.swift:377:7:377:7 | _unimplementedInitializer(className:initName:file:line:column:) |  |
+| file://:0:0:0:0 | return | cfg.swift:377:19:377:19 | exit Derived.init(n:) (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:99:7:99:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:353:7:353:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:394:7:394:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:410:9:410:9 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:417:9:417:9 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:446:7:446:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:450:7:450:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:451:7:451:7 | exit get (normal) | return |
+| file://:0:0:0:0 | return ... | cfg.swift:452:7:452:7 | exit get (normal) | return |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .b |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .b |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .bs |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .bs |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .c |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .field |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .field |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .mayB |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .mayB |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .myInt |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .b |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .bs |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .field |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .mayB |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
+| file://:0:0:0:0 | self | file://:0:0:0:0 | getter for .x |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | value | file://:0:0:0:0 |  ... = ... |  |
+| file://:0:0:0:0 | var ... = ... | cfg.swift:138:3:138:3 | .next() |  |
+| file://:0:0:0:0 | var ... = ... | cfg.swift:526:17:526:17 | .next() |  |
+| file://:0:0:0:0 | var ... = ... | cfg.swift:533:5:533:5 | .next() |  |

--- a/swift/ql/test/library-tests/controlflow/graph/Cfg.ql
+++ b/swift/ql/test/library-tests/controlflow/graph/Cfg.ql
@@ -1,20 +1,8 @@
-/**
- * @kind graph
- */
-
 import swift
 import codeql.swift.controlflow.ControlFlowGraph
 
 class MyRelevantNode extends ControlFlowNode {
   MyRelevantNode() { this.getScope().getLocation().getFile().getName().matches("%swift/ql/test%") }
-
-  private AstNode asAstNode() { result = this.getAstNode().asAstNode() }
-
-  string getOrderDisambiguation() {
-    result = concat([this.asAstNode().getAPrimaryQlClass(), this.asAstNode().toString()], ",")
-    or
-    not exists(this.asAstNode()) and result = ""
-  }
 }
 
 import codeql.swift.controlflow.internal.ControlFlowGraphImpl::TestOutput<MyRelevantNode>


### PR DESCRIPTION
The original motivation for using `@kind graph` was to be able to visualize CFGs in VS Code. However, now that we have `View CFG`, this is no longer needed. Moreover, `@kind graph` often has spurious reorderings of the output, and there are some known limitations (such as missing multi-edges, IIRC), so it is not well suited for qltest.