### PR TITLE
C++: Add test with missing flow

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -185,6 +185,8 @@ postWithInFlow
 | simple.cpp:83:12:83:13 | f1 [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:92:7:92:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
 | simple.cpp:118:7:118:7 | i [post update] | PostUpdateNode should not be the target of local flow. |
+| simple.cpp:124:5:124:6 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| simple.cpp:124:6:124:6 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | struct_init.c:24:11:24:12 | ab [inner post update] | PostUpdateNode should not be the target of local flow. |
 | struct_init.c:36:17:36:24 | nestedAB [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-diff.expected
@@ -291,3 +291,6 @@ WARNING: module 'DataFlow' has been deprecated and may be removed in future (par
 | simple.cpp:94:10:94:11 | a2 | IR only |
 | simple.cpp:118:7:118:7 | i | AST only |
 | simple.cpp:120:8:120:8 | a | IR only |
+| simple.cpp:124:5:124:6 | * ... | AST only |
+| simple.cpp:131:14:131:14 | a | IR only |
+| simple.cpp:136:10:136:10 | a | IR only |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition-ir.expected
@@ -651,6 +651,9 @@
 | simple.cpp:94:10:94:11 | a2 |
 | simple.cpp:118:5:118:5 | a |
 | simple.cpp:120:8:120:8 | a |
+| simple.cpp:131:14:131:14 | a |
+| simple.cpp:135:20:135:20 | q |
+| simple.cpp:136:10:136:10 | a |
 | struct_init.c:15:8:15:9 | ab |
 | struct_init.c:15:12:15:12 | a |
 | struct_init.c:16:8:16:9 | ab |

--- a/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/partial-definition.expected
@@ -581,6 +581,8 @@ WARNING: module 'DataFlow' has been deprecated and may be removed in future (par
 | simple.cpp:92:7:92:7 | i |
 | simple.cpp:118:5:118:5 | a |
 | simple.cpp:118:7:118:7 | i |
+| simple.cpp:124:5:124:6 | * ... |
+| simple.cpp:135:20:135:20 | q |
 | struct_init.c:15:8:15:9 | ab |
 | struct_init.c:15:12:15:12 | a |
 | struct_init.c:16:8:16:9 | ab |

--- a/cpp/ql/test/library-tests/dataflow/fields/simple.cpp
+++ b/cpp/ql/test/library-tests/dataflow/fields/simple.cpp
@@ -120,4 +120,20 @@ void post_update_to_phi_input(bool b)
   sink(a.i); // $ ast,ir
 }
 
+void write_to_param(int* p) {
+    *p = user_input();
+}
+
+void alias_with_fields(bool b) {
+    A a;
+    int* q;
+    if(b) {
+        q = &a.i;
+    } else {
+        q = nullptr;
+    }
+    write_to_param(q);
+    sink(a.i); // $ MISSING: ast,ir
+}
+
 } // namespace Simple


### PR DESCRIPTION
### Pull Request checklist

A simple testcase that demonstrate some missing flow that I may be working on addressing soon-ish.



#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
