### PR TITLE
JS: have getId always return null if skipExtractingTypes is set

### DIFF
--- a/javascript/extractor/lib/typescript/src/type_table.ts
+++ b/javascript/extractor/lib/typescript/src/type_table.ts
@@ -435,6 +435,7 @@ export class TypeTable {
    * Returns `null` if we do not support extraction of this type.
    */
   public getId(type: ts.Type, unfoldAlias: boolean): number | null {
+    if (this.skipExtractingTypes) return null;
     let cached = this.idCache.get(type) ?? [undefined, undefined];
     let cachedValue = cached[unfoldAlias ? 1 : 0];
     if (cachedValue !== undefined) return cachedValue;


### PR DESCRIPTION
Fixes the hang reported in https://github.com/github/codeql/issues/17827 (if you disable type extraction)