### PR TITLE
Java: Improve weak crypto query

### DIFF
--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -223,10 +223,7 @@ string getAnInsecureHashAlgorithmName() {
 }
 
 private string rankedInsecureAlgorithm(int i) {
-  // In this case we know these are being used for encryption, so we want to match
-  // weak hash algorithms too.
-  result =
-    rank[i](string s | s = getAnInsecureAlgorithmName() or s = getAnInsecureHashAlgorithmName())
+  result = rank[i](string s | s = getAnInsecureAlgorithmName())
 }
 
 private string insecureAlgorithmString(int i) {

--- a/java/ql/lib/semmle/code/java/security/MaybeBrokenCryptoAlgorithmQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/MaybeBrokenCryptoAlgorithmQuery.qll
@@ -30,7 +30,11 @@ class InsecureAlgoLiteral extends InsecureAlgorithm, ShortStringLiteral {
       s.length() > 1 and
       not s.regexpMatch(getSecureAlgorithmRegex()) and
       // Exclude results covered by another query.
-      not s.regexpMatch(getInsecureAlgorithmRegex())
+      not s.regexpMatch(getInsecureAlgorithmRegex()) and
+      // Exclude results covered by `InsecureAlgoProperty`.
+      // This removes duplicates when a string literal is a default value for the property,
+      // such as "MD5" in the following: `props.getProperty("hashAlg2", "MD5")`.
+      not exists(InsecureAlgoProperty insecAlgoProp | this = insecAlgoProp.getAnArgument())
     )
   }
 

--- a/java/ql/src/change-notes/2024-10-29-weak-crypto-hash.md
+++ b/java/ql/src/change-notes/2024-10-29-weak-crypto-hash.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `java/weak-cryptographic-algorithm` query has been updated to no longer report uses of hash functions such as `MD5` and `SHA1` even if they are known to be weak. These hash algorithms are used very often in non-sensitive contexts, making the query too imprecise in practice. The `java/potentially-weak-cryptographic-algorithm` query has been updated to report these uses instead.

--- a/java/ql/test/query-tests/security/CWE-327/semmle/tests/BrokenCryptoAlgorithm.expected
+++ b/java/ql/test/query-tests/security/CWE-327/semmle/tests/BrokenCryptoAlgorithm.expected
@@ -1,14 +1,8 @@
 #select
 | Test.java:19:20:19:50 | getInstance(...) | Test.java:19:45:19:49 | "DES" | Test.java:19:45:19:49 | "DES" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:19:45:19:49 | "DES" | DES |
 | Test.java:42:14:42:38 | getInstance(...) | Test.java:42:33:42:37 | "RC2" | Test.java:42:33:42:37 | "RC2" | Cryptographic algorithm $@ is weak and should not be used. | Test.java:42:33:42:37 | "RC2" | RC2 |
-| WeakHashing.java:21:30:21:92 | getInstance(...) | WeakHashing.java:21:86:21:90 | "MD5" : String | WeakHashing.java:21:56:21:91 | getProperty(...) | Cryptographic algorithm $@ is weak and should not be used. | WeakHashing.java:21:86:21:90 | "MD5" | MD5 |
 edges
-| WeakHashing.java:21:86:21:90 | "MD5" : String | WeakHashing.java:21:56:21:91 | getProperty(...) | provenance | MaD:1 |
-models
-| 1 | Summary: java.util; Properties; true; getProperty; (String,String); ; Argument[1]; ReturnValue; value; manual |
 nodes
 | Test.java:19:45:19:49 | "DES" | semmle.label | "DES" |
 | Test.java:42:33:42:37 | "RC2" | semmle.label | "RC2" |
-| WeakHashing.java:21:56:21:91 | getProperty(...) | semmle.label | getProperty(...) |
-| WeakHashing.java:21:86:21:90 | "MD5" : String | semmle.label | "MD5" : String |
 subpaths


### PR DESCRIPTION
### Description
Removes weak hash algorithms such as MD5 and SHA1 from `java/weak-cryptographic-algorithm` and adds these cases to `java/potentially-weak-cryptographic-algorithm` instead.

The removal of weak hash algorithms from `java/weak-cryptographic-algorithm` aligns with other languages, e.g. https://github.com/github/codeql/pull/11129.

### Consideration
Let me know if there is any concern with changing the behavior of `rankedInsecureAlgorithm` instead of doing the exclusion for `java/weak-cryptographic-algorithm` directly in [BrokenAlgoLiteral](https://github.com/github/codeql/blob/b00bbc9ca2fba1de83c36eb909448fdf5e85c83b/java/ql/lib/semmle/code/java/security/BrokenCryptoAlgorithmQuery.qll#L15)? I chose to do the exclusion in `rankedInsecureAlgorithm` since doing so automatically adds the weak hash cases to `java/potentially-weak-cryptographic-algorithm` due to [this code](https://github.com/github/codeql/blob/b00bbc9ca2fba1de83c36eb909448fdf5e85c83b/java/ql/lib/semmle/code/java/security/MaybeBrokenCryptoAlgorithmQuery.qll#L32-L33).

Note that there were some overlapping results between the two queries for cases where a weak hash algorithm string literal is used as the default value in a `getProperty` call (e.g. the "MD5" value in [this test case](https://github.com/github/codeql/blob/b00bbc9ca2fba1de83c36eb909448fdf5e85c83b/java/ql/test/query-tests/security/CWE-327/semmle/tests/WeakHashing.java#L21C86-L21C91)). In order to avoid duplicate results for these cases in the `java/potentially-weak-cryptographic-algorithm` query, I've added an [exclusion](https://github.com/github/codeql/pull/17869/files#diff-b763072a679fb9949df5aa2519d5411db4df861076dff66fdba037aa844a27e7R34-R37) to `InsecureAlgoLiteral`.
