### PR TITLE
Rust: Unused variable follow-up work

### DIFF
--- a/rust/ql/test/query-tests/unusedentities/main.rs
+++ b/rust/ql/test/query-tests/unusedentities/main.rs
@@ -111,7 +111,7 @@ fn arrays() {
 
     println!("lets use {:?}", js);
 
-    for k // SPURIOUS: unused variable [macros not yet supported]
+    for k
 	in ks
 	{
         println!("lets use {}", k); // [unreachable FALSE POSITIVE]
@@ -166,12 +166,12 @@ fn loops() {
 
     for _ in 1..10 {}
 
-    for x // SPURIOUS: unused variable [macros not yet supported]
+    for x
     in 1..10 {
         println!("x is {}", x);
     }
 
-    for x // SPURIOUS: unused variable [macros not yet supported]
+    for x
     in 1..10 {
         assert!(x != 11);
     }


### PR DESCRIPTION
Changes to unused variable.
- update test annotations following the changes to `.expected` results in https://github.com/github/codeql/pull/17659 .
- ~disable the workaround for `rust/unused-variable` being too noisy.~ --- still too noisy
  - DCA run for testing.