### PR TITLE
Java/C#: Add overrides to the interpretation of neutral MaD models.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/ExternalFlow.qll
@@ -318,7 +318,7 @@ private predicate elementSpec(
   or
   summaryModel(namespace, type, subtypes, name, signature, ext, _, _, _, _, _)
   or
-  neutralModel(namespace, type, name, signature, _, _) and ext = "" and subtypes = false
+  neutralModel(namespace, type, name, signature, _, _) and ext = "" and subtypes = true
 }
 
 private predicate elementSpec(
@@ -602,7 +602,7 @@ private predicate interpretSummary(
 predicate interpretNeutral(UnboundCallable c, string kind, string provenance) {
   exists(string namespace, string type, string name, string signature |
     neutralModel(namespace, type, name, signature, kind, provenance) and
-    c = interpretElement(namespace, type, false, name, signature, "")
+    c = interpretElement(namespace, type, true, name, signature, "")
   )
 }
 

--- a/java/ql/lib/ext/java.lang.model.yml
+++ b/java/ql/lib/ext/java.lang.model.yml
@@ -207,7 +207,6 @@ extensions:
       - ["java.lang", "Object", "equals", "(Object)", "summary", "manual"]
       - ["java.lang", "Object", "getClass", "()", "summary", "manual"]
       - ["java.lang", "Object", "hashCode", "()", "summary", "manual"]
-      - ["java.lang", "Object", "toString", "()", "summary", "manual"]
       - ["java.lang", "Runtime", "getRuntime", "()", "summary", "manual"]
       - ["java.lang", "String", "compareTo", "(String)", "summary", "manual"]
       - ["java.lang", "String", "contains", "(CharSequence)", "summary", "manual"]

--- a/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/ExternalFlow.qll
@@ -416,7 +416,7 @@ private predicate elementSpec(
   or
   summaryModel(package, type, subtypes, name, signature, ext, _, _, _, _, _)
   or
-  neutralModel(package, type, name, signature, _, _) and ext = "" and subtypes = false
+  neutralModel(package, type, name, signature, _, _) and ext = "" and subtypes = true
 }
 
 private string getNestedName(Type t) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -34,7 +34,7 @@ module Input implements InputSig<Location, DataFlowImplSpecific::JavaDataFlow> {
   ) {
     exists(string namespace, string type, string name, string signature |
       neutralModel(namespace, type, name, signature, kind, provenance) and
-      c.asCallable() = interpretElement(namespace, type, false, name, signature, "", isExact)
+      c.asCallable() = interpretElement(namespace, type, true, name, signature, "", isExact)
     )
   }
 

--- a/java/ql/src/utils/modeleditor/ModelEditor.qll
+++ b/java/ql/src/utils/modeleditor/ModelEditor.qll
@@ -77,7 +77,7 @@ class Endpoint extends Callable {
   predicate isNeutral() {
     exists(string namespace, string type, string name, string signature |
       neutralModel(namespace, type, name, signature, _, _) and
-      this = interpretElement(namespace, type, false, name, signature, "", _)
+      this = interpretElement(namespace, type, true, name, signature, "", _)
     )
   }
 

--- a/java/ql/test/ext/TopJdkApis/TopJdkApisTest.expected
+++ b/java/ql/test/ext/TopJdkApis/TopJdkApisTest.expected
@@ -1,3 +1,4 @@
+| java.lang.Object#toString() | no manual model |
 | java.lang.Runnable#run() | no manual model |
 | java.util.Comparator#comparing(Function) | no manual model |
 | java.util.function.BiConsumer#accept(Object,Object) | no manual model |


### PR DESCRIPTION
Neutrals generally have little impact on the analysis, but having a neutral like `Map.containsKey` also cover `HashMap.containsKey` makes a lot of sense. This might remove a tiny bit of source dispatch for low-confidence dispatch to source implementations of such methods, as that's AFAIR the only touchpoint between neutrals and analysis semantics.