### PR TITLE
Ruby: Do not distinguish between symbols and strings in hash keys

### DIFF
--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -829,7 +829,28 @@ class ContentSet extends TContentSet {
     this.isAny() and
     exists(result)
     or
-    result = this.getAnElementReadContent()
+    exists(Content elementContent | elementContent = this.getAnElementReadContent() |
+      result = elementContent
+      or
+      // Do not distinguish symbol keys from string keys. This allows us to
+      // give more precise summaries for something like `with_indifferent_access`,
+      // and the amount of false-positive flow arising from this should be very
+      // limited.
+      elementContent =
+        any(Content::KnownElementContent known, ConstantValue cv |
+          cv = known.getIndex() and
+          result.(Content::KnownElementContent).getIndex() =
+            any(ConstantValue cv2 |
+              cv2.(ConstantValue::ConstantSymbolValue).getStringlikeValue() =
+                cv.(ConstantValue::ConstantStringValue).getStringlikeValue()
+              or
+              cv2.(ConstantValue::ConstantStringValue).getStringlikeValue() =
+                cv.(ConstantValue::ConstantSymbolValue).getStringlikeValue()
+            )
+        |
+          known
+        )
+    )
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/ActiveSupport.qll
@@ -121,16 +121,6 @@ module ActiveSupport {
      * Extensions to the `Hash` class.
      */
     module Hash {
-      private class WithIndifferentAccessSummary extends SimpleSummarizedCallable {
-        WithIndifferentAccessSummary() { this = "with_indifferent_access" }
-
-        override predicate propagatesFlow(string input, string output, boolean preservesValue) {
-          input = "Argument[self].Element[any]" and
-          output = "ReturnValue.Element[any]" and
-          preservesValue = true
-        }
-      }
-
       /**
        * Flow summary for `reverse_merge`, and its alias `with_defaults`.
        */
@@ -167,8 +157,9 @@ module ActiveSupport {
         }
 
         override predicate propagatesFlow(string input, string output, boolean preservesValue) {
-          input = "Argument[self].Element[any]" and
-          output = "ReturnValue.Element[?]" and
+          // keys are considered equal modulo string/symbol in our implementation
+          input = "Argument[self].WithElement[any]" and
+          output = "ReturnValue" and
           preservesValue = true
         }
       }

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -458,22 +458,40 @@ edges
 | semantics.rb:263:14:263:14 | h [element :foo] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
 | semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
 | semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
+| semantics.rb:267:5:267:5 | [post] h [element :foo] | semantics.rb:268:5:268:5 | h [element :foo] | provenance |  |
+| semantics.rb:267:5:267:5 | [post] h [element :foo] | semantics.rb:268:5:268:5 | h [element :foo] | provenance |  |
+| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h [element :foo] | provenance |  |
+| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h [element :foo] | semantics.rb:269:5:269:5 | h [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h [element :foo] | semantics.rb:269:5:269:5 | h [element :foo] | provenance |  |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] | provenance |  |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] | provenance |  |
+| semantics.rb:268:5:268:5 | h [element :foo] | semantics.rb:268:5:268:5 | [post] h [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | h [element :foo] | semantics.rb:268:5:268:5 | [post] h [element :foo] | provenance |  |
 | semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] | provenance |  |
 | semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h [element :foo] | semantics.rb:270:5:270:5 | h [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h [element :foo] | semantics.rb:270:5:270:5 | h [element :foo] | provenance |  |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] | provenance |  |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h [element :foo] | semantics.rb:269:5:269:5 | [post] h [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h [element :foo] | semantics.rb:269:5:269:5 | [post] h [element :foo] | provenance |  |
 | semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] | provenance |  |
 | semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h [element :foo] | semantics.rb:273:14:273:14 | h [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h [element :foo] | semantics.rb:273:14:273:14 | h [element :foo] | provenance |  |
 | semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] | provenance |  |
 | semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h [element :foo] | semantics.rb:270:5:270:5 | [post] h [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h [element :foo] | semantics.rb:270:5:270:5 | [post] h [element :foo] | provenance |  |
 | semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] | provenance |  |
 | semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] | provenance |  |
 | semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] | provenance |  |
 | semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] | provenance |  |
 | semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] | provenance |  |
 | semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] | provenance |  |
+| semantics.rb:273:14:273:14 | h [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
 | semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
 | semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
 | semantics.rb:273:14:273:14 | h [element] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
@@ -538,6 +556,8 @@ edges
 | semantics.rb:291:10:291:10 | x [element :foo] | semantics.rb:291:10:291:16 | ...[...] | provenance |  |
 | semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
 | semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] | provenance |  |
 | semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] | provenance |  |
 | semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] | provenance |  |
 | semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:301:10:301:10 | x [element foo] | provenance |  |
@@ -546,6 +566,8 @@ edges
 | semantics.rb:297:9:297:24 | call to s36 [element foo] | semantics.rb:297:5:297:5 | x [element foo] | provenance |  |
 | semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] | provenance |  |
 | semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] | provenance |  |
+| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
+| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
 | semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
 | semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
 | semantics.rb:301:10:301:10 | x [element foo] | semantics.rb:301:10:301:13 | ...[...] | provenance |  |
@@ -1616,16 +1638,32 @@ nodes
 | semantics.rb:263:14:263:14 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
 | semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:267:5:267:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:267:5:267:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:267:15:267:25 | call to source | semmle.label | call to source |
