### PR TITLE
Revert "Fix bash nit"

### DIFF
--- a/actions/extractor/tools/autobuild.sh
+++ b/actions/extractor/tools/autobuild.sh
@@ -11,7 +11,7 @@ include:**/action.yaml
 END
 )
 
-if [ -n "${LGTM_INDEX_INCLUDE}" ] || [ -n "${LGTM_INDEX_EXCLUDE}" ] || [ -n "${LGTM_INDEX_FILTERS}" ] ; then
+if [ -n "${LGTM_INDEX_INCLUDE:-}" ] || [ -n "${LGTM_INDEX_EXCLUDE:-}" ] || [ -n "${LGTM_INDEX_FILTERS:-}" ] ; then
     echo "Path filters set. Passing them through to the JavaScript extractor."
 else
     echo "No path filters set. Using the default filters."


### PR DESCRIPTION
This reverts commit 3228447544a52e56da4ae7890fd17d0bc844cbeb.

Turns out that bash will report "parameter not set" if the variable is unset, as opposed to just empty. We needed the default value as empty for the test to work.
