### PR TITLE
VSCode setting: turn off `editor.suggest.matchOnWordStartOnly`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "omnisharp.autoStart": false,
   "cmake.sourceDirectory": "${workspaceFolder}/swift",
-  "cmake.buildDirectory": "${workspaceFolder}/bazel-cmake-build"
+  "cmake.buildDirectory": "${workspaceFolder}/bazel-cmake-build",
+  "editor.suggest.matchOnWordStartOnly": false
 }


### PR DESCRIPTION
When `editor.suggest.matchOnWordStartOnly` is turned on (the default), VSCode autocomplete does not return all options for a search term that is preceded by "A", such as "param" in the below images.

![image](https://github.com/user-attachments/assets/0807f674-9a1c-4bdb-9143-6c8726688d1e)

Disabling this setting allows VSCode to return all possible matches for a search term.

![image](https://github.com/user-attachments/assets/2169f29f-6092-413e-bb2a-0940c170a1e8)

Related issue: https://github.com/github/vscode-codeql/issues/2573