### PR TITLE
JS DataFlow: Update tests after merging in 'main'

### DIFF
--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -38,9 +38,9 @@ legacyDataFlowDifference
 | spread.js:4:15:4:22 | source() | spread.js:24:8:24:8 | y | only flow with NEW data flow library |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x | only flow with NEW data flow library |
 consistencyIssue
-| library-tests/TaintTracking/nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
-| library-tests/TaintTracking/stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
-| library-tests/TaintTracking/stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
+| nested-props.js:20 | expected an alert, but found none | NOT OK - but not found | Consistency |
+| stringification-read-steps.js:17 | expected an alert, but found none | NOT OK | Consistency |
+| stringification-read-steps.js:25 | expected an alert, but found none | NOT OK | Consistency |
 flow
 | access-path-sanitizer.js:2:18:2:25 | source() | access-path-sanitizer.js:4:8:4:12 | obj.x |
 | addexpr.js:4:10:4:17 | source() | addexpr.js:7:8:7:8 | x |

--- a/javascript/ql/test/query-tests/Security/CWE-020/UntrustedDataToExternalAPI/UntrustedDataToExternalAPI.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/UntrustedDataToExternalAPI/UntrustedDataToExternalAPI.expected
@@ -13,10 +13,8 @@ edges
 | tst-UntrustedDataToExternalAPI.js:3:5:3:27 | untrusted | tst-UntrustedDataToExternalAPI.js:43:8:43:16 | untrusted | provenance |  |
 | tst-UntrustedDataToExternalAPI.js:3:5:3:27 | untrusted | tst-UntrustedDataToExternalAPI.js:44:8:44:16 | untrusted | provenance |  |
 | tst-UntrustedDataToExternalAPI.js:3:17:3:27 | window.name | tst-UntrustedDataToExternalAPI.js:3:5:3:27 | untrusted | provenance |  |
-| tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] [1] | tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] | provenance |  |
-| tst-UntrustedDataToExternalAPI.js:10:19:10:27 | untrusted | tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] [1] | provenance |  |
-| tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } [y, z] | tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } | provenance |  |
-| tst-UntrustedDataToExternalAPI.js:14:12:16:9 | {\\n      ...       } [z] | tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } [y, z] | provenance |  |
+| tst-UntrustedDataToExternalAPI.js:10:19:10:27 | untrusted | tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] | provenance |  |
+| tst-UntrustedDataToExternalAPI.js:14:12:16:9 | {\\n      ...       } [z] | tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } | provenance |  |
 | tst-UntrustedDataToExternalAPI.js:15:16:15:24 | untrusted | tst-UntrustedDataToExternalAPI.js:14:12:16:9 | {\\n      ...       } [z] | provenance |  |
 | tst-UntrustedDataToExternalAPI.js:41:11:45:1 | [post update] {\\n    x ... usted\\n} [x] | tst-UntrustedDataToExternalAPI.js:41:7:41:8 | {} | provenance |  |
 | tst-UntrustedDataToExternalAPI.js:41:11:45:1 | [post update] {\\n    x ... usted\\n} [x] | tst-UntrustedDataToExternalAPI.js:41:11:45:1 | {\\n    x ... usted\\n} | provenance |  |
@@ -36,11 +34,9 @@ nodes
 | tst-UntrustedDataToExternalAPI.js:8:31:8:39 | untrusted | semmle.label | untrusted |
 | tst-UntrustedDataToExternalAPI.js:9:18:9:26 | untrusted | semmle.label | untrusted |
 | tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] | semmle.label | ['x', u ... d, 'y'] |
-| tst-UntrustedDataToExternalAPI.js:10:13:10:33 | ['x', u ... d, 'y'] [1] | semmle.label | ['x', u ... d, 'y'] [1] |
 | tst-UntrustedDataToExternalAPI.js:10:19:10:27 | untrusted | semmle.label | untrusted |
 | tst-UntrustedDataToExternalAPI.js:11:20:11:28 | untrusted | semmle.label | untrusted |
 | tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } | semmle.label | {\\n      ... }\\n    } |
-| tst-UntrustedDataToExternalAPI.js:13:8:17:5 | {\\n      ... }\\n    } [y, z] | semmle.label | {\\n      ... }\\n    } [y, z] |
 | tst-UntrustedDataToExternalAPI.js:14:12:16:9 | {\\n      ...       } [z] | semmle.label | {\\n      ...       } [z] |
 | tst-UntrustedDataToExternalAPI.js:15:16:15:24 | untrusted | semmle.label | untrusted |
 | tst-UntrustedDataToExternalAPI.js:33:14:33:22 | untrusted | semmle.label | untrusted |

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection/CommandInjection.expected
@@ -30,15 +30,10 @@ edges
 | child_process-test.js:46:9:46:17 | args [1] | child_process-test.js:49:15:49:18 | args [1] | provenance |  |
 | child_process-test.js:48:5:48:8 | [post update] args [1] | child_process-test.js:46:9:46:17 | args [1] | provenance |  |
 | child_process-test.js:48:15:48:17 | cmd | child_process-test.js:48:5:48:8 | [post update] args [1] | provenance |  |
-| child_process-test.js:49:15:49:18 | args [1] | child_process-test.js:66:19:66:22 | args [1] | provenance |  |
-| child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) [ArrayElement] | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) | provenance |  |
+| child_process-test.js:49:15:49:18 | args [1] | child_process-test.js:66:19:66:22 | args | provenance |  |
 | child_process-test.js:56:46:56:57 | ["bar", cmd] [1] | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) | provenance |  |
-| child_process-test.js:56:46:56:57 | ["bar", cmd] [1] | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) [ArrayElement] | provenance |  |
 | child_process-test.js:56:54:56:56 | cmd | child_process-test.js:56:46:56:57 | ["bar", cmd] [1] | provenance |  |
-| child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) [ArrayElement] | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) | provenance |  |
 | child_process-test.js:57:46:57:48 | cmd | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) | provenance |  |
