### PR TITLE
Java: Minor model tweak and comment fix.

### DIFF
--- a/java/ql/lib/ext/java.lang.model.yml
+++ b/java/ql/lib/ext/java.lang.model.yml
@@ -200,6 +200,7 @@ extensions:
       - ["java.lang", "ClassLoader", "loadClass", "(String,boolean)", "summary", "df-manual"]
       - ["java.lang", "ClassLoader", "setClassAssertionStatus", "(String,boolean)", "summary", "df-manual"]
       - ["java.lang", "ClassLoader", "setPackageAssertionStatus", "(String,boolean)", "summary", "df-manual"]
+      - ["java.lang", "Comparable", "compareTo", "", "summary", "manual"]
       - ["java.lang", "Enum", "Enum", "(String,int)", "summary", "manual"]
       - ["java.lang", "Enum", "equals", "(Object)", "summary", "manual"]
       - ["java.lang", "Enum", "hashCode", "()", "summary", "manual"]

--- a/java/ql/lib/ext/java.util.model.yml
+++ b/java/ql/lib/ext/java.util.model.yml
@@ -430,6 +430,7 @@ extensions:
       - ["java.util", "Collection", "contains", "(Object)", "summary", "manual"]
       - ["java.util", "Collection", "containsAll", "(Collection)", "summary", "manual"]
       - ["java.util", "Collection", "isEmpty", "()", "summary", "manual"]
+      - ["java.util", "Collection", "remove", "(Object)", "summary", "manual"]
       - ["java.util", "Collection", "removeIf", "(Predicate)", "summary", "manual"]
       - ["java.util", "Collection", "size", "()", "summary", "manual"]
       - ["java.util", "Collections", "emptyList", "()", "summary", "manual"]

--- a/java/ql/lib/ext/java.util.model.yml
+++ b/java/ql/lib/ext/java.util.model.yml
@@ -362,7 +362,7 @@ extensions:
       - ["java.util", "SequencedMap", True, "sequencedValues", "", "", "Argument[this].MapValue", "ReturnValue.Element", "value", "manual"]
       - ["java.util", "SequencedSet", True, "reversed", "", "", "Argument[this].Element", "ReturnValue.Element", "value", "manual"]
       - ["java.util", "Set", False, "copyOf", "(Collection)", "", "Argument[0].Element", "ReturnValue.Element", "value", "manual"]
