### PR TITLE
Rust: More CFG modelling

### DIFF
--- a/rust/ql/consistency-queries/CfgConsistency.ql
+++ b/rust/ql/consistency-queries/CfgConsistency.ql
@@ -11,6 +11,7 @@ import codeql.rust.controlflow.internal.Completion
 query predicate nonPostOrderExpr(Expr e, string cls) {
   cls = e.getPrimaryQlClasses() and
   not e instanceof LetExpr and
+  not e instanceof ParenExpr and
   not e instanceof LogicalAndExpr and // todo
   not e instanceof LogicalOrExpr and
   exists(AstNode last, Completion c |

--- a/rust/ql/consistency-queries/CfgConsistency.ql
+++ b/rust/ql/consistency-queries/CfgConsistency.ql
@@ -25,3 +25,9 @@ query predicate scopeNoFirst(CfgScope scope) {
   not scope = any(Function f | not exists(f.getBody())) and
   not scope = any(ClosureExpr c | not exists(c.getBody()))
 }
+
+query predicate deadEnd(CfgImpl::Node node) {
+  Consistency::deadEnd(node) and
+  // `else` blocks in `let` statements diverge, so they are by definition dead ends
+  not node.getAstNode() = any(LetStmt let).getLetElse().getBlockExpr()
+}

--- a/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
@@ -86,7 +86,7 @@ class BooleanCompletion extends ConditionalCompletion, TBooleanCompletion {
     or
     e = any(WhileExpr c).getCondition()
     or
-    any(MatchArm arm).getGuard() = e
+    any(MatchGuard guard).getCondition() = e
     or
     exists(BinaryExpr expr |
       expr.getOperatorName() = ["&&", "||"] and

--- a/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
@@ -94,6 +94,8 @@ class BooleanCompletion extends ConditionalCompletion, TBooleanCompletion {
     )
     or
     exists(Expr parent | this.isValidForSpecific0(parent) |
+      e = parent.(ParenExpr).getExpr()
+      or
       parent =
         any(PrefixExpr expr |
           expr.getOperatorName() = "!" and

--- a/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/Completion.qll
@@ -84,6 +84,8 @@ class BooleanCompletion extends ConditionalCompletion, TBooleanCompletion {
   private predicate isValidForSpecific0(AstNode e) {
     e = any(IfExpr c).getCondition()
     or
+    e = any(WhileExpr c).getCondition()
+    or
     any(MatchArm arm).getGuard() = e
     or
     exists(BinaryExpr expr |

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -369,6 +369,8 @@ class WhileExprTree extends LoopingExprTree instanceof WhileExpr {
 
   override predicate entry(AstNode node) { this.first(node) }
 
+  override predicate propagatesAbnormal(AstNode child) { child = super.getCondition() }
+
   override predicate first(AstNode node) { first(super.getCondition(), node) }
 
   private ConditionalCompletion conditionCompletion(Completion c) {
@@ -388,13 +390,6 @@ class WhileExprTree extends LoopingExprTree instanceof WhileExpr {
     this.conditionCompletion(c).failed() and
     succ = this
   }
-
-  override predicate last(AstNode last, Completion c) {
-    super.last(last, c)
-    or
-    last(super.getCondition(), last, c) and
-    not completionIsNormal(c)
-  }
 }
 
 class ForExprTree extends LoopingExprTree instanceof ForExpr {
@@ -403,6 +398,8 @@ class ForExprTree extends LoopingExprTree instanceof ForExpr {
   override Label getLabel() { result = ForExpr.super.getLabel() }
 
   override predicate entry(AstNode n) { first(super.getPat(), n) }
+
+  override predicate propagatesAbnormal(AstNode child) { child = super.getIterable() }
 
   override predicate first(AstNode node) { first(super.getIterable(), node) }
 
@@ -420,13 +417,6 @@ class ForExprTree extends LoopingExprTree instanceof ForExpr {
     last(super.getPat(), pred, c) and
     c.(MatchCompletion).failed() and
     succ = this
-  }
-
-  override predicate last(AstNode last, Completion c) {
-    super.last(last, c)
-    or
-    last(super.getIterable(), last, c) and
-    not completionIsNormal(c)
   }
 }
 

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -193,7 +193,7 @@ class IfExprTree extends PostOrderTree instanceof IfExpr {
     child = [super.getCondition(), super.getThen(), super.getElse()]
   }
 
-  ConditionalCompletion conditionCompletion(Completion c) {
+  private ConditionalCompletion conditionCompletion(Completion c) {
     if super.getCondition() instanceof LetExpr
     then result = c.(MatchCompletion)
     else result = c.(BooleanCompletion)
@@ -345,15 +345,21 @@ class WhileExprTree extends LoopingExprTree instanceof WhileExpr {
 
   override predicate first(AstNode node) { first(super.getCondition(), node) }
 
+  private ConditionalCompletion conditionCompletion(Completion c) {
+    if super.getCondition() instanceof LetExpr
+    then result = c.(MatchCompletion)
+    else result = c.(BooleanCompletion)
+  }
+
   override predicate succ(AstNode pred, AstNode succ, Completion c) {
     super.succ(pred, succ, c)
     or
     last(super.getCondition(), pred, c) and
-    c.(BooleanCompletion).succeeded() and
+    this.conditionCompletion(c).succeeded() and
     first(this.getLoopBody(), succ)
     or
     last(super.getCondition(), pred, c) and
-    c.(BooleanCompletion).failed() and
+    this.conditionCompletion(c).failed() and
     succ = this
   }
 

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -499,8 +499,18 @@ class NameRefTree extends LeafTree, NameRef { }
 
 class OffsetOfExprTree extends LeafTree instanceof OffsetOfExpr { }
 
-class ParenExprTree extends StandardPostOrderTree, ParenExpr {
-  override AstNode getChildNode(int i) { i = 0 and result = super.getExpr() }
+class ParenExprTree extends ControlFlowTree, ParenExpr {
+  private ControlFlowTree expr;
+
+  ParenExprTree() { expr = super.getExpr() }
+
+  override predicate propagatesAbnormal(AstNode child) { expr.propagatesAbnormal(child) }
+
+  override predicate first(AstNode first) { expr.first(first) }
+
+  override predicate last(AstNode last, Completion c) { expr.last(last, c) }
+
+  override predicate succ(AstNode pred, AstNode succ, Completion c) { none() }
 }
 
 // This covers all patterns as they all extend `Pat`

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -61,6 +61,10 @@ import CfgImpl
 /** Holds if `p` is a trivial pattern that is always guaranteed to match. */
 predicate trivialPat(Pat p) { p instanceof WildcardPat or p instanceof IdentPat }
 
+class ArrayExprTree extends StandardPostOrderTree, ArrayExpr {
+  override AstNode getChildNode(int i) { result = this.getExpr(i) }
+}
+
 class AsmExprTree extends LeafTree instanceof AsmExpr { }
 
 class AwaitExprTree extends StandardPostOrderTree instanceof AwaitExpr {
@@ -392,6 +396,9 @@ class ForExprTree extends LoopingExprTree instanceof ForExpr {
   }
 }
 
+// TODO: replace with expanded macro once the extractor supports it
+class MacroExprTree extends LeafTree, MacroExpr { }
+
 class MatchArmTree extends ControlFlowTree instanceof MatchArm {
   override predicate propagatesAbnormal(AstNode child) { child = super.getExpr() }
 
@@ -452,6 +459,10 @@ class MethodCallExprTree extends StandardPostOrderTree instanceof MethodCallExpr
   }
 }
 
+class NameTree extends LeafTree, Name { }
+
+class NameRefTree extends LeafTree, NameRef { }
+
 class OffsetOfExprTree extends LeafTree instanceof OffsetOfExpr { }
 
 class ParenExprTree extends StandardPostOrderTree, ParenExpr {
@@ -460,6 +471,18 @@ class ParenExprTree extends StandardPostOrderTree, ParenExpr {
 
 // This covers all patterns as they all extend `Pat`
 class PatExprTree extends LeafTree instanceof Pat { }
+
+class PathTree extends StandardPostOrderTree, Path {
+  override AstNode getChildNode(int i) {
+    i = 0 and result = this.getQualifier()
+    or
+    i = 1 and result = this.getPart()
+  }
+}
+
+class PathSegmentTree extends StandardPostOrderTree, PathSegment {
+  override AstNode getChildNode(int i) { i = 0 and result = this.getNameRef() }
+}
 
 class PathExprTree extends LeafTree instanceof PathExpr { }
 
@@ -499,6 +522,14 @@ class ReturnExprTree extends PostOrderTree instanceof ReturnExpr {
   }
 }
 
+class StaticTree extends StandardPostOrderTree, Static {
+  override AstNode getChildNode(int i) {
+    i = 0 and result = this.getName()
+    or
+    i = 1 and result = this.getBody()
+  }
+}
+
 class TupleExprTree extends StandardPostOrderTree instanceof TupleExpr {
   override AstNode getChildNode(int i) { result = super.getField(i) }
 }
@@ -506,6 +537,10 @@ class TupleExprTree extends StandardPostOrderTree instanceof TupleExpr {
 class TypeRefTree extends LeafTree instanceof TypeRef { }
 
 class UnderscoreExprTree extends LeafTree instanceof UnderscoreExpr { }
+
+class UseTree_ extends StandardPreOrderTree, Use {
+  override AstNode getChildNode(int i) { i = 0 and result = this.getUseTree().getPath() }
+}
 
 // NOTE: `yield` is a reserved but unused keyword.
 class YieldExprTree extends StandardPostOrderTree instanceof YieldExpr {

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -230,6 +230,8 @@ class IndexExprTree extends StandardPostOrderTree instanceof IndexExpr {
   }
 }
 
+class ItemTree extends LeafTree, Item { }
+
 // `LetExpr` is a pre-order tree such that the pattern itself ends up
 // dominating successors in the graph in the same way that patterns do in
 // `match` expressions.
@@ -472,18 +474,6 @@ class ParenExprTree extends StandardPostOrderTree, ParenExpr {
 // This covers all patterns as they all extend `Pat`
 class PatExprTree extends LeafTree instanceof Pat { }
 
-class PathTree extends StandardPostOrderTree, Path {
-  override AstNode getChildNode(int i) {
-    i = 0 and result = this.getQualifier()
-    or
-    i = 1 and result = this.getPart()
-  }
-}
-
-class PathSegmentTree extends StandardPostOrderTree, PathSegment {
-  override AstNode getChildNode(int i) { i = 0 and result = this.getNameRef() }
-}
-
 class PathExprTree extends LeafTree instanceof PathExpr { }
 
 class PrefixExprTree extends StandardPostOrderTree instanceof PrefixExpr {
@@ -522,14 +512,6 @@ class ReturnExprTree extends PostOrderTree instanceof ReturnExpr {
   }
 }
 
-class StaticTree extends StandardPostOrderTree, Static {
-  override AstNode getChildNode(int i) {
-    i = 0 and result = this.getName()
-    or
-    i = 1 and result = this.getBody()
-  }
-}
-
 class TupleExprTree extends StandardPostOrderTree instanceof TupleExpr {
   override AstNode getChildNode(int i) { result = super.getField(i) }
 }
@@ -537,10 +519,6 @@ class TupleExprTree extends StandardPostOrderTree instanceof TupleExpr {
 class TypeRefTree extends LeafTree instanceof TypeRef { }
 
 class UnderscoreExprTree extends LeafTree instanceof UnderscoreExpr { }
-
-class UseTree_ extends StandardPreOrderTree, Use {
-  override AstNode getChildNode(int i) { i = 0 and result = this.getUseTree().getPath() }
-}
 
 // NOTE: `yield` is a reserved but unused keyword.
 class YieldExprTree extends StandardPostOrderTree instanceof YieldExpr {

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -316,7 +316,11 @@ abstract class LoopingExprTree extends PostOrderTree {
 
   abstract Label getLabel();
 
-  abstract predicate entry(AstNode node);
+  /**
+   * Gets the node to execute when continuing the loop; either after
+   * executing the last node in the body or after an explicit `continue`.
+   */
+  abstract AstNode getLoopContinue();
 
   /** Holds if this loop captures the `c` completion. */
   private predicate capturesLoopJumpCompletion(LoopJumpCompletion c) {
@@ -339,7 +343,7 @@ abstract class LoopingExprTree extends PostOrderTree {
       or
       c.(LoopJumpCompletion).isContinue() and this.capturesLoopJumpCompletion(c)
     ) and
-    this.entry(succ)
+    first(this.getLoopContinue(), succ)
   }
 
   override predicate last(AstNode last, Completion c) {
@@ -357,7 +361,7 @@ class LoopExprTree extends LoopingExprTree instanceof LoopExpr {
 
   override Label getLabel() { result = LoopExpr.super.getLabel() }
 
-  override predicate entry(AstNode node) { this.first(node) }
+  override AstNode getLoopContinue() { result = this.getLoopBody() }
 
   override predicate first(AstNode node) { first(this.getLoopBody(), node) }
 }
@@ -367,7 +371,7 @@ class WhileExprTree extends LoopingExprTree instanceof WhileExpr {
 
   override Label getLabel() { result = WhileExpr.super.getLabel() }
 
-  override predicate entry(AstNode node) { this.first(node) }
+  override AstNode getLoopContinue() { result = super.getCondition() }
 
   override predicate propagatesAbnormal(AstNode child) { child = super.getCondition() }
 
@@ -397,7 +401,7 @@ class ForExprTree extends LoopingExprTree instanceof ForExpr {
 
   override Label getLabel() { result = ForExpr.super.getLabel() }
 
-  override predicate entry(AstNode n) { first(super.getPat(), n) }
+  override AstNode getLoopContinue() { result = super.getPat() }
 
   override predicate propagatesAbnormal(AstNode child) { child = super.getIterable() }
 

--- a/rust/ql/test/extractor-tests/generated/Abi/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Abi/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_abi.rs:3:1:6:1 | test_abi |

--- a/rust/ql/test/extractor-tests/generated/ArgList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ArgList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_arg_list.rs:3:1:6:1 | test_arg_list |

--- a/rust/ql/test/extractor-tests/generated/ArrayExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ArrayExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_array_expr.rs:5:5:5:14 | ExprStmt |

--- a/rust/ql/test/extractor-tests/generated/ArrayType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ArrayType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_array_type.rs:3:1:6:1 | test_array_type |

--- a/rust/ql/test/extractor-tests/generated/AssocItemList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/AssocItemList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_assoc_item_list.rs:3:1:6:1 | test_assoc_item_list |

--- a/rust/ql/test/extractor-tests/generated/AssocTypeArg/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/AssocTypeArg/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_assoc_type_arg.rs:3:1:6:1 | test_assoc_type_arg |

--- a/rust/ql/test/extractor-tests/generated/Attr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Attr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_attr.rs:3:1:6:1 | test_attr |

--- a/rust/ql/test/extractor-tests/generated/ClosureBinder/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ClosureBinder/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_closure_binder.rs:3:1:6:1 | test_closure_binder |

--- a/rust/ql/test/extractor-tests/generated/Const/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Const/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_const.rs:3:1:6:1 | test_const |

--- a/rust/ql/test/extractor-tests/generated/ConstArg/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ConstArg/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_const_arg.rs:3:1:6:1 | test_const_arg |

--- a/rust/ql/test/extractor-tests/generated/ConstParam/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ConstParam/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_const_param.rs:3:1:6:1 | test_const_param |

--- a/rust/ql/test/extractor-tests/generated/DynTraitType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/DynTraitType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_dyn_trait_type.rs:3:1:6:1 | test_dyn_trait_type |

--- a/rust/ql/test/extractor-tests/generated/Enum/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Enum/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_enum.rs:3:1:6:1 | test_enum |

--- a/rust/ql/test/extractor-tests/generated/ExprStmt/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ExprStmt/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_expr_stmt.rs:6:5:6:12 | CallExpr |

--- a/rust/ql/test/extractor-tests/generated/ExternBlock/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ExternBlock/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_extern_block.rs:3:1:6:1 | test_extern_block |

--- a/rust/ql/test/extractor-tests/generated/ExternCrate/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ExternCrate/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_extern_crate.rs:3:1:6:1 | test_extern_crate |

--- a/rust/ql/test/extractor-tests/generated/ExternItemList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ExternItemList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_extern_item_list.rs:3:1:6:1 | test_extern_item_list |

--- a/rust/ql/test/extractor-tests/generated/FnPtrType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/FnPtrType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_fn_ptr_type.rs:3:1:6:1 | test_fn_ptr_type |

--- a/rust/ql/test/extractor-tests/generated/ForExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ForExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_for_expr.rs:3:1:6:1 | test_for_expr |

--- a/rust/ql/test/extractor-tests/generated/ForType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ForType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_for_type.rs:3:1:6:1 | test_for_type |

--- a/rust/ql/test/extractor-tests/generated/FormatArgsArg/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/FormatArgsArg/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_format_args_arg.rs:3:1:6:1 | test_format_args_arg |

--- a/rust/ql/test/extractor-tests/generated/FormatArgsExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/FormatArgsExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_format_args_expr.rs:3:1:6:1 | test_format_args_expr |

--- a/rust/ql/test/extractor-tests/generated/GenericParamList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/GenericParamList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_generic_param_list.rs:3:1:6:1 | test_generic_param_list |

--- a/rust/ql/test/extractor-tests/generated/IfExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/IfExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_if_expr.rs:6:9:6:38 | ExprStmt |

--- a/rust/ql/test/extractor-tests/generated/Impl/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Impl/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_impl.rs:3:1:6:1 | test_impl |

--- a/rust/ql/test/extractor-tests/generated/ImplTraitType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ImplTraitType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_impl_trait_type.rs:3:1:6:1 | test_impl_trait_type |

--- a/rust/ql/test/extractor-tests/generated/InferType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/InferType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_infer_type.rs:3:1:6:1 | test_infer_type |

--- a/rust/ql/test/extractor-tests/generated/ItemList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ItemList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_item_list.rs:3:1:6:1 | test_item_list |

--- a/rust/ql/test/extractor-tests/generated/Label/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Label/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_label.rs:6:9:6:41 | ExprStmt |

--- a/rust/ql/test/extractor-tests/generated/LetElse/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/LetElse/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_let_else.rs:3:1:6:1 | test_let_else |

--- a/rust/ql/test/extractor-tests/generated/LetExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/LetExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_let_expr.rs:6:9:6:26 | ExprStmt |

--- a/rust/ql/test/extractor-tests/generated/Lifetime/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Lifetime/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_lifetime.rs:3:1:6:1 | test_lifetime |

--- a/rust/ql/test/extractor-tests/generated/LifetimeArg/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/LifetimeArg/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_lifetime_arg.rs:3:1:6:1 | test_lifetime_arg |

--- a/rust/ql/test/extractor-tests/generated/LifetimeParam/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/LifetimeParam/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_lifetime_param.rs:3:1:6:1 | test_lifetime_param |

--- a/rust/ql/test/extractor-tests/generated/LoopExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/LoopExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_loop_expr.rs:6:9:6:42 | ExprStmt |

--- a/rust/ql/test/extractor-tests/generated/MacroCall/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroCall/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_call.rs:3:1:6:1 | test_macro_call |

--- a/rust/ql/test/extractor-tests/generated/MacroDef/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroDef/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_def.rs:3:1:6:1 | test_macro_def |

--- a/rust/ql/test/extractor-tests/generated/MacroExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_expr.rs:3:1:6:1 | test_macro_expr |

--- a/rust/ql/test/extractor-tests/generated/MacroPat/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroPat/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_pat.rs:3:1:6:1 | test_macro_pat |

--- a/rust/ql/test/extractor-tests/generated/MacroRules/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroRules/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_rules.rs:3:1:6:1 | test_macro_rules |

--- a/rust/ql/test/extractor-tests/generated/MacroType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_macro_type.rs:3:1:6:1 | test_macro_type |

--- a/rust/ql/test/extractor-tests/generated/MatchArm/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MatchArm/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_match_arm.rs:10:20:10:25 | ... != ... |

--- a/rust/ql/test/extractor-tests/generated/MatchArmList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MatchArmList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_match_arm_list.rs:3:1:6:1 | test_match_arm_list |

--- a/rust/ql/test/extractor-tests/generated/MatchExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MatchExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| gen_match_expr.rs:10:20:10:25 | ... != ... |

--- a/rust/ql/test/extractor-tests/generated/MatchGuard/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MatchGuard/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_match_guard.rs:3:1:6:1 | test_match_guard |

--- a/rust/ql/test/extractor-tests/generated/Meta/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Meta/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_meta.rs:3:1:6:1 | test_meta |

--- a/rust/ql/test/extractor-tests/generated/Name/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Name/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_name.rs:3:1:6:1 | test_name |

--- a/rust/ql/test/extractor-tests/generated/NameRef/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/NameRef/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_name_ref.rs:3:1:6:1 | test_name_ref |

--- a/rust/ql/test/extractor-tests/generated/NeverType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/NeverType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_never_type.rs:3:1:6:1 | test_never_type |

--- a/rust/ql/test/extractor-tests/generated/Param/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Param/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_param.rs:3:1:6:1 | test_param |

--- a/rust/ql/test/extractor-tests/generated/ParamList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ParamList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_param_list.rs:3:1:6:1 | test_param_list |

--- a/rust/ql/test/extractor-tests/generated/ParenExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ParenExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_paren_expr.rs:3:1:6:1 | test_paren_expr |

--- a/rust/ql/test/extractor-tests/generated/ParenPat/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ParenPat/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_paren_pat.rs:3:1:6:1 | test_paren_pat |

--- a/rust/ql/test/extractor-tests/generated/ParenType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ParenType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_paren_type.rs:3:1:6:1 | test_paren_type |

--- a/rust/ql/test/extractor-tests/generated/PathSegment/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/PathSegment/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_path_segment.rs:3:1:6:1 | test_path_segment |

--- a/rust/ql/test/extractor-tests/generated/PathType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/PathType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_path_type.rs:3:1:6:1 | test_path_type |

--- a/rust/ql/test/extractor-tests/generated/PtrType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/PtrType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_ptr_type.rs:3:1:6:1 | test_ptr_type |

--- a/rust/ql/test/extractor-tests/generated/RecordExprFieldList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RecordExprFieldList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_record_expr_field_list.rs:3:1:6:1 | test_record_expr_field_list |

--- a/rust/ql/test/extractor-tests/generated/RecordField/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RecordField/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_record_field.rs:3:1:6:1 | test_record_field |

--- a/rust/ql/test/extractor-tests/generated/RecordFieldList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RecordFieldList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_record_field_list.rs:3:1:6:1 | test_record_field_list |

--- a/rust/ql/test/extractor-tests/generated/RecordPatFieldList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RecordPatFieldList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_record_pat_field_list.rs:3:1:6:1 | test_record_pat_field_list |

--- a/rust/ql/test/extractor-tests/generated/RefType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RefType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_ref_type.rs:3:1:6:1 | test_ref_type |

--- a/rust/ql/test/extractor-tests/generated/Rename/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Rename/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_rename.rs:3:1:6:1 | test_rename |

--- a/rust/ql/test/extractor-tests/generated/RestPat/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RestPat/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_rest_pat.rs:3:1:6:1 | test_rest_pat |

--- a/rust/ql/test/extractor-tests/generated/RetType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/RetType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_ret_type.rs:3:1:6:1 | test_ret_type |

--- a/rust/ql/test/extractor-tests/generated/ReturnTypeSyntax/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/ReturnTypeSyntax/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_return_type_syntax.rs:3:1:6:1 | test_return_type_syntax |

--- a/rust/ql/test/extractor-tests/generated/SelfParam/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/SelfParam/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_self_param.rs:3:1:6:1 | test_self_param |

--- a/rust/ql/test/extractor-tests/generated/SliceType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/SliceType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_slice_type.rs:3:1:6:1 | test_slice_type |

--- a/rust/ql/test/extractor-tests/generated/SourceFile/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/SourceFile/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_source_file.rs:3:1:6:1 | test_source_file |

--- a/rust/ql/test/extractor-tests/generated/Static/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Static/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_static.rs:3:1:6:1 | test_static |

--- a/rust/ql/test/extractor-tests/generated/StmtList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/StmtList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_stmt_list.rs:3:1:6:1 | test_stmt_list |

--- a/rust/ql/test/extractor-tests/generated/Struct/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Struct/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_struct.rs:3:1:6:1 | test_struct |

--- a/rust/ql/test/extractor-tests/generated/TokenTree/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TokenTree/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_token_tree.rs:3:1:6:1 | test_token_tree |

--- a/rust/ql/test/extractor-tests/generated/Trait/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Trait/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_trait.rs:3:1:6:1 | test_trait |

--- a/rust/ql/test/extractor-tests/generated/TraitAlias/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TraitAlias/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_trait_alias.rs:3:1:6:1 | test_trait_alias |

--- a/rust/ql/test/extractor-tests/generated/TryExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TryExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_try_expr.rs:3:1:6:1 | test_try_expr |

--- a/rust/ql/test/extractor-tests/generated/TupleField/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TupleField/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_tuple_field.rs:3:1:6:1 | test_tuple_field |

--- a/rust/ql/test/extractor-tests/generated/TupleFieldList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TupleFieldList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_tuple_field_list.rs:3:1:6:1 | test_tuple_field_list |

--- a/rust/ql/test/extractor-tests/generated/TupleType/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TupleType/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_tuple_type.rs:3:1:6:1 | test_tuple_type |

--- a/rust/ql/test/extractor-tests/generated/TypeAlias/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TypeAlias/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_type_alias.rs:3:1:6:1 | test_type_alias |

--- a/rust/ql/test/extractor-tests/generated/TypeArg/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TypeArg/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_type_arg.rs:3:1:6:1 | test_type_arg |

--- a/rust/ql/test/extractor-tests/generated/TypeBound/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TypeBound/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_type_bound.rs:3:1:6:1 | test_type_bound |

--- a/rust/ql/test/extractor-tests/generated/TypeBoundList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TypeBoundList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_type_bound_list.rs:3:1:6:1 | test_type_bound_list |

--- a/rust/ql/test/extractor-tests/generated/TypeParam/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/TypeParam/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_type_param.rs:3:1:6:1 | test_type_param |

--- a/rust/ql/test/extractor-tests/generated/Union/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Union/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_union.rs:3:1:6:1 | test_union |

--- a/rust/ql/test/extractor-tests/generated/Use/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Use/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_use.rs:3:1:6:1 | test_use |

--- a/rust/ql/test/extractor-tests/generated/UseTree/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/UseTree/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_use_tree.rs:3:1:6:1 | test_use_tree |

--- a/rust/ql/test/extractor-tests/generated/UseTreeList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/UseTreeList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_use_tree_list.rs:3:1:6:1 | test_use_tree_list |

--- a/rust/ql/test/extractor-tests/generated/Variant/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Variant/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_variant.rs:3:1:6:1 | test_variant |

--- a/rust/ql/test/extractor-tests/generated/VariantList/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/VariantList/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_variant_list.rs:3:1:6:1 | test_variant_list |

--- a/rust/ql/test/extractor-tests/generated/Visibility/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/Visibility/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_visibility.rs:3:1:6:1 | test_visibility |

--- a/rust/ql/test/extractor-tests/generated/WhereClause/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/WhereClause/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_where_clause.rs:3:1:6:1 | test_where_clause |

--- a/rust/ql/test/extractor-tests/generated/WherePred/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/WherePred/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_where_pred.rs:3:1:6:1 | test_where_pred |

--- a/rust/ql/test/extractor-tests/generated/WhileExpr/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/WhileExpr/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-scopeNoFirst
-| gen_while_expr.rs:3:1:6:1 | test_while_expr |

--- a/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
@@ -1,6 +1,6 @@
 deadEnd
 | test.rs:55:13:55:17 | b |
-| test.rs:224:28:224:33 | ... < ... |
-| test.rs:239:30:239:48 | BlockExpr |
+| test.rs:230:28:230:33 | ... < ... |
+| test.rs:245:30:245:48 | BlockExpr |
 scopeNoFirst
-| test.rs:62:5:66:5 | test_for |
+| test.rs:65:5:72:5 | test_for |

--- a/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
@@ -1,3 +1,2 @@
 deadEnd
-| test.rs:230:28:230:33 | ... < ... |
 | test.rs:245:30:245:48 | BlockExpr |

--- a/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
@@ -1,5 +1,4 @@
 deadEnd
-| test.rs:55:13:55:17 | b |
 | test.rs:230:28:230:33 | ... < ... |
 | test.rs:245:30:245:48 | BlockExpr |
 scopeNoFirst

--- a/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
@@ -1,2 +1,0 @@
-deadEnd
-| test.rs:245:30:245:48 | BlockExpr |

--- a/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/controlflow/CONSISTENCY/CfgConsistency.expected
@@ -1,5 +1,3 @@
 deadEnd
 | test.rs:230:28:230:33 | ... < ... |
 | test.rs:245:30:245:48 | BlockExpr |
-scopeNoFirst
-| test.rs:65:5:72:5 | test_for |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -428,7 +428,12 @@
 | test.rs:230:9:230:23 | TupleStructPat | test.rs:230:28:230:28 | x | match |
 | test.rs:230:9:230:23 | TupleStructPat | test.rs:231:9:231:23 | TupleStructPat | no-match |
 | test.rs:230:28:230:28 | x | test.rs:230:32:230:33 | 10 |  |
+| test.rs:230:28:230:33 | ... < ... | test.rs:230:38:230:38 | x | true |
+| test.rs:230:28:230:33 | ... < ... | test.rs:231:9:231:23 | TupleStructPat | false |
 | test.rs:230:32:230:33 | 10 | test.rs:230:28:230:33 | ... < ... |  |
+| test.rs:230:38:230:38 | x | test.rs:230:42:230:42 | 5 |  |
+| test.rs:230:38:230:42 | ... + ... | test.rs:229:5:233:5 | MatchExpr |  |
+| test.rs:230:42:230:42 | 5 | test.rs:230:38:230:42 | ... + ... |  |
 | test.rs:231:9:231:23 | TupleStructPat | test.rs:231:28:231:28 | x | match |
 | test.rs:231:9:231:23 | TupleStructPat | test.rs:232:9:232:20 | PathPat | no-match |
 | test.rs:231:28:231:28 | x | test.rs:229:5:233:5 | MatchExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -122,373 +122,397 @@
 | test.rs:61:13:61:21 | ... = ... | test.rs:56:17:62:9 | BlockExpr |  |
 | test.rs:61:13:61:22 | ExprStmt | test.rs:61:13:61:13 | PathExpr |  |
 | test.rs:61:17:61:21 | false | test.rs:61:13:61:21 | ... = ... |  |
-| test.rs:65:5:72:5 | enter test_for | test.rs:66:18:66:18 | 0 |  |
-| test.rs:65:5:72:5 | exit test_for (normal) | test.rs:65:5:72:5 | exit test_for |  |
-| test.rs:65:25:72:5 | BlockExpr | test.rs:65:5:72:5 | exit test_for (normal) |  |
-| test.rs:66:9:71:9 | ForExpr | test.rs:65:25:72:5 | BlockExpr |  |
-| test.rs:66:13:66:13 | i | test.rs:66:9:71:9 | ForExpr | no-match |
-| test.rs:66:13:66:13 | i | test.rs:67:13:69:13 | ExprStmt | match |
-| test.rs:66:18:66:18 | 0 | test.rs:66:21:66:22 | 10 |  |
-| test.rs:66:18:66:22 | RangeExpr | test.rs:66:13:66:13 | i |  |
-| test.rs:66:21:66:22 | 10 | test.rs:66:18:66:22 | RangeExpr |  |
-| test.rs:66:24:71:9 | BlockExpr | test.rs:66:13:66:13 | i |  |
-| test.rs:67:13:69:13 | ExprStmt | test.rs:67:17:67:17 | i |  |
-| test.rs:67:13:69:13 | IfExpr | test.rs:70:13:70:14 | ExprStmt |  |
-| test.rs:67:16:67:23 | ParenExpr | test.rs:67:13:69:13 | IfExpr | false |
-| test.rs:67:16:67:23 | ParenExpr | test.rs:68:17:68:22 | ExprStmt | true |
-| test.rs:67:17:67:17 | i | test.rs:67:22:67:22 | j |  |
-| test.rs:67:17:67:22 | ... == ... | test.rs:67:16:67:23 | ParenExpr |  |
-| test.rs:67:22:67:22 | j | test.rs:67:17:67:22 | ... == ... |  |
-| test.rs:68:17:68:21 | BreakExpr | test.rs:66:9:71:9 | ForExpr | break |
-| test.rs:68:17:68:22 | ExprStmt | test.rs:68:17:68:21 | BreakExpr |  |
-| test.rs:70:13:70:13 | 1 | test.rs:66:24:71:9 | BlockExpr |  |
-| test.rs:70:13:70:14 | ExprStmt | test.rs:70:13:70:13 | 1 |  |
-| test.rs:75:1:78:1 | enter test_nested_function | test.rs:76:5:76:28 | LetStmt |  |
-| test.rs:75:1:78:1 | exit test_nested_function (normal) | test.rs:75:1:78:1 | exit test_nested_function |  |
-| test.rs:75:40:78:1 | BlockExpr | test.rs:75:1:78:1 | exit test_nested_function (normal) |  |
-| test.rs:76:5:76:28 | LetStmt | test.rs:76:19:76:27 | ClosureExpr |  |
-| test.rs:76:9:76:15 | add_one | test.rs:77:5:77:11 | add_one | match, no-match |
-| test.rs:76:19:76:27 | ClosureExpr | test.rs:76:9:76:15 | add_one |  |
-| test.rs:76:19:76:27 | enter ClosureExpr | test.rs:76:23:76:23 | i |  |
-| test.rs:76:19:76:27 | exit ClosureExpr (normal) | test.rs:76:19:76:27 | exit ClosureExpr |  |
-| test.rs:76:23:76:23 | i | test.rs:76:27:76:27 | 1 |  |
-| test.rs:76:23:76:27 | ... + ... | test.rs:76:19:76:27 | exit ClosureExpr (normal) |  |
-| test.rs:76:27:76:27 | 1 | test.rs:76:23:76:27 | ... + ... |  |
-| test.rs:77:5:77:11 | add_one | test.rs:77:13:77:19 | add_one |  |
-| test.rs:77:5:77:23 | CallExpr | test.rs:75:40:78:1 | BlockExpr |  |
-| test.rs:77:13:77:19 | add_one | test.rs:77:21:77:21 | n |  |
-| test.rs:77:13:77:22 | CallExpr | test.rs:77:5:77:23 | CallExpr |  |
-| test.rs:77:21:77:21 | n | test.rs:77:13:77:22 | CallExpr |  |
-| test.rs:82:5:88:5 | enter test_if_else | test.rs:83:12:83:12 | n |  |
-| test.rs:82:5:88:5 | exit test_if_else (normal) | test.rs:82:5:88:5 | exit test_if_else |  |
-| test.rs:82:36:88:5 | BlockExpr | test.rs:82:5:88:5 | exit test_if_else (normal) |  |
-| test.rs:83:9:87:9 | IfExpr | test.rs:82:36:88:5 | BlockExpr |  |
-| test.rs:83:12:83:12 | n | test.rs:83:17:83:17 | 0 |  |
-| test.rs:83:12:83:17 | ... <= ... | test.rs:84:13:84:13 | 0 | true |
-| test.rs:83:12:83:17 | ... <= ... | test.rs:86:13:86:13 | n | false |
-| test.rs:83:17:83:17 | 0 | test.rs:83:12:83:17 | ... <= ... |  |
-| test.rs:83:19:85:9 | BlockExpr | test.rs:83:9:87:9 | IfExpr |  |
-| test.rs:84:13:84:13 | 0 | test.rs:83:19:85:9 | BlockExpr |  |
-| test.rs:85:16:87:9 | BlockExpr | test.rs:83:9:87:9 | IfExpr |  |
-| test.rs:86:13:86:13 | n | test.rs:86:17:86:17 | 1 |  |
-| test.rs:86:13:86:17 | ... - ... | test.rs:85:16:87:9 | BlockExpr |  |
-| test.rs:86:17:86:17 | 1 | test.rs:86:13:86:17 | ... - ... |  |
-| test.rs:90:5:96:5 | enter test_if_let_else | test.rs:91:12:91:26 | LetExpr |  |
-| test.rs:90:5:96:5 | exit test_if_let_else (normal) | test.rs:90:5:96:5 | exit test_if_let_else |  |
-| test.rs:90:48:96:5 | BlockExpr | test.rs:90:5:96:5 | exit test_if_let_else (normal) |  |
-| test.rs:91:9:95:9 | IfExpr | test.rs:90:48:96:5 | BlockExpr |  |
-| test.rs:91:12:91:26 | LetExpr | test.rs:91:16:91:22 | TupleStructPat |  |
-| test.rs:91:16:91:22 | TupleStructPat | test.rs:92:13:92:13 | n | match |
-| test.rs:91:16:91:22 | TupleStructPat | test.rs:94:13:94:13 | 0 | no-match |
-| test.rs:91:28:93:9 | BlockExpr | test.rs:91:9:95:9 | IfExpr |  |
-| test.rs:92:13:92:13 | n | test.rs:91:28:93:9 | BlockExpr |  |
-| test.rs:93:16:95:9 | BlockExpr | test.rs:91:9:95:9 | IfExpr |  |
-| test.rs:94:13:94:13 | 0 | test.rs:93:16:95:9 | BlockExpr |  |
-| test.rs:98:5:103:5 | enter test_if_let | test.rs:99:9:101:9 | ExprStmt |  |
-| test.rs:98:5:103:5 | exit test_if_let (normal) | test.rs:98:5:103:5 | exit test_if_let |  |
-| test.rs:98:43:103:5 | BlockExpr | test.rs:98:5:103:5 | exit test_if_let (normal) |  |
-| test.rs:99:9:101:9 | ExprStmt | test.rs:99:12:99:26 | LetExpr |  |
-| test.rs:99:9:101:9 | IfExpr | test.rs:102:9:102:9 | 0 |  |
-| test.rs:99:12:99:26 | LetExpr | test.rs:99:16:99:22 | TupleStructPat |  |
-| test.rs:99:16:99:22 | TupleStructPat | test.rs:99:9:101:9 | IfExpr | no-match |
-| test.rs:99:16:99:22 | TupleStructPat | test.rs:100:13:100:13 | n | match |
-| test.rs:99:28:101:9 | BlockExpr | test.rs:99:9:101:9 | IfExpr |  |
-| test.rs:100:13:100:13 | n | test.rs:99:28:101:9 | BlockExpr |  |
-| test.rs:102:9:102:9 | 0 | test.rs:98:43:103:5 | BlockExpr |  |
-| test.rs:105:5:111:5 | enter test_nested_if | test.rs:106:16:106:16 | PathExpr |  |
-| test.rs:105:5:111:5 | exit test_nested_if (normal) | test.rs:105:5:111:5 | exit test_nested_if |  |
-| test.rs:105:38:111:5 | BlockExpr | test.rs:105:5:111:5 | exit test_nested_if (normal) |  |
-| test.rs:106:9:110:9 | IfExpr | test.rs:105:38:111:5 | BlockExpr |  |
-| test.rs:106:12:106:49 | ParenExpr | test.rs:107:13:107:13 | 1 | true |
-| test.rs:106:12:106:49 | ParenExpr | test.rs:109:13:109:13 | 0 | false |
-| test.rs:106:13:106:48 | IfExpr | test.rs:106:12:106:49 | ParenExpr |  |
-| test.rs:106:16:106:16 | PathExpr | test.rs:106:20:106:20 | 0 |  |
-| test.rs:106:16:106:20 | ... < ... | test.rs:106:24:106:24 | a | true |
-| test.rs:106:16:106:20 | ... < ... | test.rs:106:41:106:41 | a | false |
-| test.rs:106:20:106:20 | 0 | test.rs:106:16:106:20 | ... < ... |  |
-| test.rs:106:22:106:32 | BlockExpr | test.rs:106:13:106:48 | IfExpr |  |
-| test.rs:106:24:106:24 | a | test.rs:106:29:106:30 | 10 |  |
-| test.rs:106:24:106:30 | ... < ... | test.rs:106:22:106:32 | BlockExpr |  |
-| test.rs:106:28:106:30 | - ... | test.rs:106:24:106:30 | ... < ... |  |
-| test.rs:106:29:106:30 | 10 | test.rs:106:28:106:30 | - ... |  |
-| test.rs:106:39:106:48 | BlockExpr | test.rs:106:13:106:48 | IfExpr |  |
-| test.rs:106:41:106:41 | a | test.rs:106:45:106:46 | 10 |  |
-| test.rs:106:41:106:46 | ... > ... | test.rs:106:39:106:48 | BlockExpr |  |
-| test.rs:106:45:106:46 | 10 | test.rs:106:41:106:46 | ... > ... |  |
-| test.rs:106:51:108:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
-| test.rs:107:13:107:13 | 1 | test.rs:106:51:108:9 | BlockExpr |  |
-| test.rs:108:16:110:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
-| test.rs:109:13:109:13 | 0 | test.rs:108:16:110:9 | BlockExpr |  |
-| test.rs:113:5:122:5 | enter test_nested_if_match | test.rs:114:19:114:19 | a |  |
-| test.rs:113:5:122:5 | exit test_nested_if_match (normal) | test.rs:113:5:122:5 | exit test_nested_if_match |  |
-| test.rs:113:44:122:5 | BlockExpr | test.rs:113:5:122:5 | exit test_nested_if_match (normal) |  |
-| test.rs:114:9:121:9 | IfExpr | test.rs:113:44:122:5 | BlockExpr |  |
-| test.rs:114:12:117:10 | ParenExpr | test.rs:118:13:118:13 | 1 | true |
-| test.rs:114:12:117:10 | ParenExpr | test.rs:120:13:120:13 | 0 | false |
-| test.rs:114:13:117:9 | MatchExpr | test.rs:114:12:117:10 | ParenExpr |  |
-| test.rs:114:19:114:19 | a | test.rs:115:13:115:13 | LiteralPat |  |
-| test.rs:115:13:115:13 | LiteralPat | test.rs:115:18:115:21 | true | match |
-| test.rs:115:13:115:13 | LiteralPat | test.rs:116:13:116:13 | WildcardPat | no-match |
-| test.rs:115:18:115:21 | true | test.rs:114:13:117:9 | MatchExpr |  |
-| test.rs:116:13:116:13 | WildcardPat | test.rs:116:18:116:22 | false | match |
-| test.rs:116:18:116:22 | false | test.rs:114:13:117:9 | MatchExpr |  |
-| test.rs:117:12:119:9 | BlockExpr | test.rs:114:9:121:9 | IfExpr |  |
-| test.rs:118:13:118:13 | 1 | test.rs:117:12:119:9 | BlockExpr |  |
-| test.rs:119:16:121:9 | BlockExpr | test.rs:114:9:121:9 | IfExpr |  |
-| test.rs:120:13:120:13 | 0 | test.rs:119:16:121:9 | BlockExpr |  |
-| test.rs:124:5:133:5 | enter test_nested_if_block | test.rs:126:13:126:15 | ExprStmt |  |
-| test.rs:124:5:133:5 | exit test_nested_if_block (normal) | test.rs:124:5:133:5 | exit test_nested_if_block |  |
-| test.rs:124:44:133:5 | BlockExpr | test.rs:124:5:133:5 | exit test_nested_if_block (normal) |  |
-| test.rs:125:9:132:9 | IfExpr | test.rs:124:44:133:5 | BlockExpr |  |
-| test.rs:125:12:128:9 | BlockExpr | test.rs:129:13:129:13 | 1 | true |
-| test.rs:125:12:128:9 | BlockExpr | test.rs:131:13:131:13 | 0 | false |
-| test.rs:126:13:126:14 | TupleExpr | test.rs:127:13:127:13 | a |  |
-| test.rs:126:13:126:15 | ExprStmt | test.rs:126:13:126:14 | TupleExpr |  |
-| test.rs:127:13:127:13 | a | test.rs:127:17:127:17 | 0 |  |
-| test.rs:127:13:127:17 | ... > ... | test.rs:125:12:128:9 | BlockExpr | false, true |
-| test.rs:127:17:127:17 | 0 | test.rs:127:13:127:17 | ... > ... |  |
-| test.rs:128:11:130:9 | BlockExpr | test.rs:125:9:132:9 | IfExpr |  |
-| test.rs:129:13:129:13 | 1 | test.rs:128:11:130:9 | BlockExpr |  |
-| test.rs:130:16:132:9 | BlockExpr | test.rs:125:9:132:9 | IfExpr |  |
-| test.rs:131:13:131:13 | 0 | test.rs:130:16:132:9 | BlockExpr |  |
-| test.rs:135:5:142:5 | enter test_if_assignment | test.rs:136:9:136:26 | LetStmt |  |
-| test.rs:135:5:142:5 | exit test_if_assignment (normal) | test.rs:135:5:142:5 | exit test_if_assignment |  |
-| test.rs:135:42:142:5 | BlockExpr | test.rs:135:5:142:5 | exit test_if_assignment (normal) |  |
-| test.rs:136:9:136:26 | LetStmt | test.rs:136:21:136:25 | false |  |
-| test.rs:136:13:136:17 | x | test.rs:137:12:137:12 | x | match, no-match |
-| test.rs:136:21:136:25 | false | test.rs:136:13:136:17 | x |  |
-| test.rs:137:9:141:9 | IfExpr | test.rs:135:42:142:5 | BlockExpr |  |
-| test.rs:137:12:137:12 | x | test.rs:137:16:137:19 | true |  |
-| test.rs:137:12:137:19 | ... = ... | test.rs:138:13:138:13 | 1 | true |
-| test.rs:137:12:137:19 | ... = ... | test.rs:140:13:140:13 | 0 | false |
-| test.rs:137:16:137:19 | true | test.rs:137:12:137:19 | ... = ... |  |
-| test.rs:137:21:139:9 | BlockExpr | test.rs:137:9:141:9 | IfExpr |  |
-| test.rs:138:13:138:13 | 1 | test.rs:137:21:139:9 | BlockExpr |  |
-| test.rs:139:16:141:9 | BlockExpr | test.rs:137:9:141:9 | IfExpr |  |
+| test.rs:65:5:72:5 | enter test_while_let | test.rs:66:9:66:29 | LetStmt |  |
+| test.rs:66:9:66:29 | LetStmt | test.rs:66:24:66:24 | 1 |  |
+| test.rs:66:13:66:20 | iter | test.rs:67:15:67:39 | LetExpr | match, no-match |
+| test.rs:66:24:66:24 | 1 | test.rs:66:27:66:28 | 10 |  |
+| test.rs:66:24:66:28 | RangeExpr | test.rs:66:13:66:20 | iter |  |
+| test.rs:66:27:66:28 | 10 | test.rs:66:24:66:28 | RangeExpr |  |
+| test.rs:67:15:67:39 | LetExpr | test.rs:67:19:67:25 | TupleStructPat |  |
+| test.rs:74:5:81:5 | enter test_for | test.rs:75:18:75:18 | 0 |  |
+| test.rs:74:5:81:5 | exit test_for (normal) | test.rs:74:5:81:5 | exit test_for |  |
+| test.rs:74:25:81:5 | BlockExpr | test.rs:74:5:81:5 | exit test_for (normal) |  |
+| test.rs:75:9:80:9 | ForExpr | test.rs:74:25:81:5 | BlockExpr |  |
+| test.rs:75:13:75:13 | i | test.rs:75:9:80:9 | ForExpr | no-match |
+| test.rs:75:13:75:13 | i | test.rs:76:13:78:13 | ExprStmt | match |
+| test.rs:75:18:75:18 | 0 | test.rs:75:21:75:22 | 10 |  |
+| test.rs:75:18:75:22 | RangeExpr | test.rs:75:13:75:13 | i |  |
+| test.rs:75:21:75:22 | 10 | test.rs:75:18:75:22 | RangeExpr |  |
+| test.rs:75:24:80:9 | BlockExpr | test.rs:75:13:75:13 | i |  |
+| test.rs:76:13:78:13 | ExprStmt | test.rs:76:17:76:17 | i |  |
+| test.rs:76:13:78:13 | IfExpr | test.rs:79:13:79:14 | ExprStmt |  |
+| test.rs:76:16:76:23 | ParenExpr | test.rs:76:13:78:13 | IfExpr | false |
+| test.rs:76:16:76:23 | ParenExpr | test.rs:77:17:77:22 | ExprStmt | true |
+| test.rs:76:17:76:17 | i | test.rs:76:22:76:22 | j |  |
+| test.rs:76:17:76:22 | ... == ... | test.rs:76:16:76:23 | ParenExpr |  |
+| test.rs:76:22:76:22 | j | test.rs:76:17:76:22 | ... == ... |  |
+| test.rs:77:17:77:21 | BreakExpr | test.rs:75:9:80:9 | ForExpr | break |
+| test.rs:77:17:77:22 | ExprStmt | test.rs:77:17:77:21 | BreakExpr |  |
+| test.rs:79:13:79:13 | 1 | test.rs:75:24:80:9 | BlockExpr |  |
+| test.rs:79:13:79:14 | ExprStmt | test.rs:79:13:79:13 | 1 |  |
+| test.rs:84:1:87:1 | enter test_nested_function | test.rs:85:5:85:28 | LetStmt |  |
+| test.rs:84:1:87:1 | exit test_nested_function (normal) | test.rs:84:1:87:1 | exit test_nested_function |  |
+| test.rs:84:40:87:1 | BlockExpr | test.rs:84:1:87:1 | exit test_nested_function (normal) |  |
+| test.rs:85:5:85:28 | LetStmt | test.rs:85:19:85:27 | ClosureExpr |  |
+| test.rs:85:9:85:15 | add_one | test.rs:86:5:86:11 | add_one | match, no-match |
+| test.rs:85:19:85:27 | ClosureExpr | test.rs:85:9:85:15 | add_one |  |
+| test.rs:85:19:85:27 | enter ClosureExpr | test.rs:85:23:85:23 | i |  |
+| test.rs:85:19:85:27 | exit ClosureExpr (normal) | test.rs:85:19:85:27 | exit ClosureExpr |  |
+| test.rs:85:23:85:23 | i | test.rs:85:27:85:27 | 1 |  |
+| test.rs:85:23:85:27 | ... + ... | test.rs:85:19:85:27 | exit ClosureExpr (normal) |  |
+| test.rs:85:27:85:27 | 1 | test.rs:85:23:85:27 | ... + ... |  |
+| test.rs:86:5:86:11 | add_one | test.rs:86:13:86:19 | add_one |  |
+| test.rs:86:5:86:23 | CallExpr | test.rs:84:40:87:1 | BlockExpr |  |
+| test.rs:86:13:86:19 | add_one | test.rs:86:21:86:21 | n |  |
+| test.rs:86:13:86:22 | CallExpr | test.rs:86:5:86:23 | CallExpr |  |
+| test.rs:86:21:86:21 | n | test.rs:86:13:86:22 | CallExpr |  |
+| test.rs:91:5:97:5 | enter test_if_else | test.rs:92:12:92:12 | n |  |
+| test.rs:91:5:97:5 | exit test_if_else (normal) | test.rs:91:5:97:5 | exit test_if_else |  |
+| test.rs:91:36:97:5 | BlockExpr | test.rs:91:5:97:5 | exit test_if_else (normal) |  |
+| test.rs:92:9:96:9 | IfExpr | test.rs:91:36:97:5 | BlockExpr |  |
+| test.rs:92:12:92:12 | n | test.rs:92:17:92:17 | 0 |  |
+| test.rs:92:12:92:17 | ... <= ... | test.rs:93:13:93:13 | 0 | true |
+| test.rs:92:12:92:17 | ... <= ... | test.rs:95:13:95:13 | n | false |
+| test.rs:92:17:92:17 | 0 | test.rs:92:12:92:17 | ... <= ... |  |
+| test.rs:92:19:94:9 | BlockExpr | test.rs:92:9:96:9 | IfExpr |  |
+| test.rs:93:13:93:13 | 0 | test.rs:92:19:94:9 | BlockExpr |  |
+| test.rs:94:16:96:9 | BlockExpr | test.rs:92:9:96:9 | IfExpr |  |
+| test.rs:95:13:95:13 | n | test.rs:95:17:95:17 | 1 |  |
+| test.rs:95:13:95:17 | ... - ... | test.rs:94:16:96:9 | BlockExpr |  |
+| test.rs:95:17:95:17 | 1 | test.rs:95:13:95:17 | ... - ... |  |
+| test.rs:99:5:105:5 | enter test_if_let_else | test.rs:100:12:100:26 | LetExpr |  |
+| test.rs:99:5:105:5 | exit test_if_let_else (normal) | test.rs:99:5:105:5 | exit test_if_let_else |  |
+| test.rs:99:48:105:5 | BlockExpr | test.rs:99:5:105:5 | exit test_if_let_else (normal) |  |
+| test.rs:100:9:104:9 | IfExpr | test.rs:99:48:105:5 | BlockExpr |  |
+| test.rs:100:12:100:26 | LetExpr | test.rs:100:16:100:22 | TupleStructPat |  |
+| test.rs:100:16:100:22 | TupleStructPat | test.rs:101:13:101:13 | n | match |
+| test.rs:100:16:100:22 | TupleStructPat | test.rs:103:13:103:13 | 0 | no-match |
+| test.rs:100:28:102:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
+| test.rs:101:13:101:13 | n | test.rs:100:28:102:9 | BlockExpr |  |
+| test.rs:102:16:104:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
+| test.rs:103:13:103:13 | 0 | test.rs:102:16:104:9 | BlockExpr |  |
+| test.rs:107:5:112:5 | enter test_if_let | test.rs:108:9:110:9 | ExprStmt |  |
+| test.rs:107:5:112:5 | exit test_if_let (normal) | test.rs:107:5:112:5 | exit test_if_let |  |
+| test.rs:107:43:112:5 | BlockExpr | test.rs:107:5:112:5 | exit test_if_let (normal) |  |
+| test.rs:108:9:110:9 | ExprStmt | test.rs:108:12:108:26 | LetExpr |  |
+| test.rs:108:9:110:9 | IfExpr | test.rs:111:9:111:9 | 0 |  |
+| test.rs:108:12:108:26 | LetExpr | test.rs:108:16:108:22 | TupleStructPat |  |
+| test.rs:108:16:108:22 | TupleStructPat | test.rs:108:9:110:9 | IfExpr | no-match |
+| test.rs:108:16:108:22 | TupleStructPat | test.rs:109:13:109:13 | n | match |
+| test.rs:108:28:110:9 | BlockExpr | test.rs:108:9:110:9 | IfExpr |  |
+| test.rs:109:13:109:13 | n | test.rs:108:28:110:9 | BlockExpr |  |
+| test.rs:111:9:111:9 | 0 | test.rs:107:43:112:5 | BlockExpr |  |
+| test.rs:114:5:120:5 | enter test_nested_if | test.rs:115:16:115:16 | PathExpr |  |
+| test.rs:114:5:120:5 | exit test_nested_if (normal) | test.rs:114:5:120:5 | exit test_nested_if |  |
+| test.rs:114:38:120:5 | BlockExpr | test.rs:114:5:120:5 | exit test_nested_if (normal) |  |
+| test.rs:115:9:119:9 | IfExpr | test.rs:114:38:120:5 | BlockExpr |  |
+| test.rs:115:12:115:49 | ParenExpr | test.rs:116:13:116:13 | 1 | true |
+| test.rs:115:12:115:49 | ParenExpr | test.rs:118:13:118:13 | 0 | false |
+| test.rs:115:13:115:48 | IfExpr | test.rs:115:12:115:49 | ParenExpr |  |
+| test.rs:115:16:115:16 | PathExpr | test.rs:115:20:115:20 | 0 |  |
+| test.rs:115:16:115:20 | ... < ... | test.rs:115:24:115:24 | a | true |
+| test.rs:115:16:115:20 | ... < ... | test.rs:115:41:115:41 | a | false |
+| test.rs:115:20:115:20 | 0 | test.rs:115:16:115:20 | ... < ... |  |
+| test.rs:115:22:115:32 | BlockExpr | test.rs:115:13:115:48 | IfExpr |  |
+| test.rs:115:24:115:24 | a | test.rs:115:29:115:30 | 10 |  |
+| test.rs:115:24:115:30 | ... < ... | test.rs:115:22:115:32 | BlockExpr |  |
+| test.rs:115:28:115:30 | - ... | test.rs:115:24:115:30 | ... < ... |  |
+| test.rs:115:29:115:30 | 10 | test.rs:115:28:115:30 | - ... |  |
+| test.rs:115:39:115:48 | BlockExpr | test.rs:115:13:115:48 | IfExpr |  |
+| test.rs:115:41:115:41 | a | test.rs:115:45:115:46 | 10 |  |
+| test.rs:115:41:115:46 | ... > ... | test.rs:115:39:115:48 | BlockExpr |  |
+| test.rs:115:45:115:46 | 10 | test.rs:115:41:115:46 | ... > ... |  |
+| test.rs:115:51:117:9 | BlockExpr | test.rs:115:9:119:9 | IfExpr |  |
+| test.rs:116:13:116:13 | 1 | test.rs:115:51:117:9 | BlockExpr |  |
+| test.rs:117:16:119:9 | BlockExpr | test.rs:115:9:119:9 | IfExpr |  |
+| test.rs:118:13:118:13 | 0 | test.rs:117:16:119:9 | BlockExpr |  |
+| test.rs:122:5:131:5 | enter test_nested_if_match | test.rs:123:19:123:19 | a |  |
+| test.rs:122:5:131:5 | exit test_nested_if_match (normal) | test.rs:122:5:131:5 | exit test_nested_if_match |  |
+| test.rs:122:44:131:5 | BlockExpr | test.rs:122:5:131:5 | exit test_nested_if_match (normal) |  |
+| test.rs:123:9:130:9 | IfExpr | test.rs:122:44:131:5 | BlockExpr |  |
+| test.rs:123:12:126:10 | ParenExpr | test.rs:127:13:127:13 | 1 | true |
+| test.rs:123:12:126:10 | ParenExpr | test.rs:129:13:129:13 | 0 | false |
+| test.rs:123:13:126:9 | MatchExpr | test.rs:123:12:126:10 | ParenExpr |  |
+| test.rs:123:19:123:19 | a | test.rs:124:13:124:13 | LiteralPat |  |
+| test.rs:124:13:124:13 | LiteralPat | test.rs:124:18:124:21 | true | match |
+| test.rs:124:13:124:13 | LiteralPat | test.rs:125:13:125:13 | WildcardPat | no-match |
+| test.rs:124:18:124:21 | true | test.rs:123:13:126:9 | MatchExpr |  |
+| test.rs:125:13:125:13 | WildcardPat | test.rs:125:18:125:22 | false | match |
+| test.rs:125:18:125:22 | false | test.rs:123:13:126:9 | MatchExpr |  |
+| test.rs:126:12:128:9 | BlockExpr | test.rs:123:9:130:9 | IfExpr |  |
+| test.rs:127:13:127:13 | 1 | test.rs:126:12:128:9 | BlockExpr |  |
+| test.rs:128:16:130:9 | BlockExpr | test.rs:123:9:130:9 | IfExpr |  |
+| test.rs:129:13:129:13 | 0 | test.rs:128:16:130:9 | BlockExpr |  |
+| test.rs:133:5:142:5 | enter test_nested_if_block | test.rs:135:13:135:15 | ExprStmt |  |
+| test.rs:133:5:142:5 | exit test_nested_if_block (normal) | test.rs:133:5:142:5 | exit test_nested_if_block |  |
+| test.rs:133:44:142:5 | BlockExpr | test.rs:133:5:142:5 | exit test_nested_if_block (normal) |  |
+| test.rs:134:9:141:9 | IfExpr | test.rs:133:44:142:5 | BlockExpr |  |
+| test.rs:134:12:137:9 | BlockExpr | test.rs:138:13:138:13 | 1 | true |
+| test.rs:134:12:137:9 | BlockExpr | test.rs:140:13:140:13 | 0 | false |
+| test.rs:135:13:135:14 | TupleExpr | test.rs:136:13:136:13 | a |  |
+| test.rs:135:13:135:15 | ExprStmt | test.rs:135:13:135:14 | TupleExpr |  |
+| test.rs:136:13:136:13 | a | test.rs:136:17:136:17 | 0 |  |
+| test.rs:136:13:136:17 | ... > ... | test.rs:134:12:137:9 | BlockExpr | false, true |
+| test.rs:136:17:136:17 | 0 | test.rs:136:13:136:17 | ... > ... |  |
+| test.rs:137:11:139:9 | BlockExpr | test.rs:134:9:141:9 | IfExpr |  |
+| test.rs:138:13:138:13 | 1 | test.rs:137:11:139:9 | BlockExpr |  |
+| test.rs:139:16:141:9 | BlockExpr | test.rs:134:9:141:9 | IfExpr |  |
 | test.rs:140:13:140:13 | 0 | test.rs:139:16:141:9 | BlockExpr |  |
-| test.rs:144:5:155:5 | enter test_if_loop1 | test.rs:146:13:148:14 | ExprStmt |  |
-| test.rs:144:5:155:5 | exit test_if_loop1 (normal) | test.rs:144:5:155:5 | exit test_if_loop1 |  |
-| test.rs:144:37:155:5 | BlockExpr | test.rs:144:5:155:5 | exit test_if_loop1 (normal) |  |
-| test.rs:145:9:154:9 | IfExpr | test.rs:144:37:155:5 | BlockExpr |  |
-| test.rs:145:12:150:10 | ParenExpr | test.rs:151:13:151:13 | 1 | true |
-| test.rs:145:12:150:10 | ParenExpr | test.rs:153:13:153:13 | 0 | false |
-| test.rs:145:13:150:9 | LoopExpr | test.rs:145:12:150:10 | ParenExpr |  |
-| test.rs:145:18:150:9 | BlockExpr | test.rs:146:13:148:14 | ExprStmt |  |
-| test.rs:146:13:148:13 | IfExpr | test.rs:149:13:149:19 | ExprStmt |  |
-| test.rs:146:13:148:14 | ExprStmt | test.rs:146:16:146:16 | a |  |
-| test.rs:146:16:146:16 | a | test.rs:146:20:146:20 | 0 |  |
-| test.rs:146:16:146:20 | ... > ... | test.rs:146:13:148:13 | IfExpr | false |
-| test.rs:146:16:146:20 | ... > ... | test.rs:147:17:147:29 | ExprStmt | true |
-| test.rs:146:20:146:20 | 0 | test.rs:146:16:146:20 | ... > ... |  |
-| test.rs:147:17:147:28 | BreakExpr | test.rs:145:13:150:9 | LoopExpr | break |
-| test.rs:147:17:147:29 | ExprStmt | test.rs:147:23:147:23 | a |  |
-| test.rs:147:23:147:23 | a | test.rs:147:27:147:28 | 10 |  |
-| test.rs:147:23:147:28 | ... > ... | test.rs:147:17:147:28 | BreakExpr |  |
-| test.rs:147:27:147:28 | 10 | test.rs:147:23:147:28 | ... > ... |  |
-| test.rs:149:13:149:13 | a | test.rs:149:17:149:18 | 10 |  |
-| test.rs:149:13:149:18 | ... < ... | test.rs:145:18:150:9 | BlockExpr |  |
-| test.rs:149:13:149:19 | ExprStmt | test.rs:149:13:149:13 | a |  |
-| test.rs:149:17:149:18 | 10 | test.rs:149:13:149:18 | ... < ... |  |
-| test.rs:150:12:152:9 | BlockExpr | test.rs:145:9:154:9 | IfExpr |  |
-| test.rs:151:13:151:13 | 1 | test.rs:150:12:152:9 | BlockExpr |  |
-| test.rs:152:16:154:9 | BlockExpr | test.rs:145:9:154:9 | IfExpr |  |
-| test.rs:153:13:153:13 | 0 | test.rs:152:16:154:9 | BlockExpr |  |
-| test.rs:157:5:168:5 | enter test_if_loop2 | test.rs:159:13:161:14 | ExprStmt |  |
-| test.rs:157:5:168:5 | exit test_if_loop2 (normal) | test.rs:157:5:168:5 | exit test_if_loop2 |  |
-| test.rs:157:37:168:5 | BlockExpr | test.rs:157:5:168:5 | exit test_if_loop2 (normal) |  |
-| test.rs:158:9:167:9 | IfExpr | test.rs:157:37:168:5 | BlockExpr |  |
-| test.rs:158:12:163:10 | ParenExpr | test.rs:164:13:164:13 | 1 | true |
-| test.rs:158:12:163:10 | ParenExpr | test.rs:166:13:166:13 | 0 | false |
-| test.rs:158:13:163:9 | LoopExpr | test.rs:158:12:163:10 | ParenExpr |  |
-| test.rs:158:26:163:9 | BlockExpr | test.rs:159:13:161:14 | ExprStmt |  |
-| test.rs:159:13:161:13 | IfExpr | test.rs:162:13:162:19 | ExprStmt |  |
-| test.rs:159:13:161:14 | ExprStmt | test.rs:159:16:159:16 | a |  |
-| test.rs:159:16:159:16 | a | test.rs:159:20:159:20 | 0 |  |
-| test.rs:159:16:159:20 | ... > ... | test.rs:159:13:161:13 | IfExpr | false |
-| test.rs:159:16:159:20 | ... > ... | test.rs:160:17:160:36 | ExprStmt | true |
-| test.rs:159:20:159:20 | 0 | test.rs:159:16:159:20 | ... > ... |  |
-| test.rs:160:17:160:35 | BreakExpr | test.rs:158:13:163:9 | LoopExpr | break('label) |
-| test.rs:160:17:160:36 | ExprStmt | test.rs:160:30:160:30 | a |  |
-| test.rs:160:30:160:30 | a | test.rs:160:34:160:35 | 10 |  |
-| test.rs:160:30:160:35 | ... > ... | test.rs:160:17:160:35 | BreakExpr |  |
-| test.rs:160:34:160:35 | 10 | test.rs:160:30:160:35 | ... > ... |  |
-| test.rs:162:13:162:13 | a | test.rs:162:17:162:18 | 10 |  |
-| test.rs:162:13:162:18 | ... < ... | test.rs:158:26:163:9 | BlockExpr |  |
-| test.rs:162:13:162:19 | ExprStmt | test.rs:162:13:162:13 | a |  |
-| test.rs:162:17:162:18 | 10 | test.rs:162:13:162:18 | ... < ... |  |
-| test.rs:163:12:165:9 | BlockExpr | test.rs:158:9:167:9 | IfExpr |  |
-| test.rs:164:13:164:13 | 1 | test.rs:163:12:165:9 | BlockExpr |  |
-| test.rs:165:16:167:9 | BlockExpr | test.rs:158:9:167:9 | IfExpr |  |
-| test.rs:166:13:166:13 | 0 | test.rs:165:16:167:9 | BlockExpr |  |
-| test.rs:170:5:178:5 | enter test_labelled_block | test.rs:172:13:172:31 | ExprStmt |  |
-| test.rs:170:5:178:5 | exit test_labelled_block (normal) | test.rs:170:5:178:5 | exit test_labelled_block |  |
-| test.rs:172:13:172:30 | BreakExpr | test.rs:170:5:178:5 | exit test_labelled_block (normal) | break('block) |
-| test.rs:172:13:172:31 | ExprStmt | test.rs:172:26:172:26 | a |  |
-| test.rs:172:26:172:26 | a | test.rs:172:30:172:30 | 0 |  |
-| test.rs:172:26:172:30 | ... > ... | test.rs:172:13:172:30 | BreakExpr |  |
-| test.rs:172:30:172:30 | 0 | test.rs:172:26:172:30 | ... > ... |  |
-| test.rs:183:5:186:5 | enter test_and_operator | test.rs:184:9:184:28 | LetStmt |  |
-| test.rs:183:5:186:5 | exit test_and_operator (normal) | test.rs:183:5:186:5 | exit test_and_operator |  |
-| test.rs:183:61:186:5 | BlockExpr | test.rs:183:5:186:5 | exit test_and_operator (normal) |  |
-| test.rs:184:9:184:28 | LetStmt | test.rs:184:17:184:27 | ... && ... |  |
-| test.rs:184:13:184:13 | d | test.rs:185:9:185:9 | d | match, no-match |
-| test.rs:184:17:184:17 | a | test.rs:184:13:184:13 | d | false |
-| test.rs:184:17:184:17 | a | test.rs:184:22:184:22 | b | true |
-| test.rs:184:17:184:22 | ... && ... | test.rs:184:17:184:17 | a |  |
-| test.rs:184:17:184:27 | ... && ... | test.rs:184:17:184:22 | ... && ... |  |
-| test.rs:184:22:184:22 | b | test.rs:184:13:184:13 | d | false |
-| test.rs:184:22:184:22 | b | test.rs:184:27:184:27 | c | true |
-| test.rs:184:27:184:27 | c | test.rs:184:13:184:13 | d |  |
-| test.rs:185:9:185:9 | d | test.rs:183:61:186:5 | BlockExpr |  |
-| test.rs:188:5:191:5 | enter test_or_operator | test.rs:189:9:189:28 | LetStmt |  |
-| test.rs:188:5:191:5 | exit test_or_operator (normal) | test.rs:188:5:191:5 | exit test_or_operator |  |
-| test.rs:188:60:191:5 | BlockExpr | test.rs:188:5:191:5 | exit test_or_operator (normal) |  |
-| test.rs:189:9:189:28 | LetStmt | test.rs:189:17:189:27 | ... \|\| ... |  |
-| test.rs:189:13:189:13 | d | test.rs:190:9:190:9 | d | match, no-match |
-| test.rs:189:17:189:17 | a | test.rs:189:13:189:13 | d | true |
-| test.rs:189:17:189:17 | a | test.rs:189:22:189:22 | b | false |
-| test.rs:189:17:189:22 | ... \|\| ... | test.rs:189:17:189:17 | a |  |
-| test.rs:189:17:189:27 | ... \|\| ... | test.rs:189:17:189:22 | ... \|\| ... |  |
-| test.rs:189:22:189:22 | b | test.rs:189:13:189:13 | d | true |
-| test.rs:189:22:189:22 | b | test.rs:189:27:189:27 | c | false |
-| test.rs:189:27:189:27 | c | test.rs:189:13:189:13 | d |  |
-| test.rs:190:9:190:9 | d | test.rs:188:60:191:5 | BlockExpr |  |
-| test.rs:193:5:196:5 | enter test_or_operator_2 | test.rs:194:9:194:36 | LetStmt |  |
-| test.rs:193:5:196:5 | exit test_or_operator_2 (normal) | test.rs:193:5:196:5 | exit test_or_operator_2 |  |
-| test.rs:193:61:196:5 | BlockExpr | test.rs:193:5:196:5 | exit test_or_operator_2 (normal) |  |
-| test.rs:194:9:194:36 | LetStmt | test.rs:194:17:194:35 | ... \|\| ... |  |
-| test.rs:194:13:194:13 | d | test.rs:195:9:195:9 | d | match, no-match |
-| test.rs:194:17:194:17 | a | test.rs:194:13:194:13 | d | true |
-| test.rs:194:17:194:17 | a | test.rs:194:23:194:23 | b | false |
-| test.rs:194:17:194:30 | ... \|\| ... | test.rs:194:17:194:17 | a |  |
-| test.rs:194:17:194:35 | ... \|\| ... | test.rs:194:17:194:30 | ... \|\| ... |  |
-| test.rs:194:22:194:30 | ParenExpr | test.rs:194:13:194:13 | d | true |
-| test.rs:194:22:194:30 | ParenExpr | test.rs:194:35:194:35 | c | false |
-| test.rs:194:23:194:23 | b | test.rs:194:28:194:29 | 28 |  |
-| test.rs:194:23:194:29 | ... == ... | test.rs:194:22:194:30 | ParenExpr |  |
-| test.rs:194:28:194:29 | 28 | test.rs:194:23:194:29 | ... == ... |  |
-| test.rs:194:35:194:35 | c | test.rs:194:13:194:13 | d |  |
-| test.rs:195:9:195:9 | d | test.rs:193:61:196:5 | BlockExpr |  |
-| test.rs:198:5:201:5 | enter test_not_operator | test.rs:199:9:199:19 | LetStmt |  |
-| test.rs:198:5:201:5 | exit test_not_operator (normal) | test.rs:198:5:201:5 | exit test_not_operator |  |
-| test.rs:198:43:201:5 | BlockExpr | test.rs:198:5:201:5 | exit test_not_operator (normal) |  |
-| test.rs:199:9:199:19 | LetStmt | test.rs:199:18:199:18 | a |  |
-| test.rs:199:13:199:13 | d | test.rs:200:9:200:9 | d | match, no-match |
-| test.rs:199:17:199:18 | ! ... | test.rs:199:13:199:13 | d |  |
-| test.rs:199:18:199:18 | a | test.rs:199:17:199:18 | ! ... |  |
-| test.rs:200:9:200:9 | d | test.rs:198:43:201:5 | BlockExpr |  |
-| test.rs:203:5:209:5 | enter test_if_and_operator | test.rs:204:12:204:22 | ... && ... |  |
-| test.rs:203:5:209:5 | exit test_if_and_operator (normal) | test.rs:203:5:209:5 | exit test_if_and_operator |  |
-| test.rs:203:63:209:5 | BlockExpr | test.rs:203:5:209:5 | exit test_if_and_operator (normal) |  |
-| test.rs:204:9:208:9 | IfExpr | test.rs:203:63:209:5 | BlockExpr |  |
-| test.rs:204:12:204:12 | a | test.rs:204:17:204:17 | b | true |
-| test.rs:204:12:204:12 | a | test.rs:207:13:207:17 | false | false |
-| test.rs:204:12:204:17 | ... && ... | test.rs:204:12:204:12 | a |  |
-| test.rs:204:12:204:22 | ... && ... | test.rs:204:12:204:17 | ... && ... |  |
-| test.rs:204:17:204:17 | b | test.rs:204:22:204:22 | c | true |
-| test.rs:204:17:204:17 | b | test.rs:207:13:207:17 | false | false |
-| test.rs:204:22:204:22 | c | test.rs:205:13:205:16 | true | true |
-| test.rs:204:22:204:22 | c | test.rs:207:13:207:17 | false | false |
-| test.rs:204:24:206:9 | BlockExpr | test.rs:204:9:208:9 | IfExpr |  |
-| test.rs:205:13:205:16 | true | test.rs:204:24:206:9 | BlockExpr |  |
-| test.rs:206:16:208:9 | BlockExpr | test.rs:204:9:208:9 | IfExpr |  |
-| test.rs:207:13:207:17 | false | test.rs:206:16:208:9 | BlockExpr |  |
-| test.rs:211:5:217:5 | enter test_if_or_operator | test.rs:212:12:212:22 | ... \|\| ... |  |
-| test.rs:211:5:217:5 | exit test_if_or_operator (normal) | test.rs:211:5:217:5 | exit test_if_or_operator |  |
-| test.rs:211:62:217:5 | BlockExpr | test.rs:211:5:217:5 | exit test_if_or_operator (normal) |  |
-| test.rs:212:9:216:9 | IfExpr | test.rs:211:62:217:5 | BlockExpr |  |
-| test.rs:212:12:212:12 | a | test.rs:212:17:212:17 | b | false |
-| test.rs:212:12:212:12 | a | test.rs:213:13:213:16 | true | true |
-| test.rs:212:12:212:17 | ... \|\| ... | test.rs:212:12:212:12 | a |  |
-| test.rs:212:12:212:22 | ... \|\| ... | test.rs:212:12:212:17 | ... \|\| ... |  |
-| test.rs:212:17:212:17 | b | test.rs:212:22:212:22 | c | false |
-| test.rs:212:17:212:17 | b | test.rs:213:13:213:16 | true | true |
-| test.rs:212:22:212:22 | c | test.rs:213:13:213:16 | true | true |
-| test.rs:212:22:212:22 | c | test.rs:215:13:215:17 | false | false |
-| test.rs:212:24:214:9 | BlockExpr | test.rs:212:9:216:9 | IfExpr |  |
-| test.rs:213:13:213:16 | true | test.rs:212:24:214:9 | BlockExpr |  |
-| test.rs:214:16:216:9 | BlockExpr | test.rs:212:9:216:9 | IfExpr |  |
-| test.rs:215:13:215:17 | false | test.rs:214:16:216:9 | BlockExpr |  |
-| test.rs:219:5:225:5 | enter test_if_not_operator | test.rs:220:13:220:13 | a |  |
-| test.rs:219:5:225:5 | exit test_if_not_operator (normal) | test.rs:219:5:225:5 | exit test_if_not_operator |  |
-| test.rs:219:46:225:5 | BlockExpr | test.rs:219:5:225:5 | exit test_if_not_operator (normal) |  |
-| test.rs:220:9:224:9 | IfExpr | test.rs:219:46:225:5 | BlockExpr |  |
-| test.rs:220:12:220:13 | ! ... | test.rs:221:13:221:16 | true | true |
-| test.rs:220:12:220:13 | ! ... | test.rs:223:13:223:17 | false | false |
-| test.rs:220:13:220:13 | a | test.rs:220:12:220:13 | ! ... | false, true |
-| test.rs:220:15:222:9 | BlockExpr | test.rs:220:9:224:9 | IfExpr |  |
-| test.rs:221:13:221:16 | true | test.rs:220:15:222:9 | BlockExpr |  |
-| test.rs:222:16:224:9 | BlockExpr | test.rs:220:9:224:9 | IfExpr |  |
-| test.rs:223:13:223:17 | false | test.rs:222:16:224:9 | BlockExpr |  |
-| test.rs:228:1:234:1 | enter test_match | test.rs:229:11:229:21 | maybe_digit |  |
-| test.rs:228:1:234:1 | exit test_match (normal) | test.rs:228:1:234:1 | exit test_match |  |
-| test.rs:228:48:234:1 | BlockExpr | test.rs:228:1:234:1 | exit test_match (normal) |  |
-| test.rs:229:5:233:5 | MatchExpr | test.rs:228:48:234:1 | BlockExpr |  |
-| test.rs:229:11:229:21 | maybe_digit | test.rs:230:9:230:23 | TupleStructPat |  |
-| test.rs:230:9:230:23 | TupleStructPat | test.rs:230:28:230:28 | x | match |
-| test.rs:230:9:230:23 | TupleStructPat | test.rs:231:9:231:23 | TupleStructPat | no-match |
-| test.rs:230:28:230:28 | x | test.rs:230:32:230:33 | 10 |  |
-| test.rs:230:28:230:33 | ... < ... | test.rs:230:38:230:38 | x | true |
-| test.rs:230:28:230:33 | ... < ... | test.rs:231:9:231:23 | TupleStructPat | false |
-| test.rs:230:32:230:33 | 10 | test.rs:230:28:230:33 | ... < ... |  |
-| test.rs:230:38:230:38 | x | test.rs:230:42:230:42 | 5 |  |
-| test.rs:230:38:230:42 | ... + ... | test.rs:229:5:233:5 | MatchExpr |  |
-| test.rs:230:42:230:42 | 5 | test.rs:230:38:230:42 | ... + ... |  |
-| test.rs:231:9:231:23 | TupleStructPat | test.rs:231:28:231:28 | x | match |
-| test.rs:231:9:231:23 | TupleStructPat | test.rs:232:9:232:20 | PathPat | no-match |
-| test.rs:231:28:231:28 | x | test.rs:229:5:233:5 | MatchExpr |  |
-| test.rs:232:9:232:20 | PathPat | test.rs:232:25:232:25 | 5 | match |
-| test.rs:232:25:232:25 | 5 | test.rs:229:5:233:5 | MatchExpr |  |
-| test.rs:237:5:242:5 | enter test_infinite_loop | test.rs:238:9:240:9 | ExprStmt |  |
-| test.rs:238:9:240:9 | ExprStmt | test.rs:239:13:239:13 | 1 |  |
-| test.rs:238:14:240:9 | BlockExpr | test.rs:239:13:239:13 | 1 |  |
-| test.rs:239:13:239:13 | 1 | test.rs:238:14:240:9 | BlockExpr |  |
-| test.rs:244:5:247:5 | enter test_let_match | test.rs:245:9:245:49 | LetStmt |  |
-| test.rs:244:5:247:5 | exit test_let_match (normal) | test.rs:244:5:247:5 | exit test_let_match |  |
-| test.rs:244:39:247:5 | BlockExpr | test.rs:244:5:247:5 | exit test_let_match (normal) |  |
-| test.rs:245:9:245:49 | LetStmt | test.rs:245:23:245:23 | a |  |
-| test.rs:245:13:245:19 | TupleStructPat | test.rs:245:32:245:46 | "Expected some" | no-match |
-| test.rs:245:13:245:19 | TupleStructPat | test.rs:246:9:246:9 | n | match |
-| test.rs:245:23:245:23 | a | test.rs:245:13:245:19 | TupleStructPat |  |
-| test.rs:245:32:245:46 | "Expected some" | test.rs:245:30:245:48 | BlockExpr |  |
-| test.rs:246:9:246:9 | n | test.rs:244:39:247:5 | BlockExpr |  |
-| test.rs:250:1:255:1 | enter dead_code | test.rs:251:5:253:5 | ExprStmt |  |
-| test.rs:250:1:255:1 | exit dead_code (normal) | test.rs:250:1:255:1 | exit dead_code |  |
-| test.rs:251:5:253:5 | ExprStmt | test.rs:251:9:251:12 | true |  |
-| test.rs:251:8:251:13 | ParenExpr | test.rs:252:9:252:17 | ExprStmt | true |
-| test.rs:251:9:251:12 | true | test.rs:251:8:251:13 | ParenExpr |  |
-| test.rs:252:9:252:16 | ReturnExpr | test.rs:250:1:255:1 | exit dead_code (normal) | return |
-| test.rs:252:9:252:17 | ExprStmt | test.rs:252:16:252:16 | 0 |  |
-| test.rs:252:16:252:16 | 0 | test.rs:252:9:252:16 | ReturnExpr |  |
-| test.rs:257:1:270:1 | enter labelled_block | test.rs:258:5:269:6 | LetStmt |  |
-| test.rs:257:1:270:1 | exit labelled_block (normal) | test.rs:257:1:270:1 | exit labelled_block |  |
-| test.rs:257:28:270:1 | BlockExpr | test.rs:257:1:270:1 | exit labelled_block (normal) |  |
-| test.rs:258:5:269:6 | LetStmt | test.rs:259:9:259:19 | ExprStmt |  |
-| test.rs:258:9:258:14 | result | test.rs:257:28:270:1 | BlockExpr | match, no-match |
-| test.rs:258:18:269:5 | BlockExpr | test.rs:258:9:258:14 | result |  |
-| test.rs:259:9:259:16 | PathExpr | test.rs:259:9:259:18 | CallExpr |  |
-| test.rs:259:9:259:18 | CallExpr | test.rs:260:9:262:9 | ExprStmt |  |
-| test.rs:259:9:259:19 | ExprStmt | test.rs:259:9:259:16 | PathExpr |  |
-| test.rs:260:9:262:9 | ExprStmt | test.rs:260:12:260:28 | PathExpr |  |
-| test.rs:260:9:262:9 | IfExpr | test.rs:263:9:263:24 | ExprStmt |  |
-| test.rs:260:12:260:28 | PathExpr | test.rs:260:12:260:30 | CallExpr |  |
-| test.rs:260:12:260:30 | CallExpr | test.rs:260:9:262:9 | IfExpr | false |
-| test.rs:260:12:260:30 | CallExpr | test.rs:261:13:261:27 | ExprStmt | true |
-| test.rs:261:13:261:26 | BreakExpr | test.rs:257:1:270:1 | exit labelled_block (normal) | break('block) |
-| test.rs:261:13:261:27 | ExprStmt | test.rs:261:26:261:26 | 1 |  |
-| test.rs:261:26:261:26 | 1 | test.rs:261:13:261:26 | BreakExpr |  |
-| test.rs:263:9:263:21 | PathExpr | test.rs:263:9:263:23 | CallExpr |  |
-| test.rs:263:9:263:23 | CallExpr | test.rs:264:9:266:9 | ExprStmt |  |
-| test.rs:263:9:263:24 | ExprStmt | test.rs:263:9:263:21 | PathExpr |  |
-| test.rs:264:9:266:9 | ExprStmt | test.rs:264:12:264:28 | PathExpr |  |
-| test.rs:264:9:266:9 | IfExpr | test.rs:267:9:267:24 | ExprStmt |  |
-| test.rs:264:12:264:28 | PathExpr | test.rs:264:12:264:30 | CallExpr |  |
-| test.rs:264:12:264:30 | CallExpr | test.rs:264:9:266:9 | IfExpr | false |
-| test.rs:264:12:264:30 | CallExpr | test.rs:265:13:265:27 | ExprStmt | true |
-| test.rs:265:13:265:26 | BreakExpr | test.rs:257:1:270:1 | exit labelled_block (normal) | break('block) |
-| test.rs:265:13:265:27 | ExprStmt | test.rs:265:26:265:26 | 2 |  |
-| test.rs:265:26:265:26 | 2 | test.rs:265:13:265:26 | BreakExpr |  |
-| test.rs:267:9:267:21 | PathExpr | test.rs:267:9:267:23 | CallExpr |  |
-| test.rs:267:9:267:23 | CallExpr | test.rs:268:9:268:9 | 3 |  |
-| test.rs:267:9:267:24 | ExprStmt | test.rs:267:9:267:21 | PathExpr |  |
-| test.rs:268:9:268:9 | 3 | test.rs:258:18:269:5 | BlockExpr |  |
+| test.rs:144:5:151:5 | enter test_if_assignment | test.rs:145:9:145:26 | LetStmt |  |
+| test.rs:144:5:151:5 | exit test_if_assignment (normal) | test.rs:144:5:151:5 | exit test_if_assignment |  |
+| test.rs:144:42:151:5 | BlockExpr | test.rs:144:5:151:5 | exit test_if_assignment (normal) |  |
+| test.rs:145:9:145:26 | LetStmt | test.rs:145:21:145:25 | false |  |
+| test.rs:145:13:145:17 | x | test.rs:146:12:146:12 | x | match, no-match |
+| test.rs:145:21:145:25 | false | test.rs:145:13:145:17 | x |  |
+| test.rs:146:9:150:9 | IfExpr | test.rs:144:42:151:5 | BlockExpr |  |
+| test.rs:146:12:146:12 | x | test.rs:146:16:146:19 | true |  |
+| test.rs:146:12:146:19 | ... = ... | test.rs:147:13:147:13 | 1 | true |
+| test.rs:146:12:146:19 | ... = ... | test.rs:149:13:149:13 | 0 | false |
+| test.rs:146:16:146:19 | true | test.rs:146:12:146:19 | ... = ... |  |
+| test.rs:146:21:148:9 | BlockExpr | test.rs:146:9:150:9 | IfExpr |  |
+| test.rs:147:13:147:13 | 1 | test.rs:146:21:148:9 | BlockExpr |  |
+| test.rs:148:16:150:9 | BlockExpr | test.rs:146:9:150:9 | IfExpr |  |
+| test.rs:149:13:149:13 | 0 | test.rs:148:16:150:9 | BlockExpr |  |
+| test.rs:153:5:164:5 | enter test_if_loop1 | test.rs:155:13:157:14 | ExprStmt |  |
+| test.rs:153:5:164:5 | exit test_if_loop1 (normal) | test.rs:153:5:164:5 | exit test_if_loop1 |  |
+| test.rs:153:37:164:5 | BlockExpr | test.rs:153:5:164:5 | exit test_if_loop1 (normal) |  |
+| test.rs:154:9:163:9 | IfExpr | test.rs:153:37:164:5 | BlockExpr |  |
+| test.rs:154:12:159:10 | ParenExpr | test.rs:160:13:160:13 | 1 | true |
+| test.rs:154:12:159:10 | ParenExpr | test.rs:162:13:162:13 | 0 | false |
+| test.rs:154:13:159:9 | LoopExpr | test.rs:154:12:159:10 | ParenExpr |  |
+| test.rs:154:18:159:9 | BlockExpr | test.rs:155:13:157:14 | ExprStmt |  |
+| test.rs:155:13:157:13 | IfExpr | test.rs:158:13:158:19 | ExprStmt |  |
+| test.rs:155:13:157:14 | ExprStmt | test.rs:155:16:155:16 | a |  |
+| test.rs:155:16:155:16 | a | test.rs:155:20:155:20 | 0 |  |
+| test.rs:155:16:155:20 | ... > ... | test.rs:155:13:157:13 | IfExpr | false |
+| test.rs:155:16:155:20 | ... > ... | test.rs:156:17:156:29 | ExprStmt | true |
+| test.rs:155:20:155:20 | 0 | test.rs:155:16:155:20 | ... > ... |  |
+| test.rs:156:17:156:28 | BreakExpr | test.rs:154:13:159:9 | LoopExpr | break |
+| test.rs:156:17:156:29 | ExprStmt | test.rs:156:23:156:23 | a |  |
+| test.rs:156:23:156:23 | a | test.rs:156:27:156:28 | 10 |  |
+| test.rs:156:23:156:28 | ... > ... | test.rs:156:17:156:28 | BreakExpr |  |
+| test.rs:156:27:156:28 | 10 | test.rs:156:23:156:28 | ... > ... |  |
+| test.rs:158:13:158:13 | a | test.rs:158:17:158:18 | 10 |  |
+| test.rs:158:13:158:18 | ... < ... | test.rs:154:18:159:9 | BlockExpr |  |
+| test.rs:158:13:158:19 | ExprStmt | test.rs:158:13:158:13 | a |  |
+| test.rs:158:17:158:18 | 10 | test.rs:158:13:158:18 | ... < ... |  |
+| test.rs:159:12:161:9 | BlockExpr | test.rs:154:9:163:9 | IfExpr |  |
+| test.rs:160:13:160:13 | 1 | test.rs:159:12:161:9 | BlockExpr |  |
+| test.rs:161:16:163:9 | BlockExpr | test.rs:154:9:163:9 | IfExpr |  |
+| test.rs:162:13:162:13 | 0 | test.rs:161:16:163:9 | BlockExpr |  |
+| test.rs:166:5:177:5 | enter test_if_loop2 | test.rs:168:13:170:14 | ExprStmt |  |
+| test.rs:166:5:177:5 | exit test_if_loop2 (normal) | test.rs:166:5:177:5 | exit test_if_loop2 |  |
+| test.rs:166:37:177:5 | BlockExpr | test.rs:166:5:177:5 | exit test_if_loop2 (normal) |  |
+| test.rs:167:9:176:9 | IfExpr | test.rs:166:37:177:5 | BlockExpr |  |
+| test.rs:167:12:172:10 | ParenExpr | test.rs:173:13:173:13 | 1 | true |
+| test.rs:167:12:172:10 | ParenExpr | test.rs:175:13:175:13 | 0 | false |
+| test.rs:167:13:172:9 | LoopExpr | test.rs:167:12:172:10 | ParenExpr |  |
+| test.rs:167:26:172:9 | BlockExpr | test.rs:168:13:170:14 | ExprStmt |  |
+| test.rs:168:13:170:13 | IfExpr | test.rs:171:13:171:19 | ExprStmt |  |
+| test.rs:168:13:170:14 | ExprStmt | test.rs:168:16:168:16 | a |  |
+| test.rs:168:16:168:16 | a | test.rs:168:20:168:20 | 0 |  |
+| test.rs:168:16:168:20 | ... > ... | test.rs:168:13:170:13 | IfExpr | false |
+| test.rs:168:16:168:20 | ... > ... | test.rs:169:17:169:36 | ExprStmt | true |
+| test.rs:168:20:168:20 | 0 | test.rs:168:16:168:20 | ... > ... |  |
+| test.rs:169:17:169:35 | BreakExpr | test.rs:167:13:172:9 | LoopExpr | break('label) |
+| test.rs:169:17:169:36 | ExprStmt | test.rs:169:30:169:30 | a |  |
+| test.rs:169:30:169:30 | a | test.rs:169:34:169:35 | 10 |  |
+| test.rs:169:30:169:35 | ... > ... | test.rs:169:17:169:35 | BreakExpr |  |
+| test.rs:169:34:169:35 | 10 | test.rs:169:30:169:35 | ... > ... |  |
+| test.rs:171:13:171:13 | a | test.rs:171:17:171:18 | 10 |  |
+| test.rs:171:13:171:18 | ... < ... | test.rs:167:26:172:9 | BlockExpr |  |
+| test.rs:171:13:171:19 | ExprStmt | test.rs:171:13:171:13 | a |  |
+| test.rs:171:17:171:18 | 10 | test.rs:171:13:171:18 | ... < ... |  |
+| test.rs:172:12:174:9 | BlockExpr | test.rs:167:9:176:9 | IfExpr |  |
+| test.rs:173:13:173:13 | 1 | test.rs:172:12:174:9 | BlockExpr |  |
+| test.rs:174:16:176:9 | BlockExpr | test.rs:167:9:176:9 | IfExpr |  |
+| test.rs:175:13:175:13 | 0 | test.rs:174:16:176:9 | BlockExpr |  |
+| test.rs:179:5:187:5 | enter test_labelled_block | test.rs:181:13:181:31 | ExprStmt |  |
+| test.rs:179:5:187:5 | exit test_labelled_block (normal) | test.rs:179:5:187:5 | exit test_labelled_block |  |
+| test.rs:181:13:181:30 | BreakExpr | test.rs:179:5:187:5 | exit test_labelled_block (normal) | break('block) |
+| test.rs:181:13:181:31 | ExprStmt | test.rs:181:26:181:26 | a |  |
+| test.rs:181:26:181:26 | a | test.rs:181:30:181:30 | 0 |  |
+| test.rs:181:26:181:30 | ... > ... | test.rs:181:13:181:30 | BreakExpr |  |
+| test.rs:181:30:181:30 | 0 | test.rs:181:26:181:30 | ... > ... |  |
+| test.rs:192:5:195:5 | enter test_and_operator | test.rs:193:9:193:28 | LetStmt |  |
+| test.rs:192:5:195:5 | exit test_and_operator (normal) | test.rs:192:5:195:5 | exit test_and_operator |  |
+| test.rs:192:61:195:5 | BlockExpr | test.rs:192:5:195:5 | exit test_and_operator (normal) |  |
+| test.rs:193:9:193:28 | LetStmt | test.rs:193:17:193:27 | ... && ... |  |
+| test.rs:193:13:193:13 | d | test.rs:194:9:194:9 | d | match, no-match |
+| test.rs:193:17:193:17 | a | test.rs:193:13:193:13 | d | false |
+| test.rs:193:17:193:17 | a | test.rs:193:22:193:22 | b | true |
+| test.rs:193:17:193:22 | ... && ... | test.rs:193:17:193:17 | a |  |
+| test.rs:193:17:193:27 | ... && ... | test.rs:193:17:193:22 | ... && ... |  |
+| test.rs:193:22:193:22 | b | test.rs:193:13:193:13 | d | false |
+| test.rs:193:22:193:22 | b | test.rs:193:27:193:27 | c | true |
+| test.rs:193:27:193:27 | c | test.rs:193:13:193:13 | d |  |
+| test.rs:194:9:194:9 | d | test.rs:192:61:195:5 | BlockExpr |  |
+| test.rs:197:5:200:5 | enter test_or_operator | test.rs:198:9:198:28 | LetStmt |  |
+| test.rs:197:5:200:5 | exit test_or_operator (normal) | test.rs:197:5:200:5 | exit test_or_operator |  |
+| test.rs:197:60:200:5 | BlockExpr | test.rs:197:5:200:5 | exit test_or_operator (normal) |  |
+| test.rs:198:9:198:28 | LetStmt | test.rs:198:17:198:27 | ... \|\| ... |  |
+| test.rs:198:13:198:13 | d | test.rs:199:9:199:9 | d | match, no-match |
+| test.rs:198:17:198:17 | a | test.rs:198:13:198:13 | d | true |
+| test.rs:198:17:198:17 | a | test.rs:198:22:198:22 | b | false |
+| test.rs:198:17:198:22 | ... \|\| ... | test.rs:198:17:198:17 | a |  |
+| test.rs:198:17:198:27 | ... \|\| ... | test.rs:198:17:198:22 | ... \|\| ... |  |
+| test.rs:198:22:198:22 | b | test.rs:198:13:198:13 | d | true |
+| test.rs:198:22:198:22 | b | test.rs:198:27:198:27 | c | false |
+| test.rs:198:27:198:27 | c | test.rs:198:13:198:13 | d |  |
+| test.rs:199:9:199:9 | d | test.rs:197:60:200:5 | BlockExpr |  |
+| test.rs:202:5:205:5 | enter test_or_operator_2 | test.rs:203:9:203:36 | LetStmt |  |
+| test.rs:202:5:205:5 | exit test_or_operator_2 (normal) | test.rs:202:5:205:5 | exit test_or_operator_2 |  |
+| test.rs:202:61:205:5 | BlockExpr | test.rs:202:5:205:5 | exit test_or_operator_2 (normal) |  |
+| test.rs:203:9:203:36 | LetStmt | test.rs:203:17:203:35 | ... \|\| ... |  |
+| test.rs:203:13:203:13 | d | test.rs:204:9:204:9 | d | match, no-match |
+| test.rs:203:17:203:17 | a | test.rs:203:13:203:13 | d | true |
+| test.rs:203:17:203:17 | a | test.rs:203:23:203:23 | b | false |
+| test.rs:203:17:203:30 | ... \|\| ... | test.rs:203:17:203:17 | a |  |
+| test.rs:203:17:203:35 | ... \|\| ... | test.rs:203:17:203:30 | ... \|\| ... |  |
+| test.rs:203:22:203:30 | ParenExpr | test.rs:203:13:203:13 | d | true |
+| test.rs:203:22:203:30 | ParenExpr | test.rs:203:35:203:35 | c | false |
+| test.rs:203:23:203:23 | b | test.rs:203:28:203:29 | 28 |  |
+| test.rs:203:23:203:29 | ... == ... | test.rs:203:22:203:30 | ParenExpr |  |
+| test.rs:203:28:203:29 | 28 | test.rs:203:23:203:29 | ... == ... |  |
+| test.rs:203:35:203:35 | c | test.rs:203:13:203:13 | d |  |
+| test.rs:204:9:204:9 | d | test.rs:202:61:205:5 | BlockExpr |  |
+| test.rs:207:5:210:5 | enter test_not_operator | test.rs:208:9:208:19 | LetStmt |  |
+| test.rs:207:5:210:5 | exit test_not_operator (normal) | test.rs:207:5:210:5 | exit test_not_operator |  |
+| test.rs:207:43:210:5 | BlockExpr | test.rs:207:5:210:5 | exit test_not_operator (normal) |  |
+| test.rs:208:9:208:19 | LetStmt | test.rs:208:18:208:18 | a |  |
+| test.rs:208:13:208:13 | d | test.rs:209:9:209:9 | d | match, no-match |
+| test.rs:208:17:208:18 | ! ... | test.rs:208:13:208:13 | d |  |
+| test.rs:208:18:208:18 | a | test.rs:208:17:208:18 | ! ... |  |
+| test.rs:209:9:209:9 | d | test.rs:207:43:210:5 | BlockExpr |  |
+| test.rs:212:5:218:5 | enter test_if_and_operator | test.rs:213:12:213:22 | ... && ... |  |
+| test.rs:212:5:218:5 | exit test_if_and_operator (normal) | test.rs:212:5:218:5 | exit test_if_and_operator |  |
+| test.rs:212:63:218:5 | BlockExpr | test.rs:212:5:218:5 | exit test_if_and_operator (normal) |  |
+| test.rs:213:9:217:9 | IfExpr | test.rs:212:63:218:5 | BlockExpr |  |
+| test.rs:213:12:213:12 | a | test.rs:213:17:213:17 | b | true |
+| test.rs:213:12:213:12 | a | test.rs:216:13:216:17 | false | false |
+| test.rs:213:12:213:17 | ... && ... | test.rs:213:12:213:12 | a |  |
+| test.rs:213:12:213:22 | ... && ... | test.rs:213:12:213:17 | ... && ... |  |
+| test.rs:213:17:213:17 | b | test.rs:213:22:213:22 | c | true |
+| test.rs:213:17:213:17 | b | test.rs:216:13:216:17 | false | false |
+| test.rs:213:22:213:22 | c | test.rs:214:13:214:16 | true | true |
+| test.rs:213:22:213:22 | c | test.rs:216:13:216:17 | false | false |
+| test.rs:213:24:215:9 | BlockExpr | test.rs:213:9:217:9 | IfExpr |  |
+| test.rs:214:13:214:16 | true | test.rs:213:24:215:9 | BlockExpr |  |
+| test.rs:215:16:217:9 | BlockExpr | test.rs:213:9:217:9 | IfExpr |  |
+| test.rs:216:13:216:17 | false | test.rs:215:16:217:9 | BlockExpr |  |
+| test.rs:220:5:226:5 | enter test_if_or_operator | test.rs:221:12:221:22 | ... \|\| ... |  |
+| test.rs:220:5:226:5 | exit test_if_or_operator (normal) | test.rs:220:5:226:5 | exit test_if_or_operator |  |
+| test.rs:220:62:226:5 | BlockExpr | test.rs:220:5:226:5 | exit test_if_or_operator (normal) |  |
+| test.rs:221:9:225:9 | IfExpr | test.rs:220:62:226:5 | BlockExpr |  |
+| test.rs:221:12:221:12 | a | test.rs:221:17:221:17 | b | false |
+| test.rs:221:12:221:12 | a | test.rs:222:13:222:16 | true | true |
+| test.rs:221:12:221:17 | ... \|\| ... | test.rs:221:12:221:12 | a |  |
+| test.rs:221:12:221:22 | ... \|\| ... | test.rs:221:12:221:17 | ... \|\| ... |  |
+| test.rs:221:17:221:17 | b | test.rs:221:22:221:22 | c | false |
+| test.rs:221:17:221:17 | b | test.rs:222:13:222:16 | true | true |
+| test.rs:221:22:221:22 | c | test.rs:222:13:222:16 | true | true |
+| test.rs:221:22:221:22 | c | test.rs:224:13:224:17 | false | false |
+| test.rs:221:24:223:9 | BlockExpr | test.rs:221:9:225:9 | IfExpr |  |
+| test.rs:222:13:222:16 | true | test.rs:221:24:223:9 | BlockExpr |  |
+| test.rs:223:16:225:9 | BlockExpr | test.rs:221:9:225:9 | IfExpr |  |
+| test.rs:224:13:224:17 | false | test.rs:223:16:225:9 | BlockExpr |  |
+| test.rs:228:5:234:5 | enter test_if_not_operator | test.rs:229:13:229:13 | a |  |
+| test.rs:228:5:234:5 | exit test_if_not_operator (normal) | test.rs:228:5:234:5 | exit test_if_not_operator |  |
+| test.rs:228:46:234:5 | BlockExpr | test.rs:228:5:234:5 | exit test_if_not_operator (normal) |  |
+| test.rs:229:9:233:9 | IfExpr | test.rs:228:46:234:5 | BlockExpr |  |
+| test.rs:229:12:229:13 | ! ... | test.rs:230:13:230:16 | true | true |
+| test.rs:229:12:229:13 | ! ... | test.rs:232:13:232:17 | false | false |
+| test.rs:229:13:229:13 | a | test.rs:229:12:229:13 | ! ... | false, true |
+| test.rs:229:15:231:9 | BlockExpr | test.rs:229:9:233:9 | IfExpr |  |
+| test.rs:230:13:230:16 | true | test.rs:229:15:231:9 | BlockExpr |  |
+| test.rs:231:16:233:9 | BlockExpr | test.rs:229:9:233:9 | IfExpr |  |
+| test.rs:232:13:232:17 | false | test.rs:231:16:233:9 | BlockExpr |  |
+| test.rs:237:1:243:1 | enter test_match | test.rs:238:11:238:21 | maybe_digit |  |
+| test.rs:237:1:243:1 | exit test_match (normal) | test.rs:237:1:243:1 | exit test_match |  |
+| test.rs:237:48:243:1 | BlockExpr | test.rs:237:1:243:1 | exit test_match (normal) |  |
+| test.rs:238:5:242:5 | MatchExpr | test.rs:237:48:243:1 | BlockExpr |  |
+| test.rs:238:11:238:21 | maybe_digit | test.rs:239:9:239:23 | TupleStructPat |  |
+| test.rs:239:9:239:23 | TupleStructPat | test.rs:239:28:239:28 | x | match |
+| test.rs:239:9:239:23 | TupleStructPat | test.rs:240:9:240:23 | TupleStructPat | no-match |
+| test.rs:239:28:239:28 | x | test.rs:239:32:239:33 | 10 |  |
+| test.rs:239:28:239:33 | ... < ... | test.rs:239:38:239:38 | x | true |
+| test.rs:239:28:239:33 | ... < ... | test.rs:240:9:240:23 | TupleStructPat | false |
+| test.rs:239:32:239:33 | 10 | test.rs:239:28:239:33 | ... < ... |  |
+| test.rs:239:38:239:38 | x | test.rs:239:42:239:42 | 5 |  |
+| test.rs:239:38:239:42 | ... + ... | test.rs:238:5:242:5 | MatchExpr |  |
+| test.rs:239:42:239:42 | 5 | test.rs:239:38:239:42 | ... + ... |  |
+| test.rs:240:9:240:23 | TupleStructPat | test.rs:240:28:240:28 | x | match |
+| test.rs:240:9:240:23 | TupleStructPat | test.rs:241:9:241:20 | PathPat | no-match |
+| test.rs:240:28:240:28 | x | test.rs:238:5:242:5 | MatchExpr |  |
+| test.rs:241:9:241:20 | PathPat | test.rs:241:25:241:25 | 5 | match |
+| test.rs:241:25:241:25 | 5 | test.rs:238:5:242:5 | MatchExpr |  |
+| test.rs:246:5:251:5 | enter test_infinite_loop | test.rs:247:9:249:9 | ExprStmt |  |
+| test.rs:247:9:249:9 | ExprStmt | test.rs:248:13:248:13 | 1 |  |
+| test.rs:247:14:249:9 | BlockExpr | test.rs:248:13:248:13 | 1 |  |
+| test.rs:248:13:248:13 | 1 | test.rs:247:14:249:9 | BlockExpr |  |
+| test.rs:253:5:256:5 | enter test_let_match | test.rs:254:9:254:49 | LetStmt |  |
+| test.rs:253:5:256:5 | exit test_let_match (normal) | test.rs:253:5:256:5 | exit test_let_match |  |
+| test.rs:253:39:256:5 | BlockExpr | test.rs:253:5:256:5 | exit test_let_match (normal) |  |
+| test.rs:254:9:254:49 | LetStmt | test.rs:254:23:254:23 | a |  |
+| test.rs:254:13:254:19 | TupleStructPat | test.rs:254:32:254:46 | "Expected some" | no-match |
+| test.rs:254:13:254:19 | TupleStructPat | test.rs:255:9:255:9 | n | match |
+| test.rs:254:23:254:23 | a | test.rs:254:13:254:19 | TupleStructPat |  |
+| test.rs:254:32:254:46 | "Expected some" | test.rs:254:30:254:48 | BlockExpr |  |
+| test.rs:255:9:255:9 | n | test.rs:253:39:256:5 | BlockExpr |  |
+| test.rs:259:1:264:1 | enter dead_code | test.rs:260:5:262:5 | ExprStmt |  |
+| test.rs:259:1:264:1 | exit dead_code (normal) | test.rs:259:1:264:1 | exit dead_code |  |
+| test.rs:260:5:262:5 | ExprStmt | test.rs:260:9:260:12 | true |  |
+| test.rs:260:8:260:13 | ParenExpr | test.rs:261:9:261:17 | ExprStmt | true |
+| test.rs:260:9:260:12 | true | test.rs:260:8:260:13 | ParenExpr |  |
+| test.rs:261:9:261:16 | ReturnExpr | test.rs:259:1:264:1 | exit dead_code (normal) | return |
+| test.rs:261:9:261:17 | ExprStmt | test.rs:261:16:261:16 | 0 |  |
+| test.rs:261:16:261:16 | 0 | test.rs:261:9:261:16 | ReturnExpr |  |
+| test.rs:266:1:279:1 | enter labelled_block1 | test.rs:267:5:278:6 | LetStmt |  |
+| test.rs:266:1:279:1 | exit labelled_block1 (normal) | test.rs:266:1:279:1 | exit labelled_block1 |  |
+| test.rs:266:29:279:1 | BlockExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) |  |
+| test.rs:267:5:278:6 | LetStmt | test.rs:268:9:268:19 | ExprStmt |  |
+| test.rs:267:9:267:14 | result | test.rs:266:29:279:1 | BlockExpr | match, no-match |
+| test.rs:267:18:278:5 | BlockExpr | test.rs:267:9:267:14 | result |  |
+| test.rs:268:9:268:16 | PathExpr | test.rs:268:9:268:18 | CallExpr |  |
+| test.rs:268:9:268:18 | CallExpr | test.rs:269:9:271:9 | ExprStmt |  |
+| test.rs:268:9:268:19 | ExprStmt | test.rs:268:9:268:16 | PathExpr |  |
+| test.rs:269:9:271:9 | ExprStmt | test.rs:269:12:269:28 | PathExpr |  |
+| test.rs:269:9:271:9 | IfExpr | test.rs:272:9:272:24 | ExprStmt |  |
+| test.rs:269:12:269:28 | PathExpr | test.rs:269:12:269:30 | CallExpr |  |
+| test.rs:269:12:269:30 | CallExpr | test.rs:269:9:271:9 | IfExpr | false |
+| test.rs:269:12:269:30 | CallExpr | test.rs:270:13:270:27 | ExprStmt | true |
+| test.rs:270:13:270:26 | BreakExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) | break('block) |
+| test.rs:270:13:270:27 | ExprStmt | test.rs:270:26:270:26 | 1 |  |
+| test.rs:270:26:270:26 | 1 | test.rs:270:13:270:26 | BreakExpr |  |
+| test.rs:272:9:272:21 | PathExpr | test.rs:272:9:272:23 | CallExpr |  |
+| test.rs:272:9:272:23 | CallExpr | test.rs:273:9:275:9 | ExprStmt |  |
+| test.rs:272:9:272:24 | ExprStmt | test.rs:272:9:272:21 | PathExpr |  |
+| test.rs:273:9:275:9 | ExprStmt | test.rs:273:12:273:28 | PathExpr |  |
+| test.rs:273:9:275:9 | IfExpr | test.rs:276:9:276:24 | ExprStmt |  |
+| test.rs:273:12:273:28 | PathExpr | test.rs:273:12:273:30 | CallExpr |  |
+| test.rs:273:12:273:30 | CallExpr | test.rs:273:9:275:9 | IfExpr | false |
+| test.rs:273:12:273:30 | CallExpr | test.rs:274:13:274:27 | ExprStmt | true |
+| test.rs:274:13:274:26 | BreakExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) | break('block) |
+| test.rs:274:13:274:27 | ExprStmt | test.rs:274:26:274:26 | 2 |  |
+| test.rs:274:26:274:26 | 2 | test.rs:274:13:274:26 | BreakExpr |  |
+| test.rs:276:9:276:21 | PathExpr | test.rs:276:9:276:23 | CallExpr |  |
+| test.rs:276:9:276:23 | CallExpr | test.rs:277:9:277:9 | 3 |  |
+| test.rs:276:9:276:24 | ExprStmt | test.rs:276:9:276:21 | PathExpr |  |
+| test.rs:277:9:277:9 | 3 | test.rs:267:18:278:5 | BlockExpr |  |
+| test.rs:281:1:289:1 | enter labelled_block2 | test.rs:282:5:288:6 | LetStmt |  |
+| test.rs:281:1:289:1 | exit labelled_block2 (normal) | test.rs:281:1:289:1 | exit labelled_block2 |  |
+| test.rs:281:29:289:1 | BlockExpr | test.rs:281:1:289:1 | exit labelled_block2 (normal) |  |
+| test.rs:282:5:288:6 | LetStmt | test.rs:283:9:283:34 | LetStmt |  |
+| test.rs:282:9:282:14 | result | test.rs:281:29:289:1 | BlockExpr | match, no-match |
+| test.rs:282:18:288:5 | BlockExpr | test.rs:282:9:282:14 | result |  |
+| test.rs:283:9:283:34 | LetStmt | test.rs:283:30:283:33 | PathExpr |  |
+| test.rs:283:13:283:13 | x | test.rs:284:9:286:10 | LetStmt | match, no-match |
+| test.rs:283:30:283:33 | PathExpr | test.rs:283:13:283:13 | x |  |
+| test.rs:284:9:286:10 | LetStmt | test.rs:284:23:284:23 | x |  |
+| test.rs:284:13:284:19 | TupleStructPat | test.rs:285:13:285:27 | ExprStmt | no-match |
+| test.rs:284:13:284:19 | TupleStructPat | test.rs:287:9:287:9 | x | match |
+| test.rs:284:23:284:23 | x | test.rs:284:13:284:19 | TupleStructPat |  |
+| test.rs:285:13:285:26 | BreakExpr | test.rs:281:1:289:1 | exit labelled_block2 (normal) | break('block) |
+| test.rs:285:13:285:27 | ExprStmt | test.rs:285:26:285:26 | 1 |  |
+| test.rs:285:26:285:26 | 1 | test.rs:285:13:285:26 | BreakExpr |  |
+| test.rs:287:9:287:9 | x | test.rs:282:18:288:5 | BlockExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -97,435 +97,451 @@
 | test.rs:47:21:47:36 | ExprStmt | test.rs:47:21:47:35 | ContinueExpr |  |
 | test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | continue('inner) |
 | test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr |  |
-| test.rs:54:5:63:5 | enter test_while | test.rs:55:9:55:25 | LetStmt |  |
-| test.rs:54:5:63:5 | exit test_while (normal) | test.rs:54:5:63:5 | exit test_while |  |
-| test.rs:54:27:63:5 | BlockExpr | test.rs:54:5:63:5 | exit test_while (normal) |  |
-| test.rs:55:9:55:25 | LetStmt | test.rs:55:21:55:24 | true |  |
-| test.rs:55:13:55:17 | b | test.rs:56:15:56:15 | b | match, no-match |
-| test.rs:55:21:55:24 | true | test.rs:55:13:55:17 | b |  |
-| test.rs:56:9:62:9 | WhileExpr | test.rs:54:27:63:5 | BlockExpr |  |
-| test.rs:56:15:56:15 | b | test.rs:56:9:62:9 | WhileExpr | false |
-| test.rs:56:15:56:15 | b | test.rs:57:13:57:14 | ExprStmt | true |
-| test.rs:56:17:62:9 | BlockExpr | test.rs:56:15:56:15 | b |  |
-| test.rs:57:13:57:13 | 1 | test.rs:58:13:60:13 | ExprStmt |  |
-| test.rs:57:13:57:14 | ExprStmt | test.rs:57:13:57:13 | 1 |  |
-| test.rs:58:13:60:13 | ExprStmt | test.rs:58:17:58:17 | i |  |
-| test.rs:58:13:60:13 | IfExpr | test.rs:61:13:61:22 | ExprStmt |  |
-| test.rs:58:17:58:17 | i | test.rs:58:21:58:21 | 0 |  |
-| test.rs:58:17:58:21 | ... > ... | test.rs:58:13:60:13 | IfExpr | false |
-| test.rs:58:17:58:21 | ... > ... | test.rs:59:17:59:22 | ExprStmt | true |
-| test.rs:58:21:58:21 | 0 | test.rs:58:17:58:21 | ... > ... |  |
-| test.rs:59:17:59:21 | BreakExpr | test.rs:56:9:62:9 | WhileExpr | break |
-| test.rs:59:17:59:22 | ExprStmt | test.rs:59:17:59:21 | BreakExpr |  |
-| test.rs:61:13:61:13 | PathExpr | test.rs:61:17:61:21 | false |  |
-| test.rs:61:13:61:21 | ... = ... | test.rs:56:17:62:9 | BlockExpr |  |
-| test.rs:61:13:61:22 | ExprStmt | test.rs:61:13:61:13 | PathExpr |  |
-| test.rs:61:17:61:21 | false | test.rs:61:13:61:21 | ... = ... |  |
-| test.rs:65:5:72:5 | enter test_while_let | test.rs:66:9:66:29 | LetStmt |  |
-| test.rs:65:5:72:5 | exit test_while_let (normal) | test.rs:65:5:72:5 | exit test_while_let |  |
-| test.rs:65:25:72:5 | BlockExpr | test.rs:65:5:72:5 | exit test_while_let (normal) |  |
-| test.rs:66:9:66:29 | LetStmt | test.rs:66:24:66:24 | 1 |  |
-| test.rs:66:13:66:20 | iter | test.rs:67:15:67:39 | LetExpr | match, no-match |
-| test.rs:66:24:66:24 | 1 | test.rs:66:27:66:28 | 10 |  |
-| test.rs:66:24:66:28 | RangeExpr | test.rs:66:13:66:20 | iter |  |
-| test.rs:66:27:66:28 | 10 | test.rs:66:24:66:28 | RangeExpr |  |
-| test.rs:67:9:71:9 | WhileExpr | test.rs:65:25:72:5 | BlockExpr |  |
-| test.rs:67:15:67:39 | LetExpr | test.rs:67:19:67:25 | TupleStructPat |  |
-| test.rs:67:19:67:25 | TupleStructPat | test.rs:67:9:71:9 | WhileExpr | no-match |
-| test.rs:67:19:67:25 | TupleStructPat | test.rs:68:17:68:17 | PathExpr | match |
-| test.rs:67:41:71:9 | BlockExpr | test.rs:67:15:67:39 | LetExpr |  |
-| test.rs:68:13:70:13 | IfExpr | test.rs:67:41:71:9 | BlockExpr |  |
-| test.rs:68:17:68:17 | PathExpr | test.rs:68:21:68:21 | 5 |  |
-| test.rs:68:17:68:21 | ... = ... | test.rs:68:13:70:13 | IfExpr | false |
-| test.rs:68:17:68:21 | ... = ... | test.rs:69:17:69:22 | ExprStmt | true |
-| test.rs:68:21:68:21 | 5 | test.rs:68:17:68:21 | ... = ... |  |
-| test.rs:69:17:69:21 | BreakExpr | test.rs:67:9:71:9 | WhileExpr | break |
-| test.rs:69:17:69:22 | ExprStmt | test.rs:69:17:69:21 | BreakExpr |  |
-| test.rs:74:5:81:5 | enter test_for | test.rs:75:18:75:18 | 0 |  |
-| test.rs:74:5:81:5 | exit test_for (normal) | test.rs:74:5:81:5 | exit test_for |  |
-| test.rs:74:25:81:5 | BlockExpr | test.rs:74:5:81:5 | exit test_for (normal) |  |
-| test.rs:75:9:80:9 | ForExpr | test.rs:74:25:81:5 | BlockExpr |  |
-| test.rs:75:13:75:13 | i | test.rs:75:9:80:9 | ForExpr | no-match |
-| test.rs:75:13:75:13 | i | test.rs:76:13:78:13 | ExprStmt | match |
-| test.rs:75:18:75:18 | 0 | test.rs:75:21:75:22 | 10 |  |
-| test.rs:75:18:75:22 | RangeExpr | test.rs:75:13:75:13 | i |  |
-| test.rs:75:21:75:22 | 10 | test.rs:75:18:75:22 | RangeExpr |  |
-| test.rs:75:24:80:9 | BlockExpr | test.rs:75:13:75:13 | i |  |
-| test.rs:76:13:78:13 | ExprStmt | test.rs:76:17:76:17 | i |  |
-| test.rs:76:13:78:13 | IfExpr | test.rs:79:13:79:14 | ExprStmt |  |
-| test.rs:76:17:76:17 | i | test.rs:76:22:76:22 | j |  |
-| test.rs:76:17:76:22 | ... == ... | test.rs:76:13:78:13 | IfExpr | false |
-| test.rs:76:17:76:22 | ... == ... | test.rs:77:17:77:22 | ExprStmt | true |
-| test.rs:76:22:76:22 | j | test.rs:76:17:76:22 | ... == ... |  |
-| test.rs:77:17:77:21 | BreakExpr | test.rs:75:9:80:9 | ForExpr | break |
-| test.rs:77:17:77:22 | ExprStmt | test.rs:77:17:77:21 | BreakExpr |  |
-| test.rs:79:13:79:13 | 1 | test.rs:75:24:80:9 | BlockExpr |  |
-| test.rs:79:13:79:14 | ExprStmt | test.rs:79:13:79:13 | 1 |  |
-| test.rs:84:1:87:1 | enter test_nested_function | test.rs:85:5:85:28 | LetStmt |  |
-| test.rs:84:1:87:1 | exit test_nested_function (normal) | test.rs:84:1:87:1 | exit test_nested_function |  |
-| test.rs:84:40:87:1 | BlockExpr | test.rs:84:1:87:1 | exit test_nested_function (normal) |  |
-| test.rs:85:5:85:28 | LetStmt | test.rs:85:19:85:27 | ClosureExpr |  |
-| test.rs:85:9:85:15 | add_one | test.rs:86:5:86:11 | add_one | match, no-match |
-| test.rs:85:19:85:27 | ClosureExpr | test.rs:85:9:85:15 | add_one |  |
-| test.rs:85:19:85:27 | enter ClosureExpr | test.rs:85:23:85:23 | i |  |
-| test.rs:85:19:85:27 | exit ClosureExpr (normal) | test.rs:85:19:85:27 | exit ClosureExpr |  |
-| test.rs:85:23:85:23 | i | test.rs:85:27:85:27 | 1 |  |
-| test.rs:85:23:85:27 | ... + ... | test.rs:85:19:85:27 | exit ClosureExpr (normal) |  |
-| test.rs:85:27:85:27 | 1 | test.rs:85:23:85:27 | ... + ... |  |
-| test.rs:86:5:86:11 | add_one | test.rs:86:13:86:19 | add_one |  |
-| test.rs:86:5:86:23 | CallExpr | test.rs:84:40:87:1 | BlockExpr |  |
-| test.rs:86:13:86:19 | add_one | test.rs:86:21:86:21 | n |  |
-| test.rs:86:13:86:22 | CallExpr | test.rs:86:5:86:23 | CallExpr |  |
-| test.rs:86:21:86:21 | n | test.rs:86:13:86:22 | CallExpr |  |
-| test.rs:91:5:97:5 | enter test_if_else | test.rs:92:12:92:12 | n |  |
-| test.rs:91:5:97:5 | exit test_if_else (normal) | test.rs:91:5:97:5 | exit test_if_else |  |
-| test.rs:91:36:97:5 | BlockExpr | test.rs:91:5:97:5 | exit test_if_else (normal) |  |
-| test.rs:92:9:96:9 | IfExpr | test.rs:91:36:97:5 | BlockExpr |  |
-| test.rs:92:12:92:12 | n | test.rs:92:17:92:17 | 0 |  |
-| test.rs:92:12:92:17 | ... <= ... | test.rs:93:13:93:13 | 0 | true |
-| test.rs:92:12:92:17 | ... <= ... | test.rs:95:13:95:13 | n | false |
-| test.rs:92:17:92:17 | 0 | test.rs:92:12:92:17 | ... <= ... |  |
-| test.rs:92:19:94:9 | BlockExpr | test.rs:92:9:96:9 | IfExpr |  |
-| test.rs:93:13:93:13 | 0 | test.rs:92:19:94:9 | BlockExpr |  |
-| test.rs:94:16:96:9 | BlockExpr | test.rs:92:9:96:9 | IfExpr |  |
-| test.rs:95:13:95:13 | n | test.rs:95:17:95:17 | 1 |  |
-| test.rs:95:13:95:17 | ... - ... | test.rs:94:16:96:9 | BlockExpr |  |
-| test.rs:95:17:95:17 | 1 | test.rs:95:13:95:17 | ... - ... |  |
-| test.rs:99:5:105:5 | enter test_if_let_else | test.rs:100:12:100:26 | LetExpr |  |
-| test.rs:99:5:105:5 | exit test_if_let_else (normal) | test.rs:99:5:105:5 | exit test_if_let_else |  |
-| test.rs:99:48:105:5 | BlockExpr | test.rs:99:5:105:5 | exit test_if_let_else (normal) |  |
-| test.rs:100:9:104:9 | IfExpr | test.rs:99:48:105:5 | BlockExpr |  |
-| test.rs:100:12:100:26 | LetExpr | test.rs:100:16:100:22 | TupleStructPat |  |
-| test.rs:100:16:100:22 | TupleStructPat | test.rs:101:13:101:13 | n | match |
-| test.rs:100:16:100:22 | TupleStructPat | test.rs:103:13:103:13 | 0 | no-match |
-| test.rs:100:28:102:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
-| test.rs:101:13:101:13 | n | test.rs:100:28:102:9 | BlockExpr |  |
-| test.rs:102:16:104:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
-| test.rs:103:13:103:13 | 0 | test.rs:102:16:104:9 | BlockExpr |  |
-| test.rs:107:5:112:5 | enter test_if_let | test.rs:108:9:110:9 | ExprStmt |  |
-| test.rs:107:5:112:5 | exit test_if_let (normal) | test.rs:107:5:112:5 | exit test_if_let |  |
-| test.rs:107:43:112:5 | BlockExpr | test.rs:107:5:112:5 | exit test_if_let (normal) |  |
-| test.rs:108:9:110:9 | ExprStmt | test.rs:108:12:108:26 | LetExpr |  |
-| test.rs:108:9:110:9 | IfExpr | test.rs:111:9:111:9 | 0 |  |
-| test.rs:108:12:108:26 | LetExpr | test.rs:108:16:108:22 | TupleStructPat |  |
-| test.rs:108:16:108:22 | TupleStructPat | test.rs:108:9:110:9 | IfExpr | no-match |
-| test.rs:108:16:108:22 | TupleStructPat | test.rs:109:13:109:13 | n | match |
-| test.rs:108:28:110:9 | BlockExpr | test.rs:108:9:110:9 | IfExpr |  |
-| test.rs:109:13:109:13 | n | test.rs:108:28:110:9 | BlockExpr |  |
-| test.rs:111:9:111:9 | 0 | test.rs:107:43:112:5 | BlockExpr |  |
-| test.rs:114:5:120:5 | enter test_nested_if | test.rs:115:16:115:16 | PathExpr |  |
-| test.rs:114:5:120:5 | exit test_nested_if (normal) | test.rs:114:5:120:5 | exit test_nested_if |  |
-| test.rs:114:38:120:5 | BlockExpr | test.rs:114:5:120:5 | exit test_nested_if (normal) |  |
-| test.rs:115:9:119:9 | IfExpr | test.rs:114:38:120:5 | BlockExpr |  |
-| test.rs:115:13:115:48 | IfExpr | test.rs:116:13:116:13 | 1 | true |
-| test.rs:115:13:115:48 | IfExpr | test.rs:118:13:118:13 | 0 | false |
-| test.rs:115:16:115:16 | PathExpr | test.rs:115:20:115:20 | 0 |  |
-| test.rs:115:16:115:20 | ... < ... | test.rs:115:24:115:24 | a | true |
-| test.rs:115:16:115:20 | ... < ... | test.rs:115:41:115:41 | a | false |
-| test.rs:115:20:115:20 | 0 | test.rs:115:16:115:20 | ... < ... |  |
-| test.rs:115:22:115:32 | BlockExpr | test.rs:115:13:115:48 | IfExpr | false, true |
-| test.rs:115:24:115:24 | a | test.rs:115:29:115:30 | 10 |  |
-| test.rs:115:24:115:30 | ... < ... | test.rs:115:22:115:32 | BlockExpr | false, true |
-| test.rs:115:28:115:30 | - ... | test.rs:115:24:115:30 | ... < ... |  |
-| test.rs:115:29:115:30 | 10 | test.rs:115:28:115:30 | - ... |  |
-| test.rs:115:39:115:48 | BlockExpr | test.rs:115:13:115:48 | IfExpr | false, true |
-| test.rs:115:41:115:41 | a | test.rs:115:45:115:46 | 10 |  |
-| test.rs:115:41:115:46 | ... > ... | test.rs:115:39:115:48 | BlockExpr | false, true |
-| test.rs:115:45:115:46 | 10 | test.rs:115:41:115:46 | ... > ... |  |
-| test.rs:115:51:117:9 | BlockExpr | test.rs:115:9:119:9 | IfExpr |  |
-| test.rs:116:13:116:13 | 1 | test.rs:115:51:117:9 | BlockExpr |  |
-| test.rs:117:16:119:9 | BlockExpr | test.rs:115:9:119:9 | IfExpr |  |
-| test.rs:118:13:118:13 | 0 | test.rs:117:16:119:9 | BlockExpr |  |
-| test.rs:122:5:131:5 | enter test_nested_if_match | test.rs:123:19:123:19 | a |  |
-| test.rs:122:5:131:5 | exit test_nested_if_match (normal) | test.rs:122:5:131:5 | exit test_nested_if_match |  |
-| test.rs:122:44:131:5 | BlockExpr | test.rs:122:5:131:5 | exit test_nested_if_match (normal) |  |
-| test.rs:123:9:130:9 | IfExpr | test.rs:122:44:131:5 | BlockExpr |  |
-| test.rs:123:13:126:9 | MatchExpr | test.rs:127:13:127:13 | 1 | true |
-| test.rs:123:13:126:9 | MatchExpr | test.rs:129:13:129:13 | 0 | false |
-| test.rs:123:19:123:19 | a | test.rs:124:13:124:13 | LiteralPat |  |
-| test.rs:124:13:124:13 | LiteralPat | test.rs:124:18:124:21 | true | match |
-| test.rs:124:13:124:13 | LiteralPat | test.rs:125:13:125:13 | WildcardPat | no-match |
-| test.rs:124:18:124:21 | true | test.rs:123:13:126:9 | MatchExpr |  |
-| test.rs:125:13:125:13 | WildcardPat | test.rs:125:18:125:22 | false | match |
-| test.rs:125:18:125:22 | false | test.rs:123:13:126:9 | MatchExpr |  |
-| test.rs:126:12:128:9 | BlockExpr | test.rs:123:9:130:9 | IfExpr |  |
-| test.rs:127:13:127:13 | 1 | test.rs:126:12:128:9 | BlockExpr |  |
-| test.rs:128:16:130:9 | BlockExpr | test.rs:123:9:130:9 | IfExpr |  |
-| test.rs:129:13:129:13 | 0 | test.rs:128:16:130:9 | BlockExpr |  |
-| test.rs:133:5:142:5 | enter test_nested_if_block | test.rs:135:13:135:15 | ExprStmt |  |
-| test.rs:133:5:142:5 | exit test_nested_if_block (normal) | test.rs:133:5:142:5 | exit test_nested_if_block |  |
-| test.rs:133:44:142:5 | BlockExpr | test.rs:133:5:142:5 | exit test_nested_if_block (normal) |  |
-| test.rs:134:9:141:9 | IfExpr | test.rs:133:44:142:5 | BlockExpr |  |
-| test.rs:134:12:137:9 | BlockExpr | test.rs:138:13:138:13 | 1 | true |
-| test.rs:134:12:137:9 | BlockExpr | test.rs:140:13:140:13 | 0 | false |
-| test.rs:135:13:135:14 | TupleExpr | test.rs:136:13:136:13 | a |  |
-| test.rs:135:13:135:15 | ExprStmt | test.rs:135:13:135:14 | TupleExpr |  |
-| test.rs:136:13:136:13 | a | test.rs:136:17:136:17 | 0 |  |
-| test.rs:136:13:136:17 | ... > ... | test.rs:134:12:137:9 | BlockExpr | false, true |
-| test.rs:136:17:136:17 | 0 | test.rs:136:13:136:17 | ... > ... |  |
-| test.rs:137:11:139:9 | BlockExpr | test.rs:134:9:141:9 | IfExpr |  |
-| test.rs:138:13:138:13 | 1 | test.rs:137:11:139:9 | BlockExpr |  |
-| test.rs:139:16:141:9 | BlockExpr | test.rs:134:9:141:9 | IfExpr |  |
-| test.rs:140:13:140:13 | 0 | test.rs:139:16:141:9 | BlockExpr |  |
-| test.rs:144:5:151:5 | enter test_if_assignment | test.rs:145:9:145:26 | LetStmt |  |
-| test.rs:144:5:151:5 | exit test_if_assignment (normal) | test.rs:144:5:151:5 | exit test_if_assignment |  |
-| test.rs:144:42:151:5 | BlockExpr | test.rs:144:5:151:5 | exit test_if_assignment (normal) |  |
-| test.rs:145:9:145:26 | LetStmt | test.rs:145:21:145:25 | false |  |
-| test.rs:145:13:145:17 | x | test.rs:146:12:146:12 | x | match, no-match |
-| test.rs:145:21:145:25 | false | test.rs:145:13:145:17 | x |  |
-| test.rs:146:9:150:9 | IfExpr | test.rs:144:42:151:5 | BlockExpr |  |
-| test.rs:146:12:146:12 | x | test.rs:146:16:146:19 | true |  |
-| test.rs:146:12:146:19 | ... = ... | test.rs:147:13:147:13 | 1 | true |
-| test.rs:146:12:146:19 | ... = ... | test.rs:149:13:149:13 | 0 | false |
-| test.rs:146:16:146:19 | true | test.rs:146:12:146:19 | ... = ... |  |
-| test.rs:146:21:148:9 | BlockExpr | test.rs:146:9:150:9 | IfExpr |  |
-| test.rs:147:13:147:13 | 1 | test.rs:146:21:148:9 | BlockExpr |  |
-| test.rs:148:16:150:9 | BlockExpr | test.rs:146:9:150:9 | IfExpr |  |
-| test.rs:149:13:149:13 | 0 | test.rs:148:16:150:9 | BlockExpr |  |
-| test.rs:153:5:164:5 | enter test_if_loop1 | test.rs:155:13:157:14 | ExprStmt |  |
-| test.rs:153:5:164:5 | exit test_if_loop1 (normal) | test.rs:153:5:164:5 | exit test_if_loop1 |  |
-| test.rs:153:37:164:5 | BlockExpr | test.rs:153:5:164:5 | exit test_if_loop1 (normal) |  |
-| test.rs:154:9:163:9 | IfExpr | test.rs:153:37:164:5 | BlockExpr |  |
-| test.rs:154:13:159:9 | LoopExpr | test.rs:160:13:160:13 | 1 | true |
-| test.rs:154:13:159:9 | LoopExpr | test.rs:162:13:162:13 | 0 | false |
-| test.rs:154:18:159:9 | BlockExpr | test.rs:155:13:157:14 | ExprStmt |  |
-| test.rs:155:13:157:13 | IfExpr | test.rs:158:13:158:19 | ExprStmt |  |
-| test.rs:155:13:157:14 | ExprStmt | test.rs:155:16:155:16 | a |  |
-| test.rs:155:16:155:16 | a | test.rs:155:20:155:20 | 0 |  |
-| test.rs:155:16:155:20 | ... > ... | test.rs:155:13:157:13 | IfExpr | false |
-| test.rs:155:16:155:20 | ... > ... | test.rs:156:17:156:29 | ExprStmt | true |
-| test.rs:155:20:155:20 | 0 | test.rs:155:16:155:20 | ... > ... |  |
-| test.rs:156:17:156:28 | BreakExpr | test.rs:154:13:159:9 | LoopExpr | break |
-| test.rs:156:17:156:29 | ExprStmt | test.rs:156:23:156:23 | a |  |
-| test.rs:156:23:156:23 | a | test.rs:156:27:156:28 | 10 |  |
-| test.rs:156:23:156:28 | ... > ... | test.rs:156:17:156:28 | BreakExpr |  |
-| test.rs:156:27:156:28 | 10 | test.rs:156:23:156:28 | ... > ... |  |
-| test.rs:158:13:158:13 | a | test.rs:158:17:158:18 | 10 |  |
-| test.rs:158:13:158:18 | ... < ... | test.rs:154:18:159:9 | BlockExpr |  |
-| test.rs:158:13:158:19 | ExprStmt | test.rs:158:13:158:13 | a |  |
-| test.rs:158:17:158:18 | 10 | test.rs:158:13:158:18 | ... < ... |  |
-| test.rs:159:12:161:9 | BlockExpr | test.rs:154:9:163:9 | IfExpr |  |
-| test.rs:160:13:160:13 | 1 | test.rs:159:12:161:9 | BlockExpr |  |
-| test.rs:161:16:163:9 | BlockExpr | test.rs:154:9:163:9 | IfExpr |  |
-| test.rs:162:13:162:13 | 0 | test.rs:161:16:163:9 | BlockExpr |  |
-| test.rs:166:5:177:5 | enter test_if_loop2 | test.rs:168:13:170:14 | ExprStmt |  |
-| test.rs:166:5:177:5 | exit test_if_loop2 (normal) | test.rs:166:5:177:5 | exit test_if_loop2 |  |
-| test.rs:166:37:177:5 | BlockExpr | test.rs:166:5:177:5 | exit test_if_loop2 (normal) |  |
-| test.rs:167:9:176:9 | IfExpr | test.rs:166:37:177:5 | BlockExpr |  |
-| test.rs:167:13:172:9 | LoopExpr | test.rs:173:13:173:13 | 1 | true |
-| test.rs:167:13:172:9 | LoopExpr | test.rs:175:13:175:13 | 0 | false |
-| test.rs:167:26:172:9 | BlockExpr | test.rs:168:13:170:14 | ExprStmt |  |
-| test.rs:168:13:170:13 | IfExpr | test.rs:171:13:171:19 | ExprStmt |  |
-| test.rs:168:13:170:14 | ExprStmt | test.rs:168:16:168:16 | a |  |
-| test.rs:168:16:168:16 | a | test.rs:168:20:168:20 | 0 |  |
-| test.rs:168:16:168:20 | ... > ... | test.rs:168:13:170:13 | IfExpr | false |
-| test.rs:168:16:168:20 | ... > ... | test.rs:169:17:169:36 | ExprStmt | true |
-| test.rs:168:20:168:20 | 0 | test.rs:168:16:168:20 | ... > ... |  |
-| test.rs:169:17:169:35 | BreakExpr | test.rs:167:13:172:9 | LoopExpr | break('label) |
-| test.rs:169:17:169:36 | ExprStmt | test.rs:169:30:169:30 | a |  |
-| test.rs:169:30:169:30 | a | test.rs:169:34:169:35 | 10 |  |
-| test.rs:169:30:169:35 | ... > ... | test.rs:169:17:169:35 | BreakExpr |  |
-| test.rs:169:34:169:35 | 10 | test.rs:169:30:169:35 | ... > ... |  |
-| test.rs:171:13:171:13 | a | test.rs:171:17:171:18 | 10 |  |
-| test.rs:171:13:171:18 | ... < ... | test.rs:167:26:172:9 | BlockExpr |  |
-| test.rs:171:13:171:19 | ExprStmt | test.rs:171:13:171:13 | a |  |
-| test.rs:171:17:171:18 | 10 | test.rs:171:13:171:18 | ... < ... |  |
-| test.rs:172:12:174:9 | BlockExpr | test.rs:167:9:176:9 | IfExpr |  |
-| test.rs:173:13:173:13 | 1 | test.rs:172:12:174:9 | BlockExpr |  |
-| test.rs:174:16:176:9 | BlockExpr | test.rs:167:9:176:9 | IfExpr |  |
-| test.rs:175:13:175:13 | 0 | test.rs:174:16:176:9 | BlockExpr |  |
-| test.rs:179:5:187:5 | enter test_labelled_block | test.rs:181:13:181:31 | ExprStmt |  |
-| test.rs:179:5:187:5 | exit test_labelled_block (normal) | test.rs:179:5:187:5 | exit test_labelled_block |  |
-| test.rs:179:43:187:5 | BlockExpr | test.rs:179:5:187:5 | exit test_labelled_block (normal) |  |
-| test.rs:180:9:186:9 | IfExpr | test.rs:179:43:187:5 | BlockExpr |  |
-| test.rs:180:13:182:9 | BlockExpr | test.rs:183:13:183:13 | 1 | true |
-| test.rs:180:13:182:9 | BlockExpr | test.rs:185:13:185:13 | 0 | false |
-| test.rs:181:13:181:30 | BreakExpr | test.rs:180:13:182:9 | BlockExpr | break('block) |
-| test.rs:181:13:181:31 | ExprStmt | test.rs:181:26:181:26 | a |  |
-| test.rs:181:26:181:26 | a | test.rs:181:30:181:30 | 0 |  |
-| test.rs:181:26:181:30 | ... > ... | test.rs:181:13:181:30 | BreakExpr |  |
-| test.rs:181:30:181:30 | 0 | test.rs:181:26:181:30 | ... > ... |  |
-| test.rs:182:12:184:9 | BlockExpr | test.rs:180:9:186:9 | IfExpr |  |
-| test.rs:183:13:183:13 | 1 | test.rs:182:12:184:9 | BlockExpr |  |
-| test.rs:184:16:186:9 | BlockExpr | test.rs:180:9:186:9 | IfExpr |  |
-| test.rs:185:13:185:13 | 0 | test.rs:184:16:186:9 | BlockExpr |  |
-| test.rs:192:5:195:5 | enter test_and_operator | test.rs:193:9:193:28 | LetStmt |  |
-| test.rs:192:5:195:5 | exit test_and_operator (normal) | test.rs:192:5:195:5 | exit test_and_operator |  |
-| test.rs:192:61:195:5 | BlockExpr | test.rs:192:5:195:5 | exit test_and_operator (normal) |  |
-| test.rs:193:9:193:28 | LetStmt | test.rs:193:17:193:27 | ... && ... |  |
-| test.rs:193:13:193:13 | d | test.rs:194:9:194:9 | d | match, no-match |
-| test.rs:193:17:193:17 | a | test.rs:193:13:193:13 | d | false |
-| test.rs:193:17:193:17 | a | test.rs:193:22:193:22 | b | true |
-| test.rs:193:17:193:22 | ... && ... | test.rs:193:17:193:17 | a |  |
-| test.rs:193:17:193:27 | ... && ... | test.rs:193:17:193:22 | ... && ... |  |
-| test.rs:193:22:193:22 | b | test.rs:193:13:193:13 | d | false |
-| test.rs:193:22:193:22 | b | test.rs:193:27:193:27 | c | true |
-| test.rs:193:27:193:27 | c | test.rs:193:13:193:13 | d |  |
-| test.rs:194:9:194:9 | d | test.rs:192:61:195:5 | BlockExpr |  |
-| test.rs:197:5:200:5 | enter test_or_operator | test.rs:198:9:198:28 | LetStmt |  |
-| test.rs:197:5:200:5 | exit test_or_operator (normal) | test.rs:197:5:200:5 | exit test_or_operator |  |
-| test.rs:197:60:200:5 | BlockExpr | test.rs:197:5:200:5 | exit test_or_operator (normal) |  |
-| test.rs:198:9:198:28 | LetStmt | test.rs:198:17:198:27 | ... \|\| ... |  |
-| test.rs:198:13:198:13 | d | test.rs:199:9:199:9 | d | match, no-match |
-| test.rs:198:17:198:17 | a | test.rs:198:13:198:13 | d | true |
-| test.rs:198:17:198:17 | a | test.rs:198:22:198:22 | b | false |
-| test.rs:198:17:198:22 | ... \|\| ... | test.rs:198:17:198:17 | a |  |
-| test.rs:198:17:198:27 | ... \|\| ... | test.rs:198:17:198:22 | ... \|\| ... |  |
-| test.rs:198:22:198:22 | b | test.rs:198:13:198:13 | d | true |
-| test.rs:198:22:198:22 | b | test.rs:198:27:198:27 | c | false |
-| test.rs:198:27:198:27 | c | test.rs:198:13:198:13 | d |  |
-| test.rs:199:9:199:9 | d | test.rs:197:60:200:5 | BlockExpr |  |
-| test.rs:202:5:205:5 | enter test_or_operator_2 | test.rs:203:9:203:36 | LetStmt |  |
-| test.rs:202:5:205:5 | exit test_or_operator_2 (normal) | test.rs:202:5:205:5 | exit test_or_operator_2 |  |
-| test.rs:202:61:205:5 | BlockExpr | test.rs:202:5:205:5 | exit test_or_operator_2 (normal) |  |
-| test.rs:203:9:203:36 | LetStmt | test.rs:203:17:203:35 | ... \|\| ... |  |
-| test.rs:203:13:203:13 | d | test.rs:204:9:204:9 | d | match, no-match |
-| test.rs:203:17:203:17 | a | test.rs:203:13:203:13 | d | true |
-| test.rs:203:17:203:17 | a | test.rs:203:23:203:23 | b | false |
-| test.rs:203:17:203:30 | ... \|\| ... | test.rs:203:17:203:17 | a |  |
-| test.rs:203:17:203:35 | ... \|\| ... | test.rs:203:17:203:30 | ... \|\| ... |  |
-| test.rs:203:23:203:23 | b | test.rs:203:28:203:29 | 28 |  |
-| test.rs:203:23:203:29 | ... == ... | test.rs:203:13:203:13 | d | true |
-| test.rs:203:23:203:29 | ... == ... | test.rs:203:35:203:35 | c | false |
-| test.rs:203:28:203:29 | 28 | test.rs:203:23:203:29 | ... == ... |  |
-| test.rs:203:35:203:35 | c | test.rs:203:13:203:13 | d |  |
-| test.rs:204:9:204:9 | d | test.rs:202:61:205:5 | BlockExpr |  |
-| test.rs:207:5:210:5 | enter test_not_operator | test.rs:208:9:208:19 | LetStmt |  |
-| test.rs:207:5:210:5 | exit test_not_operator (normal) | test.rs:207:5:210:5 | exit test_not_operator |  |
-| test.rs:207:43:210:5 | BlockExpr | test.rs:207:5:210:5 | exit test_not_operator (normal) |  |
-| test.rs:208:9:208:19 | LetStmt | test.rs:208:18:208:18 | a |  |
-| test.rs:208:13:208:13 | d | test.rs:209:9:209:9 | d | match, no-match |
-| test.rs:208:17:208:18 | ! ... | test.rs:208:13:208:13 | d |  |
-| test.rs:208:18:208:18 | a | test.rs:208:17:208:18 | ! ... |  |
-| test.rs:209:9:209:9 | d | test.rs:207:43:210:5 | BlockExpr |  |
-| test.rs:212:5:218:5 | enter test_if_and_operator | test.rs:213:12:213:22 | ... && ... |  |
-| test.rs:212:5:218:5 | exit test_if_and_operator (normal) | test.rs:212:5:218:5 | exit test_if_and_operator |  |
-| test.rs:212:63:218:5 | BlockExpr | test.rs:212:5:218:5 | exit test_if_and_operator (normal) |  |
-| test.rs:213:9:217:9 | IfExpr | test.rs:212:63:218:5 | BlockExpr |  |
-| test.rs:213:12:213:12 | a | test.rs:213:17:213:17 | b | true |
-| test.rs:213:12:213:12 | a | test.rs:216:13:216:17 | false | false |
-| test.rs:213:12:213:17 | ... && ... | test.rs:213:12:213:12 | a |  |
-| test.rs:213:12:213:22 | ... && ... | test.rs:213:12:213:17 | ... && ... |  |
-| test.rs:213:17:213:17 | b | test.rs:213:22:213:22 | c | true |
-| test.rs:213:17:213:17 | b | test.rs:216:13:216:17 | false | false |
-| test.rs:213:22:213:22 | c | test.rs:214:13:214:16 | true | true |
-| test.rs:213:22:213:22 | c | test.rs:216:13:216:17 | false | false |
-| test.rs:213:24:215:9 | BlockExpr | test.rs:213:9:217:9 | IfExpr |  |
-| test.rs:214:13:214:16 | true | test.rs:213:24:215:9 | BlockExpr |  |
-| test.rs:215:16:217:9 | BlockExpr | test.rs:213:9:217:9 | IfExpr |  |
-| test.rs:216:13:216:17 | false | test.rs:215:16:217:9 | BlockExpr |  |
-| test.rs:220:5:226:5 | enter test_if_or_operator | test.rs:221:12:221:22 | ... \|\| ... |  |
-| test.rs:220:5:226:5 | exit test_if_or_operator (normal) | test.rs:220:5:226:5 | exit test_if_or_operator |  |
-| test.rs:220:62:226:5 | BlockExpr | test.rs:220:5:226:5 | exit test_if_or_operator (normal) |  |
-| test.rs:221:9:225:9 | IfExpr | test.rs:220:62:226:5 | BlockExpr |  |
-| test.rs:221:12:221:12 | a | test.rs:221:17:221:17 | b | false |
-| test.rs:221:12:221:12 | a | test.rs:222:13:222:16 | true | true |
-| test.rs:221:12:221:17 | ... \|\| ... | test.rs:221:12:221:12 | a |  |
-| test.rs:221:12:221:22 | ... \|\| ... | test.rs:221:12:221:17 | ... \|\| ... |  |
-| test.rs:221:17:221:17 | b | test.rs:221:22:221:22 | c | false |
-| test.rs:221:17:221:17 | b | test.rs:222:13:222:16 | true | true |
-| test.rs:221:22:221:22 | c | test.rs:222:13:222:16 | true | true |
-| test.rs:221:22:221:22 | c | test.rs:224:13:224:17 | false | false |
-| test.rs:221:24:223:9 | BlockExpr | test.rs:221:9:225:9 | IfExpr |  |
-| test.rs:222:13:222:16 | true | test.rs:221:24:223:9 | BlockExpr |  |
-| test.rs:223:16:225:9 | BlockExpr | test.rs:221:9:225:9 | IfExpr |  |
-| test.rs:224:13:224:17 | false | test.rs:223:16:225:9 | BlockExpr |  |
-| test.rs:228:5:234:5 | enter test_if_not_operator | test.rs:229:13:229:13 | a |  |
-| test.rs:228:5:234:5 | exit test_if_not_operator (normal) | test.rs:228:5:234:5 | exit test_if_not_operator |  |
-| test.rs:228:46:234:5 | BlockExpr | test.rs:228:5:234:5 | exit test_if_not_operator (normal) |  |
-| test.rs:229:9:233:9 | IfExpr | test.rs:228:46:234:5 | BlockExpr |  |
-| test.rs:229:12:229:13 | ! ... | test.rs:230:13:230:16 | true | true |
-| test.rs:229:12:229:13 | ! ... | test.rs:232:13:232:17 | false | false |
-| test.rs:229:13:229:13 | a | test.rs:229:12:229:13 | ! ... | false, true |
-| test.rs:229:15:231:9 | BlockExpr | test.rs:229:9:233:9 | IfExpr |  |
-| test.rs:230:13:230:16 | true | test.rs:229:15:231:9 | BlockExpr |  |
-| test.rs:231:16:233:9 | BlockExpr | test.rs:229:9:233:9 | IfExpr |  |
-| test.rs:232:13:232:17 | false | test.rs:231:16:233:9 | BlockExpr |  |
-| test.rs:237:1:243:1 | enter test_match | test.rs:238:11:238:21 | maybe_digit |  |
-| test.rs:237:1:243:1 | exit test_match (normal) | test.rs:237:1:243:1 | exit test_match |  |
-| test.rs:237:48:243:1 | BlockExpr | test.rs:237:1:243:1 | exit test_match (normal) |  |
-| test.rs:238:5:242:5 | MatchExpr | test.rs:237:48:243:1 | BlockExpr |  |
-| test.rs:238:11:238:21 | maybe_digit | test.rs:239:9:239:23 | TupleStructPat |  |
-| test.rs:239:9:239:23 | TupleStructPat | test.rs:239:28:239:28 | x | match |
-| test.rs:239:9:239:23 | TupleStructPat | test.rs:240:9:240:23 | TupleStructPat | no-match |
-| test.rs:239:28:239:28 | x | test.rs:239:32:239:33 | 10 |  |
-| test.rs:239:28:239:33 | ... < ... | test.rs:239:38:239:38 | x | true |
-| test.rs:239:28:239:33 | ... < ... | test.rs:240:9:240:23 | TupleStructPat | false |
-| test.rs:239:32:239:33 | 10 | test.rs:239:28:239:33 | ... < ... |  |
-| test.rs:239:38:239:38 | x | test.rs:239:42:239:42 | 5 |  |
-| test.rs:239:38:239:42 | ... + ... | test.rs:238:5:242:5 | MatchExpr |  |
-| test.rs:239:42:239:42 | 5 | test.rs:239:38:239:42 | ... + ... |  |
-| test.rs:240:9:240:23 | TupleStructPat | test.rs:240:28:240:28 | x | match |
-| test.rs:240:9:240:23 | TupleStructPat | test.rs:241:9:241:20 | PathPat | no-match |
-| test.rs:240:28:240:28 | x | test.rs:238:5:242:5 | MatchExpr |  |
-| test.rs:241:9:241:20 | PathPat | test.rs:241:25:241:25 | 5 | match |
-| test.rs:241:25:241:25 | 5 | test.rs:238:5:242:5 | MatchExpr |  |
-| test.rs:246:5:251:5 | enter test_infinite_loop | test.rs:247:9:249:9 | ExprStmt |  |
-| test.rs:247:9:249:9 | ExprStmt | test.rs:248:13:248:13 | 1 |  |
-| test.rs:247:14:249:9 | BlockExpr | test.rs:248:13:248:13 | 1 |  |
-| test.rs:248:13:248:13 | 1 | test.rs:247:14:249:9 | BlockExpr |  |
-| test.rs:253:5:256:5 | enter test_let_match | test.rs:254:9:254:49 | LetStmt |  |
-| test.rs:253:5:256:5 | exit test_let_match (normal) | test.rs:253:5:256:5 | exit test_let_match |  |
-| test.rs:253:39:256:5 | BlockExpr | test.rs:253:5:256:5 | exit test_let_match (normal) |  |
-| test.rs:254:9:254:49 | LetStmt | test.rs:254:23:254:23 | a |  |
-| test.rs:254:13:254:19 | TupleStructPat | test.rs:254:32:254:46 | "Expected some" | no-match |
-| test.rs:254:13:254:19 | TupleStructPat | test.rs:255:9:255:9 | n | match |
-| test.rs:254:23:254:23 | a | test.rs:254:13:254:19 | TupleStructPat |  |
-| test.rs:254:32:254:46 | "Expected some" | test.rs:254:30:254:48 | BlockExpr |  |
-| test.rs:255:9:255:9 | n | test.rs:253:39:256:5 | BlockExpr |  |
-| test.rs:259:1:264:1 | enter dead_code | test.rs:260:5:262:5 | ExprStmt |  |
-| test.rs:259:1:264:1 | exit dead_code (normal) | test.rs:259:1:264:1 | exit dead_code |  |
-| test.rs:260:5:262:5 | ExprStmt | test.rs:260:9:260:12 | true |  |
-| test.rs:260:9:260:12 | true | test.rs:261:9:261:17 | ExprStmt | true |
-| test.rs:261:9:261:16 | ReturnExpr | test.rs:259:1:264:1 | exit dead_code (normal) | return |
-| test.rs:261:9:261:17 | ExprStmt | test.rs:261:16:261:16 | 0 |  |
-| test.rs:261:16:261:16 | 0 | test.rs:261:9:261:16 | ReturnExpr |  |
-| test.rs:266:1:279:1 | enter labelled_block1 | test.rs:267:5:278:6 | LetStmt |  |
-| test.rs:266:1:279:1 | exit labelled_block1 (normal) | test.rs:266:1:279:1 | exit labelled_block1 |  |
-| test.rs:266:29:279:1 | BlockExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) |  |
-| test.rs:267:5:278:6 | LetStmt | test.rs:268:9:268:19 | ExprStmt |  |
-| test.rs:267:9:267:14 | result | test.rs:266:29:279:1 | BlockExpr | match, no-match |
-| test.rs:267:18:278:5 | BlockExpr | test.rs:267:9:267:14 | result |  |
-| test.rs:268:9:268:16 | PathExpr | test.rs:268:9:268:18 | CallExpr |  |
-| test.rs:268:9:268:18 | CallExpr | test.rs:269:9:271:9 | ExprStmt |  |
-| test.rs:268:9:268:19 | ExprStmt | test.rs:268:9:268:16 | PathExpr |  |
-| test.rs:269:9:271:9 | ExprStmt | test.rs:269:12:269:28 | PathExpr |  |
-| test.rs:269:9:271:9 | IfExpr | test.rs:272:9:272:24 | ExprStmt |  |
-| test.rs:269:12:269:28 | PathExpr | test.rs:269:12:269:30 | CallExpr |  |
-| test.rs:269:12:269:30 | CallExpr | test.rs:269:9:271:9 | IfExpr | false |
-| test.rs:269:12:269:30 | CallExpr | test.rs:270:13:270:27 | ExprStmt | true |
-| test.rs:270:13:270:26 | BreakExpr | test.rs:267:18:278:5 | BlockExpr | break('block) |
-| test.rs:270:13:270:27 | ExprStmt | test.rs:270:26:270:26 | 1 |  |
-| test.rs:270:26:270:26 | 1 | test.rs:270:13:270:26 | BreakExpr |  |
-| test.rs:272:9:272:21 | PathExpr | test.rs:272:9:272:23 | CallExpr |  |
-| test.rs:272:9:272:23 | CallExpr | test.rs:273:9:275:9 | ExprStmt |  |
-| test.rs:272:9:272:24 | ExprStmt | test.rs:272:9:272:21 | PathExpr |  |
-| test.rs:273:9:275:9 | ExprStmt | test.rs:273:12:273:28 | PathExpr |  |
-| test.rs:273:9:275:9 | IfExpr | test.rs:276:9:276:24 | ExprStmt |  |
-| test.rs:273:12:273:28 | PathExpr | test.rs:273:12:273:30 | CallExpr |  |
-| test.rs:273:12:273:30 | CallExpr | test.rs:273:9:275:9 | IfExpr | false |
-| test.rs:273:12:273:30 | CallExpr | test.rs:274:13:274:27 | ExprStmt | true |
-| test.rs:274:13:274:26 | BreakExpr | test.rs:267:18:278:5 | BlockExpr | break('block) |
-| test.rs:274:13:274:27 | ExprStmt | test.rs:274:26:274:26 | 2 |  |
-| test.rs:274:26:274:26 | 2 | test.rs:274:13:274:26 | BreakExpr |  |
-| test.rs:276:9:276:21 | PathExpr | test.rs:276:9:276:23 | CallExpr |  |
-| test.rs:276:9:276:23 | CallExpr | test.rs:277:9:277:9 | 3 |  |
-| test.rs:276:9:276:24 | ExprStmt | test.rs:276:9:276:21 | PathExpr |  |
-| test.rs:277:9:277:9 | 3 | test.rs:267:18:278:5 | BlockExpr |  |
-| test.rs:281:1:289:1 | enter labelled_block2 | test.rs:282:5:288:6 | LetStmt |  |
-| test.rs:281:1:289:1 | exit labelled_block2 (normal) | test.rs:281:1:289:1 | exit labelled_block2 |  |
-| test.rs:281:29:289:1 | BlockExpr | test.rs:281:1:289:1 | exit labelled_block2 (normal) |  |
-| test.rs:282:5:288:6 | LetStmt | test.rs:283:9:283:34 | LetStmt |  |
-| test.rs:282:9:282:14 | result | test.rs:281:29:289:1 | BlockExpr | match, no-match |
-| test.rs:282:18:288:5 | BlockExpr | test.rs:282:9:282:14 | result |  |
-| test.rs:283:9:283:34 | LetStmt | test.rs:283:30:283:33 | PathExpr |  |
-| test.rs:283:13:283:13 | x | test.rs:284:9:286:10 | LetStmt | match, no-match |
-| test.rs:283:30:283:33 | PathExpr | test.rs:283:13:283:13 | x |  |
-| test.rs:284:9:286:10 | LetStmt | test.rs:284:23:284:23 | x |  |
-| test.rs:284:13:284:19 | TupleStructPat | test.rs:285:13:285:27 | ExprStmt | no-match |
-| test.rs:284:13:284:19 | TupleStructPat | test.rs:287:9:287:9 | x | match |
-| test.rs:284:23:284:23 | x | test.rs:284:13:284:19 | TupleStructPat |  |
-| test.rs:285:13:285:26 | BreakExpr | test.rs:282:18:288:5 | BlockExpr | break('block) |
-| test.rs:285:13:285:27 | ExprStmt | test.rs:285:26:285:26 | 1 |  |
-| test.rs:285:26:285:26 | 1 | test.rs:285:13:285:26 | BreakExpr |  |
-| test.rs:287:9:287:9 | x | test.rs:282:18:288:5 | BlockExpr |  |
+| test.rs:54:5:66:5 | enter test_loop_label_shadowing | test.rs:56:13:56:14 | ExprStmt |  |
+| test.rs:56:13:56:13 | 1 | test.rs:58:17:62:17 | ExprStmt |  |
+| test.rs:56:13:56:14 | ExprStmt | test.rs:56:13:56:13 | 1 |  |
+| test.rs:58:17:62:17 | ExprStmt | test.rs:58:20:58:20 | b |  |
+| test.rs:58:17:62:17 | IfExpr | test.rs:63:17:63:31 | ExprStmt |  |
+| test.rs:58:20:58:20 | b | test.rs:59:21:59:29 | ExprStmt | true |
+| test.rs:58:20:58:20 | b | test.rs:60:27:60:27 | b | false |
+| test.rs:59:21:59:28 | ContinueExpr | test.rs:58:17:62:17 | ExprStmt | continue |
+| test.rs:59:21:59:29 | ExprStmt | test.rs:59:21:59:28 | ContinueExpr |  |
+| test.rs:60:24:62:17 | IfExpr | test.rs:58:17:62:17 | IfExpr |  |
+| test.rs:60:27:60:27 | b | test.rs:60:24:62:17 | IfExpr | false |
+| test.rs:60:27:60:27 | b | test.rs:61:21:61:35 | ExprStmt | true |
+| test.rs:61:21:61:34 | ContinueExpr | test.rs:58:17:62:17 | ExprStmt | continue('loop) |
+| test.rs:61:21:61:35 | ExprStmt | test.rs:61:21:61:34 | ContinueExpr |  |
+| test.rs:63:17:63:30 | ContinueExpr | test.rs:58:17:62:17 | ExprStmt | continue('loop) |
+| test.rs:63:17:63:31 | ExprStmt | test.rs:63:17:63:30 | ContinueExpr |  |
+| test.rs:68:5:77:5 | enter test_while | test.rs:69:9:69:25 | LetStmt |  |
+| test.rs:68:5:77:5 | exit test_while (normal) | test.rs:68:5:77:5 | exit test_while |  |
+| test.rs:68:27:77:5 | BlockExpr | test.rs:68:5:77:5 | exit test_while (normal) |  |
+| test.rs:69:9:69:25 | LetStmt | test.rs:69:21:69:24 | true |  |
+| test.rs:69:13:69:17 | b | test.rs:70:15:70:15 | b | match, no-match |
+| test.rs:69:21:69:24 | true | test.rs:69:13:69:17 | b |  |
+| test.rs:70:9:76:9 | WhileExpr | test.rs:68:27:77:5 | BlockExpr |  |
+| test.rs:70:15:70:15 | b | test.rs:70:9:76:9 | WhileExpr | false |
+| test.rs:70:15:70:15 | b | test.rs:71:13:71:14 | ExprStmt | true |
+| test.rs:70:17:76:9 | BlockExpr | test.rs:70:15:70:15 | b |  |
+| test.rs:71:13:71:13 | 1 | test.rs:72:13:74:13 | ExprStmt |  |
+| test.rs:71:13:71:14 | ExprStmt | test.rs:71:13:71:13 | 1 |  |
+| test.rs:72:13:74:13 | ExprStmt | test.rs:72:17:72:17 | i |  |
+| test.rs:72:13:74:13 | IfExpr | test.rs:75:13:75:22 | ExprStmt |  |
+| test.rs:72:17:72:17 | i | test.rs:72:21:72:21 | 0 |  |
+| test.rs:72:17:72:21 | ... > ... | test.rs:72:13:74:13 | IfExpr | false |
+| test.rs:72:17:72:21 | ... > ... | test.rs:73:17:73:22 | ExprStmt | true |
+| test.rs:72:21:72:21 | 0 | test.rs:72:17:72:21 | ... > ... |  |
+| test.rs:73:17:73:21 | BreakExpr | test.rs:70:9:76:9 | WhileExpr | break |
+| test.rs:73:17:73:22 | ExprStmt | test.rs:73:17:73:21 | BreakExpr |  |
+| test.rs:75:13:75:13 | PathExpr | test.rs:75:17:75:21 | false |  |
+| test.rs:75:13:75:21 | ... = ... | test.rs:70:17:76:9 | BlockExpr |  |
+| test.rs:75:13:75:22 | ExprStmt | test.rs:75:13:75:13 | PathExpr |  |
+| test.rs:75:17:75:21 | false | test.rs:75:13:75:21 | ... = ... |  |
+| test.rs:79:5:86:5 | enter test_while_let | test.rs:80:9:80:29 | LetStmt |  |
+| test.rs:79:5:86:5 | exit test_while_let (normal) | test.rs:79:5:86:5 | exit test_while_let |  |
+| test.rs:79:25:86:5 | BlockExpr | test.rs:79:5:86:5 | exit test_while_let (normal) |  |
+| test.rs:80:9:80:29 | LetStmt | test.rs:80:24:80:24 | 1 |  |
+| test.rs:80:13:80:20 | iter | test.rs:81:15:81:39 | LetExpr | match, no-match |
+| test.rs:80:24:80:24 | 1 | test.rs:80:27:80:28 | 10 |  |
+| test.rs:80:24:80:28 | RangeExpr | test.rs:80:13:80:20 | iter |  |
+| test.rs:80:27:80:28 | 10 | test.rs:80:24:80:28 | RangeExpr |  |
+| test.rs:81:9:85:9 | WhileExpr | test.rs:79:25:86:5 | BlockExpr |  |
+| test.rs:81:15:81:39 | LetExpr | test.rs:81:19:81:25 | TupleStructPat |  |
+| test.rs:81:19:81:25 | TupleStructPat | test.rs:81:9:85:9 | WhileExpr | no-match |
+| test.rs:81:19:81:25 | TupleStructPat | test.rs:82:17:82:17 | PathExpr | match |
+| test.rs:81:41:85:9 | BlockExpr | test.rs:81:15:81:39 | LetExpr |  |
+| test.rs:82:13:84:13 | IfExpr | test.rs:81:41:85:9 | BlockExpr |  |
+| test.rs:82:17:82:17 | PathExpr | test.rs:82:21:82:21 | 5 |  |
+| test.rs:82:17:82:21 | ... = ... | test.rs:82:13:84:13 | IfExpr | false |
+| test.rs:82:17:82:21 | ... = ... | test.rs:83:17:83:22 | ExprStmt | true |
+| test.rs:82:21:82:21 | 5 | test.rs:82:17:82:21 | ... = ... |  |
+| test.rs:83:17:83:21 | BreakExpr | test.rs:81:9:85:9 | WhileExpr | break |
+| test.rs:83:17:83:22 | ExprStmt | test.rs:83:17:83:21 | BreakExpr |  |
+| test.rs:88:5:95:5 | enter test_for | test.rs:89:18:89:18 | 0 |  |
+| test.rs:88:5:95:5 | exit test_for (normal) | test.rs:88:5:95:5 | exit test_for |  |
+| test.rs:88:25:95:5 | BlockExpr | test.rs:88:5:95:5 | exit test_for (normal) |  |
+| test.rs:89:9:94:9 | ForExpr | test.rs:88:25:95:5 | BlockExpr |  |
+| test.rs:89:13:89:13 | i | test.rs:89:9:94:9 | ForExpr | no-match |
+| test.rs:89:13:89:13 | i | test.rs:90:13:92:13 | ExprStmt | match |
+| test.rs:89:18:89:18 | 0 | test.rs:89:21:89:22 | 10 |  |
+| test.rs:89:18:89:22 | RangeExpr | test.rs:89:13:89:13 | i |  |
+| test.rs:89:21:89:22 | 10 | test.rs:89:18:89:22 | RangeExpr |  |
+| test.rs:89:24:94:9 | BlockExpr | test.rs:89:13:89:13 | i |  |
+| test.rs:90:13:92:13 | ExprStmt | test.rs:90:17:90:17 | i |  |
+| test.rs:90:13:92:13 | IfExpr | test.rs:93:13:93:14 | ExprStmt |  |
+| test.rs:90:17:90:17 | i | test.rs:90:22:90:22 | j |  |
+| test.rs:90:17:90:22 | ... == ... | test.rs:90:13:92:13 | IfExpr | false |
+| test.rs:90:17:90:22 | ... == ... | test.rs:91:17:91:22 | ExprStmt | true |
+| test.rs:90:22:90:22 | j | test.rs:90:17:90:22 | ... == ... |  |
+| test.rs:91:17:91:21 | BreakExpr | test.rs:89:9:94:9 | ForExpr | break |
+| test.rs:91:17:91:22 | ExprStmt | test.rs:91:17:91:21 | BreakExpr |  |
+| test.rs:93:13:93:13 | 1 | test.rs:89:24:94:9 | BlockExpr |  |
+| test.rs:93:13:93:14 | ExprStmt | test.rs:93:13:93:13 | 1 |  |
+| test.rs:98:1:101:1 | enter test_nested_function | test.rs:99:5:99:28 | LetStmt |  |
+| test.rs:98:1:101:1 | exit test_nested_function (normal) | test.rs:98:1:101:1 | exit test_nested_function |  |
+| test.rs:98:40:101:1 | BlockExpr | test.rs:98:1:101:1 | exit test_nested_function (normal) |  |
+| test.rs:99:5:99:28 | LetStmt | test.rs:99:19:99:27 | ClosureExpr |  |
+| test.rs:99:9:99:15 | add_one | test.rs:100:5:100:11 | add_one | match, no-match |
+| test.rs:99:19:99:27 | ClosureExpr | test.rs:99:9:99:15 | add_one |  |
+| test.rs:99:19:99:27 | enter ClosureExpr | test.rs:99:23:99:23 | i |  |
+| test.rs:99:19:99:27 | exit ClosureExpr (normal) | test.rs:99:19:99:27 | exit ClosureExpr |  |
+| test.rs:99:23:99:23 | i | test.rs:99:27:99:27 | 1 |  |
+| test.rs:99:23:99:27 | ... + ... | test.rs:99:19:99:27 | exit ClosureExpr (normal) |  |
+| test.rs:99:27:99:27 | 1 | test.rs:99:23:99:27 | ... + ... |  |
+| test.rs:100:5:100:11 | add_one | test.rs:100:13:100:19 | add_one |  |
+| test.rs:100:5:100:23 | CallExpr | test.rs:98:40:101:1 | BlockExpr |  |
+| test.rs:100:13:100:19 | add_one | test.rs:100:21:100:21 | n |  |
+| test.rs:100:13:100:22 | CallExpr | test.rs:100:5:100:23 | CallExpr |  |
+| test.rs:100:21:100:21 | n | test.rs:100:13:100:22 | CallExpr |  |
+| test.rs:105:5:111:5 | enter test_if_else | test.rs:106:12:106:12 | n |  |
+| test.rs:105:5:111:5 | exit test_if_else (normal) | test.rs:105:5:111:5 | exit test_if_else |  |
+| test.rs:105:36:111:5 | BlockExpr | test.rs:105:5:111:5 | exit test_if_else (normal) |  |
+| test.rs:106:9:110:9 | IfExpr | test.rs:105:36:111:5 | BlockExpr |  |
+| test.rs:106:12:106:12 | n | test.rs:106:17:106:17 | 0 |  |
+| test.rs:106:12:106:17 | ... <= ... | test.rs:107:13:107:13 | 0 | true |
+| test.rs:106:12:106:17 | ... <= ... | test.rs:109:13:109:13 | n | false |
+| test.rs:106:17:106:17 | 0 | test.rs:106:12:106:17 | ... <= ... |  |
+| test.rs:106:19:108:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
+| test.rs:107:13:107:13 | 0 | test.rs:106:19:108:9 | BlockExpr |  |
+| test.rs:108:16:110:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
+| test.rs:109:13:109:13 | n | test.rs:109:17:109:17 | 1 |  |
+| test.rs:109:13:109:17 | ... - ... | test.rs:108:16:110:9 | BlockExpr |  |
+| test.rs:109:17:109:17 | 1 | test.rs:109:13:109:17 | ... - ... |  |
+| test.rs:113:5:119:5 | enter test_if_let_else | test.rs:114:12:114:26 | LetExpr |  |
+| test.rs:113:5:119:5 | exit test_if_let_else (normal) | test.rs:113:5:119:5 | exit test_if_let_else |  |
+| test.rs:113:48:119:5 | BlockExpr | test.rs:113:5:119:5 | exit test_if_let_else (normal) |  |
+| test.rs:114:9:118:9 | IfExpr | test.rs:113:48:119:5 | BlockExpr |  |
+| test.rs:114:12:114:26 | LetExpr | test.rs:114:16:114:22 | TupleStructPat |  |
+| test.rs:114:16:114:22 | TupleStructPat | test.rs:115:13:115:13 | n | match |
+| test.rs:114:16:114:22 | TupleStructPat | test.rs:117:13:117:13 | 0 | no-match |
+| test.rs:114:28:116:9 | BlockExpr | test.rs:114:9:118:9 | IfExpr |  |
+| test.rs:115:13:115:13 | n | test.rs:114:28:116:9 | BlockExpr |  |
+| test.rs:116:16:118:9 | BlockExpr | test.rs:114:9:118:9 | IfExpr |  |
+| test.rs:117:13:117:13 | 0 | test.rs:116:16:118:9 | BlockExpr |  |
+| test.rs:121:5:126:5 | enter test_if_let | test.rs:122:9:124:9 | ExprStmt |  |
+| test.rs:121:5:126:5 | exit test_if_let (normal) | test.rs:121:5:126:5 | exit test_if_let |  |
+| test.rs:121:43:126:5 | BlockExpr | test.rs:121:5:126:5 | exit test_if_let (normal) |  |
+| test.rs:122:9:124:9 | ExprStmt | test.rs:122:12:122:26 | LetExpr |  |
+| test.rs:122:9:124:9 | IfExpr | test.rs:125:9:125:9 | 0 |  |
+| test.rs:122:12:122:26 | LetExpr | test.rs:122:16:122:22 | TupleStructPat |  |
+| test.rs:122:16:122:22 | TupleStructPat | test.rs:122:9:124:9 | IfExpr | no-match |
+| test.rs:122:16:122:22 | TupleStructPat | test.rs:123:13:123:13 | n | match |
+| test.rs:122:28:124:9 | BlockExpr | test.rs:122:9:124:9 | IfExpr |  |
+| test.rs:123:13:123:13 | n | test.rs:122:28:124:9 | BlockExpr |  |
+| test.rs:125:9:125:9 | 0 | test.rs:121:43:126:5 | BlockExpr |  |
+| test.rs:128:5:134:5 | enter test_nested_if | test.rs:129:16:129:16 | PathExpr |  |
+| test.rs:128:5:134:5 | exit test_nested_if (normal) | test.rs:128:5:134:5 | exit test_nested_if |  |
+| test.rs:128:38:134:5 | BlockExpr | test.rs:128:5:134:5 | exit test_nested_if (normal) |  |
+| test.rs:129:9:133:9 | IfExpr | test.rs:128:38:134:5 | BlockExpr |  |
+| test.rs:129:13:129:48 | IfExpr | test.rs:130:13:130:13 | 1 | true |
+| test.rs:129:13:129:48 | IfExpr | test.rs:132:13:132:13 | 0 | false |
+| test.rs:129:16:129:16 | PathExpr | test.rs:129:20:129:20 | 0 |  |
+| test.rs:129:16:129:20 | ... < ... | test.rs:129:24:129:24 | a | true |
+| test.rs:129:16:129:20 | ... < ... | test.rs:129:41:129:41 | a | false |
+| test.rs:129:20:129:20 | 0 | test.rs:129:16:129:20 | ... < ... |  |
+| test.rs:129:22:129:32 | BlockExpr | test.rs:129:13:129:48 | IfExpr | false, true |
+| test.rs:129:24:129:24 | a | test.rs:129:29:129:30 | 10 |  |
+| test.rs:129:24:129:30 | ... < ... | test.rs:129:22:129:32 | BlockExpr | false, true |
+| test.rs:129:28:129:30 | - ... | test.rs:129:24:129:30 | ... < ... |  |
+| test.rs:129:29:129:30 | 10 | test.rs:129:28:129:30 | - ... |  |
+| test.rs:129:39:129:48 | BlockExpr | test.rs:129:13:129:48 | IfExpr | false, true |
+| test.rs:129:41:129:41 | a | test.rs:129:45:129:46 | 10 |  |
+| test.rs:129:41:129:46 | ... > ... | test.rs:129:39:129:48 | BlockExpr | false, true |
+| test.rs:129:45:129:46 | 10 | test.rs:129:41:129:46 | ... > ... |  |
+| test.rs:129:51:131:9 | BlockExpr | test.rs:129:9:133:9 | IfExpr |  |
+| test.rs:130:13:130:13 | 1 | test.rs:129:51:131:9 | BlockExpr |  |
+| test.rs:131:16:133:9 | BlockExpr | test.rs:129:9:133:9 | IfExpr |  |
+| test.rs:132:13:132:13 | 0 | test.rs:131:16:133:9 | BlockExpr |  |
+| test.rs:136:5:145:5 | enter test_nested_if_match | test.rs:137:19:137:19 | a |  |
+| test.rs:136:5:145:5 | exit test_nested_if_match (normal) | test.rs:136:5:145:5 | exit test_nested_if_match |  |
+| test.rs:136:44:145:5 | BlockExpr | test.rs:136:5:145:5 | exit test_nested_if_match (normal) |  |
+| test.rs:137:9:144:9 | IfExpr | test.rs:136:44:145:5 | BlockExpr |  |
+| test.rs:137:13:140:9 | MatchExpr | test.rs:141:13:141:13 | 1 | true |
+| test.rs:137:13:140:9 | MatchExpr | test.rs:143:13:143:13 | 0 | false |
+| test.rs:137:19:137:19 | a | test.rs:138:13:138:13 | LiteralPat |  |
+| test.rs:138:13:138:13 | LiteralPat | test.rs:138:18:138:21 | true | match |
+| test.rs:138:13:138:13 | LiteralPat | test.rs:139:13:139:13 | WildcardPat | no-match |
+| test.rs:138:18:138:21 | true | test.rs:137:13:140:9 | MatchExpr |  |
+| test.rs:139:13:139:13 | WildcardPat | test.rs:139:18:139:22 | false | match |
+| test.rs:139:18:139:22 | false | test.rs:137:13:140:9 | MatchExpr |  |
+| test.rs:140:12:142:9 | BlockExpr | test.rs:137:9:144:9 | IfExpr |  |
+| test.rs:141:13:141:13 | 1 | test.rs:140:12:142:9 | BlockExpr |  |
+| test.rs:142:16:144:9 | BlockExpr | test.rs:137:9:144:9 | IfExpr |  |
+| test.rs:143:13:143:13 | 0 | test.rs:142:16:144:9 | BlockExpr |  |
+| test.rs:147:5:156:5 | enter test_nested_if_block | test.rs:149:13:149:15 | ExprStmt |  |
+| test.rs:147:5:156:5 | exit test_nested_if_block (normal) | test.rs:147:5:156:5 | exit test_nested_if_block |  |
+| test.rs:147:44:156:5 | BlockExpr | test.rs:147:5:156:5 | exit test_nested_if_block (normal) |  |
+| test.rs:148:9:155:9 | IfExpr | test.rs:147:44:156:5 | BlockExpr |  |
+| test.rs:148:12:151:9 | BlockExpr | test.rs:152:13:152:13 | 1 | true |
+| test.rs:148:12:151:9 | BlockExpr | test.rs:154:13:154:13 | 0 | false |
+| test.rs:149:13:149:14 | TupleExpr | test.rs:150:13:150:13 | a |  |
+| test.rs:149:13:149:15 | ExprStmt | test.rs:149:13:149:14 | TupleExpr |  |
+| test.rs:150:13:150:13 | a | test.rs:150:17:150:17 | 0 |  |
+| test.rs:150:13:150:17 | ... > ... | test.rs:148:12:151:9 | BlockExpr | false, true |
+| test.rs:150:17:150:17 | 0 | test.rs:150:13:150:17 | ... > ... |  |
+| test.rs:151:11:153:9 | BlockExpr | test.rs:148:9:155:9 | IfExpr |  |
+| test.rs:152:13:152:13 | 1 | test.rs:151:11:153:9 | BlockExpr |  |
+| test.rs:153:16:155:9 | BlockExpr | test.rs:148:9:155:9 | IfExpr |  |
+| test.rs:154:13:154:13 | 0 | test.rs:153:16:155:9 | BlockExpr |  |
+| test.rs:158:5:165:5 | enter test_if_assignment | test.rs:159:9:159:26 | LetStmt |  |
+| test.rs:158:5:165:5 | exit test_if_assignment (normal) | test.rs:158:5:165:5 | exit test_if_assignment |  |
+| test.rs:158:42:165:5 | BlockExpr | test.rs:158:5:165:5 | exit test_if_assignment (normal) |  |
+| test.rs:159:9:159:26 | LetStmt | test.rs:159:21:159:25 | false |  |
+| test.rs:159:13:159:17 | x | test.rs:160:12:160:12 | x | match, no-match |
+| test.rs:159:21:159:25 | false | test.rs:159:13:159:17 | x |  |
+| test.rs:160:9:164:9 | IfExpr | test.rs:158:42:165:5 | BlockExpr |  |
+| test.rs:160:12:160:12 | x | test.rs:160:16:160:19 | true |  |
+| test.rs:160:12:160:19 | ... = ... | test.rs:161:13:161:13 | 1 | true |
+| test.rs:160:12:160:19 | ... = ... | test.rs:163:13:163:13 | 0 | false |
+| test.rs:160:16:160:19 | true | test.rs:160:12:160:19 | ... = ... |  |
+| test.rs:160:21:162:9 | BlockExpr | test.rs:160:9:164:9 | IfExpr |  |
+| test.rs:161:13:161:13 | 1 | test.rs:160:21:162:9 | BlockExpr |  |
+| test.rs:162:16:164:9 | BlockExpr | test.rs:160:9:164:9 | IfExpr |  |
+| test.rs:163:13:163:13 | 0 | test.rs:162:16:164:9 | BlockExpr |  |
+| test.rs:167:5:178:5 | enter test_if_loop1 | test.rs:169:13:171:14 | ExprStmt |  |
+| test.rs:167:5:178:5 | exit test_if_loop1 (normal) | test.rs:167:5:178:5 | exit test_if_loop1 |  |
+| test.rs:167:37:178:5 | BlockExpr | test.rs:167:5:178:5 | exit test_if_loop1 (normal) |  |
+| test.rs:168:9:177:9 | IfExpr | test.rs:167:37:178:5 | BlockExpr |  |
+| test.rs:168:13:173:9 | LoopExpr | test.rs:174:13:174:13 | 1 | true |
+| test.rs:168:13:173:9 | LoopExpr | test.rs:176:13:176:13 | 0 | false |
+| test.rs:168:18:173:9 | BlockExpr | test.rs:169:13:171:14 | ExprStmt |  |
+| test.rs:169:13:171:13 | IfExpr | test.rs:172:13:172:19 | ExprStmt |  |
+| test.rs:169:13:171:14 | ExprStmt | test.rs:169:16:169:16 | a |  |
+| test.rs:169:16:169:16 | a | test.rs:169:20:169:20 | 0 |  |
+| test.rs:169:16:169:20 | ... > ... | test.rs:169:13:171:13 | IfExpr | false |
+| test.rs:169:16:169:20 | ... > ... | test.rs:170:17:170:29 | ExprStmt | true |
+| test.rs:169:20:169:20 | 0 | test.rs:169:16:169:20 | ... > ... |  |
+| test.rs:170:17:170:28 | BreakExpr | test.rs:168:13:173:9 | LoopExpr | break |
+| test.rs:170:17:170:29 | ExprStmt | test.rs:170:23:170:23 | a |  |
+| test.rs:170:23:170:23 | a | test.rs:170:27:170:28 | 10 |  |
+| test.rs:170:23:170:28 | ... > ... | test.rs:170:17:170:28 | BreakExpr |  |
+| test.rs:170:27:170:28 | 10 | test.rs:170:23:170:28 | ... > ... |  |
+| test.rs:172:13:172:13 | a | test.rs:172:17:172:18 | 10 |  |
+| test.rs:172:13:172:18 | ... < ... | test.rs:168:18:173:9 | BlockExpr |  |
+| test.rs:172:13:172:19 | ExprStmt | test.rs:172:13:172:13 | a |  |
+| test.rs:172:17:172:18 | 10 | test.rs:172:13:172:18 | ... < ... |  |
+| test.rs:173:12:175:9 | BlockExpr | test.rs:168:9:177:9 | IfExpr |  |
+| test.rs:174:13:174:13 | 1 | test.rs:173:12:175:9 | BlockExpr |  |
+| test.rs:175:16:177:9 | BlockExpr | test.rs:168:9:177:9 | IfExpr |  |
+| test.rs:176:13:176:13 | 0 | test.rs:175:16:177:9 | BlockExpr |  |
+| test.rs:180:5:191:5 | enter test_if_loop2 | test.rs:182:13:184:14 | ExprStmt |  |
+| test.rs:180:5:191:5 | exit test_if_loop2 (normal) | test.rs:180:5:191:5 | exit test_if_loop2 |  |
+| test.rs:180:37:191:5 | BlockExpr | test.rs:180:5:191:5 | exit test_if_loop2 (normal) |  |
+| test.rs:181:9:190:9 | IfExpr | test.rs:180:37:191:5 | BlockExpr |  |
+| test.rs:181:13:186:9 | LoopExpr | test.rs:187:13:187:13 | 1 | true |
+| test.rs:181:13:186:9 | LoopExpr | test.rs:189:13:189:13 | 0 | false |
+| test.rs:181:26:186:9 | BlockExpr | test.rs:182:13:184:14 | ExprStmt |  |
+| test.rs:182:13:184:13 | IfExpr | test.rs:185:13:185:19 | ExprStmt |  |
+| test.rs:182:13:184:14 | ExprStmt | test.rs:182:16:182:16 | a |  |
+| test.rs:182:16:182:16 | a | test.rs:182:20:182:20 | 0 |  |
+| test.rs:182:16:182:20 | ... > ... | test.rs:182:13:184:13 | IfExpr | false |
+| test.rs:182:16:182:20 | ... > ... | test.rs:183:17:183:36 | ExprStmt | true |
+| test.rs:182:20:182:20 | 0 | test.rs:182:16:182:20 | ... > ... |  |
+| test.rs:183:17:183:35 | BreakExpr | test.rs:181:13:186:9 | LoopExpr | break('label) |
+| test.rs:183:17:183:36 | ExprStmt | test.rs:183:30:183:30 | a |  |
+| test.rs:183:30:183:30 | a | test.rs:183:34:183:35 | 10 |  |
+| test.rs:183:30:183:35 | ... > ... | test.rs:183:17:183:35 | BreakExpr |  |
+| test.rs:183:34:183:35 | 10 | test.rs:183:30:183:35 | ... > ... |  |
+| test.rs:185:13:185:13 | a | test.rs:185:17:185:18 | 10 |  |
+| test.rs:185:13:185:18 | ... < ... | test.rs:181:26:186:9 | BlockExpr |  |
+| test.rs:185:13:185:19 | ExprStmt | test.rs:185:13:185:13 | a |  |
+| test.rs:185:17:185:18 | 10 | test.rs:185:13:185:18 | ... < ... |  |
+| test.rs:186:12:188:9 | BlockExpr | test.rs:181:9:190:9 | IfExpr |  |
+| test.rs:187:13:187:13 | 1 | test.rs:186:12:188:9 | BlockExpr |  |
+| test.rs:188:16:190:9 | BlockExpr | test.rs:181:9:190:9 | IfExpr |  |
+| test.rs:189:13:189:13 | 0 | test.rs:188:16:190:9 | BlockExpr |  |
+| test.rs:193:5:201:5 | enter test_labelled_block | test.rs:195:13:195:31 | ExprStmt |  |
+| test.rs:193:5:201:5 | exit test_labelled_block (normal) | test.rs:193:5:201:5 | exit test_labelled_block |  |
+| test.rs:193:43:201:5 | BlockExpr | test.rs:193:5:201:5 | exit test_labelled_block (normal) |  |
+| test.rs:194:9:200:9 | IfExpr | test.rs:193:43:201:5 | BlockExpr |  |
+| test.rs:194:13:196:9 | BlockExpr | test.rs:197:13:197:13 | 1 | true |
+| test.rs:194:13:196:9 | BlockExpr | test.rs:199:13:199:13 | 0 | false |
+| test.rs:195:13:195:30 | BreakExpr | test.rs:194:13:196:9 | BlockExpr | break('block) |
+| test.rs:195:13:195:31 | ExprStmt | test.rs:195:26:195:26 | a |  |
+| test.rs:195:26:195:26 | a | test.rs:195:30:195:30 | 0 |  |
+| test.rs:195:26:195:30 | ... > ... | test.rs:195:13:195:30 | BreakExpr |  |
+| test.rs:195:30:195:30 | 0 | test.rs:195:26:195:30 | ... > ... |  |
+| test.rs:196:12:198:9 | BlockExpr | test.rs:194:9:200:9 | IfExpr |  |
+| test.rs:197:13:197:13 | 1 | test.rs:196:12:198:9 | BlockExpr |  |
+| test.rs:198:16:200:9 | BlockExpr | test.rs:194:9:200:9 | IfExpr |  |
+| test.rs:199:13:199:13 | 0 | test.rs:198:16:200:9 | BlockExpr |  |
+| test.rs:206:5:209:5 | enter test_and_operator | test.rs:207:9:207:28 | LetStmt |  |
+| test.rs:206:5:209:5 | exit test_and_operator (normal) | test.rs:206:5:209:5 | exit test_and_operator |  |
+| test.rs:206:61:209:5 | BlockExpr | test.rs:206:5:209:5 | exit test_and_operator (normal) |  |
+| test.rs:207:9:207:28 | LetStmt | test.rs:207:17:207:27 | ... && ... |  |
+| test.rs:207:13:207:13 | d | test.rs:208:9:208:9 | d | match, no-match |
+| test.rs:207:17:207:17 | a | test.rs:207:13:207:13 | d | false |
+| test.rs:207:17:207:17 | a | test.rs:207:22:207:22 | b | true |
+| test.rs:207:17:207:22 | ... && ... | test.rs:207:17:207:17 | a |  |
+| test.rs:207:17:207:27 | ... && ... | test.rs:207:17:207:22 | ... && ... |  |
+| test.rs:207:22:207:22 | b | test.rs:207:13:207:13 | d | false |
+| test.rs:207:22:207:22 | b | test.rs:207:27:207:27 | c | true |
+| test.rs:207:27:207:27 | c | test.rs:207:13:207:13 | d |  |
+| test.rs:208:9:208:9 | d | test.rs:206:61:209:5 | BlockExpr |  |
+| test.rs:211:5:214:5 | enter test_or_operator | test.rs:212:9:212:28 | LetStmt |  |
+| test.rs:211:5:214:5 | exit test_or_operator (normal) | test.rs:211:5:214:5 | exit test_or_operator |  |
+| test.rs:211:60:214:5 | BlockExpr | test.rs:211:5:214:5 | exit test_or_operator (normal) |  |
+| test.rs:212:9:212:28 | LetStmt | test.rs:212:17:212:27 | ... \|\| ... |  |
+| test.rs:212:13:212:13 | d | test.rs:213:9:213:9 | d | match, no-match |
+| test.rs:212:17:212:17 | a | test.rs:212:13:212:13 | d | true |
+| test.rs:212:17:212:17 | a | test.rs:212:22:212:22 | b | false |
+| test.rs:212:17:212:22 | ... \|\| ... | test.rs:212:17:212:17 | a |  |
+| test.rs:212:17:212:27 | ... \|\| ... | test.rs:212:17:212:22 | ... \|\| ... |  |
+| test.rs:212:22:212:22 | b | test.rs:212:13:212:13 | d | true |
+| test.rs:212:22:212:22 | b | test.rs:212:27:212:27 | c | false |
+| test.rs:212:27:212:27 | c | test.rs:212:13:212:13 | d |  |
+| test.rs:213:9:213:9 | d | test.rs:211:60:214:5 | BlockExpr |  |
+| test.rs:216:5:219:5 | enter test_or_operator_2 | test.rs:217:9:217:36 | LetStmt |  |
+| test.rs:216:5:219:5 | exit test_or_operator_2 (normal) | test.rs:216:5:219:5 | exit test_or_operator_2 |  |
+| test.rs:216:61:219:5 | BlockExpr | test.rs:216:5:219:5 | exit test_or_operator_2 (normal) |  |
+| test.rs:217:9:217:36 | LetStmt | test.rs:217:17:217:35 | ... \|\| ... |  |
+| test.rs:217:13:217:13 | d | test.rs:218:9:218:9 | d | match, no-match |
+| test.rs:217:17:217:17 | a | test.rs:217:13:217:13 | d | true |
+| test.rs:217:17:217:17 | a | test.rs:217:23:217:23 | b | false |
+| test.rs:217:17:217:30 | ... \|\| ... | test.rs:217:17:217:17 | a |  |
+| test.rs:217:17:217:35 | ... \|\| ... | test.rs:217:17:217:30 | ... \|\| ... |  |
+| test.rs:217:23:217:23 | b | test.rs:217:28:217:29 | 28 |  |
+| test.rs:217:23:217:29 | ... == ... | test.rs:217:13:217:13 | d | true |
+| test.rs:217:23:217:29 | ... == ... | test.rs:217:35:217:35 | c | false |
+| test.rs:217:28:217:29 | 28 | test.rs:217:23:217:29 | ... == ... |  |
+| test.rs:217:35:217:35 | c | test.rs:217:13:217:13 | d |  |
+| test.rs:218:9:218:9 | d | test.rs:216:61:219:5 | BlockExpr |  |
+| test.rs:221:5:224:5 | enter test_not_operator | test.rs:222:9:222:19 | LetStmt |  |
+| test.rs:221:5:224:5 | exit test_not_operator (normal) | test.rs:221:5:224:5 | exit test_not_operator |  |
+| test.rs:221:43:224:5 | BlockExpr | test.rs:221:5:224:5 | exit test_not_operator (normal) |  |
+| test.rs:222:9:222:19 | LetStmt | test.rs:222:18:222:18 | a |  |
+| test.rs:222:13:222:13 | d | test.rs:223:9:223:9 | d | match, no-match |
+| test.rs:222:17:222:18 | ! ... | test.rs:222:13:222:13 | d |  |
+| test.rs:222:18:222:18 | a | test.rs:222:17:222:18 | ! ... |  |
+| test.rs:223:9:223:9 | d | test.rs:221:43:224:5 | BlockExpr |  |
+| test.rs:226:5:232:5 | enter test_if_and_operator | test.rs:227:12:227:22 | ... && ... |  |
+| test.rs:226:5:232:5 | exit test_if_and_operator (normal) | test.rs:226:5:232:5 | exit test_if_and_operator |  |
+| test.rs:226:63:232:5 | BlockExpr | test.rs:226:5:232:5 | exit test_if_and_operator (normal) |  |
+| test.rs:227:9:231:9 | IfExpr | test.rs:226:63:232:5 | BlockExpr |  |
+| test.rs:227:12:227:12 | a | test.rs:227:17:227:17 | b | true |
+| test.rs:227:12:227:12 | a | test.rs:230:13:230:17 | false | false |
+| test.rs:227:12:227:17 | ... && ... | test.rs:227:12:227:12 | a |  |
+| test.rs:227:12:227:22 | ... && ... | test.rs:227:12:227:17 | ... && ... |  |
+| test.rs:227:17:227:17 | b | test.rs:227:22:227:22 | c | true |
+| test.rs:227:17:227:17 | b | test.rs:230:13:230:17 | false | false |
+| test.rs:227:22:227:22 | c | test.rs:228:13:228:16 | true | true |
+| test.rs:227:22:227:22 | c | test.rs:230:13:230:17 | false | false |
+| test.rs:227:24:229:9 | BlockExpr | test.rs:227:9:231:9 | IfExpr |  |
+| test.rs:228:13:228:16 | true | test.rs:227:24:229:9 | BlockExpr |  |
+| test.rs:229:16:231:9 | BlockExpr | test.rs:227:9:231:9 | IfExpr |  |
+| test.rs:230:13:230:17 | false | test.rs:229:16:231:9 | BlockExpr |  |
+| test.rs:234:5:240:5 | enter test_if_or_operator | test.rs:235:12:235:22 | ... \|\| ... |  |
+| test.rs:234:5:240:5 | exit test_if_or_operator (normal) | test.rs:234:5:240:5 | exit test_if_or_operator |  |
+| test.rs:234:62:240:5 | BlockExpr | test.rs:234:5:240:5 | exit test_if_or_operator (normal) |  |
+| test.rs:235:9:239:9 | IfExpr | test.rs:234:62:240:5 | BlockExpr |  |
+| test.rs:235:12:235:12 | a | test.rs:235:17:235:17 | b | false |
+| test.rs:235:12:235:12 | a | test.rs:236:13:236:16 | true | true |
+| test.rs:235:12:235:17 | ... \|\| ... | test.rs:235:12:235:12 | a |  |
+| test.rs:235:12:235:22 | ... \|\| ... | test.rs:235:12:235:17 | ... \|\| ... |  |
+| test.rs:235:17:235:17 | b | test.rs:235:22:235:22 | c | false |
+| test.rs:235:17:235:17 | b | test.rs:236:13:236:16 | true | true |
+| test.rs:235:22:235:22 | c | test.rs:236:13:236:16 | true | true |
+| test.rs:235:22:235:22 | c | test.rs:238:13:238:17 | false | false |
+| test.rs:235:24:237:9 | BlockExpr | test.rs:235:9:239:9 | IfExpr |  |
+| test.rs:236:13:236:16 | true | test.rs:235:24:237:9 | BlockExpr |  |
+| test.rs:237:16:239:9 | BlockExpr | test.rs:235:9:239:9 | IfExpr |  |
+| test.rs:238:13:238:17 | false | test.rs:237:16:239:9 | BlockExpr |  |
+| test.rs:242:5:248:5 | enter test_if_not_operator | test.rs:243:13:243:13 | a |  |
+| test.rs:242:5:248:5 | exit test_if_not_operator (normal) | test.rs:242:5:248:5 | exit test_if_not_operator |  |
+| test.rs:242:46:248:5 | BlockExpr | test.rs:242:5:248:5 | exit test_if_not_operator (normal) |  |
+| test.rs:243:9:247:9 | IfExpr | test.rs:242:46:248:5 | BlockExpr |  |
+| test.rs:243:12:243:13 | ! ... | test.rs:244:13:244:16 | true | true |
+| test.rs:243:12:243:13 | ! ... | test.rs:246:13:246:17 | false | false |
+| test.rs:243:13:243:13 | a | test.rs:243:12:243:13 | ! ... | false, true |
+| test.rs:243:15:245:9 | BlockExpr | test.rs:243:9:247:9 | IfExpr |  |
+| test.rs:244:13:244:16 | true | test.rs:243:15:245:9 | BlockExpr |  |
+| test.rs:245:16:247:9 | BlockExpr | test.rs:243:9:247:9 | IfExpr |  |
+| test.rs:246:13:246:17 | false | test.rs:245:16:247:9 | BlockExpr |  |
+| test.rs:251:1:257:1 | enter test_match | test.rs:252:11:252:21 | maybe_digit |  |
+| test.rs:251:1:257:1 | exit test_match (normal) | test.rs:251:1:257:1 | exit test_match |  |
+| test.rs:251:48:257:1 | BlockExpr | test.rs:251:1:257:1 | exit test_match (normal) |  |
+| test.rs:252:5:256:5 | MatchExpr | test.rs:251:48:257:1 | BlockExpr |  |
+| test.rs:252:11:252:21 | maybe_digit | test.rs:253:9:253:23 | TupleStructPat |  |
+| test.rs:253:9:253:23 | TupleStructPat | test.rs:253:28:253:28 | x | match |
+| test.rs:253:9:253:23 | TupleStructPat | test.rs:254:9:254:23 | TupleStructPat | no-match |
+| test.rs:253:28:253:28 | x | test.rs:253:32:253:33 | 10 |  |
+| test.rs:253:28:253:33 | ... < ... | test.rs:253:38:253:38 | x | true |
+| test.rs:253:28:253:33 | ... < ... | test.rs:254:9:254:23 | TupleStructPat | false |
+| test.rs:253:32:253:33 | 10 | test.rs:253:28:253:33 | ... < ... |  |
+| test.rs:253:38:253:38 | x | test.rs:253:42:253:42 | 5 |  |
+| test.rs:253:38:253:42 | ... + ... | test.rs:252:5:256:5 | MatchExpr |  |
+| test.rs:253:42:253:42 | 5 | test.rs:253:38:253:42 | ... + ... |  |
+| test.rs:254:9:254:23 | TupleStructPat | test.rs:254:28:254:28 | x | match |
+| test.rs:254:9:254:23 | TupleStructPat | test.rs:255:9:255:20 | PathPat | no-match |
+| test.rs:254:28:254:28 | x | test.rs:252:5:256:5 | MatchExpr |  |
+| test.rs:255:9:255:20 | PathPat | test.rs:255:25:255:25 | 5 | match |
+| test.rs:255:25:255:25 | 5 | test.rs:252:5:256:5 | MatchExpr |  |
+| test.rs:260:5:265:5 | enter test_infinite_loop | test.rs:261:9:263:9 | ExprStmt |  |
+| test.rs:261:9:263:9 | ExprStmt | test.rs:262:13:262:13 | 1 |  |
+| test.rs:261:14:263:9 | BlockExpr | test.rs:262:13:262:13 | 1 |  |
+| test.rs:262:13:262:13 | 1 | test.rs:261:14:263:9 | BlockExpr |  |
+| test.rs:267:5:270:5 | enter test_let_match | test.rs:268:9:268:49 | LetStmt |  |
+| test.rs:267:5:270:5 | exit test_let_match (normal) | test.rs:267:5:270:5 | exit test_let_match |  |
+| test.rs:267:39:270:5 | BlockExpr | test.rs:267:5:270:5 | exit test_let_match (normal) |  |
+| test.rs:268:9:268:49 | LetStmt | test.rs:268:23:268:23 | a |  |
+| test.rs:268:13:268:19 | TupleStructPat | test.rs:268:32:268:46 | "Expected some" | no-match |
+| test.rs:268:13:268:19 | TupleStructPat | test.rs:269:9:269:9 | n | match |
+| test.rs:268:23:268:23 | a | test.rs:268:13:268:19 | TupleStructPat |  |
+| test.rs:268:32:268:46 | "Expected some" | test.rs:268:30:268:48 | BlockExpr |  |
+| test.rs:269:9:269:9 | n | test.rs:267:39:270:5 | BlockExpr |  |
+| test.rs:273:1:278:1 | enter dead_code | test.rs:274:5:276:5 | ExprStmt |  |
+| test.rs:273:1:278:1 | exit dead_code (normal) | test.rs:273:1:278:1 | exit dead_code |  |
+| test.rs:274:5:276:5 | ExprStmt | test.rs:274:9:274:12 | true |  |
+| test.rs:274:9:274:12 | true | test.rs:275:9:275:17 | ExprStmt | true |
+| test.rs:275:9:275:16 | ReturnExpr | test.rs:273:1:278:1 | exit dead_code (normal) | return |
+| test.rs:275:9:275:17 | ExprStmt | test.rs:275:16:275:16 | 0 |  |
+| test.rs:275:16:275:16 | 0 | test.rs:275:9:275:16 | ReturnExpr |  |
+| test.rs:280:1:293:1 | enter labelled_block1 | test.rs:281:5:292:6 | LetStmt |  |
+| test.rs:280:1:293:1 | exit labelled_block1 (normal) | test.rs:280:1:293:1 | exit labelled_block1 |  |
+| test.rs:280:29:293:1 | BlockExpr | test.rs:280:1:293:1 | exit labelled_block1 (normal) |  |
+| test.rs:281:5:292:6 | LetStmt | test.rs:282:9:282:19 | ExprStmt |  |
+| test.rs:281:9:281:14 | result | test.rs:280:29:293:1 | BlockExpr | match, no-match |
+| test.rs:281:18:292:5 | BlockExpr | test.rs:281:9:281:14 | result |  |
+| test.rs:282:9:282:16 | PathExpr | test.rs:282:9:282:18 | CallExpr |  |
+| test.rs:282:9:282:18 | CallExpr | test.rs:283:9:285:9 | ExprStmt |  |
+| test.rs:282:9:282:19 | ExprStmt | test.rs:282:9:282:16 | PathExpr |  |
+| test.rs:283:9:285:9 | ExprStmt | test.rs:283:12:283:28 | PathExpr |  |
+| test.rs:283:9:285:9 | IfExpr | test.rs:286:9:286:24 | ExprStmt |  |
+| test.rs:283:12:283:28 | PathExpr | test.rs:283:12:283:30 | CallExpr |  |
+| test.rs:283:12:283:30 | CallExpr | test.rs:283:9:285:9 | IfExpr | false |
+| test.rs:283:12:283:30 | CallExpr | test.rs:284:13:284:27 | ExprStmt | true |
+| test.rs:284:13:284:26 | BreakExpr | test.rs:281:18:292:5 | BlockExpr | break('block) |
+| test.rs:284:13:284:27 | ExprStmt | test.rs:284:26:284:26 | 1 |  |
+| test.rs:284:26:284:26 | 1 | test.rs:284:13:284:26 | BreakExpr |  |
+| test.rs:286:9:286:21 | PathExpr | test.rs:286:9:286:23 | CallExpr |  |
+| test.rs:286:9:286:23 | CallExpr | test.rs:287:9:289:9 | ExprStmt |  |
+| test.rs:286:9:286:24 | ExprStmt | test.rs:286:9:286:21 | PathExpr |  |
+| test.rs:287:9:289:9 | ExprStmt | test.rs:287:12:287:28 | PathExpr |  |
+| test.rs:287:9:289:9 | IfExpr | test.rs:290:9:290:24 | ExprStmt |  |
+| test.rs:287:12:287:28 | PathExpr | test.rs:287:12:287:30 | CallExpr |  |
+| test.rs:287:12:287:30 | CallExpr | test.rs:287:9:289:9 | IfExpr | false |
+| test.rs:287:12:287:30 | CallExpr | test.rs:288:13:288:27 | ExprStmt | true |
+| test.rs:288:13:288:26 | BreakExpr | test.rs:281:18:292:5 | BlockExpr | break('block) |
+| test.rs:288:13:288:27 | ExprStmt | test.rs:288:26:288:26 | 2 |  |
+| test.rs:288:26:288:26 | 2 | test.rs:288:13:288:26 | BreakExpr |  |
+| test.rs:290:9:290:21 | PathExpr | test.rs:290:9:290:23 | CallExpr |  |
+| test.rs:290:9:290:23 | CallExpr | test.rs:291:9:291:9 | 3 |  |
+| test.rs:290:9:290:24 | ExprStmt | test.rs:290:9:290:21 | PathExpr |  |
+| test.rs:291:9:291:9 | 3 | test.rs:281:18:292:5 | BlockExpr |  |
+| test.rs:295:1:303:1 | enter labelled_block2 | test.rs:296:5:302:6 | LetStmt |  |
+| test.rs:295:1:303:1 | exit labelled_block2 (normal) | test.rs:295:1:303:1 | exit labelled_block2 |  |
+| test.rs:295:29:303:1 | BlockExpr | test.rs:295:1:303:1 | exit labelled_block2 (normal) |  |
+| test.rs:296:5:302:6 | LetStmt | test.rs:297:9:297:34 | LetStmt |  |
+| test.rs:296:9:296:14 | result | test.rs:295:29:303:1 | BlockExpr | match, no-match |
+| test.rs:296:18:302:5 | BlockExpr | test.rs:296:9:296:14 | result |  |
+| test.rs:297:9:297:34 | LetStmt | test.rs:297:30:297:33 | PathExpr |  |
+| test.rs:297:13:297:13 | x | test.rs:298:9:300:10 | LetStmt | match, no-match |
+| test.rs:297:30:297:33 | PathExpr | test.rs:297:13:297:13 | x |  |
+| test.rs:298:9:300:10 | LetStmt | test.rs:298:23:298:23 | x |  |
+| test.rs:298:13:298:19 | TupleStructPat | test.rs:299:13:299:27 | ExprStmt | no-match |
+| test.rs:298:13:298:19 | TupleStructPat | test.rs:301:9:301:9 | x | match |
+| test.rs:298:23:298:23 | x | test.rs:298:13:298:19 | TupleStructPat |  |
+| test.rs:299:13:299:26 | BreakExpr | test.rs:296:18:302:5 | BlockExpr | break('block) |
+| test.rs:299:13:299:27 | ExprStmt | test.rs:299:26:299:26 | 1 |  |
+| test.rs:299:26:299:26 | 1 | test.rs:299:13:299:26 | BreakExpr |  |
+| test.rs:301:9:301:9 | x | test.rs:296:18:302:5 | BlockExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -111,10 +111,9 @@
 | test.rs:57:13:57:14 | ExprStmt | test.rs:57:13:57:13 | 1 |  |
 | test.rs:58:13:60:13 | ExprStmt | test.rs:58:17:58:17 | i |  |
 | test.rs:58:13:60:13 | IfExpr | test.rs:61:13:61:22 | ExprStmt |  |
-| test.rs:58:16:58:22 | ParenExpr | test.rs:58:13:60:13 | IfExpr | false |
-| test.rs:58:16:58:22 | ParenExpr | test.rs:59:17:59:22 | ExprStmt | true |
 | test.rs:58:17:58:17 | i | test.rs:58:21:58:21 | 0 |  |
-| test.rs:58:17:58:21 | ... > ... | test.rs:58:16:58:22 | ParenExpr |  |
+| test.rs:58:17:58:21 | ... > ... | test.rs:58:13:60:13 | IfExpr | false |
+| test.rs:58:17:58:21 | ... > ... | test.rs:59:17:59:22 | ExprStmt | true |
 | test.rs:58:21:58:21 | 0 | test.rs:58:17:58:21 | ... > ... |  |
 | test.rs:59:17:59:21 | BreakExpr | test.rs:56:9:62:9 | WhileExpr | break |
 | test.rs:59:17:59:22 | ExprStmt | test.rs:59:17:59:21 | BreakExpr |  |
@@ -136,10 +135,9 @@
 | test.rs:67:19:67:25 | TupleStructPat | test.rs:68:17:68:17 | PathExpr | match |
 | test.rs:67:41:71:9 | BlockExpr | test.rs:67:15:67:39 | LetExpr |  |
 | test.rs:68:13:70:13 | IfExpr | test.rs:67:41:71:9 | BlockExpr |  |
-| test.rs:68:16:68:22 | ParenExpr | test.rs:68:13:70:13 | IfExpr | false |
-| test.rs:68:16:68:22 | ParenExpr | test.rs:69:17:69:22 | ExprStmt | true |
 | test.rs:68:17:68:17 | PathExpr | test.rs:68:21:68:21 | 5 |  |
-| test.rs:68:17:68:21 | ... = ... | test.rs:68:16:68:22 | ParenExpr |  |
+| test.rs:68:17:68:21 | ... = ... | test.rs:68:13:70:13 | IfExpr | false |
+| test.rs:68:17:68:21 | ... = ... | test.rs:69:17:69:22 | ExprStmt | true |
 | test.rs:68:21:68:21 | 5 | test.rs:68:17:68:21 | ... = ... |  |
 | test.rs:69:17:69:21 | BreakExpr | test.rs:67:9:71:9 | WhileExpr | break |
 | test.rs:69:17:69:22 | ExprStmt | test.rs:69:17:69:21 | BreakExpr |  |
@@ -155,10 +153,9 @@
 | test.rs:75:24:80:9 | BlockExpr | test.rs:75:13:75:13 | i |  |
 | test.rs:76:13:78:13 | ExprStmt | test.rs:76:17:76:17 | i |  |
 | test.rs:76:13:78:13 | IfExpr | test.rs:79:13:79:14 | ExprStmt |  |
-| test.rs:76:16:76:23 | ParenExpr | test.rs:76:13:78:13 | IfExpr | false |
-| test.rs:76:16:76:23 | ParenExpr | test.rs:77:17:77:22 | ExprStmt | true |
 | test.rs:76:17:76:17 | i | test.rs:76:22:76:22 | j |  |
-| test.rs:76:17:76:22 | ... == ... | test.rs:76:16:76:23 | ParenExpr |  |
+| test.rs:76:17:76:22 | ... == ... | test.rs:76:13:78:13 | IfExpr | false |
+| test.rs:76:17:76:22 | ... == ... | test.rs:77:17:77:22 | ExprStmt | true |
 | test.rs:76:22:76:22 | j | test.rs:76:17:76:22 | ... == ... |  |
 | test.rs:77:17:77:21 | BreakExpr | test.rs:75:9:80:9 | ForExpr | break |
 | test.rs:77:17:77:22 | ExprStmt | test.rs:77:17:77:21 | BreakExpr |  |
@@ -220,21 +217,20 @@
 | test.rs:114:5:120:5 | exit test_nested_if (normal) | test.rs:114:5:120:5 | exit test_nested_if |  |
 | test.rs:114:38:120:5 | BlockExpr | test.rs:114:5:120:5 | exit test_nested_if (normal) |  |
 | test.rs:115:9:119:9 | IfExpr | test.rs:114:38:120:5 | BlockExpr |  |
-| test.rs:115:12:115:49 | ParenExpr | test.rs:116:13:116:13 | 1 | true |
-| test.rs:115:12:115:49 | ParenExpr | test.rs:118:13:118:13 | 0 | false |
-| test.rs:115:13:115:48 | IfExpr | test.rs:115:12:115:49 | ParenExpr |  |
+| test.rs:115:13:115:48 | IfExpr | test.rs:116:13:116:13 | 1 | true |
+| test.rs:115:13:115:48 | IfExpr | test.rs:118:13:118:13 | 0 | false |
 | test.rs:115:16:115:16 | PathExpr | test.rs:115:20:115:20 | 0 |  |
 | test.rs:115:16:115:20 | ... < ... | test.rs:115:24:115:24 | a | true |
 | test.rs:115:16:115:20 | ... < ... | test.rs:115:41:115:41 | a | false |
 | test.rs:115:20:115:20 | 0 | test.rs:115:16:115:20 | ... < ... |  |
-| test.rs:115:22:115:32 | BlockExpr | test.rs:115:13:115:48 | IfExpr |  |
+| test.rs:115:22:115:32 | BlockExpr | test.rs:115:13:115:48 | IfExpr | false, true |
 | test.rs:115:24:115:24 | a | test.rs:115:29:115:30 | 10 |  |
-| test.rs:115:24:115:30 | ... < ... | test.rs:115:22:115:32 | BlockExpr |  |
+| test.rs:115:24:115:30 | ... < ... | test.rs:115:22:115:32 | BlockExpr | false, true |
 | test.rs:115:28:115:30 | - ... | test.rs:115:24:115:30 | ... < ... |  |
 | test.rs:115:29:115:30 | 10 | test.rs:115:28:115:30 | - ... |  |
-| test.rs:115:39:115:48 | BlockExpr | test.rs:115:13:115:48 | IfExpr |  |
+| test.rs:115:39:115:48 | BlockExpr | test.rs:115:13:115:48 | IfExpr | false, true |
 | test.rs:115:41:115:41 | a | test.rs:115:45:115:46 | 10 |  |
-| test.rs:115:41:115:46 | ... > ... | test.rs:115:39:115:48 | BlockExpr |  |
+| test.rs:115:41:115:46 | ... > ... | test.rs:115:39:115:48 | BlockExpr | false, true |
 | test.rs:115:45:115:46 | 10 | test.rs:115:41:115:46 | ... > ... |  |
 | test.rs:115:51:117:9 | BlockExpr | test.rs:115:9:119:9 | IfExpr |  |
 | test.rs:116:13:116:13 | 1 | test.rs:115:51:117:9 | BlockExpr |  |
@@ -244,9 +240,8 @@
 | test.rs:122:5:131:5 | exit test_nested_if_match (normal) | test.rs:122:5:131:5 | exit test_nested_if_match |  |
 | test.rs:122:44:131:5 | BlockExpr | test.rs:122:5:131:5 | exit test_nested_if_match (normal) |  |
 | test.rs:123:9:130:9 | IfExpr | test.rs:122:44:131:5 | BlockExpr |  |
-| test.rs:123:12:126:10 | ParenExpr | test.rs:127:13:127:13 | 1 | true |
-| test.rs:123:12:126:10 | ParenExpr | test.rs:129:13:129:13 | 0 | false |
-| test.rs:123:13:126:9 | MatchExpr | test.rs:123:12:126:10 | ParenExpr |  |
+| test.rs:123:13:126:9 | MatchExpr | test.rs:127:13:127:13 | 1 | true |
+| test.rs:123:13:126:9 | MatchExpr | test.rs:129:13:129:13 | 0 | false |
 | test.rs:123:19:123:19 | a | test.rs:124:13:124:13 | LiteralPat |  |
 | test.rs:124:13:124:13 | LiteralPat | test.rs:124:18:124:21 | true | match |
 | test.rs:124:13:124:13 | LiteralPat | test.rs:125:13:125:13 | WildcardPat | no-match |
@@ -291,9 +286,8 @@
 | test.rs:153:5:164:5 | exit test_if_loop1 (normal) | test.rs:153:5:164:5 | exit test_if_loop1 |  |
 | test.rs:153:37:164:5 | BlockExpr | test.rs:153:5:164:5 | exit test_if_loop1 (normal) |  |
 | test.rs:154:9:163:9 | IfExpr | test.rs:153:37:164:5 | BlockExpr |  |
-| test.rs:154:12:159:10 | ParenExpr | test.rs:160:13:160:13 | 1 | true |
-| test.rs:154:12:159:10 | ParenExpr | test.rs:162:13:162:13 | 0 | false |
-| test.rs:154:13:159:9 | LoopExpr | test.rs:154:12:159:10 | ParenExpr |  |
+| test.rs:154:13:159:9 | LoopExpr | test.rs:160:13:160:13 | 1 | true |
+| test.rs:154:13:159:9 | LoopExpr | test.rs:162:13:162:13 | 0 | false |
 | test.rs:154:18:159:9 | BlockExpr | test.rs:155:13:157:14 | ExprStmt |  |
 | test.rs:155:13:157:13 | IfExpr | test.rs:158:13:158:19 | ExprStmt |  |
 | test.rs:155:13:157:14 | ExprStmt | test.rs:155:16:155:16 | a |  |
@@ -318,9 +312,8 @@
 | test.rs:166:5:177:5 | exit test_if_loop2 (normal) | test.rs:166:5:177:5 | exit test_if_loop2 |  |
 | test.rs:166:37:177:5 | BlockExpr | test.rs:166:5:177:5 | exit test_if_loop2 (normal) |  |
 | test.rs:167:9:176:9 | IfExpr | test.rs:166:37:177:5 | BlockExpr |  |
-| test.rs:167:12:172:10 | ParenExpr | test.rs:173:13:173:13 | 1 | true |
-| test.rs:167:12:172:10 | ParenExpr | test.rs:175:13:175:13 | 0 | false |
-| test.rs:167:13:172:9 | LoopExpr | test.rs:167:12:172:10 | ParenExpr |  |
+| test.rs:167:13:172:9 | LoopExpr | test.rs:173:13:173:13 | 1 | true |
+| test.rs:167:13:172:9 | LoopExpr | test.rs:175:13:175:13 | 0 | false |
 | test.rs:167:26:172:9 | BlockExpr | test.rs:168:13:170:14 | ExprStmt |  |
 | test.rs:168:13:170:13 | IfExpr | test.rs:171:13:171:19 | ExprStmt |  |
 | test.rs:168:13:170:14 | ExprStmt | test.rs:168:16:168:16 | a |  |
@@ -345,9 +338,8 @@
 | test.rs:179:5:187:5 | exit test_labelled_block (normal) | test.rs:179:5:187:5 | exit test_labelled_block |  |
 | test.rs:179:43:187:5 | BlockExpr | test.rs:179:5:187:5 | exit test_labelled_block (normal) |  |
 | test.rs:180:9:186:9 | IfExpr | test.rs:179:43:187:5 | BlockExpr |  |
-| test.rs:180:12:182:10 | ParenExpr | test.rs:183:13:183:13 | 1 | true |
-| test.rs:180:12:182:10 | ParenExpr | test.rs:185:13:185:13 | 0 | false |
-| test.rs:180:13:182:9 | BlockExpr | test.rs:180:12:182:10 | ParenExpr |  |
+| test.rs:180:13:182:9 | BlockExpr | test.rs:183:13:183:13 | 1 | true |
+| test.rs:180:13:182:9 | BlockExpr | test.rs:185:13:185:13 | 0 | false |
 | test.rs:181:13:181:30 | BreakExpr | test.rs:180:13:182:9 | BlockExpr | break('block) |
 | test.rs:181:13:181:31 | ExprStmt | test.rs:181:26:181:26 | a |  |
 | test.rs:181:26:181:26 | a | test.rs:181:30:181:30 | 0 |  |
@@ -392,10 +384,9 @@
 | test.rs:203:17:203:17 | a | test.rs:203:23:203:23 | b | false |
 | test.rs:203:17:203:30 | ... \|\| ... | test.rs:203:17:203:17 | a |  |
 | test.rs:203:17:203:35 | ... \|\| ... | test.rs:203:17:203:30 | ... \|\| ... |  |
-| test.rs:203:22:203:30 | ParenExpr | test.rs:203:13:203:13 | d | true |
-| test.rs:203:22:203:30 | ParenExpr | test.rs:203:35:203:35 | c | false |
 | test.rs:203:23:203:23 | b | test.rs:203:28:203:29 | 28 |  |
-| test.rs:203:23:203:29 | ... == ... | test.rs:203:22:203:30 | ParenExpr |  |
+| test.rs:203:23:203:29 | ... == ... | test.rs:203:13:203:13 | d | true |
+| test.rs:203:23:203:29 | ... == ... | test.rs:203:35:203:35 | c | false |
 | test.rs:203:28:203:29 | 28 | test.rs:203:23:203:29 | ... == ... |  |
 | test.rs:203:35:203:35 | c | test.rs:203:13:203:13 | d |  |
 | test.rs:204:9:204:9 | d | test.rs:202:61:205:5 | BlockExpr |  |
@@ -485,8 +476,7 @@
 | test.rs:259:1:264:1 | enter dead_code | test.rs:260:5:262:5 | ExprStmt |  |
 | test.rs:259:1:264:1 | exit dead_code (normal) | test.rs:259:1:264:1 | exit dead_code |  |
 | test.rs:260:5:262:5 | ExprStmt | test.rs:260:9:260:12 | true |  |
-| test.rs:260:8:260:13 | ParenExpr | test.rs:261:9:261:17 | ExprStmt | true |
-| test.rs:260:9:260:12 | true | test.rs:260:8:260:13 | ParenExpr |  |
+| test.rs:260:9:260:12 | true | test.rs:261:9:261:17 | ExprStmt | true |
 | test.rs:261:9:261:16 | ReturnExpr | test.rs:259:1:264:1 | exit dead_code (normal) | return |
 | test.rs:261:9:261:17 | ExprStmt | test.rs:261:16:261:16 | 0 |  |
 | test.rs:261:16:261:16 | 0 | test.rs:261:9:261:16 | ReturnExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -97,350 +97,350 @@
 | test.rs:47:21:47:36 | ExprStmt | test.rs:47:21:47:35 | ContinueExpr |  |
 | test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | continue('inner) |
 | test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr |  |
-| test.rs:54:5:60:5 | enter test_while | test.rs:55:9:55:25 | LetStmt |  |
+| test.rs:54:5:63:5 | enter test_while | test.rs:55:9:55:25 | LetStmt |  |
 | test.rs:55:9:55:25 | LetStmt | test.rs:55:21:55:24 | true |  |
 | test.rs:55:21:55:24 | true | test.rs:55:13:55:17 | b |  |
-| test.rs:69:1:72:1 | enter test_nested_function | test.rs:70:5:70:28 | LetStmt |  |
-| test.rs:69:1:72:1 | exit test_nested_function (normal) | test.rs:69:1:72:1 | exit test_nested_function |  |
-| test.rs:69:40:72:1 | BlockExpr | test.rs:69:1:72:1 | exit test_nested_function (normal) |  |
-| test.rs:70:5:70:28 | LetStmt | test.rs:70:19:70:27 | ClosureExpr |  |
-| test.rs:70:9:70:15 | add_one | test.rs:71:5:71:11 | add_one | match, no-match |
-| test.rs:70:19:70:27 | ClosureExpr | test.rs:70:9:70:15 | add_one |  |
-| test.rs:70:19:70:27 | enter ClosureExpr | test.rs:70:23:70:23 | i |  |
-| test.rs:70:19:70:27 | exit ClosureExpr (normal) | test.rs:70:19:70:27 | exit ClosureExpr |  |
-| test.rs:70:23:70:23 | i | test.rs:70:27:70:27 | 1 |  |
-| test.rs:70:23:70:27 | ... + ... | test.rs:70:19:70:27 | exit ClosureExpr (normal) |  |
-| test.rs:70:27:70:27 | 1 | test.rs:70:23:70:27 | ... + ... |  |
-| test.rs:71:5:71:11 | add_one | test.rs:71:13:71:19 | add_one |  |
-| test.rs:71:5:71:23 | CallExpr | test.rs:69:40:72:1 | BlockExpr |  |
-| test.rs:71:13:71:19 | add_one | test.rs:71:21:71:21 | n |  |
-| test.rs:71:13:71:22 | CallExpr | test.rs:71:5:71:23 | CallExpr |  |
-| test.rs:71:21:71:21 | n | test.rs:71:13:71:22 | CallExpr |  |
-| test.rs:76:5:82:5 | enter test_if_else | test.rs:77:12:77:12 | n |  |
-| test.rs:76:5:82:5 | exit test_if_else (normal) | test.rs:76:5:82:5 | exit test_if_else |  |
-| test.rs:76:36:82:5 | BlockExpr | test.rs:76:5:82:5 | exit test_if_else (normal) |  |
-| test.rs:77:9:81:9 | IfExpr | test.rs:76:36:82:5 | BlockExpr |  |
-| test.rs:77:12:77:12 | n | test.rs:77:17:77:17 | 0 |  |
-| test.rs:77:12:77:17 | ... <= ... | test.rs:78:13:78:13 | 0 | true |
-| test.rs:77:12:77:17 | ... <= ... | test.rs:80:13:80:13 | n | false |
-| test.rs:77:17:77:17 | 0 | test.rs:77:12:77:17 | ... <= ... |  |
-| test.rs:77:19:79:9 | BlockExpr | test.rs:77:9:81:9 | IfExpr |  |
-| test.rs:78:13:78:13 | 0 | test.rs:77:19:79:9 | BlockExpr |  |
-| test.rs:79:16:81:9 | BlockExpr | test.rs:77:9:81:9 | IfExpr |  |
-| test.rs:80:13:80:13 | n | test.rs:80:17:80:17 | 1 |  |
-| test.rs:80:13:80:17 | ... - ... | test.rs:79:16:81:9 | BlockExpr |  |
-| test.rs:80:17:80:17 | 1 | test.rs:80:13:80:17 | ... - ... |  |
-| test.rs:84:5:90:5 | enter test_if_let_else | test.rs:85:12:85:26 | LetExpr |  |
-| test.rs:84:5:90:5 | exit test_if_let_else (normal) | test.rs:84:5:90:5 | exit test_if_let_else |  |
-| test.rs:84:48:90:5 | BlockExpr | test.rs:84:5:90:5 | exit test_if_let_else (normal) |  |
-| test.rs:85:9:89:9 | IfExpr | test.rs:84:48:90:5 | BlockExpr |  |
-| test.rs:85:12:85:26 | LetExpr | test.rs:85:16:85:22 | TupleStructPat |  |
-| test.rs:85:16:85:22 | TupleStructPat | test.rs:86:13:86:13 | n | match |
-| test.rs:85:16:85:22 | TupleStructPat | test.rs:88:13:88:13 | 0 | no-match |
-| test.rs:85:28:87:9 | BlockExpr | test.rs:85:9:89:9 | IfExpr |  |
-| test.rs:86:13:86:13 | n | test.rs:85:28:87:9 | BlockExpr |  |
-| test.rs:87:16:89:9 | BlockExpr | test.rs:85:9:89:9 | IfExpr |  |
-| test.rs:88:13:88:13 | 0 | test.rs:87:16:89:9 | BlockExpr |  |
-| test.rs:92:5:97:5 | enter test_if_let | test.rs:93:9:95:9 | ExprStmt |  |
-| test.rs:92:5:97:5 | exit test_if_let (normal) | test.rs:92:5:97:5 | exit test_if_let |  |
-| test.rs:92:43:97:5 | BlockExpr | test.rs:92:5:97:5 | exit test_if_let (normal) |  |
-| test.rs:93:9:95:9 | ExprStmt | test.rs:93:12:93:26 | LetExpr |  |
-| test.rs:93:9:95:9 | IfExpr | test.rs:96:9:96:9 | 0 |  |
-| test.rs:93:12:93:26 | LetExpr | test.rs:93:16:93:22 | TupleStructPat |  |
-| test.rs:93:16:93:22 | TupleStructPat | test.rs:93:9:95:9 | IfExpr | no-match |
-| test.rs:93:16:93:22 | TupleStructPat | test.rs:94:13:94:13 | n | match |
-| test.rs:93:28:95:9 | BlockExpr | test.rs:93:9:95:9 | IfExpr |  |
-| test.rs:94:13:94:13 | n | test.rs:93:28:95:9 | BlockExpr |  |
-| test.rs:96:9:96:9 | 0 | test.rs:92:43:97:5 | BlockExpr |  |
-| test.rs:99:5:105:5 | enter test_nested_if | test.rs:100:16:100:16 | PathExpr |  |
-| test.rs:99:5:105:5 | exit test_nested_if (normal) | test.rs:99:5:105:5 | exit test_nested_if |  |
-| test.rs:99:38:105:5 | BlockExpr | test.rs:99:5:105:5 | exit test_nested_if (normal) |  |
-| test.rs:100:9:104:9 | IfExpr | test.rs:99:38:105:5 | BlockExpr |  |
-| test.rs:100:12:100:49 | ParenExpr | test.rs:101:13:101:13 | 1 | true |
-| test.rs:100:12:100:49 | ParenExpr | test.rs:103:13:103:13 | 0 | false |
-| test.rs:100:13:100:48 | IfExpr | test.rs:100:12:100:49 | ParenExpr |  |
-| test.rs:100:16:100:16 | PathExpr | test.rs:100:20:100:20 | 0 |  |
-| test.rs:100:16:100:20 | ... < ... | test.rs:100:24:100:24 | a | true |
-| test.rs:100:16:100:20 | ... < ... | test.rs:100:41:100:41 | a | false |
-| test.rs:100:20:100:20 | 0 | test.rs:100:16:100:20 | ... < ... |  |
-| test.rs:100:22:100:32 | BlockExpr | test.rs:100:13:100:48 | IfExpr |  |
-| test.rs:100:24:100:24 | a | test.rs:100:29:100:30 | 10 |  |
-| test.rs:100:24:100:30 | ... < ... | test.rs:100:22:100:32 | BlockExpr |  |
-| test.rs:100:28:100:30 | - ... | test.rs:100:24:100:30 | ... < ... |  |
-| test.rs:100:29:100:30 | 10 | test.rs:100:28:100:30 | - ... |  |
-| test.rs:100:39:100:48 | BlockExpr | test.rs:100:13:100:48 | IfExpr |  |
-| test.rs:100:41:100:41 | a | test.rs:100:45:100:46 | 10 |  |
-| test.rs:100:41:100:46 | ... > ... | test.rs:100:39:100:48 | BlockExpr |  |
-| test.rs:100:45:100:46 | 10 | test.rs:100:41:100:46 | ... > ... |  |
-| test.rs:100:51:102:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
-| test.rs:101:13:101:13 | 1 | test.rs:100:51:102:9 | BlockExpr |  |
-| test.rs:102:16:104:9 | BlockExpr | test.rs:100:9:104:9 | IfExpr |  |
-| test.rs:103:13:103:13 | 0 | test.rs:102:16:104:9 | BlockExpr |  |
-| test.rs:107:5:116:5 | enter test_nested_if_match | test.rs:108:19:108:19 | a |  |
-| test.rs:107:5:116:5 | exit test_nested_if_match (normal) | test.rs:107:5:116:5 | exit test_nested_if_match |  |
-| test.rs:107:44:116:5 | BlockExpr | test.rs:107:5:116:5 | exit test_nested_if_match (normal) |  |
-| test.rs:108:9:115:9 | IfExpr | test.rs:107:44:116:5 | BlockExpr |  |
-| test.rs:108:12:111:10 | ParenExpr | test.rs:112:13:112:13 | 1 | true |
-| test.rs:108:12:111:10 | ParenExpr | test.rs:114:13:114:13 | 0 | false |
-| test.rs:108:13:111:9 | MatchExpr | test.rs:108:12:111:10 | ParenExpr |  |
-| test.rs:108:19:108:19 | a | test.rs:109:13:109:13 | LiteralPat |  |
-| test.rs:109:13:109:13 | LiteralPat | test.rs:109:18:109:21 | true | match |
-| test.rs:109:13:109:13 | LiteralPat | test.rs:110:13:110:13 | WildcardPat | no-match |
-| test.rs:109:18:109:21 | true | test.rs:108:13:111:9 | MatchExpr |  |
-| test.rs:110:13:110:13 | WildcardPat | test.rs:110:18:110:22 | false | match |
-| test.rs:110:18:110:22 | false | test.rs:108:13:111:9 | MatchExpr |  |
-| test.rs:111:12:113:9 | BlockExpr | test.rs:108:9:115:9 | IfExpr |  |
-| test.rs:112:13:112:13 | 1 | test.rs:111:12:113:9 | BlockExpr |  |
-| test.rs:113:16:115:9 | BlockExpr | test.rs:108:9:115:9 | IfExpr |  |
-| test.rs:114:13:114:13 | 0 | test.rs:113:16:115:9 | BlockExpr |  |
-| test.rs:118:5:127:5 | enter test_nested_if_block | test.rs:120:13:120:15 | ExprStmt |  |
-| test.rs:118:5:127:5 | exit test_nested_if_block (normal) | test.rs:118:5:127:5 | exit test_nested_if_block |  |
-| test.rs:118:44:127:5 | BlockExpr | test.rs:118:5:127:5 | exit test_nested_if_block (normal) |  |
-| test.rs:119:9:126:9 | IfExpr | test.rs:118:44:127:5 | BlockExpr |  |
-| test.rs:119:12:122:9 | BlockExpr | test.rs:123:13:123:13 | 1 | true |
-| test.rs:119:12:122:9 | BlockExpr | test.rs:125:13:125:13 | 0 | false |
-| test.rs:120:13:120:14 | TupleExpr | test.rs:121:13:121:13 | a |  |
-| test.rs:120:13:120:15 | ExprStmt | test.rs:120:13:120:14 | TupleExpr |  |
-| test.rs:121:13:121:13 | a | test.rs:121:17:121:17 | 0 |  |
-| test.rs:121:13:121:17 | ... > ... | test.rs:119:12:122:9 | BlockExpr | false, true |
-| test.rs:121:17:121:17 | 0 | test.rs:121:13:121:17 | ... > ... |  |
-| test.rs:122:11:124:9 | BlockExpr | test.rs:119:9:126:9 | IfExpr |  |
-| test.rs:123:13:123:13 | 1 | test.rs:122:11:124:9 | BlockExpr |  |
-| test.rs:124:16:126:9 | BlockExpr | test.rs:119:9:126:9 | IfExpr |  |
-| test.rs:125:13:125:13 | 0 | test.rs:124:16:126:9 | BlockExpr |  |
-| test.rs:129:5:136:5 | enter test_if_assignment | test.rs:130:9:130:26 | LetStmt |  |
-| test.rs:129:5:136:5 | exit test_if_assignment (normal) | test.rs:129:5:136:5 | exit test_if_assignment |  |
-| test.rs:129:42:136:5 | BlockExpr | test.rs:129:5:136:5 | exit test_if_assignment (normal) |  |
-| test.rs:130:9:130:26 | LetStmt | test.rs:130:21:130:25 | false |  |
-| test.rs:130:13:130:17 | x | test.rs:131:12:131:12 | x | match, no-match |
-| test.rs:130:21:130:25 | false | test.rs:130:13:130:17 | x |  |
-| test.rs:131:9:135:9 | IfExpr | test.rs:129:42:136:5 | BlockExpr |  |
-| test.rs:131:12:131:12 | x | test.rs:131:16:131:19 | true |  |
-| test.rs:131:12:131:19 | ... = ... | test.rs:132:13:132:13 | 1 | true |
-| test.rs:131:12:131:19 | ... = ... | test.rs:134:13:134:13 | 0 | false |
-| test.rs:131:16:131:19 | true | test.rs:131:12:131:19 | ... = ... |  |
-| test.rs:131:21:133:9 | BlockExpr | test.rs:131:9:135:9 | IfExpr |  |
-| test.rs:132:13:132:13 | 1 | test.rs:131:21:133:9 | BlockExpr |  |
-| test.rs:133:16:135:9 | BlockExpr | test.rs:131:9:135:9 | IfExpr |  |
-| test.rs:134:13:134:13 | 0 | test.rs:133:16:135:9 | BlockExpr |  |
-| test.rs:138:5:149:5 | enter test_if_loop1 | test.rs:140:13:142:14 | ExprStmt |  |
-| test.rs:138:5:149:5 | exit test_if_loop1 (normal) | test.rs:138:5:149:5 | exit test_if_loop1 |  |
-| test.rs:138:37:149:5 | BlockExpr | test.rs:138:5:149:5 | exit test_if_loop1 (normal) |  |
-| test.rs:139:9:148:9 | IfExpr | test.rs:138:37:149:5 | BlockExpr |  |
-| test.rs:139:12:144:10 | ParenExpr | test.rs:145:13:145:13 | 1 | true |
-| test.rs:139:12:144:10 | ParenExpr | test.rs:147:13:147:13 | 0 | false |
-| test.rs:139:13:144:9 | LoopExpr | test.rs:139:12:144:10 | ParenExpr |  |
-| test.rs:139:18:144:9 | BlockExpr | test.rs:140:13:142:14 | ExprStmt |  |
-| test.rs:140:13:142:13 | IfExpr | test.rs:143:13:143:19 | ExprStmt |  |
-| test.rs:140:13:142:14 | ExprStmt | test.rs:140:16:140:16 | a |  |
-| test.rs:140:16:140:16 | a | test.rs:140:20:140:20 | 0 |  |
-| test.rs:140:16:140:20 | ... > ... | test.rs:140:13:142:13 | IfExpr | false |
-| test.rs:140:16:140:20 | ... > ... | test.rs:141:17:141:29 | ExprStmt | true |
-| test.rs:140:20:140:20 | 0 | test.rs:140:16:140:20 | ... > ... |  |
-| test.rs:141:17:141:28 | BreakExpr | test.rs:139:13:144:9 | LoopExpr | break |
-| test.rs:141:17:141:29 | ExprStmt | test.rs:141:23:141:23 | a |  |
-| test.rs:141:23:141:23 | a | test.rs:141:27:141:28 | 10 |  |
-| test.rs:141:23:141:28 | ... > ... | test.rs:141:17:141:28 | BreakExpr |  |
-| test.rs:141:27:141:28 | 10 | test.rs:141:23:141:28 | ... > ... |  |
-| test.rs:143:13:143:13 | a | test.rs:143:17:143:18 | 10 |  |
-| test.rs:143:13:143:18 | ... < ... | test.rs:139:18:144:9 | BlockExpr |  |
-| test.rs:143:13:143:19 | ExprStmt | test.rs:143:13:143:13 | a |  |
-| test.rs:143:17:143:18 | 10 | test.rs:143:13:143:18 | ... < ... |  |
-| test.rs:144:12:146:9 | BlockExpr | test.rs:139:9:148:9 | IfExpr |  |
-| test.rs:145:13:145:13 | 1 | test.rs:144:12:146:9 | BlockExpr |  |
-| test.rs:146:16:148:9 | BlockExpr | test.rs:139:9:148:9 | IfExpr |  |
-| test.rs:147:13:147:13 | 0 | test.rs:146:16:148:9 | BlockExpr |  |
-| test.rs:151:5:162:5 | enter test_if_loop2 | test.rs:153:13:155:14 | ExprStmt |  |
-| test.rs:151:5:162:5 | exit test_if_loop2 (normal) | test.rs:151:5:162:5 | exit test_if_loop2 |  |
-| test.rs:151:37:162:5 | BlockExpr | test.rs:151:5:162:5 | exit test_if_loop2 (normal) |  |
-| test.rs:152:9:161:9 | IfExpr | test.rs:151:37:162:5 | BlockExpr |  |
-| test.rs:152:12:157:10 | ParenExpr | test.rs:158:13:158:13 | 1 | true |
-| test.rs:152:12:157:10 | ParenExpr | test.rs:160:13:160:13 | 0 | false |
-| test.rs:152:13:157:9 | LoopExpr | test.rs:152:12:157:10 | ParenExpr |  |
-| test.rs:152:26:157:9 | BlockExpr | test.rs:153:13:155:14 | ExprStmt |  |
-| test.rs:153:13:155:13 | IfExpr | test.rs:156:13:156:19 | ExprStmt |  |
-| test.rs:153:13:155:14 | ExprStmt | test.rs:153:16:153:16 | a |  |
-| test.rs:153:16:153:16 | a | test.rs:153:20:153:20 | 0 |  |
-| test.rs:153:16:153:20 | ... > ... | test.rs:153:13:155:13 | IfExpr | false |
-| test.rs:153:16:153:20 | ... > ... | test.rs:154:17:154:36 | ExprStmt | true |
-| test.rs:153:20:153:20 | 0 | test.rs:153:16:153:20 | ... > ... |  |
-| test.rs:154:17:154:35 | BreakExpr | test.rs:152:13:157:9 | LoopExpr | break('label) |
-| test.rs:154:17:154:36 | ExprStmt | test.rs:154:30:154:30 | a |  |
-| test.rs:154:30:154:30 | a | test.rs:154:34:154:35 | 10 |  |
-| test.rs:154:30:154:35 | ... > ... | test.rs:154:17:154:35 | BreakExpr |  |
-| test.rs:154:34:154:35 | 10 | test.rs:154:30:154:35 | ... > ... |  |
-| test.rs:156:13:156:13 | a | test.rs:156:17:156:18 | 10 |  |
-| test.rs:156:13:156:18 | ... < ... | test.rs:152:26:157:9 | BlockExpr |  |
-| test.rs:156:13:156:19 | ExprStmt | test.rs:156:13:156:13 | a |  |
-| test.rs:156:17:156:18 | 10 | test.rs:156:13:156:18 | ... < ... |  |
-| test.rs:157:12:159:9 | BlockExpr | test.rs:152:9:161:9 | IfExpr |  |
-| test.rs:158:13:158:13 | 1 | test.rs:157:12:159:9 | BlockExpr |  |
-| test.rs:159:16:161:9 | BlockExpr | test.rs:152:9:161:9 | IfExpr |  |
-| test.rs:160:13:160:13 | 0 | test.rs:159:16:161:9 | BlockExpr |  |
-| test.rs:164:5:172:5 | enter test_labelled_block | test.rs:166:13:166:31 | ExprStmt |  |
-| test.rs:164:5:172:5 | exit test_labelled_block (normal) | test.rs:164:5:172:5 | exit test_labelled_block |  |
-| test.rs:166:13:166:30 | BreakExpr | test.rs:164:5:172:5 | exit test_labelled_block (normal) | break('block) |
-| test.rs:166:13:166:31 | ExprStmt | test.rs:166:26:166:26 | a |  |
-| test.rs:166:26:166:26 | a | test.rs:166:30:166:30 | 0 |  |
-| test.rs:166:26:166:30 | ... > ... | test.rs:166:13:166:30 | BreakExpr |  |
-| test.rs:166:30:166:30 | 0 | test.rs:166:26:166:30 | ... > ... |  |
-| test.rs:177:5:180:5 | enter test_and_operator | test.rs:178:9:178:28 | LetStmt |  |
-| test.rs:177:5:180:5 | exit test_and_operator (normal) | test.rs:177:5:180:5 | exit test_and_operator |  |
-| test.rs:177:61:180:5 | BlockExpr | test.rs:177:5:180:5 | exit test_and_operator (normal) |  |
-| test.rs:178:9:178:28 | LetStmt | test.rs:178:17:178:27 | ... && ... |  |
-| test.rs:178:13:178:13 | d | test.rs:179:9:179:9 | d | match, no-match |
-| test.rs:178:17:178:17 | a | test.rs:178:13:178:13 | d | false |
-| test.rs:178:17:178:17 | a | test.rs:178:22:178:22 | b | true |
-| test.rs:178:17:178:22 | ... && ... | test.rs:178:17:178:17 | a |  |
-| test.rs:178:17:178:27 | ... && ... | test.rs:178:17:178:22 | ... && ... |  |
-| test.rs:178:22:178:22 | b | test.rs:178:13:178:13 | d | false |
-| test.rs:178:22:178:22 | b | test.rs:178:27:178:27 | c | true |
-| test.rs:178:27:178:27 | c | test.rs:178:13:178:13 | d |  |
-| test.rs:179:9:179:9 | d | test.rs:177:61:180:5 | BlockExpr |  |
-| test.rs:182:5:185:5 | enter test_or_operator | test.rs:183:9:183:28 | LetStmt |  |
-| test.rs:182:5:185:5 | exit test_or_operator (normal) | test.rs:182:5:185:5 | exit test_or_operator |  |
-| test.rs:182:60:185:5 | BlockExpr | test.rs:182:5:185:5 | exit test_or_operator (normal) |  |
-| test.rs:183:9:183:28 | LetStmt | test.rs:183:17:183:27 | ... \|\| ... |  |
-| test.rs:183:13:183:13 | d | test.rs:184:9:184:9 | d | match, no-match |
-| test.rs:183:17:183:17 | a | test.rs:183:13:183:13 | d | true |
-| test.rs:183:17:183:17 | a | test.rs:183:22:183:22 | b | false |
-| test.rs:183:17:183:22 | ... \|\| ... | test.rs:183:17:183:17 | a |  |
-| test.rs:183:17:183:27 | ... \|\| ... | test.rs:183:17:183:22 | ... \|\| ... |  |
-| test.rs:183:22:183:22 | b | test.rs:183:13:183:13 | d | true |
-| test.rs:183:22:183:22 | b | test.rs:183:27:183:27 | c | false |
-| test.rs:183:27:183:27 | c | test.rs:183:13:183:13 | d |  |
-| test.rs:184:9:184:9 | d | test.rs:182:60:185:5 | BlockExpr |  |
-| test.rs:187:5:190:5 | enter test_or_operator_2 | test.rs:188:9:188:36 | LetStmt |  |
-| test.rs:187:5:190:5 | exit test_or_operator_2 (normal) | test.rs:187:5:190:5 | exit test_or_operator_2 |  |
-| test.rs:187:61:190:5 | BlockExpr | test.rs:187:5:190:5 | exit test_or_operator_2 (normal) |  |
-| test.rs:188:9:188:36 | LetStmt | test.rs:188:17:188:35 | ... \|\| ... |  |
-| test.rs:188:13:188:13 | d | test.rs:189:9:189:9 | d | match, no-match |
-| test.rs:188:17:188:17 | a | test.rs:188:13:188:13 | d | true |
-| test.rs:188:17:188:17 | a | test.rs:188:23:188:23 | b | false |
-| test.rs:188:17:188:30 | ... \|\| ... | test.rs:188:17:188:17 | a |  |
-| test.rs:188:17:188:35 | ... \|\| ... | test.rs:188:17:188:30 | ... \|\| ... |  |
-| test.rs:188:22:188:30 | ParenExpr | test.rs:188:13:188:13 | d | true |
-| test.rs:188:22:188:30 | ParenExpr | test.rs:188:35:188:35 | c | false |
-| test.rs:188:23:188:23 | b | test.rs:188:28:188:29 | 28 |  |
-| test.rs:188:23:188:29 | ... == ... | test.rs:188:22:188:30 | ParenExpr |  |
-| test.rs:188:28:188:29 | 28 | test.rs:188:23:188:29 | ... == ... |  |
-| test.rs:188:35:188:35 | c | test.rs:188:13:188:13 | d |  |
-| test.rs:189:9:189:9 | d | test.rs:187:61:190:5 | BlockExpr |  |
-| test.rs:192:5:195:5 | enter test_not_operator | test.rs:193:9:193:19 | LetStmt |  |
-| test.rs:192:5:195:5 | exit test_not_operator (normal) | test.rs:192:5:195:5 | exit test_not_operator |  |
-| test.rs:192:43:195:5 | BlockExpr | test.rs:192:5:195:5 | exit test_not_operator (normal) |  |
-| test.rs:193:9:193:19 | LetStmt | test.rs:193:18:193:18 | a |  |
-| test.rs:193:13:193:13 | d | test.rs:194:9:194:9 | d | match, no-match |
-| test.rs:193:17:193:18 | ! ... | test.rs:193:13:193:13 | d |  |
-| test.rs:193:18:193:18 | a | test.rs:193:17:193:18 | ! ... |  |
-| test.rs:194:9:194:9 | d | test.rs:192:43:195:5 | BlockExpr |  |
-| test.rs:197:5:203:5 | enter test_if_and_operator | test.rs:198:12:198:22 | ... && ... |  |
-| test.rs:197:5:203:5 | exit test_if_and_operator (normal) | test.rs:197:5:203:5 | exit test_if_and_operator |  |
-| test.rs:197:63:203:5 | BlockExpr | test.rs:197:5:203:5 | exit test_if_and_operator (normal) |  |
-| test.rs:198:9:202:9 | IfExpr | test.rs:197:63:203:5 | BlockExpr |  |
-| test.rs:198:12:198:12 | a | test.rs:198:17:198:17 | b | true |
-| test.rs:198:12:198:12 | a | test.rs:201:13:201:17 | false | false |
-| test.rs:198:12:198:17 | ... && ... | test.rs:198:12:198:12 | a |  |
-| test.rs:198:12:198:22 | ... && ... | test.rs:198:12:198:17 | ... && ... |  |
-| test.rs:198:17:198:17 | b | test.rs:198:22:198:22 | c | true |
-| test.rs:198:17:198:17 | b | test.rs:201:13:201:17 | false | false |
-| test.rs:198:22:198:22 | c | test.rs:199:13:199:16 | true | true |
-| test.rs:198:22:198:22 | c | test.rs:201:13:201:17 | false | false |
-| test.rs:198:24:200:9 | BlockExpr | test.rs:198:9:202:9 | IfExpr |  |
-| test.rs:199:13:199:16 | true | test.rs:198:24:200:9 | BlockExpr |  |
-| test.rs:200:16:202:9 | BlockExpr | test.rs:198:9:202:9 | IfExpr |  |
-| test.rs:201:13:201:17 | false | test.rs:200:16:202:9 | BlockExpr |  |
-| test.rs:205:5:211:5 | enter test_if_or_operator | test.rs:206:12:206:22 | ... \|\| ... |  |
-| test.rs:205:5:211:5 | exit test_if_or_operator (normal) | test.rs:205:5:211:5 | exit test_if_or_operator |  |
-| test.rs:205:62:211:5 | BlockExpr | test.rs:205:5:211:5 | exit test_if_or_operator (normal) |  |
-| test.rs:206:9:210:9 | IfExpr | test.rs:205:62:211:5 | BlockExpr |  |
-| test.rs:206:12:206:12 | a | test.rs:206:17:206:17 | b | false |
-| test.rs:206:12:206:12 | a | test.rs:207:13:207:16 | true | true |
-| test.rs:206:12:206:17 | ... \|\| ... | test.rs:206:12:206:12 | a |  |
-| test.rs:206:12:206:22 | ... \|\| ... | test.rs:206:12:206:17 | ... \|\| ... |  |
-| test.rs:206:17:206:17 | b | test.rs:206:22:206:22 | c | false |
-| test.rs:206:17:206:17 | b | test.rs:207:13:207:16 | true | true |
-| test.rs:206:22:206:22 | c | test.rs:207:13:207:16 | true | true |
-| test.rs:206:22:206:22 | c | test.rs:209:13:209:17 | false | false |
-| test.rs:206:24:208:9 | BlockExpr | test.rs:206:9:210:9 | IfExpr |  |
-| test.rs:207:13:207:16 | true | test.rs:206:24:208:9 | BlockExpr |  |
-| test.rs:208:16:210:9 | BlockExpr | test.rs:206:9:210:9 | IfExpr |  |
-| test.rs:209:13:209:17 | false | test.rs:208:16:210:9 | BlockExpr |  |
-| test.rs:213:5:219:5 | enter test_if_not_operator | test.rs:214:13:214:13 | a |  |
-| test.rs:213:5:219:5 | exit test_if_not_operator (normal) | test.rs:213:5:219:5 | exit test_if_not_operator |  |
-| test.rs:213:46:219:5 | BlockExpr | test.rs:213:5:219:5 | exit test_if_not_operator (normal) |  |
-| test.rs:214:9:218:9 | IfExpr | test.rs:213:46:219:5 | BlockExpr |  |
-| test.rs:214:12:214:13 | ! ... | test.rs:215:13:215:16 | true | true |
-| test.rs:214:12:214:13 | ! ... | test.rs:217:13:217:17 | false | false |
-| test.rs:214:13:214:13 | a | test.rs:214:12:214:13 | ! ... | false, true |
-| test.rs:214:15:216:9 | BlockExpr | test.rs:214:9:218:9 | IfExpr |  |
-| test.rs:215:13:215:16 | true | test.rs:214:15:216:9 | BlockExpr |  |
-| test.rs:216:16:218:9 | BlockExpr | test.rs:214:9:218:9 | IfExpr |  |
-| test.rs:217:13:217:17 | false | test.rs:216:16:218:9 | BlockExpr |  |
-| test.rs:222:1:228:1 | enter test_match | test.rs:223:11:223:21 | maybe_digit |  |
-| test.rs:222:1:228:1 | exit test_match (normal) | test.rs:222:1:228:1 | exit test_match |  |
-| test.rs:222:48:228:1 | BlockExpr | test.rs:222:1:228:1 | exit test_match (normal) |  |
-| test.rs:223:5:227:5 | MatchExpr | test.rs:222:48:228:1 | BlockExpr |  |
-| test.rs:223:11:223:21 | maybe_digit | test.rs:224:9:224:23 | TupleStructPat |  |
-| test.rs:224:9:224:23 | TupleStructPat | test.rs:224:28:224:28 | x | match |
-| test.rs:224:9:224:23 | TupleStructPat | test.rs:225:9:225:23 | TupleStructPat | no-match |
-| test.rs:224:28:224:28 | x | test.rs:224:32:224:33 | 10 |  |
-| test.rs:224:32:224:33 | 10 | test.rs:224:28:224:33 | ... < ... |  |
-| test.rs:225:9:225:23 | TupleStructPat | test.rs:225:28:225:28 | x | match |
-| test.rs:225:9:225:23 | TupleStructPat | test.rs:226:9:226:20 | PathPat | no-match |
-| test.rs:225:28:225:28 | x | test.rs:223:5:227:5 | MatchExpr |  |
-| test.rs:226:9:226:20 | PathPat | test.rs:226:25:226:25 | 5 | match |
-| test.rs:226:25:226:25 | 5 | test.rs:223:5:227:5 | MatchExpr |  |
-| test.rs:231:5:236:5 | enter test_infinite_loop | test.rs:232:9:234:9 | ExprStmt |  |
-| test.rs:232:9:234:9 | ExprStmt | test.rs:233:13:233:13 | 1 |  |
-| test.rs:232:14:234:9 | BlockExpr | test.rs:233:13:233:13 | 1 |  |
-| test.rs:233:13:233:13 | 1 | test.rs:232:14:234:9 | BlockExpr |  |
-| test.rs:238:5:241:5 | enter test_let_match | test.rs:239:9:239:49 | LetStmt |  |
-| test.rs:238:5:241:5 | exit test_let_match (normal) | test.rs:238:5:241:5 | exit test_let_match |  |
-| test.rs:238:39:241:5 | BlockExpr | test.rs:238:5:241:5 | exit test_let_match (normal) |  |
-| test.rs:239:9:239:49 | LetStmt | test.rs:239:23:239:23 | a |  |
-| test.rs:239:13:239:19 | TupleStructPat | test.rs:239:32:239:46 | "Expected some" | no-match |
-| test.rs:239:13:239:19 | TupleStructPat | test.rs:240:9:240:9 | n | match |
-| test.rs:239:23:239:23 | a | test.rs:239:13:239:19 | TupleStructPat |  |
-| test.rs:239:32:239:46 | "Expected some" | test.rs:239:30:239:48 | BlockExpr |  |
-| test.rs:240:9:240:9 | n | test.rs:238:39:241:5 | BlockExpr |  |
-| test.rs:244:1:249:1 | enter dead_code | test.rs:245:5:247:5 | ExprStmt |  |
-| test.rs:244:1:249:1 | exit dead_code (normal) | test.rs:244:1:249:1 | exit dead_code |  |
-| test.rs:245:5:247:5 | ExprStmt | test.rs:245:9:245:12 | true |  |
-| test.rs:245:8:245:13 | ParenExpr | test.rs:246:9:246:17 | ExprStmt | true |
-| test.rs:245:9:245:12 | true | test.rs:245:8:245:13 | ParenExpr |  |
-| test.rs:246:9:246:16 | ReturnExpr | test.rs:244:1:249:1 | exit dead_code (normal) | return |
-| test.rs:246:9:246:17 | ExprStmt | test.rs:246:16:246:16 | 0 |  |
-| test.rs:246:16:246:16 | 0 | test.rs:246:9:246:16 | ReturnExpr |  |
-| test.rs:251:1:264:1 | enter labelled_block | test.rs:252:5:263:6 | LetStmt |  |
-| test.rs:251:1:264:1 | exit labelled_block (normal) | test.rs:251:1:264:1 | exit labelled_block |  |
-| test.rs:251:28:264:1 | BlockExpr | test.rs:251:1:264:1 | exit labelled_block (normal) |  |
-| test.rs:252:5:263:6 | LetStmt | test.rs:253:9:253:19 | ExprStmt |  |
-| test.rs:252:9:252:14 | result | test.rs:251:28:264:1 | BlockExpr | match, no-match |
-| test.rs:252:18:263:5 | BlockExpr | test.rs:252:9:252:14 | result |  |
-| test.rs:253:9:253:16 | PathExpr | test.rs:253:9:253:18 | CallExpr |  |
-| test.rs:253:9:253:18 | CallExpr | test.rs:254:9:256:9 | ExprStmt |  |
-| test.rs:253:9:253:19 | ExprStmt | test.rs:253:9:253:16 | PathExpr |  |
-| test.rs:254:9:256:9 | ExprStmt | test.rs:254:12:254:28 | PathExpr |  |
-| test.rs:254:9:256:9 | IfExpr | test.rs:257:9:257:24 | ExprStmt |  |
-| test.rs:254:12:254:28 | PathExpr | test.rs:254:12:254:30 | CallExpr |  |
-| test.rs:254:12:254:30 | CallExpr | test.rs:254:9:256:9 | IfExpr | false |
-| test.rs:254:12:254:30 | CallExpr | test.rs:255:13:255:27 | ExprStmt | true |
-| test.rs:255:13:255:26 | BreakExpr | test.rs:251:1:264:1 | exit labelled_block (normal) | break('block) |
-| test.rs:255:13:255:27 | ExprStmt | test.rs:255:26:255:26 | 1 |  |
-| test.rs:255:26:255:26 | 1 | test.rs:255:13:255:26 | BreakExpr |  |
-| test.rs:257:9:257:21 | PathExpr | test.rs:257:9:257:23 | CallExpr |  |
-| test.rs:257:9:257:23 | CallExpr | test.rs:258:9:260:9 | ExprStmt |  |
-| test.rs:257:9:257:24 | ExprStmt | test.rs:257:9:257:21 | PathExpr |  |
-| test.rs:258:9:260:9 | ExprStmt | test.rs:258:12:258:28 | PathExpr |  |
-| test.rs:258:9:260:9 | IfExpr | test.rs:261:9:261:24 | ExprStmt |  |
-| test.rs:258:12:258:28 | PathExpr | test.rs:258:12:258:30 | CallExpr |  |
-| test.rs:258:12:258:30 | CallExpr | test.rs:258:9:260:9 | IfExpr | false |
-| test.rs:258:12:258:30 | CallExpr | test.rs:259:13:259:27 | ExprStmt | true |
-| test.rs:259:13:259:26 | BreakExpr | test.rs:251:1:264:1 | exit labelled_block (normal) | break('block) |
-| test.rs:259:13:259:27 | ExprStmt | test.rs:259:26:259:26 | 2 |  |
-| test.rs:259:26:259:26 | 2 | test.rs:259:13:259:26 | BreakExpr |  |
-| test.rs:261:9:261:21 | PathExpr | test.rs:261:9:261:23 | CallExpr |  |
-| test.rs:261:9:261:23 | CallExpr | test.rs:262:9:262:9 | 3 |  |
-| test.rs:261:9:261:24 | ExprStmt | test.rs:261:9:261:21 | PathExpr |  |
-| test.rs:262:9:262:9 | 3 | test.rs:252:18:263:5 | BlockExpr |  |
+| test.rs:75:1:78:1 | enter test_nested_function | test.rs:76:5:76:28 | LetStmt |  |
+| test.rs:75:1:78:1 | exit test_nested_function (normal) | test.rs:75:1:78:1 | exit test_nested_function |  |
+| test.rs:75:40:78:1 | BlockExpr | test.rs:75:1:78:1 | exit test_nested_function (normal) |  |
+| test.rs:76:5:76:28 | LetStmt | test.rs:76:19:76:27 | ClosureExpr |  |
+| test.rs:76:9:76:15 | add_one | test.rs:77:5:77:11 | add_one | match, no-match |
+| test.rs:76:19:76:27 | ClosureExpr | test.rs:76:9:76:15 | add_one |  |
+| test.rs:76:19:76:27 | enter ClosureExpr | test.rs:76:23:76:23 | i |  |
+| test.rs:76:19:76:27 | exit ClosureExpr (normal) | test.rs:76:19:76:27 | exit ClosureExpr |  |
+| test.rs:76:23:76:23 | i | test.rs:76:27:76:27 | 1 |  |
+| test.rs:76:23:76:27 | ... + ... | test.rs:76:19:76:27 | exit ClosureExpr (normal) |  |
+| test.rs:76:27:76:27 | 1 | test.rs:76:23:76:27 | ... + ... |  |
+| test.rs:77:5:77:11 | add_one | test.rs:77:13:77:19 | add_one |  |
+| test.rs:77:5:77:23 | CallExpr | test.rs:75:40:78:1 | BlockExpr |  |
+| test.rs:77:13:77:19 | add_one | test.rs:77:21:77:21 | n |  |
+| test.rs:77:13:77:22 | CallExpr | test.rs:77:5:77:23 | CallExpr |  |
+| test.rs:77:21:77:21 | n | test.rs:77:13:77:22 | CallExpr |  |
+| test.rs:82:5:88:5 | enter test_if_else | test.rs:83:12:83:12 | n |  |
+| test.rs:82:5:88:5 | exit test_if_else (normal) | test.rs:82:5:88:5 | exit test_if_else |  |
+| test.rs:82:36:88:5 | BlockExpr | test.rs:82:5:88:5 | exit test_if_else (normal) |  |
+| test.rs:83:9:87:9 | IfExpr | test.rs:82:36:88:5 | BlockExpr |  |
+| test.rs:83:12:83:12 | n | test.rs:83:17:83:17 | 0 |  |
+| test.rs:83:12:83:17 | ... <= ... | test.rs:84:13:84:13 | 0 | true |
+| test.rs:83:12:83:17 | ... <= ... | test.rs:86:13:86:13 | n | false |
+| test.rs:83:17:83:17 | 0 | test.rs:83:12:83:17 | ... <= ... |  |
+| test.rs:83:19:85:9 | BlockExpr | test.rs:83:9:87:9 | IfExpr |  |
+| test.rs:84:13:84:13 | 0 | test.rs:83:19:85:9 | BlockExpr |  |
+| test.rs:85:16:87:9 | BlockExpr | test.rs:83:9:87:9 | IfExpr |  |
+| test.rs:86:13:86:13 | n | test.rs:86:17:86:17 | 1 |  |
+| test.rs:86:13:86:17 | ... - ... | test.rs:85:16:87:9 | BlockExpr |  |
+| test.rs:86:17:86:17 | 1 | test.rs:86:13:86:17 | ... - ... |  |
+| test.rs:90:5:96:5 | enter test_if_let_else | test.rs:91:12:91:26 | LetExpr |  |
+| test.rs:90:5:96:5 | exit test_if_let_else (normal) | test.rs:90:5:96:5 | exit test_if_let_else |  |
+| test.rs:90:48:96:5 | BlockExpr | test.rs:90:5:96:5 | exit test_if_let_else (normal) |  |
+| test.rs:91:9:95:9 | IfExpr | test.rs:90:48:96:5 | BlockExpr |  |
+| test.rs:91:12:91:26 | LetExpr | test.rs:91:16:91:22 | TupleStructPat |  |
+| test.rs:91:16:91:22 | TupleStructPat | test.rs:92:13:92:13 | n | match |
+| test.rs:91:16:91:22 | TupleStructPat | test.rs:94:13:94:13 | 0 | no-match |
+| test.rs:91:28:93:9 | BlockExpr | test.rs:91:9:95:9 | IfExpr |  |
+| test.rs:92:13:92:13 | n | test.rs:91:28:93:9 | BlockExpr |  |
+| test.rs:93:16:95:9 | BlockExpr | test.rs:91:9:95:9 | IfExpr |  |
+| test.rs:94:13:94:13 | 0 | test.rs:93:16:95:9 | BlockExpr |  |
+| test.rs:98:5:103:5 | enter test_if_let | test.rs:99:9:101:9 | ExprStmt |  |
+| test.rs:98:5:103:5 | exit test_if_let (normal) | test.rs:98:5:103:5 | exit test_if_let |  |
+| test.rs:98:43:103:5 | BlockExpr | test.rs:98:5:103:5 | exit test_if_let (normal) |  |
+| test.rs:99:9:101:9 | ExprStmt | test.rs:99:12:99:26 | LetExpr |  |
+| test.rs:99:9:101:9 | IfExpr | test.rs:102:9:102:9 | 0 |  |
+| test.rs:99:12:99:26 | LetExpr | test.rs:99:16:99:22 | TupleStructPat |  |
+| test.rs:99:16:99:22 | TupleStructPat | test.rs:99:9:101:9 | IfExpr | no-match |
+| test.rs:99:16:99:22 | TupleStructPat | test.rs:100:13:100:13 | n | match |
+| test.rs:99:28:101:9 | BlockExpr | test.rs:99:9:101:9 | IfExpr |  |
+| test.rs:100:13:100:13 | n | test.rs:99:28:101:9 | BlockExpr |  |
+| test.rs:102:9:102:9 | 0 | test.rs:98:43:103:5 | BlockExpr |  |
+| test.rs:105:5:111:5 | enter test_nested_if | test.rs:106:16:106:16 | PathExpr |  |
+| test.rs:105:5:111:5 | exit test_nested_if (normal) | test.rs:105:5:111:5 | exit test_nested_if |  |
+| test.rs:105:38:111:5 | BlockExpr | test.rs:105:5:111:5 | exit test_nested_if (normal) |  |
+| test.rs:106:9:110:9 | IfExpr | test.rs:105:38:111:5 | BlockExpr |  |
+| test.rs:106:12:106:49 | ParenExpr | test.rs:107:13:107:13 | 1 | true |
+| test.rs:106:12:106:49 | ParenExpr | test.rs:109:13:109:13 | 0 | false |
+| test.rs:106:13:106:48 | IfExpr | test.rs:106:12:106:49 | ParenExpr |  |
+| test.rs:106:16:106:16 | PathExpr | test.rs:106:20:106:20 | 0 |  |
+| test.rs:106:16:106:20 | ... < ... | test.rs:106:24:106:24 | a | true |
+| test.rs:106:16:106:20 | ... < ... | test.rs:106:41:106:41 | a | false |
+| test.rs:106:20:106:20 | 0 | test.rs:106:16:106:20 | ... < ... |  |
+| test.rs:106:22:106:32 | BlockExpr | test.rs:106:13:106:48 | IfExpr |  |
+| test.rs:106:24:106:24 | a | test.rs:106:29:106:30 | 10 |  |
+| test.rs:106:24:106:30 | ... < ... | test.rs:106:22:106:32 | BlockExpr |  |
+| test.rs:106:28:106:30 | - ... | test.rs:106:24:106:30 | ... < ... |  |
+| test.rs:106:29:106:30 | 10 | test.rs:106:28:106:30 | - ... |  |
+| test.rs:106:39:106:48 | BlockExpr | test.rs:106:13:106:48 | IfExpr |  |
+| test.rs:106:41:106:41 | a | test.rs:106:45:106:46 | 10 |  |
+| test.rs:106:41:106:46 | ... > ... | test.rs:106:39:106:48 | BlockExpr |  |
+| test.rs:106:45:106:46 | 10 | test.rs:106:41:106:46 | ... > ... |  |
+| test.rs:106:51:108:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
+| test.rs:107:13:107:13 | 1 | test.rs:106:51:108:9 | BlockExpr |  |
+| test.rs:108:16:110:9 | BlockExpr | test.rs:106:9:110:9 | IfExpr |  |
+| test.rs:109:13:109:13 | 0 | test.rs:108:16:110:9 | BlockExpr |  |
+| test.rs:113:5:122:5 | enter test_nested_if_match | test.rs:114:19:114:19 | a |  |
+| test.rs:113:5:122:5 | exit test_nested_if_match (normal) | test.rs:113:5:122:5 | exit test_nested_if_match |  |
+| test.rs:113:44:122:5 | BlockExpr | test.rs:113:5:122:5 | exit test_nested_if_match (normal) |  |
+| test.rs:114:9:121:9 | IfExpr | test.rs:113:44:122:5 | BlockExpr |  |
+| test.rs:114:12:117:10 | ParenExpr | test.rs:118:13:118:13 | 1 | true |
+| test.rs:114:12:117:10 | ParenExpr | test.rs:120:13:120:13 | 0 | false |
+| test.rs:114:13:117:9 | MatchExpr | test.rs:114:12:117:10 | ParenExpr |  |
+| test.rs:114:19:114:19 | a | test.rs:115:13:115:13 | LiteralPat |  |
+| test.rs:115:13:115:13 | LiteralPat | test.rs:115:18:115:21 | true | match |
+| test.rs:115:13:115:13 | LiteralPat | test.rs:116:13:116:13 | WildcardPat | no-match |
+| test.rs:115:18:115:21 | true | test.rs:114:13:117:9 | MatchExpr |  |
+| test.rs:116:13:116:13 | WildcardPat | test.rs:116:18:116:22 | false | match |
+| test.rs:116:18:116:22 | false | test.rs:114:13:117:9 | MatchExpr |  |
+| test.rs:117:12:119:9 | BlockExpr | test.rs:114:9:121:9 | IfExpr |  |
+| test.rs:118:13:118:13 | 1 | test.rs:117:12:119:9 | BlockExpr |  |
+| test.rs:119:16:121:9 | BlockExpr | test.rs:114:9:121:9 | IfExpr |  |
+| test.rs:120:13:120:13 | 0 | test.rs:119:16:121:9 | BlockExpr |  |
+| test.rs:124:5:133:5 | enter test_nested_if_block | test.rs:126:13:126:15 | ExprStmt |  |
+| test.rs:124:5:133:5 | exit test_nested_if_block (normal) | test.rs:124:5:133:5 | exit test_nested_if_block |  |
+| test.rs:124:44:133:5 | BlockExpr | test.rs:124:5:133:5 | exit test_nested_if_block (normal) |  |
+| test.rs:125:9:132:9 | IfExpr | test.rs:124:44:133:5 | BlockExpr |  |
+| test.rs:125:12:128:9 | BlockExpr | test.rs:129:13:129:13 | 1 | true |
+| test.rs:125:12:128:9 | BlockExpr | test.rs:131:13:131:13 | 0 | false |
+| test.rs:126:13:126:14 | TupleExpr | test.rs:127:13:127:13 | a |  |
+| test.rs:126:13:126:15 | ExprStmt | test.rs:126:13:126:14 | TupleExpr |  |
+| test.rs:127:13:127:13 | a | test.rs:127:17:127:17 | 0 |  |
+| test.rs:127:13:127:17 | ... > ... | test.rs:125:12:128:9 | BlockExpr | false, true |
+| test.rs:127:17:127:17 | 0 | test.rs:127:13:127:17 | ... > ... |  |
+| test.rs:128:11:130:9 | BlockExpr | test.rs:125:9:132:9 | IfExpr |  |
+| test.rs:129:13:129:13 | 1 | test.rs:128:11:130:9 | BlockExpr |  |
+| test.rs:130:16:132:9 | BlockExpr | test.rs:125:9:132:9 | IfExpr |  |
+| test.rs:131:13:131:13 | 0 | test.rs:130:16:132:9 | BlockExpr |  |
+| test.rs:135:5:142:5 | enter test_if_assignment | test.rs:136:9:136:26 | LetStmt |  |
+| test.rs:135:5:142:5 | exit test_if_assignment (normal) | test.rs:135:5:142:5 | exit test_if_assignment |  |
+| test.rs:135:42:142:5 | BlockExpr | test.rs:135:5:142:5 | exit test_if_assignment (normal) |  |
+| test.rs:136:9:136:26 | LetStmt | test.rs:136:21:136:25 | false |  |
+| test.rs:136:13:136:17 | x | test.rs:137:12:137:12 | x | match, no-match |
+| test.rs:136:21:136:25 | false | test.rs:136:13:136:17 | x |  |
+| test.rs:137:9:141:9 | IfExpr | test.rs:135:42:142:5 | BlockExpr |  |
+| test.rs:137:12:137:12 | x | test.rs:137:16:137:19 | true |  |
+| test.rs:137:12:137:19 | ... = ... | test.rs:138:13:138:13 | 1 | true |
+| test.rs:137:12:137:19 | ... = ... | test.rs:140:13:140:13 | 0 | false |
+| test.rs:137:16:137:19 | true | test.rs:137:12:137:19 | ... = ... |  |
+| test.rs:137:21:139:9 | BlockExpr | test.rs:137:9:141:9 | IfExpr |  |
+| test.rs:138:13:138:13 | 1 | test.rs:137:21:139:9 | BlockExpr |  |
+| test.rs:139:16:141:9 | BlockExpr | test.rs:137:9:141:9 | IfExpr |  |
+| test.rs:140:13:140:13 | 0 | test.rs:139:16:141:9 | BlockExpr |  |
+| test.rs:144:5:155:5 | enter test_if_loop1 | test.rs:146:13:148:14 | ExprStmt |  |
+| test.rs:144:5:155:5 | exit test_if_loop1 (normal) | test.rs:144:5:155:5 | exit test_if_loop1 |  |
+| test.rs:144:37:155:5 | BlockExpr | test.rs:144:5:155:5 | exit test_if_loop1 (normal) |  |
+| test.rs:145:9:154:9 | IfExpr | test.rs:144:37:155:5 | BlockExpr |  |
+| test.rs:145:12:150:10 | ParenExpr | test.rs:151:13:151:13 | 1 | true |
+| test.rs:145:12:150:10 | ParenExpr | test.rs:153:13:153:13 | 0 | false |
+| test.rs:145:13:150:9 | LoopExpr | test.rs:145:12:150:10 | ParenExpr |  |
+| test.rs:145:18:150:9 | BlockExpr | test.rs:146:13:148:14 | ExprStmt |  |
+| test.rs:146:13:148:13 | IfExpr | test.rs:149:13:149:19 | ExprStmt |  |
+| test.rs:146:13:148:14 | ExprStmt | test.rs:146:16:146:16 | a |  |
+| test.rs:146:16:146:16 | a | test.rs:146:20:146:20 | 0 |  |
+| test.rs:146:16:146:20 | ... > ... | test.rs:146:13:148:13 | IfExpr | false |
+| test.rs:146:16:146:20 | ... > ... | test.rs:147:17:147:29 | ExprStmt | true |
+| test.rs:146:20:146:20 | 0 | test.rs:146:16:146:20 | ... > ... |  |
+| test.rs:147:17:147:28 | BreakExpr | test.rs:145:13:150:9 | LoopExpr | break |
+| test.rs:147:17:147:29 | ExprStmt | test.rs:147:23:147:23 | a |  |
+| test.rs:147:23:147:23 | a | test.rs:147:27:147:28 | 10 |  |
+| test.rs:147:23:147:28 | ... > ... | test.rs:147:17:147:28 | BreakExpr |  |
+| test.rs:147:27:147:28 | 10 | test.rs:147:23:147:28 | ... > ... |  |
+| test.rs:149:13:149:13 | a | test.rs:149:17:149:18 | 10 |  |
+| test.rs:149:13:149:18 | ... < ... | test.rs:145:18:150:9 | BlockExpr |  |
+| test.rs:149:13:149:19 | ExprStmt | test.rs:149:13:149:13 | a |  |
+| test.rs:149:17:149:18 | 10 | test.rs:149:13:149:18 | ... < ... |  |
+| test.rs:150:12:152:9 | BlockExpr | test.rs:145:9:154:9 | IfExpr |  |
+| test.rs:151:13:151:13 | 1 | test.rs:150:12:152:9 | BlockExpr |  |
+| test.rs:152:16:154:9 | BlockExpr | test.rs:145:9:154:9 | IfExpr |  |
+| test.rs:153:13:153:13 | 0 | test.rs:152:16:154:9 | BlockExpr |  |
+| test.rs:157:5:168:5 | enter test_if_loop2 | test.rs:159:13:161:14 | ExprStmt |  |
+| test.rs:157:5:168:5 | exit test_if_loop2 (normal) | test.rs:157:5:168:5 | exit test_if_loop2 |  |
+| test.rs:157:37:168:5 | BlockExpr | test.rs:157:5:168:5 | exit test_if_loop2 (normal) |  |
+| test.rs:158:9:167:9 | IfExpr | test.rs:157:37:168:5 | BlockExpr |  |
+| test.rs:158:12:163:10 | ParenExpr | test.rs:164:13:164:13 | 1 | true |
+| test.rs:158:12:163:10 | ParenExpr | test.rs:166:13:166:13 | 0 | false |
+| test.rs:158:13:163:9 | LoopExpr | test.rs:158:12:163:10 | ParenExpr |  |
+| test.rs:158:26:163:9 | BlockExpr | test.rs:159:13:161:14 | ExprStmt |  |
+| test.rs:159:13:161:13 | IfExpr | test.rs:162:13:162:19 | ExprStmt |  |
+| test.rs:159:13:161:14 | ExprStmt | test.rs:159:16:159:16 | a |  |
+| test.rs:159:16:159:16 | a | test.rs:159:20:159:20 | 0 |  |
+| test.rs:159:16:159:20 | ... > ... | test.rs:159:13:161:13 | IfExpr | false |
+| test.rs:159:16:159:20 | ... > ... | test.rs:160:17:160:36 | ExprStmt | true |
+| test.rs:159:20:159:20 | 0 | test.rs:159:16:159:20 | ... > ... |  |
+| test.rs:160:17:160:35 | BreakExpr | test.rs:158:13:163:9 | LoopExpr | break('label) |
+| test.rs:160:17:160:36 | ExprStmt | test.rs:160:30:160:30 | a |  |
+| test.rs:160:30:160:30 | a | test.rs:160:34:160:35 | 10 |  |
+| test.rs:160:30:160:35 | ... > ... | test.rs:160:17:160:35 | BreakExpr |  |
+| test.rs:160:34:160:35 | 10 | test.rs:160:30:160:35 | ... > ... |  |
+| test.rs:162:13:162:13 | a | test.rs:162:17:162:18 | 10 |  |
+| test.rs:162:13:162:18 | ... < ... | test.rs:158:26:163:9 | BlockExpr |  |
+| test.rs:162:13:162:19 | ExprStmt | test.rs:162:13:162:13 | a |  |
+| test.rs:162:17:162:18 | 10 | test.rs:162:13:162:18 | ... < ... |  |
+| test.rs:163:12:165:9 | BlockExpr | test.rs:158:9:167:9 | IfExpr |  |
+| test.rs:164:13:164:13 | 1 | test.rs:163:12:165:9 | BlockExpr |  |
+| test.rs:165:16:167:9 | BlockExpr | test.rs:158:9:167:9 | IfExpr |  |
+| test.rs:166:13:166:13 | 0 | test.rs:165:16:167:9 | BlockExpr |  |
+| test.rs:170:5:178:5 | enter test_labelled_block | test.rs:172:13:172:31 | ExprStmt |  |
+| test.rs:170:5:178:5 | exit test_labelled_block (normal) | test.rs:170:5:178:5 | exit test_labelled_block |  |
+| test.rs:172:13:172:30 | BreakExpr | test.rs:170:5:178:5 | exit test_labelled_block (normal) | break('block) |
+| test.rs:172:13:172:31 | ExprStmt | test.rs:172:26:172:26 | a |  |
+| test.rs:172:26:172:26 | a | test.rs:172:30:172:30 | 0 |  |
+| test.rs:172:26:172:30 | ... > ... | test.rs:172:13:172:30 | BreakExpr |  |
+| test.rs:172:30:172:30 | 0 | test.rs:172:26:172:30 | ... > ... |  |
+| test.rs:183:5:186:5 | enter test_and_operator | test.rs:184:9:184:28 | LetStmt |  |
+| test.rs:183:5:186:5 | exit test_and_operator (normal) | test.rs:183:5:186:5 | exit test_and_operator |  |
+| test.rs:183:61:186:5 | BlockExpr | test.rs:183:5:186:5 | exit test_and_operator (normal) |  |
+| test.rs:184:9:184:28 | LetStmt | test.rs:184:17:184:27 | ... && ... |  |
+| test.rs:184:13:184:13 | d | test.rs:185:9:185:9 | d | match, no-match |
+| test.rs:184:17:184:17 | a | test.rs:184:13:184:13 | d | false |
+| test.rs:184:17:184:17 | a | test.rs:184:22:184:22 | b | true |
+| test.rs:184:17:184:22 | ... && ... | test.rs:184:17:184:17 | a |  |
+| test.rs:184:17:184:27 | ... && ... | test.rs:184:17:184:22 | ... && ... |  |
+| test.rs:184:22:184:22 | b | test.rs:184:13:184:13 | d | false |
+| test.rs:184:22:184:22 | b | test.rs:184:27:184:27 | c | true |
+| test.rs:184:27:184:27 | c | test.rs:184:13:184:13 | d |  |
+| test.rs:185:9:185:9 | d | test.rs:183:61:186:5 | BlockExpr |  |
+| test.rs:188:5:191:5 | enter test_or_operator | test.rs:189:9:189:28 | LetStmt |  |
+| test.rs:188:5:191:5 | exit test_or_operator (normal) | test.rs:188:5:191:5 | exit test_or_operator |  |
+| test.rs:188:60:191:5 | BlockExpr | test.rs:188:5:191:5 | exit test_or_operator (normal) |  |
+| test.rs:189:9:189:28 | LetStmt | test.rs:189:17:189:27 | ... \|\| ... |  |
+| test.rs:189:13:189:13 | d | test.rs:190:9:190:9 | d | match, no-match |
+| test.rs:189:17:189:17 | a | test.rs:189:13:189:13 | d | true |
+| test.rs:189:17:189:17 | a | test.rs:189:22:189:22 | b | false |
+| test.rs:189:17:189:22 | ... \|\| ... | test.rs:189:17:189:17 | a |  |
+| test.rs:189:17:189:27 | ... \|\| ... | test.rs:189:17:189:22 | ... \|\| ... |  |
+| test.rs:189:22:189:22 | b | test.rs:189:13:189:13 | d | true |
+| test.rs:189:22:189:22 | b | test.rs:189:27:189:27 | c | false |
+| test.rs:189:27:189:27 | c | test.rs:189:13:189:13 | d |  |
+| test.rs:190:9:190:9 | d | test.rs:188:60:191:5 | BlockExpr |  |
+| test.rs:193:5:196:5 | enter test_or_operator_2 | test.rs:194:9:194:36 | LetStmt |  |
+| test.rs:193:5:196:5 | exit test_or_operator_2 (normal) | test.rs:193:5:196:5 | exit test_or_operator_2 |  |
+| test.rs:193:61:196:5 | BlockExpr | test.rs:193:5:196:5 | exit test_or_operator_2 (normal) |  |
+| test.rs:194:9:194:36 | LetStmt | test.rs:194:17:194:35 | ... \|\| ... |  |
+| test.rs:194:13:194:13 | d | test.rs:195:9:195:9 | d | match, no-match |
+| test.rs:194:17:194:17 | a | test.rs:194:13:194:13 | d | true |
+| test.rs:194:17:194:17 | a | test.rs:194:23:194:23 | b | false |
+| test.rs:194:17:194:30 | ... \|\| ... | test.rs:194:17:194:17 | a |  |
+| test.rs:194:17:194:35 | ... \|\| ... | test.rs:194:17:194:30 | ... \|\| ... |  |
+| test.rs:194:22:194:30 | ParenExpr | test.rs:194:13:194:13 | d | true |
+| test.rs:194:22:194:30 | ParenExpr | test.rs:194:35:194:35 | c | false |
+| test.rs:194:23:194:23 | b | test.rs:194:28:194:29 | 28 |  |
+| test.rs:194:23:194:29 | ... == ... | test.rs:194:22:194:30 | ParenExpr |  |
+| test.rs:194:28:194:29 | 28 | test.rs:194:23:194:29 | ... == ... |  |
+| test.rs:194:35:194:35 | c | test.rs:194:13:194:13 | d |  |
+| test.rs:195:9:195:9 | d | test.rs:193:61:196:5 | BlockExpr |  |
+| test.rs:198:5:201:5 | enter test_not_operator | test.rs:199:9:199:19 | LetStmt |  |
+| test.rs:198:5:201:5 | exit test_not_operator (normal) | test.rs:198:5:201:5 | exit test_not_operator |  |
+| test.rs:198:43:201:5 | BlockExpr | test.rs:198:5:201:5 | exit test_not_operator (normal) |  |
+| test.rs:199:9:199:19 | LetStmt | test.rs:199:18:199:18 | a |  |
+| test.rs:199:13:199:13 | d | test.rs:200:9:200:9 | d | match, no-match |
+| test.rs:199:17:199:18 | ! ... | test.rs:199:13:199:13 | d |  |
+| test.rs:199:18:199:18 | a | test.rs:199:17:199:18 | ! ... |  |
+| test.rs:200:9:200:9 | d | test.rs:198:43:201:5 | BlockExpr |  |
+| test.rs:203:5:209:5 | enter test_if_and_operator | test.rs:204:12:204:22 | ... && ... |  |
+| test.rs:203:5:209:5 | exit test_if_and_operator (normal) | test.rs:203:5:209:5 | exit test_if_and_operator |  |
+| test.rs:203:63:209:5 | BlockExpr | test.rs:203:5:209:5 | exit test_if_and_operator (normal) |  |
+| test.rs:204:9:208:9 | IfExpr | test.rs:203:63:209:5 | BlockExpr |  |
+| test.rs:204:12:204:12 | a | test.rs:204:17:204:17 | b | true |
+| test.rs:204:12:204:12 | a | test.rs:207:13:207:17 | false | false |
+| test.rs:204:12:204:17 | ... && ... | test.rs:204:12:204:12 | a |  |
+| test.rs:204:12:204:22 | ... && ... | test.rs:204:12:204:17 | ... && ... |  |
+| test.rs:204:17:204:17 | b | test.rs:204:22:204:22 | c | true |
+| test.rs:204:17:204:17 | b | test.rs:207:13:207:17 | false | false |
+| test.rs:204:22:204:22 | c | test.rs:205:13:205:16 | true | true |
+| test.rs:204:22:204:22 | c | test.rs:207:13:207:17 | false | false |
+| test.rs:204:24:206:9 | BlockExpr | test.rs:204:9:208:9 | IfExpr |  |
+| test.rs:205:13:205:16 | true | test.rs:204:24:206:9 | BlockExpr |  |
+| test.rs:206:16:208:9 | BlockExpr | test.rs:204:9:208:9 | IfExpr |  |
+| test.rs:207:13:207:17 | false | test.rs:206:16:208:9 | BlockExpr |  |
+| test.rs:211:5:217:5 | enter test_if_or_operator | test.rs:212:12:212:22 | ... \|\| ... |  |
+| test.rs:211:5:217:5 | exit test_if_or_operator (normal) | test.rs:211:5:217:5 | exit test_if_or_operator |  |
+| test.rs:211:62:217:5 | BlockExpr | test.rs:211:5:217:5 | exit test_if_or_operator (normal) |  |
+| test.rs:212:9:216:9 | IfExpr | test.rs:211:62:217:5 | BlockExpr |  |
+| test.rs:212:12:212:12 | a | test.rs:212:17:212:17 | b | false |
+| test.rs:212:12:212:12 | a | test.rs:213:13:213:16 | true | true |
+| test.rs:212:12:212:17 | ... \|\| ... | test.rs:212:12:212:12 | a |  |
+| test.rs:212:12:212:22 | ... \|\| ... | test.rs:212:12:212:17 | ... \|\| ... |  |
+| test.rs:212:17:212:17 | b | test.rs:212:22:212:22 | c | false |
+| test.rs:212:17:212:17 | b | test.rs:213:13:213:16 | true | true |
+| test.rs:212:22:212:22 | c | test.rs:213:13:213:16 | true | true |
+| test.rs:212:22:212:22 | c | test.rs:215:13:215:17 | false | false |
+| test.rs:212:24:214:9 | BlockExpr | test.rs:212:9:216:9 | IfExpr |  |
+| test.rs:213:13:213:16 | true | test.rs:212:24:214:9 | BlockExpr |  |
+| test.rs:214:16:216:9 | BlockExpr | test.rs:212:9:216:9 | IfExpr |  |
+| test.rs:215:13:215:17 | false | test.rs:214:16:216:9 | BlockExpr |  |
+| test.rs:219:5:225:5 | enter test_if_not_operator | test.rs:220:13:220:13 | a |  |
+| test.rs:219:5:225:5 | exit test_if_not_operator (normal) | test.rs:219:5:225:5 | exit test_if_not_operator |  |
+| test.rs:219:46:225:5 | BlockExpr | test.rs:219:5:225:5 | exit test_if_not_operator (normal) |  |
+| test.rs:220:9:224:9 | IfExpr | test.rs:219:46:225:5 | BlockExpr |  |
+| test.rs:220:12:220:13 | ! ... | test.rs:221:13:221:16 | true | true |
+| test.rs:220:12:220:13 | ! ... | test.rs:223:13:223:17 | false | false |
+| test.rs:220:13:220:13 | a | test.rs:220:12:220:13 | ! ... | false, true |
+| test.rs:220:15:222:9 | BlockExpr | test.rs:220:9:224:9 | IfExpr |  |
+| test.rs:221:13:221:16 | true | test.rs:220:15:222:9 | BlockExpr |  |
+| test.rs:222:16:224:9 | BlockExpr | test.rs:220:9:224:9 | IfExpr |  |
+| test.rs:223:13:223:17 | false | test.rs:222:16:224:9 | BlockExpr |  |
+| test.rs:228:1:234:1 | enter test_match | test.rs:229:11:229:21 | maybe_digit |  |
+| test.rs:228:1:234:1 | exit test_match (normal) | test.rs:228:1:234:1 | exit test_match |  |
+| test.rs:228:48:234:1 | BlockExpr | test.rs:228:1:234:1 | exit test_match (normal) |  |
+| test.rs:229:5:233:5 | MatchExpr | test.rs:228:48:234:1 | BlockExpr |  |
+| test.rs:229:11:229:21 | maybe_digit | test.rs:230:9:230:23 | TupleStructPat |  |
+| test.rs:230:9:230:23 | TupleStructPat | test.rs:230:28:230:28 | x | match |
+| test.rs:230:9:230:23 | TupleStructPat | test.rs:231:9:231:23 | TupleStructPat | no-match |
+| test.rs:230:28:230:28 | x | test.rs:230:32:230:33 | 10 |  |
+| test.rs:230:32:230:33 | 10 | test.rs:230:28:230:33 | ... < ... |  |
+| test.rs:231:9:231:23 | TupleStructPat | test.rs:231:28:231:28 | x | match |
+| test.rs:231:9:231:23 | TupleStructPat | test.rs:232:9:232:20 | PathPat | no-match |
+| test.rs:231:28:231:28 | x | test.rs:229:5:233:5 | MatchExpr |  |
+| test.rs:232:9:232:20 | PathPat | test.rs:232:25:232:25 | 5 | match |
+| test.rs:232:25:232:25 | 5 | test.rs:229:5:233:5 | MatchExpr |  |
+| test.rs:237:5:242:5 | enter test_infinite_loop | test.rs:238:9:240:9 | ExprStmt |  |
+| test.rs:238:9:240:9 | ExprStmt | test.rs:239:13:239:13 | 1 |  |
+| test.rs:238:14:240:9 | BlockExpr | test.rs:239:13:239:13 | 1 |  |
+| test.rs:239:13:239:13 | 1 | test.rs:238:14:240:9 | BlockExpr |  |
+| test.rs:244:5:247:5 | enter test_let_match | test.rs:245:9:245:49 | LetStmt |  |
+| test.rs:244:5:247:5 | exit test_let_match (normal) | test.rs:244:5:247:5 | exit test_let_match |  |
+| test.rs:244:39:247:5 | BlockExpr | test.rs:244:5:247:5 | exit test_let_match (normal) |  |
+| test.rs:245:9:245:49 | LetStmt | test.rs:245:23:245:23 | a |  |
+| test.rs:245:13:245:19 | TupleStructPat | test.rs:245:32:245:46 | "Expected some" | no-match |
+| test.rs:245:13:245:19 | TupleStructPat | test.rs:246:9:246:9 | n | match |
+| test.rs:245:23:245:23 | a | test.rs:245:13:245:19 | TupleStructPat |  |
+| test.rs:245:32:245:46 | "Expected some" | test.rs:245:30:245:48 | BlockExpr |  |
+| test.rs:246:9:246:9 | n | test.rs:244:39:247:5 | BlockExpr |  |
+| test.rs:250:1:255:1 | enter dead_code | test.rs:251:5:253:5 | ExprStmt |  |
+| test.rs:250:1:255:1 | exit dead_code (normal) | test.rs:250:1:255:1 | exit dead_code |  |
+| test.rs:251:5:253:5 | ExprStmt | test.rs:251:9:251:12 | true |  |
+| test.rs:251:8:251:13 | ParenExpr | test.rs:252:9:252:17 | ExprStmt | true |
+| test.rs:251:9:251:12 | true | test.rs:251:8:251:13 | ParenExpr |  |
+| test.rs:252:9:252:16 | ReturnExpr | test.rs:250:1:255:1 | exit dead_code (normal) | return |
+| test.rs:252:9:252:17 | ExprStmt | test.rs:252:16:252:16 | 0 |  |
+| test.rs:252:16:252:16 | 0 | test.rs:252:9:252:16 | ReturnExpr |  |
+| test.rs:257:1:270:1 | enter labelled_block | test.rs:258:5:269:6 | LetStmt |  |
+| test.rs:257:1:270:1 | exit labelled_block (normal) | test.rs:257:1:270:1 | exit labelled_block |  |
+| test.rs:257:28:270:1 | BlockExpr | test.rs:257:1:270:1 | exit labelled_block (normal) |  |
+| test.rs:258:5:269:6 | LetStmt | test.rs:259:9:259:19 | ExprStmt |  |
+| test.rs:258:9:258:14 | result | test.rs:257:28:270:1 | BlockExpr | match, no-match |
+| test.rs:258:18:269:5 | BlockExpr | test.rs:258:9:258:14 | result |  |
+| test.rs:259:9:259:16 | PathExpr | test.rs:259:9:259:18 | CallExpr |  |
+| test.rs:259:9:259:18 | CallExpr | test.rs:260:9:262:9 | ExprStmt |  |
+| test.rs:259:9:259:19 | ExprStmt | test.rs:259:9:259:16 | PathExpr |  |
+| test.rs:260:9:262:9 | ExprStmt | test.rs:260:12:260:28 | PathExpr |  |
+| test.rs:260:9:262:9 | IfExpr | test.rs:263:9:263:24 | ExprStmt |  |
+| test.rs:260:12:260:28 | PathExpr | test.rs:260:12:260:30 | CallExpr |  |
+| test.rs:260:12:260:30 | CallExpr | test.rs:260:9:262:9 | IfExpr | false |
+| test.rs:260:12:260:30 | CallExpr | test.rs:261:13:261:27 | ExprStmt | true |
+| test.rs:261:13:261:26 | BreakExpr | test.rs:257:1:270:1 | exit labelled_block (normal) | break('block) |
+| test.rs:261:13:261:27 | ExprStmt | test.rs:261:26:261:26 | 1 |  |
+| test.rs:261:26:261:26 | 1 | test.rs:261:13:261:26 | BreakExpr |  |
+| test.rs:263:9:263:21 | PathExpr | test.rs:263:9:263:23 | CallExpr |  |
+| test.rs:263:9:263:23 | CallExpr | test.rs:264:9:266:9 | ExprStmt |  |
+| test.rs:263:9:263:24 | ExprStmt | test.rs:263:9:263:21 | PathExpr |  |
+| test.rs:264:9:266:9 | ExprStmt | test.rs:264:12:264:28 | PathExpr |  |
+| test.rs:264:9:266:9 | IfExpr | test.rs:267:9:267:24 | ExprStmt |  |
+| test.rs:264:12:264:28 | PathExpr | test.rs:264:12:264:30 | CallExpr |  |
+| test.rs:264:12:264:30 | CallExpr | test.rs:264:9:266:9 | IfExpr | false |
+| test.rs:264:12:264:30 | CallExpr | test.rs:265:13:265:27 | ExprStmt | true |
+| test.rs:265:13:265:26 | BreakExpr | test.rs:257:1:270:1 | exit labelled_block (normal) | break('block) |
+| test.rs:265:13:265:27 | ExprStmt | test.rs:265:26:265:26 | 2 |  |
+| test.rs:265:26:265:26 | 2 | test.rs:265:13:265:26 | BreakExpr |  |
+| test.rs:267:9:267:21 | PathExpr | test.rs:267:9:267:23 | CallExpr |  |
+| test.rs:267:9:267:23 | CallExpr | test.rs:268:9:268:9 | 3 |  |
+| test.rs:267:9:267:24 | ExprStmt | test.rs:267:9:267:21 | PathExpr |  |
+| test.rs:268:9:268:9 | 3 | test.rs:258:18:269:5 | BlockExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -343,11 +343,20 @@
 | test.rs:175:13:175:13 | 0 | test.rs:174:16:176:9 | BlockExpr |  |
 | test.rs:179:5:187:5 | enter test_labelled_block | test.rs:181:13:181:31 | ExprStmt |  |
 | test.rs:179:5:187:5 | exit test_labelled_block (normal) | test.rs:179:5:187:5 | exit test_labelled_block |  |
-| test.rs:181:13:181:30 | BreakExpr | test.rs:179:5:187:5 | exit test_labelled_block (normal) | break('block) |
+| test.rs:179:43:187:5 | BlockExpr | test.rs:179:5:187:5 | exit test_labelled_block (normal) |  |
+| test.rs:180:9:186:9 | IfExpr | test.rs:179:43:187:5 | BlockExpr |  |
+| test.rs:180:12:182:10 | ParenExpr | test.rs:183:13:183:13 | 1 | true |
+| test.rs:180:12:182:10 | ParenExpr | test.rs:185:13:185:13 | 0 | false |
+| test.rs:180:13:182:9 | BlockExpr | test.rs:180:12:182:10 | ParenExpr |  |
+| test.rs:181:13:181:30 | BreakExpr | test.rs:180:13:182:9 | BlockExpr | break('block) |
 | test.rs:181:13:181:31 | ExprStmt | test.rs:181:26:181:26 | a |  |
 | test.rs:181:26:181:26 | a | test.rs:181:30:181:30 | 0 |  |
 | test.rs:181:26:181:30 | ... > ... | test.rs:181:13:181:30 | BreakExpr |  |
 | test.rs:181:30:181:30 | 0 | test.rs:181:26:181:30 | ... > ... |  |
+| test.rs:182:12:184:9 | BlockExpr | test.rs:180:9:186:9 | IfExpr |  |
+| test.rs:183:13:183:13 | 1 | test.rs:182:12:184:9 | BlockExpr |  |
+| test.rs:184:16:186:9 | BlockExpr | test.rs:180:9:186:9 | IfExpr |  |
+| test.rs:185:13:185:13 | 0 | test.rs:184:16:186:9 | BlockExpr |  |
 | test.rs:192:5:195:5 | enter test_and_operator | test.rs:193:9:193:28 | LetStmt |  |
 | test.rs:192:5:195:5 | exit test_and_operator (normal) | test.rs:192:5:195:5 | exit test_and_operator |  |
 | test.rs:192:61:195:5 | BlockExpr | test.rs:192:5:195:5 | exit test_and_operator (normal) |  |
@@ -495,7 +504,7 @@
 | test.rs:269:12:269:28 | PathExpr | test.rs:269:12:269:30 | CallExpr |  |
 | test.rs:269:12:269:30 | CallExpr | test.rs:269:9:271:9 | IfExpr | false |
 | test.rs:269:12:269:30 | CallExpr | test.rs:270:13:270:27 | ExprStmt | true |
-| test.rs:270:13:270:26 | BreakExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) | break('block) |
+| test.rs:270:13:270:26 | BreakExpr | test.rs:267:18:278:5 | BlockExpr | break('block) |
 | test.rs:270:13:270:27 | ExprStmt | test.rs:270:26:270:26 | 1 |  |
 | test.rs:270:26:270:26 | 1 | test.rs:270:13:270:26 | BreakExpr |  |
 | test.rs:272:9:272:21 | PathExpr | test.rs:272:9:272:23 | CallExpr |  |
@@ -506,7 +515,7 @@
 | test.rs:273:12:273:28 | PathExpr | test.rs:273:12:273:30 | CallExpr |  |
 | test.rs:273:12:273:30 | CallExpr | test.rs:273:9:275:9 | IfExpr | false |
 | test.rs:273:12:273:30 | CallExpr | test.rs:274:13:274:27 | ExprStmt | true |
-| test.rs:274:13:274:26 | BreakExpr | test.rs:266:1:279:1 | exit labelled_block1 (normal) | break('block) |
+| test.rs:274:13:274:26 | BreakExpr | test.rs:267:18:278:5 | BlockExpr | break('block) |
 | test.rs:274:13:274:27 | ExprStmt | test.rs:274:26:274:26 | 2 |  |
 | test.rs:274:26:274:26 | 2 | test.rs:274:13:274:26 | BreakExpr |  |
 | test.rs:276:9:276:21 | PathExpr | test.rs:276:9:276:23 | CallExpr |  |
@@ -526,7 +535,7 @@
 | test.rs:284:13:284:19 | TupleStructPat | test.rs:285:13:285:27 | ExprStmt | no-match |
 | test.rs:284:13:284:19 | TupleStructPat | test.rs:287:9:287:9 | x | match |
 | test.rs:284:23:284:23 | x | test.rs:284:13:284:19 | TupleStructPat |  |
-| test.rs:285:13:285:26 | BreakExpr | test.rs:281:1:289:1 | exit labelled_block2 (normal) | break('block) |
+| test.rs:285:13:285:26 | BreakExpr | test.rs:282:18:288:5 | BlockExpr | break('block) |
 | test.rs:285:13:285:27 | ExprStmt | test.rs:285:26:285:26 | 1 |  |
 | test.rs:285:26:285:26 | 1 | test.rs:285:13:285:26 | BreakExpr |  |
 | test.rs:287:9:287:9 | x | test.rs:282:18:288:5 | BlockExpr |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -122,6 +122,27 @@
 | test.rs:61:13:61:21 | ... = ... | test.rs:56:17:62:9 | BlockExpr |  |
 | test.rs:61:13:61:22 | ExprStmt | test.rs:61:13:61:13 | PathExpr |  |
 | test.rs:61:17:61:21 | false | test.rs:61:13:61:21 | ... = ... |  |
+| test.rs:65:5:72:5 | enter test_for | test.rs:66:18:66:18 | 0 |  |
+| test.rs:65:5:72:5 | exit test_for (normal) | test.rs:65:5:72:5 | exit test_for |  |
+| test.rs:65:25:72:5 | BlockExpr | test.rs:65:5:72:5 | exit test_for (normal) |  |
+| test.rs:66:9:71:9 | ForExpr | test.rs:65:25:72:5 | BlockExpr |  |
+| test.rs:66:13:66:13 | i | test.rs:66:9:71:9 | ForExpr | no-match |
+| test.rs:66:13:66:13 | i | test.rs:67:13:69:13 | ExprStmt | match |
+| test.rs:66:18:66:18 | 0 | test.rs:66:21:66:22 | 10 |  |
+| test.rs:66:18:66:22 | RangeExpr | test.rs:66:13:66:13 | i |  |
+| test.rs:66:21:66:22 | 10 | test.rs:66:18:66:22 | RangeExpr |  |
+| test.rs:66:24:71:9 | BlockExpr | test.rs:66:13:66:13 | i |  |
+| test.rs:67:13:69:13 | ExprStmt | test.rs:67:17:67:17 | i |  |
+| test.rs:67:13:69:13 | IfExpr | test.rs:70:13:70:14 | ExprStmt |  |
+| test.rs:67:16:67:23 | ParenExpr | test.rs:67:13:69:13 | IfExpr | false |
+| test.rs:67:16:67:23 | ParenExpr | test.rs:68:17:68:22 | ExprStmt | true |
+| test.rs:67:17:67:17 | i | test.rs:67:22:67:22 | j |  |
+| test.rs:67:17:67:22 | ... == ... | test.rs:67:16:67:23 | ParenExpr |  |
+| test.rs:67:22:67:22 | j | test.rs:67:17:67:22 | ... == ... |  |
+| test.rs:68:17:68:21 | BreakExpr | test.rs:66:9:71:9 | ForExpr | break |
+| test.rs:68:17:68:22 | ExprStmt | test.rs:68:17:68:21 | BreakExpr |  |
+| test.rs:70:13:70:13 | 1 | test.rs:66:24:71:9 | BlockExpr |  |
+| test.rs:70:13:70:14 | ExprStmt | test.rs:70:13:70:13 | 1 |  |
 | test.rs:75:1:78:1 | enter test_nested_function | test.rs:76:5:76:28 | LetStmt |  |
 | test.rs:75:1:78:1 | exit test_nested_function (normal) | test.rs:75:1:78:1 | exit test_nested_function |  |
 | test.rs:75:40:78:1 | BlockExpr | test.rs:75:1:78:1 | exit test_nested_function (normal) |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -98,8 +98,30 @@
 | test.rs:49:17:49:31 | ContinueExpr | test.rs:44:17:48:17 | ExprStmt | continue('inner) |
 | test.rs:49:17:49:32 | ExprStmt | test.rs:49:17:49:31 | ContinueExpr |  |
 | test.rs:54:5:63:5 | enter test_while | test.rs:55:9:55:25 | LetStmt |  |
+| test.rs:54:5:63:5 | exit test_while (normal) | test.rs:54:5:63:5 | exit test_while |  |
+| test.rs:54:27:63:5 | BlockExpr | test.rs:54:5:63:5 | exit test_while (normal) |  |
 | test.rs:55:9:55:25 | LetStmt | test.rs:55:21:55:24 | true |  |
+| test.rs:55:13:55:17 | b | test.rs:56:15:56:15 | b | match, no-match |
 | test.rs:55:21:55:24 | true | test.rs:55:13:55:17 | b |  |
+| test.rs:56:9:62:9 | WhileExpr | test.rs:54:27:63:5 | BlockExpr |  |
+| test.rs:56:15:56:15 | b | test.rs:56:9:62:9 | WhileExpr | false |
+| test.rs:56:15:56:15 | b | test.rs:57:13:57:14 | ExprStmt | true |
+| test.rs:56:17:62:9 | BlockExpr | test.rs:56:15:56:15 | b |  |
+| test.rs:57:13:57:13 | 1 | test.rs:58:13:60:13 | ExprStmt |  |
+| test.rs:57:13:57:14 | ExprStmt | test.rs:57:13:57:13 | 1 |  |
+| test.rs:58:13:60:13 | ExprStmt | test.rs:58:17:58:17 | i |  |
+| test.rs:58:13:60:13 | IfExpr | test.rs:61:13:61:22 | ExprStmt |  |
+| test.rs:58:16:58:22 | ParenExpr | test.rs:58:13:60:13 | IfExpr | false |
+| test.rs:58:16:58:22 | ParenExpr | test.rs:59:17:59:22 | ExprStmt | true |
+| test.rs:58:17:58:17 | i | test.rs:58:21:58:21 | 0 |  |
+| test.rs:58:17:58:21 | ... > ... | test.rs:58:16:58:22 | ParenExpr |  |
+| test.rs:58:21:58:21 | 0 | test.rs:58:17:58:21 | ... > ... |  |
+| test.rs:59:17:59:21 | BreakExpr | test.rs:56:9:62:9 | WhileExpr | break |
+| test.rs:59:17:59:22 | ExprStmt | test.rs:59:17:59:21 | BreakExpr |  |
+| test.rs:61:13:61:13 | PathExpr | test.rs:61:17:61:21 | false |  |
+| test.rs:61:13:61:21 | ... = ... | test.rs:56:17:62:9 | BlockExpr |  |
+| test.rs:61:13:61:22 | ExprStmt | test.rs:61:13:61:13 | PathExpr |  |
+| test.rs:61:17:61:21 | false | test.rs:61:13:61:21 | ... = ... |  |
 | test.rs:75:1:78:1 | enter test_nested_function | test.rs:76:5:76:28 | LetStmt |  |
 | test.rs:75:1:78:1 | exit test_nested_function (normal) | test.rs:75:1:78:1 | exit test_nested_function |  |
 | test.rs:75:40:78:1 | BlockExpr | test.rs:75:1:78:1 | exit test_nested_function (normal) |  |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -123,12 +123,26 @@
 | test.rs:61:13:61:22 | ExprStmt | test.rs:61:13:61:13 | PathExpr |  |
 | test.rs:61:17:61:21 | false | test.rs:61:13:61:21 | ... = ... |  |
 | test.rs:65:5:72:5 | enter test_while_let | test.rs:66:9:66:29 | LetStmt |  |
+| test.rs:65:5:72:5 | exit test_while_let (normal) | test.rs:65:5:72:5 | exit test_while_let |  |
+| test.rs:65:25:72:5 | BlockExpr | test.rs:65:5:72:5 | exit test_while_let (normal) |  |
 | test.rs:66:9:66:29 | LetStmt | test.rs:66:24:66:24 | 1 |  |
 | test.rs:66:13:66:20 | iter | test.rs:67:15:67:39 | LetExpr | match, no-match |
 | test.rs:66:24:66:24 | 1 | test.rs:66:27:66:28 | 10 |  |
 | test.rs:66:24:66:28 | RangeExpr | test.rs:66:13:66:20 | iter |  |
 | test.rs:66:27:66:28 | 10 | test.rs:66:24:66:28 | RangeExpr |  |
+| test.rs:67:9:71:9 | WhileExpr | test.rs:65:25:72:5 | BlockExpr |  |
 | test.rs:67:15:67:39 | LetExpr | test.rs:67:19:67:25 | TupleStructPat |  |
+| test.rs:67:19:67:25 | TupleStructPat | test.rs:67:9:71:9 | WhileExpr | no-match |
+| test.rs:67:19:67:25 | TupleStructPat | test.rs:68:17:68:17 | PathExpr | match |
+| test.rs:67:41:71:9 | BlockExpr | test.rs:67:15:67:39 | LetExpr |  |
+| test.rs:68:13:70:13 | IfExpr | test.rs:67:41:71:9 | BlockExpr |  |
+| test.rs:68:16:68:22 | ParenExpr | test.rs:68:13:70:13 | IfExpr | false |
+| test.rs:68:16:68:22 | ParenExpr | test.rs:69:17:69:22 | ExprStmt | true |
+| test.rs:68:17:68:17 | PathExpr | test.rs:68:21:68:21 | 5 |  |
+| test.rs:68:17:68:21 | ... = ... | test.rs:68:16:68:22 | ParenExpr |  |
+| test.rs:68:21:68:21 | 5 | test.rs:68:17:68:21 | ... = ... |  |
+| test.rs:69:17:69:21 | BreakExpr | test.rs:67:9:71:9 | WhileExpr | break |
+| test.rs:69:17:69:22 | ExprStmt | test.rs:69:17:69:21 | BreakExpr |  |
 | test.rs:74:5:81:5 | enter test_for | test.rs:75:18:75:18 | 0 |  |
 | test.rs:74:5:81:5 | exit test_for (normal) | test.rs:74:5:81:5 | exit test_for |  |
 | test.rs:74:25:81:5 | BlockExpr | test.rs:74:5:81:5 | exit test_for (normal) |  |

--- a/rust/ql/test/library-tests/controlflow/test.rs
+++ b/rust/ql/test/library-tests/controlflow/test.rs
@@ -51,6 +51,20 @@ mod loop_expression {
         }
     }
 
+    fn test_loop_label_shadowing(b: bool) -> ! {
+        'loop: loop {
+            1;
+            'loop: loop {
+                if b {
+                    continue;
+                } else if b {
+                    continue 'loop;
+                }
+                continue 'loop;
+            }
+        }
+    }
+
     fn test_while(i: i64) {
         let mut b = true;
         while b {

--- a/rust/ql/test/library-tests/controlflow/test.rs
+++ b/rust/ql/test/library-tests/controlflow/test.rs
@@ -51,16 +51,22 @@ mod loop_expression {
         }
     }
 
-    fn test_while() {
+    fn test_while(i: i64) {
         let mut b = true;
         while b {
             1;
+            if (i > 0) {
+                break;
+            }
             b = false;
         }
     }
 
-    fn test_for() {
+    fn test_for(j: i64) {
         for i in 0..10 {
+            if (i == j) {
+                break;
+            }
             1;
         }
     }

--- a/rust/ql/test/library-tests/controlflow/test.rs
+++ b/rust/ql/test/library-tests/controlflow/test.rs
@@ -62,6 +62,15 @@ mod loop_expression {
         }
     }
 
+    fn test_while_let() {
+        let mut iter = 1..10;
+        while let Some(x) = iter.next() {
+            if (i = 5) {
+                break;
+            }
+        }
+    }
+
     fn test_for(j: i64) {
         for i in 0..10 {
             if (i == j) {
@@ -254,7 +263,7 @@ fn dead_code() -> i64 {
     return 1;
 }
 
-fn labelled_block() -> i64 {
+fn labelled_block1() -> i64 {
     let result = 'block: {
         do_thing();
         if condition_not_met() {
@@ -266,5 +275,15 @@ fn labelled_block() -> i64 {
         }
         do_last_thing();
         3
+    };
+}
+
+fn labelled_block2() -> i64 {
+    let result = 'block: {
+        let x: Option<i64> = None;
+        let Some(y) = x else {
+            break 'block 1;
+        };
+        x
     };
 }

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/CfgConsistency.expected
@@ -1,5 +1,4 @@
 deadEnd
 | variables.rs:2:5:2:22 | ExprStmt |
 | variables.rs:6:5:6:22 | ExprStmt |
-| variables.rs:200:16:200:21 | ... > ... |
 | variables.rs:310:5:310:42 | LetStmt |

--- a/rust/ql/test/library-tests/variables/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/library-tests/variables/CONSISTENCY/CfgConsistency.expected
@@ -1,4 +1,0 @@
-deadEnd
-| variables.rs:2:5:2:22 | ExprStmt |
-| variables.rs:6:5:6:22 | ExprStmt |
-| variables.rs:310:5:310:42 | LetStmt |

--- a/rust/ql/test/query-tests/diagnostics/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/query-tests/diagnostics/CONSISTENCY/CfgConsistency.expected
@@ -1,4 +1,0 @@
-deadEnd
-| error.rs:2:5:2:32 | ExprStmt |
-| my_macro.rs:16:9:16:19 | ExprStmt |
-| my_struct.rs:17:9:17:34 | ExprStmt |

--- a/rust/ql/test/query-tests/unusedentities/CONSISTENCY/CfgConsistency.expected
+++ b/rust/ql/test/query-tests/unusedentities/CONSISTENCY/CfgConsistency.expected
@@ -1,8 +1,0 @@
-deadEnd
-| main.rs:14:2:14:23 | ExprStmt |
-| main.rs:38:2:38:23 | ExprStmt |
-| main.rs:93:2:93:44 | ExprStmt |
-| main.rs:107:2:107:20 | LetStmt |
-| main.rs:151:2:151:53 | ExprStmt |
-scopeNoFirst
-| main.rs:125:1:133:1 | statics |


### PR DESCRIPTION
This PR fixes all CFG inconsistencies in our test suite, by adding missing cases to `ControlFlowGraphImpl.qll`.

Commit-by-commit review is suggested.