### PR TITLE
C++: Add missing parent scope cases

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/Element.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Element.qll
@@ -129,7 +129,7 @@ class Element extends ElementBase {
    * or certain kinds of `Statement`.
    */
   Element getParentScope() {
-    // result instanceof class
+    // result instanceof Class
     exists(Declaration m |
       m = this and
       result = m.getDeclaringType() and
@@ -138,31 +138,40 @@ class Element extends ElementBase {
     or
     exists(TemplateClass tc | this = tc.getATemplateArgument() and result = tc)
     or
-    // result instanceof namespace
+    // result instanceof Namespace
     exists(Namespace n | result = n and n.getADeclaration() = this)
     or
     exists(FriendDecl d, Namespace n | this = d and n.getADeclaration() = d and result = n)
     or
     exists(Namespace n | this = n and result = n.getParentNamespace())
     or
-    // result instanceof stmt
+    // result instanceof Stmt
     exists(LocalVariable v |
       this = v and
       exists(DeclStmt ds | ds.getADeclaration() = v and result = ds.getParent())
     )
     or
-    exists(Parameter p | this = p and result = p.getFunction())
+    exists(Parameter p |
+      this = p and
+      (
+        result = p.getFunction() or
+        result = p.getCatchBlock().getParent().(Handler).getParent().(TryStmt).getParent() or
+        result = p.getRequiresExpr().getEnclosingStmt().getParent()
+      )
+    )
     or
     exists(GlobalVariable g, Namespace n | this = g and n.getADeclaration() = g and result = n)
     or
+    exists(TemplateVariable tv | this = tv.getATemplateArgument() and result = tv)
+    or
     exists(EnumConstant e | this = e and result = e.getDeclaringEnum())
     or
-    // result instanceof block|function
+    // result instanceof Block|Function
     exists(BlockStmt b | this = b and blockscope(unresolveElement(b), unresolveElement(result)))
     or
     exists(TemplateFunction tf | this = tf.getATemplateArgument() and result = tf)
     or
-    // result instanceof stmt
+    // result instanceof Stmt
     exists(ControlStructure s | this = s and result = s.getParent())
     or
     using_container(unresolveElement(result), underlyingElement(this))

--- a/cpp/ql/test/library-tests/scopes/parents/parents.cpp
+++ b/cpp/ql/test/library-tests/scopes/parents/parents.cpp
@@ -14,6 +14,13 @@ namespace foo {
   }
 }
 
+template<typename T>
+T var = 42;
 
-                        
+int g() {
+  requires(int l) { l; };
 
+  return var<int>;
+}
+
+// semmle-extractor-options: -std=c++20

--- a/cpp/ql/test/library-tests/scopes/parents/parents.expected
+++ b/cpp/ql/test/library-tests/scopes/parents/parents.expected
@@ -1,5 +1,8 @@
 | 0 | file://:0:0:0:0 | (global namespace) | file://:0:0:0:0 | __va_list_tag |
 | 0 | file://:0:0:0:0 | (global namespace) | parents.cpp:2:11:2:13 | foo |
+| 0 | file://:0:0:0:0 | (global namespace) | parents.cpp:18:3:18:3 | var |
+| 0 | file://:0:0:0:0 | (global namespace) | parents.cpp:18:7:18:7 | var |
+| 0 | file://:0:0:0:0 | (global namespace) | parents.cpp:20:5:20:5 | g |
 | 1 | file://:0:0:0:0 | __va_list_tag | file://:0:0:0:0 | fp_offset |
 | 1 | file://:0:0:0:0 | __va_list_tag | file://:0:0:0:0 | gp_offset |
 | 1 | file://:0:0:0:0 | __va_list_tag | file://:0:0:0:0 | operator= |
@@ -14,7 +17,11 @@
 | 1 | parents.cpp:4:10:4:10 | f | parents.cpp:4:19:13:5 | { ... } |
 | 1 | parents.cpp:4:19:13:5 | { ... } | parents.cpp:5:11:5:11 | j |
 | 1 | parents.cpp:4:19:13:5 | { ... } | parents.cpp:6:11:10:7 | { ... } |
+| 1 | parents.cpp:4:19:13:5 | { ... } | parents.cpp:11:18:11:18 | e |
 | 1 | parents.cpp:4:19:13:5 | { ... } | parents.cpp:11:21:12:7 | { ... } |
 | 1 | parents.cpp:6:11:10:7 | { ... } | parents.cpp:7:9:9:9 | for(...;...;...) ... |
 | 1 | parents.cpp:6:11:10:7 | { ... } | parents.cpp:7:33:9:9 | { ... } |
 | 1 | parents.cpp:7:33:9:9 | { ... } | parents.cpp:8:15:8:15 | k |
+| 1 | parents.cpp:18:7:18:7 | var | parents.cpp:17:19:17:19 | T |
+| 1 | parents.cpp:20:5:20:5 | g | parents.cpp:20:9:24:1 | { ... } |
+| 1 | parents.cpp:20:9:24:1 | { ... } | parents.cpp:21:16:21:16 | l |


### PR DESCRIPTION
This is mostly used to detect the shadowing of variable declarations.

DCA shows no changes. This does break some coding standards tests. I'll update the test results there after this is merged, and open an issue that informs the coding standards people of this. I briefly looked at fixing the query, but (a) it's not clearly documented what the query should do, and (b) this requires digging through about 400 lines of query code, which I find very hard to follow.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
