### PR TITLE
KE2: implement basic usage of properties, variables and flexible types

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/KotlinUsesExtractor.kt
@@ -728,7 +728,11 @@ open class KotlinUsesExtractor(
                     return getFieldParent(d)
                 }
         */
-        return d.containingSymbol ?: d.containingFile
+        val rootSymbol = when (d) {
+            is KaPropertyAccessorSymbol -> d.containingSymbol
+            else -> d
+        }
+        return rootSymbol?.containingSymbol ?: rootSymbol?.containingFile
     }
 
     context(KaSession)

--- a/java/kotlin-extractor2/src/main/kotlin/TrapWriter.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/TrapWriter.kt
@@ -7,6 +7,7 @@ import com.github.codeql.KotlinUsesExtractor.LocallyVisibleFunctionLabels
 import com.intellij.psi.PsiElement
 import com.semmle.extractor.java.PopulateFile
 import com.semmle.util.unicode.UTF8Util
+import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
 import java.io.BufferedWriter
 import java.io.File
 import java.util.concurrent.locks.ReentrantLock
@@ -153,11 +154,11 @@ abstract class TrapWriter(
      * which label is used for a given local variable. This information is stored in this mapping.
      */
     // TODO: This should be in a subclass so that DiagnosticTrapWriter doesn't include it, as it is not threadsafe
-    private val variableLabelMapping: MutableMap<KtProperty, Label<out DbLocalvar>> =
-        mutableMapOf<KtProperty, Label<out DbLocalvar>>()
+    private val variableLabelMapping: MutableMap<KaVariableSymbol, Label<out DbLocalvar>> =
+        mutableMapOf<KaVariableSymbol, Label<out DbLocalvar>>()
 
     /** This returns the label used for a local variable, creating one if none currently exists. */
-    fun <T> getVariableLabelFor(v: KtProperty): Label<out DbLocalvar> {
+    fun <T> getVariableLabelFor(v: KaVariableSymbol): Label<out DbLocalvar> {
         val maybeLabel = variableLabelMapping[v]
         if (maybeLabel == null) {
             val label = getFreshIdLabel<DbLocalvar>()

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
@@ -3,11 +3,10 @@ package com.github.codeql
 import com.github.codeql.KotlinFileExtractor.StmtExprParent
 import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.analysis.api.KaSession
-import org.jetbrains.kotlin.analysis.api.resolution.KaCompoundAccessCall
-import org.jetbrains.kotlin.analysis.api.resolution.KaSimpleFunctionCall
-import org.jetbrains.kotlin.analysis.api.resolution.KaSuccessCallInfo
-import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.resolution.*
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.KaTypeNullability
 import org.jetbrains.kotlin.analysis.api.types.symbol
@@ -19,6 +18,7 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.parsing.parseNumericLiteral
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.utils.mapToIndex
 
 context(KaSession)
 private fun KotlinFileExtractor.extractExpressionBody(e: KtExpression, callable: Label<out DbCallable>) {
@@ -306,9 +306,9 @@ private fun KotlinFileExtractor.extractPostfixUnaryExpression(
 }
 
 context(KaSession)
-fun KtExpression.resolveCallTarget(): KaSimpleFunctionCall? {
+fun KtExpression.resolveCallTarget(): KaCallableMemberCall<*, *>? {
     val callInfo = this.resolveToCall() as? KaSuccessCallInfo
-    val functionCall = callInfo?.call as? KaSimpleFunctionCall
+    val functionCall = callInfo?.call as? KaCallableMemberCall<*, *>
     return functionCall
 }
 
@@ -335,7 +335,7 @@ private fun KotlinFileExtractor.extractBinaryExpression(
     parent: StmtExprParent
 ) {
     val op = expression.operationToken
-    val target = expression.resolveCallTarget()?.symbol
+    val target = expression.resolveCallTarget()?.symbol as? KaFunctionSymbol?
 
     if (op == KtTokens.PLUS && target.isBinaryPlus()) {
         extractBinaryExpression(expression, callable, parent, tw::writeExprs_addexpr)
@@ -544,6 +544,10 @@ private fun KotlinFileExtractor.extractExpression(
 
             is KtCallExpression -> {
                 extractMethodCall(e, callable, parent)
+            }
+
+            is KtReferenceExpression -> {
+                extractReferenceExpression(e, callable, parent)
             }
 
             is KtIsExpression -> {
@@ -1602,45 +1606,46 @@ OLD: KE1
             }
         }
     }
+    */
 
-    private fun extractVariableAccess(
-        variable: Label<out DbVariable>?,
-        type: TypeResults,
-        locId: Label<DbLocation>,
-        parent: Label<out DbExprparent>,
-        idx: Int,
-        callable: Label<out DbCallable>,
-        enclosingStmt: Label<out DbStmt>
-    ) =
-        tw.getFreshIdLabel<DbVaraccess>().also {
-            tw.writeExprs_varaccess(it, type.javaResult.id, parent, idx)
-            tw.writeExprsKotlinType(it, type.kotlinResult.id)
-            extractExprContext(it, locId, callable, enclosingStmt)
+private fun KotlinFileExtractor.extractVariableAccess(
+    variable: Label<out DbVariable>?,
+    type: TypeResults,
+    locId: Label<DbLocation>,
+    parent: Label<out DbExprparent>,
+    idx: Int,
+    callable: Label<out DbCallable>,
+    enclosingStmt: Label<out DbStmt>
+) =
+    tw.getFreshIdLabel<DbVaraccess>().also {
+        tw.writeExprs_varaccess(it, type.javaResult.id, parent, idx)
+        tw.writeExprsKotlinType(it, type.kotlinResult.id)
+        extractExprContext(it, locId, callable, enclosingStmt)
 
-            if (variable != null) {
-                tw.writeVariableBinding(it, variable)
-            }
+        if (variable != null) {
+            tw.writeVariableBinding(it, variable)
         }
+    }
 
-    private fun extractVariableAccess(
-        variable: Label<out DbVariable>?,
-        irType: IrType,
-        locId: Label<DbLocation>,
-        parent: Label<out DbExprparent>,
-        idx: Int,
-        callable: Label<out DbCallable>,
-        enclosingStmt: Label<out DbStmt>
-    ) =
-        extractVariableAccess(
-            variable,
-            useType(irType),
-            locId,
-            parent,
-            idx,
-            callable,
-            enclosingStmt
-        )
-*/
+private fun KotlinFileExtractor.extractVariableAccess(
+    variable: Label<out DbVariable>?,
+    type: KaType,
+    locId: Label<DbLocation>,
+    parent: Label<out DbExprparent>,
+    idx: Int,
+    callable: Label<out DbCallable>,
+    enclosingStmt: Label<out DbStmt>
+) =
+    extractVariableAccess(
+        variable,
+        useType(type),
+        locId,
+        parent,
+        idx,
+        callable,
+        enclosingStmt
+    )
+
 context(KaSession)
 private fun KotlinFileExtractor.extractLoop(
     loop: KtLoopExpression,
@@ -2707,7 +2712,7 @@ private fun KotlinFileExtractor.extractVariableExpr(
     //extractInitializer: Boolean = true  // OLD KE1
 ) {
     with("variable expr", v) {
-        val varId = useVariable(v)
+        val varId = useVariable(v.symbol)
         val exprId = tw.getFreshIdLabel<DbLocalvariabledeclexpr>()
         val locId = tw.getLocation(v) // OLD KE1: getVariableLocationProvider(v))
         val type = useType(v.returnType)
@@ -2734,6 +2739,61 @@ private fun KotlinFileExtractor.extractVariableExpr(
     }
 }
 
-private fun KotlinFileExtractor.useVariable(v: KtProperty): Label<out DbLocalvar> {
+private fun KotlinFileExtractor.useVariable(v: KaVariableSymbol): Label<out DbLocalvar> {
     return tw.getVariableLabelFor<DbLocalvar>(v)
+}
+
+context(KaSession)
+fun KotlinFileExtractor.extractReferenceExpression(
+    ref: KtReferenceExpression,
+    enclosingCallable: Label<out DbCallable>,
+    stmtExprParent: StmtExprParent
+) {
+    val exprParent = stmtExprParent.expr(ref, enclosingCallable)
+
+    when (val resolvedCall = ref.resolveCallTarget()) {
+        is KaSimpleVariableAccessCall -> {
+            when (val varSymbol = resolvedCall.symbol) {
+                is KaPropertySymbol -> {
+                    val (target, args) = when (val access = resolvedCall.simpleAccess) {
+                        is KaSimpleVariableAccess.Read -> Pair(varSymbol.getter, listOf())
+                        is KaSimpleVariableAccess.Write -> Pair(varSymbol.setter, listOf(access.value))
+                    }
+
+                    val qualifier: KtExpression? = (ref.parent as? KtDotQualifiedExpression)?.receiverExpression
+
+                    if (target == null) {
+                        TODO()
+                    }
+
+                    extractRawMethodAccess(
+                        target,
+                        tw.getLocation(ref),
+                        ref.expressionType!!,
+                        enclosingCallable,
+                        exprParent.parent,
+                        exprParent.idx,
+                        exprParent.enclosingStmt,
+                        qualifier,
+                        null,
+                        args
+                    )
+                }
+                else -> {
+                    extractVariableAccess(
+                        useVariable(varSymbol),
+                        varSymbol.returnType,
+                        tw.getLocation(ref),
+                        exprParent.parent,
+                        exprParent.idx,
+                        enclosingCallable,
+                        exprParent.enclosingStmt
+                    )
+                }
+            }
+        }
+        else -> {
+            TODO()
+        }
+    }
 }

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
@@ -2755,12 +2755,14 @@ fun KotlinFileExtractor.extractReferenceExpression(
         is KaSimpleVariableAccessCall -> {
             when (val varSymbol = resolvedCall.symbol) {
                 is KaPropertySymbol -> {
+                    // Note this could be a native Kotlin property, or a synthetic one for a Java object inferred
+                    // from getters/setters.
                     val (target, args) = when (val access = resolvedCall.simpleAccess) {
                         is KaSimpleVariableAccess.Read -> Pair(varSymbol.getter, listOf())
                         is KaSimpleVariableAccess.Write -> Pair(varSymbol.setter, listOf(access.value))
                     }
 
-                    val qualifier: KtExpression? = (ref.parent as? KtDotQualifiedExpression)?.receiverExpression
+                    val qualifier: KtExpression? = (ref.parent as? KtQualifiedExpression)?.receiverExpression
 
                     if (target == null) {
                         TODO()
@@ -2780,6 +2782,8 @@ fun KotlinFileExtractor.extractReferenceExpression(
                     )
                 }
                 else -> {
+                    // TODO: field access, enum entries, others?
+                    // but aren't property accesses?
                     extractVariableAccess(
                         useVariable(varSymbol),
                         varSymbol.returnType,

--- a/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
@@ -2,6 +2,7 @@ package com.github.codeql
 
 import com.github.codeql.KotlinFileExtractor.StmtExprParent
 import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.resolution.KaSimpleFunctionCall
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaType
@@ -17,7 +18,7 @@ fun KotlinFileExtractor.extractMethodCall(
     enclosingCallable: Label<out DbCallable>,
     stmtExprParent: StmtExprParent
 ) {
-    val callTarget = call.resolveCallTarget()
+    val callTarget = call.resolveCallTarget() as? KaSimpleFunctionCall?
     val target = callTarget?.symbol
     val argMapping = callTarget?.argumentMapping
 
@@ -30,7 +31,7 @@ fun KotlinFileExtractor.extractMethodCall(
     // - missing arguments due to default parameter values, in which case some indices are missing.
     val args = call.valueArguments
         .map { arg ->
-            val expr = arg.argumentExpression
+            val expr = arg.getArgumentExpression()
             val p = argMapping[expr]
             if (p == null) {
                 TODO("This is unexpected, no parameter was found for the argument")

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Types.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Types.kt
@@ -2,6 +2,7 @@ package com.github.codeql
 
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
+import org.jetbrains.kotlin.analysis.api.types.KaFlexibleType
 import org.jetbrains.kotlin.analysis.api.types.KaType
 
 private fun KotlinUsesExtractor.useClassType(
@@ -20,6 +21,7 @@ fun KotlinUsesExtractor.useType(t: KaType?, context: TypeContext = TypeContext.O
             return extractErrorType()
         }
         is KaClassType -> return useClassType(t)
+        is KaFlexibleType -> return useType(t.lowerBound) // TODO: take a more reasoned choice here
         else -> TODO()
     }
     /*

--- a/java/kotlin-extractor2/src/main/kotlin/utils/JvmNames.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/utils/JvmNames.kt
@@ -1,5 +1,9 @@
 package com.github.codeql.utils
 
+import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotated
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KaAnnotatedSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.name
+
 /*
 OLD: KE1
 import com.github.codeql.utils.versions.allOverriddenIncludingSelf
@@ -74,8 +78,10 @@ private fun getSpecialJvmName(f: IrFunction): String? {
     }
     return null
 }
+*/
 
-fun getJvmName(container: IrAnnotationContainer): String? {
+fun getJvmName(container: KaAnnotatedSymbol): String? {
+    /* OLD: KE1
     for (a: IrConstructorCall in container.annotations) {
         val t = a.type
         if (t is IrSimpleType && a.valueArgumentsCount == 1) {
@@ -94,5 +100,6 @@ fun getJvmName(container: IrAnnotationContainer): String? {
         }
     }
     return (container as? IrFunction)?.let { getSpecialJvmName(container) }
+    */
+    return container.name?.identifier
 }
-*/


### PR DESCRIPTION
Basic implementation of property and variable accesses, and flexible types since they were needed in passing.

Choices for comment:

* Keep KE1's choice to extract property accesses as desugared getter or setter calls.
  * Possible alternative: extract a reference expression, perhaps with the hint that the compiler knows this is targeting a property, and turn that into a getter/setter call QL-side
* For the time being, extract flexible types as their lower bound (this means `String!` is extracted as `String`; the upper bound would mean we get `String?` instead; I don't know from memory if we get flexible types that are more complex than just flexible nullability
  * Possible alternatives: extract the other bound, or extract a flexible type explicitly (and do something with this QL-side so that Java query authors need not worry about flexible types)