### PR TITLE
Go: Add helper predicate `lookThroughPointerType`

### DIFF
--- a/go/ql/lib/semmle/go/Decls.qll
+++ b/go/ql/lib/semmle/go/Decls.qll
@@ -212,10 +212,7 @@ class MethodDecl extends FuncDecl {
    *
    * is `Rectangle`.
    */
-  NamedType getReceiverBaseType() {
-    result = this.getReceiverType() or
-    result = this.getReceiverType().(PointerType).getBaseType()
-  }
+  NamedType getReceiverBaseType() { result = lookThroughPointerType(this.getReceiverType()) }
 
   /**
    * Gets the receiver variable of this method.

--- a/go/ql/lib/semmle/go/Scopes.qll
+++ b/go/ql/lib/semmle/go/Scopes.qll
@@ -519,13 +519,7 @@ class Method extends Function {
    * Gets the receiver base type of this method, that is, either the base type of the receiver type
    * if it is a pointer type, or the receiver type itself if it is not a pointer type.
    */
-  Type getReceiverBaseType() {
-    exists(Type recv | recv = this.getReceiverType() |
-      if recv instanceof PointerType
-      then result = recv.(PointerType).getBaseType()
-      else result = recv
-    )
-  }
+  Type getReceiverBaseType() { result = lookThroughPointerType(this.getReceiverType()) }
 
   /** Holds if this method has name `m` and belongs to the method set of type `tp` or `*tp`. */
   private predicate isIn(NamedType tp, string m) {

--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -485,7 +485,8 @@ class StructType extends @structtype, CompositeType {
    */
   private predicate hasEmbeddedField(Type tp, int depth) {
     exists(Field f | this.hasFieldCand(_, f, depth, true) |
-      tp = lookThroughPointerType(f.getType())
+      tp = f.getType() or
+      tp = f.getType().(PointerType).getBaseType()
     )
   }
 

--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -638,6 +638,9 @@ class PointerType extends @pointertype, CompositeType {
   override string toString() { result = "pointer type" }
 }
 
+/**
+ * Gets the base type if `t` is a pointer type, otherwise `t` itself.
+ */
 Type lookThroughPointerType(Type t) {
   not t instanceof PointerType and
   result = t

--- a/go/ql/lib/semmle/go/Types.qll
+++ b/go/ql/lib/semmle/go/Types.qll
@@ -446,11 +446,7 @@ class StructType extends @structtype, CompositeType {
       if n = ""
       then (
         isEmbedded = true and
-        (
-          name = tp.(NamedType).getName()
-          or
-          name = tp.(PointerType).getBaseType().(NamedType).getName()
-        )
+        name = lookThroughPointerType(tp).(NamedType).getName()
       ) else (
         isEmbedded = false and
         name = n
@@ -489,8 +485,7 @@ class StructType extends @structtype, CompositeType {
    */
   private predicate hasEmbeddedField(Type tp, int depth) {
     exists(Field f | this.hasFieldCand(_, f, depth, true) |
-      tp = f.getType() or
-      tp = f.getType().(PointerType).getBaseType()
+      tp = lookThroughPointerType(f.getType())
     )
   }
 
@@ -518,9 +513,7 @@ class StructType extends @structtype, CompositeType {
     this.hasFieldCand(_, embeddedParent, depth - 1, true) and
     result.getName() = name and
     (
-      result.getReceiverBaseType() = embeddedParent.getType()
-      or
-      result.getReceiverBaseType() = embeddedParent.getType().(PointerType).getBaseType()
+      result.getReceiverBaseType() = lookThroughPointerType(embeddedParent.getType())
       or
       methodhosts(result, embeddedParent.getType())
     )
@@ -642,6 +635,13 @@ class PointerType extends @pointertype, CompositeType {
   override string pp() { result = "* " + this.getBaseType().pp() }
 
   override string toString() { result = "pointer type" }
+}
+
+Type lookThroughPointerType(Type t) {
+  not t instanceof PointerType and
+  result = t
+  or
+  result = t.(PointerType).getBaseType()
 }
 
 private newtype TTypeSetTerm =

--- a/go/ql/lib/semmle/go/controlflow/IR.qll
+++ b/go/ql/lib/semmle/go/controlflow/IR.qll
@@ -358,11 +358,7 @@ module IR {
 
     override predicate reads(ValueEntity v) { v = field }
 
-    override Type getResultType() {
-      if field.getType() instanceof PointerType
-      then result = field.getType().(PointerType).getBaseType()
-      else result = field.getType()
-    }
+    override Type getResultType() { result = lookThroughPointerType(field.getType()) }
 
     override ControlFlow::Root getRoot() { result.isRootOf(e) }
 

--- a/go/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
+++ b/go/ql/src/InconsistentCode/LengthComparisonOffByOne.ql
@@ -73,7 +73,7 @@ predicate isRegexpMethodCall(DataFlow::MethodCallNode c) {
   exists(NamedType regexp, Type recvtp |
     regexp.getName() = "Regexp" and recvtp = c.getReceiver().getType()
   |
-    recvtp = regexp or recvtp.(PointerType).getBaseType() = regexp
+    lookThroughPointerType(recvtp) = regexp
   )
 }
 


### PR DESCRIPTION
I got fed up of the extra boilerplate code needed to do this in various different situations. Performance-wise I'm not sure if it's better to mark this `pragma[inline]` or if it would be better to leave it as it is. (Or even `pragma[noinline]`!) I will make sure to fix any performance problems before merging.

I'm open to suggestions for a better predicate name.