+| semantics.rb:267:15:267:25 | call to source | semmle.label | call to source |
+| semantics.rb:268:5:268:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:268:5:268:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:268:5:268:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:268:5:268:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
 | semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
+| semantics.rb:269:5:269:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:269:5:269:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:269:5:269:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:269:5:269:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
+| semantics.rb:270:5:270:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:270:5:270:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
 | semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
 | semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:270:5:270:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:270:5:270:5 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:271:5:271:5 | [post] h [element] | semmle.label | [post] h [element] |
@@ -1634,6 +1672,8 @@ nodes
 | semantics.rb:271:12:271:22 | call to source | semmle.label | call to source |
 | semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
 | semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
+| semantics.rb:273:14:273:14 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:273:14:273:14 | h [element :foo] | semmle.label | h [element :foo] |
 | semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
 | semantics.rb:273:14:273:14 | h [element] | semmle.label | h [element] |
@@ -1708,6 +1748,10 @@ nodes
 | semantics.rb:297:9:297:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
 | semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
 | semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
+| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:298:10:298:16 | ...[...] | semmle.label | ...[...] |
+| semantics.rb:298:10:298:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
 | semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
 | semantics.rb:299:10:299:17 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.rb
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.rb
@@ -270,7 +270,7 @@ def m32(h, i)
     h[1] = source("d")
     h[i] = source("e")
     
-    sink s32(h) # $ hasValueFlow=b hasValueFlow=e
+    sink s32(h) # $ hasValueFlow=b $ hasValueFlow=e $ SPURIOUS: hasValueFlow=a
 end
 
 def m33(h, i)
@@ -295,7 +295,7 @@ end
 
 def m36(h, i)
     x = s36(source("a"))
