### PR TITLE
Rust: Count number of AST inconsistencies

### DIFF
--- a/rust/ql/consistency-queries/AstConsistency.ql
+++ b/rust/ql/consistency-queries/AstConsistency.ql
@@ -1,21 +1,8 @@
-import rust
-import codeql.rust.elements.internal.generated.ParentChild
+/**
+ * @name Abstract syntax tree inconsistencies
+ * @description Lists the abstract syntax tree inconsistencies in the database.  This query is intended for internal use.
+ * @kind table
+ * @id rust/diagnostics/ast-consistency
+ */
 
-query predicate multipleToString(Element e, string s) {
-  s = strictconcat(e.toString(), ",") and
-  strictcount(e.toString()) > 1
-}
-
-query predicate multipleLocations(Locatable e) { strictcount(e.getLocation()) > 1 }
-
-query predicate multiplePrimaryQlClasses(Element e, string s) {
-  s = e.getPrimaryQlClasses() and
-  strictcount(e.getAPrimaryQlClass()) > 1
-}
-
-private Element getParent(Element child) { child = getChildAndAccessor(result, _, _) }
-
-query predicate multipleParents(Element child, Element parent) {
-  parent = getParent(child) and
-  strictcount(getParent(child)) > 1
-}
+import codeql.rust.AstConsistency

--- a/rust/ql/consistency-queries/ExtractionConsistency.ql
+++ b/rust/ql/consistency-queries/ExtractionConsistency.ql
@@ -1,3 +1,10 @@
+/**
+ * @name Extraction consistency
+ * @description Lists the extraction inconsistencies (errors) in the database.  This query is intended for internal use.
+ * @kind table
+ * @id rust/diagnostics/extraction-consistency
+ */
+
 import codeql.rust.Diagnostics
 
 query predicate extractionError(ExtractionError ee) { any() }

--- a/rust/ql/lib/codeql/rust/AstConsistency.qll
+++ b/rust/ql/lib/codeql/rust/AstConsistency.qll
@@ -35,3 +35,21 @@ query predicate multipleParents(Element child, Element parent) {
   parent = getParent(child) and
   strictcount(getParent(child)) > 1
 }
+
+/**
+ * Gets counts of abstract syntax tree inconsistencies of each type.
+ */
+int getAstInconsistencyCounts(string type) {
+  // total results from all the AST consistency query predicates.
+  type = "Multiple toStrings" and
+  result = count(Element e | multipleToStrings(e, _) | e)
+  or
+  type = "Multiple locations" and
+  result = count(Element e | multipleLocations(e) | e)
+  or
+  type = "Multiple primary QL classes" and
+  result = count(Element e | multiplePrimaryQlClasses(e, _) | e)
+  or
+  type = "Multiple parents" and
+  result = count(Element e | multipleParents(e, _) | e)
+}

--- a/rust/ql/lib/codeql/rust/AstConsistency.qll
+++ b/rust/ql/lib/codeql/rust/AstConsistency.qll
@@ -1,0 +1,25 @@
+/**
+ * Provides classes for recognizing control flow graph inconsistencies.
+ */
+
+private import rust
+private import codeql.rust.elements.internal.generated.ParentChild
+
+query predicate multipleToString(Element e, string s) {
+  s = strictconcat(e.toString(), ",") and
+  strictcount(e.toString()) > 1
+}
+
+query predicate multipleLocations(Locatable e) { strictcount(e.getLocation()) > 1 }
+
+query predicate multiplePrimaryQlClasses(Element e, string s) {
+  s = e.getPrimaryQlClasses() and
+  strictcount(e.getAPrimaryQlClass()) > 1
+}
+
+private Element getParent(Element child) { child = getChildAndAccessor(result, _, _) }
+
+query predicate multipleParents(Element child, Element parent) {
+  parent = getParent(child) and
+  strictcount(getParent(child)) > 1
+}

