### PR TITLE
Rust: Initial SSA implementation

### DIFF
--- a/rust/ql/consistency-queries/SsaConsistency.ql
+++ b/rust/ql/consistency-queries/SsaConsistency.ql
@@ -1,0 +1,19 @@
+import codeql.rust.dataflow.Ssa
+import codeql.rust.dataflow.internal.SsaImpl
+import Consistency
+
+class MyRelevantDefinition extends RelevantDefinition, Ssa::Definition {
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+class MyRelevantDefinitionExt extends RelevantDefinitionExt, DefinitionExt {
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}

--- a/rust/ql/lib/codeql/rust/dataflow/Ssa.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/Ssa.qll
@@ -1,0 +1,340 @@
+/**
+ * Provides the module `Ssa` for working with static single assignment (SSA) form.
+ */
+
+/**
+ * Provides classes for working with static single assignment (SSA) form.
+ */
+module Ssa {
+  private import rust
+  private import codeql.rust.controlflow.BasicBlocks
+  private import codeql.rust.controlflow.ControlFlowGraph
+  private import codeql.rust.controlflow.internal.ControlFlowGraphImpl as CfgImpl
+  private import internal.SsaImpl as SsaImpl
+
+  class Variable = SsaImpl::SsaInput::SourceVariable;
+
+  /** A static single assignment (SSA) definition. */
+  class Definition extends SsaImpl::Definition {
+    /**
+     * Gets the control flow node of this SSA definition, if any. Phi nodes are
+     * examples of SSA definitions without a control flow node, as they are
+     * modeled at index `-1` in the relevant basic block.
+     */
+    final CfgNode getControlFlowNode() {
+      exists(BasicBlock bb, int i | this.definesAt(_, bb, i) | result = bb.getNode(i))
+    }
+
+    /**
+     * Gets a control-flow node that reads the value of this SSA definition.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {              // defines b_0
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);         // reads x_0
+     *      println!("{}", x + 1);     // reads x_0
+     *
+     *      if b {                     // reads b_0
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);     // reads x_1
+     *          println!("{}", x + 1); // reads x_1
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);     // reads x_2
+     *          println!("{}", x + 1); // reads x_2
+     *      }
+     *                                 // defines x_3 = phi(x_1, x_2)
+     *      println!("{}", x);         // reads x_3
+     * }
+     * ```
+     */
+    final CfgNode getARead() { result = SsaImpl::getARead(this) }
+
+    /**
+     * Gets a first control-flow node that reads the value of this SSA definition.
+     * That is, a read that can be reached from this definition without passing
+     * through other reads.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {              // defines b_0
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);         // first read of x_0
+     *      println!("{}", x + 1);
+     *
+     *      if b {                     // first read of b_0
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);     // first read of x_1
+     *          println!("{}", x + 1);
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);     // first read of x_2
+     *          println!("{}", x + 1);
+     *      }
+     *                                 // defines x_3 = phi(x_1, x_2)
+     *      println!("{}", x);         // first read of x_3
+     * }
+     * ```
+     */
+    final CfgNode getAFirstRead() { SsaImpl::firstRead(this, result) }
+
+    /**
+     * Gets a last control-flow node that reads the value of this SSA definition.
+     * That is, a read that can reach the end of the enclosing CFG scope, or another
+     * SSA definition for the source variable, without passing through any other read.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {              // defines b_0
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);
+     *      println!("{}", x + 1);     // last read of x_0
+     *
+     *      if b {                     // last read of b_0
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);
+     *          println!("{}", x + 1); // last read of x_1
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);
+     *          println!("{}", x + 1); // last read of x_2
+     *      }
+     *                                 // defines x_3 = phi(x_1, x_2)
+     *      println!("{}", x);         // last read of x_3
+     * }
+     * ```
+     */
+    final CfgNode getALastRead() { SsaImpl::lastRead(this, result) }
+
+    /**
+     * Holds if `read1` and `read2` are adjacent reads of this SSA definition.
+     * That is, `read2` can be reached from `read1` without passing through
+     * another read.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);         // reads x_0 (read1)
+     *      println!("{}", x + 1);     // reads x_0 (read2)
+     *
+     *      if b {
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);     // reads x_1 (read1)
+     *          println!("{}", x + 1); // reads x_1 (read2)
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);     // reads x_2 (read1)
+     *          println!("{}", x + 1); // reads x_2 (read2)
+     *      }
+     *      println!("{}", x);
+     * }
+     * ```
+     */
+    final predicate hasAdjacentReads(CfgNode read1, CfgNode read2) {
+      SsaImpl::adjacentReadPair(this, read1, read2)
+    }
+
+    /**
+     * Gets an SSA definition whose value can flow to this one in one step. This
+     * includes inputs to phi nodes and the prior definitions of uncertain writes.
+     */
+    private Definition getAPhiInputOrPriorDefinition() {
+      result = this.(PhiDefinition).getAnInput()
+    }
+
+    /**
+     * Gets a definition that ultimately defines this SSA definition and is
+     * not itself a phi node.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);
+     *      println!("{}", x + 1);
+     *
+     *      if b {
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);
+     *          println!("{}", x + 1);
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);
+     *          println!("{}", x + 1);
+     *      }
+     *                                 // defines x_3 = phi(x_1, x_2); ultimate definitions are x_1 and x_2
+     *      println!("{}", x);
+     * }
+     * ```
+     */
+    final Definition getAnUltimateDefinition() {
+      result = this.getAPhiInputOrPriorDefinition*() and
+      not result instanceof PhiDefinition
+    }
+
+    override string toString() { result = this.getControlFlowNode().toString() }
+
+    /** Gets the scope of this SSA definition. */
+    CfgScope getScope() { result = this.getBasicBlock().getScope() }
+  }
+
+  /**
+   * An SSA definition that corresponds to a write. Example:
+   *
+   * ```rust
+   * fn m(i : i64) {     // writes `i`
+   *     let mut x = i;  // writes `x`
+   *     x = 11;         // writes `x`
+   * }
+   * ```
+   */
+  class WriteDefinition extends Definition, SsaImpl::WriteDefinition {
+    private CfgNode write;
+
+    WriteDefinition() {
+      exists(BasicBlock bb, int i, Variable v |
+        this.definesAt(v, bb, i) and
+        SsaImpl::variableWriteActual(bb, i, v, write)
+      )
+    }
+
+    /** Gets the underlying write access. */
+    final CfgNode getWriteAccess() { result = write }
+
+    /**
+     * Holds if this SSA definition assigns `value` to the underlying variable.
+     *
+     * This is either a direct assignment, `x = value`, or an assignment via
+     * simple pattern matching
+     *
+     * ```rb
+     * case value
+     *  in Foo => x then ...
+     *  in y => then ...
+     * end
+     * ```
+     */
+    predicate assigns(CfgNode value) {
+      exists(AssignmentExpr ae, BasicBlock bb, int i |
+        this.definesAt(_, bb, i) and
+        ae.getLhs() = bb.getNode(i).getAstNode() and
+        value.getAstNode() = ae.getRhs()
+      )
+    }
+
+    final override string toString() { result = write.toString() }
+
+    final override Location getLocation() { result = write.getLocation() }
+  }
+
+  /**
+   * A phi definition. For example, in
+   *
+   * ```rust
+   * if b {
+   *   x = 0
+   * } else {
+   *   x = 1
+   * }
+   * println!("{}", x);
+   * ```
+   *
+   * a phi definition for `x` is inserted just before the call to `println!`.
+   */
+  class PhiDefinition extends Definition, SsaImpl::PhiDefinition {
+    /**
+     * Gets an input of this phi definition.
+     *
+     * Example:
+     *
+     * ```rust
+     * fn phi(b : bool) {
+     *      let mut x = 1;             // defines x_0
+     *      println!("{}", x);
+     *      println!("{}", x + 1);
+     *
+     *      if b {
+     *          x = 2;                 // defines x_1
+     *          println!("{}", x);
+     *          println!("{}", x + 1);
+     *      } else {
+     *          x = 3;                 // defines x_2
+     *          println!("{}", x);
+     *          println!("{}", x + 1);
+     *      }
+     *                                 // defines x_3 = phi(x_1, x_2); inputs are x_1 and x_2
+     *      println!("{}", x);
+     * }
+     * ```
+     */
+    final Definition getAnInput() { this.hasInputFromBlock(result, _) }
+
+    /** Holds if `inp` is an input to this phi definition along the edge originating in `bb`. */
+    predicate hasInputFromBlock(Definition inp, BasicBlock bb) {
+      inp = SsaImpl::phiHasInputFromBlock(this, bb)
+    }
+
+    private string getSplitString() {
+      result = this.getBasicBlock().getFirstNode().(CfgImpl::AstCfgNode).getSplitsString()
+    }
+
+    override string toString() {
+      exists(string prefix |
+        prefix = "[" + this.getSplitString() + "] "
+        or
+        not exists(this.getSplitString()) and
+        prefix = ""
+      |
+        result = prefix + "phi"
+      )
+    }
+
+    /*
+     * The location of a phi definition is the same as the location of the first node
+     * in the basic block in which it is defined.
+     *
+     * Strictly speaking, the node is *before* the first node, but such a location
+     * does not exist in the source program.
+     */
+
+    final override Location getLocation() {
+      result = this.getBasicBlock().getFirstNode().getLocation()
+    }
+  }
+
+  /**
+   * An SSA definition inserted at the beginning of a scope to represent a
+   * captured local variable. For example, in
+   *
+   * ```rust
+   * fn capture_immut() {
+   *     let x = 100;
+   *     let mut cap = || {
+   *         println!("{}", x);
+   *     };
+   *     cap();
+   * }
+   * ```
+   *
+   * an entry definition for `x` is inserted at the start of the CFG for `cap`.
+   */
+  class CapturedEntryDefinition extends Definition, SsaImpl::WriteDefinition {
+    CapturedEntryDefinition() {
+      exists(BasicBlock bb, int i, Variable v |
+        this.definesAt(v, bb, i) and
+        SsaImpl::capturedEntryWrite(bb, i, v)
+      )
+    }
+
+    final override string toString() { result = "<captured entry> " + this.getSourceVariable() }
+
+    override Location getLocation() { result = this.getBasicBlock().getLocation() }
+  }
+}

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -1,0 +1,332 @@
+private import rust
+private import codeql.rust.controlflow.BasicBlocks as BasicBlocks
+private import BasicBlocks
+private import codeql.rust.controlflow.ControlFlowGraph as Cfg
+private import Cfg
+private import codeql.rust.controlflow.internal.ControlFlowGraphImpl as ControlFlowGraphImpl
+private import codeql.ssa.Ssa as SsaImplCommon
+
+/** Holds if `v` is introduced like `let v : i64;`. */
+private predicate isUnitializedLet(IdentPat pat, Variable v) {
+  pat = v.getPat() and
+  exists(LetStmt let |
+    let = v.getLetStmt() and
+    not let.hasInitializer()
+  )
+}
+
+/** Holds if `write` writes to variable `v`. */
+predicate variableWrite(AstNode write, Variable v) {
+  exists(IdentPat pat |
+    pat = write and
+    pat = v.getPat() and
+    not isUnitializedLet(pat, v)
+  )
+  or
+  exists(VariableAccess access |
+    access = write and
+    access.getVariable() = v
+  |
+    access instanceof VariableWriteAccess
+    or
+    // Although compound assignments, like `x += y`, may in fact not update `x`,
+    // it makes sense to treat them as such
+    access = any(CompoundAssignmentExpr cae).getLhs()
+  )
+}
+
+module SsaInput implements SsaImplCommon::InputSig<Location> {
+  class BasicBlock = BasicBlocks::BasicBlock;
+
+  class ControlFlowNode = CfgNode;
+
+  BasicBlock getImmediateBasicBlockDominator(BasicBlock bb) { result = bb.getImmediateDominator() }
+
+  BasicBlock getABasicBlockSuccessor(BasicBlock bb) { result = bb.getASuccessor() }
+
+  class ExitBasicBlock = BasicBlocks::ExitBasicBlock;
+
+  /**
+   * A variable amenable to SSA construction.
+   *
+   * All immutable variables are amenable. Mutable variables are restricted
+   * to those that are not captured by closures, and are not borrowed
+   * (either explicitly using `& mut`, or (potentially) implicit as borrowed
+   * receivers in a method call).
+   */
+  class SourceVariable extends Variable {
+    SourceVariable() {
+      this.isImmutable()
+      or
+      this.isMutable() and
+      not this.isCaptured() and
+      forall(VariableAccess va | va = this.getAnAccess() |
+        va instanceof VariableReadAccess and
+        // receivers can be borrowed implicitly, cf.
+        // https://doc.rust-lang.org/reference/expressions/method-call-expr.html
+        not va = any(MethodCallExpr mce).getReceiver()
+        or
+        variableWrite(va, this)
+      )
+    }
+  }
+
+  predicate variableWrite(BasicBlock bb, int i, SourceVariable v, boolean certain) {
+    (
+      variableWriteActual(bb, i, v, _)
+      or
+      capturedEntryWrite(bb, i, v)
+    ) and
+    certain = true
+  }
+
+  predicate variableRead(BasicBlock bb, int i, SourceVariable v, boolean certain) {
+    exists(VariableAccess va |
+      bb.getNode(i).getAstNode() = va and
+      va = v.getAnAccess()
+    |
+      va instanceof VariableReadAccess
+      or
+      // Although compound assignments, like `x += y`, may in fact not read `x`,
+      // it makes sense to treat them as such
+      va = any(CompoundAssignmentExpr cae).getLhs()
+    ) and
+    certain = true
+    or
+    // For immutable variables, we model a read when they are borrowed (although the
+    // actual read happens later, if at all). This only affects the SSA liveness
+    // analysis.
+    exists(VariableAccess va |
+      va = any(RefExpr re).getExpr() and
+      va = bb.getNode(i).getAstNode() and
+      v = va.getVariable() and
+      certain = false
+    )
+  }
+}
+
+import SsaImplCommon::Make<Location, SsaInput> as Impl
+
+class Definition = Impl::Definition;
+
+class WriteDefinition = Impl::WriteDefinition;
+
+class UncertainWriteDefinition = Impl::UncertainWriteDefinition;
+
+class PhiDefinition = Impl::PhiNode;
+
+module Consistency = Impl::Consistency;
+
+module ExposedForTestingOnly {
+  predicate ssaDefReachesReadExt = Impl::ssaDefReachesReadExt/4;
+
+  predicate phiHasInputFromBlockExt = Impl::phiHasInputFromBlockExt/3;
+}
+
+pragma[noinline]
+private predicate adjacentDefRead(
+  Definition def, BasicBlock bb1, int i1, BasicBlock bb2, int i2, SsaInput::SourceVariable v
+) {
+  Impl::adjacentDefRead(def, bb1, i1, bb2, i2) and
+  v = def.getSourceVariable()
+}
+
+pragma[noinline]
+private predicate adjacentDefReadExt(
+  DefinitionExt def, BasicBlock bb1, int i1, BasicBlock bb2, int i2, SsaInput::SourceVariable v
+) {
+  Impl::adjacentDefReadExt(def, _, bb1, i1, bb2, i2) and
+  v = def.getSourceVariable()
+}
+
+/** Holds if `v` is read at index `i` in basic block `bb`. */
+private predicate variableReadActual(BasicBlock bb, int i, Variable v) {
+  exists(VariableReadAccess read |
+    read.getVariable() = v and
+    read = bb.getNode(i).getAstNode()
+  )
+}
+
+private predicate adjacentDefReachesRead(
+  Definition def, BasicBlock bb1, int i1, BasicBlock bb2, int i2
+) {
+  exists(SsaInput::SourceVariable v | adjacentDefRead(def, bb1, i1, bb2, i2, v) |
+    def.definesAt(v, bb1, i1)
+    or
+    SsaInput::variableRead(bb1, i1, v, true)
+  )
+  or
+  exists(BasicBlock bb3, int i3 |
+    adjacentDefReachesRead(def, bb1, i1, bb3, i3) and
+    SsaInput::variableRead(bb3, i3, _, false) and
+    Impl::adjacentDefRead(def, bb3, i3, bb2, i2)
+  )
+}
+
+private predicate adjacentDefReachesReadExt(
+  DefinitionExt def, BasicBlock bb1, int i1, BasicBlock bb2, int i2
+) {
+  exists(SsaInput::SourceVariable v | adjacentDefReadExt(def, bb1, i1, bb2, i2, v) |
+    def.definesAt(v, bb1, i1, _)
+    or
+    SsaInput::variableRead(bb1, i1, v, true)
+  )
+  or
+  exists(BasicBlock bb3, int i3 |
+    adjacentDefReachesReadExt(def, bb1, i1, bb3, i3) and
+    SsaInput::variableRead(bb3, i3, _, false) and
+    Impl::adjacentDefReadExt(def, _, bb3, i3, bb2, i2)
+  )
+}
+
+/** Same as `adjacentDefRead`, but skips uncertain reads. */
+pragma[nomagic]
+private predicate adjacentDefSkipUncertainReads(
+  Definition def, BasicBlock bb1, int i1, BasicBlock bb2, int i2
+) {
+  adjacentDefReachesRead(def, bb1, i1, bb2, i2) and
+  SsaInput::variableRead(bb2, i2, _, true)
+}
+
+private predicate adjacentDefReachesUncertainReadExt(
+  DefinitionExt def, BasicBlock bb1, int i1, BasicBlock bb2, int i2
+) {
+  adjacentDefReachesReadExt(def, bb1, i1, bb2, i2) and
+  SsaInput::variableRead(bb2, i2, _, false)
+}
+
+/** Same as `lastRefRedef`, but skips uncertain reads. */
+pragma[nomagic]
+private predicate lastRefSkipUncertainReadsExt(DefinitionExt def, BasicBlock bb, int i) {
+  Impl::lastRef(def, bb, i) and
+  not SsaInput::variableRead(bb, i, def.getSourceVariable(), false)
+  or
+  exists(BasicBlock bb0, int i0 |
+    Impl::lastRef(def, bb0, i0) and
+    adjacentDefReachesUncertainReadExt(def, bb, i, bb0, i0)
+  )
+}
+
+/** Holds if `bb` contains a captured access to variable `v`. */
+pragma[nomagic]
+private predicate hasCapturedVariableAccess(BasicBlock bb, Variable v) {
+  exists(VariableAccess read |
+    read = bb.getANode().getAstNode() and
+    read.isCapture() and
+    read.getVariable() = v
+  )
+}
+
+cached
+private module Cached {
+  /**
+   * Holds if an entry definition is needed for captured variable `v` at index
+   * `i` in entry block `bb`.
+   */
+  cached
+  predicate capturedEntryWrite(EntryBasicBlock bb, int i, Variable v) {
+    hasCapturedVariableAccess(bb.getASuccessor*(), v) and
+    i = -1
+  }
+
+  /**
+   * Holds if `v` is written at index `i` in basic block `bb`, and the corresponding
+   * AST write access is `write`.
+   */
+  cached
+  predicate variableWriteActual(BasicBlock bb, int i, Variable v, CfgNode write) {
+    bb.getNode(i) = write and
+    variableWrite(write.getAstNode(), v)
+  }
+
+  cached
+  CfgNode getARead(Definition def) {
+    exists(Variable v, BasicBlock bb, int i |
+      Impl::ssaDefReachesRead(v, def, bb, i) and
+      variableReadActual(bb, i, v) and
+      result = bb.getNode(i)
+    )
+  }
+
+  cached
+  Definition phiHasInputFromBlock(PhiDefinition phi, BasicBlock bb) {
+    Impl::phiHasInputFromBlock(phi, result, bb)
+  }
+
+  /**
+   * Holds if the value defined at SSA definition `def` can reach a read at `read`,
+   * without passing through any other non-pseudo read.
+   */
+  cached
+  predicate firstRead(Definition def, CfgNode read) {
+    exists(BasicBlock bb1, int i1, BasicBlock bb2, int i2 |
+      def.definesAt(_, bb1, i1) and
+      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
+      read = bb2.getNode(i2)
+    )
+  }
+
+  /**
+   * Holds if the read at `read2` is a read of the same SSA definition `def`
+   * as the read at `read1`, and `read2` can be reached from `read1` without
+   * passing through another non-pseudo read.
+   */
+  cached
+  predicate adjacentReadPair(Definition def, CfgNode read1, CfgNode read2) {
+    exists(BasicBlock bb1, int i1, BasicBlock bb2, int i2 |
+      read1 = bb1.getNode(i1) and
+      variableReadActual(bb1, i1, _) and
+      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
+      read2 = bb2.getNode(i2)
+    )
+  }
+
+  /**
+   * Holds if the read of `def` at `read` may be a last read. That is, `read`
+   * can either reach another definition of the underlying source variable or
+   * the end of the CFG scope, without passing through another non-pseudo read.
+   */
+  cached
+  predicate lastRead(Definition def, CfgNode read) {
+    exists(BasicBlock bb, int i |
+      lastRefSkipUncertainReadsExt(def, bb, i) and
+      variableReadActual(bb, i, _) and
+      read = bb.getNode(i)
+    )
+  }
+
+  cached
+  Definition uncertainWriteDefinitionInput(UncertainWriteDefinition def) {
+    Impl::uncertainWriteDefinitionInput(def, result)
+  }
+}
+
+import Cached
+private import codeql.rust.dataflow.Ssa
+
+/**
+ * An extended static single assignment (SSA) definition.
+ *
+ * This is either a normal SSA definition (`Definition`) or a
+ * phi-read node (`PhiReadNode`).
+ *
+ * Only intended for internal use.
+ */
+class DefinitionExt extends Impl::DefinitionExt {
+  CfgNode getARead() { result = getARead(this) }
+
+  override string toString() { result = this.(Ssa::Definition).toString() }
+
+  override Location getLocation() { result = this.(Ssa::Definition).getLocation() }
+}
+
+/**
+ * A phi-read node.
+ *
+ * Only intended for internal use.
+ */
+class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
+  override string toString() { result = "SSA phi read(" + this.getSourceVariable() + ")" }
+
+  override Location getLocation() { result = Impl::PhiReadNode.super.getLocation() }
+}

