### PR TITLE
Java: update qhelp link for `java/spring-disabled-csrf-protection`

### DIFF
--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -30,8 +30,8 @@ OWASP:
 </li>
 <li>
 Spring Security Reference:
-<a href="https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#servlet-csrf">
-  Cross Site Request Forgery (CSRF) for Servlet Environments
+<a href="https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html">
+  Cross Site Request Forgery (CSRF)
 </a>.
 </li>
 </references>

--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -5,7 +5,7 @@
 <p>When you set up a web server to receive a request from a client without any mechanism
 for verifying that it was intentionally sent, then it is vulnerable to attack. An attacker can
 trick a client into making an unintended request to the web server that will be treated as
-an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can 
+an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can
 result in exposure of data or unintended code execution.</p>
 </overview>
 
@@ -30,7 +30,7 @@ OWASP:
 </li>
 <li>
 Spring Security Reference:
-<a href="https://docs.spring.io/spring-security/site/docs/current/reference/html5/#servlet-csrf">
+<a href="https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#servlet-csrf">
   Cross Site Request Forgery (CSRF) for Servlet Environments
 </a>.
 </li>


### PR DESCRIPTION
Updates the Spring Security Reference link to the current documentation.