### PR TITLE
Python: Refactor references to NormalCall.

### DIFF
--- a/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
+++ b/python/ql/src/meta/analysis-quality/CallGraphQuality.qll
@@ -103,20 +103,20 @@ module TypeTrackingBasedCallGraph {
   /** A call that can be resolved by type-tracking. */
   class ResolvableCall extends RelevantCall {
     ResolvableCall() {
-      exists(TT::TNormalCall(this, _, _))
+      TT::resolveCall(this, _, _)
       or
       TT::resolveClassCall(this, _)
     }
 
     /** Gets a resolved target of this call. */
     Target getTarget() {
-      exists(TT::DataFlowCall call, TT::CallType ct, Function targetFunc |
-        call = TT::TNormalCall(this, targetFunc, ct) and
+      exists(TT::CallType ct, Function targetFunc |
+        TT::resolveCall(this, targetFunc, ct) and
         not ct instanceof TT::CallTypeClass and
         targetFunc = result.(TargetFunction).getFunction()
       )
       or
-      // a TT::TNormalCall only exists when the call can be resolved to a function.
+      // TT::resolveCall only holds when the call can be resolved to a function.
       // Since points-to just says the call goes directly to the class itself, and
       // type-tracking based wants to resolve this to the constructor, which might not
       // exist. So to do a proper comparison, we don't require the call to be resolve to

--- a/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.ql
+++ b/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.ql
@@ -31,8 +31,7 @@ predicate typeTrackerCallEdge(CallNode call, Function callable) {
 predicate typeTrackerClassCall(CallNode call, Function callable) {
   exists(call.getLocation().getFile().getRelativePath()) and
   exists(callable.getLocation().getFile().getRelativePath()) and
-  TT::resolveCall(call, callable, any(TT::TCallType t | t instanceof TT::CallTypeClass)) and
-  TT::TFunction(callable) instanceof TT::DataFlowFunction
+  TT::resolveCall(call, callable, any(TT::TCallType t | t instanceof TT::CallTypeClass))
 }
 
 module CallGraphTest implements TestSig {

--- a/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.ql
+++ b/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.ql
@@ -31,10 +31,8 @@ predicate typeTrackerCallEdge(CallNode call, Function callable) {
 predicate typeTrackerClassCall(CallNode call, Function callable) {
   exists(call.getLocation().getFile().getRelativePath()) and
   exists(callable.getLocation().getFile().getRelativePath()) and
-  exists(TT::NormalCall cc |
-    cc = TT::TNormalCall(call, _, any(TT::TCallType t | t instanceof TT::CallTypeClass)) and
-    TT::TFunction(callable) = TT::viableCallable(cc)
-  )
+  TT::resolveCall(call, callable, any(TT::TCallType t | t instanceof TT::CallTypeClass)) and
+  TT::TFunction(callable) instanceof TT::DataFlowFunction
 }
 
 module CallGraphTest implements TestSig {

--- a/python/ql/test/library-tests/dataflow/calls/DataFlowCallTest.ql
+++ b/python/ql/test/library-tests/dataflow/calls/DataFlowCallTest.ql
@@ -21,8 +21,11 @@ module DataFlowCallTest implements TestSig {
       value = prettyExpr(call.getNode().getNode()) and
       tag = "call"
       or
-      value = call.(DataFlowDispatch::NormalCall).getCallType().toString() and
-      tag = "callType"
+      exists(DataFlowDispatch::CallType callType |
+        DataFlowDispatch::resolveCall(call.getNode(), _, callType) and
+        value = callType.toString() and
+        tag = "callType"
+      )
       or
       exists(DataFlowDispatch::ArgumentPosition pos, DataFlow::Node arg |
         arg = call.getArgument(pos)


### PR DESCRIPTION
This should be a simple semantics-preserving refactor to eliminate references to `TNormalCall`.