--- a/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
@@ -118,16 +118,23 @@ module Impl {
      */
     IdentPat getPat() { variableDecl(definingNode, result, name) }
 
+    /** Gets the `let` statement that introduces this variable, if any. */
+    LetStmt getLetStmt() { this.getPat() = result.getPat() }
+
     /** Gets the initial value of this variable, if any. */
-    Expr getInitializer() {
-      exists(LetStmt let |
-        this.getPat() = let.getPat() and
-        result = let.getInitializer()
-      )
-    }
+    Expr getInitializer() { result = this.getLetStmt().getInitializer() }
 
     /** Holds if this variable is captured. */
     predicate isCaptured() { this.getAnAccess().isCapture() }
+
+    /** Gets the parameter that introduces this variable, if any. */
+    Param getParameter() { parameterDeclInScope(result, this, _) }
+
+    /** Hold is this variable is mutable. */
+    predicate isMutable() { this.getPat().isMut() }
+
+    /** Hold is this variable is immutable. */
+    predicate isImmutable() { not this.isMutable() }
   }
 
   /** A path expression that may access a local variable. */
@@ -181,6 +188,27 @@ module Impl {
   }
 
   /**
+   * Holds if parameter `p` introduces the variable `v` inside variable scope
+   * `scope`.
+   */
+  private predicate parameterDeclInScope(Param p, Variable v, VariableScope scope) {
+    exists(Pat pat |
+      pat = getAVariablePatAncestor(v) and
+      p.getPat() = pat
+    |
+      exists(Function f |
+        f.getParamList().getAParam() = p and
+        scope = f.getBody()
+      )
+      or
+      exists(ClosureExpr ce |
+        ce.getParamList().getAParam() = p and
+        scope = ce.getBody()
+      )
+    )
+  }
+
+  /**
    * Holds if `v` is named `name` and is declared inside variable scope
    * `scope`, and `v` is bound starting from `(line, column)`.
    */