--- a/rust/ql/lib/codeql/rust/AstConsistency.qll
+++ b/rust/ql/lib/codeql/rust/AstConsistency.qll
@@ -5,20 +5,32 @@
 private import rust
 private import codeql.rust.elements.internal.generated.ParentChild
 
-query predicate multipleToString(Element e, string s) {
-  s = strictconcat(e.toString(), ",") and
+/**
+ * Holds if `e` has more than one `toString()` result.
+ */
+query predicate multipleToStrings(Element e, string s) {
+  s = strictconcat(e.toString(), ", ") and
   strictcount(e.toString()) > 1
 }
 
+/**
+ * Holds if `e` has more than one `Location`.
+ */
 query predicate multipleLocations(Locatable e) { strictcount(e.getLocation()) > 1 }
 
+/**
+ * Holds if `e` has more than one `getPrimaryQlClasses()` result.
+ */
 query predicate multiplePrimaryQlClasses(Element e, string s) {
-  s = e.getPrimaryQlClasses() and
+  s = strictconcat(e.getPrimaryQlClasses(), ", ") and
   strictcount(e.getAPrimaryQlClass()) > 1
 }
 
 private Element getParent(Element child) { child = getChildAndAccessor(result, _, _) }
 
+/**
+ * Holds if `child` has more than one AST parent.
+ */
 query predicate multipleParents(Element child, Element parent) {
   parent = getParent(child) and
   strictcount(getParent(child)) > 1

--- a/rust/ql/src/queries/diagnostics/AstConsistencyCounts.ql
+++ b/rust/ql/src/queries/diagnostics/AstConsistencyCounts.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Abstract syntax tree inconsistency counts
+ * @description Counts the number of abstract syntax tree inconsistencies of each type.  This query is intended for internal use.
+ * @kind diagnostic
+ * @id rust/diagnostics/ast-consistency-counts
+ */
+
+import rust
+import codeql.rust.AstConsistency as Consistency
+
+// see also `rust/diagnostics/ast-consistency`, which lists the
+// individual inconsistency results.
+from string type, int num
+where num = Consistency::getAstInconsistencyCounts(type)
+select type, num

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -21,7 +21,9 @@ int getLinesOfUserCode() {
 /**
  * Gets a count of the total number of abstract syntax tree inconsistencies in the database.
  */
-int getTotalAstInconsistencies() { result = sum(AstConsistency::getAstInconsistencyCounts(_)) }
+int getTotalAstInconsistencies() {
+  result = sum(string type | | AstConsistency::getAstInconsistencyCounts(type))
+}
 
 /**
  * Gets a count of the total number of control flow graph inconsistencies in the database.

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -3,6 +3,7 @@
  */
 
 import rust
+import codeql.rust.AstConsistency as AstConsistency
 private import codeql.rust.controlflow.internal.CfgConsistency as CfgConsistency
 
 /**
@@ -16,6 +17,11 @@ int getLinesOfCode() { result = sum(File f | | f.getNumberOfLinesOfCode()) }
 int getLinesOfUserCode() {
   result = sum(File f | exists(f.getRelativePath()) | f.getNumberOfLinesOfCode())
 }
+
+/**
+ * Gets a count of the total number of abstract syntax tree inconsistencies in the database.
+ */
+int getTotalAstInconsistencies() { result = sum(AstConsistency::getAstInconsistencyCounts(_)) }
 
 /**
  * Gets a count of the total number of control flow graph inconsistencies in the database.

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -1,7 +1,7 @@
 /**
  * @name Summary Statistics
  * @description A table of summary statistics about a database.
- * @kind table
+ * @kind diagnostic
  * @id rust/summary/summary-statistics
  * @tags summary
  */

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -34,5 +34,7 @@ where
   or
   key = "Lines of user code extracted" and value = getLinesOfUserCode().toString()
   or
+  key = "Inconsistencies - AST" and value = getTotalAstInconsistencies().toString()
+  or
   key = "Inconsistencies - CFG" and value = getTotalCfgInconsistencies().toString()
 select key, value

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -1,7 +1,7 @@
 /**
  * @name Summary Statistics
  * @description A table of summary statistics about a database.
- * @kind diagnostic
+ * @kind metric
  * @id rust/summary/summary-statistics
  * @tags summary
  */
@@ -10,31 +10,30 @@ import rust
 import codeql.rust.Diagnostics
 import Stats
 
-from string key, string value
+from string key, int value
 where
-  key = "Elements extracted" and value = count(Element e | not e instanceof Unextracted).toString()
+  key = "Elements extracted" and value = count(Element e | not e instanceof Unextracted)
   or
-  key = "Elements unextracted" and value = count(Unextracted e).toString()
+  key = "Elements unextracted" and value = count(Unextracted e)
   or
-  key = "Extraction errors" and value = count(ExtractionError e).toString()
+  key = "Extraction errors" and value = count(ExtractionError e)
   or
-  key = "Extraction warnings" and value = count(ExtractionWarning w).toString()
+  key = "Extraction warnings" and value = count(ExtractionWarning w)
   or
-  key = "Files extracted - total" and value = count(File f | exists(f.getRelativePath())).toString()
+  key = "Files extracted - total" and value = count(File f | exists(f.getRelativePath()))
   or
   key = "Files extracted - with errors" and
   value =
     count(File f | exists(f.getRelativePath()) and not f instanceof SuccessfullyExtractedFile)
-        .toString()
   or
   key = "Files extracted - without errors" and
-  value = count(SuccessfullyExtractedFile f | exists(f.getRelativePath())).toString()
+  value = count(SuccessfullyExtractedFile f | exists(f.getRelativePath()))
   or
-  key = "Lines of code extracted" and value = getLinesOfCode().toString()
+  key = "Lines of code extracted" and value = getLinesOfCode()
   or
-  key = "Lines of user code extracted" and value = getLinesOfUserCode().toString()
+  key = "Lines of user code extracted" and value = getLinesOfUserCode()
   or
-  key = "Inconsistencies - AST" and value = getTotalAstInconsistencies().toString()
+  key = "Inconsistencies - AST" and value = getTotalAstInconsistencies()
   or
-  key = "Inconsistencies - CFG" and value = getTotalCfgInconsistencies().toString()
+  key = "Inconsistencies - CFG" and value = getTotalCfgInconsistencies()
 select key, value

--- a/rust/ql/test/query-tests/diagnostics/AstConsistencyCounts.expected
+++ b/rust/ql/test/query-tests/diagnostics/AstConsistencyCounts.expected
@@ -1,0 +1,4 @@
+| Multiple locations | 0 |
+| Multiple parents | 0 |
+| Multiple primary QL classes | 0 |
+| Multiple toStrings | 0 |

--- a/rust/ql/test/query-tests/diagnostics/AstConsistencyCounts.qlref
+++ b/rust/ql/test/query-tests/diagnostics/AstConsistencyCounts.qlref
@@ -1,0 +1,1 @@
+queries/diagnostics/AstConsistencyCounts.ql

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -5,6 +5,7 @@
 | Files extracted - total | 7 |
 | Files extracted - with errors | 2 |
 | Files extracted - without errors | 5 |
+| Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Lines of code extracted | 59 |
 | Lines of user code extracted | 59 |


### PR DESCRIPTION
Similar to https://github.com/github/codeql/pull/17763 but for AST inconsistencies.
- we already have `rust/diagnostics/ast-consistency` which lists each AST inconsistency in a database.  Here I have given this query metadata and moved the logic out into a shared library `AstConsistency.qll`.
- new query `ust/diagnostics/ast-consistency-counts` lists the number of inconsistencies of each type in a database.
- existing query `rust/summary/summary-statistics` is extended to report the total number of AST inconsistencies (regardless of type).  I've also converted the query to a `metric` query so that it can be accessed in the DCA job.

The intent is to add the total number of AST consistencies to the DCA job, and track it as a metric.