### PR TITLE
C++: Add taint through `fopen`

### DIFF
--- a/cpp/ql/lib/change-notes/2024-10-09-fopen-taint.md
+++ b/cpp/ql/lib/change-notes/2024-10-09-fopen-taint.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint flow model for `fopen` and related functions.

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
@@ -54,7 +54,7 @@ private class Fopen extends Function, AliasFunction, SideEffectFunction, TaintFu
     output.isReturnValueDeref()
     or
     // The out parameter is a pointer to a `FILE*`.
-    this.hasGlobalOrStdName(["fopen_s"]) and
+    this.hasGlobalOrStdName("fopen_s") and
     input.isParameterDeref(1) and
     output.isParameterDeref(0, 2)
     or

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
@@ -7,7 +7,7 @@ import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
 
 /** The function `fopen` and friends. */
-private class Fopen extends Function, AliasFunction, SideEffectFunction {
+private class Fopen extends Function, AliasFunction, SideEffectFunction, TaintFunction {
   Fopen() {
     this.hasGlobalOrStdName(["fopen", "fopen_s", "freopen"])
     or
@@ -46,5 +46,20 @@ private class Fopen extends Function, AliasFunction, SideEffectFunction {
     this.hasGlobalName(["_open", "_wopen"]) and
     i = 0 and
     buffer = true
+  }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    this.hasGlobalOrStdName(["fopen", "freopen", "_wfopen", "_fsopen", "_wfsopen"]) and
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
+    or
+    // The out parameter is a pointer to a `FILE*`.
+    this.hasGlobalOrStdName(["fopen_s"]) and
+    input.isParameterDeref(1) and
+    output.isParameterDeref(0, 2)
+    or
+    this.hasGlobalName(["_open", "_wopen"]) and
+    input.isParameterDeref(0) and
+    output.isReturnValue()
   }
 }

--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Fopen.qll
@@ -49,7 +49,10 @@ private class Fopen extends Function, AliasFunction, SideEffectFunction, TaintFu
   }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    this.hasGlobalOrStdName(["fopen", "freopen", "_wfopen", "_fsopen", "_wfsopen"]) and
+    (
+      this.hasGlobalOrStdName(["fopen", "freopen"]) or
+      this.hasGlobalName(["_wfopen", "_fsopen", "_wfsopen"])
+    ) and
     input.isParameterDeref(0) and
     output.isReturnValueDeref()
     or

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6584,6 +6584,15 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | taint.cpp:767:21:767:24 | ref arg path | taint.cpp:768:8:768:11 | path |  |
 | taint.cpp:768:8:768:11 | path | taint.cpp:768:7:768:11 | * ... |  |
 | taint.cpp:778:37:778:42 | call to source | taint.cpp:779:7:779:9 | obj |  |
+| taint.cpp:785:23:785:28 | source | taint.cpp:785:23:785:28 | source |  |
+| taint.cpp:785:23:785:28 | source | taint.cpp:786:18:786:23 | source |  |
+| taint.cpp:785:23:785:28 | source | taint.cpp:790:15:790:20 | source |  |
+| taint.cpp:786:12:786:16 | call to fopen | taint.cpp:787:7:787:7 | f |  |
+| taint.cpp:789:8:789:9 | f2 | taint.cpp:790:11:790:12 | f2 |  |
+| taint.cpp:789:8:789:9 | f2 | taint.cpp:791:7:791:8 | f2 |  |
+| taint.cpp:790:10:790:12 | ref arg & ... | taint.cpp:790:11:790:12 | f2 [inner post update] |  |
+| taint.cpp:790:10:790:12 | ref arg & ... | taint.cpp:791:7:791:8 | f2 |  |
+| taint.cpp:790:11:790:12 | f2 | taint.cpp:790:10:790:12 | & ... |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:17:26:17:32 | source1 |  |
 | vector.cpp:16:43:16:49 | source1 | vector.cpp:31:38:31:44 | source1 |  |
 | vector.cpp:17:21:17:33 | call to vector | vector.cpp:19:14:19:14 | v |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -6588,6 +6588,7 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | taint.cpp:785:23:785:28 | source | taint.cpp:786:18:786:23 | source |  |
 | taint.cpp:785:23:785:28 | source | taint.cpp:790:15:790:20 | source |  |
 | taint.cpp:786:12:786:16 | call to fopen | taint.cpp:787:7:787:7 | f |  |
+| taint.cpp:786:18:786:23 | source | taint.cpp:786:12:786:16 | call to fopen | TAINT |
 | taint.cpp:789:8:789:9 | f2 | taint.cpp:790:11:790:12 | f2 |  |
 | taint.cpp:789:8:789:9 | f2 | taint.cpp:791:7:791:8 | f2 |  |
 | taint.cpp:790:10:790:12 | ref arg & ... | taint.cpp:790:11:790:12 | f2 [inner post update] |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -784,9 +784,9 @@ int fopen_s(FILE** pFile, const char *filename, const char *mode);
 
 void fopen_test(char* source) {
 	FILE* f = fopen(source, "r");
-	sink(f); // $ MISSING: ast,ir
+	sink(f); // $ ast,ir
 
 	FILE* f2;
 	fopen_s(&f2, source, "r");
-	sink(f2); // $ ast MISSING: ir
+	sink(f2); // $ ast,ir
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -778,3 +778,15 @@ void test_TaintInheritingContent() {
 	TaintInheritingContentObject obj = source(true);
 	sink(obj.flowFromObject); // $ ir MISSING: ast
 }
+
+FILE* fopen(const char*, const char*);
+int fopen_s(FILE** pFile, const char *filename, const char *mode);
+
+void fopen_test(char* source) {
+	FILE* f = fopen(source, "r");
+	sink(f); // $ MISSING: ast,ir
+
+	FILE* f2;
+	fopen_s(&f2, source, "r");
+	sink(f2); // $ ast MISSING: ir
+}


### PR DESCRIPTION
### Pull Request checklist

Ideally this should've been done through MaD, but considering that we had the `Fopen` class already I couldn't really be bothered to convert it to MaD 😂

I'll run DCA once that's unbroken.

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
