### PR TITLE
Python: Add tests for functional-like programming

### DIFF
--- a/python/ql/test/library-tests/dataflow/coverage/functional.py
+++ b/python/ql/test/library-tests/dataflow/coverage/functional.py
@@ -62,6 +62,6 @@ process_dict(func=read_sql_dict, sql=SOURCE)
 
 # TODO:
 # Consider adding tests for
-# threading.Thread, mulitprocess.Process,
+# threading.Thread, multiprocess.Process,
 # concurrent.futures.ThreadPoolExecutor,
 # and concurrent.futures.ProcessPoolExecutor.

--- a/python/ql/test/library-tests/dataflow/coverage/functional.py
+++ b/python/ql/test/library-tests/dataflow/coverage/functional.py
@@ -1,0 +1,67 @@
+# All functions starting with "test_" should run and execute `print("OK")` exactly once.
+# This can be checked by running validTest.py.
+
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname((__file__))))
+from testlib import expects
+
+# These are defined so that we can evaluate the test code.
+NONSOURCE = "not a source"
+SOURCE = "source"
+
+
+def is_source(x):
+    return x == "source" or x == b"source" or x == 42 or x == 42.0 or x == 42j
+
+
+def SINK(x):
+    if is_source(x):
+        print("OK")
+    else:
+        print("Unexpected flow", x)
+
+
+def SINK_F(x):
+    if is_source(x):
+        print("Unexpected flow", x)
+    else:
+        print("OK")
+
+# ------------------------------------------------------------------------------
+# Actual tests
+# ------------------------------------------------------------------------------
+
+def read_sql(sql):
+    SINK(sql) # $ flow="SOURCE, l:+5 -> sql"
+
+def process(func, arg): 
+    func(arg) 
+
+process(func=read_sql, arg=SOURCE)
+
+
+def read_sql_star(sql):
+    SINK(sql) # $ MISSING: flow="SOURCE, l:+5 -> sql"
+
+def process_star(func, *args): 
+    func(*args) 
+
+process_star(read_sql_star, SOURCE)
+
+
+def read_sql_dict(sql):
+    SINK(sql) # $ flow="SOURCE, l:+5 -> sql"
+
+def process_dict(func, **args): 
+    func(**args) 
+
+process_dict(func=read_sql_dict, sql=SOURCE)
+
+
+# TODO:
+# Consider adding tests for
+# threading.Thread, mulitprocess.Process,
+# concurrent.futures.ThreadPoolExecutor,
+# and concurrent.futures.ProcessPoolExecutor.

--- a/python/ql/test/library-tests/dataflow/validTest.py
+++ b/python/ql/test/library-tests/dataflow/validTest.py
@@ -66,6 +66,7 @@ if __name__ == "__main__":
     check_tests_valid("coverage.datamodel")
     check_tests_valid("coverage.test_builtins")
     check_tests_valid("coverage.loops")
+    check_tests_valid("coverage.functional")
     check_tests_valid("coverage-py2.classes")
     check_tests_valid("coverage-py3.classes")
     check_tests_valid("variable-capture.in")


### PR DESCRIPTION
This can also serve for a place to add tests for
constructs like threading.Thread, mulitprocess.Process, concurrent.futures.ThreadPoolExecutor, and concurrent.futures.ProcessPoolExecutor.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [x] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [x] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [x] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [x] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
