### PR TITLE
Rust: More test cases for unused variables

### DIFF
--- a/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
+++ b/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
@@ -16,8 +16,9 @@
 | main.rs:268:9:268:11 | Yes | Variable is not used. |
 | main.rs:269:9:269:10 | No | Variable is not used. |
 | main.rs:272:12:272:12 | j | Variable is not used. |
-| main.rs:290:25:290:25 | y | Variable is not used. |
-| main.rs:294:28:294:28 | a | Variable is not used. |
-| main.rs:298:9:298:9 | p | Variable is not used. |
-| main.rs:305:13:305:13 | y | Variable is not used. |
-| main.rs:313:21:313:21 | y | Variable is not used. |
+| main.rs:282:12:282:14 | Yes | Variable is not used. |
+| main.rs:294:25:294:25 | y | Variable is not used. |
+| main.rs:298:28:298:28 | a | Variable is not used. |
+| main.rs:302:9:302:9 | p | Variable is not used. |
+| main.rs:309:13:309:13 | y | Variable is not used. |
+| main.rs:317:21:317:21 | y | Variable is not used. |

--- a/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
+++ b/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
@@ -5,9 +5,9 @@
 | main.rs:164:9:164:9 | x | Variable is not used. |
 | main.rs:169:9:169:9 | x | Variable is not used. |
 | main.rs:174:9:174:9 | x | Variable is not used. |
-| main.rs:195:17:195:17 | a | Variable is not used. |
-| main.rs:203:20:203:22 | val | Variable is not used. |
-| main.rs:216:14:216:16 | val | Variable is not used. |
-| main.rs:218:9:218:12 | None | Variable is not used. |
-| main.rs:227:9:227:12 | None | Variable is not used. |
-| main.rs:233:24:233:26 | val | Variable is not used. |
+| main.rs:202:17:202:17 | a | Variable is not used. |
+| main.rs:210:20:210:22 | val | Variable is not used. |
+| main.rs:223:14:223:16 | val | Variable is not used. |
+| main.rs:225:9:225:12 | None | Variable is not used. |
+| main.rs:234:9:234:12 | None | Variable is not used. |
+| main.rs:248:24:248:26 | val | Variable is not used. |

--- a/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
+++ b/rust/ql/test/query-tests/unusedentities/UnusedVariable.expected
@@ -10,4 +10,14 @@
 | main.rs:223:14:223:16 | val | Variable is not used. |
 | main.rs:225:9:225:12 | None | Variable is not used. |
 | main.rs:234:9:234:12 | None | Variable is not used. |
+| main.rs:240:22:240:24 | val | Variable is not used. |
 | main.rs:248:24:248:26 | val | Variable is not used. |
+| main.rs:257:13:257:15 | num | Variable is not used. |
+| main.rs:268:9:268:11 | Yes | Variable is not used. |
+| main.rs:269:9:269:10 | No | Variable is not used. |
+| main.rs:272:12:272:12 | j | Variable is not used. |
+| main.rs:290:25:290:25 | y | Variable is not used. |
+| main.rs:294:28:294:28 | a | Variable is not used. |
+| main.rs:298:9:298:9 | p | Variable is not used. |
+| main.rs:305:13:305:13 | y | Variable is not used. |
+| main.rs:313:21:313:21 | y | Variable is not used. |

--- a/rust/ql/test/query-tests/unusedentities/main.rs
+++ b/rust/ql/test/query-tests/unusedentities/main.rs
@@ -189,12 +189,12 @@ enum YesOrNo {
     No,
 }
 
+use YesOrNo::{Yes, No}; // allows `Yes`, `No` to be accessed without qualifiers.
 
-
-
-
-
-
+struct MyPoint {
+    x: i64,
+    y: i64,
+}
 
 fn if_lets_matches() {
     let mut total: i64 = 0;
@@ -235,13 +235,13 @@ fn if_lets_matches() {
         }
     }
 
