### PR TITLE
Handle matrix jobs in accept changes script

### DIFF
--- a/misc/scripts/accept-expected-changes-from-ci.py
+++ b/misc/scripts/accept-expected-changes-from-ci.py
@@ -373,7 +373,7 @@ def main(pr_number: Optional[int], sha_override: Optional[str] = None, force=Fal
                             target_url=job["html_url"],
                             created_at=check_run["completed_at"],
                             nwo=nwo,
-                            job_ids=[job["id"]],
+                            job_ids={job["id"]},
                         ))
                         break
                 else:

--- a/misc/scripts/accept-expected-changes-from-ci.py
+++ b/misc/scripts/accept-expected-changes-from-ci.py
@@ -196,15 +196,16 @@ class GithubStatus():
     target_url: str
     created_at: datetime
     nwo: str
-    job_id: int = None
+    job_ids: set = None
 
 
 def get_log_content(status: GithubStatus) -> str:
     LOGGER.debug(f"'{status.context}': Getting logs")
-    if status.job_id:
-        content = subprocess.check_output(
-            ["gh", "api", f"/repos/{status.nwo}/actions/jobs/{status.job_id}/logs"],
-        ).decode("utf-8")
+    if status.job_ids:
+        contents = [subprocess.check_output(
+            ["gh", "api", f"/repos/{status.nwo}/actions/jobs/{job_id}/logs"],
+        ).decode("utf-8") for job_id in status.job_ids]
+        content = "\n".join(contents)
     else:
         m = re.fullmatch(r"^https://github\.com/([^/]+/[^/]+)/actions/runs/(\d+)(?:/jobs/(\d+))?$", status.target_url)
         nwo = m.group(1)
@@ -301,8 +302,10 @@ def main(pr_number: Optional[int], sha_override: Optional[str] = None, force=Fal
                 api_name: str = job["name"]
 
                 if api_name.lower().startswith(expected_workflow_name.lower()):
-                    lang_test_failure.job_id = job["id"]
-                    break
+                    if lang_test_failure.job_ids is None:
+                        lang_test_failure.job_ids = set()
+                    lang_test_failure.job_ids.add(job["id"])
+                    continue
 
                 if " / " not in api_name:
                     continue
@@ -311,11 +314,11 @@ def main(pr_number: Optional[int], sha_override: Optional[str] = None, force=Fal
                 # The job names we're looking for looks like "Python2 Language Tests / Python2 Language Tests" or "Java Language Tests / Java Language Tests Linux"
                 # for "Java Integration Tests Linux / Java Integration tests Linux" we need to ignore case :|
                 if workflow_name == expected_workflow_name and job_name.lower().startswith(lang_test_failure.context.lower()):
-                    lang_test_failure.job_id = job["id"]
-                    break
+                    lang_test_failure.job_ids.add(job["id"])
+                    continue
 
     for lang_test_failure in lang_test_failures:
-        if lang_test_failure.job_id is None:
+        if lang_test_failure.job_ids is None:
             LOGGER.error(f"Could not find job for {lang_test_failure.context!r}")
             sys.exit(1)
 
@@ -370,7 +373,7 @@ def main(pr_number: Optional[int], sha_override: Optional[str] = None, force=Fal
                             target_url=job["html_url"],
                             created_at=check_run["completed_at"],
                             nwo=nwo,
-                            job_id=job["id"],
+                            job_ids=[job["id"]],
                         ))
                         break
                 else:


### PR DESCRIPTION
When I ran the script on a PR that included [this job](https://github.com/github/semmle-code/actions/runs/11660045127), it only looked at the first sub job (https://github.com/github/semmle-code/actions/runs/11660045127/job/32461625428) and not the remaining two slices.

This change makes it run against all sub jobs; not sure if it is the right way to fix it, though. 