### PR TITLE
Go: fix missing qualified names for some promoted methods

### DIFF
--- a/go/ql/lib/change-notes/2024-11-07-fix-missing-qualified-names-for-methods.md
+++ b/go/ql/lib/change-notes/2024-11-07-fix-missing-qualified-names-for-methods.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Fixed a bug which meant that some qualified names for promoted methods were not being recognised in some very specific circumstances.

--- a/go/ql/test/library-tests/semmle/go/Types/Field_getPackage.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Field_getPackage.expected
@@ -32,6 +32,10 @@
 | pkg1/embedding.go:28:24:28:31 | embedder | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
 | pkg1/embedding.go:36:2:36:5 | base | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
 | pkg1/embedding.go:37:2:37:2 | f | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
+| pkg1/promotedStructs.go:5:2:5:7 | SField | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
+| pkg1/promotedStructs.go:14:2:14:7 | PField | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
+| pkg1/promotedStructs.go:22:22:22:22 | S | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
+| pkg1/promotedStructs.go:25:22:25:22 | P | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
 | pkg1/tst.go:4:2:4:2 | f | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
 | pkg1/tst.go:5:2:5:4 | Foo | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |
 | pkg1/tst.go:6:2:6:4 | Bar | package github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 |

--- a/go/ql/test/library-tests/semmle/go/Types/Field_hasQualifiedName2.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Field_hasQualifiedName2.expected
@@ -43,6 +43,12 @@
 | pkg1/embedding.go:28:24:28:31 | embedder | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.embedder3 | embedder |
 | pkg1/embedding.go:36:2:36:5 | base | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.embedder4 | base |
 | pkg1/embedding.go:37:2:37:2 | f | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.embedder4 | f |
+| pkg1/promotedStructs.go:5:2:5:7 | SField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.S | SField |
+| pkg1/promotedStructs.go:5:2:5:7 | SField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedS | SField |
+| pkg1/promotedStructs.go:14:2:14:7 | PField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.P | PField |
+| pkg1/promotedStructs.go:14:2:14:7 | PField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedP | PField |
+| pkg1/promotedStructs.go:22:22:22:22 | S | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedS | S |
+| pkg1/promotedStructs.go:25:22:25:22 | P | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedP | P |
 | pkg1/tst.go:4:2:4:2 | f | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T | f |
 | pkg1/tst.go:5:2:5:4 | Foo | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T | Foo |
 | pkg1/tst.go:6:2:6:4 | Bar | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T | Bar |

--- a/go/ql/test/library-tests/semmle/go/Types/Field_hasQualifiedName3.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Field_hasQualifiedName3.expected
@@ -43,6 +43,12 @@
 | pkg1/embedding.go:28:24:28:31 | embedder | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | embedder3 | embedder |
 | pkg1/embedding.go:36:2:36:5 | base | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | embedder4 | base |
 | pkg1/embedding.go:37:2:37:2 | f | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | embedder4 | f |
+| pkg1/promotedStructs.go:5:2:5:7 | SField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | S | SField |
+| pkg1/promotedStructs.go:5:2:5:7 | SField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedS | SField |
+| pkg1/promotedStructs.go:14:2:14:7 | PField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | P | PField |
+| pkg1/promotedStructs.go:14:2:14:7 | PField | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedP | PField |
+| pkg1/promotedStructs.go:22:22:22:22 | S | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedS | S |
+| pkg1/promotedStructs.go:25:22:25:22 | P | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedP | P |
 | pkg1/tst.go:4:2:4:2 | f | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T | f |
 | pkg1/tst.go:5:2:5:4 | Foo | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T | Foo |
 | pkg1/tst.go:6:2:6:4 | Bar | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T | Bar |

--- a/go/ql/test/library-tests/semmle/go/Types/MethodCount.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/MethodCount.expected
@@ -1,5 +1,11 @@
 | * Foo | 1 |
 | * P | 1 |
+| * S | 1 |
+| * SEmbedP | 1 |
+| * SEmbedS | 1 |
+| * T | 1 |
+| * T3 | 1 |
+| * T4 | 1 |
 | * base | 2 |
 | * embedder | 2 |
 | * embedder2 | 2 |

--- a/go/ql/test/library-tests/semmle/go/Types/MethodCount.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/MethodCount.expected
@@ -1,4 +1,5 @@
 | * Foo | 1 |
+| * P | 1 |
 | * base | 2 |
 | * embedder | 2 |
 | * embedder2 | 2 |