-    sink x[:foo]
+    sink x[:foo] # $ SPURIOUS: hasValueFlow=a
     sink x["foo"] # $ hasValueFlow=a
     sink x[:bar]
     sink x[i] # $ hasValueFlow=a

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -40,12 +40,16 @@ edges
 | hash_flow.rb:42:17:42:26 | call to taint | hash_flow.rb:42:5:42:8 | [post] hash [element a] | provenance |  |
 | hash_flow.rb:43:5:43:8 | [post] hash [element 0] | hash_flow.rb:44:10:44:13 | hash [element 0] | provenance |  |
 | hash_flow.rb:43:5:43:8 | [post] hash [element :a] | hash_flow.rb:46:10:46:13 | hash [element :a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash [element :a] | hash_flow.rb:48:10:48:13 | hash [element :a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash [element a] | hash_flow.rb:46:10:46:13 | hash [element a] | provenance |  |
 | hash_flow.rb:43:5:43:8 | [post] hash [element a] | hash_flow.rb:48:10:48:13 | hash [element a] | provenance |  |
 | hash_flow.rb:43:5:43:8 | hash [element 0] | hash_flow.rb:43:5:43:8 | [post] hash [element 0] | provenance |  |
 | hash_flow.rb:43:5:43:8 | hash [element :a] | hash_flow.rb:43:5:43:8 | [post] hash [element :a] | provenance |  |
 | hash_flow.rb:43:5:43:8 | hash [element a] | hash_flow.rb:43:5:43:8 | [post] hash [element a] | provenance |  |
 | hash_flow.rb:44:10:44:13 | hash [element 0] | hash_flow.rb:44:10:44:16 | ...[...] | provenance |  |
 | hash_flow.rb:46:10:46:13 | hash [element :a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
+| hash_flow.rb:46:10:46:13 | hash [element a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
+| hash_flow.rb:48:10:48:13 | hash [element :a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
 | hash_flow.rb:48:10:48:13 | hash [element a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
 | hash_flow.rb:55:5:55:9 | hash1 [element :a] | hash_flow.rb:56:10:56:14 | hash1 [element :a] | provenance |  |
 | hash_flow.rb:55:13:55:37 | ...[...] [element :a] | hash_flow.rb:55:5:55:9 | hash1 [element :a] | provenance |  |
@@ -583,7 +587,9 @@ edges
 | hash_flow.rb:626:11:626:11 | a [element] | hash_flow.rb:626:11:626:16 | ...[...] | provenance |  |
 | hash_flow.rb:626:11:626:16 | ...[...] | hash_flow.rb:626:10:626:17 | ( ... ) | provenance |  |
 | hash_flow.rb:632:5:632:8 | hash [element :a] | hash_flow.rb:639:5:639:8 | hash [element :a] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash [element :a] | hash_flow.rb:640:11:640:14 | hash [element :a] | provenance |  |
 | hash_flow.rb:632:5:632:8 | hash [element :c] | hash_flow.rb:639:5:639:8 | hash [element :c] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash [element :c] | hash_flow.rb:642:11:642:14 | hash [element :c] | provenance |  |
 | hash_flow.rb:632:12:636:5 | call to [] [element :a] | hash_flow.rb:632:5:632:8 | hash [element :a] | provenance |  |
 | hash_flow.rb:632:12:636:5 | call to [] [element :c] | hash_flow.rb:632:5:632:8 | hash [element :c] | provenance |  |
 | hash_flow.rb:633:15:633:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] [element :a] | provenance |  |
@@ -599,10 +605,12 @@ edges
 | hash_flow.rb:639:5:639:8 | hash [element :a] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
 | hash_flow.rb:639:5:639:8 | hash [element :c] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
 | hash_flow.rb:639:5:639:8 | hash [element] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
+| hash_flow.rb:640:11:640:14 | hash [element :a] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
 | hash_flow.rb:640:11:640:14 | hash [element] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
 | hash_flow.rb:640:11:640:19 | ...[...] | hash_flow.rb:640:10:640:20 | ( ... ) | provenance |  |
 | hash_flow.rb:641:11:641:14 | hash [element] | hash_flow.rb:641:11:641:19 | ...[...] | provenance |  |
 | hash_flow.rb:641:11:641:19 | ...[...] | hash_flow.rb:641:10:641:20 | ( ... ) | provenance |  |
+| hash_flow.rb:642:11:642:14 | hash [element :c] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
 | hash_flow.rb:642:11:642:14 | hash [element] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
 | hash_flow.rb:642:11:642:19 | ...[...] | hash_flow.rb:642:10:642:20 | ( ... ) | provenance |  |
 | hash_flow.rb:648:5:648:8 | hash [element :a] | hash_flow.rb:653:9:653:12 | hash [element :a] | provenance |  |
@@ -1149,7 +1157,9 @@ nodes
 | hash_flow.rb:44:10:44:13 | hash [element 0] | semmle.label | hash [element 0] |
 | hash_flow.rb:44:10:44:16 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:46:10:46:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:46:10:46:13 | hash [element a] | semmle.label | hash [element a] |
 | hash_flow.rb:46:10:46:17 | ...[...] | semmle.label | ...[...] |
+| hash_flow.rb:48:10:48:13 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:48:10:48:13 | hash [element a] | semmle.label | hash [element a] |
 | hash_flow.rb:48:10:48:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:55:5:55:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
@@ -1740,12 +1750,14 @@ nodes
 | hash_flow.rb:639:5:639:8 | hash [element :c] | semmle.label | hash [element :c] |
 | hash_flow.rb:639:5:639:8 | hash [element] | semmle.label | hash [element] |
 | hash_flow.rb:640:10:640:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:640:11:640:14 | hash [element :a] | semmle.label | hash [element :a] |
 | hash_flow.rb:640:11:640:14 | hash [element] | semmle.label | hash [element] |
 | hash_flow.rb:640:11:640:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:641:10:641:20 | ( ... ) | semmle.label | ( ... ) |
 | hash_flow.rb:641:11:641:14 | hash [element] | semmle.label | hash [element] |
 | hash_flow.rb:641:11:641:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:642:10:642:20 | ( ... ) | semmle.label | ( ... ) |
+| hash_flow.rb:642:11:642:14 | hash [element :c] | semmle.label | hash [element :c] |
 | hash_flow.rb:642:11:642:14 | hash [element] | semmle.label | hash [element] |
 | hash_flow.rb:642:11:642:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:648:5:648:8 | hash [element :a] | semmle.label | hash [element :a] |
@@ -2349,6 +2361,8 @@ hashLiteral
 | hash_flow.rb:30:10:30:16 | ...[...] | hash_flow.rb:19:14:19:23 | call to taint | hash_flow.rb:30:10:30:16 | ...[...] | $@ | hash_flow.rb:19:14:19:23 | call to taint | call to taint |
 | hash_flow.rb:44:10:44:16 | ...[...] | hash_flow.rb:38:15:38:24 | call to taint | hash_flow.rb:44:10:44:16 | ...[...] | $@ | hash_flow.rb:38:15:38:24 | call to taint | call to taint |
 | hash_flow.rb:46:10:46:17 | ...[...] | hash_flow.rb:40:16:40:25 | call to taint | hash_flow.rb:46:10:46:17 | ...[...] | $@ | hash_flow.rb:40:16:40:25 | call to taint | call to taint |
+| hash_flow.rb:46:10:46:17 | ...[...] | hash_flow.rb:42:17:42:26 | call to taint | hash_flow.rb:46:10:46:17 | ...[...] | $@ | hash_flow.rb:42:17:42:26 | call to taint | call to taint |
+| hash_flow.rb:48:10:48:18 | ...[...] | hash_flow.rb:40:16:40:25 | call to taint | hash_flow.rb:48:10:48:18 | ...[...] | $@ | hash_flow.rb:40:16:40:25 | call to taint | call to taint |
 | hash_flow.rb:48:10:48:18 | ...[...] | hash_flow.rb:42:17:42:26 | call to taint | hash_flow.rb:48:10:48:18 | ...[...] | $@ | hash_flow.rb:42:17:42:26 | call to taint | call to taint |
 | hash_flow.rb:56:10:56:18 | ...[...] | hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:56:10:56:18 | ...[...] | $@ | hash_flow.rb:55:21:55:30 | call to taint | call to taint |
 | hash_flow.rb:61:10:61:18 | ...[...] | hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:61:10:61:18 | ...[...] | $@ | hash_flow.rb:59:13:59:22 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash_flow.rb
@@ -43,9 +43,9 @@ def m2()
     hash['b'] = 3
     sink(hash[0]) # $ hasValueFlow=2.1
     sink(hash[1])
-    sink(hash[:a]) # $ hasValueFlow=2.2
+    sink(hash[:a]) # $ hasValueFlow=2.2 $ SPURIOUS hasValueFlow=2.3
     sink(hash[:b])
-    sink(hash['a']) # $ hasValueFlow=2.3
+    sink(hash['a']) # $ hasValueFlow=2.3 $ SPURIOUS hasValueFlow=2.2
     sink(hash['b'])
 end
 

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -63,19 +63,19 @@ edges
 | hash_extensions.rb:3:5:3:5 | x [element] | hash_extensions.rb:4:10:4:10 | x [element] | provenance |  |
 | hash_extensions.rb:3:9:3:9 | h [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | provenance |  |
 | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | hash_extensions.rb:3:5:3:5 | x [element] | provenance |  |
-| hash_extensions.rb:4:10:4:10 | x [element] | hash_extensions.rb:4:10:4:14 | ...[...] | provenance |  |
-| hash_extensions.rb:10:5:10:5 | h [element :a] | hash_extensions.rb:11:9:11:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:10:9:10:26 | call to [] [element :a] | hash_extensions.rb:10:5:10:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:10:14:10:24 | call to source | hash_extensions.rb:10:9:10:26 | call to [] [element :a] | provenance |  |
+| hash_extensions.rb:4:10:4:10 | x [element] | hash_extensions.rb:4:10:4:15 | ...[...] | provenance |  |
+| hash_extensions.rb:10:5:10:5 | h [element a] | hash_extensions.rb:11:9:11:9 | h [element a] | provenance |  |
+| hash_extensions.rb:10:9:10:30 | call to [] [element a] | hash_extensions.rb:10:5:10:5 | h [element a] | provenance |  |
+| hash_extensions.rb:10:18:10:28 | call to source | hash_extensions.rb:10:9:10:30 | call to [] [element a] | provenance |  |
 | hash_extensions.rb:11:5:11:5 | x [element] | hash_extensions.rb:12:10:12:10 | x [element] | provenance |  |
-| hash_extensions.rb:11:9:11:9 | h [element :a] | hash_extensions.rb:11:9:11:20 | call to to_options [element] | provenance |  |
+| hash_extensions.rb:11:9:11:9 | h [element a] | hash_extensions.rb:11:9:11:20 | call to to_options [element] | provenance |  |
 | hash_extensions.rb:11:9:11:20 | call to to_options [element] | hash_extensions.rb:11:5:11:5 | x [element] | provenance |  |
 | hash_extensions.rb:12:10:12:10 | x [element] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
-| hash_extensions.rb:18:5:18:5 | h [element :a] | hash_extensions.rb:19:9:19:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:18:9:18:26 | call to [] [element :a] | hash_extensions.rb:18:5:18:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:18:14:18:24 | call to source | hash_extensions.rb:18:9:18:26 | call to [] [element :a] | provenance |  |
+| hash_extensions.rb:18:5:18:5 | h [element a] | hash_extensions.rb:19:9:19:9 | h [element a] | provenance |  |
+| hash_extensions.rb:18:9:18:30 | call to [] [element a] | hash_extensions.rb:18:5:18:5 | h [element a] | provenance |  |
+| hash_extensions.rb:18:18:18:28 | call to source | hash_extensions.rb:18:9:18:30 | call to [] [element a] | provenance |  |
 | hash_extensions.rb:19:5:19:5 | x [element] | hash_extensions.rb:20:10:20:10 | x [element] | provenance |  |
-| hash_extensions.rb:19:9:19:9 | h [element :a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | provenance |  |
+| hash_extensions.rb:19:9:19:9 | h [element a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | provenance |  |
 | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | hash_extensions.rb:19:5:19:5 | x [element] | provenance |  |
 | hash_extensions.rb:20:10:20:10 | x [element] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
 | hash_extensions.rb:26:5:26:5 | h [element :a] | hash_extensions.rb:27:9:27:9 | h [element :a] | provenance |  |
@@ -84,12 +84,12 @@ edges
 | hash_extensions.rb:27:5:27:5 | x [element] | hash_extensions.rb:28:10:28:10 | x [element] | provenance |  |
 | hash_extensions.rb:27:9:27:9 | h [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | provenance |  |
 | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | hash_extensions.rb:27:5:27:5 | x [element] | provenance |  |
-| hash_extensions.rb:28:10:28:10 | x [element] | hash_extensions.rb:28:10:28:14 | ...[...] | provenance |  |
-| hash_extensions.rb:34:5:34:5 | h [element :a] | hash_extensions.rb:35:9:35:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:34:9:34:26 | call to [] [element :a] | hash_extensions.rb:34:5:34:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:34:14:34:24 | call to source | hash_extensions.rb:34:9:34:26 | call to [] [element :a] | provenance |  |
+| hash_extensions.rb:28:10:28:10 | x [element] | hash_extensions.rb:28:10:28:15 | ...[...] | provenance |  |
+| hash_extensions.rb:34:5:34:5 | h [element a] | hash_extensions.rb:35:9:35:9 | h [element a] | provenance |  |
+| hash_extensions.rb:34:9:34:30 | call to [] [element a] | hash_extensions.rb:34:5:34:5 | h [element a] | provenance |  |
+| hash_extensions.rb:34:18:34:28 | call to source | hash_extensions.rb:34:9:34:30 | call to [] [element a] | provenance |  |
 | hash_extensions.rb:35:5:35:5 | x [element] | hash_extensions.rb:36:10:36:10 | x [element] | provenance |  |
-| hash_extensions.rb:35:9:35:9 | h [element :a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | provenance |  |
+| hash_extensions.rb:35:9:35:9 | h [element a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | provenance |  |
 | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | hash_extensions.rb:35:5:35:5 | x [element] | provenance |  |
 | hash_extensions.rb:36:10:36:10 | x [element] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
 | hash_extensions.rb:42:5:42:5 | h [element :a] | hash_extensions.rb:43:9:43:9 | h [element :a] | provenance |  |
@@ -98,7 +98,7 @@ edges
 | hash_extensions.rb:43:5:43:5 | x [element] | hash_extensions.rb:44:10:44:10 | x [element] | provenance |  |
 | hash_extensions.rb:43:9:43:9 | h [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | provenance |  |
 | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | hash_extensions.rb:43:5:43:5 | x [element] | provenance |  |
-| hash_extensions.rb:44:10:44:10 | x [element] | hash_extensions.rb:44:10:44:14 | ...[...] | provenance |  |
+| hash_extensions.rb:44:10:44:10 | x [element] | hash_extensions.rb:44:10:44:15 | ...[...] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :a] | hash_extensions.rb:51:9:51:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | hash_extensions.rb:51:9:51:9 | h [element :b] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :d] | hash_extensions.rb:51:9:51:9 | h [element :d] | provenance |  |
@@ -309,20 +309,20 @@ nodes
 | hash_extensions.rb:3:9:3:9 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | semmle.label | call to stringify_keys [element] |
 | hash_extensions.rb:4:10:4:10 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:4:10:4:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:10:5:10:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:10:9:10:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_extensions.rb:10:14:10:24 | call to source | semmle.label | call to source |
+| hash_extensions.rb:4:10:4:15 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:10:5:10:5 | h [element a] | semmle.label | h [element a] |
+| hash_extensions.rb:10:9:10:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:10:18:10:28 | call to source | semmle.label | call to source |
 | hash_extensions.rb:11:5:11:5 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:11:9:11:9 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:11:9:11:9 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:11:9:11:20 | call to to_options [element] | semmle.label | call to to_options [element] |
 | hash_extensions.rb:12:10:12:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:18:5:18:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:18:9:18:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_extensions.rb:18:14:18:24 | call to source | semmle.label | call to source |
+| hash_extensions.rb:18:5:18:5 | h [element a] | semmle.label | h [element a] |
+| hash_extensions.rb:18:9:18:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:18:18:18:28 | call to source | semmle.label | call to source |
 | hash_extensions.rb:19:5:19:5 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:19:9:19:9 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:19:9:19:9 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | semmle.label | call to symbolize_keys [element] |
 | hash_extensions.rb:20:10:20:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
@@ -333,12 +333,12 @@ nodes
 | hash_extensions.rb:27:9:27:9 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | semmle.label | call to deep_stringify_keys [element] |
 | hash_extensions.rb:28:10:28:10 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:28:10:28:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:34:5:34:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:34:9:34:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_extensions.rb:34:14:34:24 | call to source | semmle.label | call to source |
+| hash_extensions.rb:28:10:28:15 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:34:5:34:5 | h [element a] | semmle.label | h [element a] |
+| hash_extensions.rb:34:9:34:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:34:18:34:28 | call to source | semmle.label | call to source |
 | hash_extensions.rb:35:5:35:5 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:35:9:35:9 | h [element :a] | semmle.label | h [element :a] |
+| hash_extensions.rb:35:9:35:9 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | semmle.label | call to deep_symbolize_keys [element] |
 | hash_extensions.rb:36:10:36:10 | x [element] | semmle.label | x [element] |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
@@ -349,7 +349,7 @@ nodes
 | hash_extensions.rb:43:9:43:9 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | semmle.label | call to with_indifferent_access [element] |
 | hash_extensions.rb:44:10:44:10 | x [element] | semmle.label | x [element] |
-| hash_extensions.rb:44:10:44:14 | ...[...] | semmle.label | ...[...] |
+| hash_extensions.rb:44:10:44:15 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:50:5:50:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | semmle.label | h [element :b] |
 | hash_extensions.rb:50:5:50:5 | h [element :d] | semmle.label | h [element :d] |
@@ -516,12 +516,12 @@ testFailures
 | active_support.rb:283:8:283:17 | call to presence | active_support.rb:282:7:282:16 | call to source | active_support.rb:283:8:283:17 | call to presence | $@ | active_support.rb:282:7:282:16 | call to source | call to source |
 | active_support.rb:286:8:286:17 | call to presence | active_support.rb:285:7:285:16 | call to source | active_support.rb:286:8:286:17 | call to presence | $@ | active_support.rb:285:7:285:16 | call to source | call to source |
 | active_support.rb:291:8:291:17 | call to deep_dup | active_support.rb:290:7:290:16 | call to source | active_support.rb:291:8:291:17 | call to deep_dup | $@ | active_support.rb:290:7:290:16 | call to source | call to source |
-| hash_extensions.rb:4:10:4:14 | ...[...] | hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:4:10:4:14 | ...[...] | $@ | hash_extensions.rb:2:14:2:24 | call to source | call to source |
-| hash_extensions.rb:12:10:12:14 | ...[...] | hash_extensions.rb:10:14:10:24 | call to source | hash_extensions.rb:12:10:12:14 | ...[...] | $@ | hash_extensions.rb:10:14:10:24 | call to source | call to source |
-| hash_extensions.rb:20:10:20:14 | ...[...] | hash_extensions.rb:18:14:18:24 | call to source | hash_extensions.rb:20:10:20:14 | ...[...] | $@ | hash_extensions.rb:18:14:18:24 | call to source | call to source |
-| hash_extensions.rb:28:10:28:14 | ...[...] | hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:28:10:28:14 | ...[...] | $@ | hash_extensions.rb:26:14:26:24 | call to source | call to source |
-| hash_extensions.rb:36:10:36:14 | ...[...] | hash_extensions.rb:34:14:34:24 | call to source | hash_extensions.rb:36:10:36:14 | ...[...] | $@ | hash_extensions.rb:34:14:34:24 | call to source | call to source |
-| hash_extensions.rb:44:10:44:14 | ...[...] | hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:44:10:44:14 | ...[...] | $@ | hash_extensions.rb:42:14:42:24 | call to source | call to source |
+| hash_extensions.rb:4:10:4:15 | ...[...] | hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:4:10:4:15 | ...[...] | $@ | hash_extensions.rb:2:14:2:24 | call to source | call to source |
+| hash_extensions.rb:12:10:12:14 | ...[...] | hash_extensions.rb:10:18:10:28 | call to source | hash_extensions.rb:12:10:12:14 | ...[...] | $@ | hash_extensions.rb:10:18:10:28 | call to source | call to source |
+| hash_extensions.rb:20:10:20:14 | ...[...] | hash_extensions.rb:18:18:18:28 | call to source | hash_extensions.rb:20:10:20:14 | ...[...] | $@ | hash_extensions.rb:18:18:18:28 | call to source | call to source |
+| hash_extensions.rb:28:10:28:15 | ...[...] | hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:28:10:28:15 | ...[...] | $@ | hash_extensions.rb:26:14:26:24 | call to source | call to source |
+| hash_extensions.rb:36:10:36:14 | ...[...] | hash_extensions.rb:34:18:34:28 | call to source | hash_extensions.rb:36:10:36:14 | ...[...] | $@ | hash_extensions.rb:34:18:34:28 | call to source | call to source |
+| hash_extensions.rb:44:10:44:15 | ...[...] | hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:44:10:44:15 | ...[...] | $@ | hash_extensions.rb:42:14:42:24 | call to source | call to source |
 | hash_extensions.rb:56:10:56:14 | ...[...] | hash_extensions.rb:50:52:50:61 | call to taint | hash_extensions.rb:56:10:56:14 | ...[...] | $@ | hash_extensions.rb:50:52:50:61 | call to taint | call to taint |
 | hash_extensions.rb:58:10:58:14 | ...[...] | hash_extensions.rb:50:14:50:23 | call to taint | hash_extensions.rb:58:10:58:14 | ...[...] | $@ | hash_extensions.rb:50:14:50:23 | call to taint | call to taint |
 | hash_extensions.rb:59:10:59:14 | ...[...] | hash_extensions.rb:50:29:50:38 | call to taint | hash_extensions.rb:59:10:59:14 | ...[...] | $@ | hash_extensions.rb:50:29:50:38 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -60,45 +60,45 @@ edges
 | hash_extensions.rb:2:5:2:5 | h [element :a] | hash_extensions.rb:3:9:3:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:2:9:2:26 | call to [] [element :a] | hash_extensions.rb:2:5:2:5 | h [element :a] | provenance |  |
 | hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:2:9:2:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:3:5:3:5 | x [element] | hash_extensions.rb:4:10:4:10 | x [element] | provenance |  |
-| hash_extensions.rb:3:9:3:9 | h [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | provenance |  |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | hash_extensions.rb:3:5:3:5 | x [element] | provenance |  |
-| hash_extensions.rb:4:10:4:10 | x [element] | hash_extensions.rb:4:10:4:15 | ...[...] | provenance |  |
+| hash_extensions.rb:3:5:3:5 | x [element :a] | hash_extensions.rb:4:10:4:10 | x [element :a] | provenance |  |
+| hash_extensions.rb:3:9:3:9 | h [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | provenance |  |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | hash_extensions.rb:3:5:3:5 | x [element :a] | provenance |  |
+| hash_extensions.rb:4:10:4:10 | x [element :a] | hash_extensions.rb:4:10:4:15 | ...[...] | provenance |  |
 | hash_extensions.rb:10:5:10:5 | h [element a] | hash_extensions.rb:11:9:11:9 | h [element a] | provenance |  |
 | hash_extensions.rb:10:9:10:30 | call to [] [element a] | hash_extensions.rb:10:5:10:5 | h [element a] | provenance |  |
 | hash_extensions.rb:10:18:10:28 | call to source | hash_extensions.rb:10:9:10:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:11:5:11:5 | x [element] | hash_extensions.rb:12:10:12:10 | x [element] | provenance |  |
-| hash_extensions.rb:11:9:11:9 | h [element a] | hash_extensions.rb:11:9:11:20 | call to to_options [element] | provenance |  |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element] | hash_extensions.rb:11:5:11:5 | x [element] | provenance |  |
-| hash_extensions.rb:12:10:12:10 | x [element] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
+| hash_extensions.rb:11:5:11:5 | x [element a] | hash_extensions.rb:12:10:12:10 | x [element a] | provenance |  |
+| hash_extensions.rb:11:9:11:9 | h [element a] | hash_extensions.rb:11:9:11:20 | call to to_options [element a] | provenance |  |
+| hash_extensions.rb:11:9:11:20 | call to to_options [element a] | hash_extensions.rb:11:5:11:5 | x [element a] | provenance |  |
+| hash_extensions.rb:12:10:12:10 | x [element a] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
 | hash_extensions.rb:18:5:18:5 | h [element a] | hash_extensions.rb:19:9:19:9 | h [element a] | provenance |  |
 | hash_extensions.rb:18:9:18:30 | call to [] [element a] | hash_extensions.rb:18:5:18:5 | h [element a] | provenance |  |
 | hash_extensions.rb:18:18:18:28 | call to source | hash_extensions.rb:18:9:18:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:19:5:19:5 | x [element] | hash_extensions.rb:20:10:20:10 | x [element] | provenance |  |
-| hash_extensions.rb:19:9:19:9 | h [element a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | provenance |  |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | hash_extensions.rb:19:5:19:5 | x [element] | provenance |  |
-| hash_extensions.rb:20:10:20:10 | x [element] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
+| hash_extensions.rb:19:5:19:5 | x [element a] | hash_extensions.rb:20:10:20:10 | x [element a] | provenance |  |
+| hash_extensions.rb:19:9:19:9 | h [element a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | provenance |  |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | hash_extensions.rb:19:5:19:5 | x [element a] | provenance |  |
+| hash_extensions.rb:20:10:20:10 | x [element a] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
 | hash_extensions.rb:26:5:26:5 | h [element :a] | hash_extensions.rb:27:9:27:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:26:9:26:26 | call to [] [element :a] | hash_extensions.rb:26:5:26:5 | h [element :a] | provenance |  |
 | hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:26:9:26:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:27:5:27:5 | x [element] | hash_extensions.rb:28:10:28:10 | x [element] | provenance |  |
-| hash_extensions.rb:27:9:27:9 | h [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | provenance |  |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | hash_extensions.rb:27:5:27:5 | x [element] | provenance |  |
-| hash_extensions.rb:28:10:28:10 | x [element] | hash_extensions.rb:28:10:28:15 | ...[...] | provenance |  |
+| hash_extensions.rb:27:5:27:5 | x [element :a] | hash_extensions.rb:28:10:28:10 | x [element :a] | provenance |  |
+| hash_extensions.rb:27:9:27:9 | h [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | provenance |  |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | hash_extensions.rb:27:5:27:5 | x [element :a] | provenance |  |
+| hash_extensions.rb:28:10:28:10 | x [element :a] | hash_extensions.rb:28:10:28:15 | ...[...] | provenance |  |
 | hash_extensions.rb:34:5:34:5 | h [element a] | hash_extensions.rb:35:9:35:9 | h [element a] | provenance |  |
 | hash_extensions.rb:34:9:34:30 | call to [] [element a] | hash_extensions.rb:34:5:34:5 | h [element a] | provenance |  |
 | hash_extensions.rb:34:18:34:28 | call to source | hash_extensions.rb:34:9:34:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:35:5:35:5 | x [element] | hash_extensions.rb:36:10:36:10 | x [element] | provenance |  |
-| hash_extensions.rb:35:9:35:9 | h [element a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | provenance |  |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | hash_extensions.rb:35:5:35:5 | x [element] | provenance |  |
-| hash_extensions.rb:36:10:36:10 | x [element] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
+| hash_extensions.rb:35:5:35:5 | x [element a] | hash_extensions.rb:36:10:36:10 | x [element a] | provenance |  |
+| hash_extensions.rb:35:9:35:9 | h [element a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | provenance |  |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | hash_extensions.rb:35:5:35:5 | x [element a] | provenance |  |
+| hash_extensions.rb:36:10:36:10 | x [element a] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
 | hash_extensions.rb:42:5:42:5 | h [element :a] | hash_extensions.rb:43:9:43:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:42:9:42:26 | call to [] [element :a] | hash_extensions.rb:42:5:42:5 | h [element :a] | provenance |  |
 | hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:42:9:42:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:43:5:43:5 | x [element] | hash_extensions.rb:44:10:44:10 | x [element] | provenance |  |
-| hash_extensions.rb:43:9:43:9 | h [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | provenance |  |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | hash_extensions.rb:43:5:43:5 | x [element] | provenance |  |
-| hash_extensions.rb:44:10:44:10 | x [element] | hash_extensions.rb:44:10:44:15 | ...[...] | provenance |  |
+| hash_extensions.rb:43:5:43:5 | x [element :a] | hash_extensions.rb:44:10:44:10 | x [element :a] | provenance |  |
+| hash_extensions.rb:43:9:43:9 | h [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | provenance |  |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | hash_extensions.rb:43:5:43:5 | x [element :a] | provenance |  |
+| hash_extensions.rb:44:10:44:10 | x [element :a] | hash_extensions.rb:44:10:44:15 | ...[...] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :a] | hash_extensions.rb:51:9:51:9 | h [element :a] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | hash_extensions.rb:51:9:51:9 | h [element :b] | provenance |  |
 | hash_extensions.rb:50:5:50:5 | h [element :d] | hash_extensions.rb:51:9:51:9 | h [element :d] | provenance |  |
@@ -305,50 +305,50 @@ nodes
 | hash_extensions.rb:2:5:2:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:2:9:2:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:2:14:2:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:3:5:3:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:3:5:3:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:3:9:3:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element] | semmle.label | call to stringify_keys [element] |
-| hash_extensions.rb:4:10:4:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | semmle.label | call to stringify_keys [element :a] |
+| hash_extensions.rb:4:10:4:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:4:10:4:15 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:10:5:10:5 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:10:9:10:30 | call to [] [element a] | semmle.label | call to [] [element a] |
 | hash_extensions.rb:10:18:10:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:11:5:11:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:11:5:11:5 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:11:9:11:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element] | semmle.label | call to to_options [element] |
-| hash_extensions.rb:12:10:12:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:11:9:11:20 | call to to_options [element a] | semmle.label | call to to_options [element a] |
+| hash_extensions.rb:12:10:12:10 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:18:5:18:5 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:18:9:18:30 | call to [] [element a] | semmle.label | call to [] [element a] |
 | hash_extensions.rb:18:18:18:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:19:5:19:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:19:5:19:5 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:19:9:19:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element] | semmle.label | call to symbolize_keys [element] |
-| hash_extensions.rb:20:10:20:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | semmle.label | call to symbolize_keys [element a] |
+| hash_extensions.rb:20:10:20:10 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:26:5:26:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:26:9:26:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:26:14:26:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:27:5:27:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:27:5:27:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:27:9:27:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element] | semmle.label | call to deep_stringify_keys [element] |
-| hash_extensions.rb:28:10:28:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | semmle.label | call to deep_stringify_keys [element :a] |
+| hash_extensions.rb:28:10:28:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:28:10:28:15 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:34:5:34:5 | h [element a] | semmle.label | h [element a] |
 | hash_extensions.rb:34:9:34:30 | call to [] [element a] | semmle.label | call to [] [element a] |
 | hash_extensions.rb:34:18:34:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:35:5:35:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:35:5:35:5 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:35:9:35:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element] | semmle.label | call to deep_symbolize_keys [element] |
-| hash_extensions.rb:36:10:36:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | semmle.label | call to deep_symbolize_keys [element a] |
+| hash_extensions.rb:36:10:36:10 | x [element a] | semmle.label | x [element a] |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:42:5:42:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:42:9:42:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
 | hash_extensions.rb:42:14:42:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:43:5:43:5 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:43:5:43:5 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:43:9:43:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element] | semmle.label | call to with_indifferent_access [element] |
-| hash_extensions.rb:44:10:44:10 | x [element] | semmle.label | x [element] |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | semmle.label | call to with_indifferent_access [element :a] |
+| hash_extensions.rb:44:10:44:10 | x [element :a] | semmle.label | x [element :a] |
 | hash_extensions.rb:44:10:44:15 | ...[...] | semmle.label | ...[...] |
 | hash_extensions.rb:50:5:50:5 | h [element :a] | semmle.label | h [element :a] |
 | hash_extensions.rb:50:5:50:5 | h [element :b] | semmle.label | h [element :b] |

--- a/ruby/ql/test/library-tests/frameworks/active_support/hash_extensions.rb
+++ b/ruby/ql/test/library-tests/frameworks/active_support/hash_extensions.rb
@@ -1,13 +1,13 @@
 def m_stringify_keys
     h = { a: source("a") }
     x = h.stringify_keys
-    sink x[:a] # $hasValueFlow=a
+    sink x["a"] # $hasValueFlow=a
 end
 
 m_stringify_keys()
 
 def m_to_options
-    h = { a: source("a") }
+    h = { "a" => source("a") }
     x = h.to_options
     sink x[:a] # $hasValueFlow=a
 end
@@ -15,7 +15,7 @@ end
 m_to_options()
 
 def m_symbolize_keys
-    h = { a: source("a") }
+    h = { "a" => source("a") }
     x = h.symbolize_keys
     sink x[:a] # $hasValueFlow=a
 end
@@ -25,13 +25,13 @@ m_symbolize_keys()
 def m_deep_stringify_keys
     h = { a: source("a") }
     x = h.deep_stringify_keys
-    sink x[:a] # $hasValueFlow=a
+    sink x["a"] # $hasValueFlow=a
 end
 
 m_deep_stringify_keys()
 
 def m_deep_symbolize_keys
-    h = { a: source("a") }
+    h = { "a" => source("a") }
     x = h.deep_symbolize_keys
     sink x[:a] # $hasValueFlow=a
 end
@@ -41,7 +41,7 @@ m_deep_symbolize_keys()
 def m_with_indifferent_access
     h = { a: source("a") }
     x = h.with_indifferent_access
-    sink x[:a] # $hasValueFlow=a
+    sink x["a"] # $hasValueFlow=a
 end
 
 m_with_indifferent_access()


### PR DESCRIPTION
Before this PR, we distinguished between symbols and strings in hash keys. So, for example, we would (correctly) not report flow in cases like

```rb
hash[:key] = "taint"
sink(hash["key"])
```

However, doing so meant that the flow summaries for methods such as [`with_indifferent_access`](https://api.rubyonrails.org/v4.2.0/classes/ActiveSupport/HashWithIndifferentAccess.html) would throw away any known information about the keys, leading to false positive flow.

While we could attempt to improve the summaries for methods like `with_indifferent_access`, this PR instead simply considers symbol/string hash keys equal when they denote the same value. The only potential downside is false positive flow, like in the example above, but this seems very unlikely in practice. Indeed, DCA confirms that this PR only removes results.