### PR TITLE
C++: Fix FPs in cpp/wrong-number-format-arguments

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.ql
@@ -16,6 +16,20 @@
 
 import cpp
 
+class SyntaxError extends CompilerError {
+  SyntaxError() { this.getTag().matches("exp_%") }
+
+  predicate affects(Element e) {
+    exists(Location l1, Location l2 |
+      l1 = this.getLocation() and
+      l2 = e.getLocation()
+    |
+      l1.getFile() = l2.getFile() and
+      l1.getStartLine() = l2.getStartLine()
+    )
+  }
+}
+
 from FormatLiteral fl, FormattingFunctionCall ffc, int expected, int given, string ffcName
 where
   ffc = fl.getUse() and
@@ -27,7 +41,10 @@ where
     if ffc.isInMacroExpansion()
     then ffcName = ffc.getTarget().getName() + " (in a macro expansion)"
     else ffcName = ffc.getTarget().getName()
-  )
+  ) and
+  // A typical problem is that string literals are concatenated, but if one of the string
+  // literals is an undefined macro, then this just leads to a syntax error.
+  not exists(SyntaxError e | e.affects(fl))
 select ffc,
   "Format for " + ffcName + " expects " + expected.toString() + " arguments but given " +
     given.toString()

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -5,7 +5,6 @@
 | macros.cpp:14:2:14:37 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:21:2:21:36 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:32:2:32:25 | call to printf | Format for printf (in a macro expansion) expects 1 arguments but given 0 |
-| syntax_errors.c:6:5:6:10 | call to printf | Format for printf expects 1 arguments but given 0 |
 | test.c:9:2:9:7 | call to printf | Format for printf expects 1 arguments but given 0 |
 | test.c:12:2:12:7 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:15:2:15:7 | call to printf | Format for printf expects 3 arguments but given 2 |


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