-| child_process-test.js:57:46:57:48 | cmd | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) [ArrayElement] | provenance |  |
-| child_process-test.js:66:19:66:22 | args [1] | child_process-test.js:66:19:66:22 | args | provenance |  |
 | child_process-test.js:73:9:73:49 | cmd | child_process-test.js:75:29:75:31 | cmd | provenance |  |
 | child_process-test.js:73:15:73:38 | url.par ... , true) | child_process-test.js:73:9:73:49 | cmd | provenance |  |
 | child_process-test.js:73:25:73:31 | req.url | child_process-test.js:73:15:73:38 | url.par ... , true) | provenance |  |
@@ -133,15 +128,12 @@ nodes
 | child_process-test.js:49:15:49:18 | args [1] | semmle.label | args [1] |
 | child_process-test.js:53:15:53:17 | cmd | semmle.label | cmd |
 | child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) | semmle.label | ['/C',  ... , cmd]) |
-| child_process-test.js:56:25:56:58 | ['/C',  ... , cmd]) [ArrayElement] | semmle.label | ['/C',  ... , cmd]) [ArrayElement] |
 | child_process-test.js:56:46:56:57 | ["bar", cmd] [1] | semmle.label | ["bar", cmd] [1] |
 | child_process-test.js:56:54:56:56 | cmd | semmle.label | cmd |
 | child_process-test.js:56:54:56:56 | cmd | semmle.label | cmd |
 | child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) | semmle.label | ['/C',  ... at(cmd) |
-| child_process-test.js:57:25:57:49 | ['/C',  ... at(cmd) [ArrayElement] | semmle.label | ['/C',  ... at(cmd) [ArrayElement] |
 | child_process-test.js:57:46:57:48 | cmd | semmle.label | cmd |
 | child_process-test.js:66:19:66:22 | args | semmle.label | args |
-| child_process-test.js:66:19:66:22 | args [1] | semmle.label | args [1] |
 | child_process-test.js:73:9:73:49 | cmd | semmle.label | cmd |
 | child_process-test.js:73:15:73:38 | url.par ... , true) | semmle.label | url.par ... , true) |
 | child_process-test.js:73:25:73:31 | req.url | semmle.label | req.url |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -90,15 +90,12 @@ edges
 | lib/lib.js:414:40:414:43 | name | lib/lib.js:426:11:426:14 | name | provenance |  |
 | lib/lib.js:414:40:414:43 | name | lib/lib.js:428:36:428:39 | name | provenance |  |
 | lib/lib.js:425:6:425:13 | arr | lib/lib.js:427:14:427:16 | arr | provenance |  |
-| lib/lib.js:425:6:425:13 | arr [ArrayElement] | lib/lib.js:427:14:427:16 | arr [ArrayElement] | provenance |  |
+| lib/lib.js:425:6:425:13 | arr [ArrayElement] | lib/lib.js:427:14:427:16 | arr | provenance |  |
 | lib/lib.js:426:2:426:4 | [post update] arr | lib/lib.js:425:6:425:13 | arr | provenance |  |
 | lib/lib.js:426:2:426:4 | [post update] arr [ArrayElement] | lib/lib.js:425:6:425:13 | arr [ArrayElement] | provenance |  |
 | lib/lib.js:426:11:426:14 | name | lib/lib.js:426:2:426:4 | [post update] arr | provenance |  |
 | lib/lib.js:426:11:426:14 | name | lib/lib.js:426:2:426:4 | [post update] arr [ArrayElement] | provenance |  |
-| lib/lib.js:427:14:427:16 | arr [ArrayElement] | lib/lib.js:427:14:427:16 | arr | provenance |  |
-| lib/lib.js:428:14:428:58 | build(" ...  + '-') [ArrayElement] | lib/lib.js:428:14:428:58 | build(" ...  + '-') | provenance |  |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:428:14:428:58 | build(" ...  + '-') | provenance |  |
-| lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:428:14:428:58 | build(" ...  + '-') [ArrayElement] | provenance |  |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | provenance |  |
 | lib/lib.js:428:36:428:39 | name | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | provenance |  |
 | lib/lib.js:431:23:431:26 | last | lib/lib.js:436:19:436:22 | last | provenance |  |
@@ -125,8 +122,7 @@ edges
 | lib/lib.js:509:39:509:42 | name | lib/lib.js:545:23:545:26 | name | provenance |  |
 | lib/lib.js:550:39:550:42 | name | lib/lib.js:555:33:555:36 | name | provenance |  |
 | lib/lib.js:550:39:550:42 | name | lib/lib.js:555:33:555:36 | name | provenance |  |
-| lib/lib.js:551:33:551:36 | args [1] | lib/lib.js:552:23:552:26 | args [1] | provenance |  |
-| lib/lib.js:552:23:552:26 | args [1] | lib/lib.js:552:23:552:26 | args | provenance |  |
+| lib/lib.js:551:33:551:36 | args [1] | lib/lib.js:552:23:552:26 | args | provenance |  |
 | lib/lib.js:555:25:555:37 | ["-rf", name] [1] | lib/lib.js:551:33:551:36 | args [1] | provenance |  |
 | lib/lib.js:555:33:555:36 | name | lib/lib.js:555:25:555:37 | ["-rf", name] [1] | provenance |  |
 | lib/lib.js:558:41:558:44 | name | lib/lib.js:560:26:560:29 | name | provenance |  |
@@ -283,9 +279,7 @@ nodes
 | lib/lib.js:426:11:426:14 | name | semmle.label | name |
 | lib/lib.js:426:11:426:14 | name | semmle.label | name |
 | lib/lib.js:427:14:427:16 | arr | semmle.label | arr |
-| lib/lib.js:427:14:427:16 | arr [ArrayElement] | semmle.label | arr [ArrayElement] |
 | lib/lib.js:428:14:428:58 | build(" ...  + '-') | semmle.label | build(" ...  + '-') |
-| lib/lib.js:428:14:428:58 | build(" ...  + '-') [ArrayElement] | semmle.label | build(" ...  + '-') [ArrayElement] |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | semmle.label | (name ? ... ) + '-' |
 | lib/lib.js:428:36:428:39 | name | semmle.label | name |
 | lib/lib.js:431:23:431:26 | last | semmle.label | last |
@@ -320,7 +314,6 @@ nodes
 | lib/lib.js:550:39:550:42 | name | semmle.label | name |
 | lib/lib.js:551:33:551:36 | args [1] | semmle.label | args [1] |
 | lib/lib.js:552:23:552:26 | args | semmle.label | args |
-| lib/lib.js:552:23:552:26 | args [1] | semmle.label | args [1] |
 | lib/lib.js:555:25:555:37 | ["-rf", name] [1] | semmle.label | ["-rf", name] [1] |
 | lib/lib.js:555:33:555:36 | name | semmle.label | name |
 | lib/lib.js:555:33:555:36 | name | semmle.label | name |
@@ -359,7 +352,7 @@ subpaths
 | lib/lib.js:251:27:251:30 | name | lib/lib.js:239:28:239:28 | s | lib/lib.js:245:9:245:9 | s | lib/lib.js:251:16:251:31 | cleanInput(name) |
 | lib/lib.js:340:25:340:25 | n | lib/lib.js:329:13:329:13 | x | lib/lib.js:330:9:330:9 | x | lib/lib.js:340:22:340:26 | id(n) |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | lib/lib.js:437:9:437:11 | arr | lib/lib.js:428:14:428:58 | build(" ...  + '-') |
-| lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | lib/lib.js:437:9:437:11 | arr [ArrayElement] | lib/lib.js:428:14:428:58 | build(" ...  + '-') [ArrayElement] |
+| lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | lib/lib.js:437:9:437:11 | arr [ArrayElement] | lib/lib.js:428:14:428:58 | build(" ...  + '-') |
 #select
 | lib/isImported.js:6:10:6:25 | "rm -rf " + name | lib/isImported.js:5:49:5:52 | name | lib/isImported.js:6:22:6:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/isImported.js:5:49:5:52 | name | library input | lib/isImported.js:6:2:6:26 | cp.exec ... + name) | shell command |
 | lib/lib2.js:4:10:4:25 | "rm -rf " + name | lib/lib2.js:3:28:3:31 | name | lib/lib2.js:4:22:4:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/lib2.js:3:28:3:31 | name | library input | lib/lib2.js:4:2:4:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -582,7 +582,6 @@ nodes
 | various-concat-obfuscations.js:5:12:5:18 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | semmle.label | "<div>" ... ainted) |
 | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | semmle.label | "<div>" ... /div>") |
-| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | semmle.label | "<div>" ... /div>") [ArrayElement] |
 | various-concat-obfuscations.js:6:19:6:25 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | semmle.label | ["<div> ... /div>"] |
 | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | semmle.label | ["<div> ... .join() |
@@ -593,7 +592,6 @@ nodes
 | various-concat-obfuscations.js:10:16:10:22 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | semmle.label | "<div i ... ainted) |
 | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | semmle.label | "<div i ... t("/>") |
-| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | semmle.label | "<div i ... t("/>") [ArrayElement] |
 | various-concat-obfuscations.js:11:24:11:30 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | semmle.label | ["<div  ... "\\"/>"] |
 | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | semmle.label | ["<div  ... .join() |
@@ -614,7 +612,6 @@ nodes
 | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | semmle.label | documen ... .search |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | semmle.label | documen ... h.attrs |
 | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | semmle.label | indirec ... .attrs) |
-| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | semmle.label | indirec ... .attrs) [ArrayElement] |
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | semmle.label | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | semmle.label | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted | semmle.label | tainted |
@@ -1097,16 +1094,12 @@ edges
 | various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | provenance | Config |
 | various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | provenance | Config |
 | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | provenance |  |
-| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | provenance |  |
 | various-concat-obfuscations.js:6:19:6:25 | tainted | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | provenance | Config |
 | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | provenance |  |
 | various-concat-obfuscations.js:7:14:7:20 | tainted | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | provenance | Config |
 | various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" | provenance | Config |
 | various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` | provenance | Config |
 | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | provenance |  |
-| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | provenance |  |
 | various-concat-obfuscations.js:11:24:11:30 | tainted | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | provenance | Config |
 | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | provenance |  |
 | various-concat-obfuscations.js:12:19:12:25 | tainted | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | provenance | Config |
@@ -1125,11 +1118,9 @@ edges
 | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | provenance |  |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:14:24:14:28 | attrs | provenance |  |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | provenance | Config |
-| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | provenance |  |
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | provenance |  |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | provenance |  |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | provenance | Config |
-| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | provenance | Config |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted | provenance |  |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted | provenance |  |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) | provenance |  |
@@ -1147,7 +1138,7 @@ subpaths
 | tst.js:58:26:58:30 | bar() | tst.js:48:15:48:15 | s | tst.js:50:12:50:22 | s.substr(1) | tst.js:58:21:58:31 | chop(bar()) |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:14:24:14:28 | attrs | various-concat-obfuscations.js:15:10:15:83 | '<div a ... </div>' | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
-| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 #select
 | addEventListener.js:2:20:2:29 | event.data | addEventListener.js:1:43:1:47 | event | addEventListener.js:2:20:2:29 | event.data | Cross-site scripting vulnerability due to $@. | addEventListener.js:1:43:1:47 | event | user-provided value |
 | addEventListener.js:6:20:6:23 | data | addEventListener.js:5:43:5:48 | {data} | addEventListener.js:6:20:6:23 | data | Cross-site scripting vulnerability due to $@. | addEventListener.js:5:43:5:48 | {data} | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -589,7 +589,6 @@ nodes
 | various-concat-obfuscations.js:5:12:5:18 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | semmle.label | "<div>" ... ainted) |
 | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | semmle.label | "<div>" ... /div>") |
-| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | semmle.label | "<div>" ... /div>") [ArrayElement] |
 | various-concat-obfuscations.js:6:19:6:25 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | semmle.label | ["<div> ... /div>"] |
 | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | semmle.label | ["<div> ... .join() |
@@ -600,7 +599,6 @@ nodes
 | various-concat-obfuscations.js:10:16:10:22 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | semmle.label | "<div i ... ainted) |
 | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | semmle.label | "<div i ... t("/>") |
-| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | semmle.label | "<div i ... t("/>") [ArrayElement] |
 | various-concat-obfuscations.js:11:24:11:30 | tainted | semmle.label | tainted |
 | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | semmle.label | ["<div  ... "\\"/>"] |
 | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | semmle.label | ["<div  ... .join() |
@@ -621,7 +619,6 @@ nodes
 | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | semmle.label | documen ... .search |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | semmle.label | documen ... h.attrs |
 | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | semmle.label | indirec ... .attrs) |
-| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | semmle.label | indirec ... .attrs) [ArrayElement] |
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | semmle.label | documen ... .search |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | semmle.label | documen ... h.attrs |
 | winjs.js:2:7:2:53 | tainted | semmle.label | tainted |
@@ -1122,16 +1119,12 @@ edges
 | various-concat-obfuscations.js:4:14:4:20 | tainted | various-concat-obfuscations.js:4:4:4:31 | "<div>" ... </div>" | provenance | Config |
 | various-concat-obfuscations.js:5:12:5:18 | tainted | various-concat-obfuscations.js:5:4:5:26 | `<div>$ ... </div>` | provenance | Config |
 | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | provenance |  |
-| various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") [ArrayElement] | various-concat-obfuscations.js:6:4:6:43 | "<div>" ... /div>") | provenance |  |
 | various-concat-obfuscations.js:6:19:6:25 | tainted | various-concat-obfuscations.js:6:4:6:26 | "<div>" ... ainted) | provenance | Config |
 | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | various-concat-obfuscations.js:7:4:7:38 | ["<div> ... .join() | provenance |  |
 | various-concat-obfuscations.js:7:14:7:20 | tainted | various-concat-obfuscations.js:7:4:7:31 | ["<div> ... /div>"] | provenance | Config |
 | various-concat-obfuscations.js:9:19:9:25 | tainted | various-concat-obfuscations.js:9:4:9:34 | "<div i ...  "\\"/>" | provenance | Config |
 | various-concat-obfuscations.js:10:16:10:22 | tainted | various-concat-obfuscations.js:10:4:10:27 | `<div i ... ed}"/>` | provenance | Config |
 | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | provenance |  |
-| various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") [ArrayElement] | various-concat-obfuscations.js:11:4:11:44 | "<div i ... t("/>") | provenance |  |
 | various-concat-obfuscations.js:11:24:11:30 | tainted | various-concat-obfuscations.js:11:4:11:31 | "<div i ... ainted) | provenance | Config |
 | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | various-concat-obfuscations.js:12:4:12:41 | ["<div  ... .join() | provenance |  |
 | various-concat-obfuscations.js:12:19:12:25 | tainted | various-concat-obfuscations.js:12:4:12:34 | ["<div  ... "\\"/>"] | provenance | Config |
@@ -1150,11 +1143,9 @@ edges
 | various-concat-obfuscations.js:20:17:20:40 | documen ... .search | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | provenance |  |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:14:24:14:28 | attrs | provenance |  |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) | provenance | Config |
-| various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | provenance |  |
 | various-concat-obfuscations.js:21:17:21:40 | documen ... .search | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | provenance |  |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | provenance |  |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) | provenance | Config |
-| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] | provenance | Config |
 | winjs.js:2:7:2:53 | tainted | winjs.js:3:43:3:49 | tainted | provenance |  |
 | winjs.js:2:7:2:53 | tainted | winjs.js:4:43:4:49 | tainted | provenance |  |
 | winjs.js:2:17:2:40 | documen ... .search | winjs.js:2:17:2:53 | documen ... ring(1) | provenance |  |
@@ -1183,7 +1174,7 @@ subpaths
 | tst.js:58:26:58:30 | bar() | tst.js:48:15:48:15 | s | tst.js:50:12:50:22 | s.substr(1) | tst.js:58:21:58:31 | chop(bar()) |
 | various-concat-obfuscations.js:20:17:20:46 | documen ... h.attrs | various-concat-obfuscations.js:14:24:14:28 | attrs | various-concat-obfuscations.js:15:10:15:83 | '<div a ... </div>' | various-concat-obfuscations.js:20:4:20:47 | indirec ... .attrs) |
 | various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
-| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) [ArrayElement] |
+| various-concat-obfuscations.js:21:17:21:46 | documen ... h.attrs | various-concat-obfuscations.js:17:24:17:28 | attrs | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | various-concat-obfuscations.js:21:4:21:47 | indirec ... .attrs) |
 #select
 | jwt.js:6:14:6:20 | decoded | jwt.js:4:36:4:39 | data | jwt.js:6:14:6:20 | decoded | Cross-site scripting vulnerability due to $@. | jwt.js:4:36:4:39 | data | user-provided value |
 | typeahead.js:10:16:10:18 | loc | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc | Cross-site scripting vulnerability due to $@. | typeahead.js:9:28:9:30 | loc | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss/StoredXss.expected
@@ -36,7 +36,6 @@ edges
 | xss-through-filenames.js:31:25:31:28 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | provenance |  |
 | xss-through-filenames.js:31:25:31:28 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:33:19:33:24 | files2 | xss-through-filenames.js:35:29:35:34 | files2 | provenance |  |
-| xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] | xss-through-filenames.js:33:19:33:24 | files2 | provenance |  |
 | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:35:13:35:35 | files3 | xss-through-filenames.js:37:19:37:24 | files3 | provenance |  |
 | xss-through-filenames.js:35:22:35:35 | format(files2) | xss-through-filenames.js:35:13:35:35 | files3 | provenance |  |
