### PR TITLE
Codegen: allow full annotation of classes

### DIFF
--- a/misc/codegen/lib/schemadefs.py
+++ b/misc/codegen/lib/schemadefs.py
@@ -1,40 +1,66 @@
-from typing import Callable as _Callable
+from typing import Callable as _Callable, List as _List
 from misc.codegen.lib import schema as _schema
 import inspect as _inspect
 from dataclasses import dataclass as _dataclass
 
+from misc.codegen.lib.schema import Property
 
+
+@_dataclass
 class _ChildModifier(_schema.PropertyModifier):
+    child: bool = True
+
     def modify(self, prop: _schema.Property):
         if prop.type is None or prop.type[0].islower():
             raise _schema.Error("Non-class properties cannot be children")
         if prop.is_unordered:
             raise _schema.Error("Set properties cannot be children")
-        prop.is_child = True
+        prop.is_child = self.child
+
+    def negate(self) -> _schema.PropertyModifier:
+        return _ChildModifier(False)
+
+# make ~doc same as doc(None)
+
+
+class _DocModifierMetaclass(type(_schema.PropertyModifier)):
+    def __invert__(self) -> _schema.PropertyModifier:
+        return _DocModifier(None)
 
 
 @_dataclass
-class _DocModifier(_schema.PropertyModifier):
-    doc: str
+class _DocModifier(_schema.PropertyModifier, metaclass=_DocModifierMetaclass):
+    doc: str | None
 
     def modify(self, prop: _schema.Property):
-        if "\n" in self.doc or self.doc[-1] == ".":
+        if self.doc and ("\n" in self.doc or self.doc[-1] == "."):
             raise _schema.Error("No newlines or trailing dots are allowed in doc, did you intend to use desc?")
         prop.doc = self.doc
 
+    def negate(self) -> _schema.PropertyModifier:
+        return _DocModifier(None)
+
+
+# make ~desc same as desc(None)
+class _DescModifierMetaclass(type(_schema.PropertyModifier)):
+    def __invert__(self) -> _schema.PropertyModifier:
+        return _DescModifier(None)
+
 
 @_dataclass
-class _DescModifier(_schema.PropertyModifier):
-    description: str
+class _DescModifier(_schema.PropertyModifier, metaclass=_DescModifierMetaclass):
+    description: str | None
 
     def modify(self, prop: _schema.Property):
         prop.description = _schema.split_doc(self.description)
 
+    def negate(self) -> _schema.PropertyModifier:
+        return _DescModifier(None)
+
 
 def include(source: str):
     # add to `includes` variable in calling context
-    _inspect.currentframe().f_back.f_locals.setdefault(
-        "__includes", []).append(source)
+    _inspect.currentframe().f_back.f_locals.setdefault("includes", []).append(source)
 
 
 class _Namespace:
@@ -44,9 +70,15 @@ class _Namespace:
         self.__dict__.update(kwargs)
 
 
+@_dataclass
 class _SynthModifier(_schema.PropertyModifier, _Namespace):
+    synth: bool = True
+
     def modify(self, prop: _schema.Property):
-        prop.synth = True
+        prop.synth = self.synth
+
+    def negate(self) -> "PropertyModifier":
+        return _SynthModifier(False)
 
 
 qltest = _Namespace()
@@ -63,21 +95,34 @@ class _Pragma(_schema.PropertyModifier):
     For schema classes it acts as a python decorator with `@`.
     """
     pragma: str
+    remove: bool = False
 
     def __post_init__(self):
         namespace, _, name = self.pragma.partition('_')
         setattr(globals()[namespace], name, self)
 
     def modify(self, prop: _schema.Property):
-        prop.pragmas.append(self.pragma)
+        self._apply(prop.pragmas)
+
+    def negate(self) -> "PropertyModifier":
+        return _Pragma(self.pragma, remove=True)
 
     def __call__(self, cls: type) -> type:
         """ use this pragma as a decorator on classes """
         if "_pragmas" in cls.__dict__:  # not using hasattr as we don't want to land on inherited pragmas
-            cls._pragmas.append(self.pragma)
-        else:
+            self._apply(cls._pragmas)
+        elif not self.remove:
             cls._pragmas = [self.pragma]
         return cls
+
+    def _apply(self, pragmas: _List[str]) -> None:
+        if self.remove:
+            try:
+                pragmas.remove(self.pragma)
+            except ValueError:
+                pass
+        else:
+            pragmas.append(self.pragma)
 
 
 class _Optionalizer(_schema.PropertyModifier):
@@ -172,7 +217,28 @@ synth.on_arguments = lambda **kwargs: _annotate(
     synth=_schema.SynthInfo(on_arguments={k: _schema.get_type_name(t) for k, t in kwargs.items()}))
 
 
-def annotate(annotated_cls: type) -> _Callable[[type], None]:
+class _PropertyModifierList(_schema.PropertyModifier):
+    def __init__(self):
+        self._mods = []
+
+    def __or__(self, other: _schema.PropertyModifier):
+        self._mods.append(other)
+        return self
+
+    def modify(self, prop: Property):
+        for m in self._mods:
+            m.modify(prop)
+
+
+class _PropertyAnnotation:
+    def __or__(self, other: _schema.PropertyModifier):
+        return _PropertyModifierList() | other
+
+
+_ = _PropertyAnnotation()
+
+
+def annotate(annotated_cls: type) -> _Callable[[type], _PropertyAnnotation]:
     """
     Add or modify schema annotations after a class has been defined
     For the moment, only docstring annotation is supported. In the future, any kind of