@@ -16,6 +17,8 @@
 | GenericInterface | 1 |
 | MixedExportedAndNot | 2 |
 | MyInterface | 17 |
+| S | 1 |
+| SEmbedS | 1 |
 | T | 1 |
 | T3 | 1 |
 | T4 | 1 |

--- a/go/ql/test/library-tests/semmle/go/Types/MethodTypes.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/MethodTypes.expected
@@ -50,6 +50,7 @@
 | pkg1/interfaces.go:31:6:31:7 | A2 | m | func()  |
 | pkg1/interfaces.go:35:6:35:24 | MixedExportedAndNot | Exported | func()  |
 | pkg1/interfaces.go:35:6:35:24 | MixedExportedAndNot | notExported | func()  |
+| pkg1/promotedStructs.go:22:6:22:12 | SEmbedS | SMethod | func() interface { } |
 | pkg1/tst.go:3:6:3:6 | T | half | func() Foo |
 | pkg1/tst.go:14:6:14:7 | T3 | half | func() Foo |
 | pkg1/tst.go:19:6:19:7 | T4 | half | func() Foo |

--- a/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName2.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName2.expected
@@ -55,6 +55,9 @@
 | pkg1/interfaces.go:32:2:32:2 | m | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.A2 | m |
 | pkg1/interfaces.go:36:2:36:9 | Exported | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.MixedExportedAndNot | Exported |
 | pkg1/interfaces.go:37:2:37:12 | notExported | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.MixedExportedAndNot | notExported |
+| pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.S | SMethod |
+| pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedS | SMethod |
+| pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.P | PMethod |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.Foo | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T3 | half |

--- a/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName2.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName2.expected
@@ -58,6 +58,7 @@
 | pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.S | SMethod |
 | pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedS | SMethod |
 | pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.P | PMethod |
+| pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedP | PMethod |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.Foo | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T3 | half |

--- a/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName3.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName3.expected
@@ -55,6 +55,9 @@
 | pkg1/interfaces.go:32:2:32:2 | m | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | A2 | m |
 | pkg1/interfaces.go:36:2:36:9 | Exported | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | MixedExportedAndNot | Exported |
 | pkg1/interfaces.go:37:2:37:12 | notExported | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | MixedExportedAndNot | notExported |
+| pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | S | SMethod |
+| pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedS | SMethod |
+| pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | P | PMethod |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | Foo | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T3 | half |

--- a/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName3.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Method_hasQualifiedName3.expected
@@ -58,6 +58,7 @@
 | pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | S | SMethod |
 | pkg1/promotedStructs.go:8:12:8:18 | SMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedS | SMethod |
 | pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | P | PMethod |
+| pkg1/promotedStructs.go:17:13:17:19 | PMethod | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | SEmbedP | PMethod |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | Foo | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T | half |
 | pkg1/tst.go:33:16:33:19 | half | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1 | T3 | half |

--- a/go/ql/test/library-tests/semmle/go/Types/Methods.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Methods.expected
@@ -1,5 +1,11 @@
 | * Foo | half | pkg1/tst.go:33:16:33:19 | half |
 | * P | PMethod | pkg1/promotedStructs.go:17:13:17:19 | PMethod |
+| * S | SMethod | pkg1/promotedStructs.go:8:12:8:18 | SMethod |
+| * SEmbedP | PMethod | pkg1/promotedStructs.go:17:13:17:19 | PMethod |
+| * SEmbedS | SMethod | pkg1/promotedStructs.go:8:12:8:18 | SMethod |
+| * T | half | pkg1/tst.go:33:16:33:19 | half |
+| * T3 | half | pkg1/tst.go:33:16:33:19 | half |
+| * T4 | half | pkg1/tst.go:33:16:33:19 | half |
 | * base | f | pkg1/embedding.go:10:13:10:13 | f |
 | * base | g | pkg1/embedding.go:14:14:14:14 | g |
 | * embedder | f | pkg1/embedding.go:10:13:10:13 | f |

--- a/go/ql/test/library-tests/semmle/go/Types/Methods.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Methods.expected
@@ -1,4 +1,5 @@
 | * Foo | half | pkg1/tst.go:33:16:33:19 | half |
+| * P | PMethod | pkg1/promotedStructs.go:17:13:17:19 | PMethod |
 | * base | f | pkg1/embedding.go:10:13:10:13 | f |
 | * base | g | pkg1/embedding.go:14:14:14:14 | g |
 | * embedder | f | pkg1/embedding.go:10:13:10:13 | f |