-
-
-
-
-
-
-
+    let e = Option::Some(80);
+    match e {
+        Option::Some(val) => { // BAD: unused variable
+        }
+        Option::None => {
+        }
+    }
 
     let f = MyOption::Some(90);
     match f {
@@ -250,12 +250,12 @@ fn if_lets_matches() {
         MyOption::None => {}
     }
 
-
-
-
-
-
-
+    let g : Result<i64, i64> = Ok(100);
+    match g {
+        Ok(_) => {
+        }
+        Err(num) => {} // BAD: unused variable
+    }
 
     let h = YesOrNo::Yes;
     match h {
@@ -263,11 +263,59 @@ fn if_lets_matches() {
         YesOrNo::No => {}
     }
 
+    let i = Yes;
+    match i {
+        Yes => {} // SPURIOUS: unused variable 'None'
+        No => {} // SPURIOUS: unused variable 'None'
+    }
 
+    if let j = Yes { // BAD: unused variable
+    }
 
+    if let k = Yes {
+        match k {
+            _ => {}
+        }
+    }
 
+    match 1 {
+        1 => {}
+        _ => {}
+    }
 
+    let p1 = MyPoint { x: 1, y: 2 };
+    match p1 {
+        MyPoint { x: 0, y: 0 } => {
+        }
+        MyPoint { x: 1, y } => { // BAD: unused variable
+        }
+        MyPoint { x: 2, y: _ } => {
+        }
+        MyPoint { x: 3, y: a } => { // BAD: unused variable
+        }
+        MyPoint { x: 4, .. } => {
+        }
+        p => { // BAD: unused variable
+        }
+    }
+}
 
+fn shadowing() -> i32 {
+    let x = 1; // BAD: unused value [NOT DETECTED]
+    let mut y: i32; // BAD: unused variable
+
+    {
+        let x = 2;
+        let mut y: i32;
+
+        {
+            let x = 3; // BAD: unused value [NOT DETECTED]
+            let mut y: i32; // BAD: unused variable
+        }
+
+        y = x;
+        return y;
+    }
 }
 
 fn main() {
@@ -278,6 +326,7 @@ fn main() {
     statics();
     loops();
     if_lets_matches();
+    shadowing();
 
     println!("lets use result {}", parameters(1, 2, 3));
 }

--- a/rust/ql/test/query-tests/unusedentities/main.rs
+++ b/rust/ql/test/query-tests/unusedentities/main.rs
@@ -167,12 +167,12 @@ fn loops() {
     for _ in 1..10 {}
 
     for x // SPURIOUS: unused variable [macros not yet supported]
-    in 1..10 {    
+    in 1..10 {
         println!("x is {}", x);
     }
 
     for x // SPURIOUS: unused variable [macros not yet supported]
-    in 1..10 {   
+    in 1..10 {
         assert!(x != 11);
     }
 }
@@ -189,7 +189,14 @@ enum YesOrNo {
     No,
 }
 
-fn if_lets() {
+
+
+
+
+
+
+
+fn if_lets_matches() {
     let mut total: i64 = 0;
 
     if let Some(a) = Some(10) { // BAD: unused variable
@@ -228,18 +235,39 @@ fn if_lets() {
         }
     }
 
-    let e = MyOption::Some(80);
-    match e {
+
+
+
+
+
+
+
+
+    let f = MyOption::Some(90);
+    match f {
         MyOption::Some(val) => { // BAD: unused variable
         }
         MyOption::None => {}
     }
 
-    let f = YesOrNo::Yes;
-    match f {
+
+
+
+
+
+
+
+    let h = YesOrNo::Yes;
+    match h {
         YesOrNo::Yes => {}
         YesOrNo::No => {}
     }
+
+
+
+
+
+
 }
 
 fn main() {
@@ -249,7 +277,7 @@ fn main() {
     arrays();
     statics();
     loops();
-    if_lets();
+    if_lets_matches();
 
     println!("lets use result {}", parameters(1, 2, 3));
 }

--- a/rust/ql/test/query-tests/unusedentities/main.rs
+++ b/rust/ql/test/query-tests/unusedentities/main.rs
@@ -265,8 +265,8 @@ fn if_lets_matches() {
 
     let i = Yes;
     match i {
-        Yes => {} // SPURIOUS: unused variable 'None'
-        No => {} // SPURIOUS: unused variable 'None'
+        Yes => {} // SPURIOUS: unused variable 'Yes'
+        No => {} // SPURIOUS: unused variable 'No'
     }
 
     if let j = Yes { // BAD: unused variable

--- a/rust/ql/test/query-tests/unusedentities/main.rs
+++ b/rust/ql/test/query-tests/unusedentities/main.rs
@@ -278,6 +278,10 @@ fn if_lets_matches() {
         }
     }
 
+    let l = Yes;
+    if let Yes = l { // SPURIOUS: unused variable 'Yes'
+    }
+
     match 1 {
         1 => {}
         _ => {}


### PR DESCRIPTION
More test cases for unused variables.  Confirms that the issue producing spurious results for `None` matches is due to use of unqualified enum values that are being misrecognized as variables.