### PR TITLE
Rust: Fix default source and sink in inline flow test

### DIFF
--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
@@ -1,9 +1,10 @@
 models
 edges
 nodes
+| main.rs:17:10:17:18 | CallExpr | semmle.label | CallExpr |
 subpaths
 testFailures
-| main.rs:17:22:17:40 | Comment | Missing result: hasValueFlow=1 |
 | main.rs:22:14:22:32 | Comment | Missing result: hasValueFlow=1 |
 | main.rs:33:14:33:32 | Comment | Missing result: hasValueFlow=1 |
 #select
+| main.rs:17:10:17:18 | CallExpr | main.rs:17:10:17:18 | CallExpr | main.rs:17:10:17:18 | CallExpr | $@ | main.rs:17:10:17:18 | CallExpr | CallExpr |

--- a/rust/ql/test/utils/InlineFlowTest.qll
+++ b/rust/ql/test/utils/InlineFlowTest.qll
@@ -10,15 +10,16 @@ private import codeql.rust.dataflow.internal.DataFlowImpl
 private import codeql.rust.dataflow.internal.TaintTrackingImpl
 private import internal.InlineExpectationsTestImpl as InlineExpectationsTestImpl
 
+// Holds if the target expression of `call` is a path and the string representation of the path is `name`.
+private predicate callTargetName(CallExpr call, string name) {
+  call.getExpr().(PathExpr).getPath().toString() = name
+}
+
 private module FlowTestImpl implements InputSig<Location, RustDataFlow> {
-  predicate defaultSource(DataFlow::Node source) {
-    source.asExpr().(CallExpr).getExpr().toString() = "source"
-  }
+  predicate defaultSource(DataFlow::Node source) { callTargetName(source.asExpr(), "source") }
 
   predicate defaultSink(DataFlow::Node sink) {
-    any(CallExpr call | call = sink.asExpr() and call.getExpr().toString() = "sink")
-        .getArgList()
-        .getAnArg() = sink.asExpr()
+    any(CallExpr call | callTargetName(call, "sink")).getArgList().getAnArg() = sink.asExpr()
   }
 
   private string getSourceArgString(DataFlow::Node src) {


### PR DESCRIPTION
Before `toString` was called on a `PathExpr` and we want to call it on the `Path`. This fixes a test failure in the very simple `sink(source("taint"))` case.