@@ -45,6 +46,8 @@
 | MyInterface | dummy18 | generic.go:62:2:62:8 | dummy18 |
 | MyInterface | dummy19 | generic.go:63:2:63:8 | dummy19 |
 | MyInterface | dummy20 | generic.go:64:2:64:8 | dummy20 |
+| S | SMethod | pkg1/promotedStructs.go:8:12:8:18 | SMethod |
+| SEmbedS | SMethod | pkg1/promotedStructs.go:8:12:8:18 | SMethod |
 | T | half | pkg1/tst.go:33:16:33:19 | half |
 | T3 | half | pkg1/tst.go:33:16:33:19 | half |
 | T4 | half | pkg1/tst.go:33:16:33:19 | half |

--- a/go/ql/test/library-tests/semmle/go/Types/QualifiedNames.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/QualifiedNames.expected
@@ -91,6 +91,10 @@
 | pkg1/interfaces.go:26:6:26:14 | AExtended | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.AExtended |
 | pkg1/interfaces.go:31:6:31:7 | A2 | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.A2 |
 | pkg1/interfaces.go:35:6:35:24 | MixedExportedAndNot | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.MixedExportedAndNot |
+| pkg1/promotedStructs.go:4:6:4:6 | S | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.S |
+| pkg1/promotedStructs.go:13:6:13:6 | P | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.P |
+| pkg1/promotedStructs.go:22:6:22:12 | SEmbedS | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedS |
+| pkg1/promotedStructs.go:25:6:25:12 | SEmbedP | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.SEmbedP |
 | pkg1/tst.go:3:6:3:6 | T | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T |
 | pkg1/tst.go:9:6:9:7 | T2 | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T2 |
 | pkg1/tst.go:14:6:14:7 | T3 | github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1.T3 |

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_getNumParameter.expected
@@ -11,9 +11,15 @@
 | pkg1/embedding.go:14:1:16:1 | function declaration | 0 |
 | pkg1/embedding.go:30:1:32:1 | function declaration | 0 |
 | pkg1/embedding.go:40:1:61:1 | function declaration | 0 |
+| pkg1/promotedStructs.go:8:1:10:1 | function declaration | 0 |
+| pkg1/promotedStructs.go:17:1:19:1 | function declaration | 0 |
 | pkg1/tst.go:33:1:35:1 | function declaration | 0 |
 | pkg1/tst.go:37:1:37:26 | function declaration | 1 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 2 |
+| promoted.go:7:1:10:1 | function declaration | 1 |
+| promoted.go:12:1:15:1 | function declaration | 1 |
+| promoted.go:17:1:20:1 | function declaration | 1 |
+| promoted.go:22:1:25:1 | function declaration | 1 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
 | variadicFunctions.go:5:1:8:1 | function declaration | 0 |
 | variadicFunctions.go:10:1:18:1 | function declaration | 1 |

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_getNumResult.expected
@@ -11,9 +11,15 @@
 | pkg1/embedding.go:14:1:16:1 | function declaration | 1 |
 | pkg1/embedding.go:30:1:32:1 | function declaration | 1 |
 | pkg1/embedding.go:40:1:61:1 | function declaration | 0 |
+| pkg1/promotedStructs.go:8:1:10:1 | function declaration | 1 |
+| pkg1/promotedStructs.go:17:1:19:1 | function declaration | 1 |
 | pkg1/tst.go:33:1:35:1 | function declaration | 1 |
 | pkg1/tst.go:37:1:37:26 | function declaration | 0 |
 | pkg1/tst.go:39:1:57:1 | function declaration | 0 |
+| promoted.go:7:1:10:1 | function declaration | 0 |
+| promoted.go:12:1:15:1 | function declaration | 0 |
+| promoted.go:17:1:20:1 | function declaration | 0 |
+| promoted.go:22:1:25:1 | function declaration | 0 |
 | unknownFunction.go:8:1:12:1 | function declaration | 0 |
 | variadicFunctions.go:5:1:8:1 | function declaration | 0 |
 | variadicFunctions.go:10:1:18:1 | function declaration | 1 |

--- a/go/ql/test/library-tests/semmle/go/Types/StructFields.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/StructFields.expected
@@ -45,6 +45,12 @@
 | pkg1/embedding.go:28:6:28:14 | embedder3 | pkg1/embedding.go:28:16:28:33 | struct type | embedder | embedder |
 | pkg1/embedding.go:35:6:35:14 | embedder4 | pkg1/embedding.go:35:16:38:1 | struct type | base | base |
 | pkg1/embedding.go:35:6:35:14 | embedder4 | pkg1/embedding.go:35:16:38:1 | struct type | f | int |
