### PR TITLE
Rust: `&(mut) x` is neither a read nor a write

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
@@ -1,0 +1,49 @@
+/** Provides classes for assignment operations. */
+
+private import rust
+private import codeql.rust.elements.internal.BinaryExprImpl
+
+/** An assignment operation. */
+abstract private class AssignmentOperationImpl extends Impl::BinaryExpr { }
+
+final class AssignmentOperation = AssignmentOperationImpl;
+
+/**
+ * An assignment expression, for example
+ *
+ * ```rust
+ * x = y;
+ * ```
+ */
+final class AssignmentExpr extends AssignmentOperationImpl {
+  AssignmentExpr() { this.getOperatorName() = "=" }
+
+  override string getAPrimaryQlClass() { result = "AssignmentExpr" }
+}
+
+/**
+ * A compound assignment expression, for example
+ *
+ * ```rust
+ * x += y;
+ * ```
+ *
+ * Note that compound assignment expressions are syntatic sugar for
+ * trait invocations, i.e., the above actually means
+ *
+ * ```rust
+ * (&mut x).add_assign(y);
+ * ```
+ */
+final class CompoundAssignmentExpr extends AssignmentOperationImpl {
+  private string operator;
+
+  CompoundAssignmentExpr() { this.getOperatorName().regexpCapture("(.)=", 1) = operator }
+
+  /**
+   * Gets the operator of this compound assignment expression.
+   */
+  string getOperator() { result = operator }
+
+  override string getAPrimaryQlClass() { result = "CompoundAssignmentExpr" }
+}

