### PR TITLE
Brodes/wcharcharconversion false positives upstream5

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -39,7 +39,7 @@ class UnlikelyToBeAStringType extends Type {
     exists(Type targ | getABaseType(this) = targ |
       // NOTE: not using CharType isUnsigned, but rather look for any explicitly declared unsigned
       // char types. Assuming these are used for buffers, not strings.
-      targ.(CharType).getName().toLowerCase().matches(["unsigned%"]) or
+      targ.(CharType).getName().toLowerCase().matches("unsigned%") or
       targ.getName().toLowerCase().matches(["uint8_t", "%byte%"])
     )
   }

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -36,13 +36,11 @@ Type getABaseType(Type t) {
  */
 class UnlikelyToBeAStringType extends Type {
   UnlikelyToBeAStringType() {
-    exists(Type targ |
-      // NOTE: not using CharType isUnsigned, but rather look for any explicitly declared unsigned 
+    exists(Type targ | getABaseType(this) = targ |
+      // NOTE: not using CharType isUnsigned, but rather look for any explicitly declared unsigned
       // char types. Assuming these are used for buffers, not strings.
       targ.(CharType).getName().toLowerCase().matches(["unsigned%"]) or
       targ.getName().toLowerCase().matches(["uint8_t", "%byte%"])
-    |
-      getABaseType(this) = targ
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -37,7 +37,9 @@ Type getABaseType(Type t) {
 class UnlikelyToBeAStringType extends Type {
   UnlikelyToBeAStringType() {
     exists(Type targ |
-      targ.(CharType).isUnsigned() or
+      // NOTE: not using CharType isUnsigned, but rather look for any explicitly declared unsigned 
+      // char types. Assuming these are used for buffers, not strings.
+      targ.(CharType).getName().toLowerCase().matches(["unsigned%"]) or
       targ.getName().toLowerCase().matches(["uint8_t", "%byte%"])
     |
       getABaseType(this) = targ

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -49,7 +49,7 @@ class UnlikelyToBeAStringType extends Type {
 // see https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types
 class UnicodeMacroDependentWidthType extends Type {
   UnicodeMacroDependentWidthType() {
-    exists(Type targ |
+    exists(Type targ | getABaseType(this) = targ |
       targ.getName() in [
           "LPCTSTR",
           "LPTSTR",
@@ -58,8 +58,6 @@ class UnicodeMacroDependentWidthType extends Type {
           "TBYTE",
           "TCHAR"
         ]
-    |
-      getABaseType(this) = targ
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -80,7 +80,9 @@ class UnicodeMacroInvocation extends MacroInvocation {
  */
 predicate isLikelyDynamicallyChecked(Expr e) {
   e.getType() instanceof UnicodeMacroDependentWidthType and
-  exists(GuardCondition gc, BitwiseAndExpr bai, UnicodeMacroInvocation umi | bai.getAnOperand() = umi.getExpr() |
+  exists(GuardCondition gc, BitwiseAndExpr bai, UnicodeMacroInvocation umi |
+    bai.getAnOperand() = umi.getExpr()
+  |
     // bai == 0 is false when reaching `e.getBasicBlock()`.
     // That is, bai != 0 when reaching `e.getBasicBlock()`.
     gc.ensuresEq(bai, 0, e.getBasicBlock(), false)

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -20,10 +20,8 @@ class WideCharPointerType extends PointerType {
 }
 
 /**
- * Recurse through types to find any intermediate type or final type
- * that suggests the type is unlikely to be a string.
- * Specifically looking for any unsigned character, or datatype with name containing "byte"
- * or datatype uint8_t.
+ * Given type `cur`, recurses through all intermediate types to find 
+ * any intermediate type equal to type `targ`
  */
 predicate hasIntermediateType(Type cur, Type targ) {
   cur = targ

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -20,15 +20,15 @@ class WideCharPointerType extends PointerType {
 }
 
 /**
- * Given type `cur`, recurses through all intermediate types to find 
- * any intermediate type equal to type `targ`
+ * Given type `t`, recurses through and returns all
+ * intermediate base types, including `t`.
  */
-predicate hasIntermediateType(Type cur, Type targ) {
-  cur = targ
+Type getABaseType(Type t) {
+  result = t
   or
-  hasIntermediateType(cur.(DerivedType).getBaseType(), targ)
+  result = getABaseType(t.(DerivedType).getBaseType())
   or
-  hasIntermediateType(cur.(TypedefType).getBaseType(), targ)
+  result = getABaseType(t.(TypedefType).getBaseType())
 }
 
 /**
@@ -40,7 +40,7 @@ class UnlikelyToBeAStringType extends Type {
       targ.(CharType).isUnsigned() or
       targ.getName().toLowerCase().matches(["uint8_t", "%byte%"])
     |
-      hasIntermediateType(this, targ)
+      getABaseType(this) = targ
     )
   }
 }
@@ -59,7 +59,7 @@ class UnicodeMacroDependentWidthType extends Type {
           "TCHAR"
         ]
     |
-      hasIntermediateType(this, targ)
+      getABaseType(this) = targ
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -78,9 +78,9 @@ class UnicodeMacroInvocation extends MacroInvocation {
  * the flag would indicate if UNICODE typing is set correctly to allow
  * or disallow a widening cast.
  */
-predicate isLikelyDynamicChecked(Expr e, GuardCondition gc) {
+predicate isLikelyDynamicallyChecked(Expr e) {
   e.getType() instanceof UnicodeMacroDependentWidthType and
-  exists(BitwiseAndExpr bai, UnicodeMacroInvocation umi | bai.getAnOperand() = umi.getExpr() |
+  exists(GuardCondition gc, BitwiseAndExpr bai, UnicodeMacroInvocation umi | bai.getAnOperand() = umi.getExpr() |
     // bai == 0 is false when reaching `e.getBasicBlock()`.
     // That is, bai != 0 when reaching `e.getBasicBlock()`.
     gc.ensuresEq(bai, 0, e.getBasicBlock(), false)
@@ -106,7 +106,7 @@ where
   // Avoid cases where the cast is guarded by a check to determine if
   // unicode encoding is enabled in such a way to disallow the dangerous cast
   // at runtime.
-  not isLikelyDynamicChecked(e1, _)
+  not isLikelyDynamicallyChecked(e1)
 select e1,
   "Conversion from " + e1.getType().toString() + " to " + e2.getType().toString() +
     ". Use of invalid string can lead to undefined behavior."

--- a/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
+++ b/cpp/ql/src/Security/CWE/CWE-704/WcharCharConversion.ql
@@ -13,9 +13,24 @@
  */
 
 import cpp
+import semmle.code.cpp.controlflow.Guards
 
 class WideCharPointerType extends PointerType {
   WideCharPointerType() { this.getBaseType() instanceof WideCharType }
+}
+
+/**
+ * Recurse through types to find any intermediate type or final type
+ * that suggests the type is unlikely to be a string.
+ * Specifically looking for any unsigned character, or datatype with name containing "byte"
+ * or datatype uint8_t.
+ */
+predicate hasIntermediateType(Type cur, Type targ) {
+  cur = targ
+  or
+  hasIntermediateType(cur.(DerivedType).getBaseType(), targ)
+  or
+  hasIntermediateType(cur.(TypedefType).getBaseType(), targ)
 }
 
 /**
@@ -23,11 +38,60 @@ class WideCharPointerType extends PointerType {
  */
 class UnlikelyToBeAStringType extends Type {
   UnlikelyToBeAStringType() {
-    this.(PointerType).getBaseType().(CharType).isUnsigned() or
-    this.(PointerType).getBaseType().getName().toLowerCase().matches("%byte") or
-    this.getName().toLowerCase().matches("%byte") or
-    this.(PointerType).getBaseType().hasName("uint8_t")
+    exists(Type targ |
+      targ.(CharType).isUnsigned() or
+      targ.getName().toLowerCase().matches(["uint8_t", "%byte%"])
+    |
+      hasIntermediateType(this, targ)
+    )
   }
+}
+
+// Types that can be wide depending on the UNICODE macro
+// see https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+class UnicodeMacroDependentWidthType extends Type {
+  UnicodeMacroDependentWidthType() {
+    exists(Type targ |
+      targ.getName() in [
+          "LPCTSTR",
+          "LPTSTR",
+          "PCTSTR",
+          "PTSTR",
+          "TBYTE",
+          "TCHAR"
+        ]
+    |
+      hasIntermediateType(this, targ)
+    )
+  }
+}
+
+class UnicodeMacro extends Macro {
+  UnicodeMacro() { this.getName().toLowerCase().matches("%unicode%") }
+}
+
+class UnicodeMacroInvocation extends MacroInvocation {
+  UnicodeMacroInvocation() { this.getMacro() instanceof UnicodeMacro }
+}
+
+/**
+ * Holds when a expression whose type is UnicodeMacroDependentWidthType and
+ * is observed to be guarded by a check involving a bitwise-and operation
+ * with a UnicodeMacroInvocation.
+ * Such expressions are assumed to be checked dynamically, i.e.,
+ * the flag would indicate if UNICODE typing is set correctly to allow
+ * or disallow a widening cast.
+ */
+predicate isLikelyDynamicChecked(Expr e, GuardCondition gc) {
+  e.getType() instanceof UnicodeMacroDependentWidthType and
+  exists(BitwiseAndExpr bai, UnicodeMacroInvocation umi | bai.getAnOperand() = umi.getExpr() |
+    // bai == 0 is false when reaching `e.getBasicBlock()`.
+    // That is, bai != 0 when reaching `e.getBasicBlock()`.
+    gc.ensuresEq(bai, 0, e.getBasicBlock(), false)
+    or
+    // bai == k and k != 0 is true when reaching `e.getBasicBlock()`.
+    gc.ensuresEq(bai, any(int k | k != 0), e.getBasicBlock(), true)
+  )
 }
 
 from Expr e1, Cast e2
@@ -42,7 +106,11 @@ where
   not e1.getType() instanceof UnlikelyToBeAStringType and
   // Avoid castings from 'new' expressions as typically these will be safe
   // Example: `__Type* ret = reinterpret_cast<__Type*>(New(m_pmo) char[num * sizeof(__Type)]);`
-  not exists(NewOrNewArrayExpr newExpr | newExpr.getAChild*() = e1)
+  not exists(NewOrNewArrayExpr newExpr | newExpr.getAChild*() = e1) and
+  // Avoid cases where the cast is guarded by a check to determine if
+  // unicode encoding is enabled in such a way to disallow the dangerous cast
+  // at runtime.
+  not isLikelyDynamicChecked(e1, _)
 select e1,
   "Conversion from " + e1.getType().toString() + " to " + e2.getType().toString() +
     ". Use of invalid string can lead to undefined behavior."

--- a/cpp/ql/src/change-notes/2024-09-26-wcharcharconversion-false-positives.md
+++ b/cpp/ql/src/change-notes/2024-09-26-wcharcharconversion-false-positives.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Removed false positives caused by failure to detect byte arrays
+* Removed false positives caused by failure to recognize dynamic checks prior to possible dangerous widening

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.cpp
@@ -54,3 +54,58 @@ void NonStringFalsePositiveTest2(unsigned char* buffer)
 	wchar_t *lpWchar = NULL;
 	lpWchar = (LPWSTR)buffer; // Possible False Positive
 }
+
+typedef unsigned char BYTE;
+using FOO = BYTE*;
+
+void NonStringFalsePositiveTest3(FOO buffer)
+{
+	wchar_t *lpWchar = NULL;
+	lpWchar = (LPWSTR)buffer; // GOOD
+}
+
+#define UNICODE 0x8
+
+// assume EMPTY_MACRO is tied to if UNICODE is enabled
+#ifdef EMPTY_MACRO
+typedef WCHAR* LPTSTR;
+#else
+typedef char* LPTSTR;
+#endif
+
+void CheckedConversionFalsePositiveTest3(unsigned short flags, LPTSTR buffer)
+{
+	wchar_t *lpWchar = NULL;
+	if(flags & UNICODE)
+		lpWchar = (LPWSTR)buffer; // GOOD
+	else
+		lpWchar = (LPWSTR)buffer; // BUG
+
+	if((flags & UNICODE) == 0x8)
+		lpWchar = (LPWSTR)buffer; // GOOD
+	else
+		lpWchar = (LPWSTR)buffer; // BUG
+
+	if((flags & UNICODE) != 0x8)
+		lpWchar = (LPWSTR)buffer; // BUG
+	else
+		lpWchar = (LPWSTR)buffer; // GOOD
+
+	// Bad operator precedence
+	if(flags & UNICODE == 0x8)
+		lpWchar = (LPWSTR)buffer; // BUG
+	else
+		lpWchar = (LPWSTR)buffer; // BUG
+
+	if((flags & UNICODE) != 0)
+		lpWchar = (LPWSTR)buffer; // GOOD
+	else
+		lpWchar = (LPWSTR)buffer; // BUG
+
+	if((flags & UNICODE) == 0)
+		lpWchar = (LPWSTR)buffer; // BUG
+	else
+		lpWchar = (LPWSTR)buffer; // GOOD
+
+	lpWchar = (LPWSTR)buffer; // BUG
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.expected
@@ -3,3 +3,17 @@
 | WcharCharConversion.cpp:24:22:24:27 | lpChar | Conversion from char * to wchar_t *. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:26:23:26:28 | lpChar | Conversion from char * to LPCWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:27:17:27:22 | lpChar | Conversion from char * to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:64:20:64:25 | buffer | Conversion from FOO to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:80:21:80:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:82:21:82:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:85:21:85:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:87:21:87:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:90:21:90:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:92:21:92:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:96:21:96:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:98:21:98:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:101:21:101:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:103:21:103:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:106:21:106:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:108:21:108:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
+| WcharCharConversion.cpp:110:20:110:25 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-704/WcharCharConversion.expected
@@ -3,17 +3,11 @@
 | WcharCharConversion.cpp:24:22:24:27 | lpChar | Conversion from char * to wchar_t *. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:26:23:26:28 | lpChar | Conversion from char * to LPCWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:27:17:27:22 | lpChar | Conversion from char * to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:64:20:64:25 | buffer | Conversion from FOO to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:80:21:80:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:82:21:82:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:85:21:85:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:87:21:87:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:90:21:90:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:92:21:92:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:96:21:96:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:98:21:98:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:101:21:101:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:103:21:103:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:106:21:106:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
-| WcharCharConversion.cpp:108:21:108:26 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |
 | WcharCharConversion.cpp:110:20:110:25 | buffer | Conversion from LPTSTR to LPWSTR. Use of invalid string can lead to undefined behavior. |


### PR DESCRIPTION
Addressing false positives with byte arrays. There was an existing check for byte arrays, but there were cases missed. Updated and cleaned up this logic and added test cases to expose the observed false positive.

Also addressed false positives due to types based on macro definitions, and then dynamic checks are used to determine if dangerous widening is performed at runtime. Test cases added to demonstrate the style of check.