### PR TITLE
C++: Modernize `cpp/unclear-array-index-validation`

### DIFF
--- a/cpp/ql/lib/change-notes/2024-10-07-range-analysis-of-getc.md
+++ b/cpp/ql/lib/change-notes/2024-10-07-range-analysis-of-getc.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `SimpleRangeAnalysis` library (`semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis`) now generates more precise ranges for calls to `fgetc` and `getc`.

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -14,102 +14,44 @@
 
 import cpp
 import semmle.code.cpp.controlflow.IRGuards
-import semmle.code.cpp.security.FlowSources
-import semmle.code.cpp.ir.dataflow.TaintTracking
+import semmle.code.cpp.security.FlowSources as FS
+import semmle.code.cpp.dataflow.new.TaintTracking
 import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 import ImproperArrayIndexValidation::PathGraph
-import semmle.code.cpp.security.Security
 
-predicate hasUpperBound(VariableAccess offsetExpr) {
-  exists(BasicBlock controlled, StackVariable offsetVar, SsaDefinition def |
-    controlled.contains(offsetExpr) and
-    linearBoundControls(controlled, def, offsetVar) and
-    offsetExpr = def.getAUse(offsetVar)
+predicate isFlowSource(FS::FlowSource source, string sourceType) {
+  sourceType = source.getSourceType()
+}
+
+predicate guardChecks(IRGuardCondition g, Expr e, boolean branch) {
+  exists(Operand op | op.getDef().getConvertedResultExpression() = e |
+    // op < k
+    g.comparesLt(op, _, true, any(BooleanValue bv | bv.getValue() = branch))
+    or
+    // op < _ + k
+    g.comparesLt(op, _, _, true, branch)
+    or
+    // op == k
+    g.comparesEq(op, _, true, any(BooleanValue bv | bv.getValue() = branch))
+    or
+    // op == _ + k
+    g.comparesEq(op, _, _, true, branch)
   )
-}
-
-pragma[noinline]
-predicate linearBoundControls(BasicBlock controlled, SsaDefinition def, StackVariable offsetVar) {
-  exists(GuardCondition guard, boolean branch |
-    guard.controls(controlled, branch) and
-    cmpWithLinearBound(guard, def.getAUse(offsetVar), Lesser(), branch)
-  )
-}
-
-predicate readsVariable(LoadInstruction load, Variable var) {
-  load.getSourceAddress().(VariableAddressInstruction).getAstVariable() = var
-}
-
-predicate hasUpperBoundsCheck(Variable var) {
-  exists(RelationalOperation oper, VariableAccess access |
-    oper.getAnOperand() = access and
-    access.getTarget() = var and
-    // Comparing to 0 is not an upper bound check
-    not oper.getAnOperand().getValue() = "0"
-  )
-}
-
-predicate nodeIsBarrierEqualityCandidate(DataFlow::Node node, Operand access, Variable checkedVar) {
-  readsVariable(node.asInstruction(), checkedVar) and
-  any(IRGuardCondition guard).ensuresEq(access, _, _, node.asInstruction().getBlock(), true)
-}
-
-predicate isFlowSource(FlowSource source, string sourceType) { sourceType = source.getSourceType() }
-
-predicate predictableInstruction(Instruction instr) {
-  instr instanceof ConstantInstruction
-  or
-  instr instanceof StringConstantInstruction
-  or
-  // This could be a conversion on a string literal
-  predictableInstruction(instr.(UnaryInstruction).getUnary())
 }
 
 module ImproperArrayIndexValidationConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { isFlowSource(source, _) }
 
   predicate isBarrier(DataFlow::Node node) {
-    hasUpperBound(node.asExpr())
-    or
-    // These barriers are ported from `DefaultTaintTracking` because this query is quite noisy
-    // otherwise.
-    exists(Variable checkedVar |
-      readsVariable(node.asInstruction(), checkedVar) and
-      hasUpperBoundsCheck(checkedVar)
-    )
-    or
-    exists(Variable checkedVar, Operand access |
-      readsVariable(access.getDef(), checkedVar) and
-      nodeIsBarrierEqualityCandidate(node, access, checkedVar)
-    )
-    or
-    // Don't use dataflow into binary instructions if both operands are unpredictable
-    exists(BinaryInstruction iTo |
-      iTo = node.asInstruction() and
-      not predictableInstruction(iTo.getLeft()) and
-      not predictableInstruction(iTo.getRight()) and
-      // propagate taint from either the pointer or the offset, regardless of predictability
-      not iTo instanceof PointerArithmeticInstruction
-    )
-    or
-    // don't use dataflow through calls to pure functions if two or more operands
-    // are unpredictable
-    exists(Instruction iFrom1, Instruction iFrom2, CallInstruction iTo |
-      iTo = node.asInstruction() and
-      isPureFunction(iTo.getStaticCallTarget().getName()) and
-      iFrom1 = iTo.getAnArgument() and
-      iFrom2 = iTo.getAnArgument() and
-      not predictableInstruction(iFrom1) and
-      not predictableInstruction(iFrom2) and
-      iFrom1 != iFrom2
-    )
+    node = DataFlow::BarrierGuard<guardChecks/3>::getABarrierNode()
   }
+
+  predicate isBarrierOut(DataFlow::Node node) { isSink(node) }
 
   predicate isSink(DataFlow::Node sink) {
     exists(ArrayExpr arrayExpr, VariableAccess offsetExpr |
       offsetExpr = arrayExpr.getArrayOffset() and
-      sink.asExpr() = offsetExpr and
-      not hasUpperBound(offsetExpr)
+      sink.asExpr() = offsetExpr
     )
   }
 }

--- a/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
+++ b/cpp/ql/src/Security/CWE/CWE-129/ImproperArrayIndexValidation.ql
@@ -25,11 +25,11 @@ predicate isFlowSource(FS::FlowSource source, string sourceType) {
 
 predicate guardChecks(IRGuardCondition g, Expr e, boolean branch) {
   exists(Operand op | op.getDef().getConvertedResultExpression() = e |
-    // op < k
-    g.comparesLt(op, _, true, any(BooleanValue bv | bv.getValue() = branch))
+    // `op < k` is true and `k > 0`
+    g.comparesLt(op, any(int k | k > 0), true, any(BooleanValue bv | bv.getValue() = branch))
     or
-    // op < _ + k
-    g.comparesLt(op, _, _, true, branch)
+    // `op < _ + k` is true and `k > 0`.
+    g.comparesLt(op, _, any(int k | k > 0), true, branch)
     or
     // op == k
     g.comparesEq(op, _, true, any(BooleanValue bv | bv.getValue() = branch))

--- a/cpp/ql/src/change-notes/2024-10-07-unclear-array-index-validation.md
+++ b/cpp/ql/src/change-notes/2024-10-07-unclear-array-index-validation.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/unclear-array-index-validation` ("Unclear validation of array index") query has been imoroved to reduce false positives increase true positives.

--- a/cpp/ql/src/change-notes/2024-10-07-unclear-array-index-validation.md
+++ b/cpp/ql/src/change-notes/2024-10-07-unclear-array-index-validation.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The `cpp/unclear-array-index-validation` ("Unclear validation of array index") query has been imoroved to reduce false positives increase true positives.
+* The `cpp/unclear-array-index-validation` ("Unclear validation of array index") query has been improved to reduce false positives increase true positives.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -4,15 +4,19 @@ edges
 | test1.c:8:11:8:14 | call to atoi | test1.c:11:9:11:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:12:9:12:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:13:9:13:9 | i | provenance |  |
+| test1.c:8:11:8:14 | call to atoi | test1.c:14:9:14:9 | i | provenance |  |
 | test1.c:9:9:9:9 | i | test1.c:17:16:17:16 | i | provenance |  |
 | test1.c:11:9:11:9 | i | test1.c:33:16:33:16 | i | provenance |  |
 | test1.c:12:9:12:9 | i | test1.c:41:16:41:16 | i | provenance |  |
 | test1.c:13:9:13:9 | i | test1.c:49:16:49:16 | i | provenance |  |
+| test1.c:14:9:14:9 | i | test1.c:59:16:59:16 | i | provenance |  |
 | test1.c:17:16:17:16 | i | test1.c:19:16:19:16 | i | provenance |  |
 | test1.c:33:16:33:16 | i | test1.c:34:11:34:11 | i | provenance |  |
 | test1.c:41:16:41:16 | i | test1.c:42:11:42:11 | i | provenance |  |
 | test1.c:49:16:49:16 | i | test1.c:52:3:52:7 | ... = ... | provenance |  |
 | test1.c:52:3:52:7 | ... = ... | test1.c:54:15:54:15 | j | provenance |  |
+| test1.c:59:16:59:16 | i | test1.c:60:21:60:21 | i | provenance |  |
+| test1.c:60:21:60:21 | i | test1.c:62:11:62:11 | s | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -20,6 +24,7 @@ nodes
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
+| test1.c:14:9:14:9 | i | semmle.label | i |
 | test1.c:17:16:17:16 | i | semmle.label | i |
 | test1.c:19:16:19:16 | i | semmle.label | i |
 | test1.c:33:16:33:16 | i | semmle.label | i |
@@ -29,9 +34,13 @@ nodes
 | test1.c:49:16:49:16 | i | semmle.label | i |
 | test1.c:52:3:52:7 | ... = ... | semmle.label | ... = ... |
 | test1.c:54:15:54:15 | j | semmle.label | j |
+| test1.c:59:16:59:16 | i | semmle.label | i |
+| test1.c:60:21:60:21 | i | semmle.label | i |
+| test1.c:62:11:62:11 | s | semmle.label | s |
 subpaths
 #select
 | test1.c:19:16:19:16 | i | test1.c:7:26:7:29 | **argv | test1.c:19:16:19:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:34:11:34:11 | i | test1.c:7:26:7:29 | **argv | test1.c:34:11:34:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:42:11:42:11 | i | test1.c:7:26:7:29 | **argv | test1.c:42:11:42:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:54:15:54:15 | j | test1.c:7:26:7:29 | **argv | test1.c:54:15:54:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:62:11:62:11 | s | test1.c:7:26:7:29 | **argv | test1.c:62:11:62:11 | s | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -4,15 +4,15 @@ edges
 | test1.c:8:11:8:14 | call to atoi | test1.c:11:9:11:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:12:9:12:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:13:9:13:9 | i | provenance |  |
-| test1.c:9:9:9:9 | i | test1.c:17:16:17:16 | i | provenance |  |
-| test1.c:11:9:11:9 | i | test1.c:33:16:33:16 | i | provenance |  |
-| test1.c:12:9:12:9 | i | test1.c:41:16:41:16 | i | provenance |  |
-| test1.c:13:9:13:9 | i | test1.c:49:16:49:16 | i | provenance |  |
-| test1.c:17:16:17:16 | i | test1.c:19:16:19:16 | i | provenance |  |
-| test1.c:33:16:33:16 | i | test1.c:34:11:34:11 | i | provenance |  |
-| test1.c:41:16:41:16 | i | test1.c:42:11:42:11 | i | provenance |  |
-| test1.c:49:16:49:16 | i | test1.c:52:3:52:7 | ... = ... | provenance |  |
-| test1.c:52:3:52:7 | ... = ... | test1.c:54:15:54:15 | j | provenance |  |
+| test1.c:9:9:9:9 | i | test1.c:18:16:18:16 | i | provenance |  |
+| test1.c:11:9:11:9 | i | test1.c:34:16:34:16 | i | provenance |  |
+| test1.c:12:9:12:9 | i | test1.c:42:16:42:16 | i | provenance |  |
+| test1.c:13:9:13:9 | i | test1.c:50:16:50:16 | i | provenance |  |
+| test1.c:18:16:18:16 | i | test1.c:20:16:20:16 | i | provenance |  |
+| test1.c:34:16:34:16 | i | test1.c:35:11:35:11 | i | provenance |  |
+| test1.c:42:16:42:16 | i | test1.c:43:11:43:11 | i | provenance |  |
+| test1.c:50:16:50:16 | i | test1.c:53:3:53:7 | ... = ... | provenance |  |
+| test1.c:53:3:53:7 | ... = ... | test1.c:55:15:55:15 | j | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -20,18 +20,18 @@ nodes
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
-| test1.c:17:16:17:16 | i | semmle.label | i |
-| test1.c:19:16:19:16 | i | semmle.label | i |
-| test1.c:33:16:33:16 | i | semmle.label | i |
-| test1.c:34:11:34:11 | i | semmle.label | i |
-| test1.c:41:16:41:16 | i | semmle.label | i |
-| test1.c:42:11:42:11 | i | semmle.label | i |
-| test1.c:49:16:49:16 | i | semmle.label | i |
-| test1.c:52:3:52:7 | ... = ... | semmle.label | ... = ... |
-| test1.c:54:15:54:15 | j | semmle.label | j |
+| test1.c:18:16:18:16 | i | semmle.label | i |
+| test1.c:20:16:20:16 | i | semmle.label | i |
+| test1.c:34:16:34:16 | i | semmle.label | i |
+| test1.c:35:11:35:11 | i | semmle.label | i |
+| test1.c:42:16:42:16 | i | semmle.label | i |
+| test1.c:43:11:43:11 | i | semmle.label | i |
+| test1.c:50:16:50:16 | i | semmle.label | i |
+| test1.c:53:3:53:7 | ... = ... | semmle.label | ... = ... |
+| test1.c:55:15:55:15 | j | semmle.label | j |
 subpaths
 #select
-| test1.c:19:16:19:16 | i | test1.c:7:26:7:29 | **argv | test1.c:19:16:19:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:34:11:34:11 | i | test1.c:7:26:7:29 | **argv | test1.c:34:11:34:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:42:11:42:11 | i | test1.c:7:26:7:29 | **argv | test1.c:42:11:42:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:54:15:54:15 | j | test1.c:7:26:7:29 | **argv | test1.c:54:15:54:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:20:16:20:16 | i | test1.c:7:26:7:29 | **argv | test1.c:20:16:20:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:35:11:35:11 | i | test1.c:7:26:7:29 | **argv | test1.c:35:11:35:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:43:11:43:11 | i | test1.c:7:26:7:29 | **argv | test1.c:43:11:43:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:55:15:55:15 | j | test1.c:7:26:7:29 | **argv | test1.c:55:15:55:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -2,12 +2,15 @@ edges
 | test1.c:7:26:7:29 | **argv | test1.c:8:11:8:14 | call to atoi | provenance | TaintFunction |
 | test1.c:8:11:8:14 | call to atoi | test1.c:9:9:9:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:11:9:11:9 | i | provenance |  |
+| test1.c:8:11:8:14 | call to atoi | test1.c:12:9:12:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:13:9:13:9 | i | provenance |  |
 | test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i | provenance |  |
 | test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i | provenance |  |
+| test1.c:12:9:12:9 | i | test1.c:40:16:40:16 | i | provenance |  |
 | test1.c:13:9:13:9 | i | test1.c:48:16:48:16 | i | provenance |  |
 | test1.c:16:16:16:16 | i | test1.c:18:16:18:16 | i | provenance |  |
 | test1.c:32:16:32:16 | i | test1.c:33:11:33:11 | i | provenance |  |
+| test1.c:40:16:40:16 | i | test1.c:41:11:41:11 | i | provenance |  |
 | test1.c:48:16:48:16 | i | test1.c:51:3:51:7 | ... = ... | provenance |  |
 | test1.c:51:3:51:7 | ... = ... | test1.c:53:15:53:15 | j | provenance |  |
 nodes
@@ -15,11 +18,14 @@ nodes
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
 | test1.c:9:9:9:9 | i | semmle.label | i |
 | test1.c:11:9:11:9 | i | semmle.label | i |
+| test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
 | test1.c:16:16:16:16 | i | semmle.label | i |
 | test1.c:18:16:18:16 | i | semmle.label | i |
 | test1.c:32:16:32:16 | i | semmle.label | i |
 | test1.c:33:11:33:11 | i | semmle.label | i |
+| test1.c:40:16:40:16 | i | semmle.label | i |
+| test1.c:41:11:41:11 | i | semmle.label | i |
 | test1.c:48:16:48:16 | i | semmle.label | i |
 | test1.c:51:3:51:7 | ... = ... | semmle.label | ... = ... |
 | test1.c:53:15:53:15 | j | semmle.label | j |
@@ -27,4 +33,5 @@ subpaths
 #select
 | test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | **argv | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | **argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:41:11:41:11 | i | test1.c:7:26:7:29 | **argv | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | **argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -13,6 +13,8 @@ edges
 | test1.c:42:16:42:16 | i | test1.c:43:11:43:11 | i | provenance |  |
 | test1.c:50:16:50:16 | i | test1.c:53:3:53:7 | ... = ... | provenance |  |
 | test1.c:53:3:53:7 | ... = ... | test1.c:55:15:55:15 | j | provenance |  |
+| test1.c:76:11:76:23 | ... = ... | test1.c:77:20:77:21 | ch | provenance |  |
+| test1.c:76:16:76:19 | call to getc | test1.c:76:11:76:23 | ... = ... | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -29,9 +31,13 @@ nodes
 | test1.c:50:16:50:16 | i | semmle.label | i |
 | test1.c:53:3:53:7 | ... = ... | semmle.label | ... = ... |
 | test1.c:55:15:55:15 | j | semmle.label | j |
+| test1.c:76:11:76:23 | ... = ... | semmle.label | ... = ... |
+| test1.c:76:16:76:19 | call to getc | semmle.label | call to getc |
+| test1.c:77:20:77:21 | ch | semmle.label | ch |
 subpaths
 #select
 | test1.c:20:16:20:16 | i | test1.c:7:26:7:29 | **argv | test1.c:20:16:20:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:35:11:35:11 | i | test1.c:7:26:7:29 | **argv | test1.c:35:11:35:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:43:11:43:11 | i | test1.c:7:26:7:29 | **argv | test1.c:43:11:43:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:55:15:55:15 | j | test1.c:7:26:7:29 | **argv | test1.c:55:15:55:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:77:20:77:21 | ch | test1.c:76:16:76:19 | call to getc | test1.c:77:20:77:21 | ch | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:76:16:76:19 | call to getc | external |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -4,15 +4,15 @@ edges
 | test1.c:8:11:8:14 | call to atoi | test1.c:11:9:11:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:12:9:12:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:13:9:13:9 | i | provenance |  |
-| test1.c:9:9:9:9 | i | test1.c:16:16:16:16 | i | provenance |  |
-| test1.c:11:9:11:9 | i | test1.c:32:16:32:16 | i | provenance |  |
-| test1.c:12:9:12:9 | i | test1.c:40:16:40:16 | i | provenance |  |
-| test1.c:13:9:13:9 | i | test1.c:48:16:48:16 | i | provenance |  |
-| test1.c:16:16:16:16 | i | test1.c:18:16:18:16 | i | provenance |  |
-| test1.c:32:16:32:16 | i | test1.c:33:11:33:11 | i | provenance |  |
-| test1.c:40:16:40:16 | i | test1.c:41:11:41:11 | i | provenance |  |
-| test1.c:48:16:48:16 | i | test1.c:51:3:51:7 | ... = ... | provenance |  |
-| test1.c:51:3:51:7 | ... = ... | test1.c:53:15:53:15 | j | provenance |  |
+| test1.c:9:9:9:9 | i | test1.c:17:16:17:16 | i | provenance |  |
+| test1.c:11:9:11:9 | i | test1.c:33:16:33:16 | i | provenance |  |
+| test1.c:12:9:12:9 | i | test1.c:41:16:41:16 | i | provenance |  |
+| test1.c:13:9:13:9 | i | test1.c:49:16:49:16 | i | provenance |  |
+| test1.c:17:16:17:16 | i | test1.c:19:16:19:16 | i | provenance |  |
+| test1.c:33:16:33:16 | i | test1.c:34:11:34:11 | i | provenance |  |
+| test1.c:41:16:41:16 | i | test1.c:42:11:42:11 | i | provenance |  |
+| test1.c:49:16:49:16 | i | test1.c:52:3:52:7 | ... = ... | provenance |  |
+| test1.c:52:3:52:7 | ... = ... | test1.c:54:15:54:15 | j | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -20,18 +20,18 @@ nodes
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
-| test1.c:16:16:16:16 | i | semmle.label | i |
-| test1.c:18:16:18:16 | i | semmle.label | i |
-| test1.c:32:16:32:16 | i | semmle.label | i |
-| test1.c:33:11:33:11 | i | semmle.label | i |
-| test1.c:40:16:40:16 | i | semmle.label | i |
-| test1.c:41:11:41:11 | i | semmle.label | i |
-| test1.c:48:16:48:16 | i | semmle.label | i |
-| test1.c:51:3:51:7 | ... = ... | semmle.label | ... = ... |
-| test1.c:53:15:53:15 | j | semmle.label | j |
+| test1.c:17:16:17:16 | i | semmle.label | i |
+| test1.c:19:16:19:16 | i | semmle.label | i |
+| test1.c:33:16:33:16 | i | semmle.label | i |
+| test1.c:34:11:34:11 | i | semmle.label | i |
+| test1.c:41:16:41:16 | i | semmle.label | i |
+| test1.c:42:11:42:11 | i | semmle.label | i |
+| test1.c:49:16:49:16 | i | semmle.label | i |
+| test1.c:52:3:52:7 | ... = ... | semmle.label | ... = ... |
+| test1.c:54:15:54:15 | j | semmle.label | j |
 subpaths
 #select
-| test1.c:18:16:18:16 | i | test1.c:7:26:7:29 | **argv | test1.c:18:16:18:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:33:11:33:11 | i | test1.c:7:26:7:29 | **argv | test1.c:33:11:33:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:41:11:41:11 | i | test1.c:7:26:7:29 | **argv | test1.c:41:11:41:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:53:15:53:15 | j | test1.c:7:26:7:29 | **argv | test1.c:53:15:53:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:19:16:19:16 | i | test1.c:7:26:7:29 | **argv | test1.c:19:16:19:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:34:11:34:11 | i | test1.c:7:26:7:29 | **argv | test1.c:34:11:34:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:42:11:42:11 | i | test1.c:7:26:7:29 | **argv | test1.c:42:11:42:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
+| test1.c:54:15:54:15 | j | test1.c:7:26:7:29 | **argv | test1.c:54:15:54:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -13,8 +13,6 @@ edges
 | test1.c:42:16:42:16 | i | test1.c:43:11:43:11 | i | provenance |  |
 | test1.c:50:16:50:16 | i | test1.c:53:3:53:7 | ... = ... | provenance |  |
 | test1.c:53:3:53:7 | ... = ... | test1.c:55:15:55:15 | j | provenance |  |
-| test1.c:76:11:76:23 | ... = ... | test1.c:77:20:77:21 | ch | provenance |  |
-| test1.c:76:16:76:19 | call to getc | test1.c:76:11:76:23 | ... = ... | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -31,13 +29,9 @@ nodes
 | test1.c:50:16:50:16 | i | semmle.label | i |
 | test1.c:53:3:53:7 | ... = ... | semmle.label | ... = ... |
 | test1.c:55:15:55:15 | j | semmle.label | j |
-| test1.c:76:11:76:23 | ... = ... | semmle.label | ... = ... |
-| test1.c:76:16:76:19 | call to getc | semmle.label | call to getc |
-| test1.c:77:20:77:21 | ch | semmle.label | ch |
 subpaths
 #select
 | test1.c:20:16:20:16 | i | test1.c:7:26:7:29 | **argv | test1.c:20:16:20:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:35:11:35:11 | i | test1.c:7:26:7:29 | **argv | test1.c:35:11:35:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:43:11:43:11 | i | test1.c:7:26:7:29 | **argv | test1.c:43:11:43:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:55:15:55:15 | j | test1.c:7:26:7:29 | **argv | test1.c:55:15:55:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:77:20:77:21 | ch | test1.c:76:16:76:19 | call to getc | test1.c:77:20:77:21 | ch | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:76:16:76:19 | call to getc | external |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/ImproperArrayIndexValidation.expected
@@ -4,19 +4,15 @@ edges
 | test1.c:8:11:8:14 | call to atoi | test1.c:11:9:11:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:12:9:12:9 | i | provenance |  |
 | test1.c:8:11:8:14 | call to atoi | test1.c:13:9:13:9 | i | provenance |  |
-| test1.c:8:11:8:14 | call to atoi | test1.c:14:9:14:9 | i | provenance |  |
 | test1.c:9:9:9:9 | i | test1.c:17:16:17:16 | i | provenance |  |
 | test1.c:11:9:11:9 | i | test1.c:33:16:33:16 | i | provenance |  |
 | test1.c:12:9:12:9 | i | test1.c:41:16:41:16 | i | provenance |  |
 | test1.c:13:9:13:9 | i | test1.c:49:16:49:16 | i | provenance |  |
-| test1.c:14:9:14:9 | i | test1.c:59:16:59:16 | i | provenance |  |
 | test1.c:17:16:17:16 | i | test1.c:19:16:19:16 | i | provenance |  |
 | test1.c:33:16:33:16 | i | test1.c:34:11:34:11 | i | provenance |  |
 | test1.c:41:16:41:16 | i | test1.c:42:11:42:11 | i | provenance |  |
 | test1.c:49:16:49:16 | i | test1.c:52:3:52:7 | ... = ... | provenance |  |
 | test1.c:52:3:52:7 | ... = ... | test1.c:54:15:54:15 | j | provenance |  |
-| test1.c:59:16:59:16 | i | test1.c:60:21:60:21 | i | provenance |  |
-| test1.c:60:21:60:21 | i | test1.c:62:11:62:11 | s | provenance |  |
 nodes
 | test1.c:7:26:7:29 | **argv | semmle.label | **argv |
 | test1.c:8:11:8:14 | call to atoi | semmle.label | call to atoi |
@@ -24,7 +20,6 @@ nodes
 | test1.c:11:9:11:9 | i | semmle.label | i |
 | test1.c:12:9:12:9 | i | semmle.label | i |
 | test1.c:13:9:13:9 | i | semmle.label | i |
-| test1.c:14:9:14:9 | i | semmle.label | i |
 | test1.c:17:16:17:16 | i | semmle.label | i |
 | test1.c:19:16:19:16 | i | semmle.label | i |
 | test1.c:33:16:33:16 | i | semmle.label | i |
@@ -34,13 +29,9 @@ nodes
 | test1.c:49:16:49:16 | i | semmle.label | i |
 | test1.c:52:3:52:7 | ... = ... | semmle.label | ... = ... |
 | test1.c:54:15:54:15 | j | semmle.label | j |
-| test1.c:59:16:59:16 | i | semmle.label | i |
-| test1.c:60:21:60:21 | i | semmle.label | i |
-| test1.c:62:11:62:11 | s | semmle.label | s |
 subpaths
 #select
 | test1.c:19:16:19:16 | i | test1.c:7:26:7:29 | **argv | test1.c:19:16:19:16 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:34:11:34:11 | i | test1.c:7:26:7:29 | **argv | test1.c:34:11:34:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:42:11:42:11 | i | test1.c:7:26:7:29 | **argv | test1.c:42:11:42:11 | i | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
 | test1.c:54:15:54:15 | j | test1.c:7:26:7:29 | **argv | test1.c:54:15:54:15 | j | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |
-| test1.c:62:11:62:11 | s | test1.c:7:26:7:29 | **argv | test1.c:62:11:62:11 | s | An array indexing expression depends on $@ that might be outside the bounds of the array. | test1.c:7:26:7:29 | **argv | a command-line argument |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -12,6 +12,7 @@ int main(int argc, char *argv[]) {
   test4(i);
   test5(i);
   test6(i);
+  test7(argv[1]);
 }
 
 void test1(int i) {
@@ -61,3 +62,5 @@ void test6(int i) {
 
   myTable[s] = 0; // GOOD: Input is small [FALSE POSITIVE]
 }
+
+void test7(char *s) { }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -63,4 +63,17 @@ void test6(int i) {
   myTable[s] = 0; // GOOD: Input is small [FALSE POSITIVE]
 }
 
-void test7(char *s) { }
+typedef void FILE;
+#define EOF (-1)
+
+int getc(FILE*);
+
+extern int myMaxCharTable[256];
+
+void test7(FILE* fp) {
+  int ch;
+  while ((ch = getc(fp)) != EOF) {
+    myMaxCharTable[ch] = 0; // GOOD [FALSE POSITIVE]
+  }
+}
+

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -73,7 +73,7 @@ extern int myMaxCharTable[256];
 void test7(FILE* fp) {
   int ch;
   while ((ch = getc(fp)) != EOF) {
-    myMaxCharTable[ch] = 0; // GOOD [FALSE POSITIVE]
+    myMaxCharTable[ch] = 0; // GOOD
   }
 }
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -11,6 +11,7 @@ int main(int argc, char *argv[]) {
   test3(i);
   test4(i);
   test5(i);
+  test6(i);
 }
 
 void test1(int i) {
@@ -51,4 +52,8 @@ void test5(int i) {
   j = i;
 
   j = myArray[j]; // BAD: j has not been validated
+}
+
+void test6(int i) {
+
 }

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -38,7 +38,7 @@ void test3(int i) {
 }
 
 void test4(int i) {
-  myArray[i] = 0; // BAD: i has not been validated [NOT REPORTED]
+  myArray[i] = 0; // BAD: i has not been validated
 
   if ((i < 0) || (i >= 10)) return;
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-129/semmle/ImproperArrayIndexValidation/test1.c
@@ -54,6 +54,10 @@ void test5(int i) {
   j = myArray[j]; // BAD: j has not been validated
 }
 
-void test6(int i) {
+extern int myTable[256];
 
+void test6(int i) {
+  unsigned char s = i;
+
+  myTable[s] = 0; // GOOD: Input is small [FALSE POSITIVE]
 }


### PR DESCRIPTION
### Pull Request checklist

This PR modernizes the old _low precision_ `cpp/unclear-array-index-validation` by getting rid of the old DefaultTaintTracking inherited barriers and replacing them with a more precise `BarrierGuard` instantiation, and uses of `SimpleRangeAnalysis`.

I've started two DCA runs:
- A `nightly` one to test the impact of the changes to `SimpleRangeAnalysis`
- A run with just `cpp/unclear-array-index-validation` to test the changes to that query.

Since this query isn't included in any security suite I'm not sure how much you care about the result changes on `cpp/unclear-array-index-validation`?

I did a diff MRVA run to test the results, and they look reasonable.

Commit-by-commit review recommended.

The new results are TPs. They essentially look like:
```cpp
c = fgetc(fin);
while(c != EOF) {
  if(... && (c = ... || c == EOF) {
    // ...
  }
}
```
and we now see that `c == EOF` is always false.

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
