### PR TITLE
C#/Java: Only use heuristic if no content based model exist (in mixed mode). 

### DIFF
--- a/java/ql/src/Metrics/Summaries/GeneratedVsManualCoverageQuery.qll
+++ b/java/ql/src/Metrics/Summaries/GeneratedVsManualCoverageQuery.qll
@@ -17,12 +17,12 @@ private int getNumMadModeledApis(string package, string provenance, string apiSu
       (
         // "auto-only"
         not sc.hasManualModel() and
-        sc.hasProvenance("df-generated") and
+        sc.hasGeneratedModel() and
         provenance = "generated"
         or
         sc.hasManualModel() and
         (
-          if sc.hasProvenance("df-generated")
+          if sc.hasGeneratedModel()
           then
             // "both"
             provenance = "both"

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -881,7 +881,7 @@ module MakeModelGenerator<
   string captureMixedFlow(DataFlowSummaryTargetApi api, boolean lift) {
     result = ContentSensitive::captureFlow(api, lift)
     or
-    not exists(ContentSensitive::captureFlow(api, lift)) and
+    not exists(ContentSensitive::captureFlow(api, _)) and
     result = captureFlow(api) and
     lift = true
   }


### PR DESCRIPTION
Also, another minor fix to one of the Java tests that reports *generated* models - it should take all generated models into account (and not only `df` generated models).