### PR TITLE
Bazel: add an `install` shortcut and an `experimental` attribute to `codeql_pack`

### DIFF
--- a/.github/workflows/cpp-swift-analysis.yml
+++ b/.github/workflows/cpp-swift-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     - name: "Build Swift extractor using Bazel"
       run: |
         bazel clean --expunge
-        bazel run //swift:installer --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results --spawn_strategy=local
+        bazel run //swift:install --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results --spawn_strategy=local
         bazel shutdown
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/cpp-swift-analysis.yml
+++ b/.github/workflows/cpp-swift-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     - name: "Build Swift extractor using Bazel"
       run: |
         bazel clean --expunge
-        bazel run //swift:create-extractor-pack --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results --spawn_strategy=local
+        bazel run //swift:installer --nouse_action_cache --noremote_accept_cached --noremote_upload_local_results --spawn_strategy=local
         bazel shutdown
 
     - name: Perform CodeQL Analysis

--- a/actions/BUILD.bazel
+++ b/actions/BUILD.bazel
@@ -2,19 +2,8 @@ load("//misc/bazel:pkg.bzl", "codeql_pack")
 
 package(default_visibility = ["//visibility:public"])
 
-[
-    codeql_pack(
-        name = "-".join(parts),
-        srcs = [
-            "//actions/extractor",
-        ],
-        pack_prefix = "/".join(parts),
-    )
-    for parts in (
-        ["actions"],
-        [
-            "experimental",
-            "actions",
-        ],
-    )
-]
+codeql_pack(
+    name = "actions",
+    srcs = ["//actions/extractor"],
+    experimental = True,
+)

--- a/actions/BUILD.bazel
+++ b/actions/BUILD.bazel
@@ -11,10 +11,10 @@ package(default_visibility = ["//visibility:public"])
         pack_prefix = "/".join(parts),
     )
     for parts in (
+        ["actions"],
         [
             "experimental",
             "actions",
         ],
-        ["actions"],
     )
 ]

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -451,7 +451,7 @@ def codeql_pack(
     This rule also provides a convenient installer target named `<name>-installer`, with a path governed by `install_dest`.
     This installer is used for installing this pack into the source-tree, relative to the directory where the rule is used.
     See `codeql_pack_install` for more details. The first `codeql_pack` defined in a bazel package also aliases this
-    installer target with the `installer` name as a shortcut.
+    installer target with the `install` name as a shortcut.
 
     This function does not accept `visibility`, as packs are always public to make it easy to define pack groups.
     """
@@ -475,8 +475,8 @@ def codeql_pack(
         visibility = ["//visibility:public"],
     )
     _codeql_pack_install(internal("installer"), [name], install_dest = install_dest, apply_pack_prefix = False)
-    if not native.existing_rule("installer"):
-        native.alias(name = "installer", actual = internal("installer"))
+    if not native.existing_rule("install"):
+        native.alias(name = "install", actual = internal("installer"))
 
 strip_prefix = _strip_prefix
 

--- a/misc/bazel/pkg.bzl
+++ b/misc/bazel/pkg.bzl
@@ -448,9 +448,10 @@ def codeql_pack(
     contain the `{CODEQL_PLATFORM}` marker.
     All files in the pack will be prefixed with `name`, unless `pack_prefix` is set, then is used instead.
 
-    This rule also provides a convenient installer target, with a path governed by `install_dest`.
+    This rule also provides a convenient installer target named `<name>-installer`, with a path governed by `install_dest`.
     This installer is used for installing this pack into the source-tree, relative to the directory where the rule is used.
-    See `codeql_pack_install` for more details.
+    See `codeql_pack_install` for more details. The first `codeql_pack` defined in a bazel package also aliases this
+    installer target with the `installer` name as a shortcut.
 
     This function does not accept `visibility`, as packs are always public to make it easy to define pack groups.
     """
@@ -474,6 +475,8 @@ def codeql_pack(
         visibility = ["//visibility:public"],
     )
     _codeql_pack_install(internal("installer"), [name], install_dest = install_dest, apply_pack_prefix = False)
+    if not native.existing_rule("installer"):
+        native.alias(name = "installer", actual = internal("installer"))
 
 strip_prefix = _strip_prefix
 

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -56,10 +56,10 @@ codeql_pkg_files(
         pack_prefix = "/".join(parts),
     )
     for parts in (
+        ["rust"],
         [
             "experimental",
             "rust",
         ],
-        ["rust"],
     )
 ]