@@ -97,6 +96,7 @@ subpaths
 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | xss-through-filenames.js:33:19:33:24 | files2 |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | xss-through-filenames.js:33:19:33:24 | files2 |
+| xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | xss-through-filenames.js:33:19:33:24 | files2 |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] |
 | xss-through-filenames.js:35:29:35:34 | files2 | xss-through-filenames.js:17:21:17:26 | files2 | xss-through-filenames.js:22:16:22:30 | files3.join('') | xss-through-filenames.js:35:22:35:35 | format(files2) |
 | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | xss-through-filenames.js:17:21:17:26 | files2 [ArrayElement] | xss-through-filenames.js:22:16:22:30 | files3.join('') | xss-through-filenames.js:35:22:35:35 | format(files2) |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -243,9 +243,6 @@ nodes
 | pg-promise.js:30:13:30:25 | req.params.id | semmle.label | req.params.id |
 | pg-promise.js:34:13:34:25 | req.params.id | semmle.label | req.params.id |
 | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | semmle.label | [\\n      ... n\\n    ] |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [0] | semmle.label | [\\n      ... n\\n    ] [0] |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [1] | semmle.label | [\\n      ... n\\n    ] [1] |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [2] | semmle.label | [\\n      ... n\\n    ] [2] |
 | pg-promise.js:39:7:39:19 | req.params.id | semmle.label | req.params.id |
 | pg-promise.js:40:7:40:21 | req.params.name | semmle.label | req.params.name |
 | pg-promise.js:41:7:41:20 | req.params.foo | semmle.label | req.params.foo |
