### PR TITLE
Rust: Remove unused types

### DIFF
--- a/rust/ql/lib/codeql/rust/controlflow/internal/SuccessorType.qll
+++ b/rust/ql/lib/codeql/rust/controlflow/internal/SuccessorType.qll
@@ -2,14 +2,6 @@ private import rust
 private import codeql.util.Boolean
 private import Completion
 
-newtype TLoopJumpType =
-  TContinueJump() or
-  TBreakJump()
-
-newtype TLabelType =
-  TLabel(string s) { any(Label l).getLifetime().getText() = s } or
-  TNoLabel()
-
 cached
 newtype TSuccessorType =
   TSuccessorSuccessor() or


### PR DESCRIPTION
After the simplification of break/continue labels in #17644 these types are no longer used.