### PR TITLE
Go: Fix bad join order in `SummarizedParameterNode.gettype`

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowNodes.qll
@@ -727,7 +727,10 @@ module Public {
     override string getNodeKind() { result = "external parameter node" }
 
     override Type getType() {
-      result = this.getSummarizedCallable().getType().getParameterType(this.getPos())
+      result =
+        this.getSummarizedCallable()
+            .getType()
+            .getParameterType(pragma[only_bind_into](this.getPos()))
       or
       this.getPos() = -1 and
       result = this.getSummarizedCallable().asFunction().(Method).getReceiverType()


### PR DESCRIPTION
Specifically the disjunct for this.getPos() != -1. Running on uber/aresdb, before we had this:

```
   2403   ~1%    {3} r6 = JOIN `DataFlowUtil::SummarizedParameterNode.getPos/0#dispred#70a2aab4` WITH `DataFlowPrivate::FlowSummaryNode.getSummarizedCallable/0#dispred#e79ea9be` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Rhs.1
9149774   ~5%    {4}    | JOIN WITH `Types::SignatureType.getParameterType/1#dispred#2c11bb7b_102#join_rhs` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1, Rhs.2
    923   ~9%    {2}    | JOIN WITH `Scopes::Callable.getType/0#dispred#55a0e6a2` ON FIRST 2 OUTPUT Lhs.2, Lhs.3
```

We add a binding pragma to make it not bind on this.getPos() until necessary. After we have this:

```
   2403   ~0%    {3} r6 = JOIN `DataFlowUtil::SummarizedParameterNode.getPos/0#dispred#70a2aab4` WITH `DataFlowPrivate::FlowSummaryNode.getSummarizedCallable/0#dispred#e79ea9be` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
   2373   ~0%    {3}    | JOIN WITH `Scopes::Callable.getType/0#dispred#55a0e6a2` ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1
    923   ~9%    {2}    | JOIN WITH `Types::SignatureType.getParameterType/1#dispred#2c11bb7b` ON FIRST 2 OUTPUT Lhs.2, Rhs.2
```