### PR TITLE
Python: model that `re.finditer` returns an iterable of `re.Match` objects

### DIFF
--- a/python/ql/lib/change-notes/2024-10-09-finditer-match.md
+++ b/python/ql/lib/change-notes/2024-10-09-finditer-match.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Modelled that `re.finditer` returns an iterable of `re.Match` objects. This is now understood by the API graph in many cases.

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -3285,6 +3285,18 @@ module StdlibPrivate {
   }
 
   /**
+   * A base API node for regular expression functions.
+   * Either the `re` module or a compiled regular expression.
+   */
+  private API::Node re(boolean compiled) {
+    result = API::moduleImport("re") and
+    compiled = false
+    or
+    result = any(RePatternSummary c).getACall().(API::CallNode).getReturn() and
+    compiled = true
+  }
+
+  /**
    * A flow summary for methods returning a `re.Match` object
    *
    * See https://docs.python.org/3/library/re.html#re.Match
@@ -3293,17 +3305,18 @@ module StdlibPrivate {
     ReMatchSummary() { this = ["re.Match", "compiled re.Match"] }
 
     override DataFlow::CallCfgNode getACall() {
-      this = "re.Match" and
-      result = API::moduleImport("re").getMember(["match", "search", "fullmatch"]).getACall()
-      or
-      this = "compiled re.Match" and
-      result =
-        any(RePatternSummary c)
-            .getACall()
-            .(API::CallNode)
-            .getReturn()
-            .getMember(["match", "search", "fullmatch"])
-            .getACall()
+      exists(API::Node re, boolean compiled |
+        re = re(compiled) and
+        (
+          compiled = false and
+          this = "re.Match"
+          or
+          compiled = true and
+          this = "compiled re.Match"
+        )
+      |
+        result = re.getMember(["match", "search", "fullmatch"]).getACall()
+      )
     }
 
     override DataFlow::ArgumentNode getACallback() { none() }
@@ -3340,6 +3353,13 @@ module StdlibPrivate {
     }
   }
 
+  /** An API node for a `re.Match` object */
+  private API::Node match() {
+    result = any(ReMatchSummary c).getACall().(API::CallNode).getReturn()
+    or
+    result = re(_).getMember("finditer").getReturn().getASubscript()
+  }
+
   /**
    * A flow summary for methods on a `re.Match` object
    *
@@ -3353,15 +3373,7 @@ module StdlibPrivate {
       methodName in ["expand", "group", "groups", "groupdict"]
     }
 
-    override DataFlow::CallCfgNode getACall() {
-      result =
-        any(ReMatchSummary c)
-            .getACall()
-            .(API::CallNode)
-            .getReturn()
-            .getMember(methodName)
-            .getACall()
-    }
+    override DataFlow::CallCfgNode getACall() { result = match().getMember(methodName).getACall() }
 
     override DataFlow::ArgumentNode getACallback() { none() }
 

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -3463,6 +3463,14 @@ module StdlibPrivate {
           ) and
           preservesValue = false
         )
+        or
+        // flow from input string to attribute on match object
+        exists(int arg | arg = methodName.(RegexExecutionMethod).getStringArgIndex() - offset |
+          input in ["Argument[" + arg + "]", "Argument[string:]"] and
+          methodName = "finditer" and
+          output = "ReturnValue.ListElement.Attribute[string]" and
+          preservesValue = true
+        )
       )
     }
   }

--- a/python/ql/test/library-tests/frameworks/stdlib/test_re.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/test_re.py
@@ -38,6 +38,12 @@ ensure_tainted(
 
     compiled_pat.match(ts).string, # $ tainted
     re.compile(ts).match("safe").re.pattern, # $ tainted
+
+    list(re.finditer(pat, ts))[0].string, # $ MISSING: tainted
+    [m.string for m in re.finditer(pat, ts)], # $ MISSING: tainted
+
+    list(re.finditer(pat, ts))[0].groups()[0], # $ MISSING: tainted
+    [m.groups()[0] for m in re.finditer(pat, ts)], # $ MISSING: tainted
 )
 ensure_not_tainted(
     safe_match.expand("Hello \1"),

--- a/python/ql/test/library-tests/frameworks/stdlib/test_re.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/test_re.py
@@ -39,8 +39,8 @@ ensure_tainted(
     compiled_pat.match(ts).string, # $ tainted
     re.compile(ts).match("safe").re.pattern, # $ tainted
 
-    list(re.finditer(pat, ts))[0].string, # $ MISSING: tainted
-    [m.string for m in re.finditer(pat, ts)], # $ MISSING: tainted
+    list(re.finditer(pat, ts))[0].string, # $ tainted
+    [m.string for m in re.finditer(pat, ts)], # $ tainted
 
     list(re.finditer(pat, ts))[0].groups()[0], # $ MISSING: tainted
     [m.groups()[0] for m in re.finditer(pat, ts)], # $ MISSING: tainted

--- a/python/ql/test/library-tests/frameworks/stdlib/test_re.py
+++ b/python/ql/test/library-tests/frameworks/stdlib/test_re.py
@@ -42,8 +42,8 @@ ensure_tainted(
     list(re.finditer(pat, ts))[0].string, # $ tainted
     [m.string for m in re.finditer(pat, ts)], # $ tainted
 
-    list(re.finditer(pat, ts))[0].groups()[0], # $ MISSING: tainted
-    [m.groups()[0] for m in re.finditer(pat, ts)], # $ MISSING: tainted
+    list(re.finditer(pat, ts))[0].groups()[0], # $ MISSING: tainted  // this requires list content in type tracking
+    [m.groups()[0] for m in re.finditer(pat, ts)], # $ tainted
 )
 ensure_not_tainted(
     safe_match.expand("Hello \1"),


### PR DESCRIPTION
Do we want a change note for this?

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [x] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [x] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
