### PR TITLE
C#: Set proxy environment variables, if Dependabot proxy is detected

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using Semmle.Util;
+
+namespace Semmle.Extraction.CSharp.DependencyFetching
+{
+    internal class DependabotProxy
+    {
+        private readonly string? host;
+        private readonly string? port;
+        private readonly FileInfo? certFile;
+
+        /// <summary>
+        /// The full address of the Dependabot proxy, if available.
+        /// </summary>
+        internal readonly string? Address;
+
+        /// <summary>
+        /// Gets a value indicating whether a Dependabot proxy is configured.
+        /// </summary>
+        internal bool IsConfigured => !string.IsNullOrEmpty(this.Address);
+
+        internal DependabotProxy(TemporaryDirectory tempWorkingDirectory)
+        {
+            // Obtain and store the address of the Dependabot proxy, if available.
+            this.host = Environment.GetEnvironmentVariable(EnvironmentVariableNames.ProxyHost);
+            this.port = Environment.GetEnvironmentVariable(EnvironmentVariableNames.ProxyPort);
+
+            if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(port))
+            {
+                return;
+            }
+
+            this.Address = $"http://{this.host}:{this.port}";
+
+            // Obtain and store the proxy's certificate, if available.
+            var cert = Environment.GetEnvironmentVariable(EnvironmentVariableNames.ProxyCertificate);
+
+            if (string.IsNullOrWhiteSpace(cert))
+            {
+                return;
+            }
+
+            var certDirPath = new DirectoryInfo(Path.Join(tempWorkingDirectory.DirInfo.FullName, ".dependabot-proxy"));
+            Directory.CreateDirectory(certDirPath.FullName);
+
+            this.certFile = new FileInfo(Path.Join(certDirPath.FullName, "proxy.crt"));
+
+            using var writer = this.certFile.CreateText();
+            writer.Write(cert);
+        }
+    }
+}

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using Semmle.Util;
+using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
 {
@@ -48,6 +50,18 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             using var writer = this.certFile.CreateText();
             writer.Write(cert);
+        }
+
+        internal void ApplyProxy(ILogger logger, ProcessStartInfo startInfo)
+        {
+            // If the proxy isn't configured, we have nothing to do.
+            if (!this.IsConfigured) return;
+
+            logger.LogInfo($"Setting up Dependabot proxy at {this.Address}");
+
+            startInfo.EnvironmentVariables["HTTP_PROXY"] = this.Address;
+            startInfo.EnvironmentVariables["HTTPS_PROXY"] = this.Address;
+            startInfo.EnvironmentVariables["SSL_CERT_FILE"] = this.certFile?.FullName;
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -62,6 +62,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 using var writer = certFile.CreateText();
                 writer.Write(cert);
+                writer.Close();
 
                 logger.LogInfo($"Stored Dependabot proxy certificate at {result.CertificatePath}");
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -16,6 +16,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// The full address of the Dependabot proxy, if available.
         /// </summary>
         internal readonly string? Address;
+        /// <summary>
+        /// The path to the temporary file where the certificate is stored.
+        /// </summary>
+        internal readonly string? CertificatePath;
 
         /// <summary>
         /// Gets a value indicating whether a Dependabot proxy is configured.
@@ -49,13 +53,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             var certDirPath = new DirectoryInfo(Path.Join(tempWorkingDirectory.DirInfo.FullName, ".dependabot-proxy"));
             Directory.CreateDirectory(certDirPath.FullName);
 
-            var certFilePath = Path.Join(certDirPath.FullName, "proxy.crt");
-            this.certFile = new FileInfo(certFilePath);
+            this.CertificatePath = Path.Join(certDirPath.FullName, "proxy.crt");
+            this.certFile = new FileInfo(this.CertificatePath);
 
             using var writer = this.certFile.CreateText();
             writer.Write(cert);
 
-            logger.LogInfo($"Stored Dependabot proxy certificate at {certFilePath}");
+            logger.LogInfo($"Stored Dependabot proxy certificate at {this.CertificatePath}");
         }
 
         internal void ApplyProxy(ILogger logger, ProcessStartInfo startInfo)

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -65,9 +65,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             logger.LogInfo($"Setting up Dependabot proxy at {this.Address}");
 
