### PR TITLE
C#: Add sanitizer to `cs/log-forging`.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/System.qll
@@ -354,6 +354,14 @@ class SystemStringClass extends StringType {
     result.getReturnType() instanceof StringType
   }
 
+  /** Gets the `ReplaceLineEndings(string) method. */
+  Method getReplaceLineEndingsMethod() {
+    result.getDeclaringType() = this and
+    result.hasName("ReplaceLineEndings") and
+    result.getNumberOfParameters() = 1 and
+    result.getReturnType() instanceof StringType
+  }
+
   /** Gets a `Format(...)` method. */
   Method getFormatMethod() {
     result.getDeclaringType() = this and

--- a/csharp/ql/lib/semmle/code/csharp/security/dataflow/LogForgingQuery.qll
+++ b/csharp/ql/lib/semmle/code/csharp/security/dataflow/LogForgingQuery.qll
@@ -70,7 +70,9 @@ private class ExternalLoggingExprSink extends Sink {
 private class StringReplaceSanitizer extends Sanitizer {
   StringReplaceSanitizer() {
     exists(Method m |
-      exists(SystemStringClass s | m = s.getReplaceMethod() or m = s.getRemoveMethod())
+      exists(SystemStringClass s |
+        m = s.getReplaceMethod() or m = s.getRemoveMethod() or m = s.getReplaceLineEndingsMethod()
+      )
       or
       m = any(SystemTextRegularExpressionsRegexClass r).getAReplaceMethod()
     |

--- a/csharp/ql/src/change-notes/2024-10-21-log-forging-replacelineendings.md
+++ b/csharp/ql/src/change-notes/2024-10-21-log-forging-replacelineendings.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C#: The method `string.ReplaceLineEndings(string)` is now considered a sanitizer for the `cs/log-forging` query. 

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
@@ -23,6 +23,8 @@ public class LogForgingHandler : IHttpHandler
         logger.Warn(username.Replace(Environment.NewLine, "") + " logged in");
         // GOOD: New-lines removed
         logger.Warn(username.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase) + " logged in");
+        // GOOD: New-lines replaced (False positive)
+        logger.Warn(username.ReplaceLineEndings("") + " logged in");
         // GOOD: Html encoded
         logger.Warn(WebUtility.HtmlEncode(username) + " logged in");
         // BAD: Logged as-is to TraceSource

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.cs
@@ -23,7 +23,7 @@ public class LogForgingHandler : IHttpHandler
         logger.Warn(username.Replace(Environment.NewLine, "") + " logged in");
         // GOOD: New-lines removed
         logger.Warn(username.Replace(Environment.NewLine, "", StringComparison.InvariantCultureIgnoreCase) + " logged in");
-        // GOOD: New-lines replaced (False positive)
+        // GOOD: New-lines replaced
         logger.Warn(username.ReplaceLineEndings("") + " logged in");
         // GOOD: Html encoded
         logger.Warn(WebUtility.HtmlEncode(username) + " logged in");

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -1,25 +1,33 @@
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:29:50:29:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:29:50:29:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:33:26:33:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:33:26:33:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:27:21:27:66 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:27:21:27:66 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:31:50:31:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:31:50:31:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
+| LogForging.cs:35:26:35:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:35:26:35:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |
 edges
 | LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:21:21:21:43 | ... + ... | provenance |  |
-| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:29:50:29:72 | ... + ... | provenance |  |
-| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:33:26:33:33 | access to local variable username | provenance |  |
+| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:27:21:27:28 | access to local variable username : String | provenance |  |
+| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:31:50:31:72 | ... + ... | provenance |  |
+| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:35:26:35:33 | access to local variable username | provenance |  |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:16:18:23 | access to local variable username : String | provenance |  |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:27:18:61 | access to indexer : String | provenance | MaD:1 |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:18:16:18:23 | access to local variable username : String | provenance |  |
+| LogForging.cs:27:21:27:28 | access to local variable username : String | LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | provenance | MaD:2 |
+| LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | LogForging.cs:27:21:27:66 | ... + ... | provenance |  |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | provenance |  |
 models
 | 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
+| 2 | Summary: System; String; false; ReplaceLineEndings; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
 | LogForging.cs:18:16:18:23 | access to local variable username : String | semmle.label | access to local variable username : String |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
 | LogForging.cs:21:21:21:43 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:29:50:29:72 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:33:26:33:33 | access to local variable username | semmle.label | access to local variable username |
+| LogForging.cs:27:21:27:28 | access to local variable username : String | semmle.label | access to local variable username : String |
+| LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | semmle.label | call to method ReplaceLineEndings : String |
+| LogForging.cs:27:21:27:66 | ... + ... | semmle.label | ... + ... |
+| LogForging.cs:31:50:31:72 | ... + ... | semmle.label | ... + ... |
+| LogForging.cs:35:26:35:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | semmle.label | ... + ... |
 subpaths

--- a/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-117/LogForging.expected
@@ -1,31 +1,23 @@
 #select
 | LogForging.cs:21:21:21:43 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:21:21:21:43 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
-| LogForging.cs:27:21:27:66 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:27:21:27:66 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:31:50:31:72 | ... + ... | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:31:50:31:72 | ... + ... | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForging.cs:35:26:35:33 | access to local variable username | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:35:26:35:33 | access to local variable username | This log entry depends on a $@. | LogForging.cs:18:27:18:49 | access to property QueryString | user-provided value |
 | LogForgingAsp.cs:12:21:12:43 | ... + ... | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | This log entry depends on a $@. | LogForgingAsp.cs:8:32:8:39 | username | user-provided value |
 edges
 | LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:21:21:21:43 | ... + ... | provenance |  |
-| LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:27:21:27:28 | access to local variable username : String | provenance |  |
 | LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:31:50:31:72 | ... + ... | provenance |  |
 | LogForging.cs:18:16:18:23 | access to local variable username : String | LogForging.cs:35:26:35:33 | access to local variable username | provenance |  |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:16:18:23 | access to local variable username : String | provenance |  |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | LogForging.cs:18:27:18:61 | access to indexer : String | provenance | MaD:1 |
 | LogForging.cs:18:27:18:61 | access to indexer : String | LogForging.cs:18:16:18:23 | access to local variable username : String | provenance |  |
-| LogForging.cs:27:21:27:28 | access to local variable username : String | LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | provenance | MaD:2 |
-| LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | LogForging.cs:27:21:27:66 | ... + ... | provenance |  |
 | LogForgingAsp.cs:8:32:8:39 | username : String | LogForgingAsp.cs:12:21:12:43 | ... + ... | provenance |  |
 models
 | 1 | Summary: System.Collections.Specialized; NameValueCollection; false; get_Item; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
-| 2 | Summary: System; String; false; ReplaceLineEndings; (System.String); ; Argument[this]; ReturnValue; taint; df-generated |
 nodes
 | LogForging.cs:18:16:18:23 | access to local variable username : String | semmle.label | access to local variable username : String |
 | LogForging.cs:18:27:18:49 | access to property QueryString : NameValueCollection | semmle.label | access to property QueryString : NameValueCollection |
 | LogForging.cs:18:27:18:61 | access to indexer : String | semmle.label | access to indexer : String |
 | LogForging.cs:21:21:21:43 | ... + ... | semmle.label | ... + ... |
-| LogForging.cs:27:21:27:28 | access to local variable username : String | semmle.label | access to local variable username : String |
-| LogForging.cs:27:21:27:51 | call to method ReplaceLineEndings : String | semmle.label | call to method ReplaceLineEndings : String |
-| LogForging.cs:27:21:27:66 | ... + ... | semmle.label | ... + ... |
 | LogForging.cs:31:50:31:72 | ... + ... | semmle.label | ... + ... |
 | LogForging.cs:35:26:35:33 | access to local variable username | semmle.label | access to local variable username |
 | LogForgingAsp.cs:8:32:8:39 | username : String | semmle.label | username : String |


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
