### PR TITLE
Kotlin: Log our verbosity level

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinExtractorExtension.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinExtractorExtension.kt
@@ -140,6 +140,7 @@ class KotlinExtractorExtension(
             val logger = Logger(loggerBase, tw)
             logger.info("Extraction started")
             logger.flush()
+            logger.infoVerbosity()
             logger.info("Extraction for invocation TRAP file $invocationTrapFile")
             logger.flush()
             logger.info("Kotlin version ${KotlinCompilerVersion.getVersion()}")

--- a/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/Logger.kt
@@ -244,6 +244,10 @@ open class LoggerBase(val logCounter: LogCounter) {
         }
     }
 
+    fun infoVerbosity(dtw: DiagnosticTrapWriter) {
+        info(dtw, "Kotlin extractor verbosity is " + verbosity.toString())
+    }
+
     fun warn(dtw: DiagnosticTrapWriter, msg: String, extraInfo: String?) {
         if (verbosity >= 2) {
             diagnostic(dtw, Severity.Warn, msg, extraInfo)
@@ -299,6 +303,10 @@ open class Logger(val loggerBase: LoggerBase, val dtw: DiagnosticTrapWriter) {
 
     fun info(msg: String) {
         loggerBase.info(dtw, msg)
+    }
+
+    fun infoVerbosity() {
+        loggerBase.infoVerbosity(dtw)
     }
 
     private fun warn(msg: String, extraInfo: String?) {

--- a/java/ql/integration-tests/kotlin/all-platforms/logs/logs.expected
+++ b/java/ql/integration-tests/kotlin/all-platforms/logs/logs.expected
@@ -1,5 +1,6 @@
 Log file 1
 {"origin": "CodeQL Kotlin extractor", "kind": "INFO", "message": "Extraction started"}
+{"origin": "CodeQL Kotlin extractor", "kind": "INFO", "message": "Kotlin extractor verbosity is 3"}
 {"origin": "CodeQL Kotlin extractor", "kind": "INFO", "message": "Extraction for invocation TRAP file <FILENAME>"}
 {"origin": "CodeQL Kotlin extractor", "kind": "INFO", "message": "Kotlin version <VERSION>"}
 {"origin": "CodeQL Kotlin extractor", "kind": "INFO", "message": "Extracting file test.kt"}


### PR DESCRIPTION
This makes it easy to see if setting the verbosity to 4 has actually succeeded.

I plan to force-green the "Kotlin internal queries" failure, as that is broken in main, and the motivation behind this PR is to help fix it.