### PR TITLE
TS Extractor: NodeType and Expr String escaping

### DIFF
--- a/shared/tree-sitter-extractor/src/generator/ql.rs
+++ b/shared/tree-sitter-extractor/src/generator/ql.rs
@@ -156,7 +156,13 @@ impl<'a> fmt::Display for Expression<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Expression::Var(x) => write!(f, "{}", x),
-            Expression::String(s) => write!(f, "\"{}\"", s),
+            Expression::String(s) => {
+                let s = s
+                    .replace("\'", "\\\'")
+                    .replace("\"", "\\\"")
+                    .replace("\\", "\\\\");
+                write!(f, "\"{}\"", s)
+            },
             Expression::Integer(n) => write!(f, "{}", n),
             Expression::Pred(n, args) => {
                 write!(f, "{}(", n)?;

--- a/shared/tree-sitter-extractor/src/generator/ql.rs
+++ b/shared/tree-sitter-extractor/src/generator/ql.rs
@@ -158,9 +158,8 @@ impl<'a> fmt::Display for Expression<'a> {
             Expression::Var(x) => write!(f, "{}", x),
             Expression::String(s) => {
                 let s = s
-                    .replace("\'", "\\\'")
-                    .replace("\"", "\\\"")
-                    .replace("\\", "\\\\");
+                    .replace('\'', "\'")
+                    .replace('"', "\"");
                 write!(f, "\"{}\"", s)
             },
             Expression::Integer(n) => write!(f, "{}", n),

--- a/shared/tree-sitter-extractor/src/node_types.rs
+++ b/shared/tree-sitter-extractor/src/node_types.rs
@@ -372,6 +372,7 @@ fn escape_name(name: &str) -> String {
             ':' => result.push_str("colon"),
             ';' => result.push_str("semicolon"),
             '"' => result.push_str("dquote"),
+            '\'' => result.push_str("squote"),
             '*' => result.push_str("star"),
             '+' => result.push_str("plus"),
             '-' => result.push_str("minus"),

--- a/shared/tree-sitter-extractor/tests/generator_ql.rs
+++ b/shared/tree-sitter-extractor/tests/generator_ql.rs
@@ -1,0 +1,14 @@
+use codeql_extractor::generator::ql::Expression;
+
+mod common;
+
+#[test]
+fn test_gen_string() {
+    let string = Expression::String("foo");
+    assert_eq!(string.to_string(), "\"foo\"");
+
+    let string_dquote = Expression::String("foo\"bar");
+    assert_eq!(string_dquote.to_string(), "\"foo\"bar\"");
+    let string_squote = Expression::String("foo'bar");
+    assert_eq!(string_squote.to_string(), "\"foo\'bar\"");
+}


### PR DESCRIPTION
Update the TS extractor to escape Single Quotes in the node_types and Automatic quote escaping when using String expressions for QL generation.