### PR TITLE
fix the RAM setting on Windows

### DIFF
--- a/javascript/resources/tools/autobuild.cmd
+++ b/javascript/resources/tools/autobuild.cmd
@@ -6,7 +6,7 @@ set jvm_args=-Xss16m
 rem If CODEQL_RAM is set, use half for Java and half for TS.
 if NOT [%CODEQL_RAM%] == [] (
     set /a "half_ram=CODEQL_RAM/2"
-    set LGTM_TYPESCRIPT_RAM=%half_ram%
+    set LGTM_TYPESCRIPT_RAM=!half_ram!
     set jvm_args=!jvm_args! -Xmx!half_ram!m
 )
 


### PR DESCRIPTION
I'm not sure it ever worked.  

Apparently the old syntax expands the value at parse-time (where `half_ram` doesn't exist yet).  

[The fix was found and written by ChatGPT](https://chatgpt.com/share/671fe8d0-2c70-8012-864b-db39a2b73d4f) (after I had added some debug printing, which was written by Copilot). 

It seems to work fine now. (The `Memory for TypeScript process` debug print inside the parser started printed the right value).  