### PR TITLE
Revert "C++: Do not generate IR for functions with multiple entry points"

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/internal/TranslatedElement.qll
@@ -196,8 +196,6 @@ private predicate isInvalidFunction(Function func) {
     expr.getEnclosingFunction() = func and
     not exists(expr.getType())
   )
-  or
-  count(func.getEntryPoint().getLocation()) > 1
 }
 
 /**

--- a/cpp/ql/test/library-tests/ir/multiple-entry-points/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/multiple-entry-points/raw_ir.expected
@@ -1,0 +1,67 @@
+test1.cpp:
+#    3| int foo(int)
+#    3|   Block 0
+#    3|     v3_1(void)       = EnterFunction          : 
+test2.cpp:
+#    1|     v3_1(void)       = EnterFunction          : 
+test1.cpp:
+#    3|     mu3_2(unknown)   = AliasedDefinition      : 
+test2.cpp:
+#    1|     mu3_2(unknown)   = AliasedDefinition      : 
+test1.cpp:
+#    3|     mu3_3(unknown)   = InitializeNonLocal     : 
+test2.cpp:
+#    1|     mu3_3(unknown)   = InitializeNonLocal     : 
+test1.cpp:
+#    3|     r3_4(glval<int>) = VariableAddress[i]     : 
+test2.cpp:
+#    1|     r3_4(glval<int>) = VariableAddress[i]     : 
+test1.cpp:
+#    3|     mu3_5(int)       = InitializeParameter[i] : &:r1_4, &:r3_4
+test2.cpp:
+#    1|     mu3_5(int)       = InitializeParameter[i] : &:r1_4, &:r3_4
+#-----|   Goto -> Block 2
+#-----|   Goto -> Block 2
+
+#    1|   Block 0
+#-----|   Goto -> Block 2
+#-----|   Goto -> Block 2
+
+test1.cpp:
+#    3|   Block 1
+#    3|     r3_6(glval<int>) = VariableAddress[#return] : 
+test2.cpp:
+#    1|     r3_6(glval<int>) = VariableAddress[#return] : 
+test1.cpp:
+#    3|     v3_7(void)       = ReturnValue              : &:r1_6, &:r3_6, ~m?
+test2.cpp:
+#    1|     v3_7(void)       = ReturnValue              : &:r1_6, &:r3_6, ~m?
+test1.cpp:
+#    3|     v3_8(void)       = AliasedUse               : ~m?
+test2.cpp:
+#    1|     v3_8(void)       = AliasedUse               : ~m?
+test1.cpp:
+#    3|     v3_9(void)       = ExitFunction             : 
+test2.cpp:
+#    1|     v3_9(void)       = ExitFunction             : 
+
+#    1|   Block 1
+
+test1.cpp:
+#    4|   Block 2
+#    4|     r4_1(glval<int>) = VariableAddress[#return] : 
+#    4|     r4_2(int)        = Constant[42]             : 
+#    4|     mu4_3(int)       = Store[#return]           : &:r4_1, r4_2
+#-----|   Goto -> Block 1
+#-----|   Goto -> Block 1
+
+test2.cpp:
+#    2|   Block 2
+#    2|     r2_1(glval<int>) = VariableAddress[#return] : 
+#    2|     r2_2(glval<int>) = VariableAddress[i]       : 
+#    2|     r2_3(int)        = Load[i]                  : &:r2_2, ~m?
+#    2|     mu2_4(int)       = Store[#return]           : &:r2_1, r2_3
+#-----|   Goto -> Block 1
+#-----|   Goto -> Block 1
+
+#    1| int foo(int)


### PR DESCRIPTION
Reverts github/codeql#17694

I'm reverting this due to https://github.com/github/codeql-c-team/issues/2482. The problem is that it seems that TRAP caching does pull in a few duplicate functions, which is arguably a bug but will take a bit more time to investigate. In the meantime, since github/codeql#17694 can cause results wobble, I think it would be safest to revert.

@jketema kindly do double-check that this PR is indeed the root cause of these new alert deltas.