### PR TITLE
JS: Fix bug causing re-evaluation of cached barriers

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -182,7 +182,39 @@ module TaintTracking {
    * for analysis-specific taint sanitizer guards.
    */
   cached
-  abstract class AdditionalSanitizerGuardNode extends SanitizerGuardNode {
+  abstract class AdditionalSanitizerGuardNode extends DataFlow::Node {
+    // For backwards compatibility, this contains a copy of the SanitizerGuard interface,
+    // but is does not inherit from it as that would cause re-evaluation of cached barriers.
+    /**
+     * Holds if this node blocks expression `e`, provided it evaluates to `outcome`.
+     */
+    cached
+    predicate blocks(boolean outcome, Expr e) { none() }
+
+    /**
+     * Holds if this node sanitizes expression `e`, provided it evaluates
+     * to `outcome`.
+     */
+    cached
+    abstract predicate sanitizes(boolean outcome, Expr e);
+
+    /**
+     * Holds if this node blocks expression `e` from flow of type `label`, provided it evaluates to `outcome`.
+     */
+    cached
+    predicate blocks(boolean outcome, Expr e, DataFlow::FlowLabel label) {
+      this.sanitizes(outcome, e) and label.isTaint()
+      or
+      this.sanitizes(outcome, e, label)
+    }
+
+    /**
+     * Holds if this node sanitizes expression `e`, provided it evaluates
+     * to `outcome`.
+     */
+    cached
+    predicate sanitizes(boolean outcome, Expr e, DataFlow::FlowLabel label) { none() }
+
     /**
      * Holds if this guard applies to the flow in `cfg`.
      */

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/DomBasedXssQuery.qll
@@ -55,7 +55,9 @@ module DomBasedXssConfig implements DataFlow::StateConfigSig {
     label = prefixLabel()
   }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) {
+    node instanceof Sanitizer or node = Shared::BarrierGuard::getABarrierNode()
+  }
 
   predicate isBarrier(DataFlow::Node node, DataFlow::FlowLabel lbl) {
     // copy all taint barrier guards to the TaintedUrlSuffix/PrefixLabel label

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/ExceptionXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/ExceptionXssQuery.qll
@@ -140,7 +140,9 @@ module ExceptionXssConfig implements DataFlow::StateConfigSig {
     sink instanceof XssShared::Sink and not label instanceof NotYetThrown
   }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof XssShared::Sanitizer }
+  predicate isBarrier(DataFlow::Node node) {
+    node instanceof XssShared::Sanitizer or node = XssShared::BarrierGuard::getABarrierNode()
+  }
 
   predicate isAdditionalFlowStep(
     DataFlow::Node pred, DataFlow::FlowLabel inlbl, DataFlow::Node succ, DataFlow::FlowLabel outlbl

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/StoredXssQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/StoredXssQuery.qll
@@ -15,7 +15,9 @@ module StoredXssConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) {
+    node instanceof Sanitizer or node = Shared::BarrierGuard::getABarrierNode()
+  }
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/UnsafeHtmlConstructionQuery.qll
@@ -34,6 +34,8 @@ module UnsafeHtmlConstructionConfig implements DataFlow::StateConfigSig {
     node instanceof UnsafeJQueryPlugin::Sanitizer
     or
     DomBasedXss::isOptionallySanitizedNode(node)
+    or
+    node = Shared::BarrierGuard::getABarrierNode()
   }
 
   predicate isBarrier(DataFlow::Node node, DataFlow::FlowLabel label) {

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomQuery.qll
@@ -22,7 +22,8 @@ module XssThroughDomConfig implements DataFlow::ConfigSig {
     node instanceof DomBasedXss::Sanitizer or
     DomBasedXss::isOptionallySanitizedNode(node) or
     node = DataFlow::MakeBarrierGuard<BarrierGuard>::getABarrierNode() or
-    node = DataFlow::MakeBarrierGuard<UnsafeJQuery::BarrierGuard>::getABarrierNode()
+    node = DataFlow::MakeBarrierGuard<UnsafeJQuery::BarrierGuard>::getABarrierNode() or
+    node = Shared::BarrierGuard::getABarrierNode()
   }
 
   predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {

--- a/javascript/ql/test/library-tests/TaintBarriers/tests.ql
+++ b/javascript/ql/test/library-tests/TaintBarriers/tests.ql
@@ -11,8 +11,10 @@ query predicate isLabeledBarrier(
 
 query predicate isSanitizer(ExampleConfiguration cfg, DataFlow::Node n) { cfg.isSanitizer(n) }
 
-query predicate sanitizingGuard(TaintTracking::SanitizerGuardNode g, Expr e, boolean b) {
-  g.sanitizes(b, e)
+query predicate sanitizingGuard(DataFlow::Node g, Expr e, boolean b) {
+  g.(TaintTracking::SanitizerGuardNode).sanitizes(b, e)
+  or
+  g.(TaintTracking::AdditionalSanitizerGuardNode).sanitizes(b, e)
 }
 
 query predicate taintedSink(DataFlow::Node source, DataFlow::Node sink) {

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/ConsistencyDomBasedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/ConsistencyDomBasedXss.expected
@@ -1,3 +1,0 @@
-| query-tests/Security/CWE-079/DomBasedXss/sanitiser.js:25 | did not expect an alert, but found an alert for HtmlInjection | OK | ConsistencyConfig |
-| query-tests/Security/CWE-079/DomBasedXss/sanitiser.js:28 | did not expect an alert, but found an alert for HtmlInjection | OK | ConsistencyConfig |
-| query-tests/Security/CWE-079/DomBasedXss/sanitiser.js:35 | did not expect an alert, but found an alert for HtmlInjection | OK | ConsistencyConfig |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -284,16 +284,10 @@ nodes
 | sanitiser.js:16:17:16:27 | window.name | semmle.label | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:23:29:23:35 | tainted | semmle.label | tainted |
-| sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:25:29:25:35 | tainted | semmle.label | tainted |
-| sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:28:29:28:35 | tainted | semmle.label | tainted |
 | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:30:29:30:35 | tainted | semmle.label | tainted |
 | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:33:29:33:35 | tainted | semmle.label | tainted |
-| sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:35:29:35:35 | tainted | semmle.label | tainted |
 | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:38:29:38:35 | tainted | semmle.label | tainted |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
@@ -852,21 +846,15 @@ edges
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev | provenance |  |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:25:29:25:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:28:29:28:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:30:29:30:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:33:29:33:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:35:29:35:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted | provenance |  |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted | provenance |  |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:25:29:25:35 | tainted | sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:28:29:28:35 | tainted | sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:30:29:30:35 | tainted | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:33:29:33:35 | tainted | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:35:29:35:35 | tainted | sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') | provenance |  |
@@ -1265,11 +1253,8 @@ subpaths
 | react-use-state.js:17:51:17:55 | state | react-use-state.js:16:20:16:30 | window.name | react-use-state.js:17:51:17:55 | state | Cross-site scripting vulnerability due to $@. | react-use-state.js:16:20:16:30 | window.name | user-provided value |
 | react-use-state.js:23:35:23:38 | prev | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:23:35:23:38 | prev | Cross-site scripting vulnerability due to $@. | react-use-state.js:25:20:25:30 | window.name | user-provided value |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
-| sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
-| sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
-| sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |
 | sanitiser.js:48:19:48:46 | tainted ... /g, '') | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:48:19:48:46 | tainted ... /g, '') | Cross-site scripting vulnerability due to $@. | sanitiser.js:16:17:16:27 | window.name | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -289,16 +289,10 @@ nodes
 | sanitiser.js:16:17:16:27 | window.name | semmle.label | window.name |
 | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:23:29:23:35 | tainted | semmle.label | tainted |
-| sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:25:29:25:35 | tainted | semmle.label | tainted |
-| sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:28:29:28:35 | tainted | semmle.label | tainted |
 | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:30:29:30:35 | tainted | semmle.label | tainted |
 | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:33:29:33:35 | tainted | semmle.label | tainted |
-| sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
-| sanitiser.js:35:29:35:35 | tainted | semmle.label | tainted |
 | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
 | sanitiser.js:38:29:38:35 | tainted | semmle.label | tainted |
 | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | semmle.label | '<b>' + ...  '</b>' |
@@ -876,21 +870,15 @@ edges
 | react-use-state.js:22:14:22:17 | prev | react-use-state.js:23:35:23:38 | prev | provenance |  |
 | react-use-state.js:25:20:25:30 | window.name | react-use-state.js:21:10:21:14 | state | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:23:29:23:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:25:29:25:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:28:29:28:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:30:29:30:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:33:29:33:35 | tainted | provenance |  |
-| sanitiser.js:16:7:16:27 | tainted | sanitiser.js:35:29:35:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:38:29:38:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:45:29:45:35 | tainted | provenance |  |
 | sanitiser.js:16:7:16:27 | tainted | sanitiser.js:48:19:48:25 | tainted | provenance |  |
 | sanitiser.js:16:17:16:27 | window.name | sanitiser.js:16:7:16:27 | tainted | provenance |  |
 | sanitiser.js:23:29:23:35 | tainted | sanitiser.js:23:21:23:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:25:29:25:35 | tainted | sanitiser.js:25:21:25:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:28:29:28:35 | tainted | sanitiser.js:28:21:28:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:30:29:30:35 | tainted | sanitiser.js:30:21:30:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:33:29:33:35 | tainted | sanitiser.js:33:21:33:44 | '<b>' + ...  '</b>' | provenance |  |
-| sanitiser.js:35:29:35:35 | tainted | sanitiser.js:35:21:35:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:38:29:38:35 | tainted | sanitiser.js:38:21:38:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:45:29:45:35 | tainted | sanitiser.js:45:21:45:44 | '<b>' + ...  '</b>' | provenance |  |
 | sanitiser.js:48:19:48:25 | tainted | sanitiser.js:48:19:48:46 | tainted ... /g, '') | provenance |  |


### PR DESCRIPTION
Fixes a bug that caused cached barriers nodes to be re-evaluated. Specifically, this predicate in `TaintTrackingPrivate` was re-evaluated due to the cached `AdditionalSanitizerGuardNode` inheriting from the query-specific `SanitizerGuard`:
```codeql
private class SanitizerGuardAdapter extends DataFlow::Node instanceof TaintTracking::AdditionalSanitizerGuardNode {
  ...
}

cached
predicate defaultTaintSanitizer(DataFlow::Node node) {
  node instanceof DataFlow::VarAccessBarrier or
  node = MakeBarrierGuard<SanitizerGuardAdapter>::getABarrierNode() // transitively depends on SanitizerGuardNode
}
```
The `AdditionalSanitizerGuardNode` class no longer inherits from `SanitizerGuardNode` which means its `sanitizes/blocks` predicates have their own rootdef now.

### Update to XSS queries
This revealed a bug in the some of the ported XSS queries in that they didn't explicitly include the shared XSS barrier guards. In many (but not all) cases those barrier guards worked anyway because they shared their `this` value with an `AdditionalBarrierGuard` which meant their overrides were in effect (for such `this` values), even if not explicitly opted into.

This is similar to the old problem with `isBarrierGuardNode()` not being able to accurately choose a _class_ to include, but only a set of values, and then we get interference from unrelated classes containing that value. Note that this can't happen anymore as queries now have their own `BarrierGuardNode` root class, but `AdditionalSanitizerGuardNode` hadn't yet been refactored this way until now.

### Evaluation
[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/cached-barriers__default-novscod__code-scanning__2/reports) shows a 2% performance improvement, as a result of fixing the cache re-evaluation bug.

The performance impact is more significant for the use-use flow branch, as it needs to do more work with barriers, and this PR is needed to unblock the use-use flow branch.