@@ -612,12 +609,9 @@ edges
 | pg-promise.js:22:11:22:15 | query | pg-promise.js:60:20:60:24 | query | provenance |  |
 | pg-promise.js:22:11:22:15 | query | pg-promise.js:63:23:63:27 | query | provenance |  |
 | pg-promise.js:22:11:22:15 | query | pg-promise.js:64:16:64:20 | query | provenance |  |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [0] | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [1] | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
-| pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [2] | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
-| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [0] | provenance |  |
-| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [1] | provenance |  |
-| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] [2] | provenance |  |
+| pg-promise.js:39:7:39:19 | req.params.id | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
+| pg-promise.js:40:7:40:21 | req.params.name | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
+| pg-promise.js:41:7:41:20 | req.params.foo | pg-promise.js:38:13:42:5 | [\\n      ... n\\n    ] | provenance |  |
 | redis.js:10:16:10:23 | req.body | redis.js:10:16:10:27 | req.body.key | provenance | Config |
 | redis.js:12:9:12:26 | key | redis.js:13:16:13:18 | key | provenance |  |
 | redis.js:12:9:12:26 | key | redis.js:18:16:18:18 | key | provenance |  |

--- a/javascript/ql/test/query-tests/Security/CWE-201/PostMessageStar.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-201/PostMessageStar.expected
@@ -1,9 +1,8 @@
 edges
-| PostMessageStar2.js:4:7:4:15 | data [foo] | PostMessageStar2.js:8:29:8:32 | data [foo] | provenance |  |
+| PostMessageStar2.js:4:7:4:15 | data [foo] | PostMessageStar2.js:8:29:8:32 | data | provenance |  |
 | PostMessageStar2.js:4:7:4:15 | data [foo] | PostMessageStar2.js:9:29:9:32 | data [foo] | provenance |  |
 | PostMessageStar2.js:5:3:5:6 | [post update] data [foo] | PostMessageStar2.js:4:7:4:15 | data [foo] | provenance |  |
 | PostMessageStar2.js:5:14:5:21 | password | PostMessageStar2.js:5:3:5:6 | [post update] data [foo] | provenance |  |
-| PostMessageStar2.js:8:29:8:32 | data [foo] | PostMessageStar2.js:8:29:8:32 | data | provenance |  |
 | PostMessageStar2.js:9:29:9:32 | data [foo] | PostMessageStar2.js:9:29:9:36 | data.foo | provenance |  |
 nodes
 | PostMessageStar2.js:1:27:1:34 | password | semmle.label | password |
@@ -11,7 +10,6 @@ nodes
 | PostMessageStar2.js:5:3:5:6 | [post update] data [foo] | semmle.label | [post update] data [foo] |
 | PostMessageStar2.js:5:14:5:21 | password | semmle.label | password |
 | PostMessageStar2.js:8:29:8:32 | data | semmle.label | data |
-| PostMessageStar2.js:8:29:8:32 | data [foo] | semmle.label | data [foo] |
 | PostMessageStar2.js:9:29:9:32 | data [foo] | semmle.label | data [foo] |
 | PostMessageStar2.js:9:29:9:36 | data.foo | semmle.label | data.foo |
 | PostMessageStar2.js:13:27:13:33 | authKey | semmle.label | authKey |

--- a/javascript/ql/test/query-tests/Security/CWE-312/BuildArtifactLeak.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/BuildArtifactLeak.expected
@@ -33,8 +33,7 @@ edges
 | build-leaks.js:25:12:25:13 | {} | build-leaks.js:22:49:22:51 | env | provenance |  |
 | build-leaks.js:28:12:31:5 | {\\n      ... d\\n    } [stringified, process.env] | build-leaks.js:34:26:34:45 | getEnv('production') [stringified, process.env] | provenance |  |
 | build-leaks.js:30:22:30:31 | stringifed [process.env] | build-leaks.js:28:12:31:5 | {\\n      ... d\\n    } [stringified, process.env] | provenance |  |