@@ -188,51 +216,44 @@ module Impl {
     Variable v, VariableScope scope, string name, int line, int column
   ) {
     name = v.getName() and
-    exists(Pat pat | pat = getAVariablePatAncestor(v) |
-      scope =
-        any(MatchArmScope arm |
-          arm.getPat() = pat and
-          arm.getLocation().hasLocationInfo(_, line, column, _, _)
+    (
+      parameterDeclInScope(_, v, scope) and
+      scope.getLocation().hasLocationInfo(_, line, column, _, _)
+      or
+      exists(Pat pat | pat = getAVariablePatAncestor(v) |
+        scope =
+          any(MatchArmScope arm |
+            arm.getPat() = pat and
+            arm.getLocation().hasLocationInfo(_, line, column, _, _)
+          )
+        or
+        exists(LetStmt let |
+          let.getPat() = pat and
+          scope = getEnclosingScope(let) and
+          // for `let` statements, variables are bound _after_ the statement, i.e.
+          // not in the RHS
+          let.getLocation().hasLocationInfo(_, _, _, line, column)
         )
-      or
-      exists(Function f |
-        f.getParamList().getAParam().getPat() = pat and
-        scope = f.getBody() and
-        scope.getLocation().hasLocationInfo(_, line, column, _, _)
-      )
-      or
-      exists(LetStmt let |
-        let.getPat() = pat and
-        scope = getEnclosingScope(let) and
-        // for `let` statements, variables are bound _after_ the statement, i.e.
-        // not in the RHS
-        let.getLocation().hasLocationInfo(_, _, _, line, column)
-      )
-      or
-      exists(IfExpr ie, LetExpr let |
-        let.getPat() = pat and
-        ie.getCondition() = let and
-        scope = ie.getThen() and
-        scope.getLocation().hasLocationInfo(_, line, column, _, _)
-      )
-      or
-      exists(ForExpr fe |
-        fe.getPat() = pat and
-        scope = fe.getLoopBody() and
-        scope.getLocation().hasLocationInfo(_, line, column, _, _)
-      )
-      or
-      exists(ClosureExpr ce |
-        ce.getParamList().getAParam().getPat() = pat and
-        scope = ce.getBody() and
-        scope.getLocation().hasLocationInfo(_, line, column, _, _)
-      )
-      or
-      exists(WhileExpr we, LetExpr let |
-        let.getPat() = pat and
-        we.getCondition() = let and
-        scope = we.getLoopBody() and
-        scope.getLocation().hasLocationInfo(_, line, column, _, _)
+        or
+        exists(IfExpr ie, LetExpr let |
+          let.getPat() = pat and
+          ie.getCondition() = let and
+          scope = ie.getThen() and
+          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+        )
+        or
+        exists(ForExpr fe |
+          fe.getPat() = pat and
+          scope = fe.getLoopBody() and
+          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+        )
+        or
+        exists(WhileExpr we, LetExpr let |
+          let.getPat() = pat and
+          we.getCondition() = let and
+          scope = we.getLoopBody() and
+          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+        )
       )
     )
   }
@@ -427,7 +448,8 @@ module Impl {
     exists(Expr mid |
       assignmentExprDescendant(mid) and
       getImmediateParent(e) = mid and
-      not mid.(PrefixExpr).getOperatorName() = "*"
+      not mid.(PrefixExpr).getOperatorName() = "*" and
+      not mid instanceof FieldExpr
     )
   }
 

--- a/rust/ql/test/library-tests/variables/Cfg.expected
+++ b/rust/ql/test/library-tests/variables/Cfg.expected
@@ -734,13 +734,12 @@ edges
 | variables.rs:342:5:342:16 | CallExpr | variables.rs:337:13:343:1 | BlockExpr |  |
 | variables.rs:342:5:342:17 | ExprStmt | variables.rs:342:5:342:13 | PathExpr |  |
 | variables.rs:342:15:342:15 | i | variables.rs:342:5:342:16 | CallExpr |  |
-| variables.rs:345:1:349:1 | enter mutate_param | variables.rs:345:17:345:17 | x |  |
-| variables.rs:345:1:349:1 | exit mutate_param (normal) | variables.rs:345:1:349:1 | exit mutate_param |  |
+| variables.rs:345:1:350:1 | enter mutate_param | variables.rs:345:17:345:17 | x |  |
+| variables.rs:345:1:350:1 | exit mutate_param (normal) | variables.rs:345:1:350:1 | exit mutate_param |  |
 | variables.rs:345:17:345:17 | x | variables.rs:345:17:345:28 | Param | match |
 | variables.rs:345:17:345:28 | Param | variables.rs:346:5:348:11 | ExprStmt |  |
-| variables.rs:345:31:349:1 | BlockExpr | variables.rs:345:1:349:1 | exit mutate_param (normal) |  |
 | variables.rs:346:5:346:6 | * ... | variables.rs:347:10:347:10 | x |  |
-| variables.rs:346:5:348:10 | ... = ... | variables.rs:345:31:349:1 | BlockExpr |  |
+| variables.rs:346:5:348:10 | ... = ... | variables.rs:349:5:349:13 | ExprStmt |  |
 | variables.rs:346:5:348:11 | ExprStmt | variables.rs:346:6:346:6 | x |  |
 | variables.rs:346:6:346:6 | x | variables.rs:346:5:346:6 | * ... |  |
 | variables.rs:347:9:347:10 | * ... | variables.rs:348:10:348:10 | x |  |
@@ -748,157 +747,433 @@ edges
 | variables.rs:347:10:347:10 | x | variables.rs:347:9:347:10 | * ... |  |
 | variables.rs:348:9:348:10 | * ... | variables.rs:347:9:348:10 | ... + ... |  |
 | variables.rs:348:10:348:10 | x | variables.rs:348:9:348:10 | * ... |  |
-| variables.rs:351:1:355:1 | enter mutate_arg | variables.rs:352:5:352:18 | LetStmt |  |
-| variables.rs:351:1:355:1 | exit mutate_arg (normal) | variables.rs:351:1:355:1 | exit mutate_arg |  |
-| variables.rs:351:17:355:1 | BlockExpr | variables.rs:351:1:355:1 | exit mutate_arg (normal) |  |
-| variables.rs:352:5:352:18 | LetStmt | variables.rs:352:17:352:17 | 2 |  |
-| variables.rs:352:9:352:13 | x | variables.rs:353:5:353:25 | ExprStmt | match |
-| variables.rs:352:17:352:17 | 2 | variables.rs:352:9:352:13 | x |  |
-| variables.rs:353:5:353:16 | PathExpr | variables.rs:353:23:353:23 | x |  |
-| variables.rs:353:5:353:24 | CallExpr | variables.rs:354:5:354:17 | ExprStmt |  |
-| variables.rs:353:5:353:25 | ExprStmt | variables.rs:353:5:353:16 | PathExpr |  |
-| variables.rs:353:18:353:23 | RefExpr | variables.rs:353:5:353:24 | CallExpr |  |
-| variables.rs:353:23:353:23 | x | variables.rs:353:18:353:23 | RefExpr |  |
-| variables.rs:354:5:354:13 | PathExpr | variables.rs:354:15:354:15 | x |  |
-| variables.rs:354:5:354:16 | CallExpr | variables.rs:351:17:355:1 | BlockExpr |  |
-| variables.rs:354:5:354:17 | ExprStmt | variables.rs:354:5:354:13 | PathExpr |  |
-| variables.rs:354:15:354:15 | x | variables.rs:354:5:354:16 | CallExpr |  |
-| variables.rs:357:1:363:1 | enter alias | variables.rs:358:5:358:18 | LetStmt |  |
-| variables.rs:357:1:363:1 | exit alias (normal) | variables.rs:357:1:363:1 | exit alias |  |
-| variables.rs:357:12:363:1 | BlockExpr | variables.rs:357:1:363:1 | exit alias (normal) |  |
-| variables.rs:358:5:358:18 | LetStmt | variables.rs:358:17:358:17 | 1 |  |
-| variables.rs:358:9:358:13 | x | variables.rs:359:5:360:15 | LetStmt | match |
-| variables.rs:358:17:358:17 | 1 | variables.rs:358:9:358:13 | x |  |
-| variables.rs:359:5:360:15 | LetStmt | variables.rs:360:14:360:14 | x |  |
-| variables.rs:359:9:359:9 | y | variables.rs:361:5:361:11 | ExprStmt | match |
-| variables.rs:360:9:360:14 | RefExpr | variables.rs:359:9:359:9 | y |  |
-| variables.rs:360:14:360:14 | x | variables.rs:360:9:360:14 | RefExpr |  |
-| variables.rs:361:5:361:6 | * ... | variables.rs:361:10:361:10 | 2 |  |
-| variables.rs:361:5:361:10 | ... = ... | variables.rs:362:5:362:17 | ExprStmt |  |
-| variables.rs:361:5:361:11 | ExprStmt | variables.rs:361:6:361:6 | y |  |
-| variables.rs:361:6:361:6 | y | variables.rs:361:5:361:6 | * ... |  |
-| variables.rs:361:10:361:10 | 2 | variables.rs:361:5:361:10 | ... = ... |  |
-| variables.rs:362:5:362:13 | PathExpr | variables.rs:362:15:362:15 | x |  |
-| variables.rs:362:5:362:16 | CallExpr | variables.rs:357:12:363:1 | BlockExpr |  |
-| variables.rs:362:5:362:17 | ExprStmt | variables.rs:362:5:362:13 | PathExpr |  |
-| variables.rs:362:15:362:15 | x | variables.rs:362:5:362:16 | CallExpr |  |
-| variables.rs:365:1:373:1 | enter capture | variables.rs:366:5:366:19 | LetStmt |  |
-| variables.rs:365:1:373:1 | exit capture (normal) | variables.rs:365:1:373:1 | exit capture |  |
-| variables.rs:365:14:373:1 | BlockExpr | variables.rs:365:1:373:1 | exit capture (normal) |  |
-| variables.rs:366:5:366:19 | LetStmt | variables.rs:366:17:366:18 | 10 |  |
-| variables.rs:366:9:366:13 | x | variables.rs:367:5:370:6 | LetStmt | match |
-| variables.rs:366:17:366:18 | 10 | variables.rs:366:9:366:13 | x |  |
-| variables.rs:367:5:370:6 | LetStmt | variables.rs:367:19:370:5 | ClosureExpr |  |
-| variables.rs:367:9:367:15 | cap | variables.rs:371:5:371:10 | ExprStmt | match |
-| variables.rs:367:19:370:5 | ClosureExpr | variables.rs:367:9:367:15 | cap |  |
-| variables.rs:367:19:370:5 | enter ClosureExpr | variables.rs:368:9:368:21 | ExprStmt |  |
-| variables.rs:367:19:370:5 | exit ClosureExpr (normal) | variables.rs:367:19:370:5 | exit ClosureExpr |  |
-| variables.rs:367:22:370:5 | BlockExpr | variables.rs:367:19:370:5 | exit ClosureExpr (normal) |  |
-| variables.rs:368:9:368:17 | PathExpr | variables.rs:368:19:368:19 | x |  |
-| variables.rs:368:9:368:20 | CallExpr | variables.rs:369:9:369:15 | ExprStmt |  |
-| variables.rs:368:9:368:21 | ExprStmt | variables.rs:368:9:368:17 | PathExpr |  |
-| variables.rs:368:19:368:19 | x | variables.rs:368:9:368:20 | CallExpr |  |
-| variables.rs:369:9:369:9 | x | variables.rs:369:14:369:14 | 1 |  |
-| variables.rs:369:9:369:14 | ... += ... | variables.rs:367:22:370:5 | BlockExpr |  |
-| variables.rs:369:9:369:15 | ExprStmt | variables.rs:369:9:369:9 | x |  |
-| variables.rs:369:14:369:14 | 1 | variables.rs:369:9:369:14 | ... += ... |  |
-| variables.rs:371:5:371:7 | cap | variables.rs:371:5:371:9 | CallExpr |  |
-| variables.rs:371:5:371:9 | CallExpr | variables.rs:372:5:372:17 | ExprStmt |  |
-| variables.rs:371:5:371:10 | ExprStmt | variables.rs:371:5:371:7 | cap |  |
-| variables.rs:372:5:372:13 | PathExpr | variables.rs:372:15:372:15 | x |  |
-| variables.rs:372:5:372:16 | CallExpr | variables.rs:365:14:373:1 | BlockExpr |  |
-| variables.rs:372:5:372:17 | ExprStmt | variables.rs:372:5:372:13 | PathExpr |  |
-| variables.rs:372:15:372:15 | x | variables.rs:372:5:372:16 | CallExpr |  |
-| variables.rs:375:1:403:1 | enter main | variables.rs:376:5:376:25 | ExprStmt |  |
-| variables.rs:375:1:403:1 | exit main (normal) | variables.rs:375:1:403:1 | exit main |  |
-| variables.rs:375:11:403:1 | BlockExpr | variables.rs:375:1:403:1 | exit main (normal) |  |
-| variables.rs:376:5:376:22 | PathExpr | variables.rs:376:5:376:24 | CallExpr |  |
-| variables.rs:376:5:376:24 | CallExpr | variables.rs:377:5:377:23 | ExprStmt |  |
-| variables.rs:376:5:376:25 | ExprStmt | variables.rs:376:5:376:22 | PathExpr |  |
-| variables.rs:377:5:377:20 | PathExpr | variables.rs:377:5:377:22 | CallExpr |  |
-| variables.rs:377:5:377:22 | CallExpr | variables.rs:378:5:378:23 | ExprStmt |  |
-| variables.rs:377:5:377:23 | ExprStmt | variables.rs:377:5:377:20 | PathExpr |  |
-| variables.rs:378:5:378:20 | PathExpr | variables.rs:378:5:378:22 | CallExpr |  |
-| variables.rs:378:5:378:22 | CallExpr | variables.rs:379:5:379:23 | ExprStmt |  |
-| variables.rs:378:5:378:23 | ExprStmt | variables.rs:378:5:378:20 | PathExpr |  |
-| variables.rs:379:5:379:20 | PathExpr | variables.rs:379:5:379:22 | CallExpr |  |
-| variables.rs:379:5:379:22 | CallExpr | variables.rs:380:5:380:19 | ExprStmt |  |
-| variables.rs:379:5:379:23 | ExprStmt | variables.rs:379:5:379:20 | PathExpr |  |
-| variables.rs:380:5:380:16 | PathExpr | variables.rs:380:5:380:18 | CallExpr |  |
-| variables.rs:380:5:380:18 | CallExpr | variables.rs:381:5:381:19 | ExprStmt |  |
-| variables.rs:380:5:380:19 | ExprStmt | variables.rs:380:5:380:16 | PathExpr |  |
-| variables.rs:381:5:381:16 | PathExpr | variables.rs:381:5:381:18 | CallExpr |  |
-| variables.rs:381:5:381:18 | CallExpr | variables.rs:382:5:382:19 | ExprStmt |  |
-| variables.rs:381:5:381:19 | ExprStmt | variables.rs:381:5:381:16 | PathExpr |  |
-| variables.rs:382:5:382:16 | PathExpr | variables.rs:382:5:382:18 | CallExpr |  |
-| variables.rs:382:5:382:18 | CallExpr | variables.rs:383:5:383:19 | ExprStmt |  |
-| variables.rs:382:5:382:19 | ExprStmt | variables.rs:382:5:382:16 | PathExpr |  |
-| variables.rs:383:5:383:16 | PathExpr | variables.rs:383:5:383:18 | CallExpr |  |
-| variables.rs:383:5:383:18 | CallExpr | variables.rs:384:5:384:21 | ExprStmt |  |
-| variables.rs:383:5:383:19 | ExprStmt | variables.rs:383:5:383:16 | PathExpr |  |
-| variables.rs:384:5:384:18 | PathExpr | variables.rs:384:5:384:20 | CallExpr |  |
-| variables.rs:384:5:384:20 | CallExpr | variables.rs:385:5:385:21 | ExprStmt |  |
-| variables.rs:384:5:384:21 | ExprStmt | variables.rs:384:5:384:18 | PathExpr |  |
-| variables.rs:385:5:385:18 | PathExpr | variables.rs:385:5:385:20 | CallExpr |  |
-| variables.rs:385:5:385:20 | CallExpr | variables.rs:386:5:386:21 | ExprStmt |  |
-| variables.rs:385:5:385:21 | ExprStmt | variables.rs:385:5:385:18 | PathExpr |  |
-| variables.rs:386:5:386:18 | PathExpr | variables.rs:386:5:386:20 | CallExpr |  |
-| variables.rs:386:5:386:20 | CallExpr | variables.rs:387:5:387:21 | ExprStmt |  |
-| variables.rs:386:5:386:21 | ExprStmt | variables.rs:386:5:386:18 | PathExpr |  |
-| variables.rs:387:5:387:18 | PathExpr | variables.rs:387:5:387:20 | CallExpr |  |
-| variables.rs:387:5:387:20 | CallExpr | variables.rs:388:5:388:21 | ExprStmt |  |
-| variables.rs:387:5:387:21 | ExprStmt | variables.rs:387:5:387:18 | PathExpr |  |
-| variables.rs:388:5:388:18 | PathExpr | variables.rs:388:5:388:20 | CallExpr |  |
-| variables.rs:388:5:388:20 | CallExpr | variables.rs:389:5:389:21 | ExprStmt |  |
-| variables.rs:388:5:388:21 | ExprStmt | variables.rs:388:5:388:18 | PathExpr |  |
-| variables.rs:389:5:389:18 | PathExpr | variables.rs:389:5:389:20 | CallExpr |  |
-| variables.rs:389:5:389:20 | CallExpr | variables.rs:390:5:390:21 | ExprStmt |  |
-| variables.rs:389:5:389:21 | ExprStmt | variables.rs:389:5:389:18 | PathExpr |  |
-| variables.rs:390:5:390:18 | PathExpr | variables.rs:390:5:390:20 | CallExpr |  |
-| variables.rs:390:5:390:20 | CallExpr | variables.rs:391:5:391:21 | ExprStmt |  |
-| variables.rs:390:5:390:21 | ExprStmt | variables.rs:390:5:390:18 | PathExpr |  |
-| variables.rs:391:5:391:18 | PathExpr | variables.rs:391:5:391:20 | CallExpr |  |
-| variables.rs:391:5:391:20 | CallExpr | variables.rs:392:5:392:21 | ExprStmt |  |
-| variables.rs:391:5:391:21 | ExprStmt | variables.rs:391:5:391:18 | PathExpr |  |
-| variables.rs:392:5:392:18 | PathExpr | variables.rs:392:5:392:20 | CallExpr |  |
-| variables.rs:392:5:392:20 | CallExpr | variables.rs:393:5:393:36 | ExprStmt |  |
-| variables.rs:392:5:392:21 | ExprStmt | variables.rs:392:5:392:18 | PathExpr |  |
-| variables.rs:393:5:393:18 | PathExpr | variables.rs:393:20:393:22 | "a" |  |
-| variables.rs:393:5:393:35 | CallExpr | variables.rs:394:5:394:37 | ExprStmt |  |
-| variables.rs:393:5:393:36 | ExprStmt | variables.rs:393:5:393:18 | PathExpr |  |
-| variables.rs:393:20:393:22 | "a" | variables.rs:393:26:393:28 | "b" |  |
-| variables.rs:393:25:393:34 | TupleExpr | variables.rs:393:5:393:35 | CallExpr |  |
-| variables.rs:393:26:393:28 | "b" | variables.rs:393:31:393:33 | "c" |  |
-| variables.rs:393:31:393:33 | "c" | variables.rs:393:25:393:34 | TupleExpr |  |
-| variables.rs:394:5:394:18 | PathExpr | variables.rs:394:20:394:31 | PathExpr |  |
-| variables.rs:394:5:394:36 | CallExpr | variables.rs:395:5:395:26 | ExprStmt |  |
-| variables.rs:394:5:394:37 | ExprStmt | variables.rs:394:5:394:18 | PathExpr |  |
-| variables.rs:394:20:394:31 | PathExpr | variables.rs:394:33:394:34 | 45 |  |
-| variables.rs:394:20:394:35 | CallExpr | variables.rs:394:5:394:36 | CallExpr |  |
-| variables.rs:394:33:394:34 | 45 | variables.rs:394:20:394:35 | CallExpr |  |
-| variables.rs:395:5:395:23 | PathExpr | variables.rs:395:5:395:25 | CallExpr |  |
-| variables.rs:395:5:395:25 | CallExpr | variables.rs:396:5:396:23 | ExprStmt |  |
-| variables.rs:395:5:395:26 | ExprStmt | variables.rs:395:5:395:23 | PathExpr |  |
-| variables.rs:396:5:396:20 | PathExpr | variables.rs:396:5:396:22 | CallExpr |  |
-| variables.rs:396:5:396:22 | CallExpr | variables.rs:397:5:397:19 | ExprStmt |  |
-| variables.rs:396:5:396:23 | ExprStmt | variables.rs:396:5:396:20 | PathExpr |  |
-| variables.rs:397:5:397:16 | PathExpr | variables.rs:397:5:397:18 | CallExpr |  |
-| variables.rs:397:5:397:18 | CallExpr | variables.rs:398:5:398:17 | ExprStmt |  |
-| variables.rs:397:5:397:19 | ExprStmt | variables.rs:397:5:397:16 | PathExpr |  |
-| variables.rs:398:5:398:14 | PathExpr | variables.rs:398:5:398:16 | CallExpr |  |
-| variables.rs:398:5:398:16 | CallExpr | variables.rs:399:5:399:13 | ExprStmt |  |
-| variables.rs:398:5:398:17 | ExprStmt | variables.rs:398:5:398:14 | PathExpr |  |
-| variables.rs:399:5:399:10 | PathExpr | variables.rs:399:5:399:12 | CallExpr |  |
-| variables.rs:399:5:399:12 | CallExpr | variables.rs:400:5:400:17 | ExprStmt |  |
-| variables.rs:399:5:399:13 | ExprStmt | variables.rs:399:5:399:10 | PathExpr |  |
-| variables.rs:400:5:400:14 | PathExpr | variables.rs:400:5:400:16 | CallExpr |  |
-| variables.rs:400:5:400:16 | CallExpr | variables.rs:401:5:401:12 | ExprStmt |  |
-| variables.rs:400:5:400:17 | ExprStmt | variables.rs:400:5:400:14 | PathExpr |  |
-| variables.rs:401:5:401:9 | PathExpr | variables.rs:401:5:401:11 | CallExpr |  |
-| variables.rs:401:5:401:11 | CallExpr | variables.rs:402:5:402:14 | ExprStmt |  |
-| variables.rs:401:5:401:12 | ExprStmt | variables.rs:401:5:401:9 | PathExpr |  |
-| variables.rs:402:5:402:11 | PathExpr | variables.rs:402:5:402:13 | CallExpr |  |
-| variables.rs:402:5:402:13 | CallExpr | variables.rs:375:11:403:1 | BlockExpr |  |
-| variables.rs:402:5:402:14 | ExprStmt | variables.rs:402:5:402:11 | PathExpr |  |
+| variables.rs:349:5:349:12 | ReturnExpr | variables.rs:345:1:350:1 | exit mutate_param (normal) | return |
+| variables.rs:349:5:349:13 | ExprStmt | variables.rs:349:12:349:12 | x |  |
+| variables.rs:349:12:349:12 | x | variables.rs:349:5:349:12 | ReturnExpr |  |
+| variables.rs:352:1:358:1 | enter mutate_param2 | variables.rs:352:22:352:22 | x |  |
+| variables.rs:352:1:358:1 | exit mutate_param2 (normal) | variables.rs:352:1:358:1 | exit mutate_param2 |  |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:36 | Param | match |
+| variables.rs:352:22:352:36 | Param | variables.rs:352:39:352:39 | y |  |
+| variables.rs:352:39:352:39 | y | variables.rs:352:39:352:57 | Param | match |
+| variables.rs:352:39:352:57 | Param | variables.rs:353:5:355:11 | ExprStmt |  |
+| variables.rs:352:60:358:1 | BlockExpr | variables.rs:352:1:358:1 | exit mutate_param2 (normal) |  |
+| variables.rs:353:5:353:6 | * ... | variables.rs:354:10:354:10 | x |  |
+| variables.rs:353:5:355:10 | ... = ... | variables.rs:356:5:357:10 | ExprStmt |  |
+| variables.rs:353:5:355:11 | ExprStmt | variables.rs:353:6:353:6 | x |  |
+| variables.rs:353:6:353:6 | x | variables.rs:353:5:353:6 | * ... |  |
+| variables.rs:354:9:354:10 | * ... | variables.rs:355:10:355:10 | x |  |
+| variables.rs:354:9:355:10 | ... + ... | variables.rs:353:5:355:10 | ... = ... |  |
+| variables.rs:354:10:354:10 | x | variables.rs:354:9:354:10 | * ... |  |
+| variables.rs:355:9:355:10 | * ... | variables.rs:354:9:355:10 | ... + ... |  |
+| variables.rs:355:10:355:10 | x | variables.rs:355:9:355:10 | * ... |  |
+| variables.rs:356:5:356:6 | * ... | variables.rs:357:9:357:9 | x |  |
+| variables.rs:356:5:357:9 | ... = ... | variables.rs:352:60:358:1 | BlockExpr |  |
+| variables.rs:356:5:357:10 | ExprStmt | variables.rs:356:6:356:6 | y |  |
+| variables.rs:356:6:356:6 | y | variables.rs:356:5:356:6 | * ... |  |
+| variables.rs:357:9:357:9 | x | variables.rs:356:5:357:9 | ... = ... |  |
+| variables.rs:360:1:378:1 | enter mutate_arg | variables.rs:361:5:361:18 | LetStmt |  |
+| variables.rs:360:1:378:1 | exit mutate_arg (normal) | variables.rs:360:1:378:1 | exit mutate_arg |  |
+| variables.rs:360:17:378:1 | BlockExpr | variables.rs:360:1:378:1 | exit mutate_arg (normal) |  |
+| variables.rs:361:5:361:18 | LetStmt | variables.rs:361:17:361:17 | 2 |  |
+| variables.rs:361:9:361:13 | x | variables.rs:362:5:363:29 | LetStmt | match |
+| variables.rs:361:17:361:17 | 2 | variables.rs:361:9:361:13 | x |  |
+| variables.rs:362:5:363:29 | LetStmt | variables.rs:363:9:363:20 | PathExpr |  |
+| variables.rs:362:9:362:9 | y | variables.rs:364:5:364:12 | ExprStmt | match |
+| variables.rs:363:9:363:20 | PathExpr | variables.rs:363:27:363:27 | x |  |
+| variables.rs:363:9:363:28 | CallExpr | variables.rs:362:9:362:9 | y |  |
+| variables.rs:363:22:363:27 | RefExpr | variables.rs:363:9:363:28 | CallExpr |  |
+| variables.rs:363:27:363:27 | x | variables.rs:363:22:363:27 | RefExpr |  |
+| variables.rs:364:5:364:6 | * ... | variables.rs:364:10:364:11 | 10 |  |
+| variables.rs:364:5:364:11 | ... = ... | variables.rs:366:5:366:17 | ExprStmt |  |
+| variables.rs:364:5:364:12 | ExprStmt | variables.rs:364:6:364:6 | y |  |
+| variables.rs:364:6:364:6 | y | variables.rs:364:5:364:6 | * ... |  |
+| variables.rs:364:10:364:11 | 10 | variables.rs:364:5:364:11 | ... = ... |  |
+| variables.rs:366:5:366:13 | PathExpr | variables.rs:366:15:366:15 | x |  |
+| variables.rs:366:5:366:16 | CallExpr | variables.rs:368:5:368:18 | LetStmt |  |
+| variables.rs:366:5:366:17 | ExprStmt | variables.rs:366:5:366:13 | PathExpr |  |
+| variables.rs:366:15:366:15 | x | variables.rs:366:5:366:16 | CallExpr |  |
+| variables.rs:368:5:368:18 | LetStmt | variables.rs:368:17:368:17 | 4 |  |
+| variables.rs:368:9:368:13 | z | variables.rs:369:5:370:20 | LetStmt | match |
+| variables.rs:368:17:368:17 | 4 | variables.rs:368:9:368:13 | z |  |
+| variables.rs:369:5:370:20 | LetStmt | variables.rs:370:19:370:19 | x |  |
+| variables.rs:369:9:369:9 | w | variables.rs:371:5:374:6 | ExprStmt | match |
+| variables.rs:370:9:370:19 | RefExpr | variables.rs:369:9:369:9 | w |  |
+| variables.rs:370:14:370:19 | RefExpr | variables.rs:370:9:370:19 | RefExpr |  |
+| variables.rs:370:19:370:19 | x | variables.rs:370:14:370:19 | RefExpr |  |
+| variables.rs:371:5:371:17 | PathExpr | variables.rs:372:14:372:14 | z |  |
+| variables.rs:371:5:374:5 | CallExpr | variables.rs:375:5:375:13 | ExprStmt |  |
+| variables.rs:371:5:374:6 | ExprStmt | variables.rs:371:5:371:17 | PathExpr |  |
+| variables.rs:372:9:372:14 | RefExpr | variables.rs:373:9:373:9 | w |  |
+| variables.rs:372:14:372:14 | z | variables.rs:372:9:372:14 | RefExpr |  |
+| variables.rs:373:9:373:9 | w | variables.rs:371:5:374:5 | CallExpr |  |
+| variables.rs:375:5:375:7 | * ... | variables.rs:375:11:375:12 | 11 |  |
+| variables.rs:375:5:375:12 | ... = ... | variables.rs:377:5:377:17 | ExprStmt |  |
+| variables.rs:375:5:375:13 | ExprStmt | variables.rs:375:7:375:7 | w |  |
+| variables.rs:375:6:375:7 | * ... | variables.rs:375:5:375:7 | * ... |  |
+| variables.rs:375:7:375:7 | w | variables.rs:375:6:375:7 | * ... |  |
+| variables.rs:375:11:375:12 | 11 | variables.rs:375:5:375:12 | ... = ... |  |
+| variables.rs:377:5:377:13 | PathExpr | variables.rs:377:15:377:15 | z |  |
+| variables.rs:377:5:377:16 | CallExpr | variables.rs:360:17:378:1 | BlockExpr |  |
+| variables.rs:377:5:377:17 | ExprStmt | variables.rs:377:5:377:13 | PathExpr |  |
+| variables.rs:377:15:377:15 | z | variables.rs:377:5:377:16 | CallExpr |  |
+| variables.rs:380:1:386:1 | enter alias | variables.rs:381:5:381:18 | LetStmt |  |
+| variables.rs:380:1:386:1 | exit alias (normal) | variables.rs:380:1:386:1 | exit alias |  |
+| variables.rs:380:12:386:1 | BlockExpr | variables.rs:380:1:386:1 | exit alias (normal) |  |
+| variables.rs:381:5:381:18 | LetStmt | variables.rs:381:17:381:17 | 1 |  |
+| variables.rs:381:9:381:13 | x | variables.rs:382:5:383:15 | LetStmt | match |
+| variables.rs:381:17:381:17 | 1 | variables.rs:381:9:381:13 | x |  |
+| variables.rs:382:5:383:15 | LetStmt | variables.rs:383:14:383:14 | x |  |
+| variables.rs:382:9:382:9 | y | variables.rs:384:5:384:11 | ExprStmt | match |
+| variables.rs:383:9:383:14 | RefExpr | variables.rs:382:9:382:9 | y |  |
+| variables.rs:383:14:383:14 | x | variables.rs:383:9:383:14 | RefExpr |  |
+| variables.rs:384:5:384:6 | * ... | variables.rs:384:10:384:10 | 2 |  |
+| variables.rs:384:5:384:10 | ... = ... | variables.rs:385:5:385:17 | ExprStmt |  |
+| variables.rs:384:5:384:11 | ExprStmt | variables.rs:384:6:384:6 | y |  |
+| variables.rs:384:6:384:6 | y | variables.rs:384:5:384:6 | * ... |  |
+| variables.rs:384:10:384:10 | 2 | variables.rs:384:5:384:10 | ... = ... |  |
+| variables.rs:385:5:385:13 | PathExpr | variables.rs:385:15:385:15 | x |  |
+| variables.rs:385:5:385:16 | CallExpr | variables.rs:380:12:386:1 | BlockExpr |  |
+| variables.rs:385:5:385:17 | ExprStmt | variables.rs:385:5:385:13 | PathExpr |  |
+| variables.rs:385:15:385:15 | x | variables.rs:385:5:385:16 | CallExpr |  |
+| variables.rs:388:1:396:1 | enter capture_mut | variables.rs:389:5:389:19 | LetStmt |  |
+| variables.rs:388:1:396:1 | exit capture_mut (normal) | variables.rs:388:1:396:1 | exit capture_mut |  |
+| variables.rs:388:18:396:1 | BlockExpr | variables.rs:388:1:396:1 | exit capture_mut (normal) |  |
+| variables.rs:389:5:389:19 | LetStmt | variables.rs:389:17:389:18 | 10 |  |
+| variables.rs:389:9:389:13 | x | variables.rs:390:5:393:6 | LetStmt | match |
+| variables.rs:389:17:389:18 | 10 | variables.rs:389:9:389:13 | x |  |
+| variables.rs:390:5:393:6 | LetStmt | variables.rs:390:19:393:5 | ClosureExpr |  |
+| variables.rs:390:9:390:15 | cap | variables.rs:394:5:394:10 | ExprStmt | match |
+| variables.rs:390:19:393:5 | ClosureExpr | variables.rs:390:9:390:15 | cap |  |
+| variables.rs:390:19:393:5 | enter ClosureExpr | variables.rs:391:9:391:21 | ExprStmt |  |
+| variables.rs:390:19:393:5 | exit ClosureExpr (normal) | variables.rs:390:19:393:5 | exit ClosureExpr |  |
+| variables.rs:390:22:393:5 | BlockExpr | variables.rs:390:19:393:5 | exit ClosureExpr (normal) |  |
+| variables.rs:391:9:391:17 | PathExpr | variables.rs:391:19:391:19 | x |  |
+| variables.rs:391:9:391:20 | CallExpr | variables.rs:392:9:392:15 | ExprStmt |  |
+| variables.rs:391:9:391:21 | ExprStmt | variables.rs:391:9:391:17 | PathExpr |  |
+| variables.rs:391:19:391:19 | x | variables.rs:391:9:391:20 | CallExpr |  |
+| variables.rs:392:9:392:9 | x | variables.rs:392:14:392:14 | 1 |  |
+| variables.rs:392:9:392:14 | ... += ... | variables.rs:390:22:393:5 | BlockExpr |  |
+| variables.rs:392:9:392:15 | ExprStmt | variables.rs:392:9:392:9 | x |  |
+| variables.rs:392:14:392:14 | 1 | variables.rs:392:9:392:14 | ... += ... |  |
+| variables.rs:394:5:394:7 | cap | variables.rs:394:5:394:9 | CallExpr |  |
+| variables.rs:394:5:394:9 | CallExpr | variables.rs:395:5:395:17 | ExprStmt |  |
+| variables.rs:394:5:394:10 | ExprStmt | variables.rs:394:5:394:7 | cap |  |
+| variables.rs:395:5:395:13 | PathExpr | variables.rs:395:15:395:15 | x |  |
+| variables.rs:395:5:395:16 | CallExpr | variables.rs:388:18:396:1 | BlockExpr |  |
+| variables.rs:395:5:395:17 | ExprStmt | variables.rs:395:5:395:13 | PathExpr |  |
+| variables.rs:395:15:395:15 | x | variables.rs:395:5:395:16 | CallExpr |  |
+| variables.rs:398:1:405:1 | enter capture_immut | variables.rs:399:5:399:16 | LetStmt |  |
+| variables.rs:398:1:405:1 | exit capture_immut (normal) | variables.rs:398:1:405:1 | exit capture_immut |  |
+| variables.rs:398:20:405:1 | BlockExpr | variables.rs:398:1:405:1 | exit capture_immut (normal) |  |
+| variables.rs:399:5:399:16 | LetStmt | variables.rs:399:13:399:15 | 100 |  |
+| variables.rs:399:9:399:9 | x | variables.rs:400:5:402:6 | LetStmt | match |
+| variables.rs:399:13:399:15 | 100 | variables.rs:399:9:399:9 | x |  |
+| variables.rs:400:5:402:6 | LetStmt | variables.rs:400:19:402:5 | ClosureExpr |  |
+| variables.rs:400:9:400:15 | cap | variables.rs:403:5:403:10 | ExprStmt | match |
+| variables.rs:400:19:402:5 | ClosureExpr | variables.rs:400:9:400:15 | cap |  |
+| variables.rs:400:19:402:5 | enter ClosureExpr | variables.rs:401:9:401:21 | ExprStmt |  |
+| variables.rs:400:19:402:5 | exit ClosureExpr (normal) | variables.rs:400:19:402:5 | exit ClosureExpr |  |
+| variables.rs:400:22:402:5 | BlockExpr | variables.rs:400:19:402:5 | exit ClosureExpr (normal) |  |
+| variables.rs:401:9:401:17 | PathExpr | variables.rs:401:19:401:19 | x |  |
+| variables.rs:401:9:401:20 | CallExpr | variables.rs:400:22:402:5 | BlockExpr |  |
+| variables.rs:401:9:401:21 | ExprStmt | variables.rs:401:9:401:17 | PathExpr |  |
+| variables.rs:401:19:401:19 | x | variables.rs:401:9:401:20 | CallExpr |  |
+| variables.rs:403:5:403:7 | cap | variables.rs:403:5:403:9 | CallExpr |  |
+| variables.rs:403:5:403:9 | CallExpr | variables.rs:404:5:404:17 | ExprStmt |  |
+| variables.rs:403:5:403:10 | ExprStmt | variables.rs:403:5:403:7 | cap |  |
+| variables.rs:404:5:404:13 | PathExpr | variables.rs:404:15:404:15 | x |  |
+| variables.rs:404:5:404:16 | CallExpr | variables.rs:398:20:405:1 | BlockExpr |  |
+| variables.rs:404:5:404:17 | ExprStmt | variables.rs:404:5:404:13 | PathExpr |  |
+| variables.rs:404:15:404:15 | x | variables.rs:404:5:404:16 | CallExpr |  |
+| variables.rs:407:1:421:1 | enter phi | variables.rs:407:8:407:8 | b |  |
+| variables.rs:407:1:421:1 | exit phi (normal) | variables.rs:407:1:421:1 | exit phi |  |
+| variables.rs:407:8:407:8 | b | variables.rs:407:8:407:15 | Param | match |
+| variables.rs:407:8:407:15 | Param | variables.rs:408:5:408:18 | LetStmt |  |
+| variables.rs:407:18:421:1 | BlockExpr | variables.rs:407:1:421:1 | exit phi (normal) |  |
+| variables.rs:408:5:408:18 | LetStmt | variables.rs:408:17:408:17 | 1 |  |
+| variables.rs:408:9:408:13 | x | variables.rs:409:5:409:17 | ExprStmt | match |
+| variables.rs:408:17:408:17 | 1 | variables.rs:408:9:408:13 | x |  |
+| variables.rs:409:5:409:13 | PathExpr | variables.rs:409:15:409:15 | x |  |
+| variables.rs:409:5:409:16 | CallExpr | variables.rs:410:5:410:21 | ExprStmt |  |
+| variables.rs:409:5:409:17 | ExprStmt | variables.rs:409:5:409:13 | PathExpr |  |
+| variables.rs:409:15:409:15 | x | variables.rs:409:5:409:16 | CallExpr |  |
+| variables.rs:410:5:410:13 | PathExpr | variables.rs:410:15:410:15 | x |  |
+| variables.rs:410:5:410:20 | CallExpr | variables.rs:411:5:419:5 | ExprStmt |  |
+| variables.rs:410:5:410:21 | ExprStmt | variables.rs:410:5:410:13 | PathExpr |  |
+| variables.rs:410:15:410:15 | x | variables.rs:410:19:410:19 | 1 |  |
+| variables.rs:410:15:410:19 | ... + ... | variables.rs:410:5:410:20 | CallExpr |  |
+| variables.rs:410:19:410:19 | 1 | variables.rs:410:15:410:19 | ... + ... |  |
+| variables.rs:411:5:419:5 | ExprStmt | variables.rs:411:8:411:8 | b |  |
+| variables.rs:411:5:419:5 | IfExpr | variables.rs:420:5:420:17 | ExprStmt |  |
+| variables.rs:411:8:411:8 | b | variables.rs:412:9:412:14 | ExprStmt | true |
+| variables.rs:411:8:411:8 | b | variables.rs:416:9:416:14 | ExprStmt | false |
+| variables.rs:411:10:415:5 | BlockExpr | variables.rs:411:5:419:5 | IfExpr |  |
+| variables.rs:412:9:412:9 | x | variables.rs:412:13:412:13 | 2 |  |
+| variables.rs:412:9:412:13 | ... = ... | variables.rs:413:9:413:21 | ExprStmt |  |
+| variables.rs:412:9:412:14 | ExprStmt | variables.rs:412:9:412:9 | x |  |
+| variables.rs:412:13:412:13 | 2 | variables.rs:412:9:412:13 | ... = ... |  |
+| variables.rs:413:9:413:17 | PathExpr | variables.rs:413:19:413:19 | x |  |
+| variables.rs:413:9:413:20 | CallExpr | variables.rs:414:9:414:25 | ExprStmt |  |
+| variables.rs:413:9:413:21 | ExprStmt | variables.rs:413:9:413:17 | PathExpr |  |
+| variables.rs:413:19:413:19 | x | variables.rs:413:9:413:20 | CallExpr |  |
+| variables.rs:414:9:414:17 | PathExpr | variables.rs:414:19:414:19 | x |  |
+| variables.rs:414:9:414:24 | CallExpr | variables.rs:411:10:415:5 | BlockExpr |  |
+| variables.rs:414:9:414:25 | ExprStmt | variables.rs:414:9:414:17 | PathExpr |  |
+| variables.rs:414:19:414:19 | x | variables.rs:414:23:414:23 | 1 |  |
+| variables.rs:414:19:414:23 | ... + ... | variables.rs:414:9:414:24 | CallExpr |  |
+| variables.rs:414:23:414:23 | 1 | variables.rs:414:19:414:23 | ... + ... |  |
+| variables.rs:415:12:419:5 | BlockExpr | variables.rs:411:5:419:5 | IfExpr |  |
+| variables.rs:416:9:416:9 | x | variables.rs:416:13:416:13 | 3 |  |
+| variables.rs:416:9:416:13 | ... = ... | variables.rs:417:9:417:21 | ExprStmt |  |
+| variables.rs:416:9:416:14 | ExprStmt | variables.rs:416:9:416:9 | x |  |
+| variables.rs:416:13:416:13 | 3 | variables.rs:416:9:416:13 | ... = ... |  |
+| variables.rs:417:9:417:17 | PathExpr | variables.rs:417:19:417:19 | x |  |
+| variables.rs:417:9:417:20 | CallExpr | variables.rs:418:9:418:25 | ExprStmt |  |
+| variables.rs:417:9:417:21 | ExprStmt | variables.rs:417:9:417:17 | PathExpr |  |
+| variables.rs:417:19:417:19 | x | variables.rs:417:9:417:20 | CallExpr |  |
+| variables.rs:418:9:418:17 | PathExpr | variables.rs:418:19:418:19 | x |  |
+| variables.rs:418:9:418:24 | CallExpr | variables.rs:415:12:419:5 | BlockExpr |  |
+| variables.rs:418:9:418:25 | ExprStmt | variables.rs:418:9:418:17 | PathExpr |  |
+| variables.rs:418:19:418:19 | x | variables.rs:418:23:418:23 | 1 |  |
+| variables.rs:418:19:418:23 | ... + ... | variables.rs:418:9:418:24 | CallExpr |  |
+| variables.rs:418:23:418:23 | 1 | variables.rs:418:19:418:23 | ... + ... |  |
+| variables.rs:420:5:420:13 | PathExpr | variables.rs:420:15:420:15 | x |  |
+| variables.rs:420:5:420:16 | CallExpr | variables.rs:407:18:421:1 | BlockExpr |  |
+| variables.rs:420:5:420:17 | ExprStmt | variables.rs:420:5:420:13 | PathExpr |  |
+| variables.rs:420:15:420:15 | x | variables.rs:420:5:420:16 | CallExpr |  |
+| variables.rs:423:1:436:1 | enter phi_read | variables.rs:423:13:423:14 | b1 |  |
+| variables.rs:423:1:436:1 | exit phi_read (normal) | variables.rs:423:1:436:1 | exit phi_read |  |
+| variables.rs:423:13:423:14 | b1 | variables.rs:423:13:423:21 | Param | match |
+| variables.rs:423:13:423:21 | Param | variables.rs:423:24:423:25 | b2 |  |
+| variables.rs:423:24:423:25 | b2 | variables.rs:423:24:423:32 | Param | match |
+| variables.rs:423:24:423:32 | Param | variables.rs:424:5:424:14 | LetStmt |  |
+| variables.rs:423:35:436:1 | BlockExpr | variables.rs:423:1:436:1 | exit phi_read (normal) |  |
+| variables.rs:424:5:424:14 | LetStmt | variables.rs:424:13:424:13 | 1 |  |
+| variables.rs:424:9:424:9 | x | variables.rs:425:5:429:5 | ExprStmt | match |
+| variables.rs:424:13:424:13 | 1 | variables.rs:424:9:424:9 | x |  |
+| variables.rs:425:5:429:5 | ExprStmt | variables.rs:425:8:425:9 | b1 |  |
+| variables.rs:425:5:429:5 | IfExpr | variables.rs:431:8:431:9 | b2 |  |
+| variables.rs:425:8:425:9 | b1 | variables.rs:426:9:426:21 | ExprStmt | true |
+| variables.rs:425:8:425:9 | b1 | variables.rs:428:9:428:21 | ExprStmt | false |
+| variables.rs:425:11:427:5 | BlockExpr | variables.rs:425:5:429:5 | IfExpr |  |
+| variables.rs:426:9:426:17 | PathExpr | variables.rs:426:19:426:19 | x |  |
+| variables.rs:426:9:426:20 | CallExpr | variables.rs:425:11:427:5 | BlockExpr |  |
+| variables.rs:426:9:426:21 | ExprStmt | variables.rs:426:9:426:17 | PathExpr |  |
+| variables.rs:426:19:426:19 | x | variables.rs:426:9:426:20 | CallExpr |  |
+| variables.rs:427:12:429:5 | BlockExpr | variables.rs:425:5:429:5 | IfExpr |  |
+| variables.rs:428:9:428:17 | PathExpr | variables.rs:428:19:428:19 | x |  |
+| variables.rs:428:9:428:20 | CallExpr | variables.rs:427:12:429:5 | BlockExpr |  |
+| variables.rs:428:9:428:21 | ExprStmt | variables.rs:428:9:428:17 | PathExpr |  |
+| variables.rs:428:19:428:19 | x | variables.rs:428:9:428:20 | CallExpr |  |
+| variables.rs:431:5:435:5 | IfExpr | variables.rs:423:35:436:1 | BlockExpr |  |
+| variables.rs:431:8:431:9 | b2 | variables.rs:432:9:432:21 | ExprStmt | true |
+| variables.rs:431:8:431:9 | b2 | variables.rs:434:9:434:21 | ExprStmt | false |
+| variables.rs:431:11:433:5 | BlockExpr | variables.rs:431:5:435:5 | IfExpr |  |
+| variables.rs:432:9:432:17 | PathExpr | variables.rs:432:19:432:19 | x |  |
+| variables.rs:432:9:432:20 | CallExpr | variables.rs:431:11:433:5 | BlockExpr |  |
+| variables.rs:432:9:432:21 | ExprStmt | variables.rs:432:9:432:17 | PathExpr |  |
+| variables.rs:432:19:432:19 | x | variables.rs:432:9:432:20 | CallExpr |  |
+| variables.rs:433:12:435:5 | BlockExpr | variables.rs:431:5:435:5 | IfExpr |  |
+| variables.rs:434:9:434:17 | PathExpr | variables.rs:434:19:434:19 | x |  |
+| variables.rs:434:9:434:20 | CallExpr | variables.rs:433:12:435:5 | BlockExpr |  |
+| variables.rs:434:9:434:21 | ExprStmt | variables.rs:434:9:434:17 | PathExpr |  |
+| variables.rs:434:19:434:19 | x | variables.rs:434:9:434:20 | CallExpr |  |
+| variables.rs:444:5:446:5 | enter my_get | variables.rs:445:9:445:24 | ExprStmt |  |
+| variables.rs:444:5:446:5 | exit my_get (normal) | variables.rs:444:5:446:5 | exit my_get |  |
+| variables.rs:445:9:445:23 | ReturnExpr | variables.rs:444:5:446:5 | exit my_get (normal) | return |
+| variables.rs:445:9:445:24 | ExprStmt | variables.rs:445:16:445:19 | PathExpr |  |
+| variables.rs:445:16:445:19 | PathExpr | variables.rs:445:16:445:23 | FieldExpr |  |
+| variables.rs:445:16:445:23 | FieldExpr | variables.rs:445:9:445:23 | ReturnExpr |  |
+| variables.rs:449:1:456:1 | enter structs | variables.rs:450:5:450:36 | LetStmt |  |
+| variables.rs:449:1:456:1 | exit structs (normal) | variables.rs:449:1:456:1 | exit structs |  |
+| variables.rs:449:14:456:1 | BlockExpr | variables.rs:449:1:456:1 | exit structs (normal) |  |
+| variables.rs:450:5:450:36 | LetStmt | variables.rs:450:33:450:33 | 1 |  |
+| variables.rs:450:9:450:13 | a | variables.rs:451:5:451:26 | ExprStmt | match |
+| variables.rs:450:17:450:35 | RecordExpr | variables.rs:450:9:450:13 | a |  |
+| variables.rs:450:33:450:33 | 1 | variables.rs:450:17:450:35 | RecordExpr |  |
+| variables.rs:451:5:451:13 | PathExpr | variables.rs:451:15:451:15 | a |  |
+| variables.rs:451:5:451:25 | CallExpr | variables.rs:452:5:452:14 | ExprStmt |  |
+| variables.rs:451:5:451:26 | ExprStmt | variables.rs:451:5:451:13 | PathExpr |  |
+| variables.rs:451:15:451:15 | a | variables.rs:451:15:451:24 | MethodCallExpr |  |
+| variables.rs:451:15:451:24 | MethodCallExpr | variables.rs:451:5:451:25 | CallExpr |  |
+| variables.rs:452:5:452:5 | a | variables.rs:452:5:452:9 | FieldExpr |  |
+| variables.rs:452:5:452:9 | FieldExpr | variables.rs:452:13:452:13 | 5 |  |
+| variables.rs:452:5:452:13 | ... = ... | variables.rs:453:5:453:26 | ExprStmt |  |
+| variables.rs:452:5:452:14 | ExprStmt | variables.rs:452:5:452:5 | a |  |
+| variables.rs:452:13:452:13 | 5 | variables.rs:452:5:452:13 | ... = ... |  |
+| variables.rs:453:5:453:13 | PathExpr | variables.rs:453:15:453:15 | a |  |
+| variables.rs:453:5:453:25 | CallExpr | variables.rs:454:5:454:28 | ExprStmt |  |
+| variables.rs:453:5:453:26 | ExprStmt | variables.rs:453:5:453:13 | PathExpr |  |
+| variables.rs:453:15:453:15 | a | variables.rs:453:15:453:24 | MethodCallExpr |  |
+| variables.rs:453:15:453:24 | MethodCallExpr | variables.rs:453:5:453:25 | CallExpr |  |
+| variables.rs:454:5:454:5 | a | variables.rs:454:25:454:25 | 2 |  |
+| variables.rs:454:5:454:27 | ... = ... | variables.rs:455:5:455:26 | ExprStmt |  |
+| variables.rs:454:5:454:28 | ExprStmt | variables.rs:454:5:454:5 | a |  |
+| variables.rs:454:9:454:27 | RecordExpr | variables.rs:454:5:454:27 | ... = ... |  |
+| variables.rs:454:25:454:25 | 2 | variables.rs:454:9:454:27 | RecordExpr |  |
+| variables.rs:455:5:455:13 | PathExpr | variables.rs:455:15:455:15 | a |  |
+| variables.rs:455:5:455:25 | CallExpr | variables.rs:449:14:456:1 | BlockExpr |  |
+| variables.rs:455:5:455:26 | ExprStmt | variables.rs:455:5:455:13 | PathExpr |  |
+| variables.rs:455:15:455:15 | a | variables.rs:455:15:455:24 | MethodCallExpr |  |
+| variables.rs:455:15:455:24 | MethodCallExpr | variables.rs:455:5:455:25 | CallExpr |  |
+| variables.rs:458:1:460:1 | enter ref_param | variables.rs:458:14:458:14 | x |  |
+| variables.rs:458:1:460:1 | exit ref_param (normal) | variables.rs:458:1:460:1 | exit ref_param |  |
+| variables.rs:458:14:458:14 | x | variables.rs:458:14:458:20 | Param | match |
+| variables.rs:458:14:458:20 | Param | variables.rs:459:5:459:13 | PathExpr |  |
+| variables.rs:458:23:460:1 | BlockExpr | variables.rs:458:1:460:1 | exit ref_param (normal) |  |
+| variables.rs:459:5:459:13 | PathExpr | variables.rs:459:16:459:16 | x |  |
+| variables.rs:459:5:459:17 | CallExpr | variables.rs:458:23:460:1 | BlockExpr |  |
+| variables.rs:459:15:459:16 | * ... | variables.rs:459:5:459:17 | CallExpr |  |
+| variables.rs:459:16:459:16 | x | variables.rs:459:15:459:16 | * ... |  |
+| variables.rs:462:1:469:1 | enter ref_arg | variables.rs:463:5:463:15 | LetStmt |  |
+| variables.rs:462:1:469:1 | exit ref_arg (normal) | variables.rs:462:1:469:1 | exit ref_arg |  |
+| variables.rs:462:14:469:1 | BlockExpr | variables.rs:462:1:469:1 | exit ref_arg (normal) |  |
+| variables.rs:463:5:463:15 | LetStmt | variables.rs:463:13:463:14 | 16 |  |
+| variables.rs:463:9:463:9 | x | variables.rs:464:5:464:18 | ExprStmt | match |
+| variables.rs:463:13:463:14 | 16 | variables.rs:463:9:463:9 | x |  |
+| variables.rs:464:5:464:13 | PathExpr | variables.rs:464:16:464:16 | x |  |
+| variables.rs:464:5:464:17 | CallExpr | variables.rs:465:5:465:17 | ExprStmt |  |
+| variables.rs:464:5:464:18 | ExprStmt | variables.rs:464:5:464:13 | PathExpr |  |
+| variables.rs:464:15:464:16 | RefExpr | variables.rs:464:5:464:17 | CallExpr |  |
+| variables.rs:464:16:464:16 | x | variables.rs:464:15:464:16 | RefExpr |  |
+| variables.rs:465:5:465:13 | PathExpr | variables.rs:465:15:465:15 | x |  |
+| variables.rs:465:5:465:16 | CallExpr | variables.rs:467:5:467:15 | LetStmt |  |
+| variables.rs:465:5:465:17 | ExprStmt | variables.rs:465:5:465:13 | PathExpr |  |
+| variables.rs:465:15:465:15 | x | variables.rs:465:5:465:16 | CallExpr |  |
+| variables.rs:467:5:467:15 | LetStmt | variables.rs:467:13:467:14 | 17 |  |
+| variables.rs:467:9:467:9 | z | variables.rs:468:5:468:18 | ExprStmt | match |
+| variables.rs:467:13:467:14 | 17 | variables.rs:467:9:467:9 | z |  |
+| variables.rs:468:5:468:13 | PathExpr | variables.rs:468:16:468:16 | z |  |
+| variables.rs:468:5:468:17 | CallExpr | variables.rs:462:14:469:1 | BlockExpr |  |
+| variables.rs:468:5:468:18 | ExprStmt | variables.rs:468:5:468:13 | PathExpr |  |
+| variables.rs:468:15:468:16 | RefExpr | variables.rs:468:5:468:17 | CallExpr |  |
+| variables.rs:468:16:468:16 | z | variables.rs:468:15:468:16 | RefExpr |  |
+| variables.rs:476:3:478:3 | enter bar | variables.rs:477:5:477:32 | ExprStmt |  |
+| variables.rs:476:3:478:3 | exit bar (normal) | variables.rs:476:3:478:3 | exit bar |  |
+| variables.rs:476:21:478:3 | BlockExpr | variables.rs:476:3:478:3 | exit bar (normal) |  |
+| variables.rs:477:5:477:9 | * ... | variables.rs:477:29:477:29 | 3 |  |
+| variables.rs:477:5:477:31 | ... = ... | variables.rs:476:21:478:3 | BlockExpr |  |
+| variables.rs:477:5:477:32 | ExprStmt | variables.rs:477:6:477:9 | PathExpr |  |
+| variables.rs:477:6:477:9 | PathExpr | variables.rs:477:5:477:9 | * ... |  |
+| variables.rs:477:13:477:31 | RecordExpr | variables.rs:477:5:477:31 | ... = ... |  |
+| variables.rs:477:29:477:29 | 3 | variables.rs:477:13:477:31 | RecordExpr |  |
+| variables.rs:481:1:486:1 | enter ref_methodcall_receiver | variables.rs:482:3:482:34 | LetStmt |  |
+| variables.rs:481:1:486:1 | exit ref_methodcall_receiver (normal) | variables.rs:481:1:486:1 | exit ref_methodcall_receiver |  |
+| variables.rs:481:30:486:1 | BlockExpr | variables.rs:481:1:486:1 | exit ref_methodcall_receiver (normal) |  |
+| variables.rs:482:3:482:34 | LetStmt | variables.rs:482:31:482:31 | 1 |  |
+| variables.rs:482:7:482:11 | a | variables.rs:483:3:483:10 | ExprStmt | match |
+| variables.rs:482:15:482:33 | RecordExpr | variables.rs:482:7:482:11 | a |  |
+| variables.rs:482:31:482:31 | 1 | variables.rs:482:15:482:33 | RecordExpr |  |
+| variables.rs:483:3:483:3 | a | variables.rs:483:3:483:9 | MethodCallExpr |  |
+| variables.rs:483:3:483:9 | MethodCallExpr | variables.rs:485:3:485:19 | ExprStmt |  |
+| variables.rs:483:3:483:10 | ExprStmt | variables.rs:483:3:483:3 | a |  |
+| variables.rs:485:3:485:11 | PathExpr | variables.rs:485:13:485:13 | a |  |
+| variables.rs:485:3:485:18 | CallExpr | variables.rs:481:30:486:1 | BlockExpr |  |
+| variables.rs:485:3:485:19 | ExprStmt | variables.rs:485:3:485:11 | PathExpr |  |
+| variables.rs:485:13:485:13 | a | variables.rs:485:13:485:17 | FieldExpr |  |
+| variables.rs:485:13:485:17 | FieldExpr | variables.rs:485:3:485:18 | CallExpr |  |
+| variables.rs:488:1:520:1 | enter main | variables.rs:489:5:489:25 | ExprStmt |  |
+| variables.rs:488:1:520:1 | exit main (normal) | variables.rs:488:1:520:1 | exit main |  |
+| variables.rs:488:11:520:1 | BlockExpr | variables.rs:488:1:520:1 | exit main (normal) |  |
+| variables.rs:489:5:489:22 | PathExpr | variables.rs:489:5:489:24 | CallExpr |  |
+| variables.rs:489:5:489:24 | CallExpr | variables.rs:490:5:490:23 | ExprStmt |  |
+| variables.rs:489:5:489:25 | ExprStmt | variables.rs:489:5:489:22 | PathExpr |  |
+| variables.rs:490:5:490:20 | PathExpr | variables.rs:490:5:490:22 | CallExpr |  |
+| variables.rs:490:5:490:22 | CallExpr | variables.rs:491:5:491:23 | ExprStmt |  |
+| variables.rs:490:5:490:23 | ExprStmt | variables.rs:490:5:490:20 | PathExpr |  |
+| variables.rs:491:5:491:20 | PathExpr | variables.rs:491:5:491:22 | CallExpr |  |
+| variables.rs:491:5:491:22 | CallExpr | variables.rs:492:5:492:23 | ExprStmt |  |
+| variables.rs:491:5:491:23 | ExprStmt | variables.rs:491:5:491:20 | PathExpr |  |
+| variables.rs:492:5:492:20 | PathExpr | variables.rs:492:5:492:22 | CallExpr |  |
+| variables.rs:492:5:492:22 | CallExpr | variables.rs:493:5:493:19 | ExprStmt |  |
+| variables.rs:492:5:492:23 | ExprStmt | variables.rs:492:5:492:20 | PathExpr |  |
+| variables.rs:493:5:493:16 | PathExpr | variables.rs:493:5:493:18 | CallExpr |  |
+| variables.rs:493:5:493:18 | CallExpr | variables.rs:494:5:494:19 | ExprStmt |  |
+| variables.rs:493:5:493:19 | ExprStmt | variables.rs:493:5:493:16 | PathExpr |  |
+| variables.rs:494:5:494:16 | PathExpr | variables.rs:494:5:494:18 | CallExpr |  |
+| variables.rs:494:5:494:18 | CallExpr | variables.rs:495:5:495:19 | ExprStmt |  |
+| variables.rs:494:5:494:19 | ExprStmt | variables.rs:494:5:494:16 | PathExpr |  |
+| variables.rs:495:5:495:16 | PathExpr | variables.rs:495:5:495:18 | CallExpr |  |
+| variables.rs:495:5:495:18 | CallExpr | variables.rs:496:5:496:19 | ExprStmt |  |
+| variables.rs:495:5:495:19 | ExprStmt | variables.rs:495:5:495:16 | PathExpr |  |
+| variables.rs:496:5:496:16 | PathExpr | variables.rs:496:5:496:18 | CallExpr |  |
+| variables.rs:496:5:496:18 | CallExpr | variables.rs:497:5:497:21 | ExprStmt |  |
+| variables.rs:496:5:496:19 | ExprStmt | variables.rs:496:5:496:16 | PathExpr |  |
+| variables.rs:497:5:497:18 | PathExpr | variables.rs:497:5:497:20 | CallExpr |  |
+| variables.rs:497:5:497:20 | CallExpr | variables.rs:498:5:498:21 | ExprStmt |  |
+| variables.rs:497:5:497:21 | ExprStmt | variables.rs:497:5:497:18 | PathExpr |  |
+| variables.rs:498:5:498:18 | PathExpr | variables.rs:498:5:498:20 | CallExpr |  |
+| variables.rs:498:5:498:20 | CallExpr | variables.rs:499:5:499:21 | ExprStmt |  |
+| variables.rs:498:5:498:21 | ExprStmt | variables.rs:498:5:498:18 | PathExpr |  |
+| variables.rs:499:5:499:18 | PathExpr | variables.rs:499:5:499:20 | CallExpr |  |
+| variables.rs:499:5:499:20 | CallExpr | variables.rs:500:5:500:21 | ExprStmt |  |
+| variables.rs:499:5:499:21 | ExprStmt | variables.rs:499:5:499:18 | PathExpr |  |
+| variables.rs:500:5:500:18 | PathExpr | variables.rs:500:5:500:20 | CallExpr |  |
+| variables.rs:500:5:500:20 | CallExpr | variables.rs:501:5:501:21 | ExprStmt |  |
+| variables.rs:500:5:500:21 | ExprStmt | variables.rs:500:5:500:18 | PathExpr |  |
+| variables.rs:501:5:501:18 | PathExpr | variables.rs:501:5:501:20 | CallExpr |  |
+| variables.rs:501:5:501:20 | CallExpr | variables.rs:502:5:502:21 | ExprStmt |  |
+| variables.rs:501:5:501:21 | ExprStmt | variables.rs:501:5:501:18 | PathExpr |  |
+| variables.rs:502:5:502:18 | PathExpr | variables.rs:502:5:502:20 | CallExpr |  |
+| variables.rs:502:5:502:20 | CallExpr | variables.rs:503:5:503:21 | ExprStmt |  |
+| variables.rs:502:5:502:21 | ExprStmt | variables.rs:502:5:502:18 | PathExpr |  |
+| variables.rs:503:5:503:18 | PathExpr | variables.rs:503:5:503:20 | CallExpr |  |
+| variables.rs:503:5:503:20 | CallExpr | variables.rs:504:5:504:21 | ExprStmt |  |
+| variables.rs:503:5:503:21 | ExprStmt | variables.rs:503:5:503:18 | PathExpr |  |
+| variables.rs:504:5:504:18 | PathExpr | variables.rs:504:5:504:20 | CallExpr |  |
+| variables.rs:504:5:504:20 | CallExpr | variables.rs:505:5:505:21 | ExprStmt |  |
+| variables.rs:504:5:504:21 | ExprStmt | variables.rs:504:5:504:18 | PathExpr |  |
+| variables.rs:505:5:505:18 | PathExpr | variables.rs:505:5:505:20 | CallExpr |  |
+| variables.rs:505:5:505:20 | CallExpr | variables.rs:506:5:506:36 | ExprStmt |  |
+| variables.rs:505:5:505:21 | ExprStmt | variables.rs:505:5:505:18 | PathExpr |  |
+| variables.rs:506:5:506:18 | PathExpr | variables.rs:506:20:506:22 | "a" |  |
+| variables.rs:506:5:506:35 | CallExpr | variables.rs:507:5:507:37 | ExprStmt |  |
+| variables.rs:506:5:506:36 | ExprStmt | variables.rs:506:5:506:18 | PathExpr |  |
+| variables.rs:506:20:506:22 | "a" | variables.rs:506:26:506:28 | "b" |  |
+| variables.rs:506:25:506:34 | TupleExpr | variables.rs:506:5:506:35 | CallExpr |  |
+| variables.rs:506:26:506:28 | "b" | variables.rs:506:31:506:33 | "c" |  |
+| variables.rs:506:31:506:33 | "c" | variables.rs:506:25:506:34 | TupleExpr |  |
+| variables.rs:507:5:507:18 | PathExpr | variables.rs:507:20:507:31 | PathExpr |  |
+| variables.rs:507:5:507:36 | CallExpr | variables.rs:508:5:508:26 | ExprStmt |  |
+| variables.rs:507:5:507:37 | ExprStmt | variables.rs:507:5:507:18 | PathExpr |  |
+| variables.rs:507:20:507:31 | PathExpr | variables.rs:507:33:507:34 | 45 |  |
+| variables.rs:507:20:507:35 | CallExpr | variables.rs:507:5:507:36 | CallExpr |  |
+| variables.rs:507:33:507:34 | 45 | variables.rs:507:20:507:35 | CallExpr |  |
+| variables.rs:508:5:508:23 | PathExpr | variables.rs:508:5:508:25 | CallExpr |  |
+| variables.rs:508:5:508:25 | CallExpr | variables.rs:509:5:509:23 | ExprStmt |  |
+| variables.rs:508:5:508:26 | ExprStmt | variables.rs:508:5:508:23 | PathExpr |  |
+| variables.rs:509:5:509:20 | PathExpr | variables.rs:509:5:509:22 | CallExpr |  |
+| variables.rs:509:5:509:22 | CallExpr | variables.rs:510:5:510:19 | ExprStmt |  |
+| variables.rs:509:5:509:23 | ExprStmt | variables.rs:509:5:509:20 | PathExpr |  |
+| variables.rs:510:5:510:16 | PathExpr | variables.rs:510:5:510:18 | CallExpr |  |
+| variables.rs:510:5:510:18 | CallExpr | variables.rs:511:5:511:17 | ExprStmt |  |
+| variables.rs:510:5:510:19 | ExprStmt | variables.rs:510:5:510:16 | PathExpr |  |
+| variables.rs:511:5:511:14 | PathExpr | variables.rs:511:5:511:16 | CallExpr |  |
+| variables.rs:511:5:511:16 | CallExpr | variables.rs:512:5:512:13 | ExprStmt |  |
+| variables.rs:511:5:511:17 | ExprStmt | variables.rs:511:5:511:14 | PathExpr |  |
+| variables.rs:512:5:512:10 | PathExpr | variables.rs:512:5:512:12 | CallExpr |  |
+| variables.rs:512:5:512:12 | CallExpr | variables.rs:513:5:513:17 | ExprStmt |  |
+| variables.rs:512:5:512:13 | ExprStmt | variables.rs:512:5:512:10 | PathExpr |  |
+| variables.rs:513:5:513:14 | PathExpr | variables.rs:513:5:513:16 | CallExpr |  |
+| variables.rs:513:5:513:16 | CallExpr | variables.rs:514:5:514:12 | ExprStmt |  |
+| variables.rs:513:5:513:17 | ExprStmt | variables.rs:513:5:513:14 | PathExpr |  |
+| variables.rs:514:5:514:9 | PathExpr | variables.rs:514:5:514:11 | CallExpr |  |
+| variables.rs:514:5:514:11 | CallExpr | variables.rs:515:5:515:18 | ExprStmt |  |
+| variables.rs:514:5:514:12 | ExprStmt | variables.rs:514:5:514:9 | PathExpr |  |
+| variables.rs:515:5:515:15 | PathExpr | variables.rs:515:5:515:17 | CallExpr |  |
+| variables.rs:515:5:515:17 | CallExpr | variables.rs:516:5:516:20 | ExprStmt |  |
+| variables.rs:515:5:515:18 | ExprStmt | variables.rs:515:5:515:15 | PathExpr |  |
+| variables.rs:516:5:516:17 | PathExpr | variables.rs:516:5:516:19 | CallExpr |  |
+| variables.rs:516:5:516:19 | CallExpr | variables.rs:517:5:517:14 | ExprStmt |  |
+| variables.rs:516:5:516:20 | ExprStmt | variables.rs:516:5:516:17 | PathExpr |  |
+| variables.rs:517:5:517:11 | PathExpr | variables.rs:517:5:517:13 | CallExpr |  |
+| variables.rs:517:5:517:13 | CallExpr | variables.rs:518:5:518:14 | ExprStmt |  |
+| variables.rs:517:5:517:14 | ExprStmt | variables.rs:517:5:517:11 | PathExpr |  |
+| variables.rs:518:5:518:11 | PathExpr | variables.rs:518:5:518:13 | CallExpr |  |
+| variables.rs:518:5:518:13 | CallExpr | variables.rs:519:5:519:30 | ExprStmt |  |
+| variables.rs:518:5:518:14 | ExprStmt | variables.rs:518:5:518:11 | PathExpr |  |
+| variables.rs:519:5:519:27 | PathExpr | variables.rs:519:5:519:29 | CallExpr |  |
+| variables.rs:519:5:519:29 | CallExpr | variables.rs:488:11:520:1 | BlockExpr |  |
+| variables.rs:519:5:519:30 | ExprStmt | variables.rs:519:5:519:27 | PathExpr |  |
 breakTarget
 continueTarget

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -1,0 +1,524 @@
+nonSsaVariable
+| variables.rs:330:13:330:13 | a |
+| variables.rs:338:13:338:13 | i |
+| variables.rs:361:13:361:13 | x |
+| variables.rs:368:13:368:13 | z |
+| variables.rs:381:13:381:13 | x |
+| variables.rs:389:13:389:13 | x |
+| variables.rs:450:13:450:13 | a |
+| variables.rs:482:11:482:11 | a |
+definition
+| variables.rs:3:14:3:14 | s | variables.rs:3:14:3:14 | s |
+| variables.rs:7:14:7:14 | i | variables.rs:7:14:7:14 | i |
+| variables.rs:12:9:12:10 | x1 | variables.rs:12:9:12:10 | x1 |
+| variables.rs:17:9:17:14 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 |
+| variables.rs:26:9:26:10 | x3 | variables.rs:26:9:26:10 | x3 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 |
+| variables.rs:35:13:35:14 | x4 | variables.rs:35:13:35:14 | x4 |
+| variables.rs:49:13:49:14 | a1 | variables.rs:49:13:49:14 | a1 |
+| variables.rs:50:13:50:14 | b1 | variables.rs:50:13:50:14 | b1 |
+| variables.rs:53:13:53:13 | x | variables.rs:53:13:53:13 | x |
+| variables.rs:54:13:54:13 | y | variables.rs:54:13:54:13 | y |
+| variables.rs:64:9:64:10 | p1 | variables.rs:64:9:64:10 | p1 |
+| variables.rs:66:12:66:13 | a2 | variables.rs:66:12:66:13 | a2 |
+| variables.rs:67:12:67:13 | b2 | variables.rs:67:12:67:13 | b2 |
+| variables.rs:74:9:74:10 | s1 | variables.rs:74:9:74:10 | s1 |
+| variables.rs:76:17:76:22 | s2 | variables.rs:76:21:76:22 | s2 |
+| variables.rs:83:14:83:15 | x5 | variables.rs:83:14:83:15 | x5 |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:9:91:10 | s1 |
+| variables.rs:93:20:93:25 | s2 | variables.rs:93:24:93:25 | s2 |
+| variables.rs:100:9:100:10 | x6 | variables.rs:100:9:100:10 | x6 |
+| variables.rs:101:9:101:10 | y1 | variables.rs:101:9:101:10 | y1 |
+| variables.rs:105:14:105:15 | y1 | variables.rs:105:14:105:15 | y1 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers |
+| variables.rs:121:13:121:17 | first | variables.rs:121:13:121:17 | first |
+| variables.rs:122:13:122:17 | third | variables.rs:122:13:122:17 | third |
+| variables.rs:123:13:123:17 | fifth | variables.rs:123:13:123:17 | fifth |
+| variables.rs:133:13:133:17 | first | variables.rs:133:13:133:17 | first |
+| variables.rs:135:13:135:16 | last | variables.rs:135:13:135:16 | last |
+| variables.rs:144:9:144:10 | p2 | variables.rs:144:9:144:10 | p2 |
+| variables.rs:148:16:148:17 | x7 | variables.rs:148:16:148:17 | x7 |
+| variables.rs:158:9:158:11 | msg | variables.rs:158:9:158:11 | msg |
+| variables.rs:162:17:162:35 | [match(true)] id_variable | variables.rs:162:17:162:27 | id_variable |
+| variables.rs:167:26:167:27 | id | variables.rs:167:26:167:27 | id |
+| variables.rs:178:9:178:14 | either | variables.rs:178:9:178:14 | either |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 |
+| variables.rs:180:22:180:23 | a3 | variables.rs:180:9:180:44 | a3 |
+| variables.rs:180:42:180:43 | a3 | variables.rs:180:9:180:44 | a3 |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 |
+| variables.rs:194:28:194:29 | a4 | variables.rs:194:9:194:81 | a4 |
+| variables.rs:194:54:194:55 | a4 | variables.rs:194:9:194:81 | a4 |
+| variables.rs:194:79:194:80 | a4 | variables.rs:194:9:194:81 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 |
+| variables.rs:198:10:198:57 | [match(true)] phi | variables.rs:198:9:198:83 | a5 |
+| variables.rs:198:29:198:30 | a5 | variables.rs:198:9:198:83 | a5 |
+| variables.rs:198:55:198:56 | a5 | variables.rs:198:9:198:83 | a5 |
+| variables.rs:198:81:198:82 | a5 | variables.rs:198:9:198:83 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 |
+| variables.rs:202:28:202:29 | a6 | variables.rs:202:9:202:83 | a6 |
+| variables.rs:202:35:202:82 | [match(true)] phi | variables.rs:202:9:202:83 | a6 |
+| variables.rs:202:55:202:56 | a6 | variables.rs:202:9:202:83 | a6 |
+| variables.rs:202:80:202:81 | a6 | variables.rs:202:9:202:83 | a6 |
+| variables.rs:208:9:208:14 | either | variables.rs:208:9:208:14 | either |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 |
+| variables.rs:210:22:210:23 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:210:42:210:43 | a7 | variables.rs:210:9:210:44 | a7 |
+| variables.rs:218:9:218:14 | either | variables.rs:218:9:218:14 | either |
+| variables.rs:221:9:222:52 | [match(true)] e | variables.rs:221:13:221:13 | e |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 |
+| variables.rs:222:27:222:29 | a11 | variables.rs:222:14:222:51 | a11 |
+| variables.rs:222:48:222:50 | a11 | variables.rs:222:14:222:51 | a11 |
+| variables.rs:225:33:225:35 | a12 | variables.rs:225:33:225:35 | a12 |
+| variables.rs:242:9:242:10 | fv | variables.rs:242:9:242:10 | fv |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 |
+| variables.rs:244:27:244:29 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:244:35:244:82 | [match(true)] phi | variables.rs:244:9:244:109 | a13 |
+| variables.rs:244:54:244:56 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:244:79:244:81 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:244:106:244:108 | a13 | variables.rs:244:9:244:109 | a13 |
+| variables.rs:250:5:250:6 | a8 | variables.rs:250:5:250:6 | a8 |
+| variables.rs:252:9:252:10 | b3 | variables.rs:252:9:252:10 | b3 |
+| variables.rs:253:9:253:10 | c1 | variables.rs:253:9:253:10 | c1 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 |
+| variables.rs:261:19:261:20 | a9 | variables.rs:261:6:261:41 | a9 |
+| variables.rs:261:39:261:40 | a9 | variables.rs:261:6:261:41 | a9 |
+| variables.rs:268:9:268:15 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:269:9:269:14 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:270:9:270:14 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:291:13:291:15 | a10 | variables.rs:291:13:291:15 | a10 |
+| variables.rs:292:13:292:14 | b4 | variables.rs:292:13:292:14 | b4 |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:304:9:304:23 | example_closure |
+| variables.rs:305:10:305:10 | x | variables.rs:305:10:305:10 | x |
+| variables.rs:307:9:307:10 | n1 | variables.rs:307:9:307:10 | n1 |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable |
+| variables.rs:313:10:313:10 | x | variables.rs:313:10:313:10 | x |
+| variables.rs:315:9:315:10 | n2 | variables.rs:315:9:315:10 | n2 |
+| variables.rs:321:9:321:9 | v | variables.rs:321:9:321:9 | v |
+| variables.rs:323:9:323:12 | text | variables.rs:323:9:323:12 | text |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:339:9:339:13 | ref_i |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:352:39:352:39 | y | variables.rs:352:39:352:39 | y |
+| variables.rs:362:9:362:9 | y | variables.rs:362:9:362:9 | y |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w |
+| variables.rs:382:9:382:9 | y | variables.rs:382:9:382:9 | y |
+| variables.rs:390:9:390:15 | cap | variables.rs:390:13:390:15 | cap |
+| variables.rs:399:9:399:9 | x | variables.rs:399:9:399:9 | x |
+| variables.rs:400:9:400:15 | cap | variables.rs:400:13:400:15 | cap |
+| variables.rs:400:19:402:5 | <captured entry> x | variables.rs:399:9:399:9 | x |
+| variables.rs:407:8:407:8 | b | variables.rs:407:8:407:8 | b |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:423:13:423:14 | b1 | variables.rs:423:13:423:14 | b1 |
+| variables.rs:423:24:423:25 | b2 | variables.rs:423:24:423:25 | b2 |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:458:14:458:14 | x | variables.rs:458:14:458:14 | x |
+| variables.rs:463:9:463:9 | x | variables.rs:463:9:463:9 | x |
+| variables.rs:467:9:467:9 | z | variables.rs:467:9:467:9 | z |
+read
+| variables.rs:3:14:3:14 | s | variables.rs:3:14:3:14 | s | variables.rs:4:20:4:20 | s |
+| variables.rs:7:14:7:14 | i | variables.rs:7:14:7:14 | i | variables.rs:8:20:8:20 | i |
+| variables.rs:12:9:12:10 | x1 | variables.rs:12:9:12:10 | x1 | variables.rs:13:15:13:16 | x1 |
+| variables.rs:17:9:17:14 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:18:15:18:16 | x2 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:20:15:20:16 | x2 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 | variables.rs:25:15:25:16 | x3 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 | variables.rs:27:9:27:10 | x3 |
+| variables.rs:26:9:26:10 | x3 | variables.rs:26:9:26:10 | x3 | variables.rs:28:15:28:16 | x3 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 | variables.rs:33:15:33:16 | x4 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 | variables.rs:38:15:38:16 | x4 |
+| variables.rs:35:13:35:14 | x4 | variables.rs:35:13:35:14 | x4 | variables.rs:36:19:36:20 | x4 |
+| variables.rs:49:13:49:14 | a1 | variables.rs:49:13:49:14 | a1 | variables.rs:57:15:57:16 | a1 |
+| variables.rs:50:13:50:14 | b1 | variables.rs:50:13:50:14 | b1 | variables.rs:58:15:58:16 | b1 |
+| variables.rs:53:13:53:13 | x | variables.rs:53:13:53:13 | x | variables.rs:59:15:59:15 | x |
+| variables.rs:54:13:54:13 | y | variables.rs:54:13:54:13 | y | variables.rs:60:15:60:15 | y |
+| variables.rs:64:9:64:10 | p1 | variables.rs:64:9:64:10 | p1 | variables.rs:68:9:68:10 | p1 |
+| variables.rs:66:12:66:13 | a2 | variables.rs:66:12:66:13 | a2 | variables.rs:69:15:69:16 | a2 |
+| variables.rs:67:12:67:13 | b2 | variables.rs:67:12:67:13 | b2 | variables.rs:70:15:70:16 | b2 |
+| variables.rs:74:9:74:10 | s1 | variables.rs:74:9:74:10 | s1 | variables.rs:77:11:77:12 | s1 |
+| variables.rs:76:17:76:22 | s2 | variables.rs:76:21:76:22 | s2 | variables.rs:78:19:78:20 | s2 |
+| variables.rs:83:14:83:15 | x5 | variables.rs:83:14:83:15 | x5 | variables.rs:87:15:87:16 | x5 |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:9:91:10 | s1 | variables.rs:94:11:94:12 | s1 |
+| variables.rs:93:20:93:25 | s2 | variables.rs:93:24:93:25 | s2 | variables.rs:95:19:95:20 | s2 |
+| variables.rs:100:9:100:10 | x6 | variables.rs:100:9:100:10 | x6 | variables.rs:103:11:103:12 | x6 |
+| variables.rs:101:9:101:10 | y1 | variables.rs:101:9:101:10 | y1 | variables.rs:113:15:113:16 | y1 |
+| variables.rs:105:14:105:15 | y1 | variables.rs:105:14:105:15 | y1 | variables.rs:108:23:108:24 | y1 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers | variables.rs:119:11:119:17 | numbers |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers | variables.rs:131:11:131:17 | numbers |
+| variables.rs:121:13:121:17 | first | variables.rs:121:13:121:17 | first | variables.rs:125:23:125:27 | first |
+| variables.rs:122:13:122:17 | third | variables.rs:122:13:122:17 | third | variables.rs:126:23:126:27 | third |
+| variables.rs:123:13:123:17 | fifth | variables.rs:123:13:123:17 | fifth | variables.rs:127:23:127:27 | fifth |
+| variables.rs:133:13:133:17 | first | variables.rs:133:13:133:17 | first | variables.rs:137:23:137:27 | first |
+| variables.rs:135:13:135:16 | last | variables.rs:135:13:135:16 | last | variables.rs:138:23:138:26 | last |
+| variables.rs:144:9:144:10 | p2 | variables.rs:144:9:144:10 | p2 | variables.rs:146:11:146:12 | p2 |
+| variables.rs:148:16:148:17 | x7 | variables.rs:148:16:148:17 | x7 | variables.rs:149:24:149:25 | x7 |
+| variables.rs:158:9:158:11 | msg | variables.rs:158:9:158:11 | msg | variables.rs:160:11:160:13 | msg |
+| variables.rs:162:17:162:35 | [match(true)] id_variable | variables.rs:162:17:162:27 | id_variable | variables.rs:163:24:163:34 | id_variable |
+| variables.rs:167:26:167:27 | id | variables.rs:167:26:167:27 | id | variables.rs:168:23:168:24 | id |
+| variables.rs:178:9:178:14 | either | variables.rs:178:9:178:14 | either | variables.rs:179:11:179:16 | either |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 | variables.rs:181:26:181:27 | a3 |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:193:11:193:12 | tv |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:197:11:197:12 | tv |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:201:11:201:12 | tv |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:195:26:195:27 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:199:26:199:27 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:203:26:203:27 | a6 |
+| variables.rs:208:9:208:14 | either | variables.rs:208:9:208:14 | either | variables.rs:209:11:209:16 | either |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:211:16:211:17 | a7 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:212:26:212:27 | a7 |
+| variables.rs:218:9:218:14 | either | variables.rs:218:9:218:14 | either | variables.rs:220:11:220:16 | either |
+| variables.rs:221:9:222:52 | [match(true)] e | variables.rs:221:13:221:13 | e | variables.rs:226:15:226:15 | e |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 | variables.rs:224:23:224:25 | a11 |
+| variables.rs:225:33:225:35 | a12 | variables.rs:225:33:225:35 | a12 | variables.rs:227:28:227:30 | a12 |
+| variables.rs:242:9:242:10 | fv | variables.rs:242:9:242:10 | fv | variables.rs:243:11:243:12 | fv |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:245:26:245:28 | a13 |
+| variables.rs:250:5:250:6 | a8 | variables.rs:250:5:250:6 | a8 | variables.rs:255:15:255:16 | a8 |
+| variables.rs:252:9:252:10 | b3 | variables.rs:252:9:252:10 | b3 | variables.rs:256:15:256:16 | b3 |
+| variables.rs:253:9:253:10 | c1 | variables.rs:253:9:253:10 | c1 | variables.rs:257:15:257:16 | c1 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 | variables.rs:263:15:263:16 | a9 |
+| variables.rs:268:9:268:15 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:272:15:272:17 | a10 |
+| variables.rs:269:9:269:14 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:273:15:273:16 | b4 |
+| variables.rs:270:9:270:14 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:274:15:274:16 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:283:9:283:10 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:287:15:287:16 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:282:9:282:10 | b4 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:286:15:286:16 | b4 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:300:15:300:16 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:281:9:281:11 | a10 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:285:15:285:17 | a10 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:299:15:299:17 | a10 |
+| variables.rs:291:13:291:15 | a10 | variables.rs:291:13:291:15 | a10 | variables.rs:294:23:294:25 | a10 |
+| variables.rs:292:13:292:14 | b4 | variables.rs:292:13:292:14 | b4 | variables.rs:295:23:295:24 | b4 |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:304:9:304:23 | example_closure | variables.rs:308:9:308:23 | example_closure |
+| variables.rs:305:10:305:10 | x | variables.rs:305:10:305:10 | x | variables.rs:306:9:306:9 | x |
+| variables.rs:307:9:307:10 | n1 | variables.rs:307:9:307:10 | n1 | variables.rs:309:15:309:16 | n1 |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable | variables.rs:316:9:316:26 | immutable_variable |
+| variables.rs:313:10:313:10 | x | variables.rs:313:10:313:10 | x | variables.rs:314:9:314:9 | x |
+| variables.rs:315:9:315:10 | n2 | variables.rs:315:9:315:10 | n2 | variables.rs:317:15:317:16 | n2 |
+| variables.rs:321:9:321:9 | v | variables.rs:321:9:321:9 | v | variables.rs:324:12:324:12 | v |
+| variables.rs:323:9:323:12 | text | variables.rs:323:9:323:12 | text | variables.rs:325:19:325:22 | text |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:339:9:339:13 | ref_i | variables.rs:341:6:341:10 | ref_i |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:346:6:346:6 | x |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:347:10:347:10 | x |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:348:10:348:10 | x |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:349:12:349:12 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:353:6:353:6 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:354:10:354:10 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:355:10:355:10 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:357:9:357:9 | x |
+| variables.rs:352:39:352:39 | y | variables.rs:352:39:352:39 | y | variables.rs:356:6:356:6 | y |
+| variables.rs:362:9:362:9 | y | variables.rs:362:9:362:9 | y | variables.rs:364:6:364:6 | y |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w | variables.rs:373:9:373:9 | w |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w | variables.rs:375:7:375:7 | w |
+| variables.rs:382:9:382:9 | y | variables.rs:382:9:382:9 | y | variables.rs:384:6:384:6 | y |
+| variables.rs:390:9:390:15 | cap | variables.rs:390:13:390:15 | cap | variables.rs:394:5:394:7 | cap |
+| variables.rs:399:9:399:9 | x | variables.rs:399:9:399:9 | x | variables.rs:404:15:404:15 | x |
+| variables.rs:400:9:400:15 | cap | variables.rs:400:13:400:15 | cap | variables.rs:403:5:403:7 | cap |
+| variables.rs:400:19:402:5 | <captured entry> x | variables.rs:399:9:399:9 | x | variables.rs:401:19:401:19 | x |
+| variables.rs:407:8:407:8 | b | variables.rs:407:8:407:8 | b | variables.rs:411:8:411:8 | b |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x | variables.rs:409:15:409:15 | x |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x | variables.rs:410:15:410:15 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x | variables.rs:420:15:420:15 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x | variables.rs:413:19:413:19 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x | variables.rs:414:19:414:19 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x | variables.rs:417:19:417:19 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x | variables.rs:418:19:418:19 | x |
+| variables.rs:423:13:423:14 | b1 | variables.rs:423:13:423:14 | b1 | variables.rs:425:8:425:9 | b1 |
+| variables.rs:423:24:423:25 | b2 | variables.rs:423:24:423:25 | b2 | variables.rs:431:8:431:9 | b2 |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:426:19:426:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:428:19:428:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:432:19:432:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:434:19:434:19 | x |
+| variables.rs:458:14:458:14 | x | variables.rs:458:14:458:14 | x | variables.rs:459:16:459:16 | x |
+| variables.rs:463:9:463:9 | x | variables.rs:463:9:463:9 | x | variables.rs:465:15:465:15 | x |
+firstRead
+| variables.rs:3:14:3:14 | s | variables.rs:3:14:3:14 | s | variables.rs:4:20:4:20 | s |
+| variables.rs:7:14:7:14 | i | variables.rs:7:14:7:14 | i | variables.rs:8:20:8:20 | i |
+| variables.rs:12:9:12:10 | x1 | variables.rs:12:9:12:10 | x1 | variables.rs:13:15:13:16 | x1 |
+| variables.rs:17:9:17:14 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:18:15:18:16 | x2 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:20:15:20:16 | x2 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 | variables.rs:25:15:25:16 | x3 |
+| variables.rs:26:9:26:10 | x3 | variables.rs:26:9:26:10 | x3 | variables.rs:28:15:28:16 | x3 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 | variables.rs:33:15:33:16 | x4 |
+| variables.rs:35:13:35:14 | x4 | variables.rs:35:13:35:14 | x4 | variables.rs:36:19:36:20 | x4 |
+| variables.rs:49:13:49:14 | a1 | variables.rs:49:13:49:14 | a1 | variables.rs:57:15:57:16 | a1 |
+| variables.rs:50:13:50:14 | b1 | variables.rs:50:13:50:14 | b1 | variables.rs:58:15:58:16 | b1 |
+| variables.rs:53:13:53:13 | x | variables.rs:53:13:53:13 | x | variables.rs:59:15:59:15 | x |
+| variables.rs:54:13:54:13 | y | variables.rs:54:13:54:13 | y | variables.rs:60:15:60:15 | y |
+| variables.rs:64:9:64:10 | p1 | variables.rs:64:9:64:10 | p1 | variables.rs:68:9:68:10 | p1 |
+| variables.rs:66:12:66:13 | a2 | variables.rs:66:12:66:13 | a2 | variables.rs:69:15:69:16 | a2 |
+| variables.rs:67:12:67:13 | b2 | variables.rs:67:12:67:13 | b2 | variables.rs:70:15:70:16 | b2 |
+| variables.rs:74:9:74:10 | s1 | variables.rs:74:9:74:10 | s1 | variables.rs:77:11:77:12 | s1 |
+| variables.rs:76:17:76:22 | s2 | variables.rs:76:21:76:22 | s2 | variables.rs:78:19:78:20 | s2 |
+| variables.rs:83:14:83:15 | x5 | variables.rs:83:14:83:15 | x5 | variables.rs:87:15:87:16 | x5 |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:9:91:10 | s1 | variables.rs:94:11:94:12 | s1 |
+| variables.rs:93:20:93:25 | s2 | variables.rs:93:24:93:25 | s2 | variables.rs:95:19:95:20 | s2 |
+| variables.rs:100:9:100:10 | x6 | variables.rs:100:9:100:10 | x6 | variables.rs:103:11:103:12 | x6 |
+| variables.rs:101:9:101:10 | y1 | variables.rs:101:9:101:10 | y1 | variables.rs:113:15:113:16 | y1 |
+| variables.rs:105:14:105:15 | y1 | variables.rs:105:14:105:15 | y1 | variables.rs:108:23:108:24 | y1 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers | variables.rs:119:11:119:17 | numbers |
+| variables.rs:121:13:121:17 | first | variables.rs:121:13:121:17 | first | variables.rs:125:23:125:27 | first |
+| variables.rs:122:13:122:17 | third | variables.rs:122:13:122:17 | third | variables.rs:126:23:126:27 | third |
+| variables.rs:123:13:123:17 | fifth | variables.rs:123:13:123:17 | fifth | variables.rs:127:23:127:27 | fifth |
+| variables.rs:133:13:133:17 | first | variables.rs:133:13:133:17 | first | variables.rs:137:23:137:27 | first |
+| variables.rs:135:13:135:16 | last | variables.rs:135:13:135:16 | last | variables.rs:138:23:138:26 | last |
+| variables.rs:144:9:144:10 | p2 | variables.rs:144:9:144:10 | p2 | variables.rs:146:11:146:12 | p2 |
+| variables.rs:148:16:148:17 | x7 | variables.rs:148:16:148:17 | x7 | variables.rs:149:24:149:25 | x7 |
+| variables.rs:158:9:158:11 | msg | variables.rs:158:9:158:11 | msg | variables.rs:160:11:160:13 | msg |
+| variables.rs:162:17:162:35 | [match(true)] id_variable | variables.rs:162:17:162:27 | id_variable | variables.rs:163:24:163:34 | id_variable |
+| variables.rs:167:26:167:27 | id | variables.rs:167:26:167:27 | id | variables.rs:168:23:168:24 | id |
+| variables.rs:178:9:178:14 | either | variables.rs:178:9:178:14 | either | variables.rs:179:11:179:16 | either |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 | variables.rs:181:26:181:27 | a3 |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:193:11:193:12 | tv |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:195:26:195:27 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:199:26:199:27 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:203:26:203:27 | a6 |
+| variables.rs:208:9:208:14 | either | variables.rs:208:9:208:14 | either | variables.rs:209:11:209:16 | either |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:211:16:211:17 | a7 |
+| variables.rs:218:9:218:14 | either | variables.rs:218:9:218:14 | either | variables.rs:220:11:220:16 | either |
+| variables.rs:221:9:222:52 | [match(true)] e | variables.rs:221:13:221:13 | e | variables.rs:226:15:226:15 | e |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 | variables.rs:224:23:224:25 | a11 |
+| variables.rs:225:33:225:35 | a12 | variables.rs:225:33:225:35 | a12 | variables.rs:227:28:227:30 | a12 |
+| variables.rs:242:9:242:10 | fv | variables.rs:242:9:242:10 | fv | variables.rs:243:11:243:12 | fv |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:245:26:245:28 | a13 |
+| variables.rs:250:5:250:6 | a8 | variables.rs:250:5:250:6 | a8 | variables.rs:255:15:255:16 | a8 |
+| variables.rs:252:9:252:10 | b3 | variables.rs:252:9:252:10 | b3 | variables.rs:256:15:256:16 | b3 |
+| variables.rs:253:9:253:10 | c1 | variables.rs:253:9:253:10 | c1 | variables.rs:257:15:257:16 | c1 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 | variables.rs:263:15:263:16 | a9 |
+| variables.rs:268:9:268:15 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:272:15:272:17 | a10 |
+| variables.rs:269:9:269:14 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:273:15:273:16 | b4 |
+| variables.rs:270:9:270:14 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:274:15:274:16 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:283:9:283:10 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:282:9:282:10 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:281:9:281:11 | a10 |
+| variables.rs:291:13:291:15 | a10 | variables.rs:291:13:291:15 | a10 | variables.rs:294:23:294:25 | a10 |
+| variables.rs:292:13:292:14 | b4 | variables.rs:292:13:292:14 | b4 | variables.rs:295:23:295:24 | b4 |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:304:9:304:23 | example_closure | variables.rs:308:9:308:23 | example_closure |
+| variables.rs:305:10:305:10 | x | variables.rs:305:10:305:10 | x | variables.rs:306:9:306:9 | x |
+| variables.rs:307:9:307:10 | n1 | variables.rs:307:9:307:10 | n1 | variables.rs:309:15:309:16 | n1 |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable | variables.rs:316:9:316:26 | immutable_variable |
+| variables.rs:313:10:313:10 | x | variables.rs:313:10:313:10 | x | variables.rs:314:9:314:9 | x |
+| variables.rs:315:9:315:10 | n2 | variables.rs:315:9:315:10 | n2 | variables.rs:317:15:317:16 | n2 |
+| variables.rs:321:9:321:9 | v | variables.rs:321:9:321:9 | v | variables.rs:324:12:324:12 | v |
+| variables.rs:323:9:323:12 | text | variables.rs:323:9:323:12 | text | variables.rs:325:19:325:22 | text |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:339:9:339:13 | ref_i | variables.rs:341:6:341:10 | ref_i |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:346:6:346:6 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:353:6:353:6 | x |
+| variables.rs:352:39:352:39 | y | variables.rs:352:39:352:39 | y | variables.rs:356:6:356:6 | y |
+| variables.rs:362:9:362:9 | y | variables.rs:362:9:362:9 | y | variables.rs:364:6:364:6 | y |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w | variables.rs:373:9:373:9 | w |
+| variables.rs:382:9:382:9 | y | variables.rs:382:9:382:9 | y | variables.rs:384:6:384:6 | y |
+| variables.rs:390:9:390:15 | cap | variables.rs:390:13:390:15 | cap | variables.rs:394:5:394:7 | cap |
+| variables.rs:399:9:399:9 | x | variables.rs:399:9:399:9 | x | variables.rs:404:15:404:15 | x |
+| variables.rs:400:9:400:15 | cap | variables.rs:400:13:400:15 | cap | variables.rs:403:5:403:7 | cap |
+| variables.rs:400:19:402:5 | <captured entry> x | variables.rs:399:9:399:9 | x | variables.rs:401:19:401:19 | x |
+| variables.rs:407:8:407:8 | b | variables.rs:407:8:407:8 | b | variables.rs:411:8:411:8 | b |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x | variables.rs:409:15:409:15 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x | variables.rs:420:15:420:15 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x | variables.rs:413:19:413:19 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x | variables.rs:417:19:417:19 | x |
+| variables.rs:423:13:423:14 | b1 | variables.rs:423:13:423:14 | b1 | variables.rs:425:8:425:9 | b1 |
+| variables.rs:423:24:423:25 | b2 | variables.rs:423:24:423:25 | b2 | variables.rs:431:8:431:9 | b2 |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:426:19:426:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:428:19:428:19 | x |
+| variables.rs:458:14:458:14 | x | variables.rs:458:14:458:14 | x | variables.rs:459:16:459:16 | x |
+| variables.rs:463:9:463:9 | x | variables.rs:463:9:463:9 | x | variables.rs:465:15:465:15 | x |
+lastRead
+| variables.rs:3:14:3:14 | s | variables.rs:3:14:3:14 | s | variables.rs:4:20:4:20 | s |
+| variables.rs:7:14:7:14 | i | variables.rs:7:14:7:14 | i | variables.rs:8:20:8:20 | i |
+| variables.rs:12:9:12:10 | x1 | variables.rs:12:9:12:10 | x1 | variables.rs:13:15:13:16 | x1 |
+| variables.rs:17:9:17:14 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:18:15:18:16 | x2 |
+| variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 | variables.rs:20:15:20:16 | x2 |
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 | variables.rs:27:9:27:10 | x3 |
+| variables.rs:26:9:26:10 | x3 | variables.rs:26:9:26:10 | x3 | variables.rs:28:15:28:16 | x3 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 | variables.rs:38:15:38:16 | x4 |
+| variables.rs:35:13:35:14 | x4 | variables.rs:35:13:35:14 | x4 | variables.rs:36:19:36:20 | x4 |
+| variables.rs:49:13:49:14 | a1 | variables.rs:49:13:49:14 | a1 | variables.rs:57:15:57:16 | a1 |
+| variables.rs:50:13:50:14 | b1 | variables.rs:50:13:50:14 | b1 | variables.rs:58:15:58:16 | b1 |
+| variables.rs:53:13:53:13 | x | variables.rs:53:13:53:13 | x | variables.rs:59:15:59:15 | x |
+| variables.rs:54:13:54:13 | y | variables.rs:54:13:54:13 | y | variables.rs:60:15:60:15 | y |
+| variables.rs:64:9:64:10 | p1 | variables.rs:64:9:64:10 | p1 | variables.rs:68:9:68:10 | p1 |
+| variables.rs:66:12:66:13 | a2 | variables.rs:66:12:66:13 | a2 | variables.rs:69:15:69:16 | a2 |
+| variables.rs:67:12:67:13 | b2 | variables.rs:67:12:67:13 | b2 | variables.rs:70:15:70:16 | b2 |
+| variables.rs:74:9:74:10 | s1 | variables.rs:74:9:74:10 | s1 | variables.rs:77:11:77:12 | s1 |
+| variables.rs:76:17:76:22 | s2 | variables.rs:76:21:76:22 | s2 | variables.rs:78:19:78:20 | s2 |
+| variables.rs:83:14:83:15 | x5 | variables.rs:83:14:83:15 | x5 | variables.rs:87:15:87:16 | x5 |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:9:91:10 | s1 | variables.rs:94:11:94:12 | s1 |
+| variables.rs:93:20:93:25 | s2 | variables.rs:93:24:93:25 | s2 | variables.rs:95:19:95:20 | s2 |
+| variables.rs:100:9:100:10 | x6 | variables.rs:100:9:100:10 | x6 | variables.rs:103:11:103:12 | x6 |
+| variables.rs:101:9:101:10 | y1 | variables.rs:101:9:101:10 | y1 | variables.rs:113:15:113:16 | y1 |
+| variables.rs:105:14:105:15 | y1 | variables.rs:105:14:105:15 | y1 | variables.rs:108:23:108:24 | y1 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers | variables.rs:131:11:131:17 | numbers |
+| variables.rs:121:13:121:17 | first | variables.rs:121:13:121:17 | first | variables.rs:125:23:125:27 | first |
+| variables.rs:122:13:122:17 | third | variables.rs:122:13:122:17 | third | variables.rs:126:23:126:27 | third |
+| variables.rs:123:13:123:17 | fifth | variables.rs:123:13:123:17 | fifth | variables.rs:127:23:127:27 | fifth |
+| variables.rs:133:13:133:17 | first | variables.rs:133:13:133:17 | first | variables.rs:137:23:137:27 | first |
+| variables.rs:135:13:135:16 | last | variables.rs:135:13:135:16 | last | variables.rs:138:23:138:26 | last |
+| variables.rs:144:9:144:10 | p2 | variables.rs:144:9:144:10 | p2 | variables.rs:146:11:146:12 | p2 |
+| variables.rs:148:16:148:17 | x7 | variables.rs:148:16:148:17 | x7 | variables.rs:149:24:149:25 | x7 |
+| variables.rs:158:9:158:11 | msg | variables.rs:158:9:158:11 | msg | variables.rs:160:11:160:13 | msg |
+| variables.rs:162:17:162:35 | [match(true)] id_variable | variables.rs:162:17:162:27 | id_variable | variables.rs:163:24:163:34 | id_variable |
+| variables.rs:167:26:167:27 | id | variables.rs:167:26:167:27 | id | variables.rs:168:23:168:24 | id |
+| variables.rs:178:9:178:14 | either | variables.rs:178:9:178:14 | either | variables.rs:179:11:179:16 | either |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 | variables.rs:181:26:181:27 | a3 |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:201:11:201:12 | tv |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:195:26:195:27 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:199:26:199:27 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:203:26:203:27 | a6 |
+| variables.rs:208:9:208:14 | either | variables.rs:208:9:208:14 | either | variables.rs:209:11:209:16 | either |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:211:16:211:17 | a7 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:212:26:212:27 | a7 |
+| variables.rs:218:9:218:14 | either | variables.rs:218:9:218:14 | either | variables.rs:220:11:220:16 | either |
+| variables.rs:221:9:222:52 | [match(true)] e | variables.rs:221:13:221:13 | e | variables.rs:226:15:226:15 | e |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 | variables.rs:224:23:224:25 | a11 |
+| variables.rs:225:33:225:35 | a12 | variables.rs:225:33:225:35 | a12 | variables.rs:227:28:227:30 | a12 |
+| variables.rs:242:9:242:10 | fv | variables.rs:242:9:242:10 | fv | variables.rs:243:11:243:12 | fv |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:245:26:245:28 | a13 |
+| variables.rs:250:5:250:6 | a8 | variables.rs:250:5:250:6 | a8 | variables.rs:255:15:255:16 | a8 |
+| variables.rs:252:9:252:10 | b3 | variables.rs:252:9:252:10 | b3 | variables.rs:256:15:256:16 | b3 |
+| variables.rs:253:9:253:10 | c1 | variables.rs:253:9:253:10 | c1 | variables.rs:257:15:257:16 | c1 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 | variables.rs:263:15:263:16 | a9 |
+| variables.rs:268:9:268:15 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:272:15:272:17 | a10 |
+| variables.rs:269:9:269:14 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:273:15:273:16 | b4 |
+| variables.rs:270:9:270:14 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:274:15:274:16 | c2 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:287:15:287:16 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:300:15:300:16 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:299:15:299:17 | a10 |
+| variables.rs:291:13:291:15 | a10 | variables.rs:291:13:291:15 | a10 | variables.rs:294:23:294:25 | a10 |
+| variables.rs:292:13:292:14 | b4 | variables.rs:292:13:292:14 | b4 | variables.rs:295:23:295:24 | b4 |
+| variables.rs:304:9:304:23 | example_closure | variables.rs:304:9:304:23 | example_closure | variables.rs:308:9:308:23 | example_closure |
+| variables.rs:305:10:305:10 | x | variables.rs:305:10:305:10 | x | variables.rs:306:9:306:9 | x |
+| variables.rs:307:9:307:10 | n1 | variables.rs:307:9:307:10 | n1 | variables.rs:309:15:309:16 | n1 |
+| variables.rs:312:9:312:26 | immutable_variable | variables.rs:312:9:312:26 | immutable_variable | variables.rs:316:9:316:26 | immutable_variable |
+| variables.rs:313:10:313:10 | x | variables.rs:313:10:313:10 | x | variables.rs:314:9:314:9 | x |
+| variables.rs:315:9:315:10 | n2 | variables.rs:315:9:315:10 | n2 | variables.rs:317:15:317:16 | n2 |
+| variables.rs:321:9:321:9 | v | variables.rs:321:9:321:9 | v | variables.rs:324:12:324:12 | v |
+| variables.rs:323:9:323:12 | text | variables.rs:323:9:323:12 | text | variables.rs:325:19:325:22 | text |
+| variables.rs:339:9:339:13 | ref_i | variables.rs:339:9:339:13 | ref_i | variables.rs:341:6:341:10 | ref_i |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:349:12:349:12 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:357:9:357:9 | x |
+| variables.rs:352:39:352:39 | y | variables.rs:352:39:352:39 | y | variables.rs:356:6:356:6 | y |
+| variables.rs:362:9:362:9 | y | variables.rs:362:9:362:9 | y | variables.rs:364:6:364:6 | y |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w | variables.rs:375:7:375:7 | w |
+| variables.rs:382:9:382:9 | y | variables.rs:382:9:382:9 | y | variables.rs:384:6:384:6 | y |
+| variables.rs:390:9:390:15 | cap | variables.rs:390:13:390:15 | cap | variables.rs:394:5:394:7 | cap |
+| variables.rs:399:9:399:9 | x | variables.rs:399:9:399:9 | x | variables.rs:404:15:404:15 | x |
+| variables.rs:400:9:400:15 | cap | variables.rs:400:13:400:15 | cap | variables.rs:403:5:403:7 | cap |
+| variables.rs:400:19:402:5 | <captured entry> x | variables.rs:399:9:399:9 | x | variables.rs:401:19:401:19 | x |
+| variables.rs:407:8:407:8 | b | variables.rs:407:8:407:8 | b | variables.rs:411:8:411:8 | b |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x | variables.rs:410:15:410:15 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x | variables.rs:420:15:420:15 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x | variables.rs:414:19:414:19 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x | variables.rs:418:19:418:19 | x |
+| variables.rs:423:13:423:14 | b1 | variables.rs:423:13:423:14 | b1 | variables.rs:425:8:425:9 | b1 |
+| variables.rs:423:24:423:25 | b2 | variables.rs:423:24:423:25 | b2 | variables.rs:431:8:431:9 | b2 |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:432:19:432:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:434:19:434:19 | x |
+| variables.rs:458:14:458:14 | x | variables.rs:458:14:458:14 | x | variables.rs:459:16:459:16 | x |
+| variables.rs:463:9:463:9 | x | variables.rs:463:9:463:9 | x | variables.rs:465:15:465:15 | x |
+adjacentReads
+| variables.rs:24:9:24:10 | x3 | variables.rs:24:9:24:10 | x3 | variables.rs:25:15:25:16 | x3 | variables.rs:27:9:27:10 | x3 |
+| variables.rs:32:9:32:10 | x4 | variables.rs:32:9:32:10 | x4 | variables.rs:33:15:33:16 | x4 | variables.rs:38:15:38:16 | x4 |
+| variables.rs:91:9:91:10 | s1 | variables.rs:91:9:91:10 | s1 | variables.rs:94:11:94:12 | s1 | variables.rs:94:11:94:12 | s1 |
+| variables.rs:117:9:117:15 | numbers | variables.rs:117:9:117:15 | numbers | variables.rs:119:11:119:17 | numbers | variables.rs:131:11:131:17 | numbers |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:193:11:193:12 | tv | variables.rs:197:11:197:12 | tv |
+| variables.rs:192:9:192:10 | tv | variables.rs:192:9:192:10 | tv | variables.rs:197:11:197:12 | tv | variables.rs:201:11:201:12 | tv |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:211:16:211:17 | a7 | variables.rs:212:26:212:27 | a7 |
+| variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 | variables.rs:283:9:283:10 | c2 | variables.rs:287:15:287:16 | c2 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:282:9:282:10 | b4 | variables.rs:286:15:286:16 | b4 |
+| variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 | variables.rs:286:15:286:16 | b4 | variables.rs:300:15:300:16 | b4 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:281:9:281:11 | a10 | variables.rs:285:15:285:17 | a10 |
+| variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 | variables.rs:285:15:285:17 | a10 | variables.rs:299:15:299:17 | a10 |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:346:6:346:6 | x | variables.rs:347:10:347:10 | x |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:347:10:347:10 | x | variables.rs:348:10:348:10 | x |
+| variables.rs:345:17:345:17 | x | variables.rs:345:17:345:17 | x | variables.rs:348:10:348:10 | x | variables.rs:349:12:349:12 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:353:6:353:6 | x | variables.rs:354:10:354:10 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:354:10:354:10 | x | variables.rs:355:10:355:10 | x |
+| variables.rs:352:22:352:22 | x | variables.rs:352:22:352:22 | x | variables.rs:355:10:355:10 | x | variables.rs:357:9:357:9 | x |
+| variables.rs:369:9:369:9 | w | variables.rs:369:9:369:9 | w | variables.rs:373:9:373:9 | w | variables.rs:375:7:375:7 | w |
+| variables.rs:408:9:408:13 | x | variables.rs:408:13:408:13 | x | variables.rs:409:15:409:15 | x | variables.rs:410:15:410:15 | x |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x | variables.rs:413:19:413:19 | x | variables.rs:414:19:414:19 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x | variables.rs:417:19:417:19 | x | variables.rs:418:19:418:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:426:19:426:19 | x | variables.rs:432:19:432:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:426:19:426:19 | x | variables.rs:434:19:434:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:428:19:428:19 | x | variables.rs:432:19:432:19 | x |
+| variables.rs:424:9:424:9 | x | variables.rs:424:9:424:9 | x | variables.rs:428:19:428:19 | x | variables.rs:434:19:434:19 | x |
+phi
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 | variables.rs:180:22:180:23 | a3 |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:9:180:44 | a3 | variables.rs:180:42:180:43 | a3 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:194:28:194:29 | a4 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:194:54:194:55 | a4 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:9:194:81 | a4 | variables.rs:194:79:194:80 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:198:10:198:57 | [match(true)] phi |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:198:81:198:82 | a5 |
+| variables.rs:198:10:198:57 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:198:29:198:30 | a5 |
+| variables.rs:198:10:198:57 | [match(true)] phi | variables.rs:198:9:198:83 | a5 | variables.rs:198:55:198:56 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:202:28:202:29 | a6 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:202:35:202:82 | [match(true)] phi |
+| variables.rs:202:35:202:82 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:202:55:202:56 | a6 |
+| variables.rs:202:35:202:82 | [match(true)] phi | variables.rs:202:9:202:83 | a6 | variables.rs:202:80:202:81 | a6 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:210:22:210:23 | a7 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:9:210:44 | a7 | variables.rs:210:42:210:43 | a7 |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 | variables.rs:222:27:222:29 | a11 |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:14:222:51 | a11 | variables.rs:222:48:222:50 | a11 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:244:27:244:29 | a13 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:244:35:244:82 | [match(true)] phi |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:244:106:244:108 | a13 |
+| variables.rs:244:35:244:82 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:244:54:244:56 | a13 |
+| variables.rs:244:35:244:82 | [match(true)] phi | variables.rs:244:9:244:109 | a13 | variables.rs:244:79:244:81 | a13 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 | variables.rs:261:19:261:20 | a9 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:6:261:41 | a9 | variables.rs:261:39:261:40 | a9 |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x | variables.rs:412:9:412:9 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:408:13:408:13 | x | variables.rs:416:9:416:9 | x |
+phiReadNode
+| variables.rs:93:11:94:12 | SSA phi read(s1) | variables.rs:91:9:91:10 | s1 |
+| variables.rs:425:5:429:5 | SSA phi read(x) | variables.rs:424:9:424:9 | x |
+phiReadNodeRead
+| variables.rs:93:11:94:12 | SSA phi read(s1) | variables.rs:91:9:91:10 | s1 | variables.rs:94:11:94:12 | s1 |
+| variables.rs:425:5:429:5 | SSA phi read(x) | variables.rs:424:9:424:9 | x | variables.rs:432:19:432:19 | x |
+| variables.rs:425:5:429:5 | SSA phi read(x) | variables.rs:424:9:424:9 | x | variables.rs:434:19:434:19 | x |
+phiReadInput
+| variables.rs:93:11:94:12 | SSA phi read(s1) | variables.rs:91:9:91:10 | s1 |
+| variables.rs:93:11:94:12 | SSA phi read(s1) | variables.rs:93:11:94:12 | SSA phi read(s1) |
+| variables.rs:425:5:429:5 | SSA phi read(x) | variables.rs:424:9:424:9 | x |
+ultimateDef
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:22:180:23 | a3 |
+| variables.rs:180:9:180:44 | [match(true)] phi | variables.rs:180:42:180:43 | a3 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:28:194:29 | a4 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:54:194:55 | a4 |
+| variables.rs:194:9:194:81 | [match(true)] phi | variables.rs:194:79:194:80 | a4 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:29:198:30 | a5 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:55:198:56 | a5 |
+| variables.rs:198:9:198:83 | [match(true)] phi | variables.rs:198:81:198:82 | a5 |
+| variables.rs:198:10:198:57 | [match(true)] phi | variables.rs:198:29:198:30 | a5 |
+| variables.rs:198:10:198:57 | [match(true)] phi | variables.rs:198:55:198:56 | a5 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:28:202:29 | a6 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:55:202:56 | a6 |
+| variables.rs:202:9:202:83 | [match(true)] phi | variables.rs:202:80:202:81 | a6 |
+| variables.rs:202:35:202:82 | [match(true)] phi | variables.rs:202:55:202:56 | a6 |
+| variables.rs:202:35:202:82 | [match(true)] phi | variables.rs:202:80:202:81 | a6 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:22:210:23 | a7 |
+| variables.rs:210:9:210:44 | [match(true)] phi | variables.rs:210:42:210:43 | a7 |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:27:222:29 | a11 |
+| variables.rs:222:14:222:51 | [match(true)] phi | variables.rs:222:48:222:50 | a11 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:27:244:29 | a13 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:54:244:56 | a13 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:79:244:81 | a13 |
+| variables.rs:244:9:244:109 | [match(true)] phi | variables.rs:244:106:244:108 | a13 |
+| variables.rs:244:35:244:82 | [match(true)] phi | variables.rs:244:54:244:56 | a13 |
+| variables.rs:244:35:244:82 | [match(true)] phi | variables.rs:244:79:244:81 | a13 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:19:261:20 | a9 |
+| variables.rs:261:6:261:41 | [match(true)] phi | variables.rs:261:39:261:40 | a9 |
+| variables.rs:411:5:419:5 | phi | variables.rs:412:9:412:9 | x |
+| variables.rs:411:5:419:5 | phi | variables.rs:416:9:416:9 | x |
+assigns
+| variables.rs:19:5:19:6 | x2 | variables.rs:19:10:19:10 | 5 |
+| variables.rs:412:9:412:9 | x | variables.rs:412:13:412:13 | 2 |
+| variables.rs:416:9:416:9 | x | variables.rs:416:13:416:13 | 3 |

--- a/rust/ql/test/library-tests/variables/Ssa.ql
+++ b/rust/ql/test/library-tests/variables/Ssa.ql
@@ -1,0 +1,52 @@
+import rust
+import codeql.rust.controlflow.BasicBlocks
+import codeql.rust.controlflow.ControlFlowGraph
+import codeql.rust.dataflow.Ssa
+import codeql.rust.dataflow.internal.SsaImpl
+import ExposedForTestingOnly
+
+query predicate nonSsaVariable(Variable v) { not v instanceof Ssa::Variable }
+
+query predicate definition(Ssa::Definition def, Variable v) { def.getSourceVariable() = v }
+
+query predicate read(Ssa::Definition def, Variable v, CfgNode read) {
+  def.getSourceVariable() = v and read = def.getARead()
+}
+
+query predicate firstRead(Ssa::Definition def, Variable v, CfgNode read) {
+  def.getSourceVariable() = v and read = def.getAFirstRead()
+}
+
+query predicate lastRead(Ssa::Definition def, Variable v, CfgNode read) {
+  def.getSourceVariable() = v and read = def.getALastRead()
+}
+
+query predicate adjacentReads(Ssa::Definition def, Variable v, CfgNode read1, CfgNode read2) {
+  def.getSourceVariable() = v and
+  def.hasAdjacentReads(read1, read2)
+}
+
+query predicate phi(Ssa::PhiDefinition phi, Variable v, Ssa::Definition input) {
+  phi.getSourceVariable() = v and input = phi.getAnInput()
+}
+
+query predicate phiReadNode(PhiReadNode phi, Variable v) { phi.getSourceVariable() = v }
+
+query predicate phiReadNodeRead(PhiReadNode phi, Variable v, CfgNode read) {
+  phi.getSourceVariable() = v and
+  exists(BasicBlock bb, int i |
+    ssaDefReachesReadExt(v, phi, bb, i) and
+    read = bb.getNode(i)
+  )
+}
+
+query predicate phiReadInput(PhiReadNode phi, DefinitionExt inp) {
+  phiHasInputFromBlockExt(phi, inp, _)
+}
+
+query predicate ultimateDef(Ssa::Definition def, Definition ult) {
+  ult = def.getAnUltimateDefinition() and
+  ult != def
+}
+
+query predicate assigns(Ssa::WriteDefinition def, CfgNode value) { def.assigns(value) }

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,6 +1,4 @@
 testFailures
-| variables.rs:452:5:452:5 | a | Unexpected result: write_access=a |
-| variables.rs:452:16:452:33 | Comment | Missing result:read_access=a |
 failures
 variable
 | variables.rs:3:14:3:14 | s |
@@ -247,7 +245,6 @@ variableWriteAccess
 | variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
 | variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x |
 | variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x |
-| variables.rs:452:5:452:5 | a | variables.rs:450:13:450:13 | a |
 | variables.rs:454:5:454:5 | a | variables.rs:450:13:450:13 | a |
 variableReadAccess
 | variables.rs:4:20:4:20 | s | variables.rs:3:14:3:14 | s |
@@ -371,6 +368,7 @@ variableReadAccess
 | variables.rs:432:19:432:19 | x | variables.rs:424:9:424:9 | x |
 | variables.rs:434:19:434:19 | x | variables.rs:424:9:424:9 | x |
 | variables.rs:451:15:451:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:452:5:452:5 | a | variables.rs:450:13:450:13 | a |
 | variables.rs:453:15:453:15 | a | variables.rs:450:13:450:13 | a |
 | variables.rs:455:15:455:15 | a | variables.rs:450:13:450:13 | a |
 | variables.rs:459:16:459:16 | x | variables.rs:458:14:458:14 | x |

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,4 +1,6 @@
 testFailures
+| variables.rs:452:5:452:5 | a | Unexpected result: write_access=a |
+| variables.rs:452:16:452:33 | Comment | Missing result:read_access=a |
 failures
 variable
 | variables.rs:3:14:3:14 | s |
@@ -70,11 +72,28 @@ variable
 | variables.rs:338:13:338:13 | i |
 | variables.rs:339:9:339:13 | ref_i |
 | variables.rs:345:17:345:17 | x |
-| variables.rs:352:13:352:13 | x |
-| variables.rs:358:13:358:13 | x |
-| variables.rs:359:9:359:9 | y |
-| variables.rs:366:13:366:13 | x |
-| variables.rs:367:13:367:15 | cap |
+| variables.rs:352:22:352:22 | x |
+| variables.rs:352:39:352:39 | y |
+| variables.rs:361:13:361:13 | x |
+| variables.rs:362:9:362:9 | y |
+| variables.rs:368:13:368:13 | z |
+| variables.rs:369:9:369:9 | w |
+| variables.rs:381:13:381:13 | x |
+| variables.rs:382:9:382:9 | y |
+| variables.rs:389:13:389:13 | x |
+| variables.rs:390:13:390:15 | cap |
+| variables.rs:399:9:399:9 | x |
+| variables.rs:400:13:400:15 | cap |
+| variables.rs:407:8:407:8 | b |
+| variables.rs:408:13:408:13 | x |
+| variables.rs:423:13:423:14 | b1 |
+| variables.rs:423:24:423:25 | b2 |
+| variables.rs:424:9:424:9 | x |
+| variables.rs:450:13:450:13 | a |
+| variables.rs:458:14:458:14 | x |
+| variables.rs:463:9:463:9 | x |
+| variables.rs:467:9:467:9 | z |
+| variables.rs:482:11:482:11 | a |
 variableAccess
 | variables.rs:4:20:4:20 | s | variables.rs:3:14:3:14 | s |
 | variables.rs:8:20:8:20 | i | variables.rs:7:14:7:14 | i |
@@ -170,20 +189,66 @@ variableAccess
 | variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:347:10:347:10 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:348:10:348:10 | x | variables.rs:345:17:345:17 | x |
-| variables.rs:353:23:353:23 | x | variables.rs:352:13:352:13 | x |
-| variables.rs:354:15:354:15 | x | variables.rs:352:13:352:13 | x |
-| variables.rs:360:14:360:14 | x | variables.rs:358:13:358:13 | x |
-| variables.rs:361:6:361:6 | y | variables.rs:359:9:359:9 | y |
-| variables.rs:362:15:362:15 | x | variables.rs:358:13:358:13 | x |
-| variables.rs:368:19:368:19 | x | variables.rs:366:13:366:13 | x |
-| variables.rs:369:9:369:9 | x | variables.rs:366:13:366:13 | x |
-| variables.rs:371:5:371:7 | cap | variables.rs:367:13:367:15 | cap |
-| variables.rs:372:15:372:15 | x | variables.rs:366:13:366:13 | x |
+| variables.rs:349:12:349:12 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:353:6:353:6 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:354:10:354:10 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:355:10:355:10 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:356:6:356:6 | y | variables.rs:352:39:352:39 | y |
+| variables.rs:357:9:357:9 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:363:27:363:27 | x | variables.rs:361:13:361:13 | x |
+| variables.rs:364:6:364:6 | y | variables.rs:362:9:362:9 | y |
+| variables.rs:366:15:366:15 | x | variables.rs:361:13:361:13 | x |
+| variables.rs:370:19:370:19 | x | variables.rs:361:13:361:13 | x |
+| variables.rs:372:14:372:14 | z | variables.rs:368:13:368:13 | z |
+| variables.rs:373:9:373:9 | w | variables.rs:369:9:369:9 | w |
+| variables.rs:375:7:375:7 | w | variables.rs:369:9:369:9 | w |
+| variables.rs:377:15:377:15 | z | variables.rs:368:13:368:13 | z |
+| variables.rs:383:14:383:14 | x | variables.rs:381:13:381:13 | x |
+| variables.rs:384:6:384:6 | y | variables.rs:382:9:382:9 | y |
+| variables.rs:385:15:385:15 | x | variables.rs:381:13:381:13 | x |
+| variables.rs:391:19:391:19 | x | variables.rs:389:13:389:13 | x |
+| variables.rs:392:9:392:9 | x | variables.rs:389:13:389:13 | x |
+| variables.rs:394:5:394:7 | cap | variables.rs:390:13:390:15 | cap |
+| variables.rs:395:15:395:15 | x | variables.rs:389:13:389:13 | x |
+| variables.rs:401:19:401:19 | x | variables.rs:399:9:399:9 | x |
+| variables.rs:403:5:403:7 | cap | variables.rs:400:13:400:15 | cap |
+| variables.rs:404:15:404:15 | x | variables.rs:399:9:399:9 | x |
+| variables.rs:409:15:409:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:410:15:410:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:411:8:411:8 | b | variables.rs:407:8:407:8 | b |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:413:19:413:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:414:19:414:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:417:19:417:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:418:19:418:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:420:15:420:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:425:8:425:9 | b1 | variables.rs:423:13:423:14 | b1 |
+| variables.rs:426:19:426:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:428:19:428:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:431:8:431:9 | b2 | variables.rs:423:24:423:25 | b2 |
+| variables.rs:432:19:432:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:434:19:434:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:451:15:451:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:452:5:452:5 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:453:15:453:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:454:5:454:5 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:455:15:455:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:459:16:459:16 | x | variables.rs:458:14:458:14 | x |
+| variables.rs:464:16:464:16 | x | variables.rs:463:9:463:9 | x |
+| variables.rs:465:15:465:15 | x | variables.rs:463:9:463:9 | x |
+| variables.rs:468:16:468:16 | z | variables.rs:467:9:467:9 | z |
+| variables.rs:483:3:483:3 | a | variables.rs:482:11:482:11 | a |
+| variables.rs:485:13:485:13 | a | variables.rs:482:11:482:11 | a |
 variableWriteAccess
 | variables.rs:19:5:19:6 | x2 | variables.rs:17:13:17:14 | x2 |
 | variables.rs:277:9:277:10 | c2 | variables.rs:270:13:270:14 | c2 |
 | variables.rs:278:9:278:10 | b4 | variables.rs:269:13:269:14 | b4 |
 | variables.rs:279:9:279:11 | a10 | variables.rs:268:13:268:15 | a10 |
+| variables.rs:412:9:412:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:416:9:416:9 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:452:5:452:5 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:454:5:454:5 | a | variables.rs:450:13:450:13 | a |
 variableReadAccess
 | variables.rs:4:20:4:20 | s | variables.rs:3:14:3:14 | s |
 | variables.rs:8:20:8:20 | i | variables.rs:7:14:7:14 | i |
@@ -272,12 +337,46 @@ variableReadAccess
 | variables.rs:346:6:346:6 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:347:10:347:10 | x | variables.rs:345:17:345:17 | x |
 | variables.rs:348:10:348:10 | x | variables.rs:345:17:345:17 | x |
-| variables.rs:354:15:354:15 | x | variables.rs:352:13:352:13 | x |
-| variables.rs:361:6:361:6 | y | variables.rs:359:9:359:9 | y |
-| variables.rs:362:15:362:15 | x | variables.rs:358:13:358:13 | x |
-| variables.rs:368:19:368:19 | x | variables.rs:366:13:366:13 | x |
-| variables.rs:371:5:371:7 | cap | variables.rs:367:13:367:15 | cap |
-| variables.rs:372:15:372:15 | x | variables.rs:366:13:366:13 | x |
+| variables.rs:349:12:349:12 | x | variables.rs:345:17:345:17 | x |
+| variables.rs:353:6:353:6 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:354:10:354:10 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:355:10:355:10 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:356:6:356:6 | y | variables.rs:352:39:352:39 | y |
+| variables.rs:357:9:357:9 | x | variables.rs:352:22:352:22 | x |
+| variables.rs:364:6:364:6 | y | variables.rs:362:9:362:9 | y |
+| variables.rs:366:15:366:15 | x | variables.rs:361:13:361:13 | x |
+| variables.rs:373:9:373:9 | w | variables.rs:369:9:369:9 | w |
+| variables.rs:375:7:375:7 | w | variables.rs:369:9:369:9 | w |
+| variables.rs:377:15:377:15 | z | variables.rs:368:13:368:13 | z |
+| variables.rs:384:6:384:6 | y | variables.rs:382:9:382:9 | y |
+| variables.rs:385:15:385:15 | x | variables.rs:381:13:381:13 | x |
+| variables.rs:391:19:391:19 | x | variables.rs:389:13:389:13 | x |
+| variables.rs:394:5:394:7 | cap | variables.rs:390:13:390:15 | cap |
+| variables.rs:395:15:395:15 | x | variables.rs:389:13:389:13 | x |
+| variables.rs:401:19:401:19 | x | variables.rs:399:9:399:9 | x |
+| variables.rs:403:5:403:7 | cap | variables.rs:400:13:400:15 | cap |
+| variables.rs:404:15:404:15 | x | variables.rs:399:9:399:9 | x |
+| variables.rs:409:15:409:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:410:15:410:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:411:8:411:8 | b | variables.rs:407:8:407:8 | b |
+| variables.rs:413:19:413:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:414:19:414:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:417:19:417:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:418:19:418:19 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:420:15:420:15 | x | variables.rs:408:13:408:13 | x |
+| variables.rs:425:8:425:9 | b1 | variables.rs:423:13:423:14 | b1 |
+| variables.rs:426:19:426:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:428:19:428:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:431:8:431:9 | b2 | variables.rs:423:24:423:25 | b2 |
+| variables.rs:432:19:432:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:434:19:434:19 | x | variables.rs:424:9:424:9 | x |
+| variables.rs:451:15:451:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:453:15:453:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:455:15:455:15 | a | variables.rs:450:13:450:13 | a |
+| variables.rs:459:16:459:16 | x | variables.rs:458:14:458:14 | x |
+| variables.rs:465:15:465:15 | x | variables.rs:463:9:463:9 | x |
+| variables.rs:483:3:483:3 | a | variables.rs:482:11:482:11 | a |
+| variables.rs:485:13:485:13 | a | variables.rs:482:11:482:11 | a |
 variableInitializer
 | variables.rs:12:9:12:10 | x1 | variables.rs:12:14:12:16 | "a" |
 | variables.rs:17:13:17:14 | x2 | variables.rs:17:18:17:18 | 4 |
@@ -306,13 +405,26 @@ variableInitializer
 | variables.rs:330:13:330:13 | a | variables.rs:330:17:330:17 | 0 |
 | variables.rs:338:13:338:13 | i | variables.rs:338:17:338:17 | 1 |
 | variables.rs:339:9:339:13 | ref_i | variables.rs:340:9:340:14 | RefExpr |
-| variables.rs:352:13:352:13 | x | variables.rs:352:17:352:17 | 2 |
-| variables.rs:358:13:358:13 | x | variables.rs:358:17:358:17 | 1 |
-| variables.rs:359:9:359:9 | y | variables.rs:360:9:360:14 | RefExpr |
-| variables.rs:366:13:366:13 | x | variables.rs:366:17:366:18 | 10 |
-| variables.rs:367:13:367:15 | cap | variables.rs:367:19:370:5 | ClosureExpr |
+| variables.rs:361:13:361:13 | x | variables.rs:361:17:361:17 | 2 |
+| variables.rs:362:9:362:9 | y | variables.rs:363:9:363:28 | CallExpr |
+| variables.rs:368:13:368:13 | z | variables.rs:368:17:368:17 | 4 |
+| variables.rs:369:9:369:9 | w | variables.rs:370:9:370:19 | RefExpr |
+| variables.rs:381:13:381:13 | x | variables.rs:381:17:381:17 | 1 |
+| variables.rs:382:9:382:9 | y | variables.rs:383:9:383:14 | RefExpr |
+| variables.rs:389:13:389:13 | x | variables.rs:389:17:389:18 | 10 |
+| variables.rs:390:13:390:15 | cap | variables.rs:390:19:393:5 | ClosureExpr |
+| variables.rs:399:9:399:9 | x | variables.rs:399:13:399:15 | 100 |
+| variables.rs:400:13:400:15 | cap | variables.rs:400:19:402:5 | ClosureExpr |
+| variables.rs:408:13:408:13 | x | variables.rs:408:17:408:17 | 1 |
+| variables.rs:424:9:424:9 | x | variables.rs:424:13:424:13 | 1 |
+| variables.rs:450:13:450:13 | a | variables.rs:450:17:450:35 | RecordExpr |
+| variables.rs:463:9:463:9 | x | variables.rs:463:13:463:14 | 16 |
+| variables.rs:467:9:467:9 | z | variables.rs:467:13:467:14 | 17 |
+| variables.rs:482:11:482:11 | a | variables.rs:482:15:482:33 | RecordExpr |
 capturedVariable
-| variables.rs:366:13:366:13 | x |
+| variables.rs:389:13:389:13 | x |
+| variables.rs:399:9:399:9 | x |
 capturedAccess
-| variables.rs:368:19:368:19 | x |
-| variables.rs:369:9:369:9 | x |
+| variables.rs:391:19:391:19 | x |
+| variables.rs:392:9:392:9 | x |
+| variables.rs:401:19:401:19 | x |

--- a/rust/ql/test/library-tests/variables/variables.rs
+++ b/rust/ql/test/library-tests/variables/variables.rs
@@ -342,16 +342,39 @@ fn mutate() {
     print_i64(i); // $ read_access=i
 }
 
-fn mutate_param(x : &mut i64) { // x
+fn mutate_param(x : &mut i64) -> &mut i64 {
     *x = // $ read_access=x
         *x + // $ read_access=x
         *x; // $ read_access=x
+    return x; // $ read_access=x
+}
+
+fn mutate_param2<'a>(x : &'a mut i64, y :&mut &'a mut i64) {
+    *x = // $ read_access=x
+        *x + // $ read_access=x
+        *x; // $ read_access=x
+    *y = // $ read_access=y
+        x; // $ read_access=x
 }
 
 fn mutate_arg() {
     let mut x = 2; // x
-    mutate_param(&mut x); // $ access=x
+    let y = // y
+        mutate_param(&mut x); // $ access=x
+    *y = 10; // $ read_access=y
+    // prints 10, not 4
     print_i64(x); // $ read_access=x
+
+    let mut z = 4; // z
+    let w = // w
+        &mut &mut x; // $ access=x
+    mutate_param2(
+        &mut z, // $ access=z
+        w // $ read_access=w
+    );
+    **w = 11; // $ read_access=w
+    // prints 11, not 8
+    print_i64(z); // $ read_access=z
 }
 
 fn alias() {
@@ -362,7 +385,7 @@ fn alias() {
     print_i64(x); // $ read_access=x
 }
 
-fn capture() {
+fn capture_mut() {
     let mut x = 10; // x
     let mut cap = || {
         print_i64(x); // $ read_access=x
@@ -370,6 +393,96 @@ fn capture() {
     };
     cap(); // $ read_access=cap
     print_i64(x); // $ read_access=x
+}
+
+fn capture_immut() {
+    let x = 100; // x
+    let mut cap = || {
+        print_i64(x); // $ read_access=x
+    };
+    cap(); // $ read_access=cap
+    print_i64(x); // $ read_access=x
+}
+
+fn phi(b : bool) {
+    let mut x = 1; // x
+    print_i64(x); // $ read_access=x
+    print_i64(x + 1); // $ read_access=x
+    if b { // $ read_access=b
+        x = 2; // $ write_access=x
+        print_i64(x); // $ read_access=x
+        print_i64(x + 1); // $ read_access=x
+    } else {
+        x = 3; // $ write_access=x
+        print_i64(x); // $ read_access=x
+        print_i64(x + 1); // $ read_access=x
+    }
+    print_i64(x); // $ read_access=x
+}
+
+fn phi_read(b1 : bool, b2 : bool) {
+    let x = 1; // x
+    if b1 { // $ read_access=b1
+        print_i64(x); // $ read_access=x
+    } else {
+        print_i64(x); // $ read_access=x
+    }
+
+    if b2 { // $ read_access=b2
+        print_i64(x); // $ read_access=x
+    } else {
+        print_i64(x); // $ read_access=x
+    }
+}
+
+#[derive(Debug)]
+struct MyStruct {
+    val: i64,
+}
+
+impl MyStruct {
+    fn my_get(&mut self) -> i64 {
+        return self.val;
+    }
+}
+
+fn structs() {
+    let mut a = MyStruct { val: 1 }; // a
+    print_i64(a.my_get()); // $ read_access=a
+    a.val = 5; // $ read_access=a
+    print_i64(a.my_get()); // $ read_access=a
+    a = MyStruct { val: 2 }; // $ write_access=a
+    print_i64(a.my_get()); // $ read_access=a
+}
+
+fn ref_param(x: &i64) {
+    print_i64(*x) // $ read_access=x
+}
+
+fn ref_arg() {
+    let x = 16; // x
+    ref_param(&x); // $ access=x
+    print_i64(x); // $ read_access=x
+
+    let z = 17; // z
+    ref_param(&z); // $ access=z
+}
+
+trait Bar {
+  fn bar(&self);
+}
+
+impl MyStruct {
+  fn bar(&mut self) {
+    *self = MyStruct { val: 3 };
+  }
+}
+
+fn ref_methodcall_receiver() {
+  let mut a = MyStruct { val: 1 }; // a
+  a.bar(); // $ read_access=a
+  // prints 3, not 1
+  print_i64(a.val); // $ read_access=a
 }
 
 fn main() {
@@ -399,5 +512,9 @@ fn main() {
     mutate();
     mutate_arg();
     alias();
-    capture();
+    capture_mut();
+    capture_immut();
+    structs();
+    ref_arg();
+    ref_methodcall_receiver();
 }


### PR DESCRIPTION
This PR adds an initial static single assignment (SSA) library to Rust.

In this first version, we restrict the analysis to variables that are either immutable, or mutable with the following constraints:
- the variable is not captured, and
- the variable is not borrowed, either explicitly `& mut x` or [implicitly as a method call receiver](https://doc.rust-lang.org/reference/expressions/method-call-expr.html) `x.foo()`.

We may be able to relax these constraints, but that will be done follow-up.