### PR TITLE
C#: Consider the extraction of empty binlog files acceptable

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
@@ -161,7 +161,15 @@ namespace Semmle.Extraction.CSharp
                 var allCompilationData = reader.ReadAllCompilationData(filter);
                 var allFailed = true;
 
-                logger.LogInfo($"  Found {allCompilationData.Count} compilations in binary log");
+                if (allCompilationData.Count == 0)
+                {
+                    logger.LogWarning("  No compilations found in binary log.");
+                    return ExitCode.Ok;
+                }
+                else
+                {
+                    logger.LogInfo($"  Found {allCompilationData.Count} compilations in binary log");
+                }
 
                 foreach (var compilationData in allCompilationData)
                 {


### PR DESCRIPTION
This PR changes how empty binlog files are treated. Previously, the extractor returned a failed extraction error code in such a case:

```
[ERROR] Spawned process exited abnormally (code 2; tried to run: [.../extractor-csharp/csharp/tools/autobuild.sh])
A fatal error occurred: Exit status 2 from command: [...extractor-csharp/csharp/tools/autobuild.sh]
```

Now the behavior matches what we experience in traced mode, when no source code is found:
```
Finalizing database at .../DB1.
CodeQL did not detect any code written in languages supported by this CodeQL distribution (C#, XML, Java Properties Files or Java/Kotlin). Confirm that there is some source code for one of these languages in the project. For more information, review our troubleshooting guide at https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build.
```
The exit code is:
```
❯ echo $?         
32
```

This change is in response to https://github.com/github/codeql/issues/17981#issuecomment-2476530911.