### PR TITLE
KE2: Log our verbosity level

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/KotlinExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/KotlinExtractor.kt
@@ -119,6 +119,7 @@ OLD: KE1
         val logger = Logger(loggerBase, dtw)
         logger.info("Extraction started")
         logger.flush()
+        logger.infoVerbosity()
         logger.info("Extraction for invocation TRAP file $invocationTrapFile")
         logger.flush()
         /*

--- a/java/kotlin-extractor2/src/main/kotlin/utils/Logger.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/utils/Logger.kt
@@ -268,6 +268,10 @@ class LoggerBase(val diagnosticCounter: DiagnosticCounter) : BasicLogger {
         }
     }
 
+    fun infoVerbosity(dtw: DiagnosticTrapWriter) {
+        info(dtw, "Kotlin extractor verbosity is " + verbosity.toString())
+    }
+
     override fun warn(dtw: DiagnosticTrapWriter, msg: String, extraInfo: String?) {
         warn(dtw, msg, extraInfo, null)
     }
@@ -346,6 +350,10 @@ open class Logger(val loggerBase: LoggerBase, val dtw: DiagnosticTrapWriter) : B
 
     fun info(msg: String) {
         info(dtw, msg)
+    }
+
+    fun infoVerbosity() {
+        loggerBase.infoVerbosity(dtw)
     }
 
     override fun warn(dtw: DiagnosticTrapWriter, msg: String, extraInfo: String?) {


### PR DESCRIPTION
This happens at `info` level, which is logged by default.

This ports https://github.com/github/codeql/pull/17741 to KE2.
