### PR TITLE
Java: Add more type-based sanitizers.

### DIFF
--- a/java/ql/lib/semmle/code/java/security/Sanitizers.qll
+++ b/java/ql/lib/semmle/code/java/security/Sanitizers.qll
@@ -13,6 +13,16 @@ class SimpleTypeSanitizer extends DataFlow::Node {
     this.getType() instanceof BoxedType or
     this.getType() instanceof NumberType or
     this.getType().(RefType).hasQualifiedName("java.util", "UUID") or
-    this.getType().(RefType).hasQualifiedName("java.util", "Date")
+    this.getType().(RefType).getASourceSupertype*().hasQualifiedName("java.util", "Date") or
+    this.getType().(RefType).hasQualifiedName("java.util", "Calendar") or
+    this.getType().(RefType).hasQualifiedName("java.util", "BitSet") or
+    this.getType()
+        .(RefType)
+        .getASourceSupertype*()
+        .hasQualifiedName("java.time.temporal", "TemporalAmount") or
+    this.getType()
+        .(RefType)
+        .getASourceSupertype*()
+        .hasQualifiedName("java.time.temporal", "TemporalAccessor")
   }
 }


### PR DESCRIPTION
Looking through the data from my initial MRVA top 100 speculative taint run, these additional types came up as potentially relevant to sanitize. The temporals I've also seen pop up before. This should help guard against FP flow going too much off the rails.

I'll run dca before phrasing the change note.