### PR TITLE
Go: augment test-extraction tests

### DIFF
--- a/go/ql/integration-tests/test-extraction/src/go.mod
+++ b/go/ql/integration-tests/test-extraction/src/go.mod
@@ -1,3 +1,3 @@
-go 1.14
+go 1.18
 
 module testsample

--- a/go/ql/integration-tests/test-extraction/src/pkg1/def.go
+++ b/go/ql/integration-tests/test-extraction/src/pkg1/def.go
@@ -4,4 +4,4 @@ type Generic[T any] struct {
 	element T
 }
 
-func TestMe() { }
+func TestMe() {}

--- a/go/ql/integration-tests/test-extraction/src/pkg1/def.go
+++ b/go/ql/integration-tests/test-extraction/src/pkg1/def.go
@@ -1,0 +1,7 @@
+package pkg1
+
+type Generic[T any] struct {
+	element T
+}
+
+func TestMe() { }

--- a/go/ql/integration-tests/test-extraction/src/pkg1/def_blackbox_test.go
+++ b/go/ql/integration-tests/test-extraction/src/pkg1/def_blackbox_test.go
@@ -1,0 +1,9 @@
+package pkg1_test
+
+import (
+	"testsample/pkg1"
+)
+
+func UsePkg1() {
+	pkg1.TestMe()
+}

--- a/go/ql/integration-tests/test-extraction/src/pkg1/def_test.go
+++ b/go/ql/integration-tests/test-extraction/src/pkg1/def_test.go
@@ -1,0 +1,5 @@
+package pkg1
+
+func UsePkg1() {
+	TestMe()
+}

--- a/go/ql/integration-tests/test-extraction/src/pkg2/use.go
+++ b/go/ql/integration-tests/test-extraction/src/pkg2/use.go
@@ -1,0 +1,12 @@
+package pkg2
+
+import (
+	"testsample/pkg1"
+)
+
+// This tests the case of cross-package generic type references
+// in the presence of test extraction. We need to make sure we
+// extract packages, including test variants, in the right order
+// such that we've seen pkg1.Generic before we try to use it here.
+
+type Specialised = pkg1.Generic[string]

--- a/go/ql/integration-tests/test-extraction/test.expected
+++ b/go/ql/integration-tests/test-extraction/test.expected
@@ -1,8 +1,12 @@
 #select
+| src/pkg1/def.go:0:0:0:0 | src/pkg1/def.go |
+| src/pkg1/def_test.go:0:0:0:0 | src/pkg1/def_test.go |
+| src/pkg2/use.go:0:0:0:0 | src/pkg2/use.go |
 | src/testme.go:0:0:0:0 | src/testme.go |
 | src/testme_blackbox_test.go:0:0:0:0 | src/testme_blackbox_test.go |
 | src/testme_test.go:0:0:0:0 | src/testme_test.go |
 calls
+| src/pkg1/def_test.go:4:2:4:9 | call to TestMe | src/pkg1/def.go:7:1:7:17 | function declaration |
 | src/testme_blackbox_test.go:10:18:10:44 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |
 | src/testme_test.go:9:18:9:33 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |
 | src/testme_test.go:14:19:14:35 | call to privateFunction | src/testme.go:5:1:5:39 | function declaration |

--- a/go/ql/integration-tests/test-extraction/test.expected
+++ b/go/ql/integration-tests/test-extraction/test.expected
@@ -7,8 +7,8 @@
 | src/testme_blackbox_test.go:0:0:0:0 | src/testme_blackbox_test.go |
 | src/testme_test.go:0:0:0:0 | src/testme_test.go |
 calls
-| src/pkg1/def_blackbox_test.go:8:2:8:14 | call to TestMe | src/pkg1/def.go:7:1:7:17 | function declaration |
-| src/pkg1/def_test.go:4:2:4:9 | call to TestMe | src/pkg1/def.go:7:1:7:17 | function declaration |
+| src/pkg1/def_blackbox_test.go:8:2:8:14 | call to TestMe | src/pkg1/def.go:7:1:7:16 | function declaration |
+| src/pkg1/def_test.go:4:2:4:9 | call to TestMe | src/pkg1/def.go:7:1:7:16 | function declaration |
 | src/testme_blackbox_test.go:10:18:10:44 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |
 | src/testme_test.go:9:18:9:33 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |
 | src/testme_test.go:14:19:14:35 | call to privateFunction | src/testme.go:5:1:5:39 | function declaration |

--- a/go/ql/integration-tests/test-extraction/test.expected
+++ b/go/ql/integration-tests/test-extraction/test.expected
@@ -1,11 +1,13 @@
 #select
 | src/pkg1/def.go:0:0:0:0 | src/pkg1/def.go |
+| src/pkg1/def_blackbox_test.go:0:0:0:0 | src/pkg1/def_blackbox_test.go |
 | src/pkg1/def_test.go:0:0:0:0 | src/pkg1/def_test.go |
 | src/pkg2/use.go:0:0:0:0 | src/pkg2/use.go |
 | src/testme.go:0:0:0:0 | src/testme.go |
 | src/testme_blackbox_test.go:0:0:0:0 | src/testme_blackbox_test.go |
 | src/testme_test.go:0:0:0:0 | src/testme_test.go |
 calls
+| src/pkg1/def_blackbox_test.go:8:2:8:14 | call to TestMe | src/pkg1/def.go:7:1:7:17 | function declaration |
 | src/pkg1/def_test.go:4:2:4:9 | call to TestMe | src/pkg1/def.go:7:1:7:17 | function declaration |
 | src/testme_blackbox_test.go:10:18:10:44 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |
 | src/testme_test.go:9:18:9:33 | call to PublicFunction | src/testme.go:3:1:3:38 | function declaration |

--- a/go/ql/integration-tests/test-extraction/test.py
+++ b/go/ql/integration-tests/test-extraction/test.py
@@ -1,7 +1,7 @@
 import os
 
 def test_traced(codeql, go):
-    codeql.database.create(source_root="src", command="go test -c")
+    codeql.database.create(source_root="src", command="go test -c ./...")
 
 def test_autobuild(codeql, go):
     codeql.database.create(source_root="src", extractor_option = ["extract_tests=true"])


### PR DESCRIPTION
This adds a case exercising the need for packages to be visited in topological order (cross-package type variable references), and a `_test` package that wouldn't exist in `go list` output without the `-test` flag. Unfortunately I couldn't reproduce the circumstance where that causes a crash, but by instrumenting the code that invokes `go list` I can see that with the `-test` flag we get everything we need out of one `go list` run, whereas without it we fall back to the slow path that issues individual `go list` queries on a per package basis.