### PR TITLE
Shared `ConditionalCompletionSplitting` implementation

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/controlflow/internal/ControlFlowGraphImpl.qll
@@ -53,7 +53,6 @@ private predicate idOf(AstNode x, int y) = equivalenceRelation(id/2)(x, y)
 private module CfgInput implements CfgShared::InputSig<Location> {
   private import ControlFlowGraphImpl as Impl
   private import Completion as Comp
-  private import Splitting as Splitting
   private import SuccessorType as ST
   private import semmle.code.csharp.Caching
 
@@ -80,10 +79,6 @@ private module CfgInput implements CfgShared::InputSig<Location> {
     Impl::scopeLast(scope, last, c)
   }
 
-  class SplitKindBase = Splitting::TSplitKind;
-
-  class Split = Splitting::Split;
-
   class SuccessorType = ST::SuccessorType;
 
   SuccessorType getAMatchingSuccessorType(Completion c) { result = c.getAMatchingSuccessorType() }
@@ -102,7 +97,21 @@ private module CfgInput implements CfgShared::InputSig<Location> {
   }
 }
 
-import CfgShared::Make<Location, CfgInput>
+private module CfgSplittingInput implements CfgShared::SplittingInputSig<Location, CfgInput> {
+  private import Splitting as S
+
+  class SplitKindBase = S::TSplitKind;
+
+  class Split = S::Split;
+}
+
+private module ConditionalCompletionSplittingInput implements
+  CfgShared::ConditionalCompletionSplittingInputSig<Location, CfgInput, CfgSplittingInput>
+{
+  import Splitting::ConditionalCompletionSplitting::ConditionalCompletionSplittingInput
+}
+
+import CfgShared::MakeWithSplitting<Location, CfgInput, CfgSplittingInput, ConditionalCompletionSplittingInput>
 
 /**
  * A compilation.

--- a/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/controlflow/internal/ControlFlowGraphImpl.qll
@@ -22,7 +22,6 @@ class AstNode extends Ast::AstNode {
 private module CfgInput implements CfgShared::InputSig<Location> {
   private import ControlFlowGraphImpl as Impl
   private import Completion as Comp
-  private import Splitting as Splitting
   private import codeql.ruby.CFG as Cfg
 
   class AstNode = Impl::AstNode;
@@ -45,10 +44,6 @@ private module CfgInput implements CfgShared::InputSig<Location> {
     scope.(Impl::CfgScopeImpl).exit(last, c)
   }
 
-  class SplitKindBase = Splitting::TSplitKind;
-
-  class Split = Splitting::Split;
-
   class SuccessorType = Cfg::SuccessorType;
 
   SuccessorType getAMatchingSuccessorType(Completion c) { result = c.getAMatchingSuccessorType() }
@@ -67,7 +62,21 @@ private module CfgInput implements CfgShared::InputSig<Location> {
   }
 }
 
-import CfgShared::Make<Location, CfgInput>
+private module CfgSplittingInput implements CfgShared::SplittingInputSig<Location, CfgInput> {
+  private import Splitting as S
+
+  class SplitKindBase = S::TSplitKind;
+
+  class Split = S::Split;
+}
+
+private module ConditionalCompletionSplittingInput implements
+  CfgShared::ConditionalCompletionSplittingInputSig<Location, CfgInput, CfgSplittingInput>
+{
+  import Splitting::ConditionalCompletionSplitting::ConditionalCompletionSplittingInput
+}
+
+import CfgShared::MakeWithSplitting<Location, CfgInput, CfgSplittingInput, ConditionalCompletionSplittingInput>
 
 abstract class CfgScopeImpl extends AstNode {
   abstract predicate entry(AstNode first);

--- a/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/ControlFlowGraphImpl.qll
@@ -7,7 +7,6 @@ private import codeql.rust.controlflow.ControlFlowGraph as Cfg
 private module CfgInput implements InputSig<Location> {
   private import rust as Rust
   private import Completion as C
-  private import Splitting as S
 
   class AstNode = Rust::AstNode;
 
@@ -23,10 +22,6 @@ private module CfgInput implements InputSig<Location> {
   class CfgScope = Scope::CfgScope;
 
   CfgScope getCfgScope(AstNode n) { result = Scope::scopeOfAst(n) }
-
-  class SplitKindBase = S::TSplitKind;
-
-  class Split = S::Split;
 
   class SuccessorType = Cfg::SuccessorType;
 
@@ -51,7 +46,22 @@ private module CfgInput implements InputSig<Location> {
   predicate scopeLast(CfgScope scope, AstNode last, Completion c) { scope.scopeLast(last, c) }
 }
 
-private module CfgImpl = Make<Location, CfgInput>;
+private module CfgSplittingInput implements SplittingInputSig<Location, CfgInput> {
+  private import Splitting as S
+
+  class SplitKindBase = S::TSplitKind;
+
+  class Split = S::Split;
+}
+
+private module ConditionalCompletionSplittingInput implements
+  ConditionalCompletionSplittingInputSig<Location, CfgInput, CfgSplittingInput>
+{
+  import Splitting::ConditionalCompletionSplitting::ConditionalCompletionSplittingInput
+}
+
+private module CfgImpl =
+  MakeWithSplitting<Location, CfgInput, CfgSplittingInput, ConditionalCompletionSplittingInput>;
 
 import CfgImpl
 

--- a/rust/ql/lib/codeql/rust/controlflow/internal/Splitting.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/Splitting.qll
@@ -21,7 +21,7 @@ abstract private class Split_ extends TSplit {
 
 final class Split = Split_;
 
-private module ConditionalCompletionSplitting {
+module ConditionalCompletionSplitting {
   /**
    * A split for conditional completions. For example, in
    *
@@ -39,10 +39,12 @@ private module ConditionalCompletionSplitting {
 
     ConditionalCompletionSplit() { this = TConditionalCompletionSplit(completion) }
 
+    ConditionalCompletion getCompletion() { result = completion }
+
     override string toString() { result = completion.toString() }
   }
 
-  private class ConditionalCompletionSplitKind extends SplitKind, TConditionalCompletionSplitKind {
+  private class ConditionalCompletionSplitKind_ extends SplitKind, TConditionalCompletionSplitKind {
     override int getListOrder() { result = 0 }
 
     override predicate isEnabled(AstNode cfe) { this.appliesTo(cfe) }
@@ -50,66 +52,64 @@ private module ConditionalCompletionSplitting {
     override string toString() { result = "ConditionalCompletion" }
   }
 
-  private class ConditionalCompletionSplitImpl extends SplitImpl instanceof ConditionalCompletionSplit
+  module ConditionalCompletionSplittingInput {
+    private import Completion as Comp
+
+    class ConditionalCompletion = Comp::ConditionalCompletion;
+
+    class ConditionalCompletionSplitKind extends ConditionalCompletionSplitKind_, TSplitKind { }
+
+    class ConditionalCompletionSplit = ConditionalCompletionSplitting::ConditionalCompletionSplit;
+
+    bindingset[parent, parentCompletion]
+    predicate condPropagateExpr(
+      AstNode parent, ConditionalCompletion parentCompletion, AstNode child,
+      ConditionalCompletion childCompletion
+    ) {
+      child = parent.(LogicalNotExpr).getExpr() and
+      childCompletion.getDual() = parentCompletion
+      or
+      childCompletion = parentCompletion and
+      (
+        child = parent.(BinaryLogicalOperation).getAnOperand()
+        or
+        parent = any(IfExpr ie | child = [ie.getThen(), ie.getElse()])
+        or
+        child = parent.(MatchExpr).getAnArm().getExpr()
+        or
+        child = parent.(BlockExpr).getStmtList().getTailExpr()
+      )
+    }
+  }
+
+  private class ConditionalCompletionSplitImpl extends SplitImplementations::ConditionalCompletionSplitting::ConditionalCompletionSplitImpl
   {
-    ConditionalCompletion completion;
-
-    ConditionalCompletionSplitImpl() { this = TConditionalCompletionSplit(completion) }
-
-    override ConditionalCompletionSplitKind getKind() { any() }
+    /**
+     * Gets a `break` expression whose target can have a Boolean completion that
+     * matches this split.
+     */
+    private BreakExpr getABreakExpr(Expr target) {
+      target = result.getTarget() and
+      last(target, _, this.getCompletion())
+    }
 
     override predicate hasEntry(AstNode pred, AstNode succ, Completion c) {
-      succ(pred, succ, c) and
-      last(succ, _, completion) and
-      (
-        last(succ.(LogicalNotExpr).getExpr(), pred, c) and
-        completion.(BooleanCompletion).getDual() = c
-        or
-        last(succ.(BinaryLogicalOperation).getAnOperand(), pred, c) and
-        completion = c
-        or
-        succ =
-          any(IfExpr ie |
-            last([ie.getThen(), ie.getElse()], pred, c) and
-            completion = c
-          )
-        or
-        last(succ.(MatchExpr).getAnArm().getExpr(), pred, c) and
-        completion = c
-        or
-        last(succ.(BlockExpr).getStmtList().getTailExpr(), pred, c) and
-        completion = c
-      )
+      super.hasEntry(pred, succ, c)
       or
       succ(pred, succ, c) and
       last(succ.(BreakExpr).getExpr(), pred, c) and
-      exists(AstNode target |
-        succ(succ, target, _) and
-        last(target, _, completion)
-      ) and
-      completion = c
-    }
-
-    override predicate hasEntryScope(CfgScope scope, AstNode first) { none() }
-
-    override predicate hasExit(AstNode pred, AstNode succ, Completion c) {
-      this.appliesTo(pred) and
-      succ(pred, succ, c) and
-      if c instanceof ConditionalCompletion
-      then completion = c
-      else not this.hasSuccessor(pred, succ, c)
-    }
-
-    override predicate hasExitScope(CfgScope scope, AstNode last, Completion c) {
-      this.appliesTo(last) and
-      scope.scopeLast(last, c) and
-      if c instanceof ConditionalCompletion then completion = c else any()
+      succ = this.getABreakExpr(_) and
+      c = this.getCompletion()
     }
 
     override predicate hasSuccessor(AstNode pred, AstNode succ, Completion c) {
+      super.hasSuccessor(pred, succ, c)
+      or
       this.appliesTo(pred) and
       succ(pred, succ, c) and
-      not c instanceof ConditionalCompletion
+      pred = this.getABreakExpr(succ)
     }
   }