-            startInfo.EnvironmentVariables["HTTP_PROXY"] = this.Address;
-            startInfo.EnvironmentVariables["HTTPS_PROXY"] = this.Address;
-            startInfo.EnvironmentVariables["SSL_CERT_FILE"] = this.certFile?.FullName;
+            startInfo.EnvironmentVariables.Add("HTTP_PROXY", this.Address);
+            startInfo.EnvironmentVariables.Add("HTTPS_PROXY", this.Address);
+            startInfo.EnvironmentVariables.Add("SSL_CERT_FILE", this.certFile?.FullName);
         }
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -27,6 +27,13 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         internal static DependabotProxy? GetDependabotProxy(ILogger logger, TemporaryDirectory tempWorkingDirectory)
         {
+            // Setting HTTP(S)_PROXY and SSL_CERT_FILE have no effect on Windows or macOS,
+            // but we would still end up using the Dependabot proxy to check for feed reachability.
+            // This would result in us discovering that the feeds are reachable, but `dotnet` would
+            // fail to connect to them. To prevent this from happening, we do not initialise an
+            // instance of `DependabotProxy` on those platforms.
+            if (SystemBuildActions.Instance.IsWindows() || SystemBuildActions.Instance.IsMacOs()) return null;
+
             // Obtain and store the address of the Dependabot proxy, if available.
             var host = Environment.GetEnvironmentVariable(EnvironmentVariableNames.ProxyHost);
             var port = Environment.GetEnvironmentVariable(EnvironmentVariableNames.ProxyPort);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -6,7 +6,7 @@ using Semmle.Util.Logging;
 
 namespace Semmle.Extraction.CSharp.DependencyFetching
 {
-    internal class DependabotProxy
+    public class DependabotProxy
     {
         private readonly string? host;
         private readonly string? port;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -66,7 +66,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                 logger.LogInfo($"Stored Dependabot proxy certificate at {result.CertificatePath}");
 
-                result.Certificate = new X509Certificate2(result.CertificatePath);
+                result.Certificate = X509Certificate2.CreateFromPem(cert);
             }
 
             return result;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly ILogger logger;
         private readonly IDiagnosticsWriter diagnosticsWriter;
         private readonly NugetPackageRestorer nugetPackageRestorer;
-        private readonly DependabotProxy dependabotProxy;
+        private readonly DependabotProxy? dependabotProxy;
         private readonly IDotNet dotnet;
         private readonly FileContent fileContent;
         private readonly FileProvider fileProvider;
@@ -107,7 +107,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                 return BuildScript.Success;
             }).Run(SystemBuildActions.Instance, startCallback, exitCallback);
 
-            dependabotProxy = new DependabotProxy(logger, tempWorkingDirectory);
+            dependabotProxy = DependabotProxy.GetDependabotProxy(logger, tempWorkingDirectory);
 
             try
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -545,6 +545,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public void Dispose()
         {
             nugetPackageRestorer?.Dispose();
+            dependabotProxy.Dispose();
             if (cleanupTempWorkingDirectory)
             {
                 tempWorkingDirectory?.Dispose();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -545,7 +545,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public void Dispose()
         {
             nugetPackageRestorer?.Dispose();
-            dependabotProxy.Dispose();
+            dependabotProxy?.Dispose();
             if (cleanupTempWorkingDirectory)
             {
                 tempWorkingDirectory?.Dispose();

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -27,7 +27,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             Info();
         }
 
-        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet")), logger, tempWorkingDirectory) { }
+        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), tempWorkingDirectory), logger, tempWorkingDirectory) { }
 
         internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger) => new DotNet(dotnetCliInvoker, logger);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -27,11 +27,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             Info();
         }
 
