### PR TITLE
chore(actions): bump to artifacts@v4

### DIFF
--- a/.github/workflows/csv-coverage-metrics.yml
+++ b/.github/workflows/csv-coverage-metrics.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           DATABASE="${{ runner.temp }}/java-database"
           codeql database analyze --format=sarif-latest --output=metrics-java.sarif -- "$DATABASE" ./java/ql/src/Metrics/Summaries/FrameworkCoverage.ql
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: metrics-java.sarif
           path: metrics-java.sarif
@@ -64,7 +64,7 @@ jobs:
         run: |
           DATABASE="${{ runner.temp }}/csharp-database"
           codeql database analyze --format=sarif-latest --output=metrics-csharp.sarif -- "$DATABASE" ./csharp/ql/src/Metrics/Summaries/FrameworkCoverage.ql
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: metrics-csharp.sarif
           path: metrics-csharp.sarif

--- a/.github/workflows/csv-coverage-pr-artifacts.yml
+++ b/.github/workflows/csv-coverage-pr-artifacts.yml
@@ -71,21 +71,21 @@ jobs:
         run: |
           python base/misc/scripts/library-coverage/compare-folders.py out_base out_merge comparison.md
       - name: Upload CSV package list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: csv-framework-coverage-merge
           path: |
             out_merge/framework-coverage-*.csv
             out_merge/framework-coverage-*.rst
       - name: Upload CSV package list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: csv-framework-coverage-base
           path: |
             out_base/framework-coverage-*.csv
             out_base/framework-coverage-*.rst
       - name: Upload comparison results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: comparison
           path: |
@@ -97,7 +97,7 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
       - name: Upload PR number
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
@@ -117,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
       - name: Upload comment ID (if it exists)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: comment
           path: comment/

--- a/.github/workflows/csv-coverage-timeseries.yml
+++ b/.github/workflows/csv-coverage-timeseries.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python script/misc/scripts/library-coverage/generate-timeseries.py codeqlModels
       - name: Upload timeseries CSV
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: framework-coverage-timeseries
           path: framework-coverage-timeseries-*.csv

--- a/.github/workflows/csv-coverage.yml
+++ b/.github/workflows/csv-coverage.yml
@@ -34,12 +34,12 @@ jobs:
         run: |
           python script/misc/scripts/library-coverage/generate-report.py ci codeqlModels script
       - name: Upload CSV package list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: framework-coverage-csv
           path: framework-coverage-*.csv
       - name: Upload RST package list
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: framework-coverage-rst
           path: framework-coverage-*.rst