--- a/rust/BUILD.bazel
+++ b/rust/BUILD.bazel
@@ -46,20 +46,11 @@ codeql_pkg_files(
     ],
 )
 
-[
-    codeql_pack(
-        name = "-".join(parts),
-        srcs = [
-            ":root-files",
-            ":tools",
-        ],
-        pack_prefix = "/".join(parts),
-    )
-    for parts in (
-        ["rust"],
-        [
-            "experimental",
-            "rust",
-        ],
-    )
-]
+codeql_pack(
+    name = "rust",
+    srcs = [
+        ":root-files",
+        ":tools",
+    ],
+    experimental = True,
+)

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,7 +13,7 @@ If you don't have the `semmle-code` repo you may need to install Bazel manually,
 
 This approach uses a released `codeql` version and is simpler to use for QL development. From your `semmle-code` directory run:
 ```bash
-bazel run @codeql//rust:installer
+bazel run @codeql//rust:install
 ```
 You now need to create a [per-user CodeQL configuration file](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/specifying-command-options-in-a-codeql-configuration-file#using-a-codeql-configuration-file) and specify the option:
 ```

--- a/rust/README.md
+++ b/rust/README.md
@@ -13,7 +13,7 @@ If you don't have the `semmle-code` repo you may need to install Bazel manually,
 
 This approach uses a released `codeql` version and is simpler to use for QL development. From your `semmle-code` directory run:
 ```bash
-bazel run @codeql//rust:rust-installer
+bazel run @codeql//rust:installer
 ```
 You now need to create a [per-user CodeQL configuration file](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/specifying-command-options-in-a-codeql-configuration-file#using-a-codeql-configuration-file) and specify the option:
 ```

--- a/swift/README.md
+++ b/swift/README.md
@@ -13,7 +13,7 @@ brew install bazelisk
 then from the `ql` directory run
 
 ```bash
-bazel run //swift:create-extractor-pack
+bazel run //swift:installer
 ```
 
 If you are running on macOS and you encounter errors mentioning `XXX is unavailable: introduced in macOS YY.ZZ`,

--- a/swift/README.md
+++ b/swift/README.md
@@ -13,7 +13,7 @@ brew install bazelisk
 then from the `ql` directory run
 
 ```bash
-bazel run //swift:installer
+bazel run //swift:install
 ```
 
 If you are running on macOS and you encounter errors mentioning `XXX is unavailable: introduced in macOS YY.ZZ`,

--- a/swift/actions/build-and-test/action.yml
+++ b/swift/actions/build-and-test/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: Build Swift extractor
       shell: bash
       run: |
-        bazel run //swift:create-extractor-pack
+        bazel run //swift:installer
     - name: Run codegen tests
       if : ${{ github.event_name == 'pull_request' }}
       shell: bash

--- a/swift/actions/build-and-test/action.yml
+++ b/swift/actions/build-and-test/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: Build Swift extractor
       shell: bash
       run: |
-        bazel run //swift:installer
+        bazel run //swift:install
     - name: Run codegen tests
       if : ${{ github.event_name == 'pull_request' }}
       shell: bash


### PR DESCRIPTION
This makes the first `codeql_pack` in a package add an `install` target aliasing the `<name>-installer` one. This makes it so that one can for example do `bazel run //rust:install` instead of the stuttering `bazel run //rust:rust-installer`. If a bazel package defines multiple `codeql_pack` targets, the first one only will get the `install` alias.
