### PR TITLE
Python: Improve parser logging/timing/customisability

### DIFF
--- a/python/extractor/semmle/python/imports.py
+++ b/python/extractor/semmle/python/imports.py
@@ -98,6 +98,7 @@ class ModuleImporter(object):
     def get_import_nodes(self, loaded_module):
         'Return list of AST nodes representing imports'
         try:
+            self.logger.debug("Looking for imports in %s", loaded_module.path)
             return imports_from_ast(loaded_module.py_ast)
         except Exception as ex:
             if isinstance(ex, SyntaxError):

--- a/python/extractor/semmle/python/parser/tsg_parser.py
+++ b/python/extractor/semmle/python/parser/tsg_parser.py
@@ -168,7 +168,7 @@ def read_tsg_python_output(path, logger):
     p.stdout.close()
     p.terminate()
     p.wait()
-    logger.info("Read {} nodes and {} edges from TSG output".format(len(node_attr), len(edge_attr)))
+    logger.debug("Read {} nodes and {} edges from TSG output".format(len(node_attr), len(edge_attr)))
     return node_attr, edge_attr
 
 def evaluate_string(s):

--- a/python/extractor/semmle/util.py
+++ b/python/extractor/semmle/util.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 #Semantic version of extractor.
 #Update this if any changes are made
-VERSION = "7.1.0"
+VERSION = "7.1.1"
 
 PY_EXTENSIONS = ".py", ".pyw"
 


### PR DESCRIPTION
Does a bunch of things, unfortunately all in the same place, so my apologies in advance for a slightly complicated commit.

As for the changes themselves, this PR

- Adds timers for the old and new parsers. This means we get the overall time spent on these parts of the extractor if the extractor is run with `DEBUG` output shown.
- Adds logging information (at the `DEBUG` level) to show which invocations of the parsers happen when, and whether they succeed or not.
- Adds support for using an environment variable named `CODEQL_PYTHON_DISABLE_OLD_PARSER` to disable using the old parser entirely. This makes it easier to test the new parser in isolation.
- Fixes a bug where we did not check whether a parse with the new parser had already succeeded, and so would do a superfluous second parse.
- Changes the information about number of nodes/edges coming from TSG output to be logged at the `DEBUG` level instead of `INFO` (as it was rather noisy otherwise).

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
