### PR TITLE
Rust: Fix bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/MatchExprImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/MatchExprImpl.qll
@@ -31,6 +31,7 @@ module Impl {
     /**
      * Gets the `index`th arm of this match expression.
      */
+    pragma[nomagic]
     MatchArm getArm(int index) { result = this.getMatchArmList().getArm(index) }
 
     /**
@@ -41,6 +42,7 @@ module Impl {
     /**
      * Gets the number of arms of this match expression.
      */
+    pragma[nomagic]
     int getNumberOfArms() { result = this.getMatchArmList().getNumberOfArms() }
 
     /**


### PR DESCRIPTION
Before
```
Evaluated relational algebra for predicate MatchExprImpl::Impl::MatchExpr.getLastArm/0#dispred#24e5f4cf@9cf607tl with tuple counts:
            660677  ~0%    {4} r1 = SCAN `MatchExprImpl::Impl::MatchExpr.getArm/1#dispred#817de8a3` OUTPUT _, In.0, In.2, In.1
            660677  ~0%    {3}    | REWRITE WITH Tmp.0 := 1, Out.0 := (Tmp.0 + In.3) KEEPING 3
        5342095756  ~0%    {3}    | JOIN WITH `MatchArmList::Generated::MatchArmList.getNumberOfArms/0#dispred#9ad72f08_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2
             96597  ~3%    {2}    | JOIN WITH `MatchExpr::Generated::MatchExpr.getMatchArmList/0#dispred#11f1a73e` ON FIRST 2 OUTPUT Lhs.0, Lhs.2
                           return r1
```

After
```
Evaluated relational algebra for predicate MatchExprImpl::Impl::MatchExpr.getLastArm/0#dispred#24e5f4cf@9d7a92pu with tuple counts:
        660677   ~0%    {5} r1 = JOIN `MatchExprImpl::Impl::MatchExpr.getArm/1#344daffc` WITH `MatchExprImpl::Impl::MatchExpr.getNumberOfArms/0#ab0d8732` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, _, Rhs.1
                        {4}    | REWRITE WITH Tmp.3 := 1, Out.3 := (In.4 - Tmp.3), TEST Out.3 = InOut.1 KEEPING 4
         96597   ~3%    {2}    | SCAN OUTPUT In.0, In.2
                        return r1
```