### PR TITLE
C++: Add tests for experimental `cpp/guarded-free` query

### DIFF
--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.expected
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.expected
@@ -1,0 +1,10 @@
+| test.cpp:5:7:5:7 | x | unnecessary NULL check before call to $@ | test.cpp:6:5:6:8 | call to free | free |
+| test.cpp:23:7:23:7 | x | unnecessary NULL check before call to $@ | test.cpp:26:5:26:8 | call to free | free |
+| test.cpp:31:7:31:8 | ! ... | unnecessary NULL check before call to $@ | test.cpp:35:3:35:6 | call to free | free |
+| test.cpp:31:7:31:24 | ... \|\| ... | unnecessary NULL check before call to $@ | test.cpp:35:3:35:6 | call to free | free |
+| test.cpp:31:8:31:8 | x | unnecessary NULL check before call to $@ | test.cpp:35:3:35:6 | call to free | free |
+| test.cpp:94:12:94:12 | x | unnecessary NULL check before call to $@ | test.cpp:94:3:94:13 | call to free | free |
+| test.cpp:98:6:98:7 | ! ... | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
+| test.cpp:98:7:98:7 | x | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
+| test.cpp:106:6:106:17 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:107:5:107:8 | call to free | free |
+| test.cpp:113:6:113:17 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:114:17:114:20 | call to free | free |

--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.expected
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.expected
@@ -4,7 +4,7 @@
 | test.cpp:31:7:31:24 | ... \|\| ... | unnecessary NULL check before call to $@ | test.cpp:35:3:35:6 | call to free | free |
 | test.cpp:31:8:31:8 | x | unnecessary NULL check before call to $@ | test.cpp:35:3:35:6 | call to free | free |
 | test.cpp:94:12:94:12 | x | unnecessary NULL check before call to $@ | test.cpp:94:3:94:13 | call to free | free |
-| test.cpp:98:6:98:7 | ! ... | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
-| test.cpp:98:7:98:7 | x | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
-| test.cpp:106:6:106:17 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:107:5:107:8 | call to free | free |
-| test.cpp:113:6:113:17 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:114:17:114:20 | call to free | free |
+| test.cpp:98:7:98:8 | ! ... | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
+| test.cpp:98:8:98:8 | x | unnecessary NULL check before call to $@ | test.cpp:101:3:101:6 | call to free | free |
+| test.cpp:106:7:106:18 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:107:5:107:8 | call to free | free |
+| test.cpp:113:7:113:18 | ... != ... | unnecessary NULL check before call to $@ | test.cpp:114:17:114:20 | call to free | free |

--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.qlref
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/GuardedFree.qlref
@@ -1,0 +1,1 @@
+experimental/Best Practices/GuardedFree.ql

--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
@@ -110,6 +110,6 @@ void test13(char *x) {
 void inspect(char *x);
 
 void test14(char *x) {
-  if (x != nullptr) // GOOD [FALSE POSITIVE]: x might be accessed
+  if (x != nullptr) // GOOD [FALSE POSITIVE]: x might be accessed in the first operand of the comma operator
     inspect(x), free(x);
 }

--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
@@ -1,0 +1,115 @@
+extern "C" void free(void *ptr);
+extern "C" int strcmp(const char *s1, const char *s2);
+
+void test0(int *x) {
+  if (x) // BAD
+    free(x);
+}
+
+void test1(int *x) {
+  if (x) { // BAD
+    free(x);
+  }
+}
+
+void test2(int *x) {
+  if (x) { // GOOD: x is being accessed in the body of the if
+    *x = 42;
+    free(x);
+  }
+}
+
+void test3(int *x, bool b) {
+  if (x) { // GOOD [FALSE POSITIVE]: x is being accessed in the body of the if
+    if (b)
+      *x = 42;
+    free(x);
+  }
+}
+
+bool test4(char *x, char *y) {
+  if (!x || strcmp(x, y)) { // GOOD [FALSE POSITIVE]: x is being accessed in the guard and return value depends on x
+    free(x);
+    return true;
+  }
+  free(x);
+  return false;
+}
+
+void test5(char *x) {
+  if (x)
+    *x = 42;
+  if (x) { // BAD
+    free(x);
+  }
+}
+
+void test6(char *x) {
+  *x = 42;
+  if (x) { // BAD
+    free(x);
+  }
+}
+
+void test7(char *x) {
+  if (x || x) { // BAD [NOT DETECTED]
+    free(x);
+  }
+}
+
+bool test8(char *x) {
+  if (x) { // GOOD: return value depends on x
+    free(x);
+    return true;
+  }
+  return false;
+}
+
+#ifdef FOO
+#define my_free(x) free(x - 1)
+#else
+#define my_free(x) free(x)
+#endif
+
+void test9(char *x) {
+  if (x) { // GOOD: macro may make free behave unexpectedly when compiled differently
+    my_free(x);
+  }
+}
+
+void test10(char *x) {
+  if (x) { // GOOD: #ifdef may make free behave unexpectedly when compiled differently
+#ifdef FOO
+    free(x - 1);
+#else
+    free(x);
+#endif
+  }
+}
+
+#define TRY_FREE(x) \
+  if (x) free(x);
+
+void test11(char *x) {
+  TRY_FREE(x) // BAD
+}
+
+bool test12(char *x) {
+  if(!x) // GOOD [FALSE POSITIVE]: return value depends on x
+    return false;
+
+  free(x);
+  return true;
+}
+
+void test13(char *x) {
+  if(x != nullptr) // BAD
+    free(x);
+}
+
+void inspect(char *x);
+
+void test14(char *x) {
+  if(x != nullptr) // GOOD [FALSE POSITIVE]: x might be accessed
+    inspect(x), free(x);
+}

--- a/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
+++ b/cpp/ql/test/experimental/query-tests/Best Practices/GuardedFree/test.cpp
@@ -95,7 +95,7 @@ void test11(char *x) {
 }
 
 bool test12(char *x) {
-  if(!x) // GOOD [FALSE POSITIVE]: return value depends on x
+  if (!x) // GOOD [FALSE POSITIVE]: return value depends on x
     return false;
 
   free(x);
@@ -103,13 +103,13 @@ bool test12(char *x) {
 }
 
 void test13(char *x) {
-  if(x != nullptr) // BAD
+  if (x != nullptr) // BAD
     free(x);
 }
 
 void inspect(char *x);
 
 void test14(char *x) {
-  if(x != nullptr) // GOOD [FALSE POSITIVE]: x might be accessed
+  if (x != nullptr) // GOOD [FALSE POSITIVE]: x might be accessed
     inspect(x), free(x);
 }


### PR DESCRIPTION
I investigated a bit if the query can be promoted (instead of moving it to a separate repo). The tests highlight some issues.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
