### PR TITLE
C++: Make checking for macro expansions depend less on location information

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Macro.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Macro.qll
@@ -250,19 +250,19 @@ class MacroInvocation extends MacroAccess {
    */
   string getExpandedArgument(int i) { macro_argument_expanded(underlyingElement(this), i, result) }
 
-  private Locatable getElementinMacroInvocationChain() {
+  private Locatable getAnElementInInvocationChain() {
     result = this.getAnExpandedElement()
     or
     exists(MacroInvocation child | this = child.getParentInvocation() |
-      result = child.getElementinMacroInvocationChain()
+      result = child.getAnElementInInvocationChain()
     )
   }
 
   /** Gets an element in this macro invocation. */
-  Locatable getElementinMacroInvocation() {
+  Locatable getAnElement() {
     not result instanceof MacroInvocation and
     exists(Locatable element | element.getLocation() = result.getLocation() |
-      element = this.getElementinMacroInvocationChain()
+      element = this.getAnElementInInvocationChain()
     )
   }
 }
@@ -272,7 +272,7 @@ predicate macroLocation(Location l) { macrolocationbind(_, l) }
 
 /** Holds if `element` is in the expansion of a macro. */
 predicate inMacroExpansion(Locatable element) {
-  exists(MacroInvocation invocation | element = invocation.getElementinMacroInvocation())
+  exists(MacroInvocation m | element = m.getAnElement())
 }
 
 /**

--- a/cpp/ql/lib/semmle/code/cpp/Macro.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Macro.qll
@@ -261,8 +261,8 @@ class MacroInvocation extends MacroAccess {
   /** Gets an element in this macro invocation. */
   Locatable getElementinMacroInvocation() {
     not result instanceof MacroInvocation and
-    exists(Locatable overlapping | overlapping.getLocation() = result.getLocation() |
-      overlapping = this.getElementinMacroInvocationChain()
+    exists(Locatable element | element.getLocation() = result.getLocation() |
+      element = this.getElementinMacroInvocationChain()
     )
   }
 }

--- a/cpp/ql/test/library-tests/macros/inmacroexpansion/inmacroexpansion.expected
+++ b/cpp/ql/test/library-tests/macros/inmacroexpansion/inmacroexpansion.expected
@@ -13,14 +13,14 @@
 | test.cpp:4:1:4:1 | operator= | false |
 | test.cpp:4:1:4:1 | operator= | false |
 | test.cpp:4:1:4:3 | FOO | false |
-| test.cpp:4:1:4:3 | S | false |
+| test.cpp:4:1:4:3 | S | true |
 | test.cpp:4:1:4:3 | declaration | true |
 | test.cpp:4:1:4:3 | definition of S | true |
 | test.cpp:4:1:4:3 | definition of f | true |
 | test.cpp:4:1:4:3 | definition of i | true |
 | test.cpp:4:1:4:3 | definition of j | true |
-| test.cpp:4:1:4:3 | f | false |
-| test.cpp:4:1:4:3 | i | false |
+| test.cpp:4:1:4:3 | f | true |
+| test.cpp:4:1:4:3 | i | true |
 | test.cpp:4:1:4:3 | j | true |
 | test.cpp:4:1:4:3 | return ... | true |
 | test.cpp:4:1:4:3 | { ... } | true |

--- a/cpp/ql/test/library-tests/macros/inmacroexpansion/inmacroexpansion.expected
+++ b/cpp/ql/test/library-tests/macros/inmacroexpansion/inmacroexpansion.expected
@@ -24,3 +24,11 @@
 | test.cpp:4:1:4:3 | j | true |
 | test.cpp:4:1:4:3 | return ... | true |
 | test.cpp:4:1:4:3 | { ... } | true |
+| test.cpp:6:1:6:15 | #define ID(x) x | false |
+| test.cpp:7:1:7:18 | #define A(x) ID(x) | false |
+| test.cpp:8:5:8:6 | definition of v1 | false |
+| test.cpp:8:5:8:6 | v1 | false |
+| test.cpp:8:10:8:13 | A(x) | false |
+| test.cpp:8:10:8:13 | ID(x) | false |
+| test.cpp:8:12:8:12 | 1 | true |
+| test.cpp:8:12:8:12 | initializer for v1 | true |

--- a/cpp/ql/test/library-tests/macros/inmacroexpansion/test.cpp
+++ b/cpp/ql/test/library-tests/macros/inmacroexpansion/test.cpp
@@ -3,3 +3,6 @@
 
 FOO
 
+#define ID(x) x
+#define A(x) ID(x)
+int v1 = A(1);


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
