### PR TITLE
Kotlin extractor: use special <nulltype> for null literals

### DIFF
--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -5748,7 +5748,7 @@ open class KotlinFileExtractor(
             // Match Java by using a special <nulltype> for nulls, rather than Kotlin's view of this which is
             // kotlin.Nothing?, the type that can only contain null.
             val nullTypeName = "<nulltype>"
-            val javaNullType = tw.getLabelFor(
+            val javaNullType = tw.getLabelFor<DbPrimitive>(
                 "@\"type;$nullTypeName\"",
                 { tw.writePrimitives(it, nullTypeName) }
             )

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -5745,7 +5745,14 @@ open class KotlinFileExtractor(
     ) =
         exprIdOrFresh<DbNullliteral>(overrideId).also {
             val type = useType(t)
-            tw.writeExprs_nullliteral(it, type.javaResult.id, parent, idx)
+            // Match Java by using a special <nulltype> for nulls, rather than Kotlin's view of this which is
+            // kotlin.Nothing?, the type that can only contain null.
+            val nullTypeName = "<nulltype>"
+            val javaNullType = tw.getLabelFor(
+                "@\"type;$nullTypeName\"",
+                { tw.writePrimitives(it, nullTypeName) }
+            )
+            tw.writeExprs_nullliteral(it, javaNullType, parent, idx)
             tw.writeExprsKotlinType(it, type.kotlinResult.id)
             extractExprContext(it, locId, callable, enclosingStmt)
         }

--- a/java/ql/test-kotlin1/library-tests/classes/genericExprTypes.expected
+++ b/java/ql/test-kotlin1/library-tests/classes/genericExprTypes.expected
@@ -45,9 +45,9 @@
 | generic_anonymous.kt:13:27:13:47 | get(...) | int |
 | generic_anonymous.kt:13:40:13:40 | i | int |
 | generic_anonymous.kt:17:9:17:29 | T0 | T0 |
-| generic_anonymous.kt:17:26:17:29 | null | Void |
+| generic_anonymous.kt:17:26:17:29 | null | <nulltype> |
 | generic_anonymous.kt:21:9:21:29 | T1 | T1 |
-| generic_anonymous.kt:21:26:21:29 | null | Void |
+| generic_anonymous.kt:21:26:21:29 | null | <nulltype> |
 | generic_anonymous.kt:24:5:32:5 | Unit | Unit |
 | generic_anonymous.kt:25:9:31:9 | Unit | Unit |
 | generic_anonymous.kt:26:13:26:37 | <Stmt> | new Object(...) { ... } |

--- a/java/ql/test-kotlin2/library-tests/classes/genericExprTypes.expected
+++ b/java/ql/test-kotlin2/library-tests/classes/genericExprTypes.expected
@@ -45,9 +45,9 @@
 | generic_anonymous.kt:13:27:13:47 | get(...) | int |
 | generic_anonymous.kt:13:40:13:40 | i | int |
 | generic_anonymous.kt:17:9:17:29 | T0 | T0 |
-| generic_anonymous.kt:17:26:17:29 | null | Void |
+| generic_anonymous.kt:17:26:17:29 | null | <nulltype> |
 | generic_anonymous.kt:21:9:21:29 | T1 | T1 |
-| generic_anonymous.kt:21:26:21:29 | null | Void |
+| generic_anonymous.kt:21:26:21:29 | null | <nulltype> |
 | generic_anonymous.kt:24:5:32:5 | Unit | Unit |
 | generic_anonymous.kt:25:9:31:9 | Unit | Unit |
 | generic_anonymous.kt:26:13:26:37 | <Stmt> | new Object(...) { ... } |


### PR DESCRIPTION
This matches the Java extractor's treatment of these literals, and so enables dataflow type-tracking to avoid special-casing Kotlin. Natively, Kotlin would regard this as kotlin.Nothing?, the type that can only contain null (kotlin.Nothing without a ? can take nothing at all), which gets Java-ified as java.lang.Void, and this will continue to be used when a null type has to be "boxed", as in representing substituted generic constraints with no possible type.