### PR TITLE
JS: Added support for reverse function

### DIFF
--- a/javascript/ql/lib/change-notes/2024-11-11-reserve-support.md
+++ b/javascript/ql/lib/change-notes/2024-11-11-reserve-support.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint-steps for `Array.prototype.reverse`

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -446,12 +446,12 @@ private module ArrayLibraries {
   }
 
   /**
-   * A taint propagating data flow edge arising from sorting.
+   * A taint propagating data flow edge arising from in-place array manipulation operations.
    */
-  private class SortTaintStep extends TaintTracking::SharedTaintStep {
+  private class ArrayInPlaceManipulationTaintStep extends TaintTracking::SharedTaintStep {
     override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getMethodName() = "sort" and
+        call.getMethodName() in ["sort", "reverse"] and
         pred = call.getReceiver() and
         succ = call
       )

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -447,6 +447,7 @@ private module ArrayLibraries {
 
   /**
    * A taint propagating data flow edge arising from in-place array manipulation operations.
+   * The methods return the pointer to `this` array as well.
    */
   private class ArrayInPlaceManipulationTaintStep extends TaintTracking::SharedTaintStep {
     override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -444,4 +444,17 @@ private module ArrayLibraries {
       )
     }
   }
+
+  /**
+   * A taint propagating data flow edge arising from sorting.
+   */
+  private class SortTaintStep extends TaintTracking::SharedTaintStep {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "sort" and
+        pred = call.getReceiver() and
+        succ = call
+      )
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -870,19 +870,6 @@ module TaintTracking {
   }
 
   /**
-   * A taint propagating data flow edge arising from sorting.
-   */
-  private class SortTaintStep extends SharedTaintStep {
-    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
-      exists(DataFlow::MethodCallNode call |
-        call.getMethodName() = "sort" and
-        pred = call.getReceiver() and
-        succ = call
-      )
-    }
-  }
-
-  /**
    * A taint step through an exception constructor, such as `x` to `new Error(x)`.
    */
   class ErrorConstructorTaintStep extends SharedTaintStep {

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -233,6 +233,7 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:48:10:48:22 | new Buffer(x) |
 | tst.js:2:13:2:20 | source() | tst.js:51:10:51:31 | seriali ... ript(x) |
 | tst.js:2:13:2:20 | source() | tst.js:54:14:54:19 | unsafe |
+| tst.js:2:13:2:20 | source() | tst.js:61:10:61:20 | x.reverse() |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |

--- a/javascript/ql/test/library-tests/TaintTracking/tst.js
+++ b/javascript/ql/test/library-tests/TaintTracking/tst.js
@@ -58,5 +58,5 @@ function test() {
 
     tagged`foo ${"safe"} bar ${x} baz`;
 
-    sink(x.reverse()); // NOT OK -- Should be caught but isn't
+    sink(x.reverse()); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/tst.js
+++ b/javascript/ql/test/library-tests/TaintTracking/tst.js
@@ -57,4 +57,6 @@ function test() {
     }
 
     tagged`foo ${"safe"} bar ${x} baz`;
+
+    sink(x.reverse()); // NOT OK -- Should be caught but isn't
 }


### PR DESCRIPTION
While addressing another [issue](https://github.com/github/codeql-javascript-team/issues/435) I found that we we're missing support for `Array.prototype.reverse`.  
I've added support for the method, and moved an existing related support for `.sort()` to a more relevant [location](https://github.com/github/codeql/blob/f1c6dc1d9bff7b5d4a98e6342d0cea10e183cb58/javascript/ql/lib/semmle/javascript/Arrays.qll#L451). 