--- a/.github/workflows/mad_modelDiff.yml
+++ b/.github/workflows/mad_modelDiff.yml
@@ -93,12 +93,12 @@ jobs:
             name="diff_${basename/.model.yml/""}"
             (diff -w -u $m $t | diff2html -i stdin -F $MODELS/$name.html) || true
           done
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: models
           path: tmp-models/**/**/*.model.yml
           retention-days: 20
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: diffs
           path: tmp-models/*.html

--- a/.github/workflows/mad_modelDiff.yml
+++ b/.github/workflows/mad_modelDiff.yml
@@ -38,14 +38,20 @@ jobs:
           path: codeql-main
           ref: main
       - uses: ./codeql-main/.github/actions/fetch-codeql
+      # compute the shortname of the project that does not contain any special (disk) characters
+      - run: |
+          echo "SHORTNAME=${SLUG//[^a-zA-Z0-9_]/}" >> $GITHUB_OUTPUT
+        env: 
+          SLUG: ${{ matrix.slug }}
+        id: shortname
       - name: Download database
         env:
           SLUG: ${{ matrix.slug }}
           GH_TOKEN: ${{ github.token }}
+          SHORTNAME: ${{ steps.shortname.outputs.SHORTNAME }}
         run: |
           set -x
           mkdir lib-dbs
-          SHORTNAME=${SLUG//[^a-zA-Z0-9_]/}
           gh api -H "Accept: application/zip" "/repos/${SLUG}/code-scanning/codeql/databases/java" > "$SHORTNAME.zip"
           unzip -q -d "${SHORTNAME}-db" "${SHORTNAME}.zip"
           mkdir "lib-dbs/$SHORTNAME/"
@@ -95,12 +101,12 @@ jobs:
           done
       - uses: actions/upload-artifact@v4
         with:
-          name: models
+          name: models-${{ steps.shortname.outputs.SHORTNAME }}
           path: tmp-models/**/**/*.model.yml
           retention-days: 20
       - uses: actions/upload-artifact@v4
         with:
-          name: diffs
+          name: diffs-${{ steps.shortname.outputs.SHORTNAME }}
           path: tmp-models/*.html
           # An html file is only produced if the generated models differ.
           if-no-files-found: ignore

--- a/.github/workflows/mad_regenerate-models.yml
+++ b/.github/workflows/mad_regenerate-models.yml
@@ -59,7 +59,7 @@ jobs:
           find java -name "*.model.yml" -print0 | xargs -0 git add
           git status
           git diff --cached > models.patch
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: patch
           path: models.patch

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -17,8 +17,11 @@ jobs:
   post_comment:
     runs-on: ubuntu-latest
     steps:
-      - name: Download artifact
-        run: gh run download "${WORKFLOW_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --name "comment"
+      - name: Download artifacts
+        run: |
+          gh run download "${WORKFLOW_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --name "comment-pr-number"
+          gh run download "${WORKFLOW_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --name "comment-body"
+          gh run download "${WORKFLOW_RUN_ID}" --repo "${GITHUB_REPOSITORY}" --name "comment-id"
         env:
           GITHUB_TOKEN: ${{ github.token }}
           WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -36,7 +36,7 @@ jobs:
       - run: echo "${PR_NUMBER}" > pr_number.txt
         env:
           PR_NUMBER: ${{ github.event.number }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: comment
           path: pr_number.txt
@@ -78,7 +78,7 @@ jobs:
           exit "${EXIT_CODE}"
 
       - if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: comment
           path: comment_body.txt
@@ -94,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: comment
           path: comment_id.txt

--- a/.github/workflows/qhelp-pr-preview.yml
+++ b/.github/workflows/qhelp-pr-preview.yml
@@ -38,7 +38,7 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
       - uses: actions/upload-artifact@v4
         with:
-          name: comment
+          name: comment-pr-number
           path: pr_number.txt
           if-no-files-found: error
           retention-days: 1
@@ -80,7 +80,7 @@ jobs:
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: comment
+          name: comment-body
           path: comment_body.txt
           if-no-files-found: error
           retention-days: 1
@@ -96,7 +96,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: comment
+          name: comment-id
           path: comment_id.txt
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/ql-for-ql-build.yml
+++ b/.github/workflows/ql-for-ql-build.yml
@@ -75,7 +75,7 @@ jobs:
           sarif_file: ql-for-ql.sarif
           category: ql-for-ql
       - name: Sarif as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ql-for-ql.sarif
           path: ql-for-ql.sarif
@@ -84,7 +84,7 @@ jobs:
           mkdir split-sarif
           node ./ql/scripts/split-sarif.js ql-for-ql.sarif split-sarif
       - name: Upload langs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ql-for-ql-langs
           path: split-sarif

--- a/.github/workflows/ql-for-ql-dataset_measure.yml
+++ b/.github/workflows/ql-for-ql-dataset_measure.yml
@@ -65,7 +65,7 @@ jobs:
           "${CODEQL}" dataset measure --threads 4 --output "stats/${{ matrix.repo }}/stats.xml" "${{ runner.temp }}/database/db-ql"
         env:
           CODEQL: ${{ steps.find-codeql.outputs.codeql-path }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: measurements
           path: stats
@@ -76,14 +76,14 @@ jobs:
     needs: measure
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: measurements
           path: stats
       - run: |
           python -m pip install --user lxml
           find stats -name 'stats.xml' -print0 | sort -z | xargs -0 python ruby/scripts/merge_stats.py --output ql/ql/src/ql.dbscheme.stats --normalise ql_tokeninfo
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ql.dbscheme.stats
           path: ql/ql/src/ql.dbscheme.stats

--- a/.github/workflows/query-list.yml
+++ b/.github/workflows/query-list.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         python codeql/misc/scripts/generate-code-scanning-query-list.py > code-scanning-query-list.csv
     - name: Upload code scanning query list
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: code-scanning-query-list
         path: code-scanning-query-list.csv

--- a/.github/workflows/ruby-build.yml
+++ b/.github/workflows/ruby-build.yml
@@ -92,17 +92,17 @@ jobs:
       - name: Generate dbscheme
         if: ${{ matrix.os == 'ubuntu-latest' && steps.cache-extractor.outputs.cache-hit != 'true'}}
         run: ../target/release/codeql-extractor-ruby generate --dbscheme ql/lib/ruby.dbscheme --library ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: ruby.dbscheme
           path: ruby/ql/lib/ruby.dbscheme
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ matrix.os == 'ubuntu-latest' }}
         with:
           name: TreeSitter.qll
           path: ruby/ql/lib/codeql/ruby/ast/internal/TreeSitter.qll
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: extractor-${{ matrix.os }}
           path: |
@@ -134,7 +134,7 @@ jobs:
           PACK_FOLDER=$(readlink -f "$PACKS"/codeql/ruby-queries/*)
           codeql generate query-help --format=sarifv2.1.0 --output="${PACK_FOLDER}/rules.sarif" ql/src
           (cd ql/src; find queries \( -name '*.qhelp' -o -name '*.rb' -o -name '*.erb' \) -exec bash -c 'mkdir -p "'"${PACK_FOLDER}"'/$(dirname "{}")"' \; -exec cp "{}" "${PACK_FOLDER}/{}" \;)
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: codeql-ruby-queries
           path: |
@@ -147,19 +147,19 @@ jobs:
     needs: [build, compile-queries]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ruby.dbscheme
           path: ruby/ruby
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: extractor-ubuntu-latest
           path: ruby/linux64
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: extractor-windows-latest
           path: ruby/win64
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: extractor-macos-latest
           path: ruby/osx64
@@ -172,13 +172,13 @@ jobs:
           cp win64/codeql-extractor-ruby.exe ruby/tools/win64/extractor.exe
           chmod +x ruby/tools/{linux64,osx64}/extractor
           zip -rq codeql-ruby.zip ruby
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: codeql-ruby-pack
           path: ruby/codeql-ruby.zip
           retention-days: 1
           include-hidden-files: true
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: codeql-ruby-queries
           path: ruby/qlpacks
@@ -190,7 +190,7 @@ jobs:
             ]
           }' > .codeqlmanifest.json
           zip -rq codeql-ruby-bundle.zip .codeqlmanifest.json ruby qlpacks
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: codeql-ruby-bundle
           path: ruby/codeql-ruby-bundle.zip
@@ -214,7 +214,7 @@ jobs:
         uses: ./.github/actions/fetch-codeql
 
       - name: Download Ruby bundle
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: codeql-ruby-bundle
           path: ${{ runner.temp }}

--- a/.github/workflows/ruby-dataset-measure.yml
+++ b/.github/workflows/ruby-dataset-measure.yml
@@ -54,7 +54,7 @@ jobs:
           codeql dataset measure --threads 4 --output "stats/${{ matrix.repo }}/stats.xml" "${{ runner.temp }}/database/db-ruby"
       - uses: actions/upload-artifact@v3
         with:
-          name: measurements
+          name: measurements-${{ hashFiles('stats/**') }}
           path: stats
           retention-days: 1
 
@@ -65,7 +65,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
-          name: measurements
           path: stats
       - run: |
           python -m pip install --user lxml

--- a/.github/workflows/ruby-dataset-measure.yml
+++ b/.github/workflows/ruby-dataset-measure.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mkdir -p "stats/${{ matrix.repo }}"
           codeql dataset measure --threads 4 --output "stats/${{ matrix.repo }}/stats.xml" "${{ runner.temp }}/database/db-ruby"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: measurements-${{ hashFiles('stats/**') }}
           path: stats
@@ -63,13 +63,13 @@ jobs:
     needs: measure
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: stats
       - run: |
           python -m pip install --user lxml
           find stats -name 'stats.xml' | sort | xargs python ruby/scripts/merge_stats.py --output ruby/ql/lib/ruby.dbscheme.stats --normalise ruby_tokeninfo
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ruby.dbscheme.stats
           path: ruby/ql/lib/ruby.dbscheme.stats

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Generate C++ files
         run: |
           bazel run //swift/codegen:codegen -- --generate=trap,cpp --cpp-output=$PWD/generated-cpp-files
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: swift-generated-cpp-files
           path: generated-cpp-files/**


### PR DESCRIPTION
https://github.com/actions/upload-artifact and https://github.com/actions/download-artifact are deprecating `v3` soon, and this PR bumps naively to `v4`.

~From skimming, `.github/workflows/qhelp-pr-preview.yml`~ From running, several workflows seem to be hit by the unique name restriction mentioned in https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md. This needs investigation.

- [x] fix mad_modelDiff.yml
- [x] fix ruby-dataset-measure.yml
- [x] fix qhelp-pr-preview.yml