### PR TITLE
Python: Fix bug in handling of `**kwargs` in class bases 

### DIFF
--- a/python/extractor/tests/parser/class.py
+++ b/python/extractor/tests/parser/class.py
@@ -1,2 +1,2 @@
-class Foo(int, object, metaclass=type):
+class Foo(int, object, metaclass=type, **kwargs):
     x = 5

--- a/python/extractor/tsg-python/python.tsg
+++ b/python/extractor/tsg-python/python.tsg
@@ -1277,18 +1277,29 @@
     attr (@class.inner_scope -> @stmt.node) body = (named-child-index @stmt)
 }
 
-; Class.bases - using `(_ !name)` as a proxy for all non-keyword arguments.
+; Class.bases - using `(_  !value !name)` as a proxy for all non-keyword arguments.
+; In particular, `keyword_argument` nodes have a `name` field, and `dictionary_splat`
+; nodes have a `value` field.
 (class_definition
-    superclasses: (argument_list element: (_ !name) @arg)
+    superclasses: (argument_list element: (_ !value !name) @arg)
 ) @class
 {
     edge @class.class_expr -> @arg.node
     attr (@class.class_expr -> @arg.node) bases = (named-child-index @arg)
 }
 
-; Class.keywords
+; Class.keywords of the form `foo=bar`
 (class_definition
     superclasses: (argument_list element: (keyword_argument) @arg)
+) @class
+{
+    edge @class.class_expr -> @arg.node
+    attr (@class.class_expr -> @arg.node) keywords = (named-child-index @arg)
+}
+
+; Class.keywords of the form `**kwargs`
+(class_definition
+    superclasses: (argument_list element: (dictionary_splat) @arg)
 ) @class
 {
     edge @class.class_expr -> @arg.node


### PR DESCRIPTION
This caused a dataset check error on the `python/cpython` database, as we had a `DictUnpacking` node whose parent was not a `dict_item_list`, but rather an `expr_list`.

Investigating a bit further revealed that this was because in a construction like

```python
class C[T](base, foo=bar, **kwargs): ...
```
we were mistakenly adding `**kwargs` to the same list as `base` (which is just a list of expressions), rather than the same list as `foo=bar` (which is a list of dictionary items)

The ultimate cause of this was the use of `! name` in `python.tsg` to distinguish between bases and keyword arguments (only the latter of which have the `name` field). Because `dictionary_splat` doesn't have a `name` field either, these were mistakenly put in the wrong list, leading to the error.

Also, because our previous test of `class` statements did not include a `**kwargs` construction, we were not checking that the new parser behaved correctly in this case. For the most part this was not a problem, but on files that use syntax not supported by the old parser (like type parameters on classes), this became an issue. This is also
why we did not see this error previously.

To fix this, we added `! value` (which is a field present on `dictionary_splat` nodes) as a secondary filter, and added a third stanza to handle `dictionary_splat` nodes.


### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
