### PR TITLE
Go: extractor/objecttypes consistency generics (second try)

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -1608,7 +1608,7 @@ func extractType(tw *trap.Writer, tp types.Type) trap.Label {
 		case *types.Struct:
 			kind = dbscheme.StructType.Index()
 			for i := 0; i < tp.NumFields(); i++ {
-				field := tp.Field(i)
+				field := tp.Field(i).Origin()
 
 				// ensure the field is associated with a label - note that
 				// struct fields do not have a parent scope, so they are not


### PR DESCRIPTION
https://github.com/github/codeql/pull/17709 was reverted. This PR tries to reinstate those commits with some fixes to make sure extraction doesn't fail.