+
+  int getNextListOrder() { result = 1 }
 }

--- a/shared/controlflow/codeql/controlflow/Cfg.qll
+++ b/shared/controlflow/codeql/controlflow/Cfg.qll
@@ -5,6 +5,7 @@
 
 private import codeql.util.Location
 private import codeql.util.FileSystem
+private import codeql.util.Void
 
 /** Provides the language-specific input specification. */
 signature module InputSig<LocationSig Location> {
@@ -56,18 +57,6 @@ signature module InputSig<LocationSig Location> {
   /** Holds if `scope` is exited when `last` finishes with completion `c`. */
   predicate scopeLast(CfgScope scope, AstNode last, Completion c);
 
-  /** Gets the maximum number of splits allowed for a given node. */
-  default int maxSplits() { result = 5 }
-
-  /** The base class of `SplitKind`. */
-  class SplitKindBase;
-
-  /** A split. */
-  class Split {
-    /** Gets a textual representation of this split. */
-    string toString();
-  }
-
   /** A type of a control flow successor. */
   class SuccessorType {
     /** Gets a textual representation of this successor type. */
@@ -88,6 +77,56 @@ signature module InputSig<LocationSig Location> {
 
   /** Holds if `t` is an abnormal exit type out of a CFG scope. */
   predicate isAbnormalExitType(SuccessorType t);
+}
+
+/** Provides input needed for CFG splitting. */
+signature module SplittingInputSig<LocationSig Location, InputSig<Location> Input> {
+  /** Gets the maximum number of splits allowed for a given node. */
+  default int maxSplits() { result = 5 }
+
+  /** The base class of `SplitKind`. */
+  class SplitKindBase;
+
+  /** A split. */
+  class Split {
+    /** Gets a textual representation of this split. */
+    string toString();
+  }
+}
+
+/** Provides input needed for `ConditionalCompletionSplitting`. */
+signature module ConditionalCompletionSplittingInputSig<
+  LocationSig Location, InputSig<Location> Input, SplittingInputSig<Location, Input> SplittingInput>
+{
+  /** A conditional control-flow completion. */
+  class ConditionalCompletion extends Input::Completion;
+
+  /** A split kind for `ConditionalCompletionSplitting`. */
+  class ConditionalCompletionSplitKind extends SplittingInput::SplitKindBase;
+
+  /** The user-facing split class. */
+  class ConditionalCompletionSplit extends SplittingInput::Split {
+    /** Gets the completion recorded in this split. */
+    ConditionalCompletion getCompletion();
+  }
+
+  /**
+   * Holds if `child` is a sub expression of `parent`, and whenever a last node
+   * of `child` (normally `child` itself) has `parent` as a successor with label
+   * `childCompletion`, then edges out of `parent` must have label
+   * `parentCompletion`.
+   *
+   * For example, for an expression `!x`, when `child = x` has conditional
+   * completion `c` then `parent = !x` must have the dual completion of `c`.
+   *
+   * Similarly, for an expression `x && y`, when `child = {x, y}` has conditional
+   * completion `c`, then `parent = x && y` must have the same completion of `c`.
+   */
+  bindingset[parent, parentCompletion]
+  predicate condPropagateExpr(
+    Input::AstNode parent, ConditionalCompletion parentCompletion, Input::AstNode child,
+    ConditionalCompletion childCompletion
+  );
 }
 
 /**
@@ -122,8 +161,14 @@ signature module InputSig<LocationSig Location> {
  * loop break will be caught up by its surrounding loop and turned into a normal
  * completion.
  */
-module Make<LocationSig Location, InputSig<Location> Input> {
+module MakeWithSplitting<
+  LocationSig Location, //
+  InputSig<Location> Input, //
+  SplittingInputSig<Location, Input> SplittingInput, //
+  ConditionalCompletionSplittingInputSig<Location, Input, SplittingInput> ConditionalCompletionSplittingInput>
+{
   private import Input
+  private import SplittingInput
 
   final private class AstNodeFinal = AstNode;
 
@@ -1133,6 +1178,71 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
   final class AstCfgNode = AstCfgNodeImpl;
 
+  /** Provides logic for common CFG split implementations that can be reused across languages. */
+  module SplitImplementations {
+    /**
+     * Provides an implementation of splitting for conditional completions.
+     *
+     * For example, in
+     *
+     * ```rust
+     * if x && !y {
+     *   // ...
+     * }
+     * ```
+     *
+     * we record whether `x`, `y`, and `!y` evaluate to `true` or `false`, and restrict
+     * the edges out of `!y` and `x && !y` accordingly.
+     */
+    module ConditionalCompletionSplitting {
+      private import ConditionalCompletionSplittingInput
+
+      final private class ConditionalCompletionSplitFinal =
+        ConditionalCompletionSplittingInput::ConditionalCompletionSplit;
+
+      /** A split for conditional completions. */
+      class ConditionalCompletionSplitImpl extends SplitImpl, ConditionalCompletionSplitFinal {
+        ConditionalCompletion completion;
+
+        ConditionalCompletionSplitImpl() { completion = this.getCompletion() }
+
+        override SplitKind getKind() { result instanceof ConditionalCompletionSplitKind }
+
+        override predicate hasEntry(AstNode pred, AstNode succ, Completion c) {
+          exists(AstNode child, AstNode parent |
+            last(parent, succ, completion) and
+            condPropagateExpr(parent, completion, child, c) and
+            succ(pred, succ, c) and
+            last(child, pred, c)
+          )
+        }
+
+        override predicate hasEntryScope(CfgScope scope, AstNode first) { none() }
+
+        override predicate hasExit(AstNode pred, AstNode succ, Completion c) {
+          this.appliesTo(pred) and
+          succ(pred, succ, c) and
+          if c instanceof ConditionalCompletion
+          then completion = c
+          else not this.hasSuccessor(pred, succ, c)
+        }
+
+        override predicate hasExitScope(CfgScope scope, AstNode last, Completion c) {
+          this.appliesTo(last) and
+          scopeLast(scope, last, c) and
+          if c instanceof ConditionalCompletion then completion = c else any()
+        }
+
+        override predicate hasSuccessor(AstNode pred, AstNode succ, Completion c) {
+          this.appliesTo(pred) and
+          succ(pred, succ, c) and
+          not c instanceof ConditionalCompletion and
+          completionIsNormal(c)
+        }
+      }
+    }
+  }
+
   /** A node to be included in the output of `TestOutput`. */
   signature class RelevantNodeSig extends Node;
 
@@ -1152,6 +1262,9 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         )
     }
 
+    /**
+     * Provides logic for representing a CFG as a [Mermaid diagram](https://mermaid.js.org/).
+     */
     module Mermaid {
       private string nodeId(RelevantNode n) {
         result =
@@ -1200,6 +1313,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
           )
       }
 
+      /** Holds if the Mermaid representation is `s`. */
       query predicate mermaid(string s) { s = "flowchart TD\n" + nodes() + "\n\n" + edges() }
     }
   }
@@ -1277,6 +1391,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
     import Output::Mermaid
 
+    /** Holds if `pred` -> `succ` is an edge in the CFG. */
     query predicate edges(RelevantNode pred, RelevantNode succ, string attr, string val) {
       attr = "semmle.label" and
       Output::edges(pred, succ, val)
@@ -1396,4 +1511,59 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     /** Holds if CFG scope `scope` lacks an initial AST node. */
     query predicate scopeNoFirst(CfgScope scope) { not scopeFirst(scope, _) }
   }
+}
+
+/** Provides a disabled `SplittingInputSig` implementation. */
+module NoSplittingInput<LocationSig Location, InputSig<Location> Input> implements
+  SplittingInputSig<Location, Input>
+{
+  int maxSplits() { result = 0 }
+
+  class SplitKindBase = Void;
+
+  class Split = Void;
+}
+
+/** Provides a disabled `ConditionalCompletionSplittingInputSig` implementation. */
+module NoConditionalCompletionSplittingInput<
+  LocationSig Location, InputSig<Location> Input, SplittingInputSig<Location, Input> SplittingInput>
+  implements ConditionalCompletionSplittingInputSig<Location, Input, SplittingInput>
+{
+  final private class Completion = Input::Completion;
+
+  class ConditionalCompletion extends Completion {
+    ConditionalCompletion() { none() }
+  }
+
+  final private class SplitKindBase = SplittingInput::SplitKindBase;
+
+  class ConditionalCompletionSplitKind extends SplitKindBase {
+    ConditionalCompletionSplitKind() { none() }
+
+    /** Gets a textual representation of this split kind. */
+    string toString() { none() }
+  }
+
+  final private class Split = SplittingInput::Split;
+
+  class ConditionalCompletionSplit extends Split {
+    ConditionalCompletion getCompletion() { none() }
+  }
+
+  predicate condPropagateExpr(
+    Input::AstNode parent, ConditionalCompletion parentCompletion, Input::AstNode child,
+    ConditionalCompletion childCompletion
+  ) {
+    none()
+  }
+}
+
+/** Same as `MakeWithSplitting`, but without CFG splitting. */
+module Make<LocationSig Location, InputSig<Location> Input> {
+  private module SplittingInput = NoSplittingInput<Location, Input>;
+
+  private module ConditionalCompletionSplittingInput =
+    NoConditionalCompletionSplittingInput<Location, Input, SplittingInput>;
+
+  import MakeWithSplitting<Location, Input, SplittingInput, ConditionalCompletionSplittingInput>
 }

