### PR TITLE
Revert "Codegen: allow to include `.py` files in `schema.py`"

### DIFF
--- a/misc/codegen/lib/schemadefs.py
+++ b/misc/codegen/lib/schemadefs.py
@@ -32,16 +32,9 @@ class _DescModifier(_schema.PropertyModifier):
 
 
 def include(source: str):
-    scope = _inspect.currentframe().f_back.f_locals
-    if source.endswith(".dbscheme"):
-        # add to `includes` variable in calling context
-        scope.setdefault("__includes", []).append(source)
-    elif source.endswith(".py"):
-        # just load the contents
-        with open(source) as input:
-            exec(input.read(), scope)
-    else:
-        raise _schema.Error(f"Unsupported file for inclusion: {source}")
+    # add to `includes` variable in calling context
+    _inspect.currentframe().f_back.f_locals.setdefault(
+        "__includes", []).append(source)
 
 
 class _Namespace:

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -127,7 +127,7 @@ def _check_test_with(classes: typing.Dict[str, schema.Class]):
 
 
 def load(m: types.ModuleType) -> schema.Schema:
-    includes = []
+    includes = set()
     classes = {}
     known = {"int", "string", "boolean"}
     known.update(n for n in m.__dict__ if not n.startswith("__"))

--- a/misc/codegen/test/test_schemaloader.py
+++ b/misc/codegen/test/test_schemaloader.py
@@ -13,7 +13,7 @@ def test_empty_schema():
         pass
 
     assert data.classes == {}
-    assert data.includes == []
+    assert data.includes == set()
     assert data.null is None
     assert data.null_class is None
 
@@ -836,52 +836,6 @@ def test_test_with_double():
             @defs.qltest.test_with(A)
             class C(Root):
                 pass
-
-
-def test_include_dbscheme():
-    @load
-    class data:
-        defs.include("foo.dbscheme")
-        defs.include("bar.dbscheme")
-
-    assert data.includes == ["foo.dbscheme", "bar.dbscheme"]
-
-
-def test_include_source(tmp_path):
-    (tmp_path / "foo.py").write_text("""
-class A(Root):
-    pass
-""")
-    (tmp_path / "bar.py").write_text("""
-class C(Root):
-    pass
-""")
-
-    @load
-    class data:
-        class Root:
-            pass
-
-        defs.include(str(tmp_path / "foo.py"))
-
-        class B(Root):
-            pass
-
-        defs.include(str(tmp_path / "bar.py"))
-
-    assert data.classes == {
-        "Root": schema.Class("Root", derived=set("ABC")),
-        "A": schema.Class("A", bases=["Root"]),
-        "B": schema.Class("B", bases=["Root"]),
-        "C": schema.Class("C", bases=["Root"]),
-    }
-
-
-def test_include_not_supported(tmp_path):
-    with pytest.raises(schema.Error):
-        @load
-        class data:
-            defs.include("foo.bar")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Reverts github/codeql#17514, as it's superseded by a better approach implemented in https://github.com/github/codeql/pull/17523