+| pkg1/promotedStructs.go:4:6:4:6 | S | pkg1/promotedStructs.go:4:8:6:1 | struct type | SField | string |
+| pkg1/promotedStructs.go:13:6:13:6 | P | pkg1/promotedStructs.go:13:8:15:1 | struct type | PField | string |
+| pkg1/promotedStructs.go:22:6:22:12 | SEmbedS | pkg1/promotedStructs.go:22:14:22:24 | struct type | S | S |
+| pkg1/promotedStructs.go:22:6:22:12 | SEmbedS | pkg1/promotedStructs.go:22:14:22:24 | struct type | SField | string |
+| pkg1/promotedStructs.go:25:6:25:12 | SEmbedP | pkg1/promotedStructs.go:25:14:25:24 | struct type | P | P |
+| pkg1/promotedStructs.go:25:6:25:12 | SEmbedP | pkg1/promotedStructs.go:25:14:25:24 | struct type | PField | string |
 | pkg1/tst.go:3:6:3:6 | T | pkg1/tst.go:3:8:7:1 | struct type | Bar | Bar |
 | pkg1/tst.go:3:6:3:6 | T | pkg1/tst.go:3:8:7:1 | struct type | Foo | Foo |
 | pkg1/tst.go:3:6:3:6 | T | pkg1/tst.go:3:8:7:1 | struct type | f | int |

--- a/go/ql/test/library-tests/semmle/go/Types/Types.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/Types.expected
@@ -91,6 +91,10 @@
 | pkg1/interfaces.go:26:6:26:14 | AExtended | AExtended |
 | pkg1/interfaces.go:31:6:31:7 | A2 | A2 |
 | pkg1/interfaces.go:35:6:35:24 | MixedExportedAndNot | MixedExportedAndNot |
+| pkg1/promotedStructs.go:4:6:4:6 | S | S |
+| pkg1/promotedStructs.go:13:6:13:6 | P | P |
+| pkg1/promotedStructs.go:22:6:22:12 | SEmbedS | SEmbedS |
+| pkg1/promotedStructs.go:25:6:25:12 | SEmbedP | SEmbedP |
 | pkg1/tst.go:3:6:3:6 | T | T |
 | pkg1/tst.go:9:6:9:7 | T2 | T2 |
 | pkg1/tst.go:14:6:14:7 | T3 | T3 |

--- a/go/ql/test/library-tests/semmle/go/Types/pkg1/promotedStructs.go
+++ b/go/ql/test/library-tests/semmle/go/Types/pkg1/promotedStructs.go
@@ -1,0 +1,25 @@
+package pkg1
+
+// A struct type with methods defined on it
+type S struct {
+	SField string
+}
+
+func (t S) SMethod() interface{} {
+	return nil
+}
+
+// A struct type with methods defined on its pointer type
+type P struct {
+	PField string
+}
+
+func (t *P) PMethod() interface{} {
+	return nil
+}
+
+// A struct type embedding S
+type SEmbedS struct{ S }
+
+// A struct type embedding P
+type SEmbedP struct{ P }

--- a/go/ql/test/library-tests/semmle/go/Types/promoted.go
+++ b/go/ql/test/library-tests/semmle/go/Types/promoted.go
@@ -1,0 +1,25 @@
+package main
+
+import "github.com/github/codeql-go/ql/test/library-tests/semmle/go/Types/pkg1"
+
+// IMPORTANT: Make sure that *pkg1.SEmbedP is not referenced.
+
+func testS(t pkg1.S) {
+	_ = t.SMethod()
+	_ = t.SField
+}
+
+func testP(t pkg1.P) {
+	_ = t.PMethod()
+	_ = t.PField
+}
+
+func testSEmbedS(t pkg1.SEmbedS) {
+	_ = t.SMethod()
+	_ = t.SField
+}
+
+func testSEmbedP(t pkg1.SEmbedP) {
+	_ = t.PMethod()
+	_ = t.PField
+}

--- a/go/ql/test/library-tests/semmle/go/aliases/InterfaceImpls/test.expected
+++ b/go/ql/test/library-tests/semmle/go/aliases/InterfaceImpls/test.expected
@@ -13,10 +13,16 @@ callTargets
 | test.go:57:2:57:29 | call to ImplementMe | test.go:46:1:46:87 | function declaration | ImplementMe |
 | test.go:57:2:57:29 | call to ImplementMe | test.go:53:1:53:85 | function declaration | ImplementMe |
 #select
