### PR TITLE
Rust/Codegen: allow to "detach" property emission

### DIFF
--- a/misc/codegen/lib/rust.py
+++ b/misc/codegen/lib/rust.py
@@ -1,6 +1,7 @@
 import dataclasses
 import re
 import typing
+import inflection
 
 # taken from https://doc.rust-lang.org/reference/keywords.html
 keywords = {
@@ -106,12 +107,17 @@ class Field:
     def is_label(self):
         return self.base_type == "trap::Label"
 
+    @property
+    def singular_field_name(self) -> str:
+        return inflection.singularize(self.field_name.rstrip("_"))
+
 
 @dataclasses.dataclass
 class Class:
     name: str
     entry_table: str | None = None
     fields: list[Field] = dataclasses.field(default_factory=list)
+    detached_fields: list[Field] = dataclasses.field(default_factory=list)
     ancestors: list[str] = dataclasses.field(default_factory=list)
 
     @property
@@ -127,6 +133,10 @@ class Class:
             if f.is_single:
                 ret.setdefault(f.table_name, []).append(f)
         return [{"table_name": k, "fields": v} for k, v in ret.items()]
+
+    @property
+    def has_detached_fields(self) -> bool:
+        return bool(self.detached_fields)
 
 
 @dataclasses.dataclass

--- a/misc/codegen/lib/schemadefs.py
+++ b/misc/codegen/lib/schemadefs.py
@@ -239,6 +239,7 @@ ql.add(_Pragma("internal"))
 
 cpp.add(_Pragma("skip"))
 
+rust.add(_Pragma("detach"))
 rust.add(_Pragma("skip_doc_test"))
 
 rust.add(_ParametrizedClassPragma("doc_test_signature", lambda signature: signature))

--- a/misc/codegen/templates/rust_classes.mustache
+++ b/misc/codegen/templates/rust_classes.mustache
@@ -59,6 +59,16 @@ pub struct {{name}} {
     _unused: ()
 }
 {{/is_entry}}
+{{#has_detached_fields}}
+
+impl {{name}} {
+{{#detached_fields}}
+    pub fn emit_{{singular_field_name}}(id: trap::Label<Self>, {{#is_repeated}}{{^is_unordered}}i: usize, {{/is_unordered}}{{/is_repeated}}value: {{base_type}}, out: &mut trap::Writer) {
+        out.add_tuple("{{table_name}}", vec![id.into(), {{#is_repeated}}{{^is_unordered}}i.into(), {{/is_unordered}}{{/is_repeated}}value.into()]);
+    }
+{{/detached_fields}}
+}
+{{/has_detached_fields}}
 
 impl trap::TrapClass for {{name}} {
     fn class_name() -> &'static str { "{{name}}" }


### PR DESCRIPTION
By using the `rust.detach` pragma on a property, we make that property not appear in the generated struct as a field, and provide instead a `generated::Class::emit_property` function that can be used to emit the corresponding TRAP entry independently.

