### PR TITLE
Codegen: parametrized pragmas

### DIFF
--- a/misc/codegen/generators/qlgen.py
+++ b/misc/codegen/generators/qlgen.py
@@ -96,7 +96,7 @@ def _get_doc(cls: schema.Class, prop: schema.Property, plural=None):
         return format.format(**{noun: transform(noun) for noun in nouns})
 
     prop_name = _humanize(prop.name)
-    class_name = cls.default_doc_name or _humanize(inflection.underscore(cls.name))
+    class_name = cls.pragmas.get("ql_default_doc_name", _humanize(inflection.underscore(cls.name)))
     if prop.is_predicate:
         return f"this {class_name} {prop_name}"
     if plural is not None:

--- a/misc/codegen/generators/rusttestgen.py
+++ b/misc/codegen/generators/rusttestgen.py
@@ -55,7 +55,7 @@ def generate(opts, renderer):
                 continue
             assert not adding_code, "Unterminated code block in docstring: " + "\n".join(cls.doc)
             test_name = inflection.underscore(cls.name)
-            signature = cls.rust_doc_test_function
+            signature = cls.pragmas.get("rust_doc_test_signature", "() -> ()")
             fn = signature and Function(f"test_{test_name}", signature)
             if fn:
                 indent = 4 * " "

--- a/misc/codegen/lib/schema.py
+++ b/misc/codegen/lib/schema.py
@@ -98,7 +98,6 @@ class Class:
     doc: List[str] = field(default_factory=list)
     hideable: bool = False
     test_with: Optional[str] = None
-    rust_doc_test_function: Optional["FunctionInfo"] = "() -> ()"  # TODO: parametrized pragmas
 
     def __post_init__(self):
         if not isinstance(self.pragmas, dict):

--- a/misc/codegen/lib/schema.py
+++ b/misc/codegen/lib/schema.py
@@ -32,10 +32,14 @@ class Property:
     name: Optional[str] = None
     type: Optional[str] = None
     is_child: bool = False
-    pragmas: List[str] = field(default_factory=list)
+    pragmas: List[str] | Dict[str, object] = field(default_factory=dict)
     doc: Optional[str] = None
     description: List[str] = field(default_factory=list)
     synth: bool = False
+
+    def __post_init__(self):
+        if not isinstance(self.pragmas, dict):
+            self.pragmas = dict.fromkeys(self.pragmas, None)
 
     @property
     def is_single(self) -> bool:
@@ -88,7 +92,7 @@ class Class:
     derived: Set[str] = field(default_factory=set)
     properties: List[Property] = field(default_factory=list)
     group: str = ""
-    pragmas: List[str] = field(default_factory=list)
+    pragmas: List[str] | Dict[str, object] = field(default_factory=dict)
     synth: Optional[Union[SynthInfo, bool]] = None
     """^^^ filled with `True` for non-final classes with only synthesized final descendants """
     doc: List[str] = field(default_factory=list)
@@ -96,6 +100,10 @@ class Class:
     hideable: bool = False
     test_with: Optional[str] = None
     rust_doc_test_function: Optional["FunctionInfo"] = "() -> ()"  # TODO: parametrized pragmas
+
+    def __post_init__(self):
+        if not isinstance(self.pragmas, dict):
+            self.pragmas = dict.fromkeys(self.pragmas, None)
 
     @property
     def final(self):

--- a/misc/codegen/lib/schema.py
+++ b/misc/codegen/lib/schema.py
@@ -93,8 +93,6 @@ class Class:
     properties: List[Property] = field(default_factory=list)
     group: str = ""
     pragmas: List[str] | Dict[str, object] = field(default_factory=dict)
-    synth: Optional[Union[SynthInfo, bool]] = None
-    """^^^ filled with `True` for non-final classes with only synthesized final descendants """
     doc: List[str] = field(default_factory=list)
     hideable: bool = False
     test_with: Optional[str] = None
@@ -114,12 +112,20 @@ class Class:
             _check_type(d, known)
         for p in self.properties:
             _check_type(p.type, known)