-| file://:0:0:0:0 | basic interface type | file://:0:0:0:0 | basic interface type |
-| file://:0:0:0:0 | basic interface type | test.go:18:6:18:10 | Impl1 |
-| file://:0:0:0:0 | basic interface type | test.go:23:6:23:10 | Impl2 |
-| file://:0:0:0:0 | basic interface type | test.go:28:6:28:10 | Impl3 |
-| file://:0:0:0:0 | basic interface type | test.go:35:6:35:10 | Impl4 |
-| file://:0:0:0:0 | basic interface type | test.go:42:6:42:10 | Impl5 |
-| file://:0:0:0:0 | basic interface type | test.go:49:6:49:10 | Impl6 |
+| file://:0:0:0:0 | basic interface type | * Impl1 |
+| file://:0:0:0:0 | basic interface type | * Impl2 |
+| file://:0:0:0:0 | basic interface type | * Impl3 |
+| file://:0:0:0:0 | basic interface type | * Impl4 |
+| file://:0:0:0:0 | basic interface type | * Impl5 |
+| file://:0:0:0:0 | basic interface type | * Impl6 |
+| file://:0:0:0:0 | basic interface type | Impl1 |
+| file://:0:0:0:0 | basic interface type | Impl2 |
+| file://:0:0:0:0 | basic interface type | Impl3 |
+| file://:0:0:0:0 | basic interface type | Impl4 |
+| file://:0:0:0:0 | basic interface type | Impl5 |
+| file://:0:0:0:0 | basic interface type | Impl6 |
+| file://:0:0:0:0 | basic interface type | interface { ImplementMe func(func(struct { x int }) )  } |

--- a/go/ql/test/library-tests/semmle/go/aliases/InterfaceImpls/test.ql
+++ b/go/ql/test/library-tests/semmle/go/aliases/InterfaceImpls/test.ql
@@ -8,4 +8,4 @@ from InterfaceType i, Type impl
 where
   i.hasMethod("ImplementMe", _) and
   impl.implements(i)
-select i, impl
+select i, impl.pp()

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/test.go
@@ -19,13 +19,13 @@ func TestI2(t test.I2) {
 func TestS1(t test.S1) {
 	x := t.Source()
 	y := t.Step(x)
-	t.Sink(y) // $ I1[t] S1[f] S1[t] ql_S1 SPURIOUS: IEmbedI1[t] SEmbedI1[t]
+	t.Sink(y) // $ I1[t] S1[f] S1[t] ql_S1 SPURIOUS: IEmbedI1[t] SEmbedI1[t] SEmbedS1[t]
 }
 
 func TestS2(t test.S2) {
 	x := t.Source()
 	y := t.Step(x)
-	t.Sink(y) // $ I1[t] I2[t] SPURIOUS: IEmbedI1[t] IEmbedI2[t] SEmbedI1[t] SEmbedI2[t]
+	t.Sink(y) // $ I1[t] I2[t] SPURIOUS: IEmbedI1[t] IEmbedI2[t] SEmbedI1[t] SEmbedI2[t] SEmbedS2[t]
 }
 
 func TestSEmbedI1(t test.SEmbedI1) {
@@ -67,13 +67,13 @@ func TestSImplEmbedI2(t test.SImplEmbedI2) {
 func TestSEmbedS1(t test.SEmbedS1) {
 	x := t.Source()
 	y := t.Step(x)
-	t.Sink(y) // $ I1[t] S1[t] ql_S1 SPURIOUS: IEmbedI1[t] S1[f] SEmbedI1[t]
+	t.Sink(y) // $ I1[t] S1[t] SEmbedS1[t] ql_S1 SPURIOUS: IEmbedI1[t] S1[f] SEmbedI1[t]
 }
 
 func TestSEmbedS2(t test.SEmbedS2) {
 	x := t.Source()
 	y := t.Step(x)
-	t.Sink(y) // $ I1[t] I2[t] SPURIOUS: IEmbedI1[t] IEmbedI2[t] SEmbedI1[t] SEmbedI2[t]
+	t.Sink(y) // $ I1[t] I2[t] SEmbedS2[t] SPURIOUS: IEmbedI1[t] IEmbedI2[t] SEmbedI1[t] SEmbedI2[t]
 }
 
 func TestSImplEmbedS1(t test.SImplEmbedS1) {


### PR DESCRIPTION
The fix is to always extract `*t` when we are extracting a named type `t` which can have methods defined on it (i.e. its underlying type is not a pointer or an interface).