### PR TITLE
Go: Fix type param declarations in AST viewer

### DIFF
--- a/go/ql/lib/change-notes/2024-10-17-ast-viewer-type-param-decl.md
+++ b/go/ql/lib/change-notes/2024-10-17-ast-viewer-type-param-decl.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The AST viewer now shows type parameter declarations in the correct place in the AST.

--- a/go/ql/lib/semmle/go/AST.qll
+++ b/go/ql/lib/semmle/go/AST.qll
@@ -55,6 +55,8 @@ class AstNode extends @node, Locatable {
     kind = "commentgroup" and result = this.(File).getCommentGroup(i)
     or
     kind = "comment" and result = this.(CommentGroup).getComment(i)
+    or
+    kind = "typeparamdecl" and result = this.(TypeParamDeclParent).getTypeParameterDecl(i)
   }
 
   /**

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -1,16 +1,3 @@
-other.go:
-#    8| [TypeParamDecl] type parameter declaration
-#    8|   0: [Ident, TypeName] int
-#    8|       Type = int
-#    8|   1: [Ident, TypeName] U
-#    8|       Type = U
-#   17| [TypeParamDecl] type parameter declaration
-#   17|   0: [TypeSetLiteralExpr] type set literal
-#   17|       Type = ~string
-#   17|     0: [Ident, TypeName] string
-#   17|         Type = string
-#   17|   1: [Ident, TypeName] T
-#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -652,6 +639,11 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
+#    8|     3: [TypeParamDecl] type parameter declaration
+#    8|       0: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] U
+#    8|           Type = U
 #   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
@@ -668,6 +660,13 @@ other.go:
 #   17|       1: [ArrayTypeExpr] array type
 #   17|           Type = []T
 #   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   17|       2: [TypeParamDecl] type parameter declaration
+#   17|         0: [TypeSetLiteralExpr] type set literal
+#   17|             Type = ~string
+#   17|           0: [Ident, TypeName] string
+#   17|               Type = string
+#   17|         1: [Ident, TypeName] T
 #   17|             Type = T
 #   19|   7: [MethodDecl] function declaration
 #   19|     0: [FunctionName, Ident] f

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAst.expected
@@ -1,3 +1,16 @@
+other.go:
+#    8| [TypeParamDecl] type parameter declaration
+#    8|   0: [Ident, TypeName] int
+#    8|       Type = int
+#    8|   1: [Ident, TypeName] U
+#    8|       Type = U
+#   17| [TypeParamDecl] type parameter declaration
+#   17|   0: [TypeSetLiteralExpr] type set literal
+#   17|       Type = ~string
+#   17|     0: [Ident, TypeName] string
+#   17|         Type = string
+#   17|   1: [Ident, TypeName] T
+#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -648,3 +661,25 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
+#   17|   6: [TypeDecl] type declaration
+#   17|     0: [TypeSpec] type declaration specifier
+#   17|       0: [Ident, TypeName] myType
+#   17|           Type = myType
+#   17|       1: [ArrayTypeExpr] array type
+#   17|           Type = []T
+#   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   19|   7: [MethodDecl] function declaration
+#   19|     0: [FunctionName, Ident] f
+#   19|         Type = func() 
+#   19|     1: [FuncTypeExpr] function type
+#   19|     2: [ReceiverDecl] receiver declaration
+#   19|       0: [GenericTypeInstantiationExpr] generic type instantiation expression
+#   19|           Type = myType
+#   19|         0: [Ident, TypeName] myType
+#   19|             Type = myType
+#   19|         1: [Ident, TypeName] U
+#   19|             Type = U
+#   19|       1: [Ident, VariableName] m
+#   19|           Type = myType
+#   19|     3: [BlockStmt] block statement

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -1,3 +1,16 @@
+other.go:
+#    8| [TypeParamDecl] type parameter declaration
+#    8|   0: [Ident, TypeName] int
+#    8|       Type = int
+#    8|   1: [Ident, TypeName] U
+#    8|       Type = U
+#   17| [TypeParamDecl] type parameter declaration
+#   17|   0: [TypeSetLiteralExpr] type set literal
+#   17|       Type = ~string
+#   17|     0: [Ident, TypeName] string
+#   17|         Type = string
+#   17|   1: [Ident, TypeName] T
+#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -628,3 +641,25 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
+#   17|   6: [TypeDecl] type declaration
+#   17|     0: [TypeSpec] type declaration specifier
+#   17|       0: [Ident, TypeName] myType
+#   17|           Type = myType
+#   17|       1: [ArrayTypeExpr] array type
+#   17|           Type = []T
+#   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   19|   7: [MethodDecl] function declaration
+#   19|     0: [FunctionName, Ident] f
+#   19|         Type = func() 
+#   19|     1: [FuncTypeExpr] function type
+#   19|     2: [ReceiverDecl] receiver declaration
+#   19|       0: [GenericTypeInstantiationExpr] generic type instantiation expression
+#   19|           Type = myType
+#   19|         0: [Ident, TypeName] myType
+#   19|             Type = myType
+#   19|         1: [Ident, TypeName] U
+#   19|             Type = U
+#   19|       1: [Ident, VariableName] m
+#   19|           Type = myType
+#   19|     3: [BlockStmt] block statement

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstExcludeComments.expected
@@ -1,16 +1,3 @@
-other.go:
-#    8| [TypeParamDecl] type parameter declaration
-#    8|   0: [Ident, TypeName] int
-#    8|       Type = int
-#    8|   1: [Ident, TypeName] U
-#    8|       Type = U
-#   17| [TypeParamDecl] type parameter declaration
-#   17|   0: [TypeSetLiteralExpr] type set literal
-#   17|       Type = ~string
-#   17|     0: [Ident, TypeName] string
-#   17|         Type = string
-#   17|   1: [Ident, TypeName] T
-#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -632,6 +619,11 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
+#    8|     3: [TypeParamDecl] type parameter declaration
+#    8|       0: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] U
+#    8|           Type = U
 #   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
@@ -648,6 +640,13 @@ other.go:
 #   17|       1: [ArrayTypeExpr] array type
 #   17|           Type = []T
 #   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   17|       2: [TypeParamDecl] type parameter declaration
+#   17|         0: [TypeSetLiteralExpr] type set literal
+#   17|             Type = ~string
+#   17|           0: [Ident, TypeName] string
+#   17|               Type = string
+#   17|         1: [Ident, TypeName] T
 #   17|             Type = T
 #   19|   7: [MethodDecl] function declaration
 #   19|     0: [FunctionName, Ident] f

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
@@ -1,3 +1,16 @@
+other.go:
+#    8| [TypeParamDecl] type parameter declaration
+#    8|   0: [Ident, TypeName] int
+#    8|       Type = int
+#    8|   1: [Ident, TypeName] U
+#    8|       Type = U
+#   17| [TypeParamDecl] type parameter declaration
+#   17|   0: [TypeSetLiteralExpr] type set literal
+#   17|       Type = ~string
+#   17|     0: [Ident, TypeName] string
+#   17|         Type = string
+#   17|   1: [Ident, TypeName] T
+#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -65,3 +78,11 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
+#   17|   3: [TypeDecl] type declaration
+#   17|     0: [TypeSpec] type declaration specifier
+#   17|       0: [Ident, TypeName] myType
+#   17|           Type = myType
+#   17|       1: [ArrayTypeExpr] array type
+#   17|           Type = []T
+#   17|         0: [Ident, TypeName] T
+#   17|             Type = T

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstNestedFunction.expected
@@ -1,16 +1,3 @@
-other.go:
-#    8| [TypeParamDecl] type parameter declaration
-#    8|   0: [Ident, TypeName] int
-#    8|       Type = int
-#    8|   1: [Ident, TypeName] U
-#    8|       Type = U
-#   17| [TypeParamDecl] type parameter declaration
-#   17|   0: [TypeSetLiteralExpr] type set literal
-#   17|       Type = ~string
-#   17|     0: [Ident, TypeName] string
-#   17|         Type = string
-#   17|   1: [Ident, TypeName] T
-#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -69,6 +56,11 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
+#    8|     3: [TypeParamDecl] type parameter declaration
+#    8|       0: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] U
+#    8|           Type = U
 #   15|   2: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
@@ -85,4 +77,11 @@ other.go:
 #   17|       1: [ArrayTypeExpr] array type
 #   17|           Type = []T
 #   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   17|       2: [TypeParamDecl] type parameter declaration
+#   17|         0: [TypeSetLiteralExpr] type set literal
+#   17|             Type = ~string
+#   17|           0: [Ident, TypeName] string
+#   17|               Type = string
+#   17|         1: [Ident, TypeName] T
 #   17|             Type = T

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
@@ -1,16 +1,4 @@
 other.go:
-#    8| [TypeParamDecl] type parameter declaration
-#    8|   0: [Ident, TypeName] int
-#    8|       Type = int
-#    8|   1: [Ident, TypeName] U
-#    8|       Type = U
-#   17| [TypeParamDecl] type parameter declaration
-#   17|   0: [TypeSetLiteralExpr] type set literal
-#   17|       Type = ~string
-#   17|     0: [Ident, TypeName] string
-#   17|         Type = string
-#   17|   1: [Ident, TypeName] T
-#   17|       Type = T
 #    0| [GoFile] other.go
 #    1|   package: [Ident] main
 #    3|   1: [FuncDecl] function declaration
@@ -53,6 +41,11 @@ other.go:
 #   11|             Type = int
 #   11|           0: [Ident, VariableName] myNested
 #   11|               Type = func() int
+#    8|     3: [TypeParamDecl] type parameter declaration
+#    8|       0: [Ident, TypeName] int
+#    8|           Type = int
+#    8|       1: [Ident, TypeName] U
+#    8|           Type = U
 #   15|   5: [VarDecl] variable declaration
 #   15|     0: [ValueSpec] value declaration specifier
 #   15|       0: [Ident, VariableName] x
@@ -69,6 +62,13 @@ other.go:
 #   17|       1: [ArrayTypeExpr] array type
 #   17|           Type = []T
 #   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   17|       2: [TypeParamDecl] type parameter declaration
+#   17|         0: [TypeSetLiteralExpr] type set literal
+#   17|             Type = ~string
+#   17|           0: [Ident, TypeName] string
+#   17|               Type = string
+#   17|         1: [Ident, TypeName] T
 #   17|             Type = T
 #   19|   7: [MethodDecl] function declaration
 #   19|     0: [FunctionName, Ident] f

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFile.expected
@@ -1,4 +1,16 @@
 other.go:
+#    8| [TypeParamDecl] type parameter declaration
+#    8|   0: [Ident, TypeName] int
+#    8|       Type = int
+#    8|   1: [Ident, TypeName] U
+#    8|       Type = U
+#   17| [TypeParamDecl] type parameter declaration
+#   17|   0: [TypeSetLiteralExpr] type set literal
+#   17|       Type = ~string
+#   17|     0: [Ident, TypeName] string
+#   17|         Type = string
+#   17|   1: [Ident, TypeName] T
+#   17|       Type = T
 #    0| [GoFile] other.go
 #    1|   package: [Ident] main
 #    3|   1: [FuncDecl] function declaration
@@ -50,3 +62,25 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
+#   17|   6: [TypeDecl] type declaration
+#   17|     0: [TypeSpec] type declaration specifier
+#   17|       0: [Ident, TypeName] myType
+#   17|           Type = myType
+#   17|       1: [ArrayTypeExpr] array type
+#   17|           Type = []T
+#   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   19|   7: [MethodDecl] function declaration
+#   19|     0: [FunctionName, Ident] f
+#   19|         Type = func() 
+#   19|     1: [FuncTypeExpr] function type
+#   19|     2: [ReceiverDecl] receiver declaration
+#   19|       0: [GenericTypeInstantiationExpr] generic type instantiation expression
+#   19|           Type = myType
+#   19|         0: [Ident, TypeName] myType
+#   19|             Type = myType
+#   19|         1: [Ident, TypeName] U
+#   19|             Type = U
+#   19|       1: [Ident, VariableName] m
+#   19|           Type = myType
+#   19|     3: [BlockStmt] block statement

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
@@ -4,13 +4,6 @@ other.go:
 #    8|       Type = int
 #    8|   1: [Ident, TypeName] U
 #    8|       Type = U
-#   17| [TypeParamDecl] type parameter declaration
-#   17|   0: [TypeSetLiteralExpr] type set literal
-#   17|       Type = ~string
-#   17|     0: [Ident, TypeName] string
-#   17|         Type = string
-#   17|   1: [Ident, TypeName] T
-#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -65,4 +58,11 @@ other.go:
 #   17|       1: [ArrayTypeExpr] array type
 #   17|           Type = []T
 #   17|         0: [Ident, TypeName] T
+#   17|             Type = T
+#   17|       2: [TypeParamDecl] type parameter declaration
+#   17|         0: [TypeSetLiteralExpr] type set literal
+#   17|             Type = ~string
+#   17|           0: [Ident, TypeName] string
+#   17|               Type = string
+#   17|         1: [Ident, TypeName] T
 #   17|             Type = T

--- a/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/PrintAstRestrictFunction.expected
@@ -1,3 +1,16 @@
+other.go:
+#    8| [TypeParamDecl] type parameter declaration
+#    8|   0: [Ident, TypeName] int
+#    8|       Type = int
+#    8|   1: [Ident, TypeName] U
+#    8|       Type = U
+#   17| [TypeParamDecl] type parameter declaration
+#   17|   0: [TypeSetLiteralExpr] type set literal
+#   17|       Type = ~string
+#   17|     0: [Ident, TypeName] string
+#   17|         Type = string
+#   17|   1: [Ident, TypeName] T
+#   17|       Type = T
 go.mod:
 #    0| [GoModFile] go.mod
 #    1|   0: [GoModModuleLine] go.mod module line
@@ -45,3 +58,11 @@ other.go:
 #   15|       2: [IntLit] 0
 #   15|           Type = int
 #   15|           Value = [IntLit] 0
+#   17|   3: [TypeDecl] type declaration
+#   17|     0: [TypeSpec] type declaration specifier
+#   17|       0: [Ident, TypeName] myType
+#   17|           Type = myType
+#   17|       1: [ArrayTypeExpr] array type
+#   17|           Type = []T
+#   17|         0: [Ident, TypeName] T
+#   17|             Type = T

--- a/go/ql/test/library-tests/semmle/go/PrintAst/go.mod
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/go.mod
@@ -1,4 +1,3 @@
 module codeql-go-tests/printast
 
-go 1.14
-
+go 1.18

--- a/go/ql/test/library-tests/semmle/go/PrintAst/other.go
+++ b/go/ql/test/library-tests/semmle/go/PrintAst/other.go
@@ -5,7 +5,7 @@ func main() {}
 func f() {}
 func g() {}
 
-func hasNested() {
+func hasNested[U int]() {
 
 	myNested := func() int { return 1 }
 	myNested()
@@ -13,3 +13,7 @@ func hasNested() {
 }
 
 var x int = 0
+
+type myType[T ~string] []T
+
+func (m myType[U]) f() {}


### PR DESCRIPTION
type param declarations were just floating, not part of the tree rooted in at the file node. This is easily fixed.

Should this have a change note? src or lib?

Note that we currently don't extract any kind of type parameter declaration for methods on generic types. We probably ought to, for consistency. But for now it is correct that the tests don't show anything in that case.