### PR TITLE
C#/Java: Avoid `df` and `dfc` overlap in model generation.

### DIFF
--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -639,7 +639,7 @@ public class Inheritance
         public override string Prop { get { return tainted; } }
     }
 
-    public abstract class BaseContent 
+    public abstract class BaseContent
     {
         public abstract object GetValue();
 
@@ -959,5 +959,32 @@ public class Fanout
     public string ConcatValueOnBase2(string other, Base2 b2)
     {
         return other + b2.GetValue();
+    }
+}
+
+public class AvoidDuplicateLifted
+{
+    public class A
+    {
+        public object Prop { get; set; }
+
+        // contentbased-summary=Models;AvoidDuplicateLifted+A;true;GetValue;();;Argument[this].Property[Models.AvoidDuplicateLifted+A.Prop];ReturnValue;value;dfc-generated
+        // summary=Models;AvoidDuplicateLifted+A;true;GetValue;();;Argument[this];ReturnValue;taint;df-generated
+        public virtual object GetValue()
+        {
+            return Prop;
+        }
+    }
+
+    public class B : A
+    {
+        private object field;
+
+        // No content based summary as field is a dead synthetic field.
+        // summary=Models;AvoidDuplicateLifted+A;true;GetValue;();;Argument[this];ReturnValue;taint;df-generated
+        public override object GetValue()
+        {
+            return field;
+        }
     }
 }

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -881,7 +881,13 @@ module MakeModelGenerator<
   string captureMixedFlow(DataFlowSummaryTargetApi api, boolean lift) {
     result = ContentSensitive::captureFlow(api, lift)
     or
-    not exists(ContentSensitive::captureFlow(api, _)) and
+    not exists(DataFlowSummaryTargetApi api0 |
+      (api0 = api or api.lift() = api0) and
+      exists(ContentSensitive::captureFlow(api0, false))
+      or
+      api0.lift() = api.lift() and
+      exists(ContentSensitive::captureFlow(api0, true))
+    ) and
     result = captureFlow(api) and
     lift = true
   }
@@ -895,7 +901,8 @@ module MakeModelGenerator<
     not exists(DataFlowSummaryTargetApi api0, boolean lift |
       exists(captureMixedFlow(api0, lift)) and
       (
-        lift = false and api0 = api
+        lift = false and
+        (api0 = api or api0 = api.lift())
         or
         lift = true and api0.lift() = api.lift()
       )


### PR DESCRIPTION
It turns out that we in some cases still produce *mixed* models that both have `df` and `dfc` provenance. In this PR we further reduce this overlap. 