--- a/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
+++ b/rust/ql/lib/codeql/rust/elements/AssignmentOperation.qll
@@ -38,7 +38,9 @@ final class AssignmentExpr extends AssignmentOperationImpl {
 final class CompoundAssignmentExpr extends AssignmentOperationImpl {
   private string operator;
 
-  CompoundAssignmentExpr() { this.getOperatorName().regexpCapture("(.)=", 1) = operator }
+  CompoundAssignmentExpr() {
+    this.getOperatorName().regexpCapture("(\\+|-|\\*|/|%|&|\\||\\^|<<|>>)=", 1) = operator
+  }
 
   /**
    * Gets the operator of this compound assignment expression.

--- a/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
@@ -395,34 +395,27 @@ module Impl {
   }
 
   /** Holds if `e` occurs in the LHS of an assignment or compound assignment. */
-  private predicate assignLhs(Expr e, boolean compound) {
-    exists(BinaryExpr be, string op |
-      op = be.getOperatorName().regexpCapture("(.*)=", 1) and
-      e = be.getLhs()
-    |
-      op = "" and compound = false
-      or
-      op != "" and compound = true
-    )
+  private predicate assignmentExprDescendant(Expr e) {
+    e = any(AssignmentExpr ae).getLhs()
     or
     exists(Expr mid |
-      assignLhs(mid, compound) and
-      getImmediateParent(e) = mid
+      assignmentExprDescendant(mid) and
+      getImmediateParent(e) = mid and
+      not mid.(PrefixExpr).getOperatorName() = "*"
     )
   }
 
   /** A variable write. */
   class VariableWriteAccess extends VariableAccess {
-    VariableWriteAccess() { assignLhs(this, _) }
+    VariableWriteAccess() { assignmentExprDescendant(this) }
   }
 
   /** A variable read. */
   class VariableReadAccess extends VariableAccess {
     VariableReadAccess() {
-      not this instanceof VariableWriteAccess
-      or
-      // consider LHS in compound assignments both reads and writes
-      assignLhs(this, true)
+      not this instanceof VariableWriteAccess and
+      not this = any(RefExpr re).getExpr() and
+      not this = any(CompoundAssignmentExpr cae).getLhs()
     }
   }
 

--- a/rust/ql/lib/rust.qll
+++ b/rust/ql/lib/rust.qll
@@ -3,5 +3,6 @@
 import codeql.rust.elements
 import codeql.Locations
 import codeql.files.FileSystem
+import codeql.rust.elements.AssignmentOperation
 import codeql.rust.elements.LogicalOperation
 import codeql.rust.elements.Variable

--- a/rust/ql/test/library-tests/variables/Cfg.expected
+++ b/rust/ql/test/library-tests/variables/Cfg.expected
@@ -1,616 +1,691 @@
 edges
-| variables.rs:1:1:3:1 | enter print_str | variables.rs:2:5:2:22 | ExprStmt |  |
-| variables.rs:1:1:3:1 | exit print_str (normal) | variables.rs:1:1:3:1 | exit print_str |  |
-| variables.rs:1:23:3:1 | BlockExpr | variables.rs:1:1:3:1 | exit print_str (normal) |  |
-| variables.rs:2:5:2:21 | MacroExpr | variables.rs:1:23:3:1 | BlockExpr |  |
-| variables.rs:2:5:2:22 | ExprStmt | variables.rs:2:5:2:21 | MacroExpr |  |
-| variables.rs:5:1:7:1 | enter print_i64 | variables.rs:6:5:6:22 | ExprStmt |  |
-| variables.rs:5:1:7:1 | exit print_i64 (normal) | variables.rs:5:1:7:1 | exit print_i64 |  |
-| variables.rs:5:22:7:1 | BlockExpr | variables.rs:5:1:7:1 | exit print_i64 (normal) |  |
-| variables.rs:6:5:6:21 | MacroExpr | variables.rs:5:22:7:1 | BlockExpr |  |
-| variables.rs:6:5:6:22 | ExprStmt | variables.rs:6:5:6:21 | MacroExpr |  |
-| variables.rs:9:1:12:1 | enter immutable_variable | variables.rs:10:5:10:17 | LetStmt |  |
-| variables.rs:9:1:12:1 | exit immutable_variable (normal) | variables.rs:9:1:12:1 | exit immutable_variable |  |
-| variables.rs:9:25:12:1 | BlockExpr | variables.rs:9:1:12:1 | exit immutable_variable (normal) |  |
-| variables.rs:10:5:10:17 | LetStmt | variables.rs:10:14:10:16 | "a" |  |
-| variables.rs:10:9:10:10 | x1 | variables.rs:11:5:11:18 | ExprStmt | match, no-match |
-| variables.rs:10:14:10:16 | "a" | variables.rs:10:9:10:10 | x1 |  |
-| variables.rs:11:5:11:13 | PathExpr | variables.rs:11:15:11:16 | x1 |  |
-| variables.rs:11:5:11:17 | CallExpr | variables.rs:9:25:12:1 | BlockExpr |  |
-| variables.rs:11:5:11:18 | ExprStmt | variables.rs:11:5:11:13 | PathExpr |  |
-| variables.rs:11:15:11:16 | x1 | variables.rs:11:5:11:17 | CallExpr |  |
-| variables.rs:14:1:19:1 | enter mutable_variable | variables.rs:15:5:15:19 | LetStmt |  |
-| variables.rs:14:1:19:1 | exit mutable_variable (normal) | variables.rs:14:1:19:1 | exit mutable_variable |  |
-| variables.rs:14:23:19:1 | BlockExpr | variables.rs:14:1:19:1 | exit mutable_variable (normal) |  |
-| variables.rs:15:5:15:19 | LetStmt | variables.rs:15:18:15:18 | 4 |  |
-| variables.rs:15:9:15:14 | x2 | variables.rs:16:5:16:18 | ExprStmt | match, no-match |
-| variables.rs:15:18:15:18 | 4 | variables.rs:15:9:15:14 | x2 |  |
-| variables.rs:16:5:16:13 | PathExpr | variables.rs:16:15:16:16 | x2 |  |
-| variables.rs:16:5:16:17 | CallExpr | variables.rs:17:5:17:11 | ExprStmt |  |
-| variables.rs:16:5:16:18 | ExprStmt | variables.rs:16:5:16:13 | PathExpr |  |
-| variables.rs:16:15:16:16 | x2 | variables.rs:16:5:16:17 | CallExpr |  |
-| variables.rs:17:5:17:6 | x2 | variables.rs:17:10:17:10 | 5 |  |
-| variables.rs:17:5:17:10 | ... = ... | variables.rs:18:5:18:18 | ExprStmt |  |
-| variables.rs:17:5:17:11 | ExprStmt | variables.rs:17:5:17:6 | x2 |  |
-| variables.rs:17:10:17:10 | 5 | variables.rs:17:5:17:10 | ... = ... |  |
+| variables.rs:3:1:5:1 | enter print_str | variables.rs:4:5:4:22 | ExprStmt |  |
+| variables.rs:3:1:5:1 | exit print_str (normal) | variables.rs:3:1:5:1 | exit print_str |  |
+| variables.rs:3:23:5:1 | BlockExpr | variables.rs:3:1:5:1 | exit print_str (normal) |  |
+| variables.rs:4:5:4:21 | MacroExpr | variables.rs:3:23:5:1 | BlockExpr |  |
+| variables.rs:4:5:4:22 | ExprStmt | variables.rs:4:5:4:21 | MacroExpr |  |
+| variables.rs:7:1:9:1 | enter print_i64 | variables.rs:8:5:8:22 | ExprStmt |  |
+| variables.rs:7:1:9:1 | exit print_i64 (normal) | variables.rs:7:1:9:1 | exit print_i64 |  |
+| variables.rs:7:22:9:1 | BlockExpr | variables.rs:7:1:9:1 | exit print_i64 (normal) |  |
+| variables.rs:8:5:8:21 | MacroExpr | variables.rs:7:22:9:1 | BlockExpr |  |
+| variables.rs:8:5:8:22 | ExprStmt | variables.rs:8:5:8:21 | MacroExpr |  |
+| variables.rs:11:1:14:1 | enter immutable_variable | variables.rs:12:5:12:17 | LetStmt |  |
+| variables.rs:11:1:14:1 | exit immutable_variable (normal) | variables.rs:11:1:14:1 | exit immutable_variable |  |
+| variables.rs:11:25:14:1 | BlockExpr | variables.rs:11:1:14:1 | exit immutable_variable (normal) |  |
+| variables.rs:12:5:12:17 | LetStmt | variables.rs:12:14:12:16 | "a" |  |
+| variables.rs:12:9:12:10 | x1 | variables.rs:13:5:13:18 | ExprStmt | match, no-match |
+| variables.rs:12:14:12:16 | "a" | variables.rs:12:9:12:10 | x1 |  |
+| variables.rs:13:5:13:13 | PathExpr | variables.rs:13:15:13:16 | x1 |  |
+| variables.rs:13:5:13:17 | CallExpr | variables.rs:11:25:14:1 | BlockExpr |  |
+| variables.rs:13:5:13:18 | ExprStmt | variables.rs:13:5:13:13 | PathExpr |  |
+| variables.rs:13:15:13:16 | x1 | variables.rs:13:5:13:17 | CallExpr |  |
+| variables.rs:16:1:21:1 | enter mutable_variable | variables.rs:17:5:17:19 | LetStmt |  |
+| variables.rs:16:1:21:1 | exit mutable_variable (normal) | variables.rs:16:1:21:1 | exit mutable_variable |  |
+| variables.rs:16:23:21:1 | BlockExpr | variables.rs:16:1:21:1 | exit mutable_variable (normal) |  |
+| variables.rs:17:5:17:19 | LetStmt | variables.rs:17:18:17:18 | 4 |  |
+| variables.rs:17:9:17:14 | x2 | variables.rs:18:5:18:18 | ExprStmt | match, no-match |
+| variables.rs:17:18:17:18 | 4 | variables.rs:17:9:17:14 | x2 |  |
 | variables.rs:18:5:18:13 | PathExpr | variables.rs:18:15:18:16 | x2 |  |
-| variables.rs:18:5:18:17 | CallExpr | variables.rs:14:23:19:1 | BlockExpr |  |
+| variables.rs:18:5:18:17 | CallExpr | variables.rs:19:5:19:11 | ExprStmt |  |
 | variables.rs:18:5:18:18 | ExprStmt | variables.rs:18:5:18:13 | PathExpr |  |
 | variables.rs:18:15:18:16 | x2 | variables.rs:18:5:18:17 | CallExpr |  |
-| variables.rs:21:1:27:1 | enter variable_shadow1 | variables.rs:22:5:22:15 | LetStmt |  |
-| variables.rs:21:1:27:1 | exit variable_shadow1 (normal) | variables.rs:21:1:27:1 | exit variable_shadow1 |  |
-| variables.rs:21:23:27:1 | BlockExpr | variables.rs:21:1:27:1 | exit variable_shadow1 (normal) |  |
-| variables.rs:22:5:22:15 | LetStmt | variables.rs:22:14:22:14 | 1 |  |
-| variables.rs:22:9:22:10 | x3 | variables.rs:23:5:23:18 | ExprStmt | match, no-match |
-| variables.rs:22:14:22:14 | 1 | variables.rs:22:9:22:10 | x3 |  |
-| variables.rs:23:5:23:13 | PathExpr | variables.rs:23:15:23:16 | x3 |  |
-| variables.rs:23:5:23:17 | CallExpr | variables.rs:24:5:25:15 | LetStmt |  |
-| variables.rs:23:5:23:18 | ExprStmt | variables.rs:23:5:23:13 | PathExpr |  |
-| variables.rs:23:15:23:16 | x3 | variables.rs:23:5:23:17 | CallExpr |  |
-| variables.rs:24:5:25:15 | LetStmt | variables.rs:25:9:25:10 | x3 |  |
-| variables.rs:24:9:24:10 | x3 | variables.rs:26:5:26:18 | ExprStmt | match, no-match |
-| variables.rs:25:9:25:10 | x3 | variables.rs:25:14:25:14 | 1 |  |
-| variables.rs:25:9:25:14 | ... + ... | variables.rs:24:9:24:10 | x3 |  |
-| variables.rs:25:14:25:14 | 1 | variables.rs:25:9:25:14 | ... + ... |  |
-| variables.rs:26:5:26:13 | PathExpr | variables.rs:26:15:26:16 | x3 |  |
-| variables.rs:26:5:26:17 | CallExpr | variables.rs:21:23:27:1 | BlockExpr |  |
-| variables.rs:26:5:26:18 | ExprStmt | variables.rs:26:5:26:13 | PathExpr |  |
-| variables.rs:26:15:26:16 | x3 | variables.rs:26:5:26:17 | CallExpr |  |
-| variables.rs:29:1:37:1 | enter variable_shadow2 | variables.rs:30:5:30:17 | LetStmt |  |
-| variables.rs:29:1:37:1 | exit variable_shadow2 (normal) | variables.rs:29:1:37:1 | exit variable_shadow2 |  |
-| variables.rs:29:23:37:1 | BlockExpr | variables.rs:29:1:37:1 | exit variable_shadow2 (normal) |  |
-| variables.rs:30:5:30:17 | LetStmt | variables.rs:30:14:30:16 | "a" |  |
-| variables.rs:30:9:30:10 | x4 | variables.rs:31:5:31:18 | ExprStmt | match, no-match |
-| variables.rs:30:14:30:16 | "a" | variables.rs:30:9:30:10 | x4 |  |
-| variables.rs:31:5:31:13 | PathExpr | variables.rs:31:15:31:16 | x4 |  |
-| variables.rs:31:5:31:17 | CallExpr | variables.rs:32:5:35:5 | ExprStmt |  |
-| variables.rs:31:5:31:18 | ExprStmt | variables.rs:31:5:31:13 | PathExpr |  |
-| variables.rs:31:15:31:16 | x4 | variables.rs:31:5:31:17 | CallExpr |  |
-| variables.rs:32:5:35:5 | BlockExpr | variables.rs:36:5:36:18 | ExprStmt |  |
-| variables.rs:32:5:35:5 | ExprStmt | variables.rs:33:9:33:21 | LetStmt |  |
-| variables.rs:33:9:33:21 | LetStmt | variables.rs:33:18:33:20 | "b" |  |
-| variables.rs:33:13:33:14 | x4 | variables.rs:34:9:34:22 | ExprStmt | match, no-match |
-| variables.rs:33:18:33:20 | "b" | variables.rs:33:13:33:14 | x4 |  |
-| variables.rs:34:9:34:17 | PathExpr | variables.rs:34:19:34:20 | x4 |  |
-| variables.rs:34:9:34:21 | CallExpr | variables.rs:32:5:35:5 | BlockExpr |  |
-| variables.rs:34:9:34:22 | ExprStmt | variables.rs:34:9:34:17 | PathExpr |  |
-| variables.rs:34:19:34:20 | x4 | variables.rs:34:9:34:21 | CallExpr |  |
-| variables.rs:36:5:36:13 | PathExpr | variables.rs:36:15:36:16 | x4 |  |
-| variables.rs:36:5:36:17 | CallExpr | variables.rs:29:23:37:1 | BlockExpr |  |
-| variables.rs:36:5:36:18 | ExprStmt | variables.rs:36:5:36:13 | PathExpr |  |
-| variables.rs:36:15:36:16 | x4 | variables.rs:36:5:36:17 | CallExpr |  |
-| variables.rs:44:1:59:1 | enter let_pattern1 | variables.rs:45:5:54:47 | LetStmt |  |
-| variables.rs:44:1:59:1 | exit let_pattern1 (normal) | variables.rs:44:1:59:1 | exit let_pattern1 |  |
-| variables.rs:44:19:59:1 | BlockExpr | variables.rs:44:1:59:1 | exit let_pattern1 (normal) |  |
-| variables.rs:45:5:54:47 | LetStmt | variables.rs:54:11:54:13 | "a" |  |
-| variables.rs:45:9:54:5 | TuplePat | variables.rs:55:5:55:18 | ExprStmt | match |
-| variables.rs:54:9:54:46 | TupleExpr | variables.rs:45:9:54:5 | TuplePat |  |
-| variables.rs:54:10:54:19 | TupleExpr | variables.rs:54:33:54:35 | "x" |  |
-| variables.rs:54:11:54:13 | "a" | variables.rs:54:16:54:18 | "b" |  |
-| variables.rs:54:16:54:18 | "b" | variables.rs:54:10:54:19 | TupleExpr |  |
-| variables.rs:54:22:54:45 | RecordExpr | variables.rs:54:9:54:46 | TupleExpr |  |
-| variables.rs:54:33:54:35 | "x" | variables.rs:54:41:54:43 | "y" |  |
-| variables.rs:54:41:54:43 | "y" | variables.rs:54:22:54:45 | RecordExpr |  |
-| variables.rs:55:5:55:13 | PathExpr | variables.rs:55:15:55:16 | a1 |  |
-| variables.rs:55:5:55:17 | CallExpr | variables.rs:56:5:56:18 | ExprStmt |  |
-| variables.rs:55:5:55:18 | ExprStmt | variables.rs:55:5:55:13 | PathExpr |  |
-| variables.rs:55:15:55:16 | a1 | variables.rs:55:5:55:17 | CallExpr |  |
-| variables.rs:56:5:56:13 | PathExpr | variables.rs:56:15:56:16 | b1 |  |
-| variables.rs:56:5:56:17 | CallExpr | variables.rs:57:5:57:17 | ExprStmt |  |
-| variables.rs:56:5:56:18 | ExprStmt | variables.rs:56:5:56:13 | PathExpr |  |
-| variables.rs:56:15:56:16 | b1 | variables.rs:56:5:56:17 | CallExpr |  |
-| variables.rs:57:5:57:13 | PathExpr | variables.rs:57:15:57:15 | x |  |
-| variables.rs:57:5:57:16 | CallExpr | variables.rs:58:5:58:17 | ExprStmt |  |
-| variables.rs:57:5:57:17 | ExprStmt | variables.rs:57:5:57:13 | PathExpr |  |
-| variables.rs:57:15:57:15 | x | variables.rs:57:5:57:16 | CallExpr |  |
-| variables.rs:58:5:58:13 | PathExpr | variables.rs:58:15:58:15 | y |  |
-| variables.rs:58:5:58:16 | CallExpr | variables.rs:44:19:59:1 | BlockExpr |  |
-| variables.rs:58:5:58:17 | ExprStmt | variables.rs:58:5:58:13 | PathExpr |  |
-| variables.rs:58:15:58:15 | y | variables.rs:58:5:58:16 | CallExpr |  |
-| variables.rs:61:1:69:1 | enter let_pattern2 | variables.rs:62:5:62:38 | LetStmt |  |
-| variables.rs:61:1:69:1 | exit let_pattern2 (normal) | variables.rs:61:1:69:1 | exit let_pattern2 |  |
-| variables.rs:61:19:69:1 | BlockExpr | variables.rs:61:1:69:1 | exit let_pattern2 (normal) |  |
-| variables.rs:62:5:62:38 | LetStmt | variables.rs:62:25:62:27 | "a" |  |
-| variables.rs:62:9:62:10 | p1 | variables.rs:63:5:66:11 | LetStmt | match, no-match |
-| variables.rs:62:14:62:37 | RecordExpr | variables.rs:62:9:62:10 | p1 |  |
-| variables.rs:62:25:62:27 | "a" | variables.rs:62:33:62:35 | "b" |  |
-| variables.rs:62:33:62:35 | "b" | variables.rs:62:14:62:37 | RecordExpr |  |
-| variables.rs:63:5:66:11 | LetStmt | variables.rs:66:9:66:10 | p1 |  |
-| variables.rs:63:9:66:5 | RecordPat | variables.rs:67:5:67:18 | ExprStmt | match |
-| variables.rs:66:9:66:10 | p1 | variables.rs:63:9:66:5 | RecordPat |  |
-| variables.rs:67:5:67:13 | PathExpr | variables.rs:67:15:67:16 | a2 |  |
-| variables.rs:67:5:67:17 | CallExpr | variables.rs:68:5:68:18 | ExprStmt |  |
-| variables.rs:67:5:67:18 | ExprStmt | variables.rs:67:5:67:13 | PathExpr |  |
-| variables.rs:67:15:67:16 | a2 | variables.rs:67:5:67:17 | CallExpr |  |
-| variables.rs:68:5:68:13 | PathExpr | variables.rs:68:15:68:16 | b2 |  |
-| variables.rs:68:5:68:17 | CallExpr | variables.rs:61:19:69:1 | BlockExpr |  |
-| variables.rs:68:5:68:18 | ExprStmt | variables.rs:68:5:68:13 | PathExpr |  |
-| variables.rs:68:15:68:16 | b2 | variables.rs:68:5:68:17 | CallExpr |  |
-| variables.rs:71:1:78:1 | enter let_pattern3 | variables.rs:72:5:72:42 | LetStmt |  |
-| variables.rs:71:1:78:1 | exit let_pattern3 (normal) | variables.rs:71:1:78:1 | exit let_pattern3 |  |
-| variables.rs:71:19:78:1 | BlockExpr | variables.rs:71:1:78:1 | exit let_pattern3 (normal) |  |
-| variables.rs:72:5:72:42 | LetStmt | variables.rs:72:14:72:17 | PathExpr |  |
-| variables.rs:72:9:72:10 | s1 | variables.rs:74:8:75:12 | LetExpr | match, no-match |
-| variables.rs:72:14:72:17 | PathExpr | variables.rs:72:19:72:30 | PathExpr |  |
-| variables.rs:72:14:72:41 | CallExpr | variables.rs:72:9:72:10 | s1 |  |
-| variables.rs:72:19:72:30 | PathExpr | variables.rs:72:32:72:39 | "Hello!" |  |
-| variables.rs:72:19:72:40 | CallExpr | variables.rs:72:14:72:41 | CallExpr |  |
-| variables.rs:72:32:72:39 | "Hello!" | variables.rs:72:19:72:40 | CallExpr |  |
-| variables.rs:74:5:77:5 | IfExpr | variables.rs:71:19:78:1 | BlockExpr |  |
-| variables.rs:74:8:75:12 | LetExpr | variables.rs:74:12:74:23 | TupleStructPat |  |
-| variables.rs:74:12:74:23 | TupleStructPat | variables.rs:74:5:77:5 | IfExpr | no-match |
-| variables.rs:74:12:74:23 | TupleStructPat | variables.rs:76:9:76:22 | ExprStmt | match |
-| variables.rs:75:14:77:5 | BlockExpr | variables.rs:74:5:77:5 | IfExpr |  |
-| variables.rs:76:9:76:17 | PathExpr | variables.rs:76:19:76:20 | s2 |  |
-| variables.rs:76:9:76:21 | CallExpr | variables.rs:75:14:77:5 | BlockExpr |  |
-| variables.rs:76:9:76:22 | ExprStmt | variables.rs:76:9:76:17 | PathExpr |  |
-| variables.rs:76:19:76:20 | s2 | variables.rs:76:9:76:21 | CallExpr |  |
-| variables.rs:80:1:86:1 | enter let_pattern4 | variables.rs:81:5:84:6 | LetStmt |  |
-| variables.rs:80:1:86:1 | exit let_pattern4 (normal) | variables.rs:80:1:86:1 | exit let_pattern4 |  |
-| variables.rs:80:19:86:1 | BlockExpr | variables.rs:80:1:86:1 | exit let_pattern4 (normal) |  |
-| variables.rs:81:5:84:6 | LetStmt | variables.rs:81:34:81:37 | PathExpr |  |
-| variables.rs:81:9:81:16 | TupleStructPat | variables.rs:83:9:83:15 | MacroExpr | no-match |
-| variables.rs:81:9:81:16 | TupleStructPat | variables.rs:85:5:85:18 | ExprStmt | match |
-| variables.rs:81:34:81:37 | PathExpr | variables.rs:81:39:81:42 | "x5" |  |
-| variables.rs:81:34:81:43 | CallExpr | variables.rs:81:9:81:16 | TupleStructPat |  |
-| variables.rs:81:39:81:42 | "x5" | variables.rs:81:34:81:43 | CallExpr |  |
-| variables.rs:83:9:83:15 | MacroExpr | variables.rs:81:50:84:5 | BlockExpr |  |
-| variables.rs:85:5:85:13 | PathExpr | variables.rs:85:15:85:16 | x5 |  |
-| variables.rs:85:5:85:17 | CallExpr | variables.rs:80:19:86:1 | BlockExpr |  |
-| variables.rs:85:5:85:18 | ExprStmt | variables.rs:85:5:85:13 | PathExpr |  |
-| variables.rs:85:15:85:16 | x5 | variables.rs:85:5:85:17 | CallExpr |  |
-| variables.rs:88:1:95:1 | enter let_pattern5 | variables.rs:89:5:89:42 | LetStmt |  |
-| variables.rs:88:1:95:1 | exit let_pattern5 (normal) | variables.rs:88:1:95:1 | exit let_pattern5 |  |
-| variables.rs:88:19:95:1 | BlockExpr | variables.rs:88:1:95:1 | exit let_pattern5 (normal) |  |
-| variables.rs:89:5:89:42 | LetStmt | variables.rs:89:14:89:17 | PathExpr |  |
-| variables.rs:89:9:89:10 | s1 | variables.rs:91:11:92:12 | LetExpr | match, no-match |
-| variables.rs:89:14:89:17 | PathExpr | variables.rs:89:19:89:30 | PathExpr |  |
-| variables.rs:89:14:89:41 | CallExpr | variables.rs:89:9:89:10 | s1 |  |
-| variables.rs:89:19:89:30 | PathExpr | variables.rs:89:32:89:39 | "Hello!" |  |
-| variables.rs:89:19:89:40 | CallExpr | variables.rs:89:14:89:41 | CallExpr |  |
-| variables.rs:89:32:89:39 | "Hello!" | variables.rs:89:19:89:40 | CallExpr |  |
-| variables.rs:91:5:94:5 | WhileExpr | variables.rs:88:19:95:1 | BlockExpr |  |
-| variables.rs:91:11:92:12 | LetExpr | variables.rs:91:15:91:26 | TupleStructPat |  |
-| variables.rs:91:15:91:26 | TupleStructPat | variables.rs:91:5:94:5 | WhileExpr | no-match |
-| variables.rs:91:15:91:26 | TupleStructPat | variables.rs:93:9:93:22 | ExprStmt | match |
-| variables.rs:92:14:94:5 | BlockExpr | variables.rs:91:11:92:12 | LetExpr |  |
-| variables.rs:93:9:93:17 | PathExpr | variables.rs:93:19:93:20 | s2 |  |
-| variables.rs:93:9:93:21 | CallExpr | variables.rs:92:14:94:5 | BlockExpr |  |
-| variables.rs:93:9:93:22 | ExprStmt | variables.rs:93:9:93:17 | PathExpr |  |
-| variables.rs:93:19:93:20 | s2 | variables.rs:93:9:93:21 | CallExpr |  |
-| variables.rs:97:1:112:1 | enter match_pattern1 | variables.rs:98:5:98:21 | LetStmt |  |
-| variables.rs:97:1:112:1 | exit match_pattern1 (normal) | variables.rs:97:1:112:1 | exit match_pattern1 |  |
-| variables.rs:97:21:112:1 | BlockExpr | variables.rs:97:1:112:1 | exit match_pattern1 (normal) |  |
-| variables.rs:98:5:98:21 | LetStmt | variables.rs:98:14:98:17 | PathExpr |  |
-| variables.rs:98:9:98:10 | x6 | variables.rs:99:5:99:16 | LetStmt | match, no-match |
-| variables.rs:98:14:98:17 | PathExpr | variables.rs:98:19:98:19 | 5 |  |
-| variables.rs:98:14:98:20 | CallExpr | variables.rs:98:9:98:10 | x6 |  |
-| variables.rs:98:19:98:19 | 5 | variables.rs:98:14:98:20 | CallExpr |  |
-| variables.rs:99:5:99:16 | LetStmt | variables.rs:99:14:99:15 | 10 |  |
-| variables.rs:99:9:99:10 | y1 | variables.rs:101:5:109:5 | ExprStmt | match, no-match |
-| variables.rs:99:14:99:15 | 10 | variables.rs:99:9:99:10 | y1 |  |
-| variables.rs:101:5:109:5 | ExprStmt | variables.rs:101:11:101:12 | x6 |  |
-| variables.rs:101:5:109:5 | MatchExpr | variables.rs:111:5:111:18 | ExprStmt |  |
-| variables.rs:101:11:101:12 | x6 | variables.rs:102:9:102:16 | TupleStructPat |  |
-| variables.rs:102:9:102:16 | TupleStructPat | variables.rs:102:21:102:29 | PathExpr | match |
-| variables.rs:102:9:102:16 | TupleStructPat | variables.rs:103:9:103:16 | TupleStructPat | no-match |
-| variables.rs:102:21:102:29 | PathExpr | variables.rs:102:31:102:38 | "Got 50" |  |
-| variables.rs:102:21:102:39 | CallExpr | variables.rs:101:5:109:5 | MatchExpr |  |
-| variables.rs:102:31:102:38 | "Got 50" | variables.rs:102:21:102:39 | CallExpr |  |
-| variables.rs:103:9:103:16 | TupleStructPat | variables.rs:106:13:106:21 | PathExpr | match |
-| variables.rs:103:9:103:16 | TupleStructPat | variables.rs:108:9:108:12 | None | no-match |
-| variables.rs:105:9:107:9 | BlockExpr | variables.rs:101:5:109:5 | MatchExpr |  |
-| variables.rs:106:13:106:21 | PathExpr | variables.rs:106:23:106:24 | y1 |  |
-| variables.rs:106:13:106:25 | CallExpr | variables.rs:105:9:107:9 | BlockExpr |  |
-| variables.rs:106:23:106:24 | y1 | variables.rs:106:13:106:25 | CallExpr |  |
-| variables.rs:108:9:108:12 | None | variables.rs:108:17:108:25 | PathExpr | match |
-| variables.rs:108:17:108:25 | PathExpr | variables.rs:108:27:108:32 | "NONE" |  |
-| variables.rs:108:17:108:33 | CallExpr | variables.rs:101:5:109:5 | MatchExpr |  |
-| variables.rs:108:27:108:32 | "NONE" | variables.rs:108:17:108:33 | CallExpr |  |
-| variables.rs:111:5:111:13 | PathExpr | variables.rs:111:15:111:16 | y1 |  |
-| variables.rs:111:5:111:17 | CallExpr | variables.rs:97:21:112:1 | BlockExpr |  |
-| variables.rs:111:5:111:18 | ExprStmt | variables.rs:111:5:111:13 | PathExpr |  |
-| variables.rs:111:15:111:16 | y1 | variables.rs:111:5:111:17 | CallExpr |  |
-| variables.rs:114:1:139:1 | enter match_pattern2 | variables.rs:115:5:115:36 | LetStmt |  |
-| variables.rs:114:1:139:1 | exit match_pattern2 (normal) | variables.rs:114:1:139:1 | exit match_pattern2 |  |
-| variables.rs:114:21:139:1 | BlockExpr | variables.rs:114:1:139:1 | exit match_pattern2 (normal) |  |
-| variables.rs:115:5:115:36 | LetStmt | variables.rs:115:20:115:20 | 2 |  |
-| variables.rs:115:9:115:15 | numbers | variables.rs:117:5:127:5 | ExprStmt | match, no-match |
-| variables.rs:115:19:115:35 | TupleExpr | variables.rs:115:9:115:15 | numbers |  |
-| variables.rs:115:20:115:20 | 2 | variables.rs:115:23:115:23 | 4 |  |
-| variables.rs:115:23:115:23 | 4 | variables.rs:115:26:115:26 | 8 |  |
-| variables.rs:115:26:115:26 | 8 | variables.rs:115:29:115:30 | 16 |  |
-| variables.rs:115:29:115:30 | 16 | variables.rs:115:33:115:34 | 32 |  |
-| variables.rs:115:33:115:34 | 32 | variables.rs:115:19:115:35 | TupleExpr |  |
-| variables.rs:117:5:127:5 | ExprStmt | variables.rs:117:11:117:17 | numbers |  |
-| variables.rs:117:5:127:5 | MatchExpr | variables.rs:129:11:129:17 | numbers |  |
-| variables.rs:117:11:117:17 | numbers | variables.rs:118:9:122:9 | TuplePat |  |
-| variables.rs:118:9:122:9 | TuplePat | variables.rs:123:13:123:29 | ExprStmt | match |
-| variables.rs:122:14:126:9 | BlockExpr | variables.rs:117:5:127:5 | MatchExpr |  |
-| variables.rs:123:13:123:21 | PathExpr | variables.rs:123:23:123:27 | first |  |
-| variables.rs:123:13:123:28 | CallExpr | variables.rs:124:13:124:29 | ExprStmt |  |
-| variables.rs:123:13:123:29 | ExprStmt | variables.rs:123:13:123:21 | PathExpr |  |
-| variables.rs:123:23:123:27 | first | variables.rs:123:13:123:28 | CallExpr |  |
-| variables.rs:124:13:124:21 | PathExpr | variables.rs:124:23:124:27 | third |  |
-| variables.rs:124:13:124:28 | CallExpr | variables.rs:125:13:125:29 | ExprStmt |  |
-| variables.rs:124:13:124:29 | ExprStmt | variables.rs:124:13:124:21 | PathExpr |  |
-| variables.rs:124:23:124:27 | third | variables.rs:124:13:124:28 | CallExpr |  |
-| variables.rs:125:13:125:21 | PathExpr | variables.rs:125:23:125:27 | fifth |  |
-| variables.rs:125:13:125:28 | CallExpr | variables.rs:122:14:126:9 | BlockExpr |  |
+| variables.rs:19:5:19:6 | x2 | variables.rs:19:10:19:10 | 5 |  |
+| variables.rs:19:5:19:10 | ... = ... | variables.rs:20:5:20:18 | ExprStmt |  |
+| variables.rs:19:5:19:11 | ExprStmt | variables.rs:19:5:19:6 | x2 |  |
+| variables.rs:19:10:19:10 | 5 | variables.rs:19:5:19:10 | ... = ... |  |
+| variables.rs:20:5:20:13 | PathExpr | variables.rs:20:15:20:16 | x2 |  |
+| variables.rs:20:5:20:17 | CallExpr | variables.rs:16:23:21:1 | BlockExpr |  |
+| variables.rs:20:5:20:18 | ExprStmt | variables.rs:20:5:20:13 | PathExpr |  |
+| variables.rs:20:15:20:16 | x2 | variables.rs:20:5:20:17 | CallExpr |  |
+| variables.rs:23:1:29:1 | enter variable_shadow1 | variables.rs:24:5:24:15 | LetStmt |  |
+| variables.rs:23:1:29:1 | exit variable_shadow1 (normal) | variables.rs:23:1:29:1 | exit variable_shadow1 |  |
+| variables.rs:23:23:29:1 | BlockExpr | variables.rs:23:1:29:1 | exit variable_shadow1 (normal) |  |
+| variables.rs:24:5:24:15 | LetStmt | variables.rs:24:14:24:14 | 1 |  |
+| variables.rs:24:9:24:10 | x3 | variables.rs:25:5:25:18 | ExprStmt | match, no-match |
+| variables.rs:24:14:24:14 | 1 | variables.rs:24:9:24:10 | x3 |  |
+| variables.rs:25:5:25:13 | PathExpr | variables.rs:25:15:25:16 | x3 |  |
+| variables.rs:25:5:25:17 | CallExpr | variables.rs:26:5:27:15 | LetStmt |  |
+| variables.rs:25:5:25:18 | ExprStmt | variables.rs:25:5:25:13 | PathExpr |  |
+| variables.rs:25:15:25:16 | x3 | variables.rs:25:5:25:17 | CallExpr |  |
+| variables.rs:26:5:27:15 | LetStmt | variables.rs:27:9:27:10 | x3 |  |
+| variables.rs:26:9:26:10 | x3 | variables.rs:28:5:28:18 | ExprStmt | match, no-match |
+| variables.rs:27:9:27:10 | x3 | variables.rs:27:14:27:14 | 1 |  |
+| variables.rs:27:9:27:14 | ... + ... | variables.rs:26:9:26:10 | x3 |  |
+| variables.rs:27:14:27:14 | 1 | variables.rs:27:9:27:14 | ... + ... |  |
+| variables.rs:28:5:28:13 | PathExpr | variables.rs:28:15:28:16 | x3 |  |
+| variables.rs:28:5:28:17 | CallExpr | variables.rs:23:23:29:1 | BlockExpr |  |
+| variables.rs:28:5:28:18 | ExprStmt | variables.rs:28:5:28:13 | PathExpr |  |
+| variables.rs:28:15:28:16 | x3 | variables.rs:28:5:28:17 | CallExpr |  |
+| variables.rs:31:1:39:1 | enter variable_shadow2 | variables.rs:32:5:32:17 | LetStmt |  |
+| variables.rs:31:1:39:1 | exit variable_shadow2 (normal) | variables.rs:31:1:39:1 | exit variable_shadow2 |  |
+| variables.rs:31:23:39:1 | BlockExpr | variables.rs:31:1:39:1 | exit variable_shadow2 (normal) |  |
+| variables.rs:32:5:32:17 | LetStmt | variables.rs:32:14:32:16 | "a" |  |
+| variables.rs:32:9:32:10 | x4 | variables.rs:33:5:33:18 | ExprStmt | match, no-match |
+| variables.rs:32:14:32:16 | "a" | variables.rs:32:9:32:10 | x4 |  |
+| variables.rs:33:5:33:13 | PathExpr | variables.rs:33:15:33:16 | x4 |  |
+| variables.rs:33:5:33:17 | CallExpr | variables.rs:34:5:37:5 | ExprStmt |  |
+| variables.rs:33:5:33:18 | ExprStmt | variables.rs:33:5:33:13 | PathExpr |  |
+| variables.rs:33:15:33:16 | x4 | variables.rs:33:5:33:17 | CallExpr |  |
+| variables.rs:34:5:37:5 | BlockExpr | variables.rs:38:5:38:18 | ExprStmt |  |
+| variables.rs:34:5:37:5 | ExprStmt | variables.rs:35:9:35:21 | LetStmt |  |
+| variables.rs:35:9:35:21 | LetStmt | variables.rs:35:18:35:20 | "b" |  |
+| variables.rs:35:13:35:14 | x4 | variables.rs:36:9:36:22 | ExprStmt | match, no-match |
+| variables.rs:35:18:35:20 | "b" | variables.rs:35:13:35:14 | x4 |  |
+| variables.rs:36:9:36:17 | PathExpr | variables.rs:36:19:36:20 | x4 |  |
+| variables.rs:36:9:36:21 | CallExpr | variables.rs:34:5:37:5 | BlockExpr |  |
+| variables.rs:36:9:36:22 | ExprStmt | variables.rs:36:9:36:17 | PathExpr |  |
+| variables.rs:36:19:36:20 | x4 | variables.rs:36:9:36:21 | CallExpr |  |
+| variables.rs:38:5:38:13 | PathExpr | variables.rs:38:15:38:16 | x4 |  |
+| variables.rs:38:5:38:17 | CallExpr | variables.rs:31:23:39:1 | BlockExpr |  |
+| variables.rs:38:5:38:18 | ExprStmt | variables.rs:38:5:38:13 | PathExpr |  |
+| variables.rs:38:15:38:16 | x4 | variables.rs:38:5:38:17 | CallExpr |  |
+| variables.rs:46:1:61:1 | enter let_pattern1 | variables.rs:47:5:56:47 | LetStmt |  |
+| variables.rs:46:1:61:1 | exit let_pattern1 (normal) | variables.rs:46:1:61:1 | exit let_pattern1 |  |
+| variables.rs:46:19:61:1 | BlockExpr | variables.rs:46:1:61:1 | exit let_pattern1 (normal) |  |
+| variables.rs:47:5:56:47 | LetStmt | variables.rs:56:11:56:13 | "a" |  |
+| variables.rs:47:9:56:5 | TuplePat | variables.rs:57:5:57:18 | ExprStmt | match |
+| variables.rs:56:9:56:46 | TupleExpr | variables.rs:47:9:56:5 | TuplePat |  |
+| variables.rs:56:10:56:19 | TupleExpr | variables.rs:56:33:56:35 | "x" |  |
+| variables.rs:56:11:56:13 | "a" | variables.rs:56:16:56:18 | "b" |  |
+| variables.rs:56:16:56:18 | "b" | variables.rs:56:10:56:19 | TupleExpr |  |
+| variables.rs:56:22:56:45 | RecordExpr | variables.rs:56:9:56:46 | TupleExpr |  |
+| variables.rs:56:33:56:35 | "x" | variables.rs:56:41:56:43 | "y" |  |
+| variables.rs:56:41:56:43 | "y" | variables.rs:56:22:56:45 | RecordExpr |  |
+| variables.rs:57:5:57:13 | PathExpr | variables.rs:57:15:57:16 | a1 |  |
+| variables.rs:57:5:57:17 | CallExpr | variables.rs:58:5:58:18 | ExprStmt |  |
+| variables.rs:57:5:57:18 | ExprStmt | variables.rs:57:5:57:13 | PathExpr |  |
+| variables.rs:57:15:57:16 | a1 | variables.rs:57:5:57:17 | CallExpr |  |
+| variables.rs:58:5:58:13 | PathExpr | variables.rs:58:15:58:16 | b1 |  |
+| variables.rs:58:5:58:17 | CallExpr | variables.rs:59:5:59:17 | ExprStmt |  |
+| variables.rs:58:5:58:18 | ExprStmt | variables.rs:58:5:58:13 | PathExpr |  |
+| variables.rs:58:15:58:16 | b1 | variables.rs:58:5:58:17 | CallExpr |  |
+| variables.rs:59:5:59:13 | PathExpr | variables.rs:59:15:59:15 | x |  |
+| variables.rs:59:5:59:16 | CallExpr | variables.rs:60:5:60:17 | ExprStmt |  |
+| variables.rs:59:5:59:17 | ExprStmt | variables.rs:59:5:59:13 | PathExpr |  |
+| variables.rs:59:15:59:15 | x | variables.rs:59:5:59:16 | CallExpr |  |
+| variables.rs:60:5:60:13 | PathExpr | variables.rs:60:15:60:15 | y |  |
+| variables.rs:60:5:60:16 | CallExpr | variables.rs:46:19:61:1 | BlockExpr |  |
+| variables.rs:60:5:60:17 | ExprStmt | variables.rs:60:5:60:13 | PathExpr |  |
+| variables.rs:60:15:60:15 | y | variables.rs:60:5:60:16 | CallExpr |  |
+| variables.rs:63:1:71:1 | enter let_pattern2 | variables.rs:64:5:64:38 | LetStmt |  |
+| variables.rs:63:1:71:1 | exit let_pattern2 (normal) | variables.rs:63:1:71:1 | exit let_pattern2 |  |
+| variables.rs:63:19:71:1 | BlockExpr | variables.rs:63:1:71:1 | exit let_pattern2 (normal) |  |
+| variables.rs:64:5:64:38 | LetStmt | variables.rs:64:25:64:27 | "a" |  |
+| variables.rs:64:9:64:10 | p1 | variables.rs:65:5:68:11 | LetStmt | match, no-match |
+| variables.rs:64:14:64:37 | RecordExpr | variables.rs:64:9:64:10 | p1 |  |
+| variables.rs:64:25:64:27 | "a" | variables.rs:64:33:64:35 | "b" |  |
+| variables.rs:64:33:64:35 | "b" | variables.rs:64:14:64:37 | RecordExpr |  |
+| variables.rs:65:5:68:11 | LetStmt | variables.rs:68:9:68:10 | p1 |  |
+| variables.rs:65:9:68:5 | RecordPat | variables.rs:69:5:69:18 | ExprStmt | match |
+| variables.rs:68:9:68:10 | p1 | variables.rs:65:9:68:5 | RecordPat |  |
+| variables.rs:69:5:69:13 | PathExpr | variables.rs:69:15:69:16 | a2 |  |
+| variables.rs:69:5:69:17 | CallExpr | variables.rs:70:5:70:18 | ExprStmt |  |
+| variables.rs:69:5:69:18 | ExprStmt | variables.rs:69:5:69:13 | PathExpr |  |
+| variables.rs:69:15:69:16 | a2 | variables.rs:69:5:69:17 | CallExpr |  |
+| variables.rs:70:5:70:13 | PathExpr | variables.rs:70:15:70:16 | b2 |  |
+| variables.rs:70:5:70:17 | CallExpr | variables.rs:63:19:71:1 | BlockExpr |  |
+| variables.rs:70:5:70:18 | ExprStmt | variables.rs:70:5:70:13 | PathExpr |  |
+| variables.rs:70:15:70:16 | b2 | variables.rs:70:5:70:17 | CallExpr |  |
+| variables.rs:73:1:80:1 | enter let_pattern3 | variables.rs:74:5:74:42 | LetStmt |  |
+| variables.rs:73:1:80:1 | exit let_pattern3 (normal) | variables.rs:73:1:80:1 | exit let_pattern3 |  |
+| variables.rs:73:19:80:1 | BlockExpr | variables.rs:73:1:80:1 | exit let_pattern3 (normal) |  |
+| variables.rs:74:5:74:42 | LetStmt | variables.rs:74:14:74:17 | PathExpr |  |
+| variables.rs:74:9:74:10 | s1 | variables.rs:76:8:77:12 | LetExpr | match, no-match |
+| variables.rs:74:14:74:17 | PathExpr | variables.rs:74:19:74:30 | PathExpr |  |
+| variables.rs:74:14:74:41 | CallExpr | variables.rs:74:9:74:10 | s1 |  |
+| variables.rs:74:19:74:30 | PathExpr | variables.rs:74:32:74:39 | "Hello!" |  |
+| variables.rs:74:19:74:40 | CallExpr | variables.rs:74:14:74:41 | CallExpr |  |
+| variables.rs:74:32:74:39 | "Hello!" | variables.rs:74:19:74:40 | CallExpr |  |
+| variables.rs:76:5:79:5 | IfExpr | variables.rs:73:19:80:1 | BlockExpr |  |
+| variables.rs:76:8:77:12 | LetExpr | variables.rs:76:12:76:23 | TupleStructPat |  |
+| variables.rs:76:12:76:23 | TupleStructPat | variables.rs:76:5:79:5 | IfExpr | no-match |
+| variables.rs:76:12:76:23 | TupleStructPat | variables.rs:78:9:78:22 | ExprStmt | match |
+| variables.rs:77:14:79:5 | BlockExpr | variables.rs:76:5:79:5 | IfExpr |  |
+| variables.rs:78:9:78:17 | PathExpr | variables.rs:78:19:78:20 | s2 |  |
+| variables.rs:78:9:78:21 | CallExpr | variables.rs:77:14:79:5 | BlockExpr |  |
+| variables.rs:78:9:78:22 | ExprStmt | variables.rs:78:9:78:17 | PathExpr |  |
+| variables.rs:78:19:78:20 | s2 | variables.rs:78:9:78:21 | CallExpr |  |
+| variables.rs:82:1:88:1 | enter let_pattern4 | variables.rs:83:5:86:10 | LetStmt |  |
+| variables.rs:82:1:88:1 | exit let_pattern4 (normal) | variables.rs:82:1:88:1 | exit let_pattern4 |  |
+| variables.rs:82:19:88:1 | BlockExpr | variables.rs:82:1:88:1 | exit let_pattern4 (normal) |  |
+| variables.rs:83:5:86:10 | LetStmt | variables.rs:83:34:83:37 | PathExpr |  |
+| variables.rs:83:9:83:16 | TupleStructPat | variables.rs:85:13:85:19 | MacroExpr | no-match |
+| variables.rs:83:9:83:16 | TupleStructPat | variables.rs:87:5:87:18 | ExprStmt | match |
+| variables.rs:83:34:83:37 | PathExpr | variables.rs:83:39:83:42 | "x5" |  |
+| variables.rs:83:34:83:43 | CallExpr | variables.rs:83:9:83:16 | TupleStructPat |  |
+| variables.rs:83:39:83:42 | "x5" | variables.rs:83:34:83:43 | CallExpr |  |
+| variables.rs:85:13:85:19 | MacroExpr | variables.rs:84:14:86:9 | BlockExpr |  |
+| variables.rs:87:5:87:13 | PathExpr | variables.rs:87:15:87:16 | x5 |  |
+| variables.rs:87:5:87:17 | CallExpr | variables.rs:82:19:88:1 | BlockExpr |  |
+| variables.rs:87:5:87:18 | ExprStmt | variables.rs:87:5:87:13 | PathExpr |  |
+| variables.rs:87:15:87:16 | x5 | variables.rs:87:5:87:17 | CallExpr |  |
+| variables.rs:90:1:97:1 | enter let_pattern5 | variables.rs:91:5:91:42 | LetStmt |  |
+| variables.rs:90:1:97:1 | exit let_pattern5 (normal) | variables.rs:90:1:97:1 | exit let_pattern5 |  |
+| variables.rs:90:19:97:1 | BlockExpr | variables.rs:90:1:97:1 | exit let_pattern5 (normal) |  |
+| variables.rs:91:5:91:42 | LetStmt | variables.rs:91:14:91:17 | PathExpr |  |
+| variables.rs:91:9:91:10 | s1 | variables.rs:93:11:94:12 | LetExpr | match, no-match |
+| variables.rs:91:14:91:17 | PathExpr | variables.rs:91:19:91:30 | PathExpr |  |
+| variables.rs:91:14:91:41 | CallExpr | variables.rs:91:9:91:10 | s1 |  |
+| variables.rs:91:19:91:30 | PathExpr | variables.rs:91:32:91:39 | "Hello!" |  |
+| variables.rs:91:19:91:40 | CallExpr | variables.rs:91:14:91:41 | CallExpr |  |
+| variables.rs:91:32:91:39 | "Hello!" | variables.rs:91:19:91:40 | CallExpr |  |
+| variables.rs:93:5:96:5 | WhileExpr | variables.rs:90:19:97:1 | BlockExpr |  |
+| variables.rs:93:11:94:12 | LetExpr | variables.rs:93:15:93:26 | TupleStructPat |  |
+| variables.rs:93:15:93:26 | TupleStructPat | variables.rs:93:5:96:5 | WhileExpr | no-match |
+| variables.rs:93:15:93:26 | TupleStructPat | variables.rs:95:9:95:22 | ExprStmt | match |
+| variables.rs:94:14:96:5 | BlockExpr | variables.rs:93:11:94:12 | LetExpr |  |
+| variables.rs:95:9:95:17 | PathExpr | variables.rs:95:19:95:20 | s2 |  |
+| variables.rs:95:9:95:21 | CallExpr | variables.rs:94:14:96:5 | BlockExpr |  |
+| variables.rs:95:9:95:22 | ExprStmt | variables.rs:95:9:95:17 | PathExpr |  |
+| variables.rs:95:19:95:20 | s2 | variables.rs:95:9:95:21 | CallExpr |  |
+| variables.rs:99:1:114:1 | enter match_pattern1 | variables.rs:100:5:100:21 | LetStmt |  |
+| variables.rs:99:1:114:1 | exit match_pattern1 (normal) | variables.rs:99:1:114:1 | exit match_pattern1 |  |
+| variables.rs:99:21:114:1 | BlockExpr | variables.rs:99:1:114:1 | exit match_pattern1 (normal) |  |
+| variables.rs:100:5:100:21 | LetStmt | variables.rs:100:14:100:17 | PathExpr |  |
+| variables.rs:100:9:100:10 | x6 | variables.rs:101:5:101:16 | LetStmt | match, no-match |
+| variables.rs:100:14:100:17 | PathExpr | variables.rs:100:19:100:19 | 5 |  |
+| variables.rs:100:14:100:20 | CallExpr | variables.rs:100:9:100:10 | x6 |  |
+| variables.rs:100:19:100:19 | 5 | variables.rs:100:14:100:20 | CallExpr |  |
+| variables.rs:101:5:101:16 | LetStmt | variables.rs:101:14:101:15 | 10 |  |
+| variables.rs:101:9:101:10 | y1 | variables.rs:103:5:111:5 | ExprStmt | match, no-match |
+| variables.rs:101:14:101:15 | 10 | variables.rs:101:9:101:10 | y1 |  |
+| variables.rs:103:5:111:5 | ExprStmt | variables.rs:103:11:103:12 | x6 |  |
+| variables.rs:103:5:111:5 | MatchExpr | variables.rs:113:5:113:18 | ExprStmt |  |
+| variables.rs:103:11:103:12 | x6 | variables.rs:104:9:104:16 | TupleStructPat |  |
+| variables.rs:104:9:104:16 | TupleStructPat | variables.rs:104:21:104:29 | PathExpr | match |
+| variables.rs:104:9:104:16 | TupleStructPat | variables.rs:105:9:105:16 | TupleStructPat | no-match |
+| variables.rs:104:21:104:29 | PathExpr | variables.rs:104:31:104:38 | "Got 50" |  |
+| variables.rs:104:21:104:39 | CallExpr | variables.rs:103:5:111:5 | MatchExpr |  |
+| variables.rs:104:31:104:38 | "Got 50" | variables.rs:104:21:104:39 | CallExpr |  |
+| variables.rs:105:9:105:16 | TupleStructPat | variables.rs:108:13:108:21 | PathExpr | match |
+| variables.rs:105:9:105:16 | TupleStructPat | variables.rs:110:9:110:12 | None | no-match |
+| variables.rs:107:9:109:9 | BlockExpr | variables.rs:103:5:111:5 | MatchExpr |  |
+| variables.rs:108:13:108:21 | PathExpr | variables.rs:108:23:108:24 | y1 |  |
+| variables.rs:108:13:108:25 | CallExpr | variables.rs:107:9:109:9 | BlockExpr |  |
+| variables.rs:108:23:108:24 | y1 | variables.rs:108:13:108:25 | CallExpr |  |
+| variables.rs:110:9:110:12 | None | variables.rs:110:17:110:25 | PathExpr | match |
+| variables.rs:110:17:110:25 | PathExpr | variables.rs:110:27:110:32 | "NONE" |  |
+| variables.rs:110:17:110:33 | CallExpr | variables.rs:103:5:111:5 | MatchExpr |  |
+| variables.rs:110:27:110:32 | "NONE" | variables.rs:110:17:110:33 | CallExpr |  |
+| variables.rs:113:5:113:13 | PathExpr | variables.rs:113:15:113:16 | y1 |  |
+| variables.rs:113:5:113:17 | CallExpr | variables.rs:99:21:114:1 | BlockExpr |  |
+| variables.rs:113:5:113:18 | ExprStmt | variables.rs:113:5:113:13 | PathExpr |  |
+| variables.rs:113:15:113:16 | y1 | variables.rs:113:5:113:17 | CallExpr |  |
+| variables.rs:116:1:141:1 | enter match_pattern2 | variables.rs:117:5:117:36 | LetStmt |  |
+| variables.rs:116:1:141:1 | exit match_pattern2 (normal) | variables.rs:116:1:141:1 | exit match_pattern2 |  |
+| variables.rs:116:21:141:1 | BlockExpr | variables.rs:116:1:141:1 | exit match_pattern2 (normal) |  |
+| variables.rs:117:5:117:36 | LetStmt | variables.rs:117:20:117:20 | 2 |  |
+| variables.rs:117:9:117:15 | numbers | variables.rs:119:5:129:5 | ExprStmt | match, no-match |
+| variables.rs:117:19:117:35 | TupleExpr | variables.rs:117:9:117:15 | numbers |  |
+| variables.rs:117:20:117:20 | 2 | variables.rs:117:23:117:23 | 4 |  |
+| variables.rs:117:23:117:23 | 4 | variables.rs:117:26:117:26 | 8 |  |
+| variables.rs:117:26:117:26 | 8 | variables.rs:117:29:117:30 | 16 |  |
+| variables.rs:117:29:117:30 | 16 | variables.rs:117:33:117:34 | 32 |  |
+| variables.rs:117:33:117:34 | 32 | variables.rs:117:19:117:35 | TupleExpr |  |
+| variables.rs:119:5:129:5 | ExprStmt | variables.rs:119:11:119:17 | numbers |  |
+| variables.rs:119:5:129:5 | MatchExpr | variables.rs:131:11:131:17 | numbers |  |
+| variables.rs:119:11:119:17 | numbers | variables.rs:120:9:124:9 | TuplePat |  |
+| variables.rs:120:9:124:9 | TuplePat | variables.rs:125:13:125:29 | ExprStmt | match |
+| variables.rs:124:14:128:9 | BlockExpr | variables.rs:119:5:129:5 | MatchExpr |  |
+| variables.rs:125:13:125:21 | PathExpr | variables.rs:125:23:125:27 | first |  |
+| variables.rs:125:13:125:28 | CallExpr | variables.rs:126:13:126:29 | ExprStmt |  |
 | variables.rs:125:13:125:29 | ExprStmt | variables.rs:125:13:125:21 | PathExpr |  |
-| variables.rs:125:23:125:27 | fifth | variables.rs:125:13:125:28 | CallExpr |  |
-| variables.rs:129:5:138:5 | MatchExpr | variables.rs:114:21:139:1 | BlockExpr |  |
-| variables.rs:129:11:129:17 | numbers | variables.rs:130:9:134:9 | TuplePat |  |
-| variables.rs:130:9:134:9 | TuplePat | variables.rs:135:13:135:29 | ExprStmt | match |
-| variables.rs:134:14:137:9 | BlockExpr | variables.rs:129:5:138:5 | MatchExpr |  |
-| variables.rs:135:13:135:21 | PathExpr | variables.rs:135:23:135:27 | first |  |
-| variables.rs:135:13:135:28 | CallExpr | variables.rs:136:13:136:28 | ExprStmt |  |
-| variables.rs:135:13:135:29 | ExprStmt | variables.rs:135:13:135:21 | PathExpr |  |
-| variables.rs:135:23:135:27 | first | variables.rs:135:13:135:28 | CallExpr |  |
-| variables.rs:136:13:136:21 | PathExpr | variables.rs:136:23:136:26 | last |  |
-| variables.rs:136:13:136:27 | CallExpr | variables.rs:134:14:137:9 | BlockExpr |  |
-| variables.rs:136:13:136:28 | ExprStmt | variables.rs:136:13:136:21 | PathExpr |  |
-| variables.rs:136:23:136:26 | last | variables.rs:136:13:136:27 | CallExpr |  |
-| variables.rs:141:1:149:1 | enter match_pattern3 | variables.rs:142:5:142:38 | LetStmt |  |
-| variables.rs:141:1:149:1 | exit match_pattern3 (normal) | variables.rs:141:1:149:1 | exit match_pattern3 |  |
-| variables.rs:141:21:149:1 | BlockExpr | variables.rs:141:1:149:1 | exit match_pattern3 (normal) |  |
-| variables.rs:142:5:142:38 | LetStmt | variables.rs:142:25:142:27 | "x" |  |
-| variables.rs:142:9:142:10 | p2 | variables.rs:144:11:144:12 | p2 | match, no-match |
-| variables.rs:142:14:142:37 | RecordExpr | variables.rs:142:9:142:10 | p2 |  |
-| variables.rs:142:25:142:27 | "x" | variables.rs:142:33:142:35 | "y" |  |
-| variables.rs:142:33:142:35 | "y" | variables.rs:142:14:142:37 | RecordExpr |  |
-| variables.rs:144:5:148:5 | MatchExpr | variables.rs:141:21:149:1 | BlockExpr |  |
-| variables.rs:144:11:144:12 | p2 | variables.rs:145:9:147:9 | RecordPat |  |
-| variables.rs:145:9:147:9 | RecordPat | variables.rs:147:14:147:22 | PathExpr | match |
-| variables.rs:147:14:147:22 | PathExpr | variables.rs:147:24:147:25 | x7 |  |
-| variables.rs:147:14:147:26 | CallExpr | variables.rs:144:5:148:5 | MatchExpr |  |
-| variables.rs:147:24:147:25 | x7 | variables.rs:147:14:147:26 | CallExpr |  |
-| variables.rs:155:1:168:1 | enter match_pattern4 | variables.rs:156:5:156:39 | LetStmt |  |
-| variables.rs:155:1:168:1 | exit match_pattern4 (normal) | variables.rs:155:1:168:1 | exit match_pattern4 |  |
-| variables.rs:155:21:168:1 | BlockExpr | variables.rs:155:1:168:1 | exit match_pattern4 (normal) |  |
-| variables.rs:156:5:156:39 | LetStmt | variables.rs:156:36:156:36 | 0 |  |
-| variables.rs:156:9:156:11 | msg | variables.rs:158:11:158:13 | msg | match, no-match |
-| variables.rs:156:15:156:38 | RecordExpr | variables.rs:156:9:156:11 | msg |  |
-| variables.rs:156:36:156:36 | 0 | variables.rs:156:15:156:38 | RecordExpr |  |
-| variables.rs:158:5:167:5 | MatchExpr | variables.rs:155:21:168:1 | BlockExpr |  |
-| variables.rs:158:11:158:13 | msg | variables.rs:159:9:161:9 | RecordPat |  |
-| variables.rs:159:9:161:9 | RecordPat | variables.rs:161:14:161:22 | PathExpr | match |
-| variables.rs:159:9:161:9 | RecordPat | variables.rs:162:9:162:38 | RecordPat | no-match |
-| variables.rs:161:14:161:22 | PathExpr | variables.rs:161:24:161:34 | id_variable |  |
-| variables.rs:161:14:161:35 | CallExpr | variables.rs:158:5:167:5 | MatchExpr |  |
-| variables.rs:161:24:161:34 | id_variable | variables.rs:161:14:161:35 | CallExpr |  |
-| variables.rs:162:9:162:38 | RecordPat | variables.rs:163:13:163:52 | MacroExpr | match |
-| variables.rs:162:9:162:38 | RecordPat | variables.rs:165:9:165:29 | RecordPat | no-match |
-| variables.rs:162:43:164:9 | BlockExpr | variables.rs:158:5:167:5 | MatchExpr |  |
-| variables.rs:163:13:163:52 | MacroExpr | variables.rs:162:43:164:9 | BlockExpr |  |
-| variables.rs:165:9:165:29 | RecordPat | variables.rs:166:13:166:21 | PathExpr | match |
-| variables.rs:166:13:166:21 | PathExpr | variables.rs:166:23:166:24 | id |  |
-| variables.rs:166:13:166:25 | CallExpr | variables.rs:158:5:167:5 | MatchExpr |  |
-| variables.rs:166:23:166:24 | id | variables.rs:166:13:166:25 | CallExpr |  |
-| variables.rs:175:1:181:1 | enter match_pattern5 | variables.rs:176:5:176:34 | LetStmt |  |
-| variables.rs:175:1:181:1 | exit match_pattern5 (normal) | variables.rs:175:1:181:1 | exit match_pattern5 |  |
-| variables.rs:175:21:181:1 | BlockExpr | variables.rs:175:1:181:1 | exit match_pattern5 (normal) |  |
-| variables.rs:176:5:176:34 | LetStmt | variables.rs:176:18:176:29 | PathExpr |  |
-| variables.rs:176:9:176:14 | either | variables.rs:177:11:177:16 | either | match, no-match |
-| variables.rs:176:18:176:29 | PathExpr | variables.rs:176:31:176:32 | 32 |  |
-| variables.rs:176:18:176:33 | CallExpr | variables.rs:176:9:176:14 | either |  |
-| variables.rs:176:31:176:32 | 32 | variables.rs:176:18:176:33 | CallExpr |  |
-| variables.rs:177:5:180:5 | MatchExpr | variables.rs:175:21:181:1 | BlockExpr |  |
-| variables.rs:177:11:177:16 | either | variables.rs:178:9:178:44 | OrPat |  |
-| variables.rs:178:9:178:44 | OrPat | variables.rs:179:16:179:24 | PathExpr | match |
-| variables.rs:179:16:179:24 | PathExpr | variables.rs:179:26:179:27 | a3 |  |
-| variables.rs:179:16:179:28 | CallExpr | variables.rs:177:5:180:5 | MatchExpr |  |
-| variables.rs:179:26:179:27 | a3 | variables.rs:179:16:179:28 | CallExpr |  |
-| variables.rs:189:1:203:1 | enter match_pattern6 | variables.rs:190:5:190:37 | LetStmt |  |
-| variables.rs:189:1:203:1 | exit match_pattern6 (normal) | variables.rs:189:1:203:1 | exit match_pattern6 |  |
-| variables.rs:189:21:203:1 | BlockExpr | variables.rs:189:1:203:1 | exit match_pattern6 (normal) |  |
-| variables.rs:190:5:190:37 | LetStmt | variables.rs:190:14:190:32 | PathExpr |  |
-| variables.rs:190:9:190:10 | tv | variables.rs:191:5:194:5 | ExprStmt | match, no-match |
-| variables.rs:190:14:190:32 | PathExpr | variables.rs:190:34:190:35 | 62 |  |
-| variables.rs:190:14:190:36 | CallExpr | variables.rs:190:9:190:10 | tv |  |
-| variables.rs:190:34:190:35 | 62 | variables.rs:190:14:190:36 | CallExpr |  |
-| variables.rs:191:5:194:5 | ExprStmt | variables.rs:191:11:191:12 | tv |  |
-| variables.rs:191:5:194:5 | MatchExpr | variables.rs:195:5:198:5 | ExprStmt |  |
-| variables.rs:191:11:191:12 | tv | variables.rs:192:9:192:81 | OrPat |  |
-| variables.rs:192:9:192:81 | OrPat | variables.rs:193:16:193:24 | PathExpr | match |
-| variables.rs:193:16:193:24 | PathExpr | variables.rs:193:26:193:27 | a4 |  |
-| variables.rs:193:16:193:28 | CallExpr | variables.rs:191:5:194:5 | MatchExpr |  |
-| variables.rs:193:26:193:27 | a4 | variables.rs:193:16:193:28 | CallExpr |  |
-| variables.rs:195:5:198:5 | ExprStmt | variables.rs:195:11:195:12 | tv |  |
-| variables.rs:195:5:198:5 | MatchExpr | variables.rs:199:11:199:12 | tv |  |
-| variables.rs:195:11:195:12 | tv | variables.rs:196:9:196:83 | OrPat |  |
-| variables.rs:196:9:196:83 | OrPat | variables.rs:197:16:197:24 | PathExpr | match |
-| variables.rs:197:16:197:24 | PathExpr | variables.rs:197:26:197:27 | a5 |  |
-| variables.rs:197:16:197:28 | CallExpr | variables.rs:195:5:198:5 | MatchExpr |  |
-| variables.rs:197:26:197:27 | a5 | variables.rs:197:16:197:28 | CallExpr |  |
-| variables.rs:199:5:202:5 | MatchExpr | variables.rs:189:21:203:1 | BlockExpr |  |
-| variables.rs:199:11:199:12 | tv | variables.rs:200:9:200:83 | OrPat |  |
-| variables.rs:200:9:200:83 | OrPat | variables.rs:201:16:201:24 | PathExpr | match |
-| variables.rs:201:16:201:24 | PathExpr | variables.rs:201:26:201:27 | a6 |  |
-| variables.rs:201:16:201:28 | CallExpr | variables.rs:199:5:202:5 | MatchExpr |  |
-| variables.rs:201:26:201:27 | a6 | variables.rs:201:16:201:28 | CallExpr |  |
-| variables.rs:205:1:213:1 | enter match_pattern7 | variables.rs:206:5:206:34 | LetStmt |  |
-| variables.rs:205:1:213:1 | exit match_pattern7 (normal) | variables.rs:205:1:213:1 | exit match_pattern7 |  |
-| variables.rs:205:21:213:1 | BlockExpr | variables.rs:205:1:213:1 | exit match_pattern7 (normal) |  |
-| variables.rs:206:5:206:34 | LetStmt | variables.rs:206:18:206:29 | PathExpr |  |
-| variables.rs:206:9:206:14 | either | variables.rs:207:11:207:16 | either | match, no-match |
-| variables.rs:206:18:206:29 | PathExpr | variables.rs:206:31:206:32 | 32 |  |
-| variables.rs:206:18:206:33 | CallExpr | variables.rs:206:9:206:14 | either |  |
-| variables.rs:206:31:206:32 | 32 | variables.rs:206:18:206:33 | CallExpr |  |
-| variables.rs:207:5:212:5 | MatchExpr | variables.rs:205:21:213:1 | BlockExpr |  |
-| variables.rs:207:11:207:16 | either | variables.rs:208:9:208:44 | OrPat |  |
-| variables.rs:208:9:208:44 | OrPat | variables.rs:209:16:209:17 | a7 | match |
-| variables.rs:208:9:208:44 | OrPat | variables.rs:211:9:211:9 | WildcardPat | no-match |
-| variables.rs:209:16:209:17 | a7 | variables.rs:209:21:209:21 | 0 |  |
-| variables.rs:209:16:209:21 | ... > ... | variables.rs:210:16:210:24 | PathExpr | true |
-| variables.rs:209:16:209:21 | ... > ... | variables.rs:211:9:211:9 | WildcardPat | false |
-| variables.rs:209:21:209:21 | 0 | variables.rs:209:16:209:21 | ... > ... |  |
-| variables.rs:210:16:210:24 | PathExpr | variables.rs:210:26:210:27 | a7 |  |
-| variables.rs:210:16:210:28 | CallExpr | variables.rs:207:5:212:5 | MatchExpr |  |
-| variables.rs:210:26:210:27 | a7 | variables.rs:210:16:210:28 | CallExpr |  |
-| variables.rs:211:9:211:9 | WildcardPat | variables.rs:211:14:211:15 | TupleExpr | match |
-| variables.rs:211:14:211:15 | TupleExpr | variables.rs:207:5:212:5 | MatchExpr |  |
-| variables.rs:215:1:230:1 | enter match_pattern8 | variables.rs:216:5:216:34 | LetStmt |  |
-| variables.rs:215:1:230:1 | exit match_pattern8 (normal) | variables.rs:215:1:230:1 | exit match_pattern8 |  |
-| variables.rs:215:21:230:1 | BlockExpr | variables.rs:215:1:230:1 | exit match_pattern8 (normal) |  |
-| variables.rs:216:5:216:34 | LetStmt | variables.rs:216:18:216:29 | PathExpr |  |
-| variables.rs:216:9:216:14 | either | variables.rs:218:11:218:16 | either | match, no-match |
-| variables.rs:216:18:216:29 | PathExpr | variables.rs:216:31:216:32 | 32 |  |
-| variables.rs:216:18:216:33 | CallExpr | variables.rs:216:9:216:14 | either |  |
-| variables.rs:216:31:216:32 | 32 | variables.rs:216:18:216:33 | CallExpr |  |
-| variables.rs:218:5:229:5 | MatchExpr | variables.rs:215:21:230:1 | BlockExpr |  |
-| variables.rs:218:11:218:16 | either | variables.rs:219:9:220:52 | e |  |
-| variables.rs:219:9:220:52 | e | variables.rs:222:13:222:27 | ExprStmt | match |
-| variables.rs:219:9:220:52 | e | variables.rs:228:9:228:9 | WildcardPat | no-match |
-| variables.rs:221:12:227:9 | BlockExpr | variables.rs:218:5:229:5 | MatchExpr |  |
-| variables.rs:222:13:222:21 | PathExpr | variables.rs:222:23:222:25 | a11 |  |
-| variables.rs:222:13:222:26 | CallExpr | variables.rs:223:16:224:15 | LetExpr |  |
-| variables.rs:222:13:222:27 | ExprStmt | variables.rs:222:13:222:21 | PathExpr |  |
-| variables.rs:222:23:222:25 | a11 | variables.rs:222:13:222:26 | CallExpr |  |
-| variables.rs:223:13:226:13 | IfExpr | variables.rs:221:12:227:9 | BlockExpr |  |
-| variables.rs:223:16:224:15 | LetExpr | variables.rs:223:20:223:36 | TupleStructPat |  |
-| variables.rs:223:20:223:36 | TupleStructPat | variables.rs:223:13:226:13 | IfExpr | no-match |
-| variables.rs:223:20:223:36 | TupleStructPat | variables.rs:225:17:225:32 | ExprStmt | match |
-| variables.rs:224:17:226:13 | BlockExpr | variables.rs:223:13:226:13 | IfExpr |  |
-| variables.rs:225:17:225:25 | PathExpr | variables.rs:225:28:225:30 | a12 |  |
-| variables.rs:225:17:225:31 | CallExpr | variables.rs:224:17:226:13 | BlockExpr |  |
-| variables.rs:225:17:225:32 | ExprStmt | variables.rs:225:17:225:25 | PathExpr |  |
-| variables.rs:225:27:225:30 | * ... | variables.rs:225:17:225:31 | CallExpr |  |
-| variables.rs:225:28:225:30 | a12 | variables.rs:225:27:225:30 | * ... |  |
-| variables.rs:228:9:228:9 | WildcardPat | variables.rs:228:14:228:15 | TupleExpr | match |
-| variables.rs:228:14:228:15 | TupleExpr | variables.rs:218:5:229:5 | MatchExpr |  |
-| variables.rs:239:1:245:1 | enter match_pattern9 | variables.rs:240:5:240:36 | LetStmt |  |
-| variables.rs:239:1:245:1 | exit match_pattern9 (normal) | variables.rs:239:1:245:1 | exit match_pattern9 |  |
-| variables.rs:239:21:245:1 | BlockExpr | variables.rs:239:1:245:1 | exit match_pattern9 (normal) |  |
-| variables.rs:240:5:240:36 | LetStmt | variables.rs:240:14:240:31 | PathExpr |  |
-| variables.rs:240:9:240:10 | fv | variables.rs:241:11:241:12 | fv | match, no-match |
-| variables.rs:240:14:240:31 | PathExpr | variables.rs:240:33:240:34 | 62 |  |
-| variables.rs:240:14:240:35 | CallExpr | variables.rs:240:9:240:10 | fv |  |
-| variables.rs:240:33:240:34 | 62 | variables.rs:240:14:240:35 | CallExpr |  |
-| variables.rs:241:5:244:5 | MatchExpr | variables.rs:239:21:245:1 | BlockExpr |  |
-| variables.rs:241:11:241:12 | fv | variables.rs:242:9:242:109 | OrPat |  |
-| variables.rs:242:9:242:109 | OrPat | variables.rs:243:16:243:24 | PathExpr | match |
-| variables.rs:243:16:243:24 | PathExpr | variables.rs:243:26:243:28 | a13 |  |
-| variables.rs:243:16:243:29 | CallExpr | variables.rs:241:5:244:5 | MatchExpr |  |
-| variables.rs:243:26:243:28 | a13 | variables.rs:243:16:243:29 | CallExpr |  |
-| variables.rs:247:1:256:1 | enter param_pattern1 | variables.rs:253:5:253:18 | ExprStmt |  |
-| variables.rs:247:1:256:1 | exit param_pattern1 (normal) | variables.rs:247:1:256:1 | exit param_pattern1 |  |
-| variables.rs:252:28:256:1 | BlockExpr | variables.rs:247:1:256:1 | exit param_pattern1 (normal) |  |
-| variables.rs:253:5:253:13 | PathExpr | variables.rs:253:15:253:16 | a8 |  |
-| variables.rs:253:5:253:17 | CallExpr | variables.rs:254:5:254:18 | ExprStmt |  |
-| variables.rs:253:5:253:18 | ExprStmt | variables.rs:253:5:253:13 | PathExpr |  |
-| variables.rs:253:15:253:16 | a8 | variables.rs:253:5:253:17 | CallExpr |  |
-| variables.rs:254:5:254:13 | PathExpr | variables.rs:254:15:254:16 | b3 |  |
-| variables.rs:254:5:254:17 | CallExpr | variables.rs:255:5:255:18 | ExprStmt |  |
-| variables.rs:254:5:254:18 | ExprStmt | variables.rs:254:5:254:13 | PathExpr |  |
-| variables.rs:254:15:254:16 | b3 | variables.rs:254:5:254:17 | CallExpr |  |
-| variables.rs:255:5:255:13 | PathExpr | variables.rs:255:15:255:16 | c1 |  |
-| variables.rs:255:5:255:17 | CallExpr | variables.rs:252:28:256:1 | BlockExpr |  |
+| variables.rs:125:23:125:27 | first | variables.rs:125:13:125:28 | CallExpr |  |
+| variables.rs:126:13:126:21 | PathExpr | variables.rs:126:23:126:27 | third |  |
+| variables.rs:126:13:126:28 | CallExpr | variables.rs:127:13:127:29 | ExprStmt |  |
+| variables.rs:126:13:126:29 | ExprStmt | variables.rs:126:13:126:21 | PathExpr |  |
+| variables.rs:126:23:126:27 | third | variables.rs:126:13:126:28 | CallExpr |  |
+| variables.rs:127:13:127:21 | PathExpr | variables.rs:127:23:127:27 | fifth |  |
+| variables.rs:127:13:127:28 | CallExpr | variables.rs:124:14:128:9 | BlockExpr |  |
+| variables.rs:127:13:127:29 | ExprStmt | variables.rs:127:13:127:21 | PathExpr |  |
+| variables.rs:127:23:127:27 | fifth | variables.rs:127:13:127:28 | CallExpr |  |
+| variables.rs:131:5:140:5 | MatchExpr | variables.rs:116:21:141:1 | BlockExpr |  |
+| variables.rs:131:11:131:17 | numbers | variables.rs:132:9:136:9 | TuplePat |  |
+| variables.rs:132:9:136:9 | TuplePat | variables.rs:137:13:137:29 | ExprStmt | match |
+| variables.rs:136:14:139:9 | BlockExpr | variables.rs:131:5:140:5 | MatchExpr |  |
+| variables.rs:137:13:137:21 | PathExpr | variables.rs:137:23:137:27 | first |  |
+| variables.rs:137:13:137:28 | CallExpr | variables.rs:138:13:138:28 | ExprStmt |  |
+| variables.rs:137:13:137:29 | ExprStmt | variables.rs:137:13:137:21 | PathExpr |  |
+| variables.rs:137:23:137:27 | first | variables.rs:137:13:137:28 | CallExpr |  |
+| variables.rs:138:13:138:21 | PathExpr | variables.rs:138:23:138:26 | last |  |
+| variables.rs:138:13:138:27 | CallExpr | variables.rs:136:14:139:9 | BlockExpr |  |
+| variables.rs:138:13:138:28 | ExprStmt | variables.rs:138:13:138:21 | PathExpr |  |
+| variables.rs:138:23:138:26 | last | variables.rs:138:13:138:27 | CallExpr |  |
+| variables.rs:143:1:151:1 | enter match_pattern3 | variables.rs:144:5:144:38 | LetStmt |  |
+| variables.rs:143:1:151:1 | exit match_pattern3 (normal) | variables.rs:143:1:151:1 | exit match_pattern3 |  |
+| variables.rs:143:21:151:1 | BlockExpr | variables.rs:143:1:151:1 | exit match_pattern3 (normal) |  |
+| variables.rs:144:5:144:38 | LetStmt | variables.rs:144:25:144:27 | "x" |  |
+| variables.rs:144:9:144:10 | p2 | variables.rs:146:11:146:12 | p2 | match, no-match |
+| variables.rs:144:14:144:37 | RecordExpr | variables.rs:144:9:144:10 | p2 |  |
+| variables.rs:144:25:144:27 | "x" | variables.rs:144:33:144:35 | "y" |  |
+| variables.rs:144:33:144:35 | "y" | variables.rs:144:14:144:37 | RecordExpr |  |
+| variables.rs:146:5:150:5 | MatchExpr | variables.rs:143:21:151:1 | BlockExpr |  |
+| variables.rs:146:11:146:12 | p2 | variables.rs:147:9:149:9 | RecordPat |  |
+| variables.rs:147:9:149:9 | RecordPat | variables.rs:149:14:149:22 | PathExpr | match |
+| variables.rs:149:14:149:22 | PathExpr | variables.rs:149:24:149:25 | x7 |  |
+| variables.rs:149:14:149:26 | CallExpr | variables.rs:146:5:150:5 | MatchExpr |  |
+| variables.rs:149:24:149:25 | x7 | variables.rs:149:14:149:26 | CallExpr |  |
+| variables.rs:157:1:170:1 | enter match_pattern4 | variables.rs:158:5:158:39 | LetStmt |  |
+| variables.rs:157:1:170:1 | exit match_pattern4 (normal) | variables.rs:157:1:170:1 | exit match_pattern4 |  |
+| variables.rs:157:21:170:1 | BlockExpr | variables.rs:157:1:170:1 | exit match_pattern4 (normal) |  |
+| variables.rs:158:5:158:39 | LetStmt | variables.rs:158:36:158:36 | 0 |  |
+| variables.rs:158:9:158:11 | msg | variables.rs:160:11:160:13 | msg | match, no-match |
+| variables.rs:158:15:158:38 | RecordExpr | variables.rs:158:9:158:11 | msg |  |
+| variables.rs:158:36:158:36 | 0 | variables.rs:158:15:158:38 | RecordExpr |  |
+| variables.rs:160:5:169:5 | MatchExpr | variables.rs:157:21:170:1 | BlockExpr |  |
+| variables.rs:160:11:160:13 | msg | variables.rs:161:9:163:9 | RecordPat |  |
+| variables.rs:161:9:163:9 | RecordPat | variables.rs:163:14:163:22 | PathExpr | match |
+| variables.rs:161:9:163:9 | RecordPat | variables.rs:164:9:164:38 | RecordPat | no-match |
+| variables.rs:163:14:163:22 | PathExpr | variables.rs:163:24:163:34 | id_variable |  |
+| variables.rs:163:14:163:35 | CallExpr | variables.rs:160:5:169:5 | MatchExpr |  |
+| variables.rs:163:24:163:34 | id_variable | variables.rs:163:14:163:35 | CallExpr |  |
+| variables.rs:164:9:164:38 | RecordPat | variables.rs:165:13:165:52 | MacroExpr | match |
+| variables.rs:164:9:164:38 | RecordPat | variables.rs:167:9:167:29 | RecordPat | no-match |
+| variables.rs:164:43:166:9 | BlockExpr | variables.rs:160:5:169:5 | MatchExpr |  |
+| variables.rs:165:13:165:52 | MacroExpr | variables.rs:164:43:166:9 | BlockExpr |  |
+| variables.rs:167:9:167:29 | RecordPat | variables.rs:168:13:168:21 | PathExpr | match |
+| variables.rs:168:13:168:21 | PathExpr | variables.rs:168:23:168:24 | id |  |
+| variables.rs:168:13:168:25 | CallExpr | variables.rs:160:5:169:5 | MatchExpr |  |
+| variables.rs:168:23:168:24 | id | variables.rs:168:13:168:25 | CallExpr |  |
+| variables.rs:177:1:183:1 | enter match_pattern5 | variables.rs:178:5:178:34 | LetStmt |  |
+| variables.rs:177:1:183:1 | exit match_pattern5 (normal) | variables.rs:177:1:183:1 | exit match_pattern5 |  |
+| variables.rs:177:21:183:1 | BlockExpr | variables.rs:177:1:183:1 | exit match_pattern5 (normal) |  |
+| variables.rs:178:5:178:34 | LetStmt | variables.rs:178:18:178:29 | PathExpr |  |
+| variables.rs:178:9:178:14 | either | variables.rs:179:11:179:16 | either | match, no-match |
+| variables.rs:178:18:178:29 | PathExpr | variables.rs:178:31:178:32 | 32 |  |
+| variables.rs:178:18:178:33 | CallExpr | variables.rs:178:9:178:14 | either |  |
+| variables.rs:178:31:178:32 | 32 | variables.rs:178:18:178:33 | CallExpr |  |
+| variables.rs:179:5:182:5 | MatchExpr | variables.rs:177:21:183:1 | BlockExpr |  |
+| variables.rs:179:11:179:16 | either | variables.rs:180:9:180:44 | OrPat |  |
+| variables.rs:180:9:180:44 | OrPat | variables.rs:181:16:181:24 | PathExpr | match |
+| variables.rs:181:16:181:24 | PathExpr | variables.rs:181:26:181:27 | a3 |  |
+| variables.rs:181:16:181:28 | CallExpr | variables.rs:179:5:182:5 | MatchExpr |  |
+| variables.rs:181:26:181:27 | a3 | variables.rs:181:16:181:28 | CallExpr |  |
+| variables.rs:191:1:205:1 | enter match_pattern6 | variables.rs:192:5:192:37 | LetStmt |  |
+| variables.rs:191:1:205:1 | exit match_pattern6 (normal) | variables.rs:191:1:205:1 | exit match_pattern6 |  |
+| variables.rs:191:21:205:1 | BlockExpr | variables.rs:191:1:205:1 | exit match_pattern6 (normal) |  |
+| variables.rs:192:5:192:37 | LetStmt | variables.rs:192:14:192:32 | PathExpr |  |
+| variables.rs:192:9:192:10 | tv | variables.rs:193:5:196:5 | ExprStmt | match, no-match |
+| variables.rs:192:14:192:32 | PathExpr | variables.rs:192:34:192:35 | 62 |  |
+| variables.rs:192:14:192:36 | CallExpr | variables.rs:192:9:192:10 | tv |  |
+| variables.rs:192:34:192:35 | 62 | variables.rs:192:14:192:36 | CallExpr |  |
+| variables.rs:193:5:196:5 | ExprStmt | variables.rs:193:11:193:12 | tv |  |
+| variables.rs:193:5:196:5 | MatchExpr | variables.rs:197:5:200:5 | ExprStmt |  |
+| variables.rs:193:11:193:12 | tv | variables.rs:194:9:194:81 | OrPat |  |
+| variables.rs:194:9:194:81 | OrPat | variables.rs:195:16:195:24 | PathExpr | match |
+| variables.rs:195:16:195:24 | PathExpr | variables.rs:195:26:195:27 | a4 |  |
+| variables.rs:195:16:195:28 | CallExpr | variables.rs:193:5:196:5 | MatchExpr |  |
+| variables.rs:195:26:195:27 | a4 | variables.rs:195:16:195:28 | CallExpr |  |
+| variables.rs:197:5:200:5 | ExprStmt | variables.rs:197:11:197:12 | tv |  |
+| variables.rs:197:5:200:5 | MatchExpr | variables.rs:201:11:201:12 | tv |  |
+| variables.rs:197:11:197:12 | tv | variables.rs:198:9:198:83 | OrPat |  |
+| variables.rs:198:9:198:83 | OrPat | variables.rs:199:16:199:24 | PathExpr | match |
+| variables.rs:199:16:199:24 | PathExpr | variables.rs:199:26:199:27 | a5 |  |
+| variables.rs:199:16:199:28 | CallExpr | variables.rs:197:5:200:5 | MatchExpr |  |
+| variables.rs:199:26:199:27 | a5 | variables.rs:199:16:199:28 | CallExpr |  |
+| variables.rs:201:5:204:5 | MatchExpr | variables.rs:191:21:205:1 | BlockExpr |  |
+| variables.rs:201:11:201:12 | tv | variables.rs:202:9:202:83 | OrPat |  |
+| variables.rs:202:9:202:83 | OrPat | variables.rs:203:16:203:24 | PathExpr | match |
+| variables.rs:203:16:203:24 | PathExpr | variables.rs:203:26:203:27 | a6 |  |
+| variables.rs:203:16:203:28 | CallExpr | variables.rs:201:5:204:5 | MatchExpr |  |
+| variables.rs:203:26:203:27 | a6 | variables.rs:203:16:203:28 | CallExpr |  |
+| variables.rs:207:1:215:1 | enter match_pattern7 | variables.rs:208:5:208:34 | LetStmt |  |
+| variables.rs:207:1:215:1 | exit match_pattern7 (normal) | variables.rs:207:1:215:1 | exit match_pattern7 |  |
+| variables.rs:207:21:215:1 | BlockExpr | variables.rs:207:1:215:1 | exit match_pattern7 (normal) |  |
+| variables.rs:208:5:208:34 | LetStmt | variables.rs:208:18:208:29 | PathExpr |  |
+| variables.rs:208:9:208:14 | either | variables.rs:209:11:209:16 | either | match, no-match |
+| variables.rs:208:18:208:29 | PathExpr | variables.rs:208:31:208:32 | 32 |  |
+| variables.rs:208:18:208:33 | CallExpr | variables.rs:208:9:208:14 | either |  |
+| variables.rs:208:31:208:32 | 32 | variables.rs:208:18:208:33 | CallExpr |  |
+| variables.rs:209:5:214:5 | MatchExpr | variables.rs:207:21:215:1 | BlockExpr |  |
+| variables.rs:209:11:209:16 | either | variables.rs:210:9:210:44 | OrPat |  |
+| variables.rs:210:9:210:44 | OrPat | variables.rs:211:16:211:17 | a7 | match |
+| variables.rs:210:9:210:44 | OrPat | variables.rs:213:9:213:9 | WildcardPat | no-match |
+| variables.rs:211:16:211:17 | a7 | variables.rs:211:21:211:21 | 0 |  |
+| variables.rs:211:16:211:21 | ... > ... | variables.rs:212:16:212:24 | PathExpr | true |
+| variables.rs:211:16:211:21 | ... > ... | variables.rs:213:9:213:9 | WildcardPat | false |
+| variables.rs:211:21:211:21 | 0 | variables.rs:211:16:211:21 | ... > ... |  |
+| variables.rs:212:16:212:24 | PathExpr | variables.rs:212:26:212:27 | a7 |  |
+| variables.rs:212:16:212:28 | CallExpr | variables.rs:209:5:214:5 | MatchExpr |  |
+| variables.rs:212:26:212:27 | a7 | variables.rs:212:16:212:28 | CallExpr |  |
+| variables.rs:213:9:213:9 | WildcardPat | variables.rs:213:14:213:15 | TupleExpr | match |
+| variables.rs:213:14:213:15 | TupleExpr | variables.rs:209:5:214:5 | MatchExpr |  |
+| variables.rs:217:1:232:1 | enter match_pattern8 | variables.rs:218:5:218:34 | LetStmt |  |
+| variables.rs:217:1:232:1 | exit match_pattern8 (normal) | variables.rs:217:1:232:1 | exit match_pattern8 |  |
+| variables.rs:217:21:232:1 | BlockExpr | variables.rs:217:1:232:1 | exit match_pattern8 (normal) |  |
+| variables.rs:218:5:218:34 | LetStmt | variables.rs:218:18:218:29 | PathExpr |  |
+| variables.rs:218:9:218:14 | either | variables.rs:220:11:220:16 | either | match, no-match |
+| variables.rs:218:18:218:29 | PathExpr | variables.rs:218:31:218:32 | 32 |  |
+| variables.rs:218:18:218:33 | CallExpr | variables.rs:218:9:218:14 | either |  |
+| variables.rs:218:31:218:32 | 32 | variables.rs:218:18:218:33 | CallExpr |  |
+| variables.rs:220:5:231:5 | MatchExpr | variables.rs:217:21:232:1 | BlockExpr |  |
+| variables.rs:220:11:220:16 | either | variables.rs:221:9:222:52 | e |  |
+| variables.rs:221:9:222:52 | e | variables.rs:224:13:224:27 | ExprStmt | match |
+| variables.rs:221:9:222:52 | e | variables.rs:230:9:230:9 | WildcardPat | no-match |
+| variables.rs:223:12:229:9 | BlockExpr | variables.rs:220:5:231:5 | MatchExpr |  |
+| variables.rs:224:13:224:21 | PathExpr | variables.rs:224:23:224:25 | a11 |  |
+| variables.rs:224:13:224:26 | CallExpr | variables.rs:225:16:226:15 | LetExpr |  |
+| variables.rs:224:13:224:27 | ExprStmt | variables.rs:224:13:224:21 | PathExpr |  |
+| variables.rs:224:23:224:25 | a11 | variables.rs:224:13:224:26 | CallExpr |  |
+| variables.rs:225:13:228:13 | IfExpr | variables.rs:223:12:229:9 | BlockExpr |  |
+| variables.rs:225:16:226:15 | LetExpr | variables.rs:225:20:225:36 | TupleStructPat |  |
+| variables.rs:225:20:225:36 | TupleStructPat | variables.rs:225:13:228:13 | IfExpr | no-match |
+| variables.rs:225:20:225:36 | TupleStructPat | variables.rs:227:17:227:32 | ExprStmt | match |
+| variables.rs:226:17:228:13 | BlockExpr | variables.rs:225:13:228:13 | IfExpr |  |
+| variables.rs:227:17:227:25 | PathExpr | variables.rs:227:28:227:30 | a12 |  |
+| variables.rs:227:17:227:31 | CallExpr | variables.rs:226:17:228:13 | BlockExpr |  |
+| variables.rs:227:17:227:32 | ExprStmt | variables.rs:227:17:227:25 | PathExpr |  |
+| variables.rs:227:27:227:30 | * ... | variables.rs:227:17:227:31 | CallExpr |  |
+| variables.rs:227:28:227:30 | a12 | variables.rs:227:27:227:30 | * ... |  |
+| variables.rs:230:9:230:9 | WildcardPat | variables.rs:230:14:230:15 | TupleExpr | match |
+| variables.rs:230:14:230:15 | TupleExpr | variables.rs:220:5:231:5 | MatchExpr |  |
+| variables.rs:241:1:247:1 | enter match_pattern9 | variables.rs:242:5:242:36 | LetStmt |  |
+| variables.rs:241:1:247:1 | exit match_pattern9 (normal) | variables.rs:241:1:247:1 | exit match_pattern9 |  |
+| variables.rs:241:21:247:1 | BlockExpr | variables.rs:241:1:247:1 | exit match_pattern9 (normal) |  |
+| variables.rs:242:5:242:36 | LetStmt | variables.rs:242:14:242:31 | PathExpr |  |
+| variables.rs:242:9:242:10 | fv | variables.rs:243:11:243:12 | fv | match, no-match |
+| variables.rs:242:14:242:31 | PathExpr | variables.rs:242:33:242:34 | 62 |  |
+| variables.rs:242:14:242:35 | CallExpr | variables.rs:242:9:242:10 | fv |  |
+| variables.rs:242:33:242:34 | 62 | variables.rs:242:14:242:35 | CallExpr |  |
+| variables.rs:243:5:246:5 | MatchExpr | variables.rs:241:21:247:1 | BlockExpr |  |
+| variables.rs:243:11:243:12 | fv | variables.rs:244:9:244:109 | OrPat |  |
+| variables.rs:244:9:244:109 | OrPat | variables.rs:245:16:245:24 | PathExpr | match |
+| variables.rs:245:16:245:24 | PathExpr | variables.rs:245:26:245:28 | a13 |  |
+| variables.rs:245:16:245:29 | CallExpr | variables.rs:243:5:246:5 | MatchExpr |  |
+| variables.rs:245:26:245:28 | a13 | variables.rs:245:16:245:29 | CallExpr |  |
+| variables.rs:249:1:258:1 | enter param_pattern1 | variables.rs:255:5:255:18 | ExprStmt |  |
+| variables.rs:249:1:258:1 | exit param_pattern1 (normal) | variables.rs:249:1:258:1 | exit param_pattern1 |  |
+| variables.rs:254:28:258:1 | BlockExpr | variables.rs:249:1:258:1 | exit param_pattern1 (normal) |  |
+| variables.rs:255:5:255:13 | PathExpr | variables.rs:255:15:255:16 | a8 |  |
+| variables.rs:255:5:255:17 | CallExpr | variables.rs:256:5:256:18 | ExprStmt |  |
 | variables.rs:255:5:255:18 | ExprStmt | variables.rs:255:5:255:13 | PathExpr |  |
-| variables.rs:255:15:255:16 | c1 | variables.rs:255:5:255:17 | CallExpr |  |
-| variables.rs:258:1:262:1 | enter param_pattern2 | variables.rs:261:5:261:18 | ExprStmt |  |
-| variables.rs:258:1:262:1 | exit param_pattern2 (normal) | variables.rs:258:1:262:1 | exit param_pattern2 |  |
-| variables.rs:260:9:262:1 | BlockExpr | variables.rs:258:1:262:1 | exit param_pattern2 (normal) |  |
-| variables.rs:261:5:261:13 | PathExpr | variables.rs:261:15:261:16 | a9 |  |
-| variables.rs:261:5:261:17 | CallExpr | variables.rs:260:9:262:1 | BlockExpr |  |
-| variables.rs:261:5:261:18 | ExprStmt | variables.rs:261:5:261:13 | PathExpr |  |
-| variables.rs:261:15:261:16 | a9 | variables.rs:261:5:261:17 | CallExpr |  |
-| variables.rs:264:1:299:1 | enter destruct_assignment | variables.rs:265:5:269:18 | LetStmt |  |
-| variables.rs:264:1:299:1 | exit destruct_assignment (normal) | variables.rs:264:1:299:1 | exit destruct_assignment |  |
-| variables.rs:264:26:299:1 | BlockExpr | variables.rs:264:1:299:1 | exit destruct_assignment (normal) |  |
-| variables.rs:265:5:269:18 | LetStmt | variables.rs:269:10:269:10 | 1 |  |
-| variables.rs:265:9:269:5 | TuplePat | variables.rs:270:5:270:19 | ExprStmt | match |
-| variables.rs:269:9:269:17 | TupleExpr | variables.rs:265:9:269:5 | TuplePat |  |
-| variables.rs:269:10:269:10 | 1 | variables.rs:269:13:269:13 | 2 |  |
-| variables.rs:269:13:269:13 | 2 | variables.rs:269:16:269:16 | 3 |  |
-| variables.rs:269:16:269:16 | 3 | variables.rs:269:9:269:17 | TupleExpr |  |
-| variables.rs:270:5:270:13 | PathExpr | variables.rs:270:15:270:17 | a10 |  |
-| variables.rs:270:5:270:18 | CallExpr | variables.rs:271:5:271:18 | ExprStmt |  |
-| variables.rs:270:5:270:19 | ExprStmt | variables.rs:270:5:270:13 | PathExpr |  |
-| variables.rs:270:15:270:17 | a10 | variables.rs:270:5:270:18 | CallExpr |  |
-| variables.rs:271:5:271:13 | PathExpr | variables.rs:271:15:271:16 | b4 |  |
-| variables.rs:271:5:271:17 | CallExpr | variables.rs:272:5:272:18 | ExprStmt |  |
-| variables.rs:271:5:271:18 | ExprStmt | variables.rs:271:5:271:13 | PathExpr |  |
-| variables.rs:271:15:271:16 | b4 | variables.rs:271:5:271:17 | CallExpr |  |
-| variables.rs:272:5:272:13 | PathExpr | variables.rs:272:15:272:16 | c2 |  |
-| variables.rs:272:5:272:17 | CallExpr | variables.rs:274:5:282:6 | ExprStmt |  |
-| variables.rs:272:5:272:18 | ExprStmt | variables.rs:272:5:272:13 | PathExpr |  |
-| variables.rs:272:15:272:16 | c2 | variables.rs:272:5:272:17 | CallExpr |  |
-| variables.rs:274:5:278:5 | TupleExpr | variables.rs:279:9:279:11 | a10 |  |
-| variables.rs:274:5:282:5 | ... = ... | variables.rs:283:5:283:19 | ExprStmt |  |
-| variables.rs:274:5:282:6 | ExprStmt | variables.rs:275:9:275:10 | c2 |  |
-| variables.rs:275:9:275:10 | c2 | variables.rs:276:9:276:10 | b4 |  |
-| variables.rs:276:9:276:10 | b4 | variables.rs:277:9:277:11 | a10 |  |
-| variables.rs:277:9:277:11 | a10 | variables.rs:274:5:278:5 | TupleExpr |  |
-| variables.rs:278:9:282:5 | TupleExpr | variables.rs:274:5:282:5 | ... = ... |  |
-| variables.rs:279:9:279:11 | a10 | variables.rs:280:9:280:10 | b4 |  |
-| variables.rs:280:9:280:10 | b4 | variables.rs:281:9:281:10 | c2 |  |
-| variables.rs:281:9:281:10 | c2 | variables.rs:278:9:282:5 | TupleExpr |  |
-| variables.rs:283:5:283:13 | PathExpr | variables.rs:283:15:283:17 | a10 |  |
-| variables.rs:283:5:283:18 | CallExpr | variables.rs:284:5:284:18 | ExprStmt |  |
-| variables.rs:283:5:283:19 | ExprStmt | variables.rs:283:5:283:13 | PathExpr |  |
-| variables.rs:283:15:283:17 | a10 | variables.rs:283:5:283:18 | CallExpr |  |
-| variables.rs:284:5:284:13 | PathExpr | variables.rs:284:15:284:16 | b4 |  |
-| variables.rs:284:5:284:17 | CallExpr | variables.rs:285:5:285:18 | ExprStmt |  |
-| variables.rs:284:5:284:18 | ExprStmt | variables.rs:284:5:284:13 | PathExpr |  |
-| variables.rs:284:15:284:16 | b4 | variables.rs:284:5:284:17 | CallExpr |  |
-| variables.rs:285:5:285:13 | PathExpr | variables.rs:285:15:285:16 | c2 |  |
-| variables.rs:285:5:285:17 | CallExpr | variables.rs:287:5:295:5 | ExprStmt |  |
-| variables.rs:285:5:285:18 | ExprStmt | variables.rs:285:5:285:13 | PathExpr |  |
-| variables.rs:285:15:285:16 | c2 | variables.rs:285:5:285:17 | CallExpr |  |
-| variables.rs:287:5:295:5 | ExprStmt | variables.rs:287:12:287:12 | 4 |  |
-| variables.rs:287:5:295:5 | MatchExpr | variables.rs:297:5:297:19 | ExprStmt |  |
-| variables.rs:287:11:287:16 | TupleExpr | variables.rs:288:9:291:9 | TuplePat |  |
-| variables.rs:287:12:287:12 | 4 | variables.rs:287:15:287:15 | 5 |  |
-| variables.rs:287:15:287:15 | 5 | variables.rs:287:11:287:16 | TupleExpr |  |
-| variables.rs:288:9:291:9 | TuplePat | variables.rs:292:13:292:27 | ExprStmt | match |
-| variables.rs:291:14:294:9 | BlockExpr | variables.rs:287:5:295:5 | MatchExpr |  |
-| variables.rs:292:13:292:21 | PathExpr | variables.rs:292:23:292:25 | a10 |  |
-| variables.rs:292:13:292:26 | CallExpr | variables.rs:293:13:293:26 | ExprStmt |  |
-| variables.rs:292:13:292:27 | ExprStmt | variables.rs:292:13:292:21 | PathExpr |  |
-| variables.rs:292:23:292:25 | a10 | variables.rs:292:13:292:26 | CallExpr |  |
-| variables.rs:293:13:293:21 | PathExpr | variables.rs:293:23:293:24 | b4 |  |
-| variables.rs:293:13:293:25 | CallExpr | variables.rs:291:14:294:9 | BlockExpr |  |
-| variables.rs:293:13:293:26 | ExprStmt | variables.rs:293:13:293:21 | PathExpr |  |
-| variables.rs:293:23:293:24 | b4 | variables.rs:293:13:293:25 | CallExpr |  |
-| variables.rs:297:5:297:13 | PathExpr | variables.rs:297:15:297:17 | a10 |  |
-| variables.rs:297:5:297:18 | CallExpr | variables.rs:298:5:298:18 | ExprStmt |  |
-| variables.rs:297:5:297:19 | ExprStmt | variables.rs:297:5:297:13 | PathExpr |  |
-| variables.rs:297:15:297:17 | a10 | variables.rs:297:5:297:18 | CallExpr |  |
-| variables.rs:298:5:298:13 | PathExpr | variables.rs:298:15:298:16 | b4 |  |
-| variables.rs:298:5:298:17 | CallExpr | variables.rs:264:26:299:1 | BlockExpr |  |
-| variables.rs:298:5:298:18 | ExprStmt | variables.rs:298:5:298:13 | PathExpr |  |
-| variables.rs:298:15:298:16 | b4 | variables.rs:298:5:298:17 | CallExpr |  |
-| variables.rs:301:1:316:1 | enter closure_variable | variables.rs:302:5:304:10 | LetStmt |  |
-| variables.rs:301:1:316:1 | exit closure_variable (normal) | variables.rs:301:1:316:1 | exit closure_variable |  |
-| variables.rs:301:23:316:1 | BlockExpr | variables.rs:301:1:316:1 | exit closure_variable (normal) |  |
-| variables.rs:302:5:304:10 | LetStmt | variables.rs:303:9:304:9 | ClosureExpr |  |
-| variables.rs:302:9:302:23 | example_closure | variables.rs:305:5:306:27 | LetStmt | match, no-match |
-| variables.rs:303:9:304:9 | ClosureExpr | variables.rs:302:9:302:23 | example_closure |  |
-| variables.rs:303:9:304:9 | enter ClosureExpr | variables.rs:304:9:304:9 | x |  |
-| variables.rs:303:9:304:9 | exit ClosureExpr (normal) | variables.rs:303:9:304:9 | exit ClosureExpr |  |
-| variables.rs:304:9:304:9 | x | variables.rs:303:9:304:9 | exit ClosureExpr (normal) |  |
-| variables.rs:305:5:306:27 | LetStmt | variables.rs:306:9:306:23 | example_closure |  |
-| variables.rs:305:9:305:10 | n1 | variables.rs:307:5:307:18 | ExprStmt | match, no-match |
-| variables.rs:306:9:306:23 | example_closure | variables.rs:306:25:306:25 | 5 |  |
-| variables.rs:306:9:306:26 | CallExpr | variables.rs:305:9:305:10 | n1 |  |
-| variables.rs:306:25:306:25 | 5 | variables.rs:306:9:306:26 | CallExpr |  |
-| variables.rs:307:5:307:13 | PathExpr | variables.rs:307:15:307:16 | n1 |  |
-| variables.rs:307:5:307:17 | CallExpr | variables.rs:309:5:309:25 | ExprStmt |  |
-| variables.rs:307:5:307:18 | ExprStmt | variables.rs:307:5:307:13 | PathExpr |  |
-| variables.rs:307:15:307:16 | n1 | variables.rs:307:5:307:17 | CallExpr |  |
-| variables.rs:309:5:309:22 | PathExpr | variables.rs:309:5:309:24 | CallExpr |  |
-| variables.rs:309:5:309:24 | CallExpr | variables.rs:310:5:312:10 | LetStmt |  |
-| variables.rs:309:5:309:25 | ExprStmt | variables.rs:309:5:309:22 | PathExpr |  |
-| variables.rs:310:5:312:10 | LetStmt | variables.rs:311:9:312:9 | ClosureExpr |  |
-| variables.rs:310:9:310:26 | immutable_variable | variables.rs:313:5:314:30 | LetStmt | match, no-match |
-| variables.rs:311:9:312:9 | ClosureExpr | variables.rs:310:9:310:26 | immutable_variable |  |
-| variables.rs:311:9:312:9 | enter ClosureExpr | variables.rs:312:9:312:9 | x |  |
-| variables.rs:311:9:312:9 | exit ClosureExpr (normal) | variables.rs:311:9:312:9 | exit ClosureExpr |  |
-| variables.rs:312:9:312:9 | x | variables.rs:311:9:312:9 | exit ClosureExpr (normal) |  |
-| variables.rs:313:5:314:30 | LetStmt | variables.rs:314:9:314:26 | immutable_variable |  |
-| variables.rs:313:9:313:10 | n2 | variables.rs:315:5:315:18 | ExprStmt | match, no-match |
-| variables.rs:314:9:314:26 | immutable_variable | variables.rs:314:28:314:28 | 6 |  |
-| variables.rs:314:9:314:29 | CallExpr | variables.rs:313:9:313:10 | n2 |  |
-| variables.rs:314:28:314:28 | 6 | variables.rs:314:9:314:29 | CallExpr |  |
-| variables.rs:315:5:315:13 | PathExpr | variables.rs:315:15:315:16 | n2 |  |
-| variables.rs:315:5:315:17 | CallExpr | variables.rs:301:23:316:1 | BlockExpr |  |
-| variables.rs:315:5:315:18 | ExprStmt | variables.rs:315:5:315:13 | PathExpr |  |
-| variables.rs:315:15:315:16 | n2 | variables.rs:315:5:315:17 | CallExpr |  |
-| variables.rs:318:1:325:1 | enter for_variable | variables.rs:319:5:319:42 | LetStmt |  |
-| variables.rs:318:1:325:1 | exit for_variable (normal) | variables.rs:318:1:325:1 | exit for_variable |  |
-| variables.rs:318:19:325:1 | BlockExpr | variables.rs:318:1:325:1 | exit for_variable (normal) |  |
-| variables.rs:319:5:319:42 | LetStmt | variables.rs:319:15:319:22 | "apples" |  |
-| variables.rs:319:9:319:9 | v | variables.rs:322:12:322:12 | v | match, no-match |
-| variables.rs:319:13:319:41 | RefExpr | variables.rs:319:9:319:9 | v |  |
-| variables.rs:319:14:319:41 | ArrayExpr | variables.rs:319:13:319:41 | RefExpr |  |
-| variables.rs:319:15:319:22 | "apples" | variables.rs:319:25:319:30 | "cake" |  |
-| variables.rs:319:25:319:30 | "cake" | variables.rs:319:33:319:40 | "coffee" |  |
-| variables.rs:319:33:319:40 | "coffee" | variables.rs:319:14:319:41 | ArrayExpr |  |
-| variables.rs:321:5:324:5 | ForExpr | variables.rs:318:19:325:1 | BlockExpr |  |
-| variables.rs:321:9:321:12 | text | variables.rs:321:5:324:5 | ForExpr | no-match |
-| variables.rs:321:9:321:12 | text | variables.rs:323:9:323:24 | ExprStmt | match |
-| variables.rs:322:12:322:12 | v | variables.rs:321:9:321:12 | text |  |
-| variables.rs:322:14:324:5 | BlockExpr | variables.rs:321:9:321:12 | text |  |
-| variables.rs:323:9:323:17 | PathExpr | variables.rs:323:19:323:22 | text |  |
-| variables.rs:323:9:323:23 | CallExpr | variables.rs:322:14:324:5 | BlockExpr |  |
-| variables.rs:323:9:323:24 | ExprStmt | variables.rs:323:9:323:17 | PathExpr |  |
-| variables.rs:323:19:323:22 | text | variables.rs:323:9:323:23 | CallExpr |  |
-| variables.rs:327:1:350:1 | enter main | variables.rs:328:5:328:25 | ExprStmt |  |
-| variables.rs:327:1:350:1 | exit main (normal) | variables.rs:327:1:350:1 | exit main |  |
-| variables.rs:327:11:350:1 | BlockExpr | variables.rs:327:1:350:1 | exit main (normal) |  |
-| variables.rs:328:5:328:22 | PathExpr | variables.rs:328:5:328:24 | CallExpr |  |
-| variables.rs:328:5:328:24 | CallExpr | variables.rs:329:5:329:23 | ExprStmt |  |
-| variables.rs:328:5:328:25 | ExprStmt | variables.rs:328:5:328:22 | PathExpr |  |
-| variables.rs:329:5:329:20 | PathExpr | variables.rs:329:5:329:22 | CallExpr |  |
-| variables.rs:329:5:329:22 | CallExpr | variables.rs:330:5:330:23 | ExprStmt |  |
-| variables.rs:329:5:329:23 | ExprStmt | variables.rs:329:5:329:20 | PathExpr |  |
-| variables.rs:330:5:330:20 | PathExpr | variables.rs:330:5:330:22 | CallExpr |  |
-| variables.rs:330:5:330:22 | CallExpr | variables.rs:331:5:331:23 | ExprStmt |  |
-| variables.rs:330:5:330:23 | ExprStmt | variables.rs:330:5:330:20 | PathExpr |  |
-| variables.rs:331:5:331:20 | PathExpr | variables.rs:331:5:331:22 | CallExpr |  |
-| variables.rs:331:5:331:22 | CallExpr | variables.rs:332:5:332:19 | ExprStmt |  |
-| variables.rs:331:5:331:23 | ExprStmt | variables.rs:331:5:331:20 | PathExpr |  |
-| variables.rs:332:5:332:16 | PathExpr | variables.rs:332:5:332:18 | CallExpr |  |
-| variables.rs:332:5:332:18 | CallExpr | variables.rs:333:5:333:19 | ExprStmt |  |
-| variables.rs:332:5:332:19 | ExprStmt | variables.rs:332:5:332:16 | PathExpr |  |
-| variables.rs:333:5:333:16 | PathExpr | variables.rs:333:5:333:18 | CallExpr |  |
-| variables.rs:333:5:333:18 | CallExpr | variables.rs:334:5:334:19 | ExprStmt |  |
-| variables.rs:333:5:333:19 | ExprStmt | variables.rs:333:5:333:16 | PathExpr |  |
-| variables.rs:334:5:334:16 | PathExpr | variables.rs:334:5:334:18 | CallExpr |  |
-| variables.rs:334:5:334:18 | CallExpr | variables.rs:335:5:335:19 | ExprStmt |  |
-| variables.rs:334:5:334:19 | ExprStmt | variables.rs:334:5:334:16 | PathExpr |  |
-| variables.rs:335:5:335:16 | PathExpr | variables.rs:335:5:335:18 | CallExpr |  |
-| variables.rs:335:5:335:18 | CallExpr | variables.rs:336:5:336:21 | ExprStmt |  |
-| variables.rs:335:5:335:19 | ExprStmt | variables.rs:335:5:335:16 | PathExpr |  |
-| variables.rs:336:5:336:18 | PathExpr | variables.rs:336:5:336:20 | CallExpr |  |
-| variables.rs:336:5:336:20 | CallExpr | variables.rs:337:5:337:21 | ExprStmt |  |
-| variables.rs:336:5:336:21 | ExprStmt | variables.rs:336:5:336:18 | PathExpr |  |
-| variables.rs:337:5:337:18 | PathExpr | variables.rs:337:5:337:20 | CallExpr |  |
-| variables.rs:337:5:337:20 | CallExpr | variables.rs:338:5:338:21 | ExprStmt |  |
-| variables.rs:337:5:337:21 | ExprStmt | variables.rs:337:5:337:18 | PathExpr |  |
-| variables.rs:338:5:338:18 | PathExpr | variables.rs:338:5:338:20 | CallExpr |  |
-| variables.rs:338:5:338:20 | CallExpr | variables.rs:339:5:339:21 | ExprStmt |  |
-| variables.rs:338:5:338:21 | ExprStmt | variables.rs:338:5:338:18 | PathExpr |  |
-| variables.rs:339:5:339:18 | PathExpr | variables.rs:339:5:339:20 | CallExpr |  |
-| variables.rs:339:5:339:20 | CallExpr | variables.rs:340:5:340:21 | ExprStmt |  |
-| variables.rs:339:5:339:21 | ExprStmt | variables.rs:339:5:339:18 | PathExpr |  |
-| variables.rs:340:5:340:18 | PathExpr | variables.rs:340:5:340:20 | CallExpr |  |
-| variables.rs:340:5:340:20 | CallExpr | variables.rs:341:5:341:21 | ExprStmt |  |
-| variables.rs:340:5:340:21 | ExprStmt | variables.rs:340:5:340:18 | PathExpr |  |
-| variables.rs:341:5:341:18 | PathExpr | variables.rs:341:5:341:20 | CallExpr |  |
-| variables.rs:341:5:341:20 | CallExpr | variables.rs:342:5:342:21 | ExprStmt |  |
-| variables.rs:341:5:341:21 | ExprStmt | variables.rs:341:5:341:18 | PathExpr |  |
-| variables.rs:342:5:342:18 | PathExpr | variables.rs:342:5:342:20 | CallExpr |  |
-| variables.rs:342:5:342:20 | CallExpr | variables.rs:343:5:343:21 | ExprStmt |  |
-| variables.rs:342:5:342:21 | ExprStmt | variables.rs:342:5:342:18 | PathExpr |  |
-| variables.rs:343:5:343:18 | PathExpr | variables.rs:343:5:343:20 | CallExpr |  |
-| variables.rs:343:5:343:20 | CallExpr | variables.rs:344:5:344:21 | ExprStmt |  |
-| variables.rs:343:5:343:21 | ExprStmt | variables.rs:343:5:343:18 | PathExpr |  |
-| variables.rs:344:5:344:18 | PathExpr | variables.rs:344:5:344:20 | CallExpr |  |
-| variables.rs:344:5:344:20 | CallExpr | variables.rs:345:5:345:36 | ExprStmt |  |
-| variables.rs:344:5:344:21 | ExprStmt | variables.rs:344:5:344:18 | PathExpr |  |
-| variables.rs:345:5:345:18 | PathExpr | variables.rs:345:20:345:22 | "a" |  |
-| variables.rs:345:5:345:35 | CallExpr | variables.rs:346:5:346:37 | ExprStmt |  |
-| variables.rs:345:5:345:36 | ExprStmt | variables.rs:345:5:345:18 | PathExpr |  |
-| variables.rs:345:20:345:22 | "a" | variables.rs:345:26:345:28 | "b" |  |
-| variables.rs:345:25:345:34 | TupleExpr | variables.rs:345:5:345:35 | CallExpr |  |
-| variables.rs:345:26:345:28 | "b" | variables.rs:345:31:345:33 | "c" |  |
-| variables.rs:345:31:345:33 | "c" | variables.rs:345:25:345:34 | TupleExpr |  |
-| variables.rs:346:5:346:18 | PathExpr | variables.rs:346:20:346:31 | PathExpr |  |
-| variables.rs:346:5:346:36 | CallExpr | variables.rs:347:5:347:26 | ExprStmt |  |
-| variables.rs:346:5:346:37 | ExprStmt | variables.rs:346:5:346:18 | PathExpr |  |
-| variables.rs:346:20:346:31 | PathExpr | variables.rs:346:33:346:34 | 45 |  |
-| variables.rs:346:20:346:35 | CallExpr | variables.rs:346:5:346:36 | CallExpr |  |
-| variables.rs:346:33:346:34 | 45 | variables.rs:346:20:346:35 | CallExpr |  |
-| variables.rs:347:5:347:23 | PathExpr | variables.rs:347:5:347:25 | CallExpr |  |
-| variables.rs:347:5:347:25 | CallExpr | variables.rs:348:5:348:23 | ExprStmt |  |
-| variables.rs:347:5:347:26 | ExprStmt | variables.rs:347:5:347:23 | PathExpr |  |
-| variables.rs:348:5:348:20 | PathExpr | variables.rs:348:5:348:22 | CallExpr |  |
-| variables.rs:348:5:348:22 | CallExpr | variables.rs:349:5:349:19 | ExprStmt |  |
-| variables.rs:348:5:348:23 | ExprStmt | variables.rs:348:5:348:20 | PathExpr |  |
-| variables.rs:349:5:349:16 | PathExpr | variables.rs:349:5:349:18 | CallExpr |  |
-| variables.rs:349:5:349:18 | CallExpr | variables.rs:327:11:350:1 | BlockExpr |  |
-| variables.rs:349:5:349:19 | ExprStmt | variables.rs:349:5:349:16 | PathExpr |  |
+| variables.rs:255:15:255:16 | a8 | variables.rs:255:5:255:17 | CallExpr |  |
+| variables.rs:256:5:256:13 | PathExpr | variables.rs:256:15:256:16 | b3 |  |
+| variables.rs:256:5:256:17 | CallExpr | variables.rs:257:5:257:18 | ExprStmt |  |
+| variables.rs:256:5:256:18 | ExprStmt | variables.rs:256:5:256:13 | PathExpr |  |
+| variables.rs:256:15:256:16 | b3 | variables.rs:256:5:256:17 | CallExpr |  |
+| variables.rs:257:5:257:13 | PathExpr | variables.rs:257:15:257:16 | c1 |  |
+| variables.rs:257:5:257:17 | CallExpr | variables.rs:254:28:258:1 | BlockExpr |  |
+| variables.rs:257:5:257:18 | ExprStmt | variables.rs:257:5:257:13 | PathExpr |  |
+| variables.rs:257:15:257:16 | c1 | variables.rs:257:5:257:17 | CallExpr |  |
+| variables.rs:260:1:264:1 | enter param_pattern2 | variables.rs:263:5:263:18 | ExprStmt |  |
+| variables.rs:260:1:264:1 | exit param_pattern2 (normal) | variables.rs:260:1:264:1 | exit param_pattern2 |  |
+| variables.rs:262:9:264:1 | BlockExpr | variables.rs:260:1:264:1 | exit param_pattern2 (normal) |  |
+| variables.rs:263:5:263:13 | PathExpr | variables.rs:263:15:263:16 | a9 |  |
+| variables.rs:263:5:263:17 | CallExpr | variables.rs:262:9:264:1 | BlockExpr |  |
+| variables.rs:263:5:263:18 | ExprStmt | variables.rs:263:5:263:13 | PathExpr |  |
+| variables.rs:263:15:263:16 | a9 | variables.rs:263:5:263:17 | CallExpr |  |
+| variables.rs:266:1:301:1 | enter destruct_assignment | variables.rs:267:5:271:18 | LetStmt |  |
+| variables.rs:266:1:301:1 | exit destruct_assignment (normal) | variables.rs:266:1:301:1 | exit destruct_assignment |  |
+| variables.rs:266:26:301:1 | BlockExpr | variables.rs:266:1:301:1 | exit destruct_assignment (normal) |  |
+| variables.rs:267:5:271:18 | LetStmt | variables.rs:271:10:271:10 | 1 |  |
+| variables.rs:267:9:271:5 | TuplePat | variables.rs:272:5:272:19 | ExprStmt | match |
+| variables.rs:271:9:271:17 | TupleExpr | variables.rs:267:9:271:5 | TuplePat |  |
+| variables.rs:271:10:271:10 | 1 | variables.rs:271:13:271:13 | 2 |  |
+| variables.rs:271:13:271:13 | 2 | variables.rs:271:16:271:16 | 3 |  |
+| variables.rs:271:16:271:16 | 3 | variables.rs:271:9:271:17 | TupleExpr |  |
+| variables.rs:272:5:272:13 | PathExpr | variables.rs:272:15:272:17 | a10 |  |
+| variables.rs:272:5:272:18 | CallExpr | variables.rs:273:5:273:18 | ExprStmt |  |
+| variables.rs:272:5:272:19 | ExprStmt | variables.rs:272:5:272:13 | PathExpr |  |
+| variables.rs:272:15:272:17 | a10 | variables.rs:272:5:272:18 | CallExpr |  |
+| variables.rs:273:5:273:13 | PathExpr | variables.rs:273:15:273:16 | b4 |  |
+| variables.rs:273:5:273:17 | CallExpr | variables.rs:274:5:274:18 | ExprStmt |  |
+| variables.rs:273:5:273:18 | ExprStmt | variables.rs:273:5:273:13 | PathExpr |  |
+| variables.rs:273:15:273:16 | b4 | variables.rs:273:5:273:17 | CallExpr |  |
+| variables.rs:274:5:274:13 | PathExpr | variables.rs:274:15:274:16 | c2 |  |
+| variables.rs:274:5:274:17 | CallExpr | variables.rs:276:5:284:6 | ExprStmt |  |
+| variables.rs:274:5:274:18 | ExprStmt | variables.rs:274:5:274:13 | PathExpr |  |
+| variables.rs:274:15:274:16 | c2 | variables.rs:274:5:274:17 | CallExpr |  |
+| variables.rs:276:5:280:5 | TupleExpr | variables.rs:281:9:281:11 | a10 |  |
+| variables.rs:276:5:284:5 | ... = ... | variables.rs:285:5:285:19 | ExprStmt |  |
+| variables.rs:276:5:284:6 | ExprStmt | variables.rs:277:9:277:10 | c2 |  |
+| variables.rs:277:9:277:10 | c2 | variables.rs:278:9:278:10 | b4 |  |
+| variables.rs:278:9:278:10 | b4 | variables.rs:279:9:279:11 | a10 |  |
+| variables.rs:279:9:279:11 | a10 | variables.rs:276:5:280:5 | TupleExpr |  |
+| variables.rs:280:9:284:5 | TupleExpr | variables.rs:276:5:284:5 | ... = ... |  |
+| variables.rs:281:9:281:11 | a10 | variables.rs:282:9:282:10 | b4 |  |
+| variables.rs:282:9:282:10 | b4 | variables.rs:283:9:283:10 | c2 |  |
+| variables.rs:283:9:283:10 | c2 | variables.rs:280:9:284:5 | TupleExpr |  |
+| variables.rs:285:5:285:13 | PathExpr | variables.rs:285:15:285:17 | a10 |  |
+| variables.rs:285:5:285:18 | CallExpr | variables.rs:286:5:286:18 | ExprStmt |  |
+| variables.rs:285:5:285:19 | ExprStmt | variables.rs:285:5:285:13 | PathExpr |  |
+| variables.rs:285:15:285:17 | a10 | variables.rs:285:5:285:18 | CallExpr |  |
+| variables.rs:286:5:286:13 | PathExpr | variables.rs:286:15:286:16 | b4 |  |
+| variables.rs:286:5:286:17 | CallExpr | variables.rs:287:5:287:18 | ExprStmt |  |
+| variables.rs:286:5:286:18 | ExprStmt | variables.rs:286:5:286:13 | PathExpr |  |
+| variables.rs:286:15:286:16 | b4 | variables.rs:286:5:286:17 | CallExpr |  |
+| variables.rs:287:5:287:13 | PathExpr | variables.rs:287:15:287:16 | c2 |  |
+| variables.rs:287:5:287:17 | CallExpr | variables.rs:289:5:297:5 | ExprStmt |  |
+| variables.rs:287:5:287:18 | ExprStmt | variables.rs:287:5:287:13 | PathExpr |  |
+| variables.rs:287:15:287:16 | c2 | variables.rs:287:5:287:17 | CallExpr |  |
+| variables.rs:289:5:297:5 | ExprStmt | variables.rs:289:12:289:12 | 4 |  |
+| variables.rs:289:5:297:5 | MatchExpr | variables.rs:299:5:299:19 | ExprStmt |  |
+| variables.rs:289:11:289:16 | TupleExpr | variables.rs:290:9:293:9 | TuplePat |  |
+| variables.rs:289:12:289:12 | 4 | variables.rs:289:15:289:15 | 5 |  |
+| variables.rs:289:15:289:15 | 5 | variables.rs:289:11:289:16 | TupleExpr |  |
+| variables.rs:290:9:293:9 | TuplePat | variables.rs:294:13:294:27 | ExprStmt | match |
+| variables.rs:293:14:296:9 | BlockExpr | variables.rs:289:5:297:5 | MatchExpr |  |
+| variables.rs:294:13:294:21 | PathExpr | variables.rs:294:23:294:25 | a10 |  |
+| variables.rs:294:13:294:26 | CallExpr | variables.rs:295:13:295:26 | ExprStmt |  |
+| variables.rs:294:13:294:27 | ExprStmt | variables.rs:294:13:294:21 | PathExpr |  |
+| variables.rs:294:23:294:25 | a10 | variables.rs:294:13:294:26 | CallExpr |  |
+| variables.rs:295:13:295:21 | PathExpr | variables.rs:295:23:295:24 | b4 |  |
+| variables.rs:295:13:295:25 | CallExpr | variables.rs:293:14:296:9 | BlockExpr |  |
+| variables.rs:295:13:295:26 | ExprStmt | variables.rs:295:13:295:21 | PathExpr |  |
+| variables.rs:295:23:295:24 | b4 | variables.rs:295:13:295:25 | CallExpr |  |
+| variables.rs:299:5:299:13 | PathExpr | variables.rs:299:15:299:17 | a10 |  |
+| variables.rs:299:5:299:18 | CallExpr | variables.rs:300:5:300:18 | ExprStmt |  |
+| variables.rs:299:5:299:19 | ExprStmt | variables.rs:299:5:299:13 | PathExpr |  |
+| variables.rs:299:15:299:17 | a10 | variables.rs:299:5:299:18 | CallExpr |  |
+| variables.rs:300:5:300:13 | PathExpr | variables.rs:300:15:300:16 | b4 |  |
+| variables.rs:300:5:300:17 | CallExpr | variables.rs:266:26:301:1 | BlockExpr |  |
+| variables.rs:300:5:300:18 | ExprStmt | variables.rs:300:5:300:13 | PathExpr |  |
+| variables.rs:300:15:300:16 | b4 | variables.rs:300:5:300:17 | CallExpr |  |
+| variables.rs:303:1:318:1 | enter closure_variable | variables.rs:304:5:306:10 | LetStmt |  |
+| variables.rs:303:1:318:1 | exit closure_variable (normal) | variables.rs:303:1:318:1 | exit closure_variable |  |
+| variables.rs:303:23:318:1 | BlockExpr | variables.rs:303:1:318:1 | exit closure_variable (normal) |  |
+| variables.rs:304:5:306:10 | LetStmt | variables.rs:305:9:306:9 | ClosureExpr |  |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:307:5:308:27 | LetStmt | match, no-match |
+| variables.rs:305:9:306:9 | ClosureExpr | variables.rs:304:9:304:23 | example_closure |  |
+| variables.rs:305:9:306:9 | enter ClosureExpr | variables.rs:306:9:306:9 | x |  |
+| variables.rs:305:9:306:9 | exit ClosureExpr (normal) | variables.rs:305:9:306:9 | exit ClosureExpr |  |
+| variables.rs:306:9:306:9 | x | variables.rs:305:9:306:9 | exit ClosureExpr (normal) |  |
+| variables.rs:307:5:308:27 | LetStmt | variables.rs:308:9:308:23 | example_closure |  |
+| variables.rs:307:9:307:10 | n1 | variables.rs:309:5:309:18 | ExprStmt | match, no-match |
+| variables.rs:308:9:308:23 | example_closure | variables.rs:308:25:308:25 | 5 |  |
+| variables.rs:308:9:308:26 | CallExpr | variables.rs:307:9:307:10 | n1 |  |
+| variables.rs:308:25:308:25 | 5 | variables.rs:308:9:308:26 | CallExpr |  |
+| variables.rs:309:5:309:13 | PathExpr | variables.rs:309:15:309:16 | n1 |  |
+| variables.rs:309:5:309:17 | CallExpr | variables.rs:311:5:311:25 | ExprStmt |  |
+| variables.rs:309:5:309:18 | ExprStmt | variables.rs:309:5:309:13 | PathExpr |  |
+| variables.rs:309:15:309:16 | n1 | variables.rs:309:5:309:17 | CallExpr |  |
+| variables.rs:311:5:311:22 | PathExpr | variables.rs:311:5:311:24 | CallExpr |  |
+| variables.rs:311:5:311:24 | CallExpr | variables.rs:312:5:314:10 | LetStmt |  |
+| variables.rs:311:5:311:25 | ExprStmt | variables.rs:311:5:311:22 | PathExpr |  |
+| variables.rs:312:5:314:10 | LetStmt | variables.rs:313:9:314:9 | ClosureExpr |  |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:315:5:316:30 | LetStmt | match, no-match |
+| variables.rs:313:9:314:9 | ClosureExpr | variables.rs:312:9:312:26 | immutable_variable |  |
+| variables.rs:313:9:314:9 | enter ClosureExpr | variables.rs:314:9:314:9 | x |  |
+| variables.rs:313:9:314:9 | exit ClosureExpr (normal) | variables.rs:313:9:314:9 | exit ClosureExpr |  |
+| variables.rs:314:9:314:9 | x | variables.rs:313:9:314:9 | exit ClosureExpr (normal) |  |
+| variables.rs:315:5:316:30 | LetStmt | variables.rs:316:9:316:26 | immutable_variable |  |
+| variables.rs:315:9:315:10 | n2 | variables.rs:317:5:317:18 | ExprStmt | match, no-match |
+| variables.rs:316:9:316:26 | immutable_variable | variables.rs:316:28:316:28 | 6 |  |
+| variables.rs:316:9:316:29 | CallExpr | variables.rs:315:9:315:10 | n2 |  |
+| variables.rs:316:28:316:28 | 6 | variables.rs:316:9:316:29 | CallExpr |  |
+| variables.rs:317:5:317:13 | PathExpr | variables.rs:317:15:317:16 | n2 |  |
+| variables.rs:317:5:317:17 | CallExpr | variables.rs:303:23:318:1 | BlockExpr |  |
+| variables.rs:317:5:317:18 | ExprStmt | variables.rs:317:5:317:13 | PathExpr |  |
+| variables.rs:317:15:317:16 | n2 | variables.rs:317:5:317:17 | CallExpr |  |
+| variables.rs:320:1:327:1 | enter for_variable | variables.rs:321:5:321:42 | LetStmt |  |
+| variables.rs:320:1:327:1 | exit for_variable (normal) | variables.rs:320:1:327:1 | exit for_variable |  |
+| variables.rs:320:19:327:1 | BlockExpr | variables.rs:320:1:327:1 | exit for_variable (normal) |  |
+| variables.rs:321:5:321:42 | LetStmt | variables.rs:321:15:321:22 | "apples" |  |
+| variables.rs:321:9:321:9 | v | variables.rs:324:12:324:12 | v | match, no-match |
+| variables.rs:321:13:321:41 | RefExpr | variables.rs:321:9:321:9 | v |  |
+| variables.rs:321:14:321:41 | ArrayExpr | variables.rs:321:13:321:41 | RefExpr |  |
+| variables.rs:321:15:321:22 | "apples" | variables.rs:321:25:321:30 | "cake" |  |
+| variables.rs:321:25:321:30 | "cake" | variables.rs:321:33:321:40 | "coffee" |  |
+| variables.rs:321:33:321:40 | "coffee" | variables.rs:321:14:321:41 | ArrayExpr |  |
+| variables.rs:323:5:326:5 | ForExpr | variables.rs:320:19:327:1 | BlockExpr |  |
+| variables.rs:323:9:323:12 | text | variables.rs:323:5:326:5 | ForExpr | no-match |
+| variables.rs:323:9:323:12 | text | variables.rs:325:9:325:24 | ExprStmt | match |
+| variables.rs:324:12:324:12 | v | variables.rs:323:9:323:12 | text |  |
+| variables.rs:324:14:326:5 | BlockExpr | variables.rs:323:9:323:12 | text |  |
+| variables.rs:325:9:325:17 | PathExpr | variables.rs:325:19:325:22 | text |  |
+| variables.rs:325:9:325:23 | CallExpr | variables.rs:324:14:326:5 | BlockExpr |  |
+| variables.rs:325:9:325:24 | ExprStmt | variables.rs:325:9:325:17 | PathExpr |  |
+| variables.rs:325:19:325:22 | text | variables.rs:325:9:325:23 | CallExpr |  |
+| variables.rs:329:1:335:1 | enter add_assign | variables.rs:330:5:330:18 | LetStmt |  |
+| variables.rs:329:1:335:1 | exit add_assign (normal) | variables.rs:329:1:335:1 | exit add_assign |  |
+| variables.rs:329:17:335:1 | BlockExpr | variables.rs:329:1:335:1 | exit add_assign (normal) |  |
+| variables.rs:330:5:330:18 | LetStmt | variables.rs:330:17:330:17 | 0 |  |
+| variables.rs:330:9:330:13 | a | variables.rs:331:5:331:11 | ExprStmt | match, no-match |
+| variables.rs:330:17:330:17 | 0 | variables.rs:330:9:330:13 | a |  |
+| variables.rs:331:5:331:5 | a | variables.rs:331:10:331:10 | 1 |  |
+| variables.rs:331:5:331:10 | ... += ... | variables.rs:332:5:332:17 | ExprStmt |  |
+| variables.rs:331:5:331:11 | ExprStmt | variables.rs:331:5:331:5 | a |  |
+| variables.rs:331:10:331:10 | 1 | variables.rs:331:5:331:10 | ... += ... |  |
+| variables.rs:332:5:332:13 | PathExpr | variables.rs:332:15:332:15 | a |  |
+| variables.rs:332:5:332:16 | CallExpr | variables.rs:333:5:333:28 | ExprStmt |  |
+| variables.rs:332:5:332:17 | ExprStmt | variables.rs:332:5:332:13 | PathExpr |  |
+| variables.rs:332:15:332:15 | a | variables.rs:332:5:332:16 | CallExpr |  |
+| variables.rs:333:5:333:27 | MethodCallExpr | variables.rs:334:5:334:17 | ExprStmt |  |
+| variables.rs:333:5:333:28 | ExprStmt | variables.rs:333:5:333:27 | MethodCallExpr |  |
+| variables.rs:334:5:334:13 | PathExpr | variables.rs:334:15:334:15 | a |  |
+| variables.rs:334:5:334:16 | CallExpr | variables.rs:329:17:335:1 | BlockExpr |  |
+| variables.rs:334:5:334:17 | ExprStmt | variables.rs:334:5:334:13 | PathExpr |  |
+| variables.rs:334:15:334:15 | a | variables.rs:334:5:334:16 | CallExpr |  |
+| variables.rs:337:1:343:1 | enter mutate | variables.rs:338:5:338:18 | LetStmt |  |
+| variables.rs:337:1:343:1 | exit mutate (normal) | variables.rs:337:1:343:1 | exit mutate |  |
+| variables.rs:337:13:343:1 | BlockExpr | variables.rs:337:1:343:1 | exit mutate (normal) |  |
+| variables.rs:338:5:338:18 | LetStmt | variables.rs:338:17:338:17 | 1 |  |
+| variables.rs:338:9:338:13 | i | variables.rs:339:5:340:15 | LetStmt | match, no-match |
+| variables.rs:338:17:338:17 | 1 | variables.rs:338:9:338:13 | i |  |
+| variables.rs:339:5:340:15 | LetStmt | variables.rs:340:14:340:14 | i |  |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:341:5:341:15 | ExprStmt | match, no-match |
+| variables.rs:340:9:340:14 | RefExpr | variables.rs:339:9:339:13 | ref_i |  |
+| variables.rs:340:14:340:14 | i | variables.rs:340:9:340:14 | RefExpr |  |
+| variables.rs:341:5:341:10 | * ... | variables.rs:341:14:341:14 | 2 |  |
+| variables.rs:341:5:341:14 | ... = ... | variables.rs:342:5:342:17 | ExprStmt |  |
+| variables.rs:341:5:341:15 | ExprStmt | variables.rs:341:6:341:10 | ref_i |  |
+| variables.rs:341:6:341:10 | ref_i | variables.rs:341:5:341:10 | * ... |  |
+| variables.rs:341:14:341:14 | 2 | variables.rs:341:5:341:14 | ... = ... |  |
+| variables.rs:342:5:342:13 | PathExpr | variables.rs:342:15:342:15 | i |  |
+| variables.rs:342:5:342:16 | CallExpr | variables.rs:337:13:343:1 | BlockExpr |  |
+| variables.rs:342:5:342:17 | ExprStmt | variables.rs:342:5:342:13 | PathExpr |  |
+| variables.rs:342:15:342:15 | i | variables.rs:342:5:342:16 | CallExpr |  |
+| variables.rs:345:1:349:1 | enter mutate_param | variables.rs:346:5:348:11 | ExprStmt |  |
+| variables.rs:345:1:349:1 | exit mutate_param (normal) | variables.rs:345:1:349:1 | exit mutate_param |  |
+| variables.rs:345:31:349:1 | BlockExpr | variables.rs:345:1:349:1 | exit mutate_param (normal) |  |
+| variables.rs:346:5:346:6 | * ... | variables.rs:347:10:347:10 | x |  |
+| variables.rs:346:5:348:10 | ... = ... | variables.rs:345:31:349:1 | BlockExpr |  |
+| variables.rs:346:5:348:11 | ExprStmt | variables.rs:346:6:346:6 | x |  |
+| variables.rs:346:6:346:6 | x | variables.rs:346:5:346:6 | * ... |  |
+| variables.rs:347:9:347:10 | * ... | variables.rs:348:10:348:10 | x |  |
+| variables.rs:347:9:348:10 | ... + ... | variables.rs:346:5:348:10 | ... = ... |  |
+| variables.rs:347:10:347:10 | x | variables.rs:347:9:347:10 | * ... |  |
+| variables.rs:348:9:348:10 | * ... | variables.rs:347:9:348:10 | ... + ... |  |
+| variables.rs:348:10:348:10 | x | variables.rs:348:9:348:10 | * ... |  |
+| variables.rs:351:1:355:1 | enter mutate_arg | variables.rs:352:5:352:18 | LetStmt |  |
+| variables.rs:351:1:355:1 | exit mutate_arg (normal) | variables.rs:351:1:355:1 | exit mutate_arg |  |
+| variables.rs:351:17:355:1 | BlockExpr | variables.rs:351:1:355:1 | exit mutate_arg (normal) |  |
+| variables.rs:352:5:352:18 | LetStmt | variables.rs:352:17:352:17 | 2 |  |
+| variables.rs:352:9:352:13 | x | variables.rs:353:5:353:25 | ExprStmt | match, no-match |
+| variables.rs:352:17:352:17 | 2 | variables.rs:352:9:352:13 | x |  |
+| variables.rs:353:5:353:16 | PathExpr | variables.rs:353:23:353:23 | x |  |
+| variables.rs:353:5:353:24 | CallExpr | variables.rs:354:5:354:17 | ExprStmt |  |
+| variables.rs:353:5:353:25 | ExprStmt | variables.rs:353:5:353:16 | PathExpr |  |
+| variables.rs:353:18:353:23 | RefExpr | variables.rs:353:5:353:24 | CallExpr |  |
+| variables.rs:353:23:353:23 | x | variables.rs:353:18:353:23 | RefExpr |  |
+| variables.rs:354:5:354:13 | PathExpr | variables.rs:354:15:354:15 | x |  |
+| variables.rs:354:5:354:16 | CallExpr | variables.rs:351:17:355:1 | BlockExpr |  |
+| variables.rs:354:5:354:17 | ExprStmt | variables.rs:354:5:354:13 | PathExpr |  |
+| variables.rs:354:15:354:15 | x | variables.rs:354:5:354:16 | CallExpr |  |
+| variables.rs:357:1:383:1 | enter main | variables.rs:358:5:358:25 | ExprStmt |  |
+| variables.rs:357:1:383:1 | exit main (normal) | variables.rs:357:1:383:1 | exit main |  |
+| variables.rs:357:11:383:1 | BlockExpr | variables.rs:357:1:383:1 | exit main (normal) |  |
+| variables.rs:358:5:358:22 | PathExpr | variables.rs:358:5:358:24 | CallExpr |  |
+| variables.rs:358:5:358:24 | CallExpr | variables.rs:359:5:359:23 | ExprStmt |  |
+| variables.rs:358:5:358:25 | ExprStmt | variables.rs:358:5:358:22 | PathExpr |  |
+| variables.rs:359:5:359:20 | PathExpr | variables.rs:359:5:359:22 | CallExpr |  |
+| variables.rs:359:5:359:22 | CallExpr | variables.rs:360:5:360:23 | ExprStmt |  |
+| variables.rs:359:5:359:23 | ExprStmt | variables.rs:359:5:359:20 | PathExpr |  |
+| variables.rs:360:5:360:20 | PathExpr | variables.rs:360:5:360:22 | CallExpr |  |
+| variables.rs:360:5:360:22 | CallExpr | variables.rs:361:5:361:23 | ExprStmt |  |
+| variables.rs:360:5:360:23 | ExprStmt | variables.rs:360:5:360:20 | PathExpr |  |
+| variables.rs:361:5:361:20 | PathExpr | variables.rs:361:5:361:22 | CallExpr |  |
+| variables.rs:361:5:361:22 | CallExpr | variables.rs:362:5:362:19 | ExprStmt |  |
+| variables.rs:361:5:361:23 | ExprStmt | variables.rs:361:5:361:20 | PathExpr |  |
+| variables.rs:362:5:362:16 | PathExpr | variables.rs:362:5:362:18 | CallExpr |  |
+| variables.rs:362:5:362:18 | CallExpr | variables.rs:363:5:363:19 | ExprStmt |  |
+| variables.rs:362:5:362:19 | ExprStmt | variables.rs:362:5:362:16 | PathExpr |  |
+| variables.rs:363:5:363:16 | PathExpr | variables.rs:363:5:363:18 | CallExpr |  |
+| variables.rs:363:5:363:18 | CallExpr | variables.rs:364:5:364:19 | ExprStmt |  |
+| variables.rs:363:5:363:19 | ExprStmt | variables.rs:363:5:363:16 | PathExpr |  |
+| variables.rs:364:5:364:16 | PathExpr | variables.rs:364:5:364:18 | CallExpr |  |
+| variables.rs:364:5:364:18 | CallExpr | variables.rs:365:5:365:19 | ExprStmt |  |
+| variables.rs:364:5:364:19 | ExprStmt | variables.rs:364:5:364:16 | PathExpr |  |
+| variables.rs:365:5:365:16 | PathExpr | variables.rs:365:5:365:18 | CallExpr |  |
+| variables.rs:365:5:365:18 | CallExpr | variables.rs:366:5:366:21 | ExprStmt |  |
+| variables.rs:365:5:365:19 | ExprStmt | variables.rs:365:5:365:16 | PathExpr |  |
+| variables.rs:366:5:366:18 | PathExpr | variables.rs:366:5:366:20 | CallExpr |  |
+| variables.rs:366:5:366:20 | CallExpr | variables.rs:367:5:367:21 | ExprStmt |  |
+| variables.rs:366:5:366:21 | ExprStmt | variables.rs:366:5:366:18 | PathExpr |  |
+| variables.rs:367:5:367:18 | PathExpr | variables.rs:367:5:367:20 | CallExpr |  |
+| variables.rs:367:5:367:20 | CallExpr | variables.rs:368:5:368:21 | ExprStmt |  |
+| variables.rs:367:5:367:21 | ExprStmt | variables.rs:367:5:367:18 | PathExpr |  |
+| variables.rs:368:5:368:18 | PathExpr | variables.rs:368:5:368:20 | CallExpr |  |
+| variables.rs:368:5:368:20 | CallExpr | variables.rs:369:5:369:21 | ExprStmt |  |
+| variables.rs:368:5:368:21 | ExprStmt | variables.rs:368:5:368:18 | PathExpr |  |
+| variables.rs:369:5:369:18 | PathExpr | variables.rs:369:5:369:20 | CallExpr |  |
+| variables.rs:369:5:369:20 | CallExpr | variables.rs:370:5:370:21 | ExprStmt |  |
+| variables.rs:369:5:369:21 | ExprStmt | variables.rs:369:5:369:18 | PathExpr |  |
+| variables.rs:370:5:370:18 | PathExpr | variables.rs:370:5:370:20 | CallExpr |  |
+| variables.rs:370:5:370:20 | CallExpr | variables.rs:371:5:371:21 | ExprStmt |  |
+| variables.rs:370:5:370:21 | ExprStmt | variables.rs:370:5:370:18 | PathExpr |  |
+| variables.rs:371:5:371:18 | PathExpr | variables.rs:371:5:371:20 | CallExpr |  |
+| variables.rs:371:5:371:20 | CallExpr | variables.rs:372:5:372:21 | ExprStmt |  |
+| variables.rs:371:5:371:21 | ExprStmt | variables.rs:371:5:371:18 | PathExpr |  |
+| variables.rs:372:5:372:18 | PathExpr | variables.rs:372:5:372:20 | CallExpr |  |
+| variables.rs:372:5:372:20 | CallExpr | variables.rs:373:5:373:21 | ExprStmt |  |
+| variables.rs:372:5:372:21 | ExprStmt | variables.rs:372:5:372:18 | PathExpr |  |
+| variables.rs:373:5:373:18 | PathExpr | variables.rs:373:5:373:20 | CallExpr |  |
+| variables.rs:373:5:373:20 | CallExpr | variables.rs:374:5:374:21 | ExprStmt |  |
+| variables.rs:373:5:373:21 | ExprStmt | variables.rs:373:5:373:18 | PathExpr |  |
+| variables.rs:374:5:374:18 | PathExpr | variables.rs:374:5:374:20 | CallExpr |  |
+| variables.rs:374:5:374:20 | CallExpr | variables.rs:375:5:375:36 | ExprStmt |  |
+| variables.rs:374:5:374:21 | ExprStmt | variables.rs:374:5:374:18 | PathExpr |  |
+| variables.rs:375:5:375:18 | PathExpr | variables.rs:375:20:375:22 | "a" |  |
+| variables.rs:375:5:375:35 | CallExpr | variables.rs:376:5:376:37 | ExprStmt |  |
+| variables.rs:375:5:375:36 | ExprStmt | variables.rs:375:5:375:18 | PathExpr |  |
+| variables.rs:375:20:375:22 | "a" | variables.rs:375:26:375:28 | "b" |  |
+| variables.rs:375:25:375:34 | TupleExpr | variables.rs:375:5:375:35 | CallExpr |  |
+| variables.rs:375:26:375:28 | "b" | variables.rs:375:31:375:33 | "c" |  |
+| variables.rs:375:31:375:33 | "c" | variables.rs:375:25:375:34 | TupleExpr |  |
+| variables.rs:376:5:376:18 | PathExpr | variables.rs:376:20:376:31 | PathExpr |  |
+| variables.rs:376:5:376:36 | CallExpr | variables.rs:377:5:377:26 | ExprStmt |  |
+| variables.rs:376:5:376:37 | ExprStmt | variables.rs:376:5:376:18 | PathExpr |  |
+| variables.rs:376:20:376:31 | PathExpr | variables.rs:376:33:376:34 | 45 |  |
+| variables.rs:376:20:376:35 | CallExpr | variables.rs:376:5:376:36 | CallExpr |  |
+| variables.rs:376:33:376:34 | 45 | variables.rs:376:20:376:35 | CallExpr |  |
+| variables.rs:377:5:377:23 | PathExpr | variables.rs:377:5:377:25 | CallExpr |  |
+| variables.rs:377:5:377:25 | CallExpr | variables.rs:378:5:378:23 | ExprStmt |  |
+| variables.rs:377:5:377:26 | ExprStmt | variables.rs:377:5:377:23 | PathExpr |  |
+| variables.rs:378:5:378:20 | PathExpr | variables.rs:378:5:378:22 | CallExpr |  |
+| variables.rs:378:5:378:22 | CallExpr | variables.rs:379:5:379:19 | ExprStmt |  |
+| variables.rs:378:5:378:23 | ExprStmt | variables.rs:378:5:378:20 | PathExpr |  |
+| variables.rs:379:5:379:16 | PathExpr | variables.rs:379:5:379:18 | CallExpr |  |
+| variables.rs:379:5:379:18 | CallExpr | variables.rs:380:5:380:17 | ExprStmt |  |
+| variables.rs:379:5:379:19 | ExprStmt | variables.rs:379:5:379:16 | PathExpr |  |
+| variables.rs:380:5:380:14 | PathExpr | variables.rs:380:5:380:16 | CallExpr |  |
+| variables.rs:380:5:380:16 | CallExpr | variables.rs:381:5:381:13 | ExprStmt |  |
+| variables.rs:380:5:380:17 | ExprStmt | variables.rs:380:5:380:14 | PathExpr |  |
+| variables.rs:381:5:381:10 | PathExpr | variables.rs:381:5:381:12 | CallExpr |  |
+| variables.rs:381:5:381:12 | CallExpr | variables.rs:382:5:382:17 | ExprStmt |  |
+| variables.rs:381:5:381:13 | ExprStmt | variables.rs:381:5:381:10 | PathExpr |  |
+| variables.rs:382:5:382:14 | PathExpr | variables.rs:382:5:382:16 | CallExpr |  |
+| variables.rs:382:5:382:16 | CallExpr | variables.rs:357:11:383:1 | BlockExpr |  |
+| variables.rs:382:5:382:17 | ExprStmt | variables.rs:382:5:382:14 | PathExpr |  |
 breakTarget
 continueTarget

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,261 +1,308 @@
 testFailures
+| variables.rs:331:5:331:5 | a | Unexpected result: read_access=a |
+| variables.rs:331:5:331:5 | a | Unexpected result: write_access=a |
+| variables.rs:331:13:331:25 | Comment | Missing result:access=a |
+| variables.rs:333:11:333:11 | a | Unexpected result: read_access=a |
+| variables.rs:333:30:333:42 | Comment | Missing result:access=a |
+| variables.rs:340:14:340:14 | i | Unexpected result: read_access=i |
+| variables.rs:340:17:340:29 | Comment | Missing result:access=i |
+| variables.rs:341:6:341:10 | ref_i | Unexpected result: write_access=ref_i |
+| variables.rs:341:17:341:38 | Comment | Missing result:read_access=ref_i |
+| variables.rs:346:6:346:6 | x | Unexpected result: write_access=x |
+| variables.rs:346:10:346:27 | Comment | Missing result:read_access=x |
+| variables.rs:353:23:353:23 | x | Unexpected result: read_access=x |
+| variables.rs:353:27:353:39 | Comment | Missing result:access=x |
 failures
 variable
-| variables.rs:1:14:1:14 | s |
-| variables.rs:5:14:5:14 | i |
-| variables.rs:10:9:10:10 | x1 |
-| variables.rs:15:13:15:14 | x2 |
-| variables.rs:22:9:22:10 | x3 |
+| variables.rs:3:14:3:14 | s |
+| variables.rs:7:14:7:14 | i |
+| variables.rs:12:9:12:10 | x1 |
+| variables.rs:17:13:17:14 | x2 |
 | variables.rs:24:9:24:10 | x3 |
-| variables.rs:30:9:30:10 | x4 |
-| variables.rs:33:13:33:14 | x4 |
-| variables.rs:47:13:47:14 | a1 |
-| variables.rs:48:13:48:14 | b1 |
-| variables.rs:51:13:51:13 | x |
-| variables.rs:52:13:52:13 | y |
-| variables.rs:62:9:62:10 | p1 |
-| variables.rs:64:12:64:13 | a2 |
-| variables.rs:65:12:65:13 | b2 |
-| variables.rs:72:9:72:10 | s1 |
-| variables.rs:74:21:74:22 | s2 |
-| variables.rs:81:14:81:15 | x5 |
-| variables.rs:89:9:89:10 | s1 |
-| variables.rs:91:24:91:25 | s2 |
-| variables.rs:98:9:98:10 | x6 |
-| variables.rs:99:9:99:10 | y1 |
-| variables.rs:103:14:103:15 | y1 |
-| variables.rs:108:9:108:12 | None |
-| variables.rs:115:9:115:15 | numbers |
-| variables.rs:119:13:119:17 | first |
-| variables.rs:120:13:120:17 | third |
-| variables.rs:121:13:121:17 | fifth |
-| variables.rs:131:13:131:17 | first |
-| variables.rs:133:13:133:16 | last |
-| variables.rs:142:9:142:10 | p2 |
-| variables.rs:146:16:146:17 | x7 |
-| variables.rs:156:9:156:11 | msg |
-| variables.rs:160:17:160:27 | id_variable |
-| variables.rs:165:26:165:27 | id |
-| variables.rs:176:9:176:14 | either |
-| variables.rs:178:9:178:44 | a3 |
-| variables.rs:190:9:190:10 | tv |
-| variables.rs:192:9:192:81 | a4 |
-| variables.rs:196:9:196:83 | a5 |
-| variables.rs:200:9:200:83 | a6 |
-| variables.rs:206:9:206:14 | either |
-| variables.rs:208:9:208:44 | a7 |
-| variables.rs:216:9:216:14 | either |
-| variables.rs:219:13:219:13 | e |
-| variables.rs:220:14:220:51 | a11 |
-| variables.rs:223:33:223:35 | a12 |
-| variables.rs:240:9:240:10 | fv |
-| variables.rs:242:9:242:109 | a13 |
-| variables.rs:248:5:248:6 | a8 |
-| variables.rs:250:9:250:10 | b3 |
-| variables.rs:251:9:251:10 | c1 |
-| variables.rs:259:6:259:41 | a9 |
-| variables.rs:266:13:266:15 | a10 |
-| variables.rs:267:13:267:14 | b4 |
-| variables.rs:268:13:268:14 | c2 |
-| variables.rs:289:13:289:15 | a10 |
-| variables.rs:290:13:290:14 | b4 |
-| variables.rs:302:9:302:23 | example_closure |
-| variables.rs:303:10:303:10 | x |
-| variables.rs:305:9:305:10 | n1 |
-| variables.rs:310:9:310:26 | immutable_variable |
-| variables.rs:311:10:311:10 | x |
-| variables.rs:313:9:313:10 | n2 |
-| variables.rs:319:9:319:9 | v |
-| variables.rs:321:9:321:12 | text |
+| variables.rs:26:9:26:10 | x3 |
+| variables.rs:32:9:32:10 | x4 |
+| variables.rs:35:13:35:14 | x4 |
+| variables.rs:49:13:49:14 | a1 |
+| variables.rs:50:13:50:14 | b1 |
+| variables.rs:53:13:53:13 | x |
+| variables.rs:54:13:54:13 | y |
+| variables.rs:64:9:64:10 | p1 |
+| variables.rs:66:12:66:13 | a2 |
+| variables.rs:67:12:67:13 | b2 |
+| variables.rs:74:9:74:10 | s1 |
+| variables.rs:76:21:76:22 | s2 |
+| variables.rs:83:14:83:15 | x5 |
+| variables.rs:91:9:91:10 | s1 |
+| variables.rs:93:24:93:25 | s2 |
+| variables.rs:100:9:100:10 | x6 |
+| variables.rs:101:9:101:10 | y1 |
+| variables.rs:105:14:105:15 | y1 |
+| variables.rs:110:9:110:12 | None |
+| variables.rs:117:9:117:15 | numbers |
+| variables.rs:121:13:121:17 | first |
+| variables.rs:122:13:122:17 | third |
+| variables.rs:123:13:123:17 | fifth |
+| variables.rs:133:13:133:17 | first |
+| variables.rs:135:13:135:16 | last |
+| variables.rs:144:9:144:10 | p2 |
+| variables.rs:148:16:148:17 | x7 |
+| variables.rs:158:9:158:11 | msg |
+| variables.rs:162:17:162:27 | id_variable |
+| variables.rs:167:26:167:27 | id |
+| variables.rs:178:9:178:14 | either |
+| variables.rs:180:9:180:44 | a3 |
+| variables.rs:192:9:192:10 | tv |
+| variables.rs:194:9:194:81 | a4 |
+| variables.rs:198:9:198:83 | a5 |
+| variables.rs:202:9:202:83 | a6 |
+| variables.rs:208:9:208:14 | either |
+| variables.rs:210:9:210:44 | a7 |
+| variables.rs:218:9:218:14 | either |
+| variables.rs:221:13:221:13 | e |
+| variables.rs:222:14:222:51 | a11 |
+| variables.rs:225:33:225:35 | a12 |
+| variables.rs:242:9:242:10 | fv |
+| variables.rs:244:9:244:109 | a13 |
+| variables.rs:250:5:250:6 | a8 |
+| variables.rs:252:9:252:10 | b3 |
+| variables.rs:253:9:253:10 | c1 |
+| variables.rs:261:6:261:41 | a9 |
+| variables.rs:268:13:268:15 | a10 |
+| variables.rs:269:13:269:14 | b4 |
+| variables.rs:270:13:270:14 | c2 |
+| variables.rs:291:13:291:15 | a10 |
+| variables.rs:292:13:292:14 | b4 |
+| variables.rs:304:9:304:23 | example_closure |
+| variables.rs:305:10:305:10 | x |
+| variables.rs:307:9:307:10 | n1 |
+| variables.rs:312:9:312:26 | immutable_variable |
+| variables.rs:313:10:313:10 | x |
+| variables.rs:315:9:315:10 | n2 |
+| variables.rs:321:9:321:9 | v |
+| variables.rs:323:9:323:12 | text |
+| variables.rs:330:13:330:13 | a |
+| variables.rs:338:13:338:13 | i |
+| variables.rs:339:9:339:13 | ref_i |
+| variables.rs:345:17:345:17 | x |
+| variables.rs:352:13:352:13 | x |
 variableAccess
-| variables.rs:11:15:11:16 | x1 | variables.rs:10:9:10:10 | x1 |
-| variables.rs:16:15:16:16 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:17:5:17:6 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:18:15:18:16 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:23:15:23:16 | x3 | variables.rs:22:9:22:10 | x3 |
-| variables.rs:25:9:25:10 | x3 | variables.rs:22:9:22:10 | x3 |
-| variables.rs:26:15:26:16 | x3 | variables.rs:24:9:24:10 | x3 |
-| variables.rs:31:15:31:16 | x4 | variables.rs:30:9:30:10 | x4 |
-| variables.rs:34:19:34:20 | x4 | variables.rs:33:13:33:14 | x4 |
-| variables.rs:36:15:36:16 | x4 | variables.rs:30:9:30:10 | x4 |
-| variables.rs:55:15:55:16 | a1 | variables.rs:47:13:47:14 | a1 |
-| variables.rs:56:15:56:16 | b1 | variables.rs:48:13:48:14 | b1 |
-| variables.rs:57:15:57:15 | x | variables.rs:51:13:51:13 | x |
-| variables.rs:58:15:58:15 | y | variables.rs:52:13:52:13 | y |
-| variables.rs:66:9:66:10 | p1 | variables.rs:62:9:62:10 | p1 |
-| variables.rs:67:15:67:16 | a2 | variables.rs:64:12:64:13 | a2 |
-| variables.rs:68:15:68:16 | b2 | variables.rs:65:12:65:13 | b2 |
-| variables.rs:75:11:75:12 | s1 | variables.rs:72:9:72:10 | s1 |
-| variables.rs:76:19:76:20 | s2 | variables.rs:74:21:74:22 | s2 |
-| variables.rs:85:15:85:16 | x5 | variables.rs:81:14:81:15 | x5 |
-| variables.rs:92:11:92:12 | s1 | variables.rs:89:9:89:10 | s1 |
-| variables.rs:93:19:93:20 | s2 | variables.rs:91:24:91:25 | s2 |
-| variables.rs:101:11:101:12 | x6 | variables.rs:98:9:98:10 | x6 |
-| variables.rs:106:23:106:24 | y1 | variables.rs:103:14:103:15 | y1 |
-| variables.rs:111:15:111:16 | y1 | variables.rs:99:9:99:10 | y1 |
-| variables.rs:117:11:117:17 | numbers | variables.rs:115:9:115:15 | numbers |
-| variables.rs:123:23:123:27 | first | variables.rs:119:13:119:17 | first |
-| variables.rs:124:23:124:27 | third | variables.rs:120:13:120:17 | third |
-| variables.rs:125:23:125:27 | fifth | variables.rs:121:13:121:17 | fifth |
-| variables.rs:129:11:129:17 | numbers | variables.rs:115:9:115:15 | numbers |
-| variables.rs:135:23:135:27 | first | variables.rs:131:13:131:17 | first |
-| variables.rs:136:23:136:26 | last | variables.rs:133:13:133:16 | last |
-| variables.rs:144:11:144:12 | p2 | variables.rs:142:9:142:10 | p2 |
-| variables.rs:147:24:147:25 | x7 | variables.rs:146:16:146:17 | x7 |
-| variables.rs:158:11:158:13 | msg | variables.rs:156:9:156:11 | msg |
-| variables.rs:161:24:161:34 | id_variable | variables.rs:160:17:160:27 | id_variable |
-| variables.rs:166:23:166:24 | id | variables.rs:165:26:165:27 | id |
-| variables.rs:177:11:177:16 | either | variables.rs:176:9:176:14 | either |
-| variables.rs:179:26:179:27 | a3 | variables.rs:178:9:178:44 | a3 |
-| variables.rs:191:11:191:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:193:26:193:27 | a4 | variables.rs:192:9:192:81 | a4 |
-| variables.rs:195:11:195:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:197:26:197:27 | a5 | variables.rs:196:9:196:83 | a5 |
-| variables.rs:199:11:199:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:201:26:201:27 | a6 | variables.rs:200:9:200:83 | a6 |
-| variables.rs:207:11:207:16 | either | variables.rs:206:9:206:14 | either |
-| variables.rs:209:16:209:17 | a7 | variables.rs:208:9:208:44 | a7 |
-| variables.rs:210:26:210:27 | a7 | variables.rs:208:9:208:44 | a7 |
-| variables.rs:218:11:218:16 | either | variables.rs:216:9:216:14 | either |
-| variables.rs:222:23:222:25 | a11 | variables.rs:220:14:220:51 | a11 |
-| variables.rs:224:15:224:15 | e | variables.rs:219:13:219:13 | e |
-| variables.rs:225:28:225:30 | a12 | variables.rs:223:33:223:35 | a12 |
-| variables.rs:241:11:241:12 | fv | variables.rs:240:9:240:10 | fv |
-| variables.rs:243:26:243:28 | a13 | variables.rs:242:9:242:109 | a13 |
-| variables.rs:253:15:253:16 | a8 | variables.rs:248:5:248:6 | a8 |
-| variables.rs:254:15:254:16 | b3 | variables.rs:250:9:250:10 | b3 |
-| variables.rs:255:15:255:16 | c1 | variables.rs:251:9:251:10 | c1 |
-| variables.rs:261:15:261:16 | a9 | variables.rs:259:6:259:41 | a9 |
-| variables.rs:270:15:270:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:271:15:271:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:272:15:272:16 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:275:9:275:10 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:276:9:276:10 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:277:9:277:11 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:279:9:279:11 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:280:9:280:10 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:281:9:281:10 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:283:15:283:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:284:15:284:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:285:15:285:16 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:292:23:292:25 | a10 | variables.rs:289:13:289:15 | a10 |
-| variables.rs:293:23:293:24 | b4 | variables.rs:290:13:290:14 | b4 |
-| variables.rs:297:15:297:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:298:15:298:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:304:9:304:9 | x | variables.rs:303:10:303:10 | x |
-| variables.rs:306:9:306:23 | example_closure | variables.rs:302:9:302:23 | example_closure |
-| variables.rs:307:15:307:16 | n1 | variables.rs:305:9:305:10 | n1 |
-| variables.rs:312:9:312:9 | x | variables.rs:311:10:311:10 | x |
-| variables.rs:314:9:314:26 | immutable_variable | variables.rs:310:9:310:26 | immutable_variable |
-| variables.rs:315:15:315:16 | n2 | variables.rs:313:9:313:10 | n2 |
-| variables.rs:322:12:322:12 | v | variables.rs:319:9:319:9 | v |
-| variables.rs:323:19:323:22 | text | variables.rs:321:9:321:12 | text |
+| variables.rs:13:15:13:16 | x1 | variables.rs:12:9:12:10 | x1 |
+| variables.rs:18:15:18:16 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:20:15:20:16 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:25:15:25:16 | x3 | variables.rs:24:9:24:10 | x3 |
+| variables.rs:27:9:27:10 | x3 | variables.rs:24:9:24:10 | x3 |
+| variables.rs:28:15:28:16 | x3 | variables.rs:26:9:26:10 | x3 |
+| variables.rs:33:15:33:16 | x4 | variables.rs:32:9:32:10 | x4 |
+| variables.rs:36:19:36:20 | x4 | variables.rs:35:13:35:14 | x4 |
+| variables.rs:38:15:38:16 | x4 | variables.rs:32:9:32:10 | x4 |
+| variables.rs:57:15:57:16 | a1 | variables.rs:49:13:49:14 | a1 |
+| variables.rs:58:15:58:16 | b1 | variables.rs:50:13:50:14 | b1 |
+| variables.rs:59:15:59:15 | x | variables.rs:53:13:53:13 | x |
+| variables.rs:60:15:60:15 | y | variables.rs:54:13:54:13 | y |
+| variables.rs:68:9:68:10 | p1 | variables.rs:64:9:64:10 | p1 |
+| variables.rs:69:15:69:16 | a2 | variables.rs:66:12:66:13 | a2 |
+| variables.rs:70:15:70:16 | b2 | variables.rs:67:12:67:13 | b2 |
+| variables.rs:77:11:77:12 | s1 | variables.rs:74:9:74:10 | s1 |
+| variables.rs:78:19:78:20 | s2 | variables.rs:76:21:76:22 | s2 |
+| variables.rs:87:15:87:16 | x5 | variables.rs:83:14:83:15 | x5 |
+| variables.rs:94:11:94:12 | s1 | variables.rs:91:9:91:10 | s1 |
+| variables.rs:95:19:95:20 | s2 | variables.rs:93:24:93:25 | s2 |
+| variables.rs:103:11:103:12 | x6 | variables.rs:100:9:100:10 | x6 |
+| variables.rs:108:23:108:24 | y1 | variables.rs:105:14:105:15 | y1 |
+| variables.rs:113:15:113:16 | y1 | variables.rs:101:9:101:10 | y1 |
+| variables.rs:119:11:119:17 | numbers | variables.rs:117:9:117:15 | numbers |
+| variables.rs:125:23:125:27 | first | variables.rs:121:13:121:17 | first |
+| variables.rs:126:23:126:27 | third | variables.rs:122:13:122:17 | third |
+| variables.rs:127:23:127:27 | fifth | variables.rs:123:13:123:17 | fifth |
+| variables.rs:131:11:131:17 | numbers | variables.rs:117:9:117:15 | numbers |
+| variables.rs:137:23:137:27 | first | variables.rs:133:13:133:17 | first |
+| variables.rs:138:23:138:26 | last | variables.rs:135:13:135:16 | last |
+| variables.rs:146:11:146:12 | p2 | variables.rs:144:9:144:10 | p2 |
+| variables.rs:149:24:149:25 | x7 | variables.rs:148:16:148:17 | x7 |
+| variables.rs:160:11:160:13 | msg | variables.rs:158:9:158:11 | msg |
+| variables.rs:163:24:163:34 | id_variable | variables.rs:162:17:162:27 | id_variable |
+| variables.rs:168:23:168:24 | id | variables.rs:167:26:167:27 | id |
+| variables.rs:179:11:179:16 | either | variables.rs:178:9:178:14 | either |
+| variables.rs:181:26:181:27 | a3 | variables.rs:180:9:180:44 | a3 |
+| variables.rs:193:11:193:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:195:26:195:27 | a4 | variables.rs:194:9:194:81 | a4 |
+| variables.rs:197:11:197:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:199:26:199:27 | a5 | variables.rs:198:9:198:83 | a5 |
+| variables.rs:201:11:201:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:203:26:203:27 | a6 | variables.rs:202:9:202:83 | a6 |
+| variables.rs:209:11:209:16 | either | variables.rs:208:9:208:14 | either |
+| variables.rs:211:16:211:17 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:212:26:212:27 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:220:11:220:16 | either | variables.rs:218:9:218:14 | either |
+| variables.rs:224:23:224:25 | a11 | variables.rs:222:14:222:51 | a11 |
+| variables.rs:226:15:226:15 | e | variables.rs:221:13:221:13 | e |
+| variables.rs:227:28:227:30 | a12 | variables.rs:225:33:225:35 | a12 |
+| variables.rs:243:11:243:12 | fv | variables.rs:242:9:242:10 | fv |
+| variables.rs:245:26:245:28 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:255:15:255:16 | a8 | variables.rs:250:5:250:6 | a8 |
+| variables.rs:256:15:256:16 | b3 | variables.rs:252:9:252:10 | b3 |
+| variables.rs:257:15:257:16 | c1 | variables.rs:253:9:253:10 | c1 |
+| variables.rs:263:15:263:16 | a9 | variables.rs:261:6:261:41 | a9 |
+| variables.rs:272:15:272:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:273:15:273:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:274:15:274:16 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:281:9:281:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:282:9:282:10 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:283:9:283:10 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:285:15:285:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:286:15:286:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:287:15:287:16 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:294:23:294:25 | a10 | variables.rs:291:13:291:15 | a10 |
+| variables.rs:295:23:295:24 | b4 | variables.rs:292:13:292:14 | b4 |
+| variables.rs:299:15:299:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:300:15:300:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:306:9:306:9 | x | variables.rs:305:10:305:10 | x |
+| variables.rs:308:9:308:23 | example_closure | variables.rs:304:9:304:23 | example_closure |
+| variables.rs:309:15:309:16 | n1 | variables.rs:307:9:307:10 | n1 |
+| variables.rs:314:9:314:9 | x | variables.rs:313:10:313:10 | x |
+| variables.rs:316:9:316:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable |
+| variables.rs:317:15:317:16 | n2 | variables.rs:315:9:315:10 | n2 |
+| variables.rs:324:12:324:12 | v | variables.rs:321:9:321:9 | v |
+| variables.rs:325:19:325:22 | text | variables.rs:323:9:323:12 | text |
+| variables.rs:331:5:331:5 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:332:15:332:15 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:333:11:333:11 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:334:15:334:15 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:340:14:340:14 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:341:6:341:10 | ref_i | variables.rs:339:9:339:13 | ref_i |
+| variables.rs:342:15:342:15 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:347:10:347:10 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:348:10:348:10 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:353:23:353:23 | x | variables.rs:352:13:352:13 | x |
+| variables.rs:354:15:354:15 | x | variables.rs:352:13:352:13 | x |
 variableWriteAccess
-| variables.rs:17:5:17:6 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:275:9:275:10 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:276:9:276:10 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:277:9:277:11 | a10 | variables.rs:266:13:266:15 | a10 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:331:5:331:5 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:341:6:341:10 | ref_i | variables.rs:339:9:339:13 | ref_i |
+| variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
 variableReadAccess
-| variables.rs:11:15:11:16 | x1 | variables.rs:10:9:10:10 | x1 |
-| variables.rs:16:15:16:16 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:18:15:18:16 | x2 | variables.rs:15:13:15:14 | x2 |
-| variables.rs:23:15:23:16 | x3 | variables.rs:22:9:22:10 | x3 |
-| variables.rs:25:9:25:10 | x3 | variables.rs:22:9:22:10 | x3 |
-| variables.rs:26:15:26:16 | x3 | variables.rs:24:9:24:10 | x3 |
-| variables.rs:31:15:31:16 | x4 | variables.rs:30:9:30:10 | x4 |
-| variables.rs:34:19:34:20 | x4 | variables.rs:33:13:33:14 | x4 |
-| variables.rs:36:15:36:16 | x4 | variables.rs:30:9:30:10 | x4 |
-| variables.rs:55:15:55:16 | a1 | variables.rs:47:13:47:14 | a1 |
-| variables.rs:56:15:56:16 | b1 | variables.rs:48:13:48:14 | b1 |
-| variables.rs:57:15:57:15 | x | variables.rs:51:13:51:13 | x |
-| variables.rs:58:15:58:15 | y | variables.rs:52:13:52:13 | y |
-| variables.rs:66:9:66:10 | p1 | variables.rs:62:9:62:10 | p1 |
-| variables.rs:67:15:67:16 | a2 | variables.rs:64:12:64:13 | a2 |
-| variables.rs:68:15:68:16 | b2 | variables.rs:65:12:65:13 | b2 |
-| variables.rs:75:11:75:12 | s1 | variables.rs:72:9:72:10 | s1 |
-| variables.rs:76:19:76:20 | s2 | variables.rs:74:21:74:22 | s2 |
-| variables.rs:85:15:85:16 | x5 | variables.rs:81:14:81:15 | x5 |
-| variables.rs:92:11:92:12 | s1 | variables.rs:89:9:89:10 | s1 |
-| variables.rs:93:19:93:20 | s2 | variables.rs:91:24:91:25 | s2 |
-| variables.rs:101:11:101:12 | x6 | variables.rs:98:9:98:10 | x6 |
-| variables.rs:106:23:106:24 | y1 | variables.rs:103:14:103:15 | y1 |
-| variables.rs:111:15:111:16 | y1 | variables.rs:99:9:99:10 | y1 |
-| variables.rs:117:11:117:17 | numbers | variables.rs:115:9:115:15 | numbers |
-| variables.rs:123:23:123:27 | first | variables.rs:119:13:119:17 | first |
-| variables.rs:124:23:124:27 | third | variables.rs:120:13:120:17 | third |
-| variables.rs:125:23:125:27 | fifth | variables.rs:121:13:121:17 | fifth |
-| variables.rs:129:11:129:17 | numbers | variables.rs:115:9:115:15 | numbers |
-| variables.rs:135:23:135:27 | first | variables.rs:131:13:131:17 | first |
-| variables.rs:136:23:136:26 | last | variables.rs:133:13:133:16 | last |
-| variables.rs:144:11:144:12 | p2 | variables.rs:142:9:142:10 | p2 |
-| variables.rs:147:24:147:25 | x7 | variables.rs:146:16:146:17 | x7 |
-| variables.rs:158:11:158:13 | msg | variables.rs:156:9:156:11 | msg |
-| variables.rs:161:24:161:34 | id_variable | variables.rs:160:17:160:27 | id_variable |
-| variables.rs:166:23:166:24 | id | variables.rs:165:26:165:27 | id |
-| variables.rs:177:11:177:16 | either | variables.rs:176:9:176:14 | either |
-| variables.rs:179:26:179:27 | a3 | variables.rs:178:9:178:44 | a3 |
-| variables.rs:191:11:191:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:193:26:193:27 | a4 | variables.rs:192:9:192:81 | a4 |
-| variables.rs:195:11:195:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:197:26:197:27 | a5 | variables.rs:196:9:196:83 | a5 |
-| variables.rs:199:11:199:12 | tv | variables.rs:190:9:190:10 | tv |
-| variables.rs:201:26:201:27 | a6 | variables.rs:200:9:200:83 | a6 |
-| variables.rs:207:11:207:16 | either | variables.rs:206:9:206:14 | either |
-| variables.rs:209:16:209:17 | a7 | variables.rs:208:9:208:44 | a7 |
-| variables.rs:210:26:210:27 | a7 | variables.rs:208:9:208:44 | a7 |
-| variables.rs:218:11:218:16 | either | variables.rs:216:9:216:14 | either |
-| variables.rs:222:23:222:25 | a11 | variables.rs:220:14:220:51 | a11 |
-| variables.rs:224:15:224:15 | e | variables.rs:219:13:219:13 | e |
-| variables.rs:225:28:225:30 | a12 | variables.rs:223:33:223:35 | a12 |
-| variables.rs:241:11:241:12 | fv | variables.rs:240:9:240:10 | fv |
-| variables.rs:243:26:243:28 | a13 | variables.rs:242:9:242:109 | a13 |
-| variables.rs:253:15:253:16 | a8 | variables.rs:248:5:248:6 | a8 |
-| variables.rs:254:15:254:16 | b3 | variables.rs:250:9:250:10 | b3 |
-| variables.rs:255:15:255:16 | c1 | variables.rs:251:9:251:10 | c1 |
-| variables.rs:261:15:261:16 | a9 | variables.rs:259:6:259:41 | a9 |
-| variables.rs:270:15:270:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:271:15:271:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:272:15:272:16 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:279:9:279:11 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:280:9:280:10 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:281:9:281:10 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:283:15:283:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:284:15:284:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:285:15:285:16 | c2 | variables.rs:268:13:268:14 | c2 |
-| variables.rs:292:23:292:25 | a10 | variables.rs:289:13:289:15 | a10 |
-| variables.rs:293:23:293:24 | b4 | variables.rs:290:13:290:14 | b4 |
-| variables.rs:297:15:297:17 | a10 | variables.rs:266:13:266:15 | a10 |
-| variables.rs:298:15:298:16 | b4 | variables.rs:267:13:267:14 | b4 |
-| variables.rs:304:9:304:9 | x | variables.rs:303:10:303:10 | x |
-| variables.rs:306:9:306:23 | example_closure | variables.rs:302:9:302:23 | example_closure |
-| variables.rs:307:15:307:16 | n1 | variables.rs:305:9:305:10 | n1 |
-| variables.rs:312:9:312:9 | x | variables.rs:311:10:311:10 | x |
-| variables.rs:314:9:314:26 | immutable_variable | variables.rs:310:9:310:26 | immutable_variable |
-| variables.rs:315:15:315:16 | n2 | variables.rs:313:9:313:10 | n2 |
-| variables.rs:322:12:322:12 | v | variables.rs:319:9:319:9 | v |
-| variables.rs:323:19:323:22 | text | variables.rs:321:9:321:12 | text |
+| variables.rs:13:15:13:16 | x1 | variables.rs:12:9:12:10 | x1 |
+| variables.rs:18:15:18:16 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:20:15:20:16 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:25:15:25:16 | x3 | variables.rs:24:9:24:10 | x3 |
+| variables.rs:27:9:27:10 | x3 | variables.rs:24:9:24:10 | x3 |
+| variables.rs:28:15:28:16 | x3 | variables.rs:26:9:26:10 | x3 |
+| variables.rs:33:15:33:16 | x4 | variables.rs:32:9:32:10 | x4 |
+| variables.rs:36:19:36:20 | x4 | variables.rs:35:13:35:14 | x4 |
+| variables.rs:38:15:38:16 | x4 | variables.rs:32:9:32:10 | x4 |
+| variables.rs:57:15:57:16 | a1 | variables.rs:49:13:49:14 | a1 |
+| variables.rs:58:15:58:16 | b1 | variables.rs:50:13:50:14 | b1 |
+| variables.rs:59:15:59:15 | x | variables.rs:53:13:53:13 | x |
+| variables.rs:60:15:60:15 | y | variables.rs:54:13:54:13 | y |
+| variables.rs:68:9:68:10 | p1 | variables.rs:64:9:64:10 | p1 |
+| variables.rs:69:15:69:16 | a2 | variables.rs:66:12:66:13 | a2 |
+| variables.rs:70:15:70:16 | b2 | variables.rs:67:12:67:13 | b2 |
+| variables.rs:77:11:77:12 | s1 | variables.rs:74:9:74:10 | s1 |
+| variables.rs:78:19:78:20 | s2 | variables.rs:76:21:76:22 | s2 |
+| variables.rs:87:15:87:16 | x5 | variables.rs:83:14:83:15 | x5 |
+| variables.rs:94:11:94:12 | s1 | variables.rs:91:9:91:10 | s1 |
+| variables.rs:95:19:95:20 | s2 | variables.rs:93:24:93:25 | s2 |
+| variables.rs:103:11:103:12 | x6 | variables.rs:100:9:100:10 | x6 |
+| variables.rs:108:23:108:24 | y1 | variables.rs:105:14:105:15 | y1 |
+| variables.rs:113:15:113:16 | y1 | variables.rs:101:9:101:10 | y1 |
+| variables.rs:119:11:119:17 | numbers | variables.rs:117:9:117:15 | numbers |
+| variables.rs:125:23:125:27 | first | variables.rs:121:13:121:17 | first |
+| variables.rs:126:23:126:27 | third | variables.rs:122:13:122:17 | third |
+| variables.rs:127:23:127:27 | fifth | variables.rs:123:13:123:17 | fifth |
+| variables.rs:131:11:131:17 | numbers | variables.rs:117:9:117:15 | numbers |
+| variables.rs:137:23:137:27 | first | variables.rs:133:13:133:17 | first |
+| variables.rs:138:23:138:26 | last | variables.rs:135:13:135:16 | last |
+| variables.rs:146:11:146:12 | p2 | variables.rs:144:9:144:10 | p2 |
+| variables.rs:149:24:149:25 | x7 | variables.rs:148:16:148:17 | x7 |
+| variables.rs:160:11:160:13 | msg | variables.rs:158:9:158:11 | msg |
+| variables.rs:163:24:163:34 | id_variable | variables.rs:162:17:162:27 | id_variable |
+| variables.rs:168:23:168:24 | id | variables.rs:167:26:167:27 | id |
+| variables.rs:179:11:179:16 | either | variables.rs:178:9:178:14 | either |
+| variables.rs:181:26:181:27 | a3 | variables.rs:180:9:180:44 | a3 |
+| variables.rs:193:11:193:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:195:26:195:27 | a4 | variables.rs:194:9:194:81 | a4 |
+| variables.rs:197:11:197:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:199:26:199:27 | a5 | variables.rs:198:9:198:83 | a5 |
+| variables.rs:201:11:201:12 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:203:26:203:27 | a6 | variables.rs:202:9:202:83 | a6 |
+| variables.rs:209:11:209:16 | either | variables.rs:208:9:208:14 | either |
+| variables.rs:211:16:211:17 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:212:26:212:27 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:220:11:220:16 | either | variables.rs:218:9:218:14 | either |
+| variables.rs:224:23:224:25 | a11 | variables.rs:222:14:222:51 | a11 |
+| variables.rs:226:15:226:15 | e | variables.rs:221:13:221:13 | e |
+| variables.rs:227:28:227:30 | a12 | variables.rs:225:33:225:35 | a12 |
+| variables.rs:243:11:243:12 | fv | variables.rs:242:9:242:10 | fv |
+| variables.rs:245:26:245:28 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:255:15:255:16 | a8 | variables.rs:250:5:250:6 | a8 |
+| variables.rs:256:15:256:16 | b3 | variables.rs:252:9:252:10 | b3 |
+| variables.rs:257:15:257:16 | c1 | variables.rs:253:9:253:10 | c1 |
+| variables.rs:263:15:263:16 | a9 | variables.rs:261:6:261:41 | a9 |
+| variables.rs:272:15:272:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:273:15:273:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:274:15:274:16 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:281:9:281:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:282:9:282:10 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:283:9:283:10 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:285:15:285:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:286:15:286:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:287:15:287:16 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:294:23:294:25 | a10 | variables.rs:291:13:291:15 | a10 |
+| variables.rs:295:23:295:24 | b4 | variables.rs:292:13:292:14 | b4 |
+| variables.rs:299:15:299:17 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:300:15:300:16 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:306:9:306:9 | x | variables.rs:305:10:305:10 | x |
+| variables.rs:308:9:308:23 | example_closure | variables.rs:304:9:304:23 | example_closure |
+| variables.rs:309:15:309:16 | n1 | variables.rs:307:9:307:10 | n1 |
+| variables.rs:314:9:314:9 | x | variables.rs:313:10:313:10 | x |
+| variables.rs:316:9:316:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable |
+| variables.rs:317:15:317:16 | n2 | variables.rs:315:9:315:10 | n2 |
+| variables.rs:324:12:324:12 | v | variables.rs:321:9:321:9 | v |
+| variables.rs:325:19:325:22 | text | variables.rs:323:9:323:12 | text |
+| variables.rs:331:5:331:5 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:332:15:332:15 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:333:11:333:11 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:334:15:334:15 | a | variables.rs:330:13:330:13 | a |
+| variables.rs:340:14:340:14 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:342:15:342:15 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:347:10:347:10 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:348:10:348:10 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:353:23:353:23 | x | variables.rs:352:13:352:13 | x |
+| variables.rs:354:15:354:15 | x | variables.rs:352:13:352:13 | x |
 variableInitializer
-| variables.rs:10:9:10:10 | x1 | variables.rs:10:14:10:16 | "a" |
-| variables.rs:15:13:15:14 | x2 | variables.rs:15:18:15:18 | 4 |
-| variables.rs:22:9:22:10 | x3 | variables.rs:22:14:22:14 | 1 |
-| variables.rs:24:9:24:10 | x3 | variables.rs:25:9:25:14 | ... + ... |
-| variables.rs:30:9:30:10 | x4 | variables.rs:30:14:30:16 | "a" |
-| variables.rs:33:13:33:14 | x4 | variables.rs:33:18:33:20 | "b" |
-| variables.rs:62:9:62:10 | p1 | variables.rs:62:14:62:37 | RecordExpr |
-| variables.rs:72:9:72:10 | s1 | variables.rs:72:14:72:41 | CallExpr |
-| variables.rs:89:9:89:10 | s1 | variables.rs:89:14:89:41 | CallExpr |
-| variables.rs:98:9:98:10 | x6 | variables.rs:98:14:98:20 | CallExpr |
-| variables.rs:99:9:99:10 | y1 | variables.rs:99:14:99:15 | 10 |
-| variables.rs:115:9:115:15 | numbers | variables.rs:115:19:115:35 | TupleExpr |
-| variables.rs:142:9:142:10 | p2 | variables.rs:142:14:142:37 | RecordExpr |
-| variables.rs:156:9:156:11 | msg | variables.rs:156:15:156:38 | RecordExpr |
-| variables.rs:176:9:176:14 | either | variables.rs:176:18:176:33 | CallExpr |
-| variables.rs:190:9:190:10 | tv | variables.rs:190:14:190:36 | CallExpr |
-| variables.rs:206:9:206:14 | either | variables.rs:206:18:206:33 | CallExpr |
-| variables.rs:216:9:216:14 | either | variables.rs:216:18:216:33 | CallExpr |
-| variables.rs:240:9:240:10 | fv | variables.rs:240:14:240:35 | CallExpr |
-| variables.rs:302:9:302:23 | example_closure | variables.rs:303:9:304:9 | ClosureExpr |
-| variables.rs:305:9:305:10 | n1 | variables.rs:306:9:306:26 | CallExpr |
-| variables.rs:310:9:310:26 | immutable_variable | variables.rs:311:9:312:9 | ClosureExpr |
-| variables.rs:313:9:313:10 | n2 | variables.rs:314:9:314:29 | CallExpr |
-| variables.rs:319:9:319:9 | v | variables.rs:319:13:319:41 | RefExpr |
+| variables.rs:12:9:12:10 | x1 | variables.rs:12:14:12:16 | "a" |
+| variables.rs:17:13:17:14 | x2 | variables.rs:17:18:17:18 | 4 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:14:24:14 | 1 |
+| variables.rs:26:9:26:10 | x3 | variables.rs:27:9:27:14 | ... + ... |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:14:32:16 | "a" |
+| variables.rs:35:13:35:14 | x4 | variables.rs:35:18:35:20 | "b" |
+| variables.rs:64:9:64:10 | p1 | variables.rs:64:14:64:37 | RecordExpr |
+| variables.rs:74:9:74:10 | s1 | variables.rs:74:14:74:41 | CallExpr |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:14:91:41 | CallExpr |
+| variables.rs:100:9:100:10 | x6 | variables.rs:100:14:100:20 | CallExpr |
+| variables.rs:101:9:101:10 | y1 | variables.rs:101:14:101:15 | 10 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:19:117:35 | TupleExpr |
+| variables.rs:144:9:144:10 | p2 | variables.rs:144:14:144:37 | RecordExpr |
+| variables.rs:158:9:158:11 | msg | variables.rs:158:15:158:38 | RecordExpr |
+| variables.rs:178:9:178:14 | either | variables.rs:178:18:178:33 | CallExpr |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:14:192:36 | CallExpr |
+| variables.rs:208:9:208:14 | either | variables.rs:208:18:208:33 | CallExpr |
+| variables.rs:218:9:218:14 | either | variables.rs:218:18:218:33 | CallExpr |
+| variables.rs:242:9:242:10 | fv | variables.rs:242:14:242:35 | CallExpr |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:305:9:306:9 | ClosureExpr |
+| variables.rs:307:9:307:10 | n1 | variables.rs:308:9:308:26 | CallExpr |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:313:9:314:9 | ClosureExpr |
+| variables.rs:315:9:315:10 | n2 | variables.rs:316:9:316:29 | CallExpr |
+| variables.rs:321:9:321:9 | v | variables.rs:321:13:321:41 | RefExpr |
+| variables.rs:330:13:330:13 | a | variables.rs:330:17:330:17 | 0 |
+| variables.rs:338:13:338:13 | i | variables.rs:338:17:338:17 | 1 |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:340:9:340:14 | RefExpr |
+| variables.rs:352:13:352:13 | x | variables.rs:352:17:352:17 | 2 |

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,17 +1,4 @@
 testFailures
-| variables.rs:331:5:331:5 | a | Unexpected result: read_access=a |
-| variables.rs:331:5:331:5 | a | Unexpected result: write_access=a |
-| variables.rs:331:13:331:25 | Comment | Missing result:access=a |
-| variables.rs:333:11:333:11 | a | Unexpected result: read_access=a |
-| variables.rs:333:30:333:42 | Comment | Missing result:access=a |
-| variables.rs:340:14:340:14 | i | Unexpected result: read_access=i |
-| variables.rs:340:17:340:29 | Comment | Missing result:access=i |
-| variables.rs:341:6:341:10 | ref_i | Unexpected result: write_access=ref_i |
-| variables.rs:341:17:341:38 | Comment | Missing result:read_access=ref_i |
-| variables.rs:346:6:346:6 | x | Unexpected result: write_access=x |
-| variables.rs:346:10:346:27 | Comment | Missing result:read_access=x |
-| variables.rs:353:23:353:23 | x | Unexpected result: read_access=x |
-| variables.rs:353:27:353:39 | Comment | Missing result:access=x |
 failures
 variable
 | variables.rs:3:14:3:14 | s |
@@ -185,9 +172,6 @@ variableWriteAccess
 | variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 |
 | variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 |
 | variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
-| variables.rs:331:5:331:5 | a | variables.rs:330:13:330:13 | a |
-| variables.rs:341:6:341:10 | ref_i | variables.rs:339:9:339:13 | ref_i |
-| variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
 variableReadAccess
 | variables.rs:13:15:13:16 | x1 | variables.rs:12:9:12:10 | x1 |
 | variables.rs:18:15:18:16 | x2 | variables.rs:17:13:17:14 | x2 |
@@ -267,15 +251,13 @@ variableReadAccess
 | variables.rs:317:15:317:16 | n2 | variables.rs:315:9:315:10 | n2 |
 | variables.rs:324:12:324:12 | v | variables.rs:321:9:321:9 | v |
 | variables.rs:325:19:325:22 | text | variables.rs:323:9:323:12 | text |
-| variables.rs:331:5:331:5 | a | variables.rs:330:13:330:13 | a |
 | variables.rs:332:15:332:15 | a | variables.rs:330:13:330:13 | a |
-| variables.rs:333:11:333:11 | a | variables.rs:330:13:330:13 | a |
 | variables.rs:334:15:334:15 | a | variables.rs:330:13:330:13 | a |
-| variables.rs:340:14:340:14 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:341:6:341:10 | ref_i | variables.rs:339:9:339:13 | ref_i |
 | variables.rs:342:15:342:15 | i | variables.rs:338:13:338:13 | i |
+| variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:347:10:347:10 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:348:10:348:10 | x | variables.rs:345:17:345:17 | x |
-| variables.rs:353:23:353:23 | x | variables.rs:352:13:352:13 | x |
 | variables.rs:354:15:354:15 | x | variables.rs:352:13:352:13 | x |
 variableInitializer
 | variables.rs:12:9:12:10 | x1 | variables.rs:12:14:12:16 | "a" |

--- a/rust/ql/test/library-tests/variables/variables.ql
+++ b/rust/ql/test/library-tests/variables/variables.ql
@@ -12,7 +12,7 @@ query predicate variableReadAccess(VariableReadAccess va, Variable v) { v = va.g
 query predicate variableInitializer(Variable v, Expr e) { e = v.getInitializer() }
 
 module VariableAccessTest implements TestSig {
-  string getARelevantTag() { result = "access" }
+  string getARelevantTag() { result = ["", "write_", "read_"] + "access" }
 
   private predicate declAt(Variable v, string filepath, int line) {
     v.getLocation().hasLocationInfo(filepath, _, _, line, _)
@@ -38,8 +38,15 @@ module VariableAccessTest implements TestSig {
     exists(VariableAccess va |
       location = va.getLocation() and
       element = va.toString() and
-      tag = "access" and
       decl(va.getVariable(), value)
+    |
+      va instanceof VariableWriteAccess and tag = "write_access"
+      or
+      va instanceof VariableReadAccess and tag = "read_access"
+      or
+      not va instanceof VariableWriteAccess and
+      not va instanceof VariableReadAccess and
+      tag = "access"
     )
   }
 }

--- a/rust/ql/test/library-tests/variables/variables.rs
+++ b/rust/ql/test/library-tests/variables/variables.rs
@@ -1,3 +1,5 @@
+use std::ops::AddAssign;
+
 fn print_str(s: &str) {
     println!("{}", s);
 }
@@ -8,32 +10,32 @@ fn print_i64(i: i64) {
 
 fn immutable_variable() {
     let x1 = "a"; // x1
-    print_str(x1); // $ access=x1
+    print_str(x1); // $ read_access=x1
 }
 
 fn mutable_variable() {
     let mut x2 = 4; // x2
-    print_i64(x2); // $ access=x2
-    x2 = 5; // $ access=x2
-    print_i64(x2); // $ access=x2
+    print_i64(x2); // $ read_access=x2
+    x2 = 5; // $ write_access=x2
+    print_i64(x2); // $ read_access=x2
 }
 
 fn variable_shadow1() {
     let x3 = 1; // x3_1
-    print_i64(x3); // $ access=x3_1
+    print_i64(x3); // $ read_access=x3_1
     let x3 = // x3_2
-        x3 + 1; // $ access=x3_1
-    print_i64(x3); // $ access=x3_2
+        x3 + 1; // $ read_access=x3_1
+    print_i64(x3); // $ read_access=x3_2
 }
 
 fn variable_shadow2() {
     let x4 = "a"; // x4_1
-    print_str(x4); // $ access=x4_1
+    print_str(x4); // $ read_access=x4_1
     {
         let x4 = "b"; // x4_2
-        print_str(x4); // $ access=x4_2
+        print_str(x4); // $ read_access=x4_2
     }
-    print_str(x4); // $ access=x4_1
+    print_str(x4); // $ read_access=x4_1
 }
 
 struct Point<'a> {
@@ -52,10 +54,10 @@ fn let_pattern1() {
             y, // y
         },
     ) = (("a", "b"), Point { x: "x", y: "y" });
-    print_str(a1); // $ access=a1
-    print_str(b1); // $ access=b1
-    print_str(x); // $ access=x
-    print_str(y); // $ access=y
+    print_str(a1); // $ read_access=a1
+    print_str(b1); // $ read_access=b1
+    print_str(x); // $ read_access=x
+    print_str(y); // $ read_access=y
 }
 
 fn let_pattern2() {
@@ -63,34 +65,34 @@ fn let_pattern2() {
     let Point {
         x: a2, // a2
         y: b2, // b2
-    } = p1; // $ access=p1
-    print_str(a2); // $ access=a2
-    print_str(b2); // $ access=b2
+    } = p1; // $ read_access=p1
+    print_str(a2); // $ read_access=a2
+    print_str(b2); // $ read_access=b2
 }
 
 fn let_pattern3() {
     let s1 = Some(String::from("Hello!")); // s1
 
     if let Some(ref s2) // s2
-        = s1 { // $ access=s1
-        print_str(s2); // $ access=s2
+        = s1 { // $ read_access=s1
+        print_str(s2); // $ read_access=s2
     }
 }
 
 fn let_pattern4() {
-    let Some(x5): Option<&str> = Some("x5") else {
-        // x5
-        todo!()
-    };
-    print_str(x5); // $ access=x5
+    let Some(x5): Option<&str> = Some("x5") // x5
+        else {
+            todo!()
+        };
+    print_str(x5); // $ read_access=x5
 }
 
 fn let_pattern5() {
     let s1 = Some(String::from("Hello!")); // s1
 
     while let Some(ref s2) // s2
-        = s1 { // $ access=s1
-        print_str(s2); // $ access=s2
+        = s1 { // $ read_access=s1
+        print_str(s2); // $ read_access=s2
     }
 }
 
@@ -98,42 +100,42 @@ fn match_pattern1() {
     let x6 = Some(5); // x6
     let y1 = 10; // y1_1
 
-    match x6 { // $ access=x6
+    match x6 { // $ read_access=x6
         Some(50) => print_str("Got 50"),
         Some(y1) // y1_2
         =>
         {
-            print_i64(y1)// $ access=y1_2
+            print_i64(y1)// $ read_access=y1_2
         } 
         None => print_str("NONE"),
     }
 
-    print_i64(y1); // $ access=y1_1
+    print_i64(y1); // $ read_access=y1_1
 }
 
 fn match_pattern2() {
     let numbers = (2, 4, 8, 16, 32); // numbers
 
-    match numbers { // $ access=numbers
+    match numbers { // $ read_access=numbers
         (
             first, _, // first
             third, _, // third
             fifth // fifth
         ) => {
-            print_i64(first); // $ access=first
-            print_i64(third); // $ access=third
-            print_i64(fifth); // $ access=fifth
+            print_i64(first); // $ read_access=first
+            print_i64(third); // $ read_access=third
+            print_i64(fifth); // $ read_access=fifth
         }
     }
 
-    match numbers { // $ access=numbers
+    match numbers { // $ read_access=numbers
         (
             first, // first
             ..,
             last // last
         ) => {
-            print_i64(first); // $ access=first
-            print_i64(last); // $ access=last
+            print_i64(first); // $ read_access=first
+            print_i64(last); // $ read_access=last
         }
     }
 }
@@ -141,10 +143,10 @@ fn match_pattern2() {
 fn match_pattern3() {
     let p2 = Point { x: "x", y: "y" }; // p2
 
-    match p2 { // $ access=p2
+    match p2 { // $ read_access=p2
         Point {
             x: x7, .. // x7
-        } => print_str(x7), // $ access=x7
+        } => print_str(x7), // $ read_access=x7
     }
 }
 
@@ -155,15 +157,15 @@ enum Message {
 fn match_pattern4() {
     let msg = Message::Hello { id: 0 }; // msg
 
-    match msg { // $ access=msg
+    match msg { // $ read_access=msg
         Message::Hello {
             id: id_variable @ 3..=7, // id_variable
-        } => print_i64(id_variable), // $ access=id_variable
+        } => print_i64(id_variable), // $ read_access=id_variable
         Message::Hello { id: 10..=12 } => {
             println!("Found an id in another range")
         }
         Message::Hello { id } => // id
-            print_i64(id), // $ access=id
+            print_i64(id), // $ read_access=id
     }
 }
 
@@ -174,9 +176,9 @@ enum Either {
 
 fn match_pattern5() {
     let either = Either::Left(32); // either
-    match either { // $ access=either
+    match either { // $ read_access=either
         Either::Left(a3) | Either::Right(a3) // a3
-            => print_i64(a3), // $ access=a3
+            => print_i64(a3), // $ read_access=a3
     }
 }
 
@@ -188,26 +190,26 @@ enum ThreeValued {
 
 fn match_pattern6() {
     let tv = ThreeValued::Second(62); // tv
-    match tv { // $ access=tv
+    match tv { // $ read_access=tv
         ThreeValued::First(a4) | ThreeValued::Second(a4) | ThreeValued::Third(a4) // a4
-            => print_i64(a4), // $ access=a4
+            => print_i64(a4), // $ read_access=a4
     }
-    match tv { // $ access=tv
+    match tv { // $ read_access=tv
         (ThreeValued::First(a5) | ThreeValued::Second(a5)) | ThreeValued::Third(a5) // a5
-            => print_i64(a5), // $ access=a5
+            => print_i64(a5), // $ read_access=a5
     }
-    match tv { // $ access=tv
+    match tv { // $ read_access=tv
         ThreeValued::First(a6) | (ThreeValued::Second(a6) | ThreeValued::Third(a6)) // a6
-            => print_i64(a6), // $ access=a6
+            => print_i64(a6), // $ read_access=a6
     }
 }
 
 fn match_pattern7() {
     let either = Either::Left(32); // either
-    match either { // $ access=either
+    match either { // $ read_access=either
         Either::Left(a7) | Either::Right(a7) // a7
-            if a7 > 0 // $ access=a7
-            => print_i64(a7), // $ access=a7
+            if a7 > 0 // $ read_access=a7
+            => print_i64(a7), // $ read_access=a7
         _ => (),
     }
 }
@@ -215,14 +217,14 @@ fn match_pattern7() {
 fn match_pattern8() {
     let either = Either::Left(32); // either
 
-    match either { // $ access=either
+    match either { // $ read_access=either
         ref e @ // e
             (Either::Left(a11) | Either::Right(a11)) // a11
         => {
-            print_i64(a11); // $ access=a11
+            print_i64(a11); // $ read_access=a11
             if let Either::Left(a12) // a12
-            = e { // $ access=e
-                print_i64(*a12); // $ access=a12
+            = e { // $ read_access=e
+                print_i64(*a12); // $ read_access=a12
             }
         }
         _ => (),
@@ -238,9 +240,9 @@ enum FourValued {
 
 fn match_pattern9() {
     let fv = FourValued::Second(62); // tv
-    match fv { // $ access=tv
+    match fv { // $ read_access=tv
         FourValued::First(a13) | (FourValued::Second(a13) | FourValued::Third(a13)) | FourValued::Fourth(a13) // a13
-            => print_i64(a13), // $ access=a13
+            => print_i64(a13), // $ read_access=a13
     }
 }
 
@@ -250,15 +252,15 @@ fn param_pattern1(
         b3, // b3
         c1, // c1
     ): (&str, &str)) -> () {
-    print_str(a8); // $ access=a8
-    print_str(b3); // $ access=b3
-    print_str(c1); // $ access=c1
+    print_str(a8); // $ read_access=a8
+    print_str(b3); // $ read_access=b3
+    print_str(c1); // $ read_access=c1
 }
 
 fn param_pattern2(
     (Either::Left(a9) | Either::Right(a9)): Either // a9
 ) -> () {
-    print_i64(a9); // $ access=a9
+    print_i64(a9); // $ read_access=a9
 }
 
 fn destruct_assignment() {
@@ -267,61 +269,89 @@ fn destruct_assignment() {
         mut b4, // b4
         mut c2 // c2
     ) = (1, 2, 3);
-    print_i64(a10); // $ access=a10
-    print_i64(b4); // $ access=b4
-    print_i64(c2); // $ access=c2
+    print_i64(a10); // $ read_access=a10
+    print_i64(b4); // $ read_access=b4
+    print_i64(c2); // $ read_access=c2
 
     (
-        c2, // $ access=c2
-        b4, // $ access=b4
-        a10 // $ access=a10
+        c2, // $ write_access=c2
+        b4, // $ write_access=b4
+        a10 // $ write_access=a10
     ) = (
-        a10, // $ access=a10
-        b4, // $ access=b4
-        c2 // $ access=c2
+        a10, // $ read_access=a10
+        b4, // $ read_access=b4
+        c2 // $ read_access=c2
     );
-    print_i64(a10); // $ access=a10
-    print_i64(b4); // $ access=b4
-    print_i64(c2); // $ access=c2
+    print_i64(a10); // $ read_access=a10
+    print_i64(b4); // $ read_access=b4
+    print_i64(c2); // $ read_access=c2
 
     match (4, 5) {
         (
             a10, // a10_2
             b4 // b4
         ) => {
-            print_i64(a10); // $ access=a10_2
-            print_i64(b4); // $ access=b4
+            print_i64(a10); // $ read_access=a10_2
+            print_i64(b4); // $ read_access=b4
         }
     }
 
-    print_i64(a10); // $ access=a10
-    print_i64(b4); // $ access=b4
+    print_i64(a10); // $ read_access=a10
+    print_i64(b4); // $ read_access=b4
 }
 
 fn closure_variable() {
     let example_closure = // example_closure
         |x: i64| // x_1
-        x; // $ access=x_1
+        x; // $ read_access=x_1
     let n1 = // n1
-        example_closure(5); // $ access=example_closure
-    print_i64(n1); // $ access=n1
+        example_closure(5); // $ read_access=example_closure
+    print_i64(n1); // $ read_access=n1
 
     immutable_variable();
     let immutable_variable =
         |x: i64| // x_2
-        x; // $ access=x_2
+        x; // $ read_access=x_2
     let n2 = // n2
-        immutable_variable(6); // $ access=immutable_variable
-    print_i64(n2); // $ access=n2
+        immutable_variable(6); // $ read_access=immutable_variable
+    print_i64(n2); // $ read_access=n2
 }
 
 fn for_variable() {
     let v = &["apples", "cake", "coffee"]; // v
 
     for text // text
-        in v { // $ access=v
-        print_str(text); // $ access=text
+        in v { // $ read_access=v
+        print_str(text); // $ read_access=text
     }
+}
+
+fn add_assign() {
+    let mut a = 0; // a
+    a += 1; // $ access=a
+    print_i64(a); // $ read_access=a
+    (&mut a).add_assign(10); // $ access=a
+    print_i64(a); // $ read_access=a
+}
+
+fn mutate() {
+    let mut i = 1; // i
+    let ref_i = // ref_i
+        &mut i; // $ access=i
+    *ref_i = 2; // $ read_access=ref_i
+    print_i64(i); // $ read_access=i
+}
+
+fn mutate_param(x : &mut i64) { // x
+    *x = // $ read_access=x
+        *x + // $ read_access=x
+        *x; // $ read_access=x
+}
+
+fn mutate_arg() {
+    let mut x = 2; // x
+    mutate_param(&mut x); // $ access=x
+    print_i64(x); // $ read_access=x
 }
 
 fn main() {
@@ -347,4 +377,7 @@ fn main() {
     destruct_assignment();
     closure_variable();
     for_variable();
+    add_assign();
+    mutate();
+    mutate_arg();
 }


### PR DESCRIPTION
Taking the address of a variable `x` via `&(mut) x` neither reads nor writes the variable, so the access to `x` should neither be a `VariableReadAccess` nor a `VariableWriteAccess`. This also includes implicit references in compound assignments `x += y` which [really means](https://doc.rust-lang.org/std/ops/trait.AddAssign.html) `(&mut x).add_assign(y)`.

Note that once we implement SSA support, then (some) variable references will be modeled as uncertain variable writes.