-        if self.synth is not None:
-            _check_type(self.synth.from_class, known)
-            if self.synth.on_arguments is not None:
-                for t in self.synth.on_arguments.values():
+        if "synth" in self.pragmas:
+            synth = self.pragmas["synth"]
+            _check_type(synth.from_class, known)
+            if synth.on_arguments is not None:
+                for t in synth.on_arguments.values():
                     _check_type(t, known)
         _check_type(self.test_with, known)
+
+    @property
+    def synth(self) -> SynthInfo | bool | None:
+        return self.pragmas.get("synth")
+
+    def mark_synth(self):
+        self.pragmas.setdefault("synth", True)
 
 
 @dataclass

--- a/misc/codegen/lib/schema.py
+++ b/misc/codegen/lib/schema.py
@@ -96,7 +96,6 @@ class Class:
     synth: Optional[Union[SynthInfo, bool]] = None
     """^^^ filled with `True` for non-final classes with only synthesized final descendants """
     doc: List[str] = field(default_factory=list)
-    default_doc_name: Optional[str] = None
     hideable: bool = False
     test_with: Optional[str] = None
     rust_doc_test_function: Optional["FunctionInfo"] = "() -> ()"  # TODO: parametrized pragmas

--- a/misc/codegen/lib/schemadefs.py
+++ b/misc/codegen/lib/schemadefs.py
@@ -67,9 +67,9 @@ class _Namespace:
     """ simple namespacing mechanism """
     name: str
 
-    def add(self, pragma: "_PragmaBase"):
+    def add(self, pragma: "_PragmaBase", key: str | None = None):
         self.__dict__[pragma.pragma] = pragma
-        pragma.pragma = f"{self.name}_{pragma.pragma}"
+        pragma.pragma = key or f"{self.name}_{pragma.pragma}"
 
 
 @_dataclass