-        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), tempWorkingDirectory), logger, tempWorkingDirectory) { }
+        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, tempWorkingDirectory) { }
 
         internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger) => new DotNet(dotnetCliInvoker, logger);
 
-        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory) => new DotNet(logger, dotNetPath, tempWorkingDirectory);
+        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
 
         private void Info()
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -27,11 +27,11 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             Info();
         }
 
-        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, tempWorkingDirectory) { }
+        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, tempWorkingDirectory) { }
 
         internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger) => new DotNet(dotnetCliInvoker, logger);
 
-        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
+        public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
 
         private void Info()
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -44,10 +44,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             // Configure the proxy settings, if applicable.
             this.proxy.ApplyProxy(this.logger, startInfo);
 
-            this.logger.LogInfo(startInfo.EnvironmentVariables["HTTP_PROXY"] ?? "");
-            this.logger.LogInfo(startInfo.EnvironmentVariables["HTTPS_PROXY"] ?? "");
-            this.logger.LogInfo(startInfo.EnvironmentVariables["SSL_CERT_FILE"] ?? "");
-
             return startInfo;
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -16,10 +16,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
         public string Exec { get; }
 
-        public DotNetCliInvoker(ILogger logger, string exec, TemporaryDirectory tempWorkingDirectory)
+        public DotNetCliInvoker(ILogger logger, string exec, DependabotProxy dependabotProxy)
         {
             this.logger = logger;
-            this.proxy = new DependabotProxy(logger, tempWorkingDirectory);
+            this.proxy = dependabotProxy;
             this.Exec = exec;
             logger.LogInfo($"Using .NET CLI executable: '{Exec}'");
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -19,7 +19,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         public DotNetCliInvoker(ILogger logger, string exec, TemporaryDirectory tempWorkingDirectory)
         {
             this.logger = logger;
-            this.proxy = new DependabotProxy(tempWorkingDirectory);
+            this.proxy = new DependabotProxy(logger, tempWorkingDirectory);
             this.Exec = exec;
             logger.LogInfo($"Using .NET CLI executable: '{Exec}'");
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/EnvironmentVariableNames.cs
@@ -74,5 +74,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         /// Specifies the location of the diagnostic directory.
         /// </summary>
         public const string DiagnosticDir = "CODEQL_EXTRACTOR_CSHARP_DIAGNOSTIC_DIR";
+
+        /// <summary>
+        /// Specifies the hostname of the Dependabot proxy.
+        /// </summary>
+        public const string ProxyHost = "CODEQL_PROXY_HOST";
+
+        /// <summary>
+        /// Specifies the hostname of the Dependabot proxy.
+        /// </summary>
+        public const string ProxyPort = "CODEQL_PROXY_PORT";
+
+        /// <summary>
+        /// Contains the certificate used by the Dependabot proxy.
+        /// </summary>
+        public const string ProxyCertificate = "CODEQL_PROXY_CA_CERTIFICATE";
     }
 }

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -20,6 +20,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly FileProvider fileProvider;
         private readonly FileContent fileContent;
         private readonly IDotNet dotnet;
+        private readonly DependabotProxy dependabotProxy;
         private readonly IDiagnosticsWriter diagnosticsWriter;
         private readonly TemporaryDirectory legacyPackageDirectory;
         private readonly TemporaryDirectory missingPackageDirectory;
@@ -32,6 +33,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             FileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
+            DependabotProxy dependabotProxy,
             IDiagnosticsWriter diagnosticsWriter,
             ILogger logger,
             ICompilationInfoContainer compilationInfoContainer)
@@ -39,6 +41,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             this.fileProvider = fileProvider;
             this.fileContent = fileContent;
             this.dotnet = dotnet;
