### PR TITLE
C#: `AttributeCollection` is no longer considered a HTML sink.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
@@ -56,13 +56,11 @@ class HtmlTextWriterSink extends HtmlSink {
 }
 
 /**
- * An expression that is used as an argument to an HTML sink method on
- * `AttributeCollection`.
+ * DEPRECATED: Attribute collections are no longer considered HTML sinks.
  */
-class AttributeCollectionSink extends HtmlSink {
+deprecated class AttributeCollectionSink extends DataFlow::ExprNode {
   AttributeCollectionSink() {
     exists(SystemWebUIAttributeCollectionClass ac, Parameter p |
-      p = ac.getAddMethod().getParameter(1) or
       p = ac.getItemProperty().getSetter().getParameter(0)
     |
       this.getExpr() = p.getAnAssignedArgument()

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/flowsinks/Html.qll
@@ -61,6 +61,7 @@ class HtmlTextWriterSink extends HtmlSink {
 deprecated class AttributeCollectionSink extends DataFlow::ExprNode {
   AttributeCollectionSink() {
     exists(SystemWebUIAttributeCollectionClass ac, Parameter p |
+      p = ac.getAddMethod().getParameter(1) or
       p = ac.getItemProperty().getSetter().getParameter(0)
     |
       this.getExpr() = p.getAnAssignedArgument()

--- a/csharp/ql/src/change-notes/2024-09-25-attribute-collection-sink.md
+++ b/csharp/ql/src/change-notes/2024-09-25-attribute-collection-sink.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* C#: The indexer and `Add` method on `System.Web.UI.AttributeCollection` is no longer considered a HTML sink.
+* C#: The indexer and `Add` method on `System.Web.UI.AttributeCollection` is no longer considered an HTML sink.

--- a/csharp/ql/src/change-notes/2024-09-25-attribute-collection-sink.md
+++ b/csharp/ql/src/change-notes/2024-09-25-attribute-collection-sink.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C#: The indexer and `Add` method on `System.Web.UI.AttributeCollection` is no longer considered a HTML sink.

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/AspInline.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/AspInline.expected
@@ -1,5 +1,5 @@
-| script.aspx:4:1:4:23 | <%= ... %> | XSS.cs:115:16:115:29 | someJavascript |
-| script.aspx:8:1:8:12 | <%= ... %> | XSS.cs:122:24:122:28 | Field |
+| script.aspx:4:1:4:23 | <%= ... %> | XSS.cs:120:16:120:29 | someJavascript |
+| script.aspx:8:1:8:12 | <%= ... %> | XSS.cs:127:24:127:28 | Field |
 | script.aspx:12:1:12:14 | <%= ... %> | <outside test directory> | Request |
 | script.aspx:16:1:16:34 | <%= ... %> | <outside test directory> | QueryString |
 | script.aspx:20:1:20:41 | <%= ... %> | <outside test directory> | QueryString |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.cs
@@ -17,6 +17,7 @@ namespace Test
         Table table;
         Label label;
         string connectionString;
+        public Button button;
 
         public void WebUIXSS()
         {
@@ -100,6 +101,10 @@ namespace Test
             // GOOD: HTML encoding
             string name = context.Request.QueryString["name"];
             new StringContent(HttpUtility.HtmlEncode(name));
+
+            // GOOD: Implicit HTML encoding
+            string html = context.Request.QueryString["html"];
+            button.Attributes.Add("data-href", html);
         }
 
         public void UrlEncoded(HttpContextBase context)

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
@@ -9,7 +9,6 @@
 | XSS.cs:87:28:87:31 | access to local variable name | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:87:28:87:31 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | User-provided value |
 | XSS.cs:88:31:88:34 | access to local variable name | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:88:31:88:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | User-provided value |
 | XSS.cs:96:31:96:34 | access to local variable name | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:96:31:96:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:107:48:107:51 | access to local variable html | XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:107:48:107:51 | access to local variable html | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | User-provided value |
 | XSS.cs:140:20:140:33 | access to property RawUrl | XSS.cs:140:20:140:33 | access to property RawUrl | XSS.cs:140:20:140:33 | access to property RawUrl | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:140:20:140:33 | access to property RawUrl | User-provided value |
 | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | $@ flows to here and is a remote source accessed inline in an ASPX page. | script.aspx:12:1:12:14 | <%= ... %> | User-provided value |
 | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | $@ flows to here and is a remote source accessed inline in an ASPX page. | script.aspx:16:1:16:34 | <%= ... %> | User-provided value |
@@ -46,10 +45,6 @@ edges
 | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:95:20:95:23 | access to local variable name : String | provenance |  |
 | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:95:27:95:61 | access to indexer : String | provenance | MaD:6 |
 | XSS.cs:95:27:95:61 | access to indexer : String | XSS.cs:95:20:95:23 | access to local variable name : String | provenance |  |
-| XSS.cs:106:20:106:23 | access to local variable html : String | XSS.cs:107:48:107:51 | access to local variable html | provenance |  |
-| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:106:20:106:23 | access to local variable html : String | provenance |  |
-| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:106:27:106:61 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:106:27:106:61 | access to indexer : String | XSS.cs:106:20:106:23 | access to local variable html : String | provenance |  |
 | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | provenance |  |
 | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | provenance |  |
 | script.aspx:20:1:20:41 | <%= ... %> | script.aspx:20:1:20:41 | <%= ... %> | provenance |  |
@@ -94,10 +89,6 @@ nodes
 | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | XSS.cs:95:27:95:61 | access to indexer : String | semmle.label | access to indexer : String |
 | XSS.cs:96:31:96:34 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:106:20:106:23 | access to local variable html : String | semmle.label | access to local variable html : String |
-| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:106:27:106:61 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:107:48:107:51 | access to local variable html | semmle.label | access to local variable html |
 | XSS.cs:140:20:140:33 | access to property RawUrl | semmle.label | access to property RawUrl |
 | script.aspx:12:1:12:14 | <%= ... %> | semmle.label | <%= ... %> |
 | script.aspx:16:1:16:34 | <%= ... %> | semmle.label | <%= ... %> |

--- a/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-079/XSSAsp/XSS.expected
@@ -1,50 +1,55 @@
 #select
-| XSS.cs:26:32:26:51 | call to method ToString | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:26:32:26:51 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | User-provided value |
-| XSS.cs:27:29:27:48 | call to method ToString | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:27:29:27:48 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | User-provided value |
-| XSS.cs:28:26:28:45 | call to method ToString | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:28:26:28:45 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | User-provided value |
-| XSS.cs:38:36:38:39 | access to local variable name | XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | XSS.cs:38:36:38:39 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:59:22:59:25 | access to local variable name | XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | XSS.cs:59:22:59:25 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:76:36:76:39 | access to local variable name | XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | XSS.cs:76:36:76:39 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:79:36:79:40 | access to local variable name2 | XSS.cs:78:28:78:42 | access to property Request : HttpRequestBase | XSS.cs:79:36:79:40 | access to local variable name2 | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:78:28:78:42 | access to property Request : HttpRequestBase | User-provided value |
-| XSS.cs:86:28:86:31 | access to local variable name | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:86:28:86:31 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:87:31:87:34 | access to local variable name | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:87:31:87:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:95:31:95:34 | access to local variable name | XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | XSS.cs:95:31:95:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | User-provided value |
-| XSS.cs:135:20:135:33 | access to property RawUrl | XSS.cs:135:20:135:33 | access to property RawUrl | XSS.cs:135:20:135:33 | access to property RawUrl | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:135:20:135:33 | access to property RawUrl | User-provided value |
+| XSS.cs:27:32:27:51 | call to method ToString | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | XSS.cs:27:32:27:51 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | User-provided value |
+| XSS.cs:28:29:28:48 | call to method ToString | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | XSS.cs:28:29:28:48 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | User-provided value |
+| XSS.cs:29:26:29:45 | call to method ToString | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | XSS.cs:29:26:29:45 | call to method ToString | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | User-provided value |
+| XSS.cs:39:36:39:39 | access to local variable name | XSS.cs:38:27:38:53 | access to property QueryString : NameValueCollection | XSS.cs:39:36:39:39 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:38:27:38:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:60:22:60:25 | access to local variable name | XSS.cs:58:27:58:65 | access to property QueryString : NameValueCollection | XSS.cs:60:22:60:25 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:58:27:58:65 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:77:36:77:39 | access to local variable name | XSS.cs:76:27:76:53 | access to property QueryString : NameValueCollection | XSS.cs:77:36:77:39 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:76:27:76:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:80:36:80:40 | access to local variable name2 | XSS.cs:79:28:79:42 | access to property Request : HttpRequestBase | XSS.cs:80:36:80:40 | access to local variable name2 | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:79:28:79:42 | access to property Request : HttpRequestBase | User-provided value |
+| XSS.cs:87:28:87:31 | access to local variable name | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:87:28:87:31 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:88:31:88:34 | access to local variable name | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:88:31:88:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:96:31:96:34 | access to local variable name | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:96:31:96:34 | access to local variable name | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:107:48:107:51 | access to local variable html | XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:107:48:107:51 | access to local variable html | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | User-provided value |
+| XSS.cs:140:20:140:33 | access to property RawUrl | XSS.cs:140:20:140:33 | access to property RawUrl | XSS.cs:140:20:140:33 | access to property RawUrl | $@ flows to here and is written to HTML or JavaScript. | XSS.cs:140:20:140:33 | access to property RawUrl | User-provided value |
 | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | $@ flows to here and is a remote source accessed inline in an ASPX page. | script.aspx:12:1:12:14 | <%= ... %> | User-provided value |
 | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | $@ flows to here and is a remote source accessed inline in an ASPX page. | script.aspx:16:1:16:34 | <%= ... %> | User-provided value |
 | script.aspx:20:1:20:41 | <%= ... %> | script.aspx:20:1:20:41 | <%= ... %> | script.aspx:20:1:20:41 | <%= ... %> | $@ flows to here and is a remote source accessed inline in an ASPX page. | script.aspx:20:1:20:41 | <%= ... %> | User-provided value |
 edges
-| XSS.cs:25:13:25:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:26:32:26:40 | access to local variable userInput : StringBuilder | provenance |  |
-| XSS.cs:25:13:25:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:27:29:27:37 | access to local variable userInput : StringBuilder | provenance |  |
-| XSS.cs:25:13:25:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:28:26:28:34 | access to local variable userInput : StringBuilder | provenance |  |
-| XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | XSS.cs:25:48:25:67 | access to property Text : String | provenance | MaD:4 |
-| XSS.cs:25:48:25:67 | access to property Text : String | XSS.cs:25:13:25:21 | [post] access to local variable userInput : StringBuilder | provenance | MaD:2 |
-| XSS.cs:26:32:26:40 | access to local variable userInput : StringBuilder | XSS.cs:26:32:26:51 | call to method ToString | provenance | MaD:3 |
-| XSS.cs:27:29:27:37 | access to local variable userInput : StringBuilder | XSS.cs:27:29:27:48 | call to method ToString | provenance | MaD:3 |
-| XSS.cs:28:26:28:34 | access to local variable userInput : StringBuilder | XSS.cs:28:26:28:45 | call to method ToString | provenance | MaD:3 |
-| XSS.cs:37:20:37:23 | access to local variable name : String | XSS.cs:38:36:38:39 | access to local variable name | provenance | Sink:MaD:5 |
-| XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | XSS.cs:37:20:37:23 | access to local variable name : String | provenance |  |
-| XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | XSS.cs:37:27:37:61 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:37:27:37:61 | access to indexer : String | XSS.cs:37:20:37:23 | access to local variable name : String | provenance |  |
-| XSS.cs:57:20:57:23 | access to local variable name : String | XSS.cs:59:22:59:25 | access to local variable name | provenance |  |
-| XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | XSS.cs:57:20:57:23 | access to local variable name : String | provenance |  |
-| XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | XSS.cs:57:27:57:73 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:57:27:57:73 | access to indexer : String | XSS.cs:57:20:57:23 | access to local variable name : String | provenance |  |
-| XSS.cs:75:20:75:23 | access to local variable name : String | XSS.cs:76:36:76:39 | access to local variable name | provenance |  |
-| XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | XSS.cs:75:20:75:23 | access to local variable name : String | provenance |  |
-| XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | XSS.cs:75:27:75:61 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:75:27:75:61 | access to indexer : String | XSS.cs:75:20:75:23 | access to local variable name : String | provenance |  |
-| XSS.cs:78:20:78:24 | access to local variable name2 : String | XSS.cs:79:36:79:40 | access to local variable name2 | provenance |  |
-| XSS.cs:78:28:78:42 | access to property Request : HttpRequestBase | XSS.cs:78:20:78:24 | access to local variable name2 : String | provenance |  |
-| XSS.cs:85:20:85:23 | access to local variable name : String | XSS.cs:86:28:86:31 | access to local variable name | provenance |  |
-| XSS.cs:85:20:85:23 | access to local variable name : String | XSS.cs:87:31:87:34 | access to local variable name | provenance |  |
-| XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:85:20:85:23 | access to local variable name : String | provenance |  |
-| XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | XSS.cs:85:27:85:61 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:85:27:85:61 | access to indexer : String | XSS.cs:85:20:85:23 | access to local variable name : String | provenance |  |
-| XSS.cs:94:20:94:23 | access to local variable name : String | XSS.cs:95:31:95:34 | access to local variable name | provenance | Sink:MaD:1 |
-| XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | XSS.cs:94:20:94:23 | access to local variable name : String | provenance |  |
-| XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | XSS.cs:94:27:94:61 | access to indexer : String | provenance | MaD:6 |
-| XSS.cs:94:27:94:61 | access to indexer : String | XSS.cs:94:20:94:23 | access to local variable name : String | provenance |  |
+| XSS.cs:26:13:26:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:27:32:27:40 | access to local variable userInput : StringBuilder | provenance |  |
+| XSS.cs:26:13:26:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:28:29:28:37 | access to local variable userInput : StringBuilder | provenance |  |
+| XSS.cs:26:13:26:21 | [post] access to local variable userInput : StringBuilder | XSS.cs:29:26:29:34 | access to local variable userInput : StringBuilder | provenance |  |
+| XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | XSS.cs:26:48:26:67 | access to property Text : String | provenance | MaD:4 |
+| XSS.cs:26:48:26:67 | access to property Text : String | XSS.cs:26:13:26:21 | [post] access to local variable userInput : StringBuilder | provenance | MaD:2 |
+| XSS.cs:27:32:27:40 | access to local variable userInput : StringBuilder | XSS.cs:27:32:27:51 | call to method ToString | provenance | MaD:3 |
+| XSS.cs:28:29:28:37 | access to local variable userInput : StringBuilder | XSS.cs:28:29:28:48 | call to method ToString | provenance | MaD:3 |
+| XSS.cs:29:26:29:34 | access to local variable userInput : StringBuilder | XSS.cs:29:26:29:45 | call to method ToString | provenance | MaD:3 |
+| XSS.cs:38:20:38:23 | access to local variable name : String | XSS.cs:39:36:39:39 | access to local variable name | provenance | Sink:MaD:5 |
+| XSS.cs:38:27:38:53 | access to property QueryString : NameValueCollection | XSS.cs:38:20:38:23 | access to local variable name : String | provenance |  |
+| XSS.cs:38:27:38:53 | access to property QueryString : NameValueCollection | XSS.cs:38:27:38:61 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:38:27:38:61 | access to indexer : String | XSS.cs:38:20:38:23 | access to local variable name : String | provenance |  |
+| XSS.cs:58:20:58:23 | access to local variable name : String | XSS.cs:60:22:60:25 | access to local variable name | provenance |  |
+| XSS.cs:58:27:58:65 | access to property QueryString : NameValueCollection | XSS.cs:58:20:58:23 | access to local variable name : String | provenance |  |
+| XSS.cs:58:27:58:65 | access to property QueryString : NameValueCollection | XSS.cs:58:27:58:73 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:58:27:58:73 | access to indexer : String | XSS.cs:58:20:58:23 | access to local variable name : String | provenance |  |
+| XSS.cs:76:20:76:23 | access to local variable name : String | XSS.cs:77:36:77:39 | access to local variable name | provenance |  |
+| XSS.cs:76:27:76:53 | access to property QueryString : NameValueCollection | XSS.cs:76:20:76:23 | access to local variable name : String | provenance |  |
+| XSS.cs:76:27:76:53 | access to property QueryString : NameValueCollection | XSS.cs:76:27:76:61 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:76:27:76:61 | access to indexer : String | XSS.cs:76:20:76:23 | access to local variable name : String | provenance |  |
+| XSS.cs:79:20:79:24 | access to local variable name2 : String | XSS.cs:80:36:80:40 | access to local variable name2 | provenance |  |
+| XSS.cs:79:28:79:42 | access to property Request : HttpRequestBase | XSS.cs:79:20:79:24 | access to local variable name2 : String | provenance |  |
+| XSS.cs:86:20:86:23 | access to local variable name : String | XSS.cs:87:28:87:31 | access to local variable name | provenance |  |
+| XSS.cs:86:20:86:23 | access to local variable name : String | XSS.cs:88:31:88:34 | access to local variable name | provenance |  |
+| XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:86:20:86:23 | access to local variable name : String | provenance |  |
+| XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | XSS.cs:86:27:86:61 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:86:27:86:61 | access to indexer : String | XSS.cs:86:20:86:23 | access to local variable name : String | provenance |  |
+| XSS.cs:95:20:95:23 | access to local variable name : String | XSS.cs:96:31:96:34 | access to local variable name | provenance | Sink:MaD:1 |
+| XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:95:20:95:23 | access to local variable name : String | provenance |  |
+| XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | XSS.cs:95:27:95:61 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:95:27:95:61 | access to indexer : String | XSS.cs:95:20:95:23 | access to local variable name : String | provenance |  |
+| XSS.cs:106:20:106:23 | access to local variable html : String | XSS.cs:107:48:107:51 | access to local variable html | provenance |  |
+| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:106:20:106:23 | access to local variable html : String | provenance |  |
+| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | XSS.cs:106:27:106:61 | access to indexer : String | provenance | MaD:6 |
+| XSS.cs:106:27:106:61 | access to indexer : String | XSS.cs:106:20:106:23 | access to local variable html : String | provenance |  |
 | script.aspx:12:1:12:14 | <%= ... %> | script.aspx:12:1:12:14 | <%= ... %> | provenance |  |
 | script.aspx:16:1:16:34 | <%= ... %> | script.aspx:16:1:16:34 | <%= ... %> | provenance |  |
 | script.aspx:20:1:20:41 | <%= ... %> | script.aspx:20:1:20:41 | <%= ... %> | provenance |  |
@@ -56,40 +61,44 @@ models
 | 5 | Sink: System.Web; HttpResponse; false; Write; ; ; Argument[0]; html-injection; manual |
 | 6 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
-| XSS.cs:25:13:25:21 | [post] access to local variable userInput : StringBuilder | semmle.label | [post] access to local variable userInput : StringBuilder |
-| XSS.cs:25:48:25:62 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
-| XSS.cs:25:48:25:67 | access to property Text : String | semmle.label | access to property Text : String |
-| XSS.cs:26:32:26:40 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
-| XSS.cs:26:32:26:51 | call to method ToString | semmle.label | call to method ToString |
-| XSS.cs:27:29:27:37 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
-| XSS.cs:27:29:27:48 | call to method ToString | semmle.label | call to method ToString |
-| XSS.cs:28:26:28:34 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
-| XSS.cs:28:26:28:45 | call to method ToString | semmle.label | call to method ToString |
-| XSS.cs:37:20:37:23 | access to local variable name : String | semmle.label | access to local variable name : String |
-| XSS.cs:37:27:37:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:37:27:37:61 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:38:36:38:39 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:57:20:57:23 | access to local variable name : String | semmle.label | access to local variable name : String |
-| XSS.cs:57:27:57:65 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:57:27:57:73 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:59:22:59:25 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:75:20:75:23 | access to local variable name : String | semmle.label | access to local variable name : String |
-| XSS.cs:75:27:75:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:75:27:75:61 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:76:36:76:39 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:78:20:78:24 | access to local variable name2 : String | semmle.label | access to local variable name2 : String |
-| XSS.cs:78:28:78:42 | access to property Request : HttpRequestBase | semmle.label | access to property Request : HttpRequestBase |
-| XSS.cs:79:36:79:40 | access to local variable name2 | semmle.label | access to local variable name2 |
-| XSS.cs:85:20:85:23 | access to local variable name : String | semmle.label | access to local variable name : String |
-| XSS.cs:85:27:85:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:85:27:85:61 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:86:28:86:31 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:87:31:87:34 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:94:20:94:23 | access to local variable name : String | semmle.label | access to local variable name : String |
-| XSS.cs:94:27:94:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
-| XSS.cs:94:27:94:61 | access to indexer : String | semmle.label | access to indexer : String |
-| XSS.cs:95:31:95:34 | access to local variable name | semmle.label | access to local variable name |
-| XSS.cs:135:20:135:33 | access to property RawUrl | semmle.label | access to property RawUrl |
+| XSS.cs:26:13:26:21 | [post] access to local variable userInput : StringBuilder | semmle.label | [post] access to local variable userInput : StringBuilder |
+| XSS.cs:26:48:26:62 | access to field categoryTextBox : TextBox | semmle.label | access to field categoryTextBox : TextBox |
+| XSS.cs:26:48:26:67 | access to property Text : String | semmle.label | access to property Text : String |
+| XSS.cs:27:32:27:40 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
+| XSS.cs:27:32:27:51 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:28:29:28:37 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
+| XSS.cs:28:29:28:48 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:29:26:29:34 | access to local variable userInput : StringBuilder | semmle.label | access to local variable userInput : StringBuilder |
+| XSS.cs:29:26:29:45 | call to method ToString | semmle.label | call to method ToString |
+| XSS.cs:38:20:38:23 | access to local variable name : String | semmle.label | access to local variable name : String |
+| XSS.cs:38:27:38:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:38:27:38:61 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:39:36:39:39 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:58:20:58:23 | access to local variable name : String | semmle.label | access to local variable name : String |
+| XSS.cs:58:27:58:65 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:58:27:58:73 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:60:22:60:25 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:76:20:76:23 | access to local variable name : String | semmle.label | access to local variable name : String |
+| XSS.cs:76:27:76:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:76:27:76:61 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:77:36:77:39 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:79:20:79:24 | access to local variable name2 : String | semmle.label | access to local variable name2 : String |
+| XSS.cs:79:28:79:42 | access to property Request : HttpRequestBase | semmle.label | access to property Request : HttpRequestBase |
+| XSS.cs:80:36:80:40 | access to local variable name2 | semmle.label | access to local variable name2 |
+| XSS.cs:86:20:86:23 | access to local variable name : String | semmle.label | access to local variable name : String |
+| XSS.cs:86:27:86:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:86:27:86:61 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:87:28:87:31 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:88:31:88:34 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:95:20:95:23 | access to local variable name : String | semmle.label | access to local variable name : String |
+| XSS.cs:95:27:95:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:95:27:95:61 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:96:31:96:34 | access to local variable name | semmle.label | access to local variable name |
+| XSS.cs:106:20:106:23 | access to local variable html : String | semmle.label | access to local variable html : String |
+| XSS.cs:106:27:106:53 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
+| XSS.cs:106:27:106:61 | access to indexer : String | semmle.label | access to indexer : String |
+| XSS.cs:107:48:107:51 | access to local variable html | semmle.label | access to local variable html |
+| XSS.cs:140:20:140:33 | access to property RawUrl | semmle.label | access to property RawUrl |
 | script.aspx:12:1:12:14 | <%= ... %> | semmle.label | <%= ... %> |
 | script.aspx:16:1:16:34 | <%= ... %> | semmle.label | <%= ... %> |
 | script.aspx:20:1:20:41 | <%= ... %> | semmle.label | <%= ... %> |


### PR DESCRIPTION
In this PR we remove the indexer and `Add` method of `System.Web.UI.AttributeCollection` as possible HTML sinks as the information is HTML encoded when the control is rendered.

This can be confirmed by running (needs to be a .NET Framework app).
```csharp
using System;
using System.Web.UI;
using System.Web.UI.WebControls;

class Program
{
    static void Main(string[] args)
    {
        Button b = new Button();
        b.Attributes.Add("my_key", "<some value & my stuff");
        b.Attributes["my_index_key"] = "my_<index&_value";
        b.RenderControl(new HtmlTextWriter(Console.Out));
    }
}
```