### PR TITLE
C#: Models for higher order methods.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1149,7 +1149,7 @@ private module Cached {
     } or
     TCapturedVariableContent(VariableCapture::CapturedVariable v) or
     TDelegateCallArgumentContent(int i) {
-      i = [0 .. max(int j | j = any(DelegateCall dc).getNumberOfArguments())]
+      i = [0 .. max(any(DelegateCall dc).getNumberOfArguments())]
     } or
     TDelegateCallReturnContent()
 
@@ -2287,10 +2287,10 @@ private predicate recordProperty(RecordType t, ContentSet c, string name) {
  * If there is a delegate call f(x), then we store "x" on "f"
  * using a delegate argument content set.
  */
-private predicate storeStepDelegateCall(Node node1, ContentSet c, Node node2) {
-  exists(DelegateCall call, int i |
-    node1.asExpr() = call.getArgument(i) and
-    node2.(PostUpdateNode).getPreUpdateNode().asExpr() = call.getExpr() and
+private predicate storeStepDelegateCall(ExplicitArgumentNode node1, ContentSet c, Node node2) {
+  exists(ExplicitDelegateLikeDataFlowCall call, int i |
+    node1.argumentOf(call, TPositionalArgumentPosition(i)) and
+    lambdaCall(call, _, node2.(PostUpdateNode).getPreUpdateNode()) and
     c.isDelegateCallArgument(i)
   )
 }
@@ -2456,10 +2456,10 @@ private predicate readContentStep(Node node1, Content c, Node node2) {
  * If there is a delegate call f(x), then we read the return of the delegate
  * call.
  */
-private predicate readStepDelegateCall(Node node1, ContentSet c, Node node2) {
-  exists(DelegateCall call |
-    node1.asExpr() = call.getExpr() and
-    node2.asExpr() = call and
+private predicate readStepDelegateCall(Node node1, ContentSet c, OutNode node2) {
+  exists(ExplicitDelegateLikeDataFlowCall call |
+    lambdaCall(call, _, node1) and
+    node2.getCall(TNormalReturnKind()) = call and
     c.isDelegateCallReturn()
   )
 }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1149,7 +1149,7 @@ private module Cached {
     } or
     TCapturedVariableContent(VariableCapture::CapturedVariable v) or
     TDelegateCallArgumentContent(int i) {
-      i = [0 .. max(any(DelegateCall dc).getNumberOfArguments())]
+      i = [0 .. max(any(DelegateLikeCall dc).getNumberOfArguments()) - 1]
     } or
     TDelegateCallReturnContent()
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -240,58 +240,27 @@ class PropertyContent extends Content, TPropertyContent {
 }
 
 /**
- * A reference to the index of an argument of a delegate call
- * (where the delegate is a parameter)
+ * A reference to the index of an argument of a delegate call.
  */
 class DelegateCallArgumentContent extends Content, TDelegateCallArgumentContent {
-  private Parameter p;
   private int i;
 
-  DelegateCallArgumentContent() { this = TDelegateCallArgumentContent(p, i) }
+  DelegateCallArgumentContent() { this = TDelegateCallArgumentContent(i) }
 
-  /** Gets the underlying parameter. */
-  Parameter getParameter() { result = p }
+  override string toString() { result = "delegate argument at position " + i }
 
-  /**
-   * Gets the type of the `i`th parameter of the underlying parameter `p`
-   * (which is of delegate type).
-   */
-  Type getType() {
-    result =
-      p.getType()
-          .(SystemLinqExpressions::DelegateExtType)
-          .getDelegateType()
-          .getParameter(i)
-          .getType()
-  }
-
-  override string toString() { result = "delegate parameter " + p.getName() + " at position " + i }
-
-  override Location getLocation() { result = p.getLocation() }
+  override Location getLocation() { result instanceof EmptyLocation }
 }
 
 /**
- * A reference to the return of a delegate call
- * (where the delegate is a parameter)
+ * A reference to the return of a delegate call.
  */
 class DelegateCallReturnContent extends Content, TDelegateCallReturnContent {
-  private Parameter p;
+  DelegateCallReturnContent() { this = TDelegateCallReturnContent() }
 
-  DelegateCallReturnContent() { this = TDelegateCallReturnContent(p) }
+  override string toString() { result = "delegate return" }
 
-  /** Gets the underlying parameter. */
-  Parameter getParameter() { result = p }
-
-  /**
-   * Gets the return type of the underlying parameter `p` (which is of delegate type).
-   */
-  Type getType() {
-    result = p.getType().(SystemLinqExpressions::DelegateExtType).getDelegateType().getReturnType()
-  }
-
-  override string toString() { result = "delegate parameter " + p.getName() + " result" }
-
-  override Location getLocation() { result = p.getLocation() }
+  override Location getLocation() { result instanceof EmptyLocation }
 }
 
 /**
@@ -356,18 +325,14 @@ class ContentSet extends TContentSet {
   predicate isProperty(Property p) { this = TPropertyContentSet(p) }
 
   /**
-   * Holds if this content set represents the `i`th argument of
-   * the parameter `p` of delegate type in a delegate call.
+   * Holds if this content set represents the `i`th argument of a delegate call.
    */
-  predicate isDelegateCallArgument(Parameter p, int i) {
-    this.isSingleton(TDelegateCallArgumentContent(p, i))
-  }
+  predicate isDelegateCallArgument(int i) { this.isSingleton(TDelegateCallArgumentContent(i)) }
 
   /**
-   * Holds if this content set represents the return of a delegate call
-   * of parameter `p` (which is of delegate type).
+   * Holds if this content set represents the return of a delegate call.
    */
-  predicate isDelegateCallReturn(Parameter p) { this.isSingleton(TDelegateCallReturnContent(p)) }
+  predicate isDelegateCallReturn() { this.isSingleton(TDelegateCallReturnContent()) }
 
   /** Holds if this content set represents the field `f`. */
   predicate isField(Field f) { this.isSingleton(TFieldContent(f)) }

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -176,10 +176,15 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
    * Gets the underlying type of the content `c`.
    */
   private CS::Type getUnderlyingContType(DataFlow::Content c) {
-    result = c.(DataFlow::FieldContent).getField().getType() or
-    result = c.(DataFlow::SyntheticFieldContent).getField().getType() or
-    result = c.(DataFlow::DelegateCallArgumentContent).getType() or
-    result = c.(DataFlow::DelegateCallReturnContent).getType()
+    result = c.(DataFlow::FieldContent).getField().getType()
+    or
+    result = c.(DataFlow::SyntheticFieldContent).getField().getType()
+    or
+    // Use System.Object as the type of delegate arguments and returns as the content doesn't
+    // contain any type information.
+    c instanceof DataFlow::DelegateCallArgumentContent and result instanceof ObjectType
+    or
+    c instanceof DataFlow::DelegateCallReturnContent and result instanceof ObjectType
   }
 
   Type getUnderlyingContentType(DataFlow::ContentSet c) {
@@ -347,9 +352,9 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     c.isElement() and
     result = "Element"
     or
-    exists(int i | c.isDelegateCallArgument(_, i) and result = "Parameter[" + i + "]")
+    exists(int i | c.isDelegateCallArgument(i) and result = "Parameter[" + i + "]")
     or
-    c.isDelegateCallReturn(_) and result = "ReturnValue"
+    c.isDelegateCallReturn() and result = "ReturnValue"
   }
 
   predicate partialModel = ExternalFlow::partialModel/6;

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -101,7 +101,9 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     api = any(FlowSummaryImpl::Public::NeutralSinkCallable sc | sc.hasManualModel())
   }
 
-  predicate isUninterestingForDataFlowModels(Callable api) { isHigherOrder(api) }
+  predicate isUninterestingForDataFlowModels(Callable api) { none() }
+
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { isHigherOrder(api) }
 
   class SourceOrSinkTargetApi extends Callable {
     SourceOrSinkTargetApi() { relevant(this) }
@@ -175,7 +177,9 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
    */
   private CS::Type getUnderlyingContType(DataFlow::Content c) {
     result = c.(DataFlow::FieldContent).getField().getType() or
-    result = c.(DataFlow::SyntheticFieldContent).getField().getType()
+    result = c.(DataFlow::SyntheticFieldContent).getField().getType() or
+    result = c.(DataFlow::DelegateCallArgumentContent).getType() or
+    result = c.(DataFlow::DelegateCallReturnContent).getType()
   }
 
   Type getUnderlyingContentType(DataFlow::ContentSet c) {
@@ -342,6 +346,10 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     or
     c.isElement() and
     result = "Element"
+    or
+    exists(int i | c.isDelegateCallArgument(_, i) and result = "Parameter[" + i + "]")
+    or
+    c.isDelegateCallReturn(_) and result = "ReturnValue"
   }
 
   predicate partialModel = ExternalFlow::partialModel/6;

--- a/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/csharp/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -318,6 +318,10 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, CsharpDat
     c.isField(_) or c.isSyntheticField(_) or c.isProperty(_)
   }
 
+  predicate isCallback(DataFlow::ContentSet c) {
+    c.isDelegateCallArgument(_) or c.isDelegateCallReturn()
+  }
+
   string getSyntheticName(DataFlow::ContentSet c) {
     exists(CS::Field f |
       not f.isEffectivelyPublic() and

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -497,18 +497,55 @@ public class SimpleTypes
     }
 }
 
-// No models as higher order methods are excluded
-// from model generation.
+// Methods in this class are "neutral" with respect to the heuristic model generation, but
+// the content based model generation is able to produce flow summaries for them.
 public class HigherOrderParameters
 {
+    // neutral=Models;HigherOrderParameters;M1;(System.String,System.Func<System.String,System.String>);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;M1;(System.String,System.Func<System.String,System.String>);;Argument[0];ReturnValue;value;dfc-generated
     public string M1(string s, Func<string, string> map)
     {
         return s;
     }
 
-    public object M2(Func<object, object> map, object o)
+    // neutral=Models;HigherOrderParameters;Map;(System.Func<System.Object,System.Object>,System.Object);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Map;(System.Func<System.Object,System.Object>,System.Object);;Argument[1];Argument[0].Parameter[0];value;dfc-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Map;(System.Func<System.Object,System.Object>,System.Object);;Argument[0].ReturnValue;ReturnValue;value;dfc-generated
+    public object Map(Func<object, object> f, object o)
     {
-        return map(o);
+        return f(o);
+    }
+
+    // neutral=Models;HigherOrderParameters;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[0];Argument[1].Parameter[1];value;dfc-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
+    public object Map2(object o, Func<object, object, object> f)
+    {
+        var x = f(null, o);
+        return x;
+    }
+
+    // neutral=Models;HigherOrderParameters;Apply;(System.Action<System.Object>,System.Object);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Apply;(System.Action<System.Object>,System.Object);;Argument[1];Argument[0].Parameter[0];value;dfc-generated
+    public void Apply(Action<object> a, object o)
+    {
+        a(o);
+    }
+}
+
+public static class HigherOrderExtensionMethods
+{
+    // neutral=Models;HigherOrderExtensionMethods;Select<TSource,TResult>;(System.Collections.Generic.IEnumerable<TSource>,System.Func<TSource,TResult>);summary;df-generated
+    // contentbased-summary=Models;HigherOrderExtensionMethods;false;Select<TSource,TResult>;(System.Collections.Generic.IEnumerable<TSource>,System.Func<TSource,TResult>);;Argument[0].Element;Argument[1].Parameter[0];value;dfc-generated
+    // contentbased-summary=Models;HigherOrderExtensionMethods;false;Select<TSource,TResult>;(System.Collections.Generic.IEnumerable<TSource>,System.Func<TSource,TResult>);;Argument[1].ReturnValue;ReturnValue.Element;value;dfc-generated
+    public static IEnumerable<TResult> Select<TSource, TResult>(
+            this IEnumerable<TSource> source,
+            Func<TSource, TResult> selector)
+    {
+        foreach (var item in source)
+        {
+            yield return selector(item);
+        }
     }
 }
 

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -64,10 +64,10 @@ public class BasicFlow
     }
 
     public Func<object, object> MyFunction;
-    // summary=Models;BasicFlow;false;MapMyFunction;(System.Object);;Argument[0];Argument[this];taint;df-generated
-    // summary=Models;BasicFlow;false;MapMyFunction;(System.Object);;Argument[this];ReturnValue;taint;df-generated
+    // summary=Models;BasicFlow;false;ApplyMyFunction;(System.Object);;Argument[0];Argument[this];taint;df-generated
+    // summary=Models;BasicFlow;false;ApplyMyFunction;(System.Object);;Argument[this];ReturnValue;taint;df-generated
     // No content based flow as MaD doesn't support callback logic in fields and properties.
-    public object MapMyFunction(object o)
+    public object ApplyMyFunction(object o)
     {
         return MyFunction(o);
     }
@@ -517,18 +517,18 @@ public class HigherOrderParameters
         return s;
     }
 
-    // neutral=Models;HigherOrderParameters;Map;(System.Func<System.Object,System.Object>,System.Object);summary;df-generated
-    // contentbased-summary=Models;HigherOrderParameters;false;Map;(System.Func<System.Object,System.Object>,System.Object);;Argument[1];Argument[0].Parameter[0];value;dfc-generated
-    // contentbased-summary=Models;HigherOrderParameters;false;Map;(System.Func<System.Object,System.Object>,System.Object);;Argument[0].ReturnValue;ReturnValue;value;dfc-generated
-    public object Map(Func<object, object> f, object o)
+    // neutral=Models;HigherOrderParameters;Apply;(System.Func<System.Object,System.Object>,System.Object);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Apply;(System.Func<System.Object,System.Object>,System.Object);;Argument[1];Argument[0].Parameter[0];value;dfc-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Apply;(System.Func<System.Object,System.Object>,System.Object);;Argument[0].ReturnValue;ReturnValue;value;dfc-generated
+    public object Apply(Func<object, object> f, object o)
     {
         return f(o);
     }
 
-    // neutral=Models;HigherOrderParameters;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);summary;df-generated
-    // contentbased-summary=Models;HigherOrderParameters;false;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[0];Argument[1].Parameter[1];value;dfc-generated
-    // contentbased-summary=Models;HigherOrderParameters;false;Map2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
-    public object Map2(object o, Func<object, object, object> f)
+    // neutral=Models;HigherOrderParameters;Apply2;(System.Object,System.Func<System.Object,System.Object,System.Object>);summary;df-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Apply2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[0];Argument[1].Parameter[1];value;dfc-generated
+    // contentbased-summary=Models;HigherOrderParameters;false;Apply2;(System.Object,System.Func<System.Object,System.Object,System.Object>);;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
+    public object Apply2(object o, Func<object, object, object> f)
     {
         var x = f(null, o);
         return x;

--- a/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
+++ b/csharp/ql/test/utils/modelgenerator/dataflow/Summaries.cs
@@ -62,6 +62,15 @@ public class BasicFlow
     {
         return tainted;
     }
+
+    public Func<object, object> MyFunction;
+    // summary=Models;BasicFlow;false;MapMyFunction;(System.Object);;Argument[0];Argument[this];taint;df-generated
+    // summary=Models;BasicFlow;false;MapMyFunction;(System.Object);;Argument[this];ReturnValue;taint;df-generated
+    // No content based flow as MaD doesn't support callback logic in fields and properties.
+    public object MapMyFunction(object o)
+    {
+        return MyFunction(o);
+    }
 }
 
 public class CollectionFlow

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -254,6 +254,8 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
     c instanceof DataFlowUtil::SyntheticFieldContent
   }
 
+  predicate isCallback(DataFlow::ContentSet c) { none() }
+
   string getSyntheticName(DataFlow::ContentSet c) {
     exists(Field f |
       not f.isPublic() and

--- a/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/java/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -88,6 +88,8 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, JavaDataF
     api.getDeclaringType() instanceof J::Interface and not exists(api.getBody())
   }
 
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api) { none() }
+
   class SourceOrSinkTargetApi extends Callable {
     SourceOrSinkTargetApi() { relevant(this) }
   }

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -224,6 +224,15 @@ signature module ModelGeneratorInputSig<LocationSig Location, InputSig<Location>
   predicate isUninterestingForDataFlowModels(Callable api);
 
   /**
+   * Holds if it is irrelevant to generate models for `api` based on the heuristic
+   * (non-content) flow analysis.
+   *
+   * This serves as an extra filter for the `relevant`
+   * and `isUninterestingForDataFlowModels` predicates.
+   */
+  predicate isUninterestingForHeuristicDataFlowModels(Callable api);
+
+  /**
    * Holds if `namespace`, `type`, `extensible`, `name` and `parameters` are string representations
    * for the corresponding MaD columns for `api`.
    */
@@ -300,7 +309,7 @@ module MakeModelGenerator<
     }
   }
 
