### PR TITLE
JS: Added support for toSorted and toReversed

### DIFF
--- a/javascript/ql/lib/change-notes/2024-11-12-immutable-array-operations.md
+++ b/javascript/ql/lib/change-notes/2024-11-12-immutable-array-operations.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added taint-steps for `Array.prototype.toReversed`.
+* Added taint-steps for `Array.prototype.toSorted`.

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -458,4 +458,18 @@ private module ArrayLibraries {
       )
     }
   }
+
+  /**
+   * A taint propagating data flow edge arising from array transformation operations
+   * that return a new array instead of modifying the original array in place.
+   */
+  private class ImmutableArrayTransformStep extends TaintTracking::SharedTaintStep {
+    override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
+      exists(DataFlow::MethodCallNode call |
+        call.getMethodName() = "toSorted" and
+        pred = call.getReceiver() and
+        succ = call
+      )
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/Arrays.qll
+++ b/javascript/ql/lib/semmle/javascript/Arrays.qll
@@ -466,7 +466,7 @@ private module ArrayLibraries {
   private class ImmutableArrayTransformStep extends TaintTracking::SharedTaintStep {
     override predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::MethodCallNode call |
-        call.getMethodName() = "toSorted" and
+        call.getMethodName() in ["toSorted", "toReversed"] and
         pred = call.getReceiver() and
         succ = call
       )

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -234,6 +234,8 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:51:10:51:31 | seriali ... ript(x) |
 | tst.js:2:13:2:20 | source() | tst.js:54:14:54:19 | unsafe |
 | tst.js:2:13:2:20 | source() | tst.js:61:10:61:20 | x.reverse() |
+| tst.js:2:13:2:20 | source() | tst.js:63:10:63:21 | x.toSorted() |
+| tst.js:2:13:2:20 | source() | tst.js:65:10:65:16 | xSorted |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -236,6 +236,8 @@ typeInferenceMismatch
 | tst.js:2:13:2:20 | source() | tst.js:61:10:61:20 | x.reverse() |
 | tst.js:2:13:2:20 | source() | tst.js:63:10:63:21 | x.toSorted() |
 | tst.js:2:13:2:20 | source() | tst.js:65:10:65:16 | xSorted |
+| tst.js:2:13:2:20 | source() | tst.js:67:10:67:23 | x.toReversed() |
+| tst.js:2:13:2:20 | source() | tst.js:69:10:69:18 | xReversed |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |
 | xml.js:12:17:12:24 | source() | xml.js:13:14:13:19 | result |
 | xml.js:23:18:23:25 | source() | xml.js:20:14:20:17 | attr |

--- a/javascript/ql/test/library-tests/TaintTracking/tst.js
+++ b/javascript/ql/test/library-tests/TaintTracking/tst.js
@@ -59,4 +59,8 @@ function test() {
     tagged`foo ${"safe"} bar ${x} baz`;
 
     sink(x.reverse()); // NOT OK
+
+    sink(x.toSorted()) // NOT OK
+    const xSorted = x.toSorted();
+    sink(xSorted) // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/tst.js
+++ b/javascript/ql/test/library-tests/TaintTracking/tst.js
@@ -63,4 +63,8 @@ function test() {
     sink(x.toSorted()) // NOT OK
     const xSorted = x.toSorted();
     sink(xSorted) // NOT OK
+
+    sink(x.toReversed()) // NOT OK
+    const xReversed = x.toReversed();
+    sink(xReversed) // NOT OK
 }

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
@@ -372,6 +372,18 @@ Array.prototype.slice = function(opt_begin, opt_end) {};
 Array.prototype.sort = function(opt_compareFunction) {};
 
 /**
+ * Returns a new array with the elements sorted.
+ *
+ * @param {function(T,T):number=} opt_compareFunction Specifies a function that
+ *     defines the sort order. If omitted, the array elements are converted to strings,
+ *     then sorted according to each character's Unicode code point value.
+ * @this {{length: number}|Array.}
+ * @template T
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted
+ */
+Array.prototype.toSorted = function(opt_compareFunction) {};
+
+/**
  * Changes the content of an array, adding new elements while removing old
  * elements.
  *

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
@@ -334,15 +334,6 @@ Array.prototype.push = function(var_args) {};
 Array.prototype.reverse = function() {};
 
 /**
- * Returns a new array with the elements in reversed order.
- *
- * @this {{length: number}}
- * @template T
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed
- */
-Array.prototype.toReversed = function() {};
-
-/**
  * Removes the first element from an array and returns that element. This
  * method changes the length of the array.
  *
@@ -379,18 +370,6 @@ Array.prototype.slice = function(opt_begin, opt_end) {};
  * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/sort
  */
 Array.prototype.sort = function(opt_compareFunction) {};
-
-/**
- * Returns a new array with the elements sorted.
- *
- * @param {function(T,T):number=} opt_compareFunction Specifies a function that
- *     defines the sort order. If omitted, the array elements are converted to strings,
- *     then sorted according to each character's Unicode code point value.
- * @this {{length: number}|Array.}
- * @template T
- * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted
- */
-Array.prototype.toSorted = function(opt_compareFunction) {};
 
 /**
  * Changes the content of an array, adding new elements while removing old

--- a/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
+++ b/javascript/ql/test/query-tests/NodeJS/DubiousImport/externs.js
@@ -334,6 +334,15 @@ Array.prototype.push = function(var_args) {};
 Array.prototype.reverse = function() {};
 
 /**
+ * Returns a new array with the elements in reversed order.
+ *
+ * @this {{length: number}}
+ * @template T
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed
+ */
+Array.prototype.toReversed = function() {};
+
+/**
  * Removes the first element from an array and returns that element. This
  * method changes the length of the array.
  *


### PR DESCRIPTION
Added missing QL support for JavaScript `Array.prototype.toReversed` and `Array.prototype.toReversed` addressing [issue](https://github.com/github/codeql-javascript-team/issues/435).