### PR TITLE
Python: Fix pruning of literals in `match` pattern

### DIFF
--- a/python/extractor/semmle/python/passes/pruner.py
+++ b/python/extractor/semmle/python/passes/pruner.py
@@ -196,6 +196,25 @@ class SkippedVisitor(ASTVisitor):
         if isinstance(node.value, ast.Name):
             self.nodes.add(node.value)
 
+class NotBooleanTestVisitor(ASTVisitor):
+    """Visitor that checks if a test is not a boolean test."""
+
+    def __init__(self):
+        self.nodes = set()
+
+    def visit_MatchLiteralPattern(self, node):
+        # MatchLiteralPatterns _look_ like boolean tests, but are not.
+        # Thus, without this check, we would interpret
+        #
+        # match x:
+        #    case False:
+        #        pass
+        #
+        # (and similarly for True) as if it was a boolean test. This would cause the true edge
+        # (leading to pass) to be pruned later on.
+        if isinstance(node.literal, ast.Name) and node.literal.id in ('True', 'False'):
+            self.nodes.add(node.literal)
+
 class NonlocalVisitor(ASTVisitor):
     def __init__(self):
         self.names = set()
@@ -306,6 +325,8 @@ def effective_constants_definitions(bool_const_defns, graph, branching_edges):
 def do_pruning(tree, graph):
     v = BoolConstVisitor()
     v.visit(tree)
+    not_boolean_test = NotBooleanTestVisitor()
+    not_boolean_test.visit(tree)
     nonlocals = NonlocalVisitor()
     nonlocals.visit(tree)
     global_vars = GlobalVisitor()
@@ -352,6 +373,8 @@ def do_pruning(tree, graph):
                 continue
             b = const_value(pred.node)
             if b is None:
+                continue
+            if pred.node in not_boolean_test.nodes:
                 continue
             if b.contradicts(val):
                 to_be_removed.add((pred, succ))

--- a/python/ql/test/query-tests/Statements/unreachable/UnreachableCode.expected
+++ b/python/ql/test/query-tests/Statements/unreachable/UnreachableCode.expected
@@ -4,5 +4,3 @@
 | test.py:21:5:21:38 | For | This statement is unreachable. |
 | test.py:28:9:28:21 | ExprStmt | This statement is unreachable. |
 | test.py:84:5:84:21 | ExceptStmt | This statement is unreachable. |
-| test.py:144:13:144:16 | Pass | This statement is unreachable. |
-| test.py:147:9:148:16 | Case | This statement is unreachable. |


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
