### PR TITLE
KE2: Enable attaching debugger to extractor

### DIFF
--- a/java/kotlin-extractor2/ke2.sh
+++ b/java/kotlin-extractor2/ke2.sh
@@ -31,4 +31,4 @@ else
   JAVA=java
 fi
 
-"$JAVA" -Xmx2G -cp "$SCRIPT_DIR/ke2.jar" com.github.codeql.KotlinExtractorKt "$INVOCATION_TRAP" "$@"
+"$JAVA" -Xmx2G $CODEQL_KOTLIN_EXTRACTOR_JVM_ARGS -cp "$SCRIPT_DIR/ke2.jar" com.github.codeql.KotlinExtractorKt "$INVOCATION_TRAP" "$@"


### PR DESCRIPTION
Example usage:

```
CODEQL_JAVA_HOME=/openjdk23/home/ CODEQL_KOTLIN_EXTRACTOR_JVM_ARGS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8888" codeql database create -l java -c "kotlinc test.kt" db
```