### PR TITLE
Rust: use common config for analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,3 +9,5 @@ paths-ignore:
   - '/python/'
   - '/javascript/ql/test'
   - '/javascript/extractor/tests'
+  - '/rust/ql/test'
+  - '/rust/ql/integration-tests'

--- a/.github/workflows/rust-analysis.yml
+++ b/.github/workflows/rust-analysis.yml
@@ -55,12 +55,7 @@ jobs:
       with:
         tools: ${{ steps.codeql.outputs.nightly_bundle }}
         languages: ${{ matrix.language }}
-        config: |
-          disable-default-queries: true
-          queries:
-            - uses: security-and-quality
-          paths-ignore:
-            - '/rust/ql/tests'
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Autobuild
       uses: github/codeql-action/autobuild@main


### PR DESCRIPTION
Now that the nightly bundle has the default query set, we don't need a special inline config.