### PR TITLE
Java: Make separate classes for different control flow node kinds

### DIFF
--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -129,13 +129,16 @@ module ControlFlow {
     Callable getEnclosingCallable() { none() }
 
     /** Gets the statement this `Node` corresponds to, if any. */
-    Stmt asStmt() { none() }
+    Stmt asStmt() { this = TStmtNode(result) }
 
     /** Gets the expression this `Node` corresponds to, if any. */
-    Expr asExpr() { none() }
+    Expr asExpr() { this = TExprNode(result) }
 
     /** Gets the call this `Node` corresponds to, if any. */
-    Call asCall() { none() }
+    Call asCall() {
+      result = this.asExpr() or
+      result = this.asStmt()
+    }
 
     /** Gets a textual representation of this element. */
     string toString() { none() }
@@ -159,10 +162,6 @@ module ControlFlow {
 
     override Callable getEnclosingCallable() { result = e.getEnclosingCallable() }
 
-    override Expr asExpr() { result = e }
-
-    override Call asCall() { result = e }
-
     override ExprParent getAstNode() { result = e }
 
     /** Gets a textual representation of this element. */
@@ -181,10 +180,6 @@ module ControlFlow {
     override Stmt getEnclosingStmt() { result = s }
 
     override Callable getEnclosingCallable() { result = s.getEnclosingCallable() }
-
-    override Stmt asStmt() { result = s }
-
-    override Call asCall() { result = s }
 
     override ExprParent getAstNode() { result = s }
 

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -105,29 +105,19 @@ module ControlFlow {
   /** A node in the expression-level control-flow graph. */
   class Node extends TNode {
     /** Gets the statement containing this node, if any. */
-    Stmt getEnclosingStmt() {
-      result = this.asStmt() or
-      result = this.asExpr().getEnclosingStmt()
-    }
+    Stmt getEnclosingStmt() { none() }
 
     /** Gets the immediately enclosing callable whose body contains this node. */
-    Callable getEnclosingCallable() {
-      this = TExitNode(result) or
-      result = this.asStmt().getEnclosingCallable() or
-      result = this.asExpr().getEnclosingCallable()
-    }
+    Callable getEnclosingCallable() { none() }
 
     /** Gets the statement this `Node` corresponds to, if any. */
-    Stmt asStmt() { this = TStmtNode(result) }
+    Stmt asStmt() { none() }
 
     /** Gets the expression this `Node` corresponds to, if any. */
-    Expr asExpr() { this = TExprNode(result) }
+    Expr asExpr() { none() }
 
     /** Gets the call this `Node` corresponds to, if any. */
-    Call asCall() {
-      result = this.asExpr() or
-      result = this.asStmt()
-    }
+    Call asCall() { none() }
 
     /** Gets an immediate successor of this node. */
     Node getASuccessor() { result = succ(this) }
@@ -148,33 +138,77 @@ module ControlFlow {
     BasicBlock getBasicBlock() { result.getANode() = this }
 
     /** Gets a textual representation of this element. */
-    string toString() {
-      result = this.asExpr().toString()
-      or
-      result = this.asStmt().toString()
-      or
-      result = "Exit" and this instanceof ExitNode
-    }
+    string toString() { none() }
 
     /** Gets the source location for this element. */
-    Location getLocation() {
-      result = this.asExpr().getLocation() or
-      result = this.asStmt().getLocation() or
-      result = this.(ExitNode).getEnclosingCallable().getLocation()
-    }
+    Location getLocation() { none() }
 
     /**
      * Gets the most appropriate AST node for this control flow node, if any.
      */
-    ExprParent getAstNode() {
-      result = this.asExpr() or
-      result = this.asStmt() or
-      this = TExitNode(result)
-    }
+    ExprParent getAstNode() { none() }
+  }
+
+  /** A control-flow node that represents the evaluation of an expression. */
+  class ExprNode extends Node, TExprNode {
+    Expr e;
+
+    ExprNode() { this = TExprNode(e) }
+
+    override Stmt getEnclosingStmt() { result = e.getEnclosingStmt() }
+
+    override Callable getEnclosingCallable() { result = e.getEnclosingCallable() }
+
+    override Expr asExpr() { result = e }
+
+    override Call asCall() { result = e }
+
+    override ExprParent getAstNode() { result = e }
+
+    /** Gets a textual representation of this element. */
+    override string toString() { result = e.toString() }
+
+    /** Gets the source location for this element. */
+    override Location getLocation() { result = e.getLocation() }
+  }
+
+  /** A control-flow node that represents a statement. */
+  class StmtNode extends Node, TStmtNode {
+    Stmt s;
+
+    StmtNode() { this = TStmtNode(s) }
+
+    override Stmt getEnclosingStmt() { result = s }
+
+    override Callable getEnclosingCallable() { result = s.getEnclosingCallable() }
+
+    override Stmt asStmt() { result = s }
+
+    override Call asCall() { result = s }
+
+    override ExprParent getAstNode() { result = s }
+
+    override string toString() { result = s.toString() }
+
+    override Location getLocation() { result = s.getLocation() }
   }
 
   /** A control flow node indicating the termination of a callable. */
-  class ExitNode extends Node, TExitNode { }
+  class ExitNode extends Node, TExitNode {
+    Callable c;
+
+    ExitNode() { this = TExitNode(c) }
+
+    override Callable getEnclosingCallable() { result = c }
+
+    override ExprParent getAstNode() { result = c }
+
+    /** Gets a textual representation of this element. */
+    override string toString() { result = "Exit" }
+
+    /** Gets the source location for this element. */
+    override Location getLocation() { result = c.getLocation() }
+  }
 }
 
 class ControlFlowNode = ControlFlow::Node;

--- a/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/lib/semmle/code/java/ControlFlowGraph.qll
@@ -104,21 +104,6 @@ module ControlFlow {
 
   /** A node in the expression-level control-flow graph. */
   class Node extends TNode {
-    /** Gets the statement containing this node, if any. */
-    Stmt getEnclosingStmt() { none() }
-
-    /** Gets the immediately enclosing callable whose body contains this node. */
-    Callable getEnclosingCallable() { none() }
-
-    /** Gets the statement this `Node` corresponds to, if any. */
-    Stmt asStmt() { none() }
-
-    /** Gets the expression this `Node` corresponds to, if any. */
-    Expr asExpr() { none() }
-
-    /** Gets the call this `Node` corresponds to, if any. */
-    Call asCall() { none() }
-
     /** Gets an immediate successor of this node. */
     Node getASuccessor() { result = succ(this) }
 
@@ -136,6 +121,21 @@ module ControlFlow {
 
     /** Gets the basic block that contains this node. */
     BasicBlock getBasicBlock() { result.getANode() = this }
+
+    /** Gets the statement containing this node, if any. */
+    Stmt getEnclosingStmt() { none() }
+
+    /** Gets the immediately enclosing callable whose body contains this node. */
+    Callable getEnclosingCallable() { none() }
+
+    /** Gets the statement this `Node` corresponds to, if any. */
+    Stmt asStmt() { none() }
+
+    /** Gets the expression this `Node` corresponds to, if any. */
+    Expr asExpr() { none() }
+
+    /** Gets the call this `Node` corresponds to, if any. */
+    Call asCall() { none() }
 
     /** Gets a textual representation of this element. */
     string toString() { none() }


### PR DESCRIPTION
This PR is built on top of https://github.com/github/codeql/pull/17970. That should be merged first. Only review after the commit "Undo accidental bugfix".

This PR is purely a refactoring to make the code easier to read and to make it easier to add new kinds of control flow nodes. As a guide I used [the equivalent class in the go library](https://github.com/github/codeql/blob/main/go/ql/lib/semmle/go/controlflow/ControlFlowGraph.qll#L39).