+            this.dependabotProxy = dependabotProxy;
             this.diagnosticsWriter = diagnosticsWriter;
             this.logger = logger;
             this.compilationInfoContainer = compilationInfoContainer;

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly FileProvider fileProvider;
         private readonly FileContent fileContent;
         private readonly IDotNet dotnet;
-        private readonly DependabotProxy dependabotProxy;
+        private readonly DependabotProxy? dependabotProxy;
         private readonly IDiagnosticsWriter diagnosticsWriter;
         private readonly TemporaryDirectory legacyPackageDirectory;
         private readonly TemporaryDirectory missingPackageDirectory;
@@ -35,7 +35,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             FileProvider fileProvider,
             FileContent fileContent,
             IDotNet dotnet,
-            DependabotProxy dependabotProxy,
+            DependabotProxy? dependabotProxy,
             IDiagnosticsWriter diagnosticsWriter,
             ILogger logger,
             ICompilationInfoContainer compilationInfoContainer)
@@ -596,7 +596,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             // Configure the HttpClient to be aware of the Dependabot Proxy, if used.
             HttpClientHandler httpClientHandler = new();
-            if (this.dependabotProxy.IsConfigured)
+            if (this.dependabotProxy != null)
             {
                 httpClientHandler.Proxy = new WebProxy(this.dependabotProxy.Address);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -3,7 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -591,7 +593,26 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private bool IsFeedReachable(string feed, int timeoutMilliSeconds, int tryCount, bool allowExceptions = true)
         {
             logger.LogInfo($"Checking if Nuget feed '{feed}' is reachable...");
-            using HttpClient client = new();
+
+            // Configure the HttpClient to be aware of the Dependabot Proxy, if used.
+            HttpClientHandler httpClientHandler = new();
+            if (this.dependabotProxy.IsConfigured)
+            {
+                httpClientHandler.Proxy = new WebProxy(this.dependabotProxy.Address);
+
+                if (!String.IsNullOrEmpty(this.dependabotProxy.CertificatePath))
+                {
+                    X509Certificate2 proxyCert = new X509Certificate2(this.dependabotProxy.CertificatePath);
+                    httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
+                    {
+                        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                        chain.ChainPolicy.CustomTrustStore.Add(proxyCert);
+                        return chain.Build(cert);
+                    };
+                }
+            }
+
+            using HttpClient client = new(httpClientHandler);
 
             for (var i = 0; i < tryCount; i++)
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -600,13 +600,12 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 httpClientHandler.Proxy = new WebProxy(this.dependabotProxy.Address);
 
-                if (!String.IsNullOrEmpty(this.dependabotProxy.CertificatePath))
+                if (this.dependabotProxy.Certificate != null)
                 {
-                    X509Certificate2 proxyCert = new X509Certificate2(this.dependabotProxy.CertificatePath);
                     httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, _) =>
                     {
                         chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                        chain.ChainPolicy.CustomTrustStore.Add(proxyCert);
+                        chain.ChainPolicy.CustomTrustStore.Add(this.dependabotProxy.Certificate);
                         return chain.Build(cert);
                     };
                 }


### PR DESCRIPTION
This PR is part of work to enable private package registries to be used in Default Setup. 

The existing Default Setup workflow will initialise the Dependabot package proxy, if a private package registry configuration is set. The host, port, and certificate used by the proxy are then passed to CodeQL in the `analyze` step. 

The changes in this PR modify the C# extractor to recognise when the corresponding environment variables are set. If so, we use the data from those environment variables to:

1. Construct the proxy address from the host and port and pass it to `dotnet` via the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
2. Store the certificate on disk, and pass the path to `dotnet` via `SSL_CERT_FILE`.
3. We also configure a suitable proxy for the feed reachability checks.

In testing so far, this works fine on Linux with fairly arbitrary versions of `dotnet`. It does not seem to work on macOS and likely also does not work on Windows.