### PR TITLE
JS: Fix jump steps generated by IIFEs and exception flow

### DIFF
--- a/javascript/ql/lib/semmle/javascript/StandardLibrary.qll
+++ b/javascript/ql/lib/semmle/javascript/StandardLibrary.qll
@@ -69,7 +69,7 @@ private class ArrayIterationCallbackAsPartialInvoke extends DataFlow::PartialInv
  * A flow step propagating the exception thrown from a callback to a method whose name coincides
  * a built-in Array iteration method, such as `forEach` or `map`.
  */
-private class IteratorExceptionStep extends DataFlow::SharedFlowStep {
+private class IteratorExceptionStep extends DataFlow::LegacyFlowStep {
   override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
     exists(DataFlow::MethodCallNode call |
       call.getMethodName() = ["forEach", "each", "map", "filter", "some", "every", "fold", "reduce"] and

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/VariableCapture.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/VariableCapture.qll
@@ -8,7 +8,7 @@ module VariableCaptureConfig implements InputSig<js::DbLocation> {
   private js::Function getLambdaFromVariable(js::LocalVariable variable) {
     result.getVariable() = variable
     or
-    result = variable.getAnAssignedExpr()
+    result = variable.getAnAssignedExpr().getUnderlyingValue()
     or
     exists(js::ClassDeclStmt cls |
       result = cls.getConstructor().getBody() and
@@ -148,9 +148,11 @@ module VariableCaptureConfig implements InputSig<js::DbLocation> {
     predicate hasAliasedAccess(Expr e) {
       e = this
       or
+      e.(js::Expr).getUnderlyingValue() = this
+      or
       exists(js::LocalVariable variable |
         this = getLambdaFromVariable(variable) and
-        e = variable.getAnAccess()
+        e.(js::Expr).getUnderlyingValue() = variable.getAnAccess()
       )
     }
   }

--- a/javascript/ql/lib/semmle/javascript/filters/ClassifyFiles.qll
+++ b/javascript/ql/lib/semmle/javascript/filters/ClassifyFiles.qll
@@ -61,6 +61,8 @@ predicate isTestFile(File f) {
   )
   or
   f.getAbsolutePath().regexpMatch(".*/__(mocks|tests)__/.*")
+  or
+  f.getBaseName().matches("%.test.%")
 }
 
 /**

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
@@ -1,6 +1,7 @@
 private import AmbiguousCoreMethods
 private import Arrays
 private import AsyncAwait
+private import ExceptionFlow
 private import ForOfLoops
 private import Generators
 private import Iterators

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/ExceptionFlow.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/ExceptionFlow.qll
@@ -1,0 +1,32 @@
+/**
+ * Contains a summary for propagating exceptions out of callbacks
+ */
+
+private import javascript
+private import FlowSummaryUtil
+private import semmle.javascript.dataflow.internal.AdditionalFlowInternal
+private import semmle.javascript.dataflow.FlowSummary
+private import semmle.javascript.internal.flow_summaries.Promises
+
+/**
+ * Summary that propagates exceptions out of callbacks back to the caller.
+ */
+private class ExceptionFlowSummary extends SummarizedCallable {
+  ExceptionFlowSummary() { this = "Exception propagator" }
+
+  override DataFlow::CallNode getACall() {
+    not exists(result.getACallee()) and
+    // Avoid a few common cases where the exception should not propagate back
+    not result.getCalleeName() =
+      ["then", "catch", "finally", "addEventListener", EventEmitter::on()] and
+    not result = promiseConstructorRef().getAnInvocation() and
+    // Restrict to cases where a callback is known to flow in, as lambda flow in DataFlowImplCommon blows up otherwise
+    exists(result.getABoundCallbackParameter(_, _))
+  }
+
+  override predicate propagatesFlowExt(string input, string output, boolean preservesValue) {
+    preservesValue = true and
+    input = "Argument[0..].ReturnValue[exception]" and
+    output = "ReturnValue[exception]"
+  }
+}

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Promises.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/Promises.qll
@@ -6,7 +6,7 @@ private import javascript
 private import semmle.javascript.dataflow.FlowSummary
 private import FlowSummaryUtil
 
-private DataFlow::SourceNode promiseConstructorRef() {
+DataFlow::SourceNode promiseConstructorRef() {
   result = Promises::promiseConstructorRef()
   or
   result = DataFlow::moduleImport("bluebird")

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureRandomnessQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/InsecureRandomnessQuery.qll
@@ -11,6 +11,7 @@ import javascript
 private import semmle.javascript.security.SensitiveActions
 import InsecureRandomnessCustomizations::InsecureRandomness
 private import InsecureRandomnessCustomizations::InsecureRandomness as InsecureRandomness
+private import semmle.javascript.filters.ClassifyFiles as ClassifyFiles
 
 /**
  * A taint tracking configuration for random values that are not cryptographically secure.
@@ -20,7 +21,11 @@ module InsecureRandomnessConfig implements DataFlow::ConfigSig {
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
-  predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+  predicate isBarrier(DataFlow::Node node) {
+    node instanceof Sanitizer
+    or
+    ClassifyFiles::isTestFile(node.getFile())
+  }
 
   predicate isBarrierOut(DataFlow::Node node) {
     // stop propagation at the sinks to avoid double reporting

--- a/javascript/ql/test/library-tests/TripleDot/exceptions.js
+++ b/javascript/ql/test/library-tests/TripleDot/exceptions.js
@@ -1,0 +1,65 @@
+import 'dummy';
+
+function e1() {
+    let array = [source('e1.1')];
+    try {
+        array.forEach(x => {
+            throw x;
+        });
+        array.forEach(x => {
+            throw source('e1.2');
+        });
+    } catch (err) {
+        sink(err); // $ hasValueFlow=e1.2 hasValueFlow=e1.1
+    }
+}
+
+function e2() {
+    let array = [source('e2.1')];
+    try {
+        array.unknown(x => {
+            throw x;
+        });
+        array.unknown(x => {
+            throw source('e2.2');
+        });
+    } catch (err) {
+        sink(err); // $ MISSING: hasValueFlow=e2.2
+    }
+}
+
+function e3() {
+    const events = getSomething();
+    try {
+        events.addEventListener('click', () =>{
+            throw source('e3.1');
+        });
+        events.addListener('click', () =>{
+            throw source('e3.2');
+        });
+        events.on('click', () =>{
+            throw source('e3.3');
+        });
+        events.unknownMethod('click', () =>{
+            throw source('e3.4');
+        });
+    } catch (err) {
+        sink(err); // $ MISSING: hasValueFlow=e3.4
+    }
+}
+
+function e4() {
+    function thrower(array) {
+        array.forEach(x => { throw x });
+    }
+    try {
+        thrower([source("e4.1")]);
+    } catch (e) {
+        sink(e); // $ hasValueFlow=e4.1
+    }
+    try {
+        thrower(["safe"]);
+    } catch (e) {
+        sink(e); // $ SPURIOUS: hasValueFlow=e4.1
+    }
+}

--- a/javascript/ql/test/library-tests/TripleDot/exceptions.js
+++ b/javascript/ql/test/library-tests/TripleDot/exceptions.js
@@ -10,7 +10,7 @@ function e1() {
             throw source('e1.2');
         });
     } catch (err) {
-        sink(err); // $ hasValueFlow=e1.2 hasValueFlow=e1.1
+        sink(err); // $ hasValueFlow=e1.2 MISSING: hasValueFlow=e1.1
     }
 }
 
@@ -24,7 +24,7 @@ function e2() {
             throw source('e2.2');
         });
     } catch (err) {
-        sink(err); // $ MISSING: hasValueFlow=e2.2
+        sink(err); // $ hasValueFlow=e2.2
     }
 }
 
@@ -55,11 +55,11 @@ function e4() {
     try {
         thrower([source("e4.1")]);
     } catch (e) {
-        sink(e); // $ hasValueFlow=e4.1
+        sink(e); // $ MISSING: hasValueFlow=e4.1
     }
     try {
         thrower(["safe"]);
     } catch (e) {
-        sink(e); // $ SPURIOUS: hasValueFlow=e4.1
+        sink(e);
     }
 }

--- a/javascript/ql/test/library-tests/TripleDot/iife.js
+++ b/javascript/ql/test/library-tests/TripleDot/iife.js
@@ -1,0 +1,43 @@
+function f1() {
+    function inner(x) {
+        return (function(p) {
+            return p; // argument to return
+        })(x);
+    }
+    sink(inner(source("f1.1"))); // $ hasValueFlow=f1.1 SPURIOUS: hasValueFlow=f1.2
+    sink(inner(source("f1.2"))); // $ hasValueFlow=f1.2 SPURIOUS: hasValueFlow=f1.1
+}
+
+function f2() {
+    function inner(x) {
+        let y;
+        (function(p) {
+            y = p; // parameter to captured variable
+        })(x);
+        return y;
+    }
+    sink(inner(source("f2.1"))); // $ hasValueFlow=f2.1 SPURIOUS: hasValueFlow=f2.2
+    sink(inner(source("f2.2"))); // $ hasValueFlow=f2.2 SPURIOUS: hasValueFlow=f2.1
+}
+
+function f3() {
+    function inner(x) {
+        return (function() {
+            return x; // captured variable to return
+        })();
+    }
+    sink(inner(source("f3.1"))); // $ hasValueFlow=f3.1 SPURIOUS: hasValueFlow=f3.2
+    sink(inner(source("f3.2"))); // $ hasValueFlow=f3.2 SPURIOUS: hasValueFlow=f3.1
+}
+
+function f4() {
+    function inner(x) {
+        let y;
+        (function() {
+            y = x; // captured variable to captured variable
+        })();
+        return y;
+    }
+    sink(inner(source("f4.1"))); // $ hasValueFlow=f4.1
+    sink(inner(source("f4.2"))); // $ hasValueFlow=f4.2
+}

--- a/javascript/ql/test/library-tests/TripleDot/iife.js
+++ b/javascript/ql/test/library-tests/TripleDot/iife.js
@@ -16,8 +16,8 @@ function f2() {
         })(x);
         return y;
     }
-    sink(inner(source("f2.1"))); // $ MISSING: hasValueFlow=f2.1
-    sink(inner(source("f2.2"))); // $ MISSING: hasValueFlow=f2.2
+    sink(inner(source("f2.1"))); // $ hasValueFlow=f2.1
+    sink(inner(source("f2.2"))); // $ hasValueFlow=f2.2
 }
 
 function f3() {
@@ -64,8 +64,8 @@ function f6() {
         (nested)(x); // same as f5, except the callee is parenthesised here
         return y;
     }
-    sink(inner(source("f6.1"))); // $ MISSING: hasValueFlow=f6.1
-    sink(inner(source("f6.2"))); // $ MISSING: hasValueFlow=f6.2
+    sink(inner(source("f6.1"))); // $ hasValueFlow=f6.1
+    sink(inner(source("f6.2"))); // $ hasValueFlow=f6.2
 }
 
 function f7() {
@@ -77,6 +77,6 @@ function f7() {
         nested(x); // same as f5, except the function definition is parenthesised
         return y;
     }
-    sink(inner(source("f7.1"))); // $ MISSING: hasValueFlow=f7.1
-    sink(inner(source("f7.2"))); // $ MISSING: hasValueFlow=f7.2
+    sink(inner(source("f7.1"))); // $ hasValueFlow=f7.1
+    sink(inner(source("f7.2"))); // $ hasValueFlow=f7.2
 }

--- a/javascript/ql/test/library-tests/TripleDot/iife.js
+++ b/javascript/ql/test/library-tests/TripleDot/iife.js
@@ -4,8 +4,8 @@ function f1() {
             return p; // argument to return
         })(x);
     }
-    sink(inner(source("f1.1"))); // $ hasValueFlow=f1.1 SPURIOUS: hasValueFlow=f1.2
-    sink(inner(source("f1.2"))); // $ hasValueFlow=f1.2 SPURIOUS: hasValueFlow=f1.1
+    sink(inner(source("f1.1"))); // $ hasValueFlow=f1.1
+    sink(inner(source("f1.2"))); // $ hasValueFlow=f1.2
 }
 
 function f2() {
@@ -16,8 +16,8 @@ function f2() {
         })(x);
         return y;
     }
-    sink(inner(source("f2.1"))); // $ hasValueFlow=f2.1 SPURIOUS: hasValueFlow=f2.2
-    sink(inner(source("f2.2"))); // $ hasValueFlow=f2.2 SPURIOUS: hasValueFlow=f2.1
+    sink(inner(source("f2.1"))); // $ MISSING: hasValueFlow=f2.1
+    sink(inner(source("f2.2"))); // $ MISSING: hasValueFlow=f2.2
 }
 
 function f3() {
@@ -26,8 +26,8 @@ function f3() {
             return x; // captured variable to return
         })();
     }
-    sink(inner(source("f3.1"))); // $ hasValueFlow=f3.1 SPURIOUS: hasValueFlow=f3.2
-    sink(inner(source("f3.2"))); // $ hasValueFlow=f3.2 SPURIOUS: hasValueFlow=f3.1
+    sink(inner(source("f3.1"))); // $ hasValueFlow=f3.1
+    sink(inner(source("f3.2"))); // $ hasValueFlow=f3.2
 }
 
 function f4() {

--- a/javascript/ql/test/library-tests/TripleDot/iife.js
+++ b/javascript/ql/test/library-tests/TripleDot/iife.js
@@ -41,3 +41,42 @@ function f4() {
     sink(inner(source("f4.1"))); // $ hasValueFlow=f4.1
     sink(inner(source("f4.2"))); // $ hasValueFlow=f4.2
 }
+
+function f5() {
+    function inner(x) {
+        let y;
+        function nested(p) {
+            y = p;
+        }
+        nested(x);
+        return y;
+    }
+    sink(inner(source("f5.1"))); // $ hasValueFlow=f5.1
+    sink(inner(source("f5.2"))); // $ hasValueFlow=f5.2
+}
+
+function f6() {
+    function inner(x) {
+        let y;
+        function nested(p) {
+            y = p;
+        }
+        (nested)(x); // same as f5, except the callee is parenthesised here
+        return y;
+    }
+    sink(inner(source("f6.1"))); // $ MISSING: hasValueFlow=f6.1
+    sink(inner(source("f6.2"))); // $ MISSING: hasValueFlow=f6.2
+}
+
+function f7() {
+    function inner(x) {
+        let y;
+        let nested = (function (p) {
+            y = p;
+        });
+        nested(x); // same as f5, except the function definition is parenthesised
+        return y;
+    }
+    sink(inner(source("f7.1"))); // $ MISSING: hasValueFlow=f7.1
+    sink(inner(source("f7.2"))); // $ MISSING: hasValueFlow=f7.2
+}


### PR DESCRIPTION
This PR fixes a few issues that cause performance (and precision) problems:
- Removes jump steps generated by local flow into and out of immediately-invoked function expressions (IIFEs), and fixes some bugs so that the same flow is now handled by regular flow rules. IIFEs are special-cased in the local flow relation, which benefits things like type tracking and type inference, but is unhelpful for the data flow library.
- Removes jump steps resulting from exception-propagating flow steps. A flow summary is now used to propagate exceptions out of callbacks. Apart from the added precision of not using jump steps, the new version also errs on the side of propagating exception more often, using a denylist rather than an allowlist to specify functions that propagate exceptions from callbacks.
- `js/insecure-randomness` now blocks flow through test cases. Perhaps more queries ought to do this, but it seems particularly problematic for this query. Also broadens our classifications of test files a bit.

[Evaluation](https://github.com/github/codeql-dca-main/tree/data/asgerf/jump-and-test-e__default__code-scanning__2/reports) looks good:
- Yet another 78% speedup on `vscode`, which means it is down to being "only" 79% slower than on `main` (the similar numbers is a coincidence).
- 48 fixed FPs, mainly due to the change to `js/insecure-randomness`
- 2 gained FPs, due to imprecise higher-order function flow combined with more exception propagation.

[Evaluation against main](https://github.com/github/codeql-dca-main/tree/data/asgerf/jump-and-test-e__default__code-scanning__3/reports) shows that we're down to a median 26% slowdown, with a 100% worst-case slowdown.