### PR TITLE
Rust: Cache `Locatable.getLocation` and `Location`

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/FormatArgumentImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/FormatArgumentImpl.qll
@@ -47,11 +47,9 @@ module Impl {
     ) {
       // TODO: handle locations in multi-line comments
       // TODO: handle the case where the template is from a nested macro call
-      Synth::convertFormatArgsExprFromRaw(parent)
-          .(FormatArgsExpr)
-          .getTemplate()
-          .getLocation()
-          .hasLocationInfo(file.getAbsolutePath(), startline, startcolumn - offset, _, _) and
+      LocatableImpl::getLocationDefault(Synth::convertFormatArgsExprFromRaw(parent)
+            .(FormatArgsExpr)
+            .getTemplate()).hasLocationFileInfo(file, startline, startcolumn - offset, _, _) and
       endline = startline and
       endcolumn = startcolumn + name.length() - 1
     }

--- a/rust/ql/lib/codeql/rust/elements/internal/FormatConstructor.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/FormatConstructor.qll
@@ -5,6 +5,7 @@
  */
 
 private import codeql.rust.elements.internal.generated.Raw
+private import codeql.rust.internal.CachedStages
 
 /**
  *  The characteristic predicate of `Format` synthesized instances.
@@ -22,6 +23,7 @@ predicate constructFormat(Raw::FormatArgsExpr parent, int index, string text, in
  * Match an element of a format string, either text (`Hello`) or a format placeholder (`{}`).
  */
 string formatElement(Raw::FormatArgsExpr parent, int occurrenceIndex, int occurrenceOffset) {
+  Stages::AstStage::ref() and
   result =
     parent
         .getTemplate()

--- a/rust/ql/lib/codeql/rust/elements/internal/FormatImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/FormatImpl.qll
@@ -79,10 +79,8 @@ module Impl {
     override predicate hasSynthLocationInfo(
       File file, int startline, int startcolumn, int endline, int endcolumn
     ) {
-      this.getParent()
-          .getTemplate()
-          .getLocation()
-          .hasLocationInfo(file.getAbsolutePath(), startline, startcolumn - offset, _, _) and
+      LocatableImpl::getLocationDefault(this.getParent().getTemplate())
+          .hasLocationFileInfo(file, startline, startcolumn - offset, _, _) and
       endline = startline and
       endcolumn = startcolumn + text.length() - 1
     }

--- a/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/VariableImpl.qll
@@ -229,13 +229,13 @@ module Impl {
     name = v.getName() and
     (
       parameterDeclInScope(_, v, scope) and
-      scope.getLocation().hasLocationInfo(_, line, column, _, _)
+      scope.getLocation().hasLocationFileInfo(_, line, column, _, _)
       or
       exists(Pat pat | pat = getAVariablePatAncestor(v) |
         scope =
           any(MatchArmScope arm |
             arm.getPat() = pat and
-            arm.getLocation().hasLocationInfo(_, line, column, _, _)
+            arm.getLocation().hasLocationFileInfo(_, line, column, _, _)
           )
         or
         exists(LetStmt let |
@@ -243,27 +243,27 @@ module Impl {
           scope = getEnclosingScope(let) and
           // for `let` statements, variables are bound _after_ the statement, i.e.
           // not in the RHS
-          let.getLocation().hasLocationInfo(_, _, _, line, column)
+          let.getLocation().hasLocationFileInfo(_, _, _, line, column)
         )
         or
         exists(IfExpr ie, LetExpr let |
           let.getPat() = pat and
           ie.getCondition() = let and
           scope = ie.getThen() and
-          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+          scope.getLocation().hasLocationFileInfo(_, line, column, _, _)
         )
         or
         exists(ForExpr fe |
           fe.getPat() = pat and
           scope = fe.getLoopBody() and
-          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+          scope.getLocation().hasLocationFileInfo(_, line, column, _, _)
         )
         or
         exists(WhileExpr we, LetExpr let |
           let.getPat() = pat and
           we.getCondition() = let and
           scope = we.getLoopBody() and
-          scope.getLocation().hasLocationInfo(_, line, column, _, _)
+          scope.getLocation().hasLocationFileInfo(_, line, column, _, _)
         )
       )
     )
@@ -283,7 +283,7 @@ module Impl {
   ) {
     name = cand.getName() and
     scope = [cand.(VariableScope), getEnclosingScope(cand)] and
-    cand.getLocation().hasLocationInfo(_, startline, startcolumn, endline, endcolumn) and
+    cand.getLocation().hasLocationFileInfo(_, startline, startcolumn, endline, endcolumn) and
     nestLevel = 0
     or
     exists(VariableScope inner |
@@ -292,7 +292,7 @@ module Impl {
       // Use the location of the inner scope as the location of the access, instead of the
       // actual access location. This allows us to collapse multiple accesses in inner
       // scopes to a single entity
-      inner.getLocation().hasLocationInfo(_, startline, startcolumn, endline, endcolumn)
+      inner.getLocation().hasLocationFileInfo(_, startline, startcolumn, endline, endcolumn)
     )
   }
 

--- a/rust/ql/lib/codeql/rust/internal/CachedStages.qll
+++ b/rust/ql/lib/codeql/rust/internal/CachedStages.qll
@@ -31,6 +31,39 @@ import rust
  */
 module Stages {
   /**
+   * The abstract syntex tree (AST) stage.
+   */
+  cached
+  module AstStage {
+    private import codeql.rust.controlflow.internal.Splitting
+    private import codeql.rust.controlflow.internal.SuccessorType
+    private import codeql.rust.controlflow.internal.ControlFlowGraphImpl
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the AST stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DO NOT USE!
+     *
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(Location l)
+      or
+      exists(any(Locatable l).getLocation())
+      or
+      exists(Format f)
+    }
+  }
+
+  /**
    * The control flow graph (CFG) stage.
    */
   cached
@@ -41,7 +74,7 @@ module Stages {
 
     /**
      * Always holds.
-     * Ensures that a predicate is evaluated as part of the BasicBlocks stage.
+     * Ensures that a predicate is evaluated as part of the CFG stage.
      */
     cached
     predicate ref() { 1 = 1 }


### PR DESCRIPTION
Follows up on https://github.com/github/codeql/pull/17791. Recovers most of the performance we lost.