### PR TITLE
Go: Fix makefile to use bash to look up bazel path.

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,3 +1,5 @@
+BAZEL := $(shell bash -c "which bazel")
+
 all: gen extractor
 
 EXTRACTOR_PACK_OUT = extractor-pack
@@ -28,10 +30,10 @@ qhelp-to-markdown:
 	scripts/qhelp-to-markdown.sh ql/src "$(QHELP_OUT_DIR)"
 
 extractor:
-	bazel run :go-installer
+	$(BAZEL) run :go-installer
 
 gen:
-	bazel run :gen
+	$(BAZEL) run :gen
 
 build/stats/src.stamp:
 	mkdir -p $(@D)/src
@@ -48,7 +50,7 @@ test: all build/testdb/check-upgrade-path
 	codeql test run -j0 ql/test --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache)
 #	use GOOS=linux because GOOS=darwin GOARCH=386 is no longer supported
 	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache)
-	cd extractor; bazel test ...
+	cd extractor; $(BAZEL) test ...
 	bash extractor-smoke-test/test.sh || (echo "Extractor smoke test FAILED"; exit 1)
 
 .PHONY: build/testdb/check-upgrade-path

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,3 +1,8 @@
+# On Windows, make's path resolution algorithm is incorrect. It picks up a bazel.exe in PATH that's
+# after a bazel binary. In particular, on actions, the non-exe binary is a bazelisk instance, whereas
+# bazel.exe is a bazel installation.
+# This means we pick up the wrong bazel version, and if the differences between the bazel we want
+# and that we actually get are too big, the build fails on CI.
 BAZEL := $(shell bash -c "which bazel")
 
 all: gen extractor


### PR DESCRIPTION
On Windows, make's path resolution algorithm is incorrect. It picks up a bazel.exe in PATH that's _after_ a bazel binary. In particular, on actions, the non-exe binary is a bazelisk instance, whereas bazel.exe is a bazel (at the current time 7.3.2) installation.
This means we pick up the wrong bazel version, and if the differences between the bazel we want and that we actually get are too big, the build fails.

Thanks to @smowton and @redsun82 for debugging help!