### PR TITLE
Rust: fix codegen to allow `--force` again

### DIFF
--- a/rust/codegen/BUILD.bazel
+++ b/rust/codegen/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
 _args = [
     "//rust/ast-generator",
     "//rust/ast-generator:manifest",
@@ -14,4 +16,17 @@ sh_binary(
     deps = [
         "//misc/bazel:sh_runfiles",
     ],
+)
+
+native_binary(
+    name = "py",
+    src = "//misc/codegen",
+    out = "codegen",
+    args = [
+        "--configuration-file=$(location //rust:codegen-conf)",
+    ],
+    data = [
+        "//rust:codegen-conf",
+    ],
+    visibility = ["//rust:__subpackages__"],
 )

--- a/rust/codegen/codegen.sh
+++ b/rust/codegen/codegen.sh
@@ -4,7 +4,6 @@ set -eu
 
 source misc/bazel/runfiles.sh 2>/dev/null || source external/ql+/misc/bazel/runfiles.sh
 
-
 ast_generator="$(rlocation "$1")"
 ast_generator_manifest="$(rlocation "$2")"
 codegen="$(rlocation "$3")"

--- a/rust/codegen/codegen.sh
+++ b/rust/codegen/codegen.sh
@@ -4,10 +4,12 @@ set -eu
 
 source misc/bazel/runfiles.sh 2>/dev/null || source external/ql+/misc/bazel/runfiles.sh
 
+
 ast_generator="$(rlocation "$1")"
 ast_generator_manifest="$(rlocation "$2")"
 codegen="$(rlocation "$3")"
 codegen_conf="$(rlocation "$4")"
+shift 4
 
 CARGO_MANIFEST_DIR="$(dirname "$ast_generator_manifest")" "$ast_generator"
-"$codegen" --configuration-file="$codegen_conf"
+"$codegen" --configuration-file="$codegen_conf" "$@"


### PR DESCRIPTION
This passes command line arguments to codegen, allowing in particular `--force` to be passed.

Also, a convenience `//rust/codegen:py` is added to only run the python based code generation, which will be faster and enough when `ast-generator` is unchanged.