-  string getOutput(ReturnNodeExt node) {
+  private string getOutput(ReturnNodeExt node) {
     result = PrintReturnNodeExt<paramReturnNodeAsOutput/2>::getOutput(node)
   }
 
@@ -432,7 +441,11 @@ module MakeModelGenerator<
 
     predicate isSource(DataFlow::Node source, FlowState state) {
       source instanceof DataFlow::ParameterNode and
-      source.(NodeExtended).getEnclosingCallable() instanceof DataFlowSummaryTargetApi and
+      exists(Callable c |
+        c = source.(NodeExtended).getEnclosingCallable() and
+        c instanceof DataFlowSummaryTargetApi and
+        not isUninterestingForHeuristicDataFlowModels(c)
+      ) and
       state.(TaintRead).getStep() = 0
     }
 

--- a/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
+++ b/shared/mad/codeql/mad/modelgenerator/internal/ModelGeneratorImpl.qll
@@ -631,7 +631,11 @@ module MakeModelGenerator<
     }
 
     /**
-     * Models as Data currently doesn't support callback logic in fields.
+     * Holds if the access path `ap` is not a parameter or returnvalue of a callback
+     * stored in a field.
+     *
+     * That is, we currently don't include summaries that rely on parameters or return values
+     * of callbacks stored in fields.
      */
     private predicate validateAccessPath(PropagateContentFlow::AccessPath ap) {
       not (mentionsField(ap) and mentionsCallback(ap))


### PR DESCRIPTION
In this PR we added support for read/store steps for delegate calls (where the delegate being called is parameter of a callable) for C#.
The read and store steps for delegate calls and delegate returns are basically "dead ends" and are only relevant for content dataflow related to model generation.
