### PR TITLE
Shared: cache getBasicBlock() as it is needed from BarrierGuards

### DIFF
--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -979,6 +979,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     /** Gets the basic block to which this SSA definition belongs. */
+    cached // needed by BarrierGuards
     final BasicBlock getBasicBlock() { this.definesAt(_, result, _, _) }
 
     /** Gets a textual representation of this SSA definition. */


### PR DESCRIPTION
BarrierGuards<> is instantiated on a per-query basis, so it shouldn't reference uncached predicates that could cause a cascade of re-evaluations. This is already enforced in most placces but it seems the call to getBasicBlock() slipped through the cracks.