-| build-leaks.js:34:26:34:45 | getEnv('production') [stringified, process.env] | build-leaks.js:34:26:34:57 | getEnv( ... ngified [process.env] | provenance |  |
-| build-leaks.js:34:26:34:57 | getEnv( ... ngified [process.env] | build-leaks.js:34:26:34:57 | getEnv( ... ngified | provenance |  |
+| build-leaks.js:34:26:34:45 | getEnv('production') [stringified, process.env] | build-leaks.js:34:26:34:57 | getEnv( ... ngified | provenance |  |
 | build-leaks.js:40:9:40:60 | pw | build-leaks.js:41:82:41:83 | pw | provenance |  |
 | build-leaks.js:40:14:40:60 | url.par ... assword | build-leaks.js:40:9:40:60 | pw | provenance |  |
 | build-leaks.js:41:43:41:86 | [post update] { "proc ... y(pw) } [process.env.secret] | build-leaks.js:41:43:41:86 | { "proc ... y(pw) } | provenance |  |
@@ -73,7 +72,6 @@ nodes
 | build-leaks.js:30:22:30:31 | stringifed [process.env] | semmle.label | stringifed [process.env] |
 | build-leaks.js:34:26:34:45 | getEnv('production') [stringified, process.env] | semmle.label | getEnv('production') [stringified, process.env] |
 | build-leaks.js:34:26:34:57 | getEnv( ... ngified | semmle.label | getEnv( ... ngified |
-| build-leaks.js:34:26:34:57 | getEnv( ... ngified [process.env] | semmle.label | getEnv( ... ngified [process.env] |
 | build-leaks.js:40:9:40:60 | pw | semmle.label | pw |
 | build-leaks.js:40:14:40:60 | url.par ... assword | semmle.label | url.par ... assword |
 | build-leaks.js:41:43:41:86 | [post update] { "proc ... y(pw) } [process.env.secret] | semmle.label | [post update] { "proc ... y(pw) } [process.env.secret] |

--- a/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-312/CleartextLogging.expected
@@ -3,16 +3,13 @@ edges
 | passwords.js:10:11:10:18 | password | passwords.js:7:20:7:20 | x | provenance |  |
 | passwords.js:14:31:14:38 | password | passwords.js:14:17:14:38 | name +  ... assword | provenance |  |
 | passwords.js:16:29:16:36 | password | passwords.js:16:17:16:38 | `${name ... sword}` | provenance |  |
-| passwords.js:18:9:20:5 | obj1 [password] | passwords.js:21:17:21:20 | obj1 [password] | provenance |  |
+| passwords.js:18:9:20:5 | obj1 [password] | passwords.js:21:17:21:20 | obj1 | provenance |  |
 | passwords.js:18:16:20:5 | {\\n      ... x\\n    } [password] | passwords.js:18:9:20:5 | obj1 [password] | provenance |  |
 | passwords.js:19:19:19:19 | x | passwords.js:18:16:20:5 | {\\n      ... x\\n    } [password] | provenance |  |
-| passwords.js:21:17:21:20 | obj1 [password] | passwords.js:21:17:21:20 | obj1 | provenance |  |
-| passwords.js:23:9:25:5 | obj2 [x] | passwords.js:26:17:26:20 | obj2 [x] | provenance |  |
+| passwords.js:23:9:25:5 | obj2 [x] | passwords.js:26:17:26:20 | obj2 | provenance |  |
 | passwords.js:23:16:25:5 | {\\n      ... d\\n    } [x] | passwords.js:23:9:25:5 | obj2 [x] | provenance |  |
 | passwords.js:24:12:24:19 | password | passwords.js:23:16:25:5 | {\\n      ... d\\n    } [x] | provenance |  |
-| passwords.js:26:17:26:20 | obj2 [x] | passwords.js:26:17:26:20 | obj2 | provenance |  |
-| passwords.js:28:9:28:17 | obj3 [x] | passwords.js:29:17:29:20 | obj3 [x] | provenance |  |
-| passwords.js:29:17:29:20 | obj3 [x] | passwords.js:29:17:29:20 | obj3 | provenance |  |
+| passwords.js:28:9:28:17 | obj3 [x] | passwords.js:29:17:29:20 | obj3 | provenance |  |
 | passwords.js:30:5:30:8 | [post update] obj3 [x] | passwords.js:28:9:28:17 | obj3 [x] | provenance |  |
 | passwords.js:30:14:30:21 | password | passwords.js:30:5:30:8 | [post update] obj3 [x] | provenance |  |
 | passwords.js:77:9:77:55 | temp [encryptedPassword] | passwords.js:78:17:78:20 | temp [encryptedPassword] | provenance |  |
@@ -32,10 +29,10 @@ edges
 | passwords.js:122:31:122:49 | password.toString() | passwords.js:122:17:122:49 | name +  ... tring() | provenance |  |
 | passwords.js:123:31:123:38 | password | passwords.js:123:31:123:48 | password.valueOf() | provenance |  |
 | passwords.js:123:31:123:48 | password.valueOf() | passwords.js:123:17:123:48 | name +  ... lueOf() | provenance |  |
-| passwords.js:127:9:132:5 | config [password] | passwords.js:135:17:135:22 | config [password] | provenance |  |
-| passwords.js:127:9:132:5 | config [x] | passwords.js:135:17:135:22 | config [x] | provenance |  |
+| passwords.js:127:9:132:5 | config [password] | passwords.js:135:17:135:22 | config | provenance |  |
+| passwords.js:127:9:132:5 | config [x] | passwords.js:135:17:135:22 | config | provenance |  |
 | passwords.js:127:9:132:5 | config [x] | passwords.js:136:17:136:22 | config [x] | provenance |  |
-| passwords.js:127:9:132:5 | config [y] | passwords.js:135:17:135:22 | config [y] | provenance |  |
+| passwords.js:127:9:132:5 | config [y] | passwords.js:135:17:135:22 | config | provenance |  |
 | passwords.js:127:9:132:5 | config [y] | passwords.js:137:17:137:22 | config [y] | provenance |  |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } [password] | passwords.js:127:9:132:5 | config [password] | provenance |  |
 | passwords.js:127:18:132:5 | {\\n      ... )\\n    } [x] | passwords.js:127:9:132:5 | config [x] | provenance |  |
@@ -43,27 +40,25 @@ edges
 | passwords.js:128:19:128:19 | x | passwords.js:127:18:132:5 | {\\n      ... )\\n    } [password] | provenance |  |
 | passwords.js:130:12:130:19 | password | passwords.js:127:18:132:5 | {\\n      ... )\\n    } [x] | provenance |  |
 | passwords.js:131:12:131:24 | getPassword() | passwords.js:127:18:132:5 | {\\n      ... )\\n    } [y] | provenance |  |
-| passwords.js:135:17:135:22 | config [password] | passwords.js:135:17:135:22 | config | provenance |  |
-| passwords.js:135:17:135:22 | config [x] | passwords.js:135:17:135:22 | config | provenance |  |
-| passwords.js:135:17:135:22 | config [y] | passwords.js:135:17:135:22 | config | provenance |  |
 | passwords.js:136:17:136:22 | config [x] | passwords.js:136:17:136:24 | config.x | provenance |  |
 | passwords.js:137:17:137:22 | config [y] | passwords.js:137:17:137:24 | config.y | provenance |  |
+| passwords.js:142:26:142:34 | [apply call taint node] | passwords.js:142:26:142:34 | arguments | provenance |  |
+| passwords.js:142:26:142:34 | [apply call taint node] | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:142:26:142:34 | [apply call taint node] | passwords.js:142:26:142:34 | arguments [ArrayElement] | provenance |  |
 | passwords.js:142:26:142:34 | [apply call taint node] | passwords.js:142:26:142:34 | arguments [ArrayElement] | provenance |  |
 | passwords.js:142:26:142:34 | arguments | passwords.js:142:26:142:34 | [apply call taint node] | provenance |  |
 | passwords.js:142:26:142:34 | arguments [0] | passwords.js:142:26:142:34 | [apply call taint node] | provenance |  |
-| passwords.js:142:26:142:34 | arguments [0] | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:142:26:142:34 | arguments [ArrayElement] | passwords.js:142:26:142:34 | [apply call taint node] | provenance |  |
 | passwords.js:142:26:142:34 | arguments [ArrayElement] | passwords.js:142:26:142:34 | [apply call taint node] | provenance |  |
-| passwords.js:142:26:142:34 | arguments [ArrayElement] | passwords.js:142:26:142:34 | arguments | provenance |  |
-| passwords.js:142:26:142:34 | arguments [ArrayElement] | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:146:9:148:5 | config [x] | passwords.js:149:21:149:26 | config [x] | provenance |  |
 | passwords.js:146:18:148:5 | {\\n      ... d\\n    } [x] | passwords.js:146:9:148:5 | config [x] | provenance |  |
 | passwords.js:147:12:147:19 | password | passwords.js:146:18:148:5 | {\\n      ... d\\n    } [x] | provenance |  |
 | passwords.js:149:21:149:26 | config [x] | passwords.js:149:21:149:28 | config.x | provenance |  |
+| passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:149:21:149:28 | config.x | passwords.js:142:26:142:34 | arguments [0] | provenance |  |
+| passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:150:21:150:31 | process.env | passwords.js:142:26:142:34 | arguments [0] | provenance |  |
@@ -71,6 +66,7 @@ edges
 | passwords.js:152:20:152:44 | Util.in ... ss.env) | passwords.js:152:20:152:63 | Util.in ... /g, '') | provenance |  |
 | passwords.js:152:20:152:63 | Util.in ... /g, '') | passwords.js:152:9:152:63 | procdesc | provenance |  |
 | passwords.js:152:33:152:43 | process.env | passwords.js:152:20:152:44 | Util.in ... ss.env) | provenance |  |
+| passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments | provenance |  |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments | provenance | Config |
 | passwords.js:154:21:154:28 | procdesc | passwords.js:142:26:142:34 | arguments [0] | provenance |  |
@@ -97,15 +93,12 @@ nodes
 | passwords.js:18:16:20:5 | {\\n      ... x\\n    } [password] | semmle.label | {\\n      ... x\\n    } [password] |
 | passwords.js:19:19:19:19 | x | semmle.label | x |
 | passwords.js:21:17:21:20 | obj1 | semmle.label | obj1 |
-| passwords.js:21:17:21:20 | obj1 [password] | semmle.label | obj1 [password] |
 | passwords.js:23:9:25:5 | obj2 [x] | semmle.label | obj2 [x] |
 | passwords.js:23:16:25:5 | {\\n      ... d\\n    } [x] | semmle.label | {\\n      ... d\\n    } [x] |
 | passwords.js:24:12:24:19 | password | semmle.label | password |
 | passwords.js:26:17:26:20 | obj2 | semmle.label | obj2 |
-| passwords.js:26:17:26:20 | obj2 [x] | semmle.label | obj2 [x] |
 | passwords.js:28:9:28:17 | obj3 [x] | semmle.label | obj3 [x] |
 | passwords.js:29:17:29:20 | obj3 | semmle.label | obj3 |
-| passwords.js:29:17:29:20 | obj3 [x] | semmle.label | obj3 [x] |
 | passwords.js:30:5:30:8 | [post update] obj3 [x] | semmle.label | [post update] obj3 [x] |
 | passwords.js:30:14:30:21 | password | semmle.label | password |
 | passwords.js:77:9:77:55 | temp [encryptedPassword] | semmle.label | temp [encryptedPassword] |
@@ -145,9 +138,6 @@ nodes
 | passwords.js:130:12:130:19 | password | semmle.label | password |
 | passwords.js:131:12:131:24 | getPassword() | semmle.label | getPassword() |
 | passwords.js:135:17:135:22 | config | semmle.label | config |
-| passwords.js:135:17:135:22 | config [password] | semmle.label | config [password] |
-| passwords.js:135:17:135:22 | config [x] | semmle.label | config [x] |
-| passwords.js:135:17:135:22 | config [y] | semmle.label | config [y] |
 | passwords.js:136:17:136:22 | config [x] | semmle.label | config [x] |
 | passwords.js:136:17:136:24 | config.x | semmle.label | config.x |
 | passwords.js:137:17:137:22 | config [y] | semmle.label | config [y] |

--- a/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-601/ServerSideUrlRedirect/ServerSideUrlRedirect.expected
@@ -22,13 +22,12 @@ edges
 | express.js:150:7:150:34 | target | express.js:160:18:160:23 | target | provenance |  |
 | express.js:150:16:150:34 | req.param("target") | express.js:150:7:150:34 | target | provenance |  |
 | express.js:164:7:164:54 | myThing | express.js:165:16:165:22 | myThing | provenance |  |
-| express.js:164:7:164:54 | myThing [ArrayElement] | express.js:165:16:165:22 | myThing [ArrayElement] | provenance |  |
+| express.js:164:7:164:54 | myThing [ArrayElement] | express.js:165:16:165:22 | myThing | provenance |  |
 | express.js:164:17:164:41 | JSON.st ... .query) | express.js:164:17:164:54 | JSON.st ... (1, -1) | provenance |  |
 | express.js:164:17:164:41 | JSON.st ... .query) | express.js:164:17:164:54 | JSON.st ... (1, -1) [ArrayElement] | provenance |  |
 | express.js:164:17:164:54 | JSON.st ... (1, -1) | express.js:164:7:164:54 | myThing | provenance |  |
 | express.js:164:17:164:54 | JSON.st ... (1, -1) [ArrayElement] | express.js:164:7:164:54 | myThing [ArrayElement] | provenance |  |
 | express.js:164:32:164:40 | req.query | express.js:164:17:164:41 | JSON.st ... .query) | provenance |  |
