### PR TITLE
Rust: accept some inconsitencies for now

### DIFF
--- a/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/DataFlowConsistency.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/DataFlowConsistency.expected
@@ -1,0 +1,3 @@
+uniqueCallEnclosingCallable
+| canonical_paths.rs:32:9:32:14 | CallExpr | Call should have one enclosing callable but has 0. |
+| canonical_paths.rs:66:13:66:20 | CallExpr | Call should have one enclosing callable but has 0. |

--- a/rust/ql/test/extractor-tests/generated/MacroItems/CONSISTENCY/DataFlowConsistency.expected
+++ b/rust/ql/test/extractor-tests/generated/MacroItems/CONSISTENCY/DataFlowConsistency.expected
@@ -1,7 +1,7 @@
 uniqueNodeLocation
+| file://:0:0:0:0 | ... .parent(...) | Node should have one location but has 0. |
+| file://:0:0:0:0 | ... .unwrap(...) | Node should have one location but has 0. |
 | file://:0:0:0:0 | BlockExpr | Node should have one location but has 0. |
-| file://:0:0:0:0 | MethodCallExpr | Node should have one location but has 0. |
-| file://:0:0:0:0 | MethodCallExpr | Node should have one location but has 0. |
 | file://:0:0:0:0 | Param | Node should have one location but has 0. |
 | file://:0:0:0:0 | PathExpr | Node should have one location but has 0. |
 missingLocation


### PR DESCRIPTION
The modified result is just a change due to a semantic conflict after introducing some `toString` implementations.

The new inconsistency should be looked at more in detail.

