### PR TITLE
Add the Actions extractor to the build

### DIFF
--- a/actions/BUILD.bazel
+++ b/actions/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("//misc/bazel:pkg.bzl", "codeql_pack", "codeql_pkg_files")
+
+package(default_visibility = ["//visibility:public"])
+
+[
+    codeql_pack(
+        name = "-".join(parts),
+        srcs = [
+            "//actions/extractor",
+        ],
+        pack_prefix = "/".join(parts),
+    )
+    for parts in (
+        [
+            "experimental",
+            "actions",
+        ],
+        ["actions"],
+    )
+]

--- a/actions/BUILD.bazel
+++ b/actions/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
-load("//misc/bazel:pkg.bzl", "codeql_pack", "codeql_pkg_files")
+load("//misc/bazel:pkg.bzl", "codeql_pack")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/actions/extractor/BUILD.bazel
+++ b/actions/extractor/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//misc/bazel:pkg.bzl", "codeql_pkg_files", "strip_prefix")
+
+codeql_pkg_files(
+    name = "extractor",
+    srcs = [
+        "codeql-extractor.yml",
+    ] + glob(["tools/**"]),
+    strip_prefix = strip_prefix.from_pkg(),
+    visibility = ["//actions:__pkg__"],
+)

--- a/actions/ql/test/query-tests/Placeholder/Placeholder.expected
+++ b/actions/ql/test/query-tests/Placeholder/Placeholder.expected
@@ -1,1 +1,1 @@
-| .github/workflows/shell.yml:0:0:0:0 | .github/workflows/shell.yml | File |
+| .github/workflows/shell.yml:0:0:0:0 | .github/workflows/shell.yml | Analyzed a file. |


### PR DESCRIPTION
This PR adds the new Actions extractor to the CLI build. Most of the Bazel code has been lifted from the Rust extractor, which was just added a couple weeks ago. Like Rust, the Actions extractor will wind up in the `experimental` directory of the CLI build for now.

I'll open the internal CLI PR one these changes are merged and the submodule is bumped.
