### PR TITLE
Rust: Clean up unreachable test

### DIFF
--- a/rust/ql/test/query-tests/unusedentities/UnusedValue.expected
+++ b/rust/ql/test/query-tests/unusedentities/UnusedValue.expected
@@ -23,8 +23,3 @@
 | more.rs:46:9:46:14 | a_ptr4 | Variable is assigned a value that is never used. |
 | more.rs:61:9:61:13 | d_ptr | Variable is assigned a value that is never used. |
 | more.rs:67:9:67:17 | f_ptr | Variable is assigned a value that is never used. |
-| unreachable.rs:166:6:166:6 | x | Variable is assigned a value that is never used. |
-| unreachable.rs:190:14:190:14 | a | Variable is assigned a value that is never used. |
-| unreachable.rs:199:9:199:9 | a | Variable is assigned a value that is never used. |
-| unreachable.rs:210:11:210:11 | a | Variable is assigned a value that is never used. |
-| unreachable.rs:217:6:217:6 | a | Variable is assigned a value that is never used. |

--- a/rust/ql/test/query-tests/unusedentities/unreachable.rs
+++ b/rust/ql/test/query-tests/unusedentities/unreachable.rs
@@ -163,7 +163,7 @@ fn unreachable_loop() {
 		do_something(); // BAD: unreachable code
 	}
 
-	for x in 1..10 {
+	for x in 1..10 { // BAD: unused value `x`
 		if cond() {
 			continue;
 			do_something(); // BAD: unreachable code
@@ -187,7 +187,7 @@ fn unreachable_paren() {
 }
 
 fn unreachable_let_1() {
-	if let Some(a) = maybe_get_a_number() {
+	if let Some(a) = maybe_get_a_number() { // BAD: unused value `a`
 		do_something();
 		return;
 	} else {
@@ -196,7 +196,7 @@ fn unreachable_let_1() {
 
 	do_something(); // SPURIOUS: unreachable code
 
-	if let a = get_a_number() { // (always succeeds)
+	if let a = get_a_number() { // (always succeeds) BAD: unused value `a`
 		do_something();
 		return;
 	} else {
@@ -207,14 +207,14 @@ fn unreachable_let_1() {
 }
 
 fn unreachable_let_2() {
-	let Some(a) = maybe_get_a_number() else {
+	let Some(a) = maybe_get_a_number() else { // BAD: unused value `a`
 		do_something();
 		return;
 	};
 
 	do_something();
 
-	let a = maybe_get_a_number() else { // (always succeeds)
+	let a = maybe_get_a_number() else { // (always succeeds) BAD: unused value `x`
 		do_something(); // BAD: unreachable code
 		return;
 	};

--- a/rust/ql/test/query-tests/unusedentities/unreachable.rs
+++ b/rust/ql/test/query-tests/unusedentities/unreachable.rs
@@ -163,7 +163,7 @@ fn unreachable_loop() {
 		do_something(); // BAD: unreachable code
 	}
 
-	for x in 1..10 { // BAD: unused value `x`
+	for _ in 1..10 {
 		if cond() {
 			continue;
 			do_something(); // BAD: unreachable code
@@ -187,7 +187,7 @@ fn unreachable_paren() {
 }
 
 fn unreachable_let_1() {
-	if let Some(a) = maybe_get_a_number() { // BAD: unused value `a`
+	if let Some(_) = maybe_get_a_number() {
 		do_something();
 		return;
 	} else {
@@ -196,7 +196,7 @@ fn unreachable_let_1() {
 
 	do_something(); // SPURIOUS: unreachable code
 
-	if let a = get_a_number() { // (always succeeds) BAD: unused value `a`
+	if let _ = get_a_number() { // (always succeeds)
 		do_something();
 		return;
 	} else {
@@ -207,14 +207,14 @@ fn unreachable_let_1() {
 }
 
 fn unreachable_let_2() {
-	let Some(a) = maybe_get_a_number() else { // BAD: unused value `a`
+	let Some(_) = maybe_get_a_number() else {
 		do_something();
 		return;
 	};
 
 	do_something();
 
-	let a = maybe_get_a_number() else { // (always succeeds) BAD: unused value `x`
+	let _ = maybe_get_a_number() else { // (always succeeds)
 		do_something(); // BAD: unreachable code
 		return;
 	};


### PR DESCRIPTION
Clean up the `unusedentities/unreachable.rs` test.  There were a handful of accidental unused value results in the test introduced in https://github.com/github/codeql/pull/17803 that weren't annotated.  First I added annotations.  Then I decided the test code should be fixed, as these results aren't interesting (they're similar to cases in the other test file) and they distract from what `unreachable.rs` is about.