### PR TITLE
Supplement 'query-type: graph' with actual query metadata

### DIFF
--- a/cpp/ql/test/library-tests/basic_blocks/bb_cfg.ql
+++ b/cpp/ql/test/library-tests/basic_blocks/bb_cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/basic_blocks/cfg.ql
+++ b/cpp/ql/test/library-tests/basic_blocks/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/c++_exceptions/graphable.ql
+++ b/cpp/ql/test/library-tests/c++_exceptions/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/constexpr_if/cfg.ql
+++ b/cpp/ql/test/library-tests/constexpr_if/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/destructors/cfg.ql
+++ b/cpp/ql/test/library-tests/destructors/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/lambdas/cfg/cfg.ql
+++ b/cpp/ql/test/library-tests/lambdas/cfg/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/pointsto/basic/sets.ql
+++ b/cpp/ql/test/library-tests/pointsto/basic/sets.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 import semmle.code.cpp.pointsto.PointsTo
 

--- a/cpp/ql/test/library-tests/sub_basic_blocks/cut.ql
+++ b/cpp/ql/test/library-tests/sub_basic_blocks/cut.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import sbb_test
 
 class CutCall extends SubBasicBlockCutNode {

--- a/cpp/ql/test/library-tests/sub_basic_blocks/no_cut.ql
+++ b/cpp/ql/test/library-tests/sub_basic_blocks/no_cut.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import sbb_test
 
 // Note: no instance of `SubBasicBlockCutNode`

--- a/cpp/ql/test/library-tests/virtual_functions/cfg/cfg.ql
+++ b/cpp/ql/test/library-tests/virtual_functions/cfg/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/library-tests/vla/cfg.ql
+++ b/cpp/ql/test/library-tests/vla/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/break_labels/cfg.ql
+++ b/cpp/ql/test/successor-tests/break_labels/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/conditional_destructors/cfg.ql
+++ b/cpp/ql/test/successor-tests/conditional_destructors/cfg.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/exceptionhandler/ellipsisexceptionhandler/graphable.ql
+++ b/cpp/ql/test/successor-tests/exceptionhandler/ellipsisexceptionhandler/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/exceptionhandler/exceptionhandler/graphable.ql
+++ b/cpp/ql/test/successor-tests/exceptionhandler/exceptionhandler/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/pruning/graphable.ql
+++ b/cpp/ql/test/successor-tests/pruning/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/returnstmt/graphable.ql
+++ b/cpp/ql/test/successor-tests/returnstmt/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/stackvariables/stackvariables/graphable.ql
+++ b/cpp/ql/test/successor-tests/stackvariables/stackvariables/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {

--- a/cpp/ql/test/successor-tests/switchstmt/switchbody/graphable.ql
+++ b/cpp/ql/test/successor-tests/switchstmt/switchbody/graphable.ql
@@ -1,4 +1,9 @@
-// query-type: graph
+/**
+ * query-type: graph
+ *
+ * @kind graph-equivalence-test
+ */
+
 import cpp
 
 class DestructorCallEnhanced extends DestructorCall {


### PR DESCRIPTION
A number of CPP library tests contain `// query-type: graph` annotations that make the test driver compare the output from the test query in a special mode. (This feature is not used by other languages).

It's somewhat awkward in the implementation of `codeql test run` that this annotation is not an ordinary item of query metadata -- essentially it means that _every_ test query has to be opened and read an extra time to look for this annotation. I'd like to move towards using ordinary query metadata for this, since the QL compiler already parses it anyway.

(It seems unlikely that there exist any test _outside_ this repository that uses `// query-type: graph`).

For the time being, give the annotation in both old and new syntaxes, until a CLI that recognizes both has been released.
