### PR TITLE
Rust: Remove the workaround in rust/unused-variable.

### DIFF
--- a/rust/ql/src/queries/unusedentities/UnusedVariable.ql
+++ b/rust/ql/src/queries/unusedentities/UnusedVariable.ql
@@ -14,6 +14,5 @@ from Variable v
 where
   not exists(v.getAnAccess()) and
   not exists(v.getInitializer()) and
-  not v.getName().charAt(0) = "_" and
-  exists(File f | f.getBaseName() = "main.rs" | v.getLocation().getFile() = f) // temporarily severely limit results
+  not v.getName().charAt(0) = "_"
 select v, "Variable is not used."


### PR DESCRIPTION
Remove the workaround in `rust/unused-variable` that restricts results to files called `main.rs` (because we were getting far too many results otherwise).

Once the necessary fixes are in, we can check a DCA run succeeds [sufficiently cleanly] with this change, merge it, and the query is finished!