@@ -142,7 +142,7 @@ class _ParametrizedClassPragma(_PragmaBase):
     """
     _pragma_class: _ClassVar[type] = _ClassPragma
 
-    function: _Callable[[...], object] = None
+    function: _Callable[..., object] = None
 
     def __post_init__(self):
         self.__signature__ = _inspect.signature(self.function).replace(return_annotation=self._pragma_class)
@@ -248,10 +248,10 @@ def group(name: str = "") -> _ClassDecorator:
     return _annotate(group=name)
 
 
-synth.from_class = lambda ref: _annotate(synth=_schema.SynthInfo(
-    from_class=_schema.get_type_name(ref)))
-synth.on_arguments = lambda **kwargs: _annotate(
-    synth=_schema.SynthInfo(on_arguments={k: _schema.get_type_name(t) for k, t in kwargs.items()}))
+synth.add(_ParametrizedClassPragma("from_class", lambda ref: _schema.SynthInfo(
+    from_class=_schema.get_type_name(ref))), key="synth")
+synth.add(_ParametrizedClassPragma("on_arguments", lambda **kwargs:
+                                   _schema.SynthInfo(on_arguments={k: _schema.get_type_name(t) for k, t in kwargs.items()})), key="synth")
 
 
 class _PropertyModifierList(_schema.PropertyModifier):

--- a/misc/codegen/lib/schemadefs.py
+++ b/misc/codegen/lib/schemadefs.py
@@ -241,7 +241,7 @@ cpp.add(_Pragma("skip"))
 
 rust.add(_Pragma("skip_doc_test"))
 
-rust.doc_test_signature = lambda signature: _annotate(rust_doc_test_function=signature)
+rust.add(_ParametrizedClassPragma("doc_test_signature", lambda signature: signature))
 
 
 def group(name: str = "") -> _ClassDecorator:

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -56,8 +56,6 @@ def _get_class(cls: type) -> schema.Class:
                             for n, a in cls.__dict__.get("__annotations__", {}).items()
                         ],
                         doc=schema.split_doc(cls.__doc__),
-                        rust_doc_test_function=cls.__dict__.get("_rust_doc_test_function",
-                                                                schema.Class.rust_doc_test_function)
                         )
 
 

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -56,7 +56,6 @@ def _get_class(cls: type) -> schema.Class:
                             for n, a in cls.__dict__.get("__annotations__", {}).items()
                         ],
                         doc=schema.split_doc(cls.__doc__),
-                        default_doc_name=cls.__dict__.get("_doc_name"),
                         rust_doc_test_function=cls.__dict__.get("_rust_doc_test_function",
                                                                 schema.Class.rust_doc_test_function)
                         )

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -50,7 +50,6 @@ def _get_class(cls: type) -> schema.Class:
                         test_with=_get_name(getattr(cls, "_test_with", None)),
                         # in the following we don't use `getattr` to avoid inheriting
                         pragmas=cls.__dict__.get("_pragmas", {}),
-                        synth=cls.__dict__.get("_synth", None),
                         properties=[
                             a | _PropertyNamer(n)
                             for n, a in cls.__dict__.get("__annotations__", {}).items()
@@ -100,8 +99,8 @@ def _fill_synth_information(classes: typing.Dict[str, schema.Class]):
     fill_is_synth(root)
 
     for name, cls in classes.items():
-        if cls.synth is None and is_synth[name]:
-            cls.synth = True
+        if is_synth[name]:
+            cls.mark_synth()
 
 
 def _fill_hideable_information(classes: typing.Dict[str, schema.Class]):

--- a/misc/codegen/loaders/schemaloader.py
+++ b/misc/codegen/loaders/schemaloader.py
@@ -49,7 +49,7 @@ def _get_class(cls: type) -> schema.Class:
                         hideable=getattr(cls, "_hideable", False),
                         test_with=_get_name(getattr(cls, "_test_with", None)),
                         # in the following we don't use `getattr` to avoid inheriting
-                        pragmas=cls.__dict__.get("_pragmas", []),
+                        pragmas=cls.__dict__.get("_pragmas", {}),
                         synth=cls.__dict__.get("_synth", None),
                         properties=[
                             a | _PropertyNamer(n)

--- a/misc/codegen/test/test_cppgen.py
+++ b/misc/codegen/test/test_cppgen.py
@@ -185,15 +185,15 @@ def test_synth_classes_ignored(generate):
     assert generate([
         schema.Class(
             name="W",
-            synth=schema.SynthInfo(),
+            pragmas={"synth": schema.SynthInfo()},
         ),
         schema.Class(
             name="X",
-            synth=schema.SynthInfo(from_class="A"),
+            pragmas={"synth": schema.SynthInfo(from_class="A")},
         ),
         schema.Class(
             name="Y",
-            synth=schema.SynthInfo(on_arguments={"a": "A", "b": "int"}),
+            pragmas={"synth": schema.SynthInfo(on_arguments={"a": "A", "b": "int"})},
         ),
         schema.Class(
             name="Z",

--- a/misc/codegen/test/test_dbschemegen.py
+++ b/misc/codegen/test/test_dbschemegen.py
@@ -536,9 +536,9 @@ def test_null_class(generate):
 
 def test_synth_classes_ignored(generate):
     assert generate([
-        schema.Class(name="A", synth=schema.SynthInfo()),
-        schema.Class(name="B", synth=schema.SynthInfo(from_class="A")),
-        schema.Class(name="C", synth=schema.SynthInfo(on_arguments={"x": "A"})),
+        schema.Class(name="A", pragmas={"synth": schema.SynthInfo()}),
+        schema.Class(name="B", pragmas={"synth": schema.SynthInfo(from_class="A")}),
+        schema.Class(name="C", pragmas={"synth": schema.SynthInfo(on_arguments={"x": "A"})}),
     ]) == dbscheme.Scheme(
         src=schema_file.name,
         includes=[],
@@ -549,7 +549,7 @@ def test_synth_classes_ignored(generate):
 def test_synth_derived_classes_ignored(generate):
     assert generate([
         schema.Class(name="A", derived={"B", "C"}),
-        schema.Class(name="B", bases=["A"], synth=schema.SynthInfo()),
+        schema.Class(name="B", bases=["A"], pragmas={"synth": schema.SynthInfo()}),
         schema.Class(name="C", bases=["A"]),
     ]) == dbscheme.Scheme(
         src=schema_file.name,

--- a/misc/codegen/test/test_qlgen.py
+++ b/misc/codegen/test/test_qlgen.py
@@ -922,7 +922,7 @@ def test_property_on_class_with_default_doc_name(generate_classes):
     assert generate_classes([
         schema.Class("MyObject", properties=[
             schema.SingleProperty("foo", "bar")],
-            default_doc_name="baz"),
+            pragmas={"ql_default_doc_name": "baz"}),
     ]) == {
         "MyObject.qll": (a_ql_class_public(name="MyObject"),
                          a_ql_stub(name="MyObject"),

--- a/misc/codegen/test/test_qlgen.py
+++ b/misc/codegen/test/test_qlgen.py
@@ -937,7 +937,7 @@ def test_property_on_class_with_default_doc_name(generate_classes):
 
 def test_stub_on_class_with_synth_from_class(generate_classes):
     assert generate_classes([
-        schema.Class("MyObject", synth=schema.SynthInfo(from_class="A"),
+        schema.Class("MyObject", pragmas={"synth": schema.SynthInfo(from_class="A")},
                      properties=[schema.SingleProperty("foo", "bar")]),
     ]) == {
         "MyObject.qll": (a_ql_class_public(name="MyObject"), a_ql_stub(name="MyObject", synth_accessors=[
@@ -952,7 +952,7 @@ def test_stub_on_class_with_synth_from_class(generate_classes):
 
 def test_stub_on_class_with_synth_on_arguments(generate_classes):
     assert generate_classes([
-        schema.Class("MyObject", synth=schema.SynthInfo(on_arguments={"base": "A", "index": "int", "label": "string"}),
+        schema.Class("MyObject", pragmas={"synth": schema.SynthInfo(on_arguments={"base": "A", "index": "int", "label": "string"})},
                      properties=[schema.SingleProperty("foo", "bar")]),
     ]) == {
         "MyObject.qll": (a_ql_class_public(name="MyObject"), a_ql_stub(name="MyObject", synth_accessors=[

--- a/misc/codegen/test/test_schemaloader.py
+++ b/misc/codegen/test/test_schemaloader.py
@@ -269,15 +269,21 @@ def test_builtin_predicate_and_set_children_not_allowed(spec):
                 x: spec | defs.child
 
 
-_pragmas = [(defs.qltest.skip, "qltest_skip"),
-            (defs.qltest.collapse_hierarchy, "qltest_collapse_hierarchy"),
-            (defs.qltest.uncollapse_hierarchy, "qltest_uncollapse_hierarchy"),
-            (defs.cpp.skip, "cpp_skip"),
-            (defs.ql.internal, "ql_internal"),
-            ]
+_class_pragmas = [
+    (defs.qltest.collapse_hierarchy, "qltest_collapse_hierarchy"),
+    (defs.qltest.uncollapse_hierarchy, "qltest_uncollapse_hierarchy"),
+]
+
+_property_pragmas = [
+    (defs.qltest.skip, "qltest_skip"),
+    (defs.cpp.skip, "cpp_skip"),
+    (defs.ql.internal, "ql_internal"),
+]
+
+_pragmas = _class_pragmas + _property_pragmas
 
 
-@pytest.mark.parametrize("pragma,expected", _pragmas)
+@pytest.mark.parametrize("pragma,expected", _property_pragmas)
 def test_property_with_pragma(pragma, expected):
     @load
     class data:
@@ -293,7 +299,7 @@ def test_property_with_pragma(pragma, expected):
 
 def test_property_with_pragmas():
     spec = defs.string
-    for pragma, _ in _pragmas:
+    for pragma, _ in _property_pragmas:
         spec |= pragma
 
     @load
@@ -303,7 +309,7 @@ def test_property_with_pragmas():
 
     assert data.classes == {
         'A': schema.Class('A', properties=[
-            schema.SingleProperty('x', 'string', pragmas=[expected for _, expected in _pragmas]),
+            schema.SingleProperty('x', 'string', pragmas=[expected for _, expected in _property_pragmas]),
         ]),
     }
 
@@ -636,7 +642,7 @@ def test_class_default_doc_name():
             pass
 
     assert data.classes == {
-        'A': schema.Class('A', default_doc_name="b"),
+        'A': schema.Class('A', pragmas={"ql_default_doc_name": "b"}),
     }
 
 

--- a/misc/codegen/test/test_schemaloader.py
+++ b/misc/codegen/test/test_schemaloader.py
@@ -355,8 +355,8 @@ def test_synth_from_class():
             pass
 
     assert data.classes == {
-        'A': schema.Class('A', derived={'B'}, synth=True),
-        'B': schema.Class('B', bases=['A'], synth=schema.SynthInfo(from_class="A")),
+        'A': schema.Class('A', derived={'B'}, pragmas={"synth": True}),
+        'B': schema.Class('B', bases=['A'], pragmas={"synth": schema.SynthInfo(from_class="A")}),
     }
 
 
@@ -371,7 +371,7 @@ def test_synth_from_class_ref():
             pass
 
     assert data.classes == {
-        'A': schema.Class('A', derived={'B'}, synth=schema.SynthInfo(from_class="B")),
+        'A': schema.Class('A', derived={'B'}, pragmas={"synth": schema.SynthInfo(from_class="B")}),
         'B': schema.Class('B', bases=['A']),
     }
 
@@ -396,8 +396,8 @@ def test_synth_class_on():
             pass
 
     assert data.classes == {
-        'A': schema.Class('A', derived={'B'}, synth=True),
-        'B': schema.Class('B', bases=['A'], synth=schema.SynthInfo(on_arguments={'a': 'A', 'i': 'int'})),
+        'A': schema.Class('A', derived={'B'}, pragmas={"synth": True}),
+        'B': schema.Class('B', bases=['A'], pragmas={"synth": schema.SynthInfo(on_arguments={'a': 'A', 'i': 'int'})}),
     }
 
 
@@ -415,7 +415,7 @@ def test_synth_class_on_ref():
             pass
 
     assert data.classes == {
-        'A': schema.Class('A', derived={'B'}, synth=schema.SynthInfo(on_arguments={'b': 'B', 'i': 'int'})),
+        'A': schema.Class('A', derived={'B'}, pragmas={"synth": schema.SynthInfo(on_arguments={'b': 'B', 'i': 'int'})}),
         'B': schema.Class('B', bases=['A']),
     }
 
@@ -454,10 +454,10 @@ def test_synth_class_hierarchy():
 
     assert data.classes == {
         'Root': schema.Class('Root', derived={'Base', 'C'}),
-        'Base': schema.Class('Base', bases=['Root'], derived={'Intermediate', 'B'}, synth=True),
-        'Intermediate': schema.Class('Intermediate', bases=['Base'], derived={'A'}, synth=True),
-        'A': schema.Class('A', bases=['Intermediate'], synth=schema.SynthInfo(on_arguments={'a': 'Base', 'i': 'int'})),
-        'B': schema.Class('B', bases=['Base'], synth=schema.SynthInfo(from_class='Base')),
+        'Base': schema.Class('Base', bases=['Root'], derived={'Intermediate', 'B'}, pragmas={"synth": True}),
+        'Intermediate': schema.Class('Intermediate', bases=['Base'], derived={'A'}, pragmas={"synth": True}),
+        'A': schema.Class('A', bases=['Intermediate'], pragmas={"synth": schema.SynthInfo(on_arguments={'a': 'Base', 'i': 'int'})}),
+        'B': schema.Class('B', bases=['Base'], pragmas={"synth": schema.SynthInfo(from_class='Base')}),
         'C': schema.Class('C', bases=['Root']),
     }
 

--- a/misc/codegen/test/test_schemaloader.py
+++ b/misc/codegen/test/test_schemaloader.py
@@ -798,8 +798,7 @@ def test_annotate_decorations():
             pass
 
     assert data.classes == {
-        "Root": schema.Class("Root", hideable=True,
-                             pragmas=["qltest_skip", "cpp_skip", "qltest_collapse_hierarchy"]),
+        "Root": schema.Class("Root", hideable=True, pragmas=["qltest_skip", "cpp_skip", "qltest_collapse_hierarchy"]),
     }
 
 


### PR DESCRIPTION
This is mostly an internal cleanup where some `schema.Class` special properties are moved to pragmas, allowing the latter to have parameters. In the long run this allows easier integration of new domain-specific things without having to pollute `schema.Class` and `schemaloader`.

For the moment I've kept some class annotations not as pragmas (`hideable`, `group`, `test_with`) , because they are automatically inherited from super classes, which the current pragma mechanism does not give. I might do another pass to get those in the pragmas as well.

Finally, there's also a finer distinction between class-only pragmas and general pragmas, so that for example `ql_test.collapse_hiearchy` can't be applied any more on a property, as that does not make any sense.