-      - ["java.util", "Set", False, "clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
+      - ["java.util", "Set", True, "clear", "()", "", "Argument[this].WithoutElement", "Argument[this]", "value", "manual"]
       - ["java.util", "Set", False, "of", "(Object)", "", "Argument[0]", "ReturnValue.Element", "value", "manual"]
       - ["java.util", "Set", False, "of", "(Object,Object)", "", "Argument[0..1]", "ReturnValue.Element", "value", "manual"]
       - ["java.util", "Set", False, "of", "(Object,Object,Object)", "", "Argument[0..2]", "ReturnValue.Element", "value", "manual"]

--- a/java/ql/lib/ext/java.util.model.yml
+++ b/java/ql/lib/ext/java.util.model.yml
@@ -430,6 +430,7 @@ extensions:
       - ["java.util", "Collection", "contains", "(Object)", "summary", "manual"]
       - ["java.util", "Collection", "containsAll", "(Collection)", "summary", "manual"]
       - ["java.util", "Collection", "isEmpty", "()", "summary", "manual"]
+      - ["java.util", "Collection", "removeIf", "(Predicate)", "summary", "manual"]
       - ["java.util", "Collection", "size", "()", "summary", "manual"]
       - ["java.util", "Collections", "emptyList", "()", "summary", "manual"]
       - ["java.util", "Collections", "emptyMap", "()", "summary", "manual"]
@@ -451,12 +452,14 @@ extensions:
       - ["java.util", "HashMap", "size", "()", "summary", "manual"]
       - ["java.util", "HashSet", "HashSet", "(int)", "summary", "manual"]
       - ["java.util", "Iterator", "hasNext", "()", "summary", "manual"]
+      - ["java.util", "Iterator", "remove", "()", "summary", "manual"]
       - ["java.util", "List", "contains", "(Object)", "summary", "manual"]
       - ["java.util", "List", "equals", "(Object)", "summary", "manual"]
       - ["java.util", "List", "hashCode", "()", "summary", "manual"]
       - ["java.util", "List", "indexOf", "(Object)", "summary", "manual"]
       - ["java.util", "List", "isEmpty", "()", "summary", "manual"]
       - ["java.util", "List", "of", "()", "summary", "manual"]
+      - ["java.util", "List", "remove", "(Object)", "summary", "manual"]
       - ["java.util", "List", "sort", "(Comparator)", "summary", "manual"]
       - ["java.util", "List", "size", "()", "summary", "manual"]
       - ["java.util", "Locale$Builder", "addUnicodeLocaleAttribute", "(String)", "summary", "df-manual"]
@@ -535,6 +538,8 @@ extensions:
       - ["java.util", "Scanner", "locale", "()", "summary", "df-manual"]
       - ["java.util", "Set", "contains", "(Object)", "summary", "manual"]
       - ["java.util", "Set", "isEmpty", "()", "summary", "manual"]
+      - ["java.util", "Set", "remove", "(Object)", "summary", "manual"]
+      - ["java.util", "Set", "removeAll", "(Collection)", "summary", "manual"]
       - ["java.util", "Set", "size", "()", "summary", "manual"]
       - ["java.util", "TreeMap", "TreeMap", "(Comparator)", "summary", "df-manual"]
       - ["java.util", "TreeSet", "TreeSet", "(Comparator)", "summary", "df-manual"]
@@ -545,14 +550,8 @@ extensions:
       - ["java.util", "TimeZone", "getTimeZone", "(String)", "summary", "manual"]
       - ["java.util", "Vector", "size", "()", "summary", "manual"]
 
-      # The below APIs are currently being stored as neutral models since `WithoutElement` has not yet been implemented for Java.
-      # When `WithoutElement` is implemented, these should be changed to summary models of the form `Argument[this].WithoutElement -> Argument[this]`.
-      - ["java.util", "Collection", "removeIf", "(Predicate)", "summary", "manual"]
-      - ["java.util", "Iterator", "remove", "()", "summary", "manual"]
-      - ["java.util", "List", "remove", "(Object)", "summary", "manual"]
+      # The below API is currently being stored as neutral models since `WithoutElement` does not yet have a counterpart for MapValue/MapKey.
       - ["java.util", "Map", "clear", "()", "summary", "manual"]
-      - ["java.util", "Set", "remove", "(Object)", "summary", "manual"]
-      - ["java.util", "Set", "removeAll", "(Collection)", "summary", "manual"]
 
       # The below APIs have numeric flow and are currently being stored as neutral models.
       # These may be changed to summary models with kinds "value-numeric" and "taint-numeric" (or similar) in the future.

--- a/java/ql/test/library-tests/dataflow/collections/containerflow.expected
+++ b/java/ql/test/library-tests/dataflow/collections/containerflow.expected
@@ -297,7 +297,7 @@ models
 | 296 | Summary: java.util; SequencedMap; true; sequencedValues; ; ; Argument[this].MapValue; ReturnValue.Element; value; manual |
 | 297 | Summary: java.util; SequencedSet; true; reversed; ; ; Argument[this].Element; ReturnValue.Element; value; manual |
 | 298 | Summary: java.util; Set; false; copyOf; (Collection); ; Argument[0].Element; ReturnValue.Element; value; manual |
-| 299 | Summary: java.util; Set; false; clear; (); ; Argument[this].WithoutElement; Argument[this]; value; manual |
+| 299 | Summary: java.util; Set; true; clear; (); ; Argument[this].WithoutElement; Argument[this]; value; manual |
 | 300 | Summary: java.util; Set; false; of; (Object); ; Argument[0]; ReturnValue.Element; value; manual |
 | 301 | Summary: java.util; Set; false; of; (Object,Object); ; Argument[0..1]; ReturnValue.Element; value; manual |
 | 302 | Summary: java.util; Set; false; of; (Object,Object,Object); ; Argument[0..2]; ReturnValue.Element; value; manual |


### PR DESCRIPTION
The comment about `WithoutElement` in relation to the `remove` methods was wrong, so fix that. Also, a couple of very small actual tweaks in relation to that: `Set.clear` should apply to overrides, and add neutrals for `Collection.remove` and `Comparable.compareTo`.