@@ -180,9 +246,17 @@ def annotate(annotated_cls: type) -> _Callable[[type], None]:
 
     The name of the class used for annotation must be `_`
     """
-    def decorator(cls: type) -> None:
+    def decorator(cls: type) -> _PropertyAnnotation:
         if cls.__name__ != "_":
             raise _schema.Error("Annotation classes must be named _")
         annotated_cls.__doc__ = cls.__doc__
-        return None
+        for p, a in cls.__annotations__.items():
+            if p in annotated_cls.__annotations__:
+                annotated_cls.__annotations__[p] |= a
+            elif isinstance(a, (_PropertyAnnotation, _PropertyModifierList)):
+                raise _schema.Error(f"annotated property {p} not present in annotated class "
+                                    f"{annotated_cls.__name__}")
+            else:
+                annotated_cls.__annotations__[p] = a
+        return _
     return decorator

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -136,7 +136,7 @@ def load(m: types.ModuleType) -> schema.Schema:
     for name, data in m.__dict__.items():
         if hasattr(defs, name):
             continue
-        if name == "__includes":
+        if name == "includes":
             includes = data
             continue
         if name.startswith("__") or name == "_":

--- a/misc/codegen/test/test_schemaloader.py
+++ b/misc/codegen/test/test_schemaloader.py
@@ -763,6 +763,9 @@ def test_annotate_docstring():
         class Root:
             """ old docstring """
 
+        class A(Root):
+            """ A docstring """
+
         @defs.annotate(Root)
         class _:
             """
@@ -770,8 +773,33 @@ def test_annotate_docstring():
             docstring
             """
 
+        @defs.annotate(A)
+        class _:
+            pass
+
     assert data.classes == {
-        "Root": schema.Class("Root", doc=["new", "docstring"]),
+        "Root": schema.Class("Root", doc=["new", "docstring"], derived={"A"}),
+        "A": schema.Class("A", bases=["Root"], doc=["A docstring"]),
+    }
+
+
+def test_annotate_decorations():
+    @load
+    class data:
+        @defs.qltest.skip
+        class Root:
+            pass
+
+        @defs.annotate(Root)
+        @defs.qltest.collapse_hierarchy
+        @defs.ql.hideable
+        @defs.cpp.skip
+        class _:
+            pass
+
+    assert data.classes == {
+        "Root": schema.Class("Root", hideable=True,
+                             pragmas=["qltest_skip", "cpp_skip", "qltest_collapse_hierarchy"]),
     }
 
 

--- a/rust/schema/__init__.py
+++ b/rust/schema/__init__.py
@@ -11,6 +11,3 @@ For how documentation of generated QL code works, please read `misc/codegen/sche
 
 from .prelude import *
 from .ast import *
-
-include("../shared/tree-sitter-extractor/src/generator/prefix.dbscheme")
-include("prefix.dbscheme")

--- a/rust/schema/prelude.py
+++ b/rust/schema/prelude.py
@@ -1,5 +1,8 @@
 from misc.codegen.lib.schemadefs import *
 
+include("../shared/tree-sitter-extractor/src/generator/prefix.dbscheme")
+include("prefix.dbscheme")
+
 @qltest.skip
 class Element:
     pass


### PR DESCRIPTION
This allows to fully reannotate classes with the `@annotate` decoration. Properties can be modified by adding property modifiers to the special `_` placeholder. Property modifiers can also be undone with `~`. See unit tests for example (`defs` namespacing is only used in tests).