-| express.js:165:16:165:22 | myThing [ArrayElement] | express.js:165:16:165:22 | myThing | provenance |  |
 | koa.js:6:6:6:27 | url | koa.js:7:15:7:17 | url | provenance |  |
 | koa.js:6:6:6:27 | url | koa.js:8:18:8:20 | url | provenance |  |
 | koa.js:6:6:6:27 | url | koa.js:14:16:14:18 | url | provenance |  |
@@ -93,7 +92,6 @@ nodes
 | express.js:164:17:164:54 | JSON.st ... (1, -1) [ArrayElement] | semmle.label | JSON.st ... (1, -1) [ArrayElement] |
 | express.js:164:32:164:40 | req.query | semmle.label | req.query |
 | express.js:165:16:165:22 | myThing | semmle.label | myThing |
-| express.js:165:16:165:22 | myThing [ArrayElement] | semmle.label | myThing [ArrayElement] |
 | koa.js:6:6:6:27 | url | semmle.label | url |
 | koa.js:6:12:6:27 | ctx.query.target | semmle.label | ctx.query.target |
 | koa.js:7:15:7:17 | url | semmle.label | url |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingAssignment/Consistency.expected
@@ -1,1 +1,1 @@
-| query-tests/Security/CWE-915/PrototypePollutingAssignment/lib.js:70 | expected an alert, but found none | NOT OK | Config |
+| lib.js:70 | expected an alert, but found none | NOT OK | Config |

--- a/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingMergeCall/PrototypePollutingMergeCall.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-915/PrototypePollutingMergeCall/PrototypePollutingMergeCall.expected
@@ -6,14 +6,12 @@ nodes
 | src-vulnerable-lodash/tst.js:7:17:7:29 | req.query.foo | semmle.label | req.query.foo |
 | src-vulnerable-lodash/tst.js:10:17:12:5 | [post update] {\\n      ... K\\n    } [value] | semmle.label | [post update] {\\n      ... K\\n    } [value] |
 | src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } | semmle.label | {\\n      ... K\\n    } |
-| src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } [value] | semmle.label | {\\n      ... K\\n    } [value] |
 | src-vulnerable-lodash/tst.js:11:16:11:30 | req.query.value | semmle.label | req.query.value |
 | src-vulnerable-lodash/tst.js:14:9:16:5 | opts [thing] | semmle.label | opts [thing] |
 | src-vulnerable-lodash/tst.js:14:16:16:5 | {\\n      ... e\\n    } [thing] | semmle.label | {\\n      ... e\\n    } [thing] |
 | src-vulnerable-lodash/tst.js:15:14:15:28 | req.query.value | semmle.label | req.query.value |
 | src-vulnerable-lodash/tst.js:17:17:19:5 | [post update] {\\n      ... K\\n    } [value] | semmle.label | [post update] {\\n      ... K\\n    } [value] |
 | src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } | semmle.label | {\\n      ... K\\n    } |
-| src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } [value] | semmle.label | {\\n      ... K\\n    } [value] |
 | src-vulnerable-lodash/tst.js:18:16:18:19 | opts [thing] | semmle.label | opts [thing] |
 | src-vulnerable-lodash/tst.js:18:16:18:25 | opts.thing | semmle.label | opts.thing |
 | webix/webix.html:3:34:3:38 | event | semmle.label | event |
@@ -34,14 +32,12 @@ edges
 | angularmerge.js:1:30:1:34 | event | angularmerge.js:2:32:2:36 | event | provenance |  |
 | angularmerge.js:2:32:2:36 | event | angularmerge.js:2:32:2:41 | event.data | provenance |  |
 | angularmerge.js:2:32:2:41 | event.data | angularmerge.js:2:21:2:42 | JSON.pa ... t.data) | provenance | Config |
-| src-vulnerable-lodash/tst.js:10:17:12:5 | [post update] {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } [value] | provenance |  |
-| src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } | provenance |  |
+| src-vulnerable-lodash/tst.js:10:17:12:5 | [post update] {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:10:17:12:5 | {\\n      ... K\\n    } | provenance |  |
 | src-vulnerable-lodash/tst.js:11:16:11:30 | req.query.value | src-vulnerable-lodash/tst.js:10:17:12:5 | [post update] {\\n      ... K\\n    } [value] | provenance |  |
 | src-vulnerable-lodash/tst.js:14:9:16:5 | opts [thing] | src-vulnerable-lodash/tst.js:18:16:18:19 | opts [thing] | provenance |  |
 | src-vulnerable-lodash/tst.js:14:16:16:5 | {\\n      ... e\\n    } [thing] | src-vulnerable-lodash/tst.js:14:9:16:5 | opts [thing] | provenance |  |
 | src-vulnerable-lodash/tst.js:15:14:15:28 | req.query.value | src-vulnerable-lodash/tst.js:14:16:16:5 | {\\n      ... e\\n    } [thing] | provenance |  |
-| src-vulnerable-lodash/tst.js:17:17:19:5 | [post update] {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } [value] | provenance |  |
-| src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } | provenance |  |
+| src-vulnerable-lodash/tst.js:17:17:19:5 | [post update] {\\n      ... K\\n    } [value] | src-vulnerable-lodash/tst.js:17:17:19:5 | {\\n      ... K\\n    } | provenance |  |
 | src-vulnerable-lodash/tst.js:18:16:18:19 | opts [thing] | src-vulnerable-lodash/tst.js:18:16:18:25 | opts.thing | provenance |  |
 | src-vulnerable-lodash/tst.js:18:16:18:25 | opts.thing | src-vulnerable-lodash/tst.js:17:17:19:5 | [post update] {\\n      ... K\\n    } [value] | provenance |  |
 | webix/webix.html:3:34:3:38 | event | webix/webix.html:4:37:4:41 | event | provenance |  |


### PR DESCRIPTION
- Filenames are now relative to the test case, not the qlpack
- Data flow paths going through an implicit read have changed slightly