--- a/shared/util/codeql/util/Void.qll
+++ b/shared/util/codeql/util/Void.qll
@@ -1,0 +1,10 @@
+/** Provides the empty `Void` class. */
+
+/** The empty void type. */
+private newtype TVoid = TMkVoid() { none() }
+
+/** The trivial empty type. */
+final class Void extends TVoid {
+  /** Gets a textual representation of this element. */
+  string toString() { result = "dummy" }
+}

--- a/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplSpecific.qll
+++ b/swift/ql/lib/codeql/swift/controlflow/internal/ControlFlowGraphImplSpecific.qll
@@ -46,10 +46,6 @@ module CfgInput implements InputSig<Location> {
 
   CfgScope getCfgScope(AstNode n) { result = scopeOfAst(n.asAstNode()) }
 
-  class SplitKindBase = Splitting::TSplitKind;
-
-  class Split = Splitting::Split;
-
   class SuccessorType = Cfg::SuccessorType;
 
   /** Gets a successor type that matches completion `c`. */
@@ -88,4 +84,19 @@ module CfgInput implements InputSig<Location> {
   }
 }
 
-module CfgImpl = Make<Location, CfgInput>;
+private module CfgSplittingInput implements SplittingInputSig<Location, CfgInput> {
+  private import Splitting as S
+
+  class SplitKindBase = S::TSplitKind;
+
+  class Split = S::Split;
+}
+
+private module ConditionalCompletionSplittingInput implements
+  ConditionalCompletionSplittingInputSig<Location, CfgInput, CfgSplittingInput>
+{
+  import Splitting::ConditionalCompletionSplitting::ConditionalCompletionSplittingInput
+}
+
+module CfgImpl =
+  MakeWithSplitting<Location, CfgInput, CfgSplittingInput, ConditionalCompletionSplittingInput>;


### PR DESCRIPTION
Ideally, I would have liked for `SplitImplementations::ConditionalCompletionSplitting` to be parameterized over `ConditionalCompletionSplittingInput` instead of having the outer `MakeWithSplitting` be parameterized over it, but then it would not be possible to extend the abstract `SplitImpl` class.