### PR TITLE
JS: Merge 'main' and implement 'speculativeTaintStep'

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
@@ -104,3 +104,12 @@ predicate defaultImplicitTaintRead(DataFlow::Node node, ContentSet c) {
   // Optional steps are added through isAdditionalFlowStep but we don't want the implicit reads
   not optionalStep(node, _, _)
 }
+
+predicate speculativeTaintStep(DataFlow::Node node1, DataFlow::Node node2) {
+  exists(DataFlow::CallNode call, DataFlowCall c |
+    not exists(viableCallable(c)) and
+    c.asOrdinaryCall() = call and
+    node1 = call.getAnArgument() and
+    node2 = call
+  )
+}

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/IndirectCommandInjectionQuery.qll
@@ -26,10 +26,6 @@ module IndirectCommandInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { isSinkWithHighlight(sink, _) }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
-
-  predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
-    argsParseStep(pred, succ)
-  }
 }
 
 /**

--- a/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
+++ b/javascript/ql/test/experimental/Security/CWE-918/SSRF.expected
@@ -12,6 +12,7 @@ edges
 | check-regex.js:31:29:31:45 | req.query.tainted | check-regex.js:31:15:31:45 | "test.c ... tainted | provenance |  |
 | check-regex.js:34:25:34:42 | req.params.tainted | check-regex.js:34:15:34:42 | baseURL ... tainted | provenance |  |
 | check-regex.js:41:27:41:43 | req.query.tainted | check-regex.js:41:13:41:43 | "test.c ... tainted | provenance |  |
+| check-regex.js:61:25:61:42 | req.params.tainted | check-regex.js:61:15:61:42 | baseURL ... tainted | provenance |  |
 | check-validator.js:15:29:15:45 | req.query.tainted | check-validator.js:15:15:15:45 | "test.c ... tainted | provenance |  |
 | check-validator.js:27:29:27:45 | req.query.tainted | check-validator.js:27:15:27:45 | "test.c ... tainted | provenance |  |
 | check-validator.js:50:29:50:45 | req.query.tainted | check-validator.js:50:15:50:45 | "test.c ... tainted | provenance |  |
@@ -47,6 +48,8 @@ nodes
 | check-regex.js:34:25:34:42 | req.params.tainted | semmle.label | req.params.tainted |
 | check-regex.js:41:13:41:43 | "test.c ... tainted | semmle.label | "test.c ... tainted |
 | check-regex.js:41:27:41:43 | req.query.tainted | semmle.label | req.query.tainted |
+| check-regex.js:61:15:61:42 | baseURL ... tainted | semmle.label | baseURL ... tainted |
+| check-regex.js:61:25:61:42 | req.params.tainted | semmle.label | req.params.tainted |
 | check-validator.js:15:15:15:45 | "test.c ... tainted | semmle.label | "test.c ... tainted |
 | check-validator.js:15:29:15:45 | req.query.tainted | semmle.label | req.query.tainted |
 | check-validator.js:27:15:27:45 | "test.c ... tainted | semmle.label | "test.c ... tainted |
@@ -76,6 +79,7 @@ subpaths
 | check-regex.js:31:15:31:45 | "test.c ... tainted | check-regex.js:31:29:31:45 | req.query.tainted | check-regex.js:31:15:31:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-regex.js:34:15:34:42 | baseURL ... tainted | check-regex.js:34:25:34:42 | req.params.tainted | check-regex.js:34:15:34:42 | baseURL ... tainted | The URL of this request depends on a user-provided value. |
 | check-regex.js:41:13:41:43 | "test.c ... tainted | check-regex.js:41:27:41:43 | req.query.tainted | check-regex.js:41:13:41:43 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
+| check-regex.js:61:15:61:42 | baseURL ... tainted | check-regex.js:61:25:61:42 | req.params.tainted | check-regex.js:61:15:61:42 | baseURL ... tainted | The URL of this request depends on a user-provided value. |
 | check-validator.js:15:15:15:45 | "test.c ... tainted | check-validator.js:15:29:15:45 | req.query.tainted | check-validator.js:15:15:15:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-validator.js:27:15:27:45 | "test.c ... tainted | check-validator.js:27:29:27:45 | req.query.tainted | check-validator.js:27:15:27:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |
 | check-validator.js:50:15:50:45 | "test.c ... tainted | check-validator.js:50:29:50:45 | req.query.tainted | check-validator.js:50:15:50:45 | "test.c ... tainted | The URL of this request depends on a user-provided value. |

--- a/javascript/ql/test/library-tests/Arrays/DataFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/DataFlow.expected
@@ -17,6 +17,7 @@ flow
 | arrays.js:2:16:2:23 | "source" | arrays.js:86:8:86:35 | arrayFi ... llback) |
 | arrays.js:2:16:2:23 | "source" | arrays.js:90:10:90:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:93:8:93:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:110:8:110:24 | arr8_spread.pop() |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
@@ -28,3 +29,5 @@ flow
 | arrays.js:53:4:53:11 | "source" | arrays.js:54:10:54:18 | ary.pop() |
 | arrays.js:96:9:96:16 | "source" | arrays.js:96:8:96:40 | ["sourc ... ).pop() |
 | arrays.js:97:9:97:16 | "source" | arrays.js:97:8:97:42 | ["sourc ... ).pop() |
+| arrays.js:100:31:100:38 | "source" | arrays.js:101:8:101:17 | arr8.pop() |
+| arrays.js:104:55:104:62 | "source" | arrays.js:106:8:106:25 | arr8_variant.pop() |

--- a/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
+++ b/javascript/ql/test/library-tests/Arrays/TaintFlow.expected
@@ -16,6 +16,7 @@ flow
 | arrays.js:2:16:2:23 | "source" | arrays.js:86:8:86:35 | arrayFi ... llback) |
 | arrays.js:2:16:2:23 | "source" | arrays.js:90:10:90:10 | x |
 | arrays.js:2:16:2:23 | "source" | arrays.js:93:8:93:17 | arr.at(-1) |
+| arrays.js:2:16:2:23 | "source" | arrays.js:110:8:110:24 | arr8_spread.pop() |
 | arrays.js:18:22:18:29 | "source" | arrays.js:18:50:18:50 | e |
 | arrays.js:22:15:22:22 | "source" | arrays.js:23:8:23:17 | arr2.pop() |
 | arrays.js:25:15:25:22 | "source" | arrays.js:26:8:26:17 | arr3.pop() |
@@ -29,3 +30,5 @@ flow
 | arrays.js:95:9:95:16 | "source" | arrays.js:95:8:95:17 | ["source"] |
 | arrays.js:96:9:96:16 | "source" | arrays.js:96:8:96:40 | ["sourc ... ).pop() |
 | arrays.js:97:9:97:16 | "source" | arrays.js:97:8:97:42 | ["sourc ... ).pop() |
+| arrays.js:100:31:100:38 | "source" | arrays.js:101:8:101:17 | arr8.pop() |
+| arrays.js:104:55:104:62 | "source" | arrays.js:106:8:106:25 | arr8_variant.pop() |

--- a/javascript/ql/test/library-tests/Arrays/printAst.expected
+++ b/javascript/ql/test/library-tests/Arrays/printAst.expected
@@ -1,9 +1,9 @@
 nodes
-| arrays.js:1:1:99:2 | [ParExpr] (functi ... OK }) | semmle.label | [ParExpr] (functi ... OK }) |
-| arrays.js:1:1:99:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
-| arrays.js:1:1:99:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
-| arrays.js:1:2:99:1 | [FunctionExpr] functio ... T OK } | semmle.label | [FunctionExpr] functio ... T OK } |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | semmle.label | [BlockStmt] { let ... T OK } |
+| arrays.js:1:1:111:2 | [ParExpr] (functi ... T OK }) | semmle.label | [ParExpr] (functi ... T OK }) |
+| arrays.js:1:1:111:3 | [ExprStmt] (functi ... OK }); | semmle.label | [ExprStmt] (functi ... OK }); |
+| arrays.js:1:1:111:3 | [ExprStmt] (functi ... OK }); | semmle.order | 1 |
+| arrays.js:1:2:111:1 | [FunctionExpr] functio ... OT OK } | semmle.label | [FunctionExpr] functio ... OT OK } |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | semmle.label | [BlockStmt] { let ... OT OK } |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | [DeclStmt] let source = ... |
 | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | [VarDecl] source |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | [VariableDeclarator] source = "source" |
@@ -428,6 +428,82 @@ nodes
 | arrays.js:97:34:97:35 | [UnaryExpr] !x | semmle.label | [UnaryExpr] !x |
 | arrays.js:97:35:97:35 | [VarRef] x | semmle.label | [VarRef] x |
 | arrays.js:97:38:97:40 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:99:3:99:16 | [DeclStmt] var arr8 = ... | semmle.label | [DeclStmt] var arr8 = ... |
+| arrays.js:99:7:99:10 | [VarDecl] arr8 | semmle.label | [VarDecl] arr8 |
+| arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | semmle.label | [VariableDeclarator] arr8 = [] |
+| arrays.js:99:14:99:15 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:100:3:100:6 | [VarRef] arr8 | semmle.label | [VarRef] arr8 |
+| arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | semmle.label | [AssignExpr] arr8 = ... ource") |
+| arrays.js:100:3:100:40 | [ExprStmt] arr8 = ... urce"); | semmle.label | [ExprStmt] arr8 = ... urce"); |
+| arrays.js:100:10:100:13 | [VarRef] arr8 | semmle.label | [VarRef] arr8 |
+| arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | semmle.label | [DotExpr] arr8.toSpliced |
+| arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | semmle.label | [MethodCallExpr] arr8.to ... ource") |
+| arrays.js:100:15:100:23 | [Label] toSpliced | semmle.label | [Label] toSpliced |
+| arrays.js:100:25:100:25 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:100:28:100:28 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:100:31:100:38 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:101:3:101:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | semmle.label | [CallExpr] sink(arr8.pop()) |
+| arrays.js:101:3:101:19 | [ExprStmt] sink(arr8.pop()); | semmle.label | [ExprStmt] sink(arr8.pop()); |
+| arrays.js:101:8:101:11 | [VarRef] arr8 | semmle.label | [VarRef] arr8 |
+| arrays.js:101:8:101:15 | [DotExpr] arr8.pop | semmle.label | [DotExpr] arr8.pop |
+| arrays.js:101:8:101:17 | [MethodCallExpr] arr8.pop() | semmle.label | [MethodCallExpr] arr8.pop() |
+| arrays.js:101:13:101:15 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:103:3:103:24 | [DeclStmt] var arr8_variant = ... | semmle.label | [DeclStmt] var arr8_variant = ... |
+| arrays.js:103:7:103:18 | [VarDecl] arr8_variant | semmle.label | [VarDecl] arr8_variant |
+| arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | semmle.label | [VariableDeclarator] arr8_variant = [] |
+| arrays.js:103:22:103:23 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:104:3:104:14 | [VarRef] arr8_variant | semmle.label | [VarRef] arr8_variant |
+| arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | semmle.label | [AssignExpr] arr8_va ... ource") |
+| arrays.js:104:3:104:64 | [ExprStmt] arr8_va ... urce"); | semmle.label | [ExprStmt] arr8_va ... urce"); |
+| arrays.js:104:18:104:29 | [VarRef] arr8_variant | semmle.label | [VarRef] arr8_variant |
+| arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | semmle.label | [DotExpr] arr8_va ... Spliced |
+| arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | semmle.label | [MethodCallExpr] arr8_va ... ource") |
+| arrays.js:104:31:104:39 | [Label] toSpliced | semmle.label | [Label] toSpliced |
+| arrays.js:104:41:104:41 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:104:44:104:44 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:104:47:104:52 | [Literal] "safe" | semmle.label | [Literal] "safe" |
+| arrays.js:104:55:104:62 | [Literal] "source" | semmle.label | [Literal] "source" |
+| arrays.js:105:3:105:14 | [VarRef] arr8_variant | semmle.label | [VarRef] arr8_variant |
+| arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | semmle.label | [DotExpr] arr8_variant.pop |
+| arrays.js:105:3:105:20 | [MethodCallExpr] arr8_variant.pop() | semmle.label | [MethodCallExpr] arr8_variant.pop() |
+| arrays.js:105:3:105:21 | [ExprStmt] arr8_variant.pop(); | semmle.label | [ExprStmt] arr8_variant.pop(); |
+| arrays.js:105:16:105:18 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:106:3:106:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:106:3:106:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:106:8:106:19 | [VarRef] arr8_variant | semmle.label | [VarRef] arr8_variant |
+| arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | semmle.label | [DotExpr] arr8_variant.pop |
+| arrays.js:106:8:106:25 | [MethodCallExpr] arr8_variant.pop() | semmle.label | [MethodCallExpr] arr8_variant.pop() |
+| arrays.js:106:21:106:23 | [Label] pop | semmle.label | [Label] pop |
+| arrays.js:108:3:108:23 | [DeclStmt] var arr8_spread = ... | semmle.label | [DeclStmt] var arr8_spread = ... |
+| arrays.js:108:7:108:17 | [VarDecl] arr8_spread | semmle.label | [VarDecl] arr8_spread |
+| arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | semmle.label | [VariableDeclarator] arr8_spread = [] |
+| arrays.js:108:21:108:22 | [ArrayExpr] [] | semmle.label | [ArrayExpr] [] |
+| arrays.js:109:3:109:13 | [VarRef] arr8_spread | semmle.label | [VarRef] arr8_spread |
+| arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | semmle.label | [AssignExpr] arr8_sp ... ...arr) |
+| arrays.js:109:3:109:52 | [ExprStmt] arr8_sp ... ..arr); | semmle.label | [ExprStmt] arr8_sp ... ..arr); |
+| arrays.js:109:17:109:27 | [VarRef] arr8_spread | semmle.label | [VarRef] arr8_spread |
+| arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | semmle.label | [DotExpr] arr8_sp ... Spliced |
+| arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | semmle.label | [MethodCallExpr] arr8_sp ... ...arr) |
+| arrays.js:109:29:109:37 | [Label] toSpliced | semmle.label | [Label] toSpliced |
+| arrays.js:109:39:109:39 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:109:42:109:42 | [Literal] 0 | semmle.label | [Literal] 0 |
+| arrays.js:109:45:109:50 | [SpreadElement] ...arr | semmle.label | [SpreadElement] ...arr |
+| arrays.js:109:48:109:50 | [VarRef] arr | semmle.label | [VarRef] arr |
+| arrays.js:110:3:110:6 | [VarRef] sink | semmle.label | [VarRef] sink |
+| arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | semmle.label | [CallExpr] sink(ar ... .pop()) |
+| arrays.js:110:3:110:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | [ExprStmt] sink(ar ... pop()); |
+| arrays.js:110:8:110:18 | [VarRef] arr8_spread | semmle.label | [VarRef] arr8_spread |
+| arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | semmle.label | [DotExpr] arr8_spread.pop |
+| arrays.js:110:8:110:24 | [MethodCallExpr] arr8_spread.pop() | semmle.label | [MethodCallExpr] arr8_spread.pop() |
+| arrays.js:110:20:110:22 | [Label] pop | semmle.label | [Label] pop |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
+| file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
 | file://:0:0:0:0 | (Arguments) | semmle.label | (Arguments) |
@@ -488,110 +564,130 @@ nodes
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 | file://:0:0:0:0 | (Parameters) | semmle.label | (Parameters) |
 edges
-| arrays.js:1:1:99:2 | [ParExpr] (functi ... OK }) | arrays.js:1:2:99:1 | [FunctionExpr] functio ... T OK } | semmle.label | 1 |
-| arrays.js:1:1:99:2 | [ParExpr] (functi ... OK }) | arrays.js:1:2:99:1 | [FunctionExpr] functio ... T OK } | semmle.order | 1 |
-| arrays.js:1:1:99:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:99:2 | [ParExpr] (functi ... OK }) | semmle.label | 1 |
-| arrays.js:1:1:99:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:99:2 | [ParExpr] (functi ... OK }) | semmle.order | 1 |
-| arrays.js:1:2:99:1 | [FunctionExpr] functio ... T OK } | arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | semmle.label | 5 |
-| arrays.js:1:2:99:1 | [FunctionExpr] functio ... T OK } | arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | semmle.order | 5 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | 18 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.order | 18 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | 19 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.order | 19 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | 20 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.label | 22 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.order | 22 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.label | 23 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.order | 23 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | 25 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.order | 25 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 26 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 26 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 27 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 27 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | 28 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.order | 28 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | 29 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.order | 29 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 30 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 30 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 31 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 31 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | 32 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.order | 32 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 34 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 34 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | 36 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.order | 36 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 37 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 37 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 39 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 39 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | 40 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.order | 40 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 41 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 41 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | 42 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.order | 42 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 43 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 43 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | 44 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.order | 44 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | 45 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.order | 45 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 46 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 46 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:95:3:95:19 | [ExprStmt] sink(["source"]); | semmle.label | 47 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:95:3:95:19 | [ExprStmt] sink(["source"]); | semmle.order | 47 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:96:3:96:42 | [ExprStmt] sink([" ... pop()); | semmle.label | 48 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:96:3:96:42 | [ExprStmt] sink([" ... pop()); | semmle.order | 48 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:97:3:97:44 | [ExprStmt] sink([" ... pop()); | semmle.label | 49 |
-| arrays.js:1:14:99:1 | [BlockStmt] { let ... T OK } | arrays.js:97:3:97:44 | [ExprStmt] sink([" ... pop()); | semmle.order | 49 |
+| arrays.js:1:1:111:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:111:1 | [FunctionExpr] functio ... OT OK } | semmle.label | 1 |
+| arrays.js:1:1:111:2 | [ParExpr] (functi ... T OK }) | arrays.js:1:2:111:1 | [FunctionExpr] functio ... OT OK } | semmle.order | 1 |
+| arrays.js:1:1:111:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:111:2 | [ParExpr] (functi ... T OK }) | semmle.label | 1 |
+| arrays.js:1:1:111:3 | [ExprStmt] (functi ... OK }); | arrays.js:1:1:111:2 | [ParExpr] (functi ... T OK }) | semmle.order | 1 |
+| arrays.js:1:2:111:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | semmle.label | 5 |
+| arrays.js:1:2:111:1 | [FunctionExpr] functio ... OT OK } | arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | semmle.order | 5 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.label | 1 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | semmle.order | 1 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.label | 2 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:4:3:4:28 | [DeclStmt] var obj = ... | semmle.order | 2 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.label | 3 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:5:3:5:16 | [ExprStmt] sink(obj.foo); | semmle.order | 3 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.label | 4 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:7:3:7:15 | [DeclStmt] var arr = ... | semmle.order | 4 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.label | 5 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:8:3:8:19 | [ExprStmt] arr.push(source); | semmle.order | 5 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.label | 6 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:10:3:12:3 | [ForStmt] for (va ... OK } | semmle.order | 6 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.label | 7 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:15:3:15:30 | [ExprStmt] arr.for ... nk(e)); | semmle.order | 7 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.label | 8 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:16:3:16:26 | [ExprStmt] arr.map ... nk(e)); | semmle.order | 8 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.label | 9 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:18:3:18:53 | [ExprStmt] [1, 2, ... nk(e)); | semmle.order | 9 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.label | 10 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:20:3:20:18 | [ExprStmt] sink(arr.pop()); | semmle.order | 10 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.label | 11 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:22:3:22:24 | [DeclStmt] var arr2 = ... | semmle.order | 11 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.label | 12 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:23:3:23:19 | [ExprStmt] sink(arr2.pop()); | semmle.order | 12 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.label | 13 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:25:3:25:24 | [DeclStmt] var arr3 = ... | semmle.order | 13 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.label | 14 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:26:3:26:19 | [ExprStmt] sink(arr3.pop()); | semmle.order | 14 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.label | 15 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:28:3:28:16 | [DeclStmt] var arr4 = ... | semmle.order | 15 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.label | 16 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:29:3:29:30 | [ExprStmt] arr4.sp ... urce"); | semmle.order | 16 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.label | 17 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:30:3:30:19 | [ExprStmt] sink(arr4.pop()); | semmle.order | 17 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.label | 18 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:32:3:32:24 | [DeclStmt] var arr4_variant = ... | semmle.order | 18 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.label | 19 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:33:3:33:46 | [ExprStmt] arr4_va ... urce"); | semmle.order | 19 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.label | 20 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:34:3:34:21 | [ExprStmt] arr4_variant.pop(); | semmle.order | 20 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 21 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:35:3:35:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 21 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.label | 22 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:37:3:37:23 | [DeclStmt] var arr4_spread = ... | semmle.order | 22 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.label | 23 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:38:3:38:35 | [ExprStmt] arr4_sp ... ..arr); | semmle.order | 23 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | 24 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:39:3:39:26 | [ExprStmt] sink(ar ... pop()); | semmle.order | 24 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.label | 25 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:41:3:41:29 | [DeclStmt] var arr5 = ... | semmle.order | 25 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.label | 26 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:42:3:42:19 | [ExprStmt] sink(arr5.pop()); | semmle.order | 26 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.label | 27 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:44:3:44:28 | [ExprStmt] sink(ar ... pop()); | semmle.order | 27 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.label | 28 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:46:3:46:16 | [DeclStmt] var arr6 = ... | semmle.order | 28 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.label | 29 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:47:3:49:3 | [ForStmt] for (va ... i]; } | semmle.order | 29 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.label | 30 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:50:3:50:19 | [ExprStmt] sink(arr6.pop()); | semmle.order | 30 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.label | 31 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:53:3:56:5 | [ExprStmt] ["sourc ... . }); | semmle.order | 31 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.label | 32 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:58:3:58:15 | [ExprStmt] sink(arr[0]); | semmle.order | 32 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.label | 33 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:60:3:62:3 | [ForOfStmt] for (co ... OK } | semmle.order | 33 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.label | 34 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:64:3:66:3 | [ForOfStmt] for (co ... OK } | semmle.order | 34 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.label | 35 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:68:3:70:3 | [ForOfStmt] for (co ... OK } | semmle.order | 35 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.label | 36 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:72:3:72:16 | [DeclStmt] var arr7 = ... | semmle.order | 36 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.label | 37 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:73:3:73:20 | [ExprStmt] arr7.push(...arr); | semmle.order | 37 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.label | 38 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:74:3:76:3 | [ForOfStmt] for (co ... OK } | semmle.order | 38 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.label | 39 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:78:3:78:42 | [DeclStmt] const arrayFrom = ... | semmle.order | 39 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.label | 40 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:79:3:81:3 | [ForOfStmt] for (co ... OK } | semmle.order | 40 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.label | 41 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:83:3:83:31 | [ExprStmt] sink(ar ... back)); | semmle.order | 41 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.label | 42 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:85:3:85:42 | [DeclStmt] const arrayFind = ... | semmle.order | 42 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.label | 43 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:86:3:86:37 | [ExprStmt] sink(ar ... back)); | semmle.order | 43 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.label | 44 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:88:3:88:31 | [DeclStmt] const uniq = ... | semmle.order | 44 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.label | 45 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:89:3:91:3 | [ForOfStmt] for (co ... OK } | semmle.order | 45 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.label | 46 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:93:3:93:19 | [ExprStmt] sink(arr.at(-1)); | semmle.order | 46 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:19 | [ExprStmt] sink(["source"]); | semmle.label | 47 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:95:3:95:19 | [ExprStmt] sink(["source"]); | semmle.order | 47 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:42 | [ExprStmt] sink([" ... pop()); | semmle.label | 48 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:96:3:96:42 | [ExprStmt] sink([" ... pop()); | semmle.order | 48 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:97:3:97:44 | [ExprStmt] sink([" ... pop()); | semmle.label | 49 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:97:3:97:44 | [ExprStmt] sink([" ... pop()); | semmle.order | 49 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:99:3:99:16 | [DeclStmt] var arr8 = ... | semmle.label | 50 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:99:3:99:16 | [DeclStmt] var arr8 = ... | semmle.order | 50 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:100:3:100:40 | [ExprStmt] arr8 = ... urce"); | semmle.label | 51 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:100:3:100:40 | [ExprStmt] arr8 = ... urce"); | semmle.order | 51 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:101:3:101:19 | [ExprStmt] sink(arr8.pop()); | semmle.label | 52 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:101:3:101:19 | [ExprStmt] sink(arr8.pop()); | semmle.order | 52 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:103:3:103:24 | [DeclStmt] var arr8_variant = ... | semmle.label | 53 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:103:3:103:24 | [DeclStmt] var arr8_variant = ... | semmle.order | 53 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:104:3:104:64 | [ExprStmt] arr8_va ... urce"); | semmle.label | 54 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:104:3:104:64 | [ExprStmt] arr8_va ... urce"); | semmle.order | 54 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:105:3:105:21 | [ExprStmt] arr8_variant.pop(); | semmle.label | 55 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:105:3:105:21 | [ExprStmt] arr8_variant.pop(); | semmle.order | 55 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:106:3:106:27 | [ExprStmt] sink(ar ... pop()); | semmle.label | 56 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:106:3:106:27 | [ExprStmt] sink(ar ... pop()); | semmle.order | 56 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:108:3:108:23 | [DeclStmt] var arr8_spread = ... | semmle.label | 57 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:108:3:108:23 | [DeclStmt] var arr8_spread = ... | semmle.order | 57 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:109:3:109:52 | [ExprStmt] arr8_sp ... ..arr); | semmle.label | 58 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:109:3:109:52 | [ExprStmt] arr8_sp ... ..arr); | semmle.order | 58 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:110:3:110:26 | [ExprStmt] sink(ar ... pop()); | semmle.label | 59 |
+| arrays.js:1:14:111:1 | [BlockStmt] { let ... OT OK } | arrays.js:110:3:110:26 | [ExprStmt] sink(ar ... pop()); | semmle.order | 59 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.label | 1 |
 | arrays.js:2:3:2:24 | [DeclStmt] let source = ... | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | semmle.order | 1 |
 | arrays.js:2:7:2:23 | [VariableDeclarator] source = "source" | arrays.js:2:7:2:12 | [VarDecl] source | semmle.label | 1 |
@@ -1322,6 +1418,112 @@ edges
 | arrays.js:97:33:97:35 | [UnaryExpr] !!x | arrays.js:97:34:97:35 | [UnaryExpr] !x | semmle.order | 1 |
 | arrays.js:97:34:97:35 | [UnaryExpr] !x | arrays.js:97:35:97:35 | [VarRef] x | semmle.label | 1 |
 | arrays.js:97:34:97:35 | [UnaryExpr] !x | arrays.js:97:35:97:35 | [VarRef] x | semmle.order | 1 |
+| arrays.js:99:3:99:16 | [DeclStmt] var arr8 = ... | arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | semmle.label | 1 |
+| arrays.js:99:3:99:16 | [DeclStmt] var arr8 = ... | arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | semmle.order | 1 |
+| arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | arrays.js:99:7:99:10 | [VarDecl] arr8 | semmle.label | 1 |
+| arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | arrays.js:99:7:99:10 | [VarDecl] arr8 | semmle.order | 1 |
+| arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | arrays.js:99:14:99:15 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:99:7:99:15 | [VariableDeclarator] arr8 = [] | arrays.js:99:14:99:15 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | arrays.js:100:3:100:6 | [VarRef] arr8 | semmle.label | 1 |
+| arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | arrays.js:100:3:100:6 | [VarRef] arr8 | semmle.order | 1 |
+| arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | semmle.label | 2 |
+| arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | semmle.order | 2 |
+| arrays.js:100:3:100:40 | [ExprStmt] arr8 = ... urce"); | arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | semmle.label | 1 |
+| arrays.js:100:3:100:40 | [ExprStmt] arr8 = ... urce"); | arrays.js:100:3:100:39 | [AssignExpr] arr8 = ... ource") | semmle.order | 1 |
+| arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | arrays.js:100:10:100:13 | [VarRef] arr8 | semmle.label | 1 |
+| arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | arrays.js:100:10:100:13 | [VarRef] arr8 | semmle.order | 1 |
+| arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | arrays.js:100:15:100:23 | [Label] toSpliced | semmle.label | 2 |
+| arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | arrays.js:100:15:100:23 | [Label] toSpliced | semmle.order | 2 |
+| arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | semmle.label | 0 |
+| arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | arrays.js:100:10:100:23 | [DotExpr] arr8.toSpliced | semmle.order | 0 |
+| arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:100:10:100:39 | [MethodCallExpr] arr8.to ... ource") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | arrays.js:101:3:101:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | arrays.js:101:3:101:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:101:3:101:19 | [ExprStmt] sink(arr8.pop()); | arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | semmle.label | 1 |
+| arrays.js:101:3:101:19 | [ExprStmt] sink(arr8.pop()); | arrays.js:101:3:101:18 | [CallExpr] sink(arr8.pop()) | semmle.order | 1 |
+| arrays.js:101:8:101:15 | [DotExpr] arr8.pop | arrays.js:101:8:101:11 | [VarRef] arr8 | semmle.label | 1 |
+| arrays.js:101:8:101:15 | [DotExpr] arr8.pop | arrays.js:101:8:101:11 | [VarRef] arr8 | semmle.order | 1 |
+| arrays.js:101:8:101:15 | [DotExpr] arr8.pop | arrays.js:101:13:101:15 | [Label] pop | semmle.label | 2 |
+| arrays.js:101:8:101:15 | [DotExpr] arr8.pop | arrays.js:101:13:101:15 | [Label] pop | semmle.order | 2 |
+| arrays.js:101:8:101:17 | [MethodCallExpr] arr8.pop() | arrays.js:101:8:101:15 | [DotExpr] arr8.pop | semmle.label | 0 |
+| arrays.js:101:8:101:17 | [MethodCallExpr] arr8.pop() | arrays.js:101:8:101:15 | [DotExpr] arr8.pop | semmle.order | 0 |
+| arrays.js:103:3:103:24 | [DeclStmt] var arr8_variant = ... | arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | semmle.label | 1 |
+| arrays.js:103:3:103:24 | [DeclStmt] var arr8_variant = ... | arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | semmle.order | 1 |
+| arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | arrays.js:103:7:103:18 | [VarDecl] arr8_variant | semmle.label | 1 |
+| arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | arrays.js:103:7:103:18 | [VarDecl] arr8_variant | semmle.order | 1 |
+| arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | arrays.js:103:22:103:23 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:103:7:103:23 | [VariableDeclarator] arr8_variant = [] | arrays.js:103:22:103:23 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | arrays.js:104:3:104:14 | [VarRef] arr8_variant | semmle.label | 1 |
+| arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | arrays.js:104:3:104:14 | [VarRef] arr8_variant | semmle.order | 1 |
+| arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | semmle.label | 2 |
+| arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | semmle.order | 2 |
+| arrays.js:104:3:104:64 | [ExprStmt] arr8_va ... urce"); | arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | semmle.label | 1 |
+| arrays.js:104:3:104:64 | [ExprStmt] arr8_va ... urce"); | arrays.js:104:3:104:63 | [AssignExpr] arr8_va ... ource") | semmle.order | 1 |
+| arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | arrays.js:104:18:104:29 | [VarRef] arr8_variant | semmle.label | 1 |
+| arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | arrays.js:104:18:104:29 | [VarRef] arr8_variant | semmle.order | 1 |
+| arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | arrays.js:104:31:104:39 | [Label] toSpliced | semmle.label | 2 |
+| arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | arrays.js:104:31:104:39 | [Label] toSpliced | semmle.order | 2 |
+| arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | semmle.label | 0 |
+| arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | arrays.js:104:18:104:39 | [DotExpr] arr8_va ... Spliced | semmle.order | 0 |
+| arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:104:18:104:63 | [MethodCallExpr] arr8_va ... ource") | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | arrays.js:105:3:105:14 | [VarRef] arr8_variant | semmle.label | 1 |
+| arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | arrays.js:105:3:105:14 | [VarRef] arr8_variant | semmle.order | 1 |
+| arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | arrays.js:105:16:105:18 | [Label] pop | semmle.label | 2 |
+| arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | arrays.js:105:16:105:18 | [Label] pop | semmle.order | 2 |
+| arrays.js:105:3:105:20 | [MethodCallExpr] arr8_variant.pop() | arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | semmle.label | 0 |
+| arrays.js:105:3:105:20 | [MethodCallExpr] arr8_variant.pop() | arrays.js:105:3:105:18 | [DotExpr] arr8_variant.pop | semmle.order | 0 |
+| arrays.js:105:3:105:21 | [ExprStmt] arr8_variant.pop(); | arrays.js:105:3:105:20 | [MethodCallExpr] arr8_variant.pop() | semmle.label | 1 |
+| arrays.js:105:3:105:21 | [ExprStmt] arr8_variant.pop(); | arrays.js:105:3:105:20 | [MethodCallExpr] arr8_variant.pop() | semmle.order | 1 |
+| arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | arrays.js:106:3:106:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | arrays.js:106:3:106:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:106:3:106:27 | [ExprStmt] sink(ar ... pop()); | arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:106:3:106:27 | [ExprStmt] sink(ar ... pop()); | arrays.js:106:3:106:26 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | arrays.js:106:8:106:19 | [VarRef] arr8_variant | semmle.label | 1 |
+| arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | arrays.js:106:8:106:19 | [VarRef] arr8_variant | semmle.order | 1 |
+| arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | arrays.js:106:21:106:23 | [Label] pop | semmle.label | 2 |
+| arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | arrays.js:106:21:106:23 | [Label] pop | semmle.order | 2 |
+| arrays.js:106:8:106:25 | [MethodCallExpr] arr8_variant.pop() | arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | semmle.label | 0 |
+| arrays.js:106:8:106:25 | [MethodCallExpr] arr8_variant.pop() | arrays.js:106:8:106:23 | [DotExpr] arr8_variant.pop | semmle.order | 0 |
+| arrays.js:108:3:108:23 | [DeclStmt] var arr8_spread = ... | arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | semmle.label | 1 |
+| arrays.js:108:3:108:23 | [DeclStmt] var arr8_spread = ... | arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | semmle.order | 1 |
+| arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | arrays.js:108:7:108:17 | [VarDecl] arr8_spread | semmle.label | 1 |
+| arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | arrays.js:108:7:108:17 | [VarDecl] arr8_spread | semmle.order | 1 |
+| arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | arrays.js:108:21:108:22 | [ArrayExpr] [] | semmle.label | 2 |
+| arrays.js:108:7:108:22 | [VariableDeclarator] arr8_spread = [] | arrays.js:108:21:108:22 | [ArrayExpr] [] | semmle.order | 2 |
+| arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | arrays.js:109:3:109:13 | [VarRef] arr8_spread | semmle.label | 1 |
+| arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | arrays.js:109:3:109:13 | [VarRef] arr8_spread | semmle.order | 1 |
+| arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | semmle.label | 2 |
+| arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | semmle.order | 2 |
+| arrays.js:109:3:109:52 | [ExprStmt] arr8_sp ... ..arr); | arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | semmle.label | 1 |
+| arrays.js:109:3:109:52 | [ExprStmt] arr8_sp ... ..arr); | arrays.js:109:3:109:51 | [AssignExpr] arr8_sp ... ...arr) | semmle.order | 1 |
+| arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | arrays.js:109:17:109:27 | [VarRef] arr8_spread | semmle.label | 1 |
+| arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | arrays.js:109:17:109:27 | [VarRef] arr8_spread | semmle.order | 1 |
+| arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | arrays.js:109:29:109:37 | [Label] toSpliced | semmle.label | 2 |
+| arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | arrays.js:109:29:109:37 | [Label] toSpliced | semmle.order | 2 |
+| arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | semmle.label | 0 |
+| arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | arrays.js:109:17:109:37 | [DotExpr] arr8_sp ... Spliced | semmle.order | 0 |
+| arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:109:17:109:51 | [MethodCallExpr] arr8_sp ... ...arr) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:109:45:109:50 | [SpreadElement] ...arr | arrays.js:109:48:109:50 | [VarRef] arr | semmle.label | 1 |
+| arrays.js:109:45:109:50 | [SpreadElement] ...arr | arrays.js:109:48:109:50 | [VarRef] arr | semmle.order | 1 |
+| arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | arrays.js:110:3:110:6 | [VarRef] sink | semmle.label | 0 |
+| arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | arrays.js:110:3:110:6 | [VarRef] sink | semmle.order | 0 |
+| arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.label | 1 |
+| arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | file://:0:0:0:0 | (Arguments) | semmle.order | 1 |
+| arrays.js:110:3:110:26 | [ExprStmt] sink(ar ... pop()); | arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | semmle.label | 1 |
+| arrays.js:110:3:110:26 | [ExprStmt] sink(ar ... pop()); | arrays.js:110:3:110:25 | [CallExpr] sink(ar ... .pop()) | semmle.order | 1 |
+| arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | arrays.js:110:8:110:18 | [VarRef] arr8_spread | semmle.label | 1 |
+| arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | arrays.js:110:8:110:18 | [VarRef] arr8_spread | semmle.order | 1 |
+| arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | arrays.js:110:20:110:22 | [Label] pop | semmle.label | 2 |
+| arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | arrays.js:110:20:110:22 | [Label] pop | semmle.order | 2 |
+| arrays.js:110:8:110:24 | [MethodCallExpr] arr8_spread.pop() | arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | semmle.label | 0 |
+| arrays.js:110:8:110:24 | [MethodCallExpr] arr8_spread.pop() | arrays.js:110:8:110:22 | [DotExpr] arr8_spread.pop | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:5:8:5:14 | [DotExpr] obj.foo | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:8:12:8:17 | [VarRef] source | semmle.label | 0 |
@@ -1442,6 +1644,32 @@ edges
 | file://:0:0:0:0 | (Arguments) | arrays.js:97:8:97:42 | [MethodCallExpr] ["sourc ... ).pop() | semmle.order | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:97:26:97:35 | [ArrowFunctionExpr] (x) => !!x | semmle.label | 0 |
 | file://:0:0:0:0 | (Arguments) | arrays.js:97:26:97:35 | [ArrowFunctionExpr] (x) => !!x | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:25:100:25 | [Literal] 0 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:25:100:25 | [Literal] 0 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:28:100:28 | [Literal] 0 | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:28:100:28 | [Literal] 0 | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:31:100:38 | [Literal] "source" | semmle.label | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:100:31:100:38 | [Literal] "source" | semmle.order | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:101:8:101:17 | [MethodCallExpr] arr8.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:101:8:101:17 | [MethodCallExpr] arr8.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:41:104:41 | [Literal] 0 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:41:104:41 | [Literal] 0 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:44:104:44 | [Literal] 0 | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:44:104:44 | [Literal] 0 | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:47:104:52 | [Literal] "safe" | semmle.label | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:47:104:52 | [Literal] "safe" | semmle.order | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:55:104:62 | [Literal] "source" | semmle.label | 3 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:104:55:104:62 | [Literal] "source" | semmle.order | 3 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:106:8:106:25 | [MethodCallExpr] arr8_variant.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:106:8:106:25 | [MethodCallExpr] arr8_variant.pop() | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:39:109:39 | [Literal] 0 | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:39:109:39 | [Literal] 0 | semmle.order | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:42:109:42 | [Literal] 0 | semmle.label | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:42:109:42 | [Literal] 0 | semmle.order | 1 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:45:109:50 | [SpreadElement] ...arr | semmle.label | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:109:45:109:50 | [SpreadElement] ...arr | semmle.order | 2 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:110:8:110:24 | [MethodCallExpr] arr8_spread.pop() | semmle.label | 0 |
+| file://:0:0:0:0 | (Arguments) | arrays.js:110:8:110:24 | [MethodCallExpr] arr8_spread.pop() | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.label | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:15:16:15:16 | [SimpleParameter] e | semmle.order | 0 |
 | file://:0:0:0:0 | (Parameters) | arrays.js:16:12:16:12 | [SimpleParameter] e | semmle.label | 0 |

--- a/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
+++ b/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
@@ -198,3 +198,5 @@ multipleArgumentCall
 | tst.js:266:3:266:6 | map3 | tst.js:266:3:266:14 | map3.forEach (as accessor call) | Multiple calls for argument node. |
 | tst.js:266:3:266:6 | map3 | tst.js:266:3:266:36 | map3.fo ... value)) | Multiple calls for argument node. |
 lambdaCallEnclosingCallableMismatch
+speculativeStepAlreadyHasModel
+| tst.js:223:39:223:44 | array4 | tst.js:223:12:223:45 | Array.p ... array4) | dispatch |

--- a/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
+++ b/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
@@ -199,4 +199,3 @@ multipleArgumentCall
 | tst.js:266:3:266:6 | map3 | tst.js:266:3:266:36 | map3.fo ... value)) | Multiple calls for argument node. |
 lambdaCallEnclosingCallableMismatch
 speculativeStepAlreadyHasModel
-| tst.js:223:39:223:44 | array4 | tst.js:223:12:223:45 | Array.p ... array4) | dispatch |

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -52,6 +52,11 @@ flow
 | array-mutation.js:31:33:31:40 | source() | array-mutation.js:32:8:32:8 | h |
 | array-mutation.js:35:36:35:43 | source() | array-mutation.js:36:8:36:8 | i |
 | array-mutation.js:39:17:39:24 | source() | array-mutation.js:40:8:40:8 | j |
+| array-mutation.js:43:36:43:43 | source() | array-mutation.js:45:8:45:15 | kSpliced |
+| array-mutation.js:48:25:48:32 | source() | array-mutation.js:49:8:49:8 | l |
+| array-mutation.js:68:21:68:28 | source() | array-mutation.js:69:8:69:8 | q |
+| array-mutation.js:72:39:72:46 | source() | array-mutation.js:73:8:73:15 | rSpliced |
+| array-mutation.js:75:28:75:35 | source() | array-mutation.js:76:8:76:8 | r |
 | arrays-init.js:2:16:2:23 | source() | arrays-init.js:17:8:17:13 | arr[1] |
 | arrays-init.js:2:16:2:23 | source() | arrays-init.js:22:8:22:13 | arr[6] |
 | arrays-init.js:2:16:2:23 | source() | arrays-init.js:28:8:28:13 | arr[1] |
@@ -296,6 +301,14 @@ flow
 | tst.js:2:13:2:20 | source() | tst.js:48:10:48:22 | new Buffer(x) |
 | tst.js:2:13:2:20 | source() | tst.js:51:10:51:31 | seriali ... ript(x) |
 | tst.js:2:13:2:20 | source() | tst.js:54:14:54:19 | unsafe |
+| tst.js:2:13:2:20 | source() | tst.js:61:10:61:20 | x.reverse() |
+| tst.js:2:13:2:20 | source() | tst.js:62:10:62:22 | x.toSpliced() |
+| tst.js:2:13:2:20 | source() | tst.js:64:10:64:21 | x.toSorted() |
+| tst.js:2:13:2:20 | source() | tst.js:66:10:66:16 | xSorted |
+| tst.js:2:13:2:20 | source() | tst.js:68:10:68:23 | x.toReversed() |
+| tst.js:2:13:2:20 | source() | tst.js:70:10:70:18 | xReversed |
+| tst.js:2:13:2:20 | source() | tst.js:72:10:72:17 | x.with() |
+| tst.js:2:13:2:20 | source() | tst.js:74:10:74:14 | xWith |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:8:10:8:17 | captured |
 | use-use-after-implicit-read.js:7:17:7:24 | source() | use-use-after-implicit-read.js:15:10:15:10 | x |
 | xml.js:5:18:5:25 | source() | xml.js:8:14:8:17 | text |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -313,6 +313,11 @@ nodes
 | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | semmle.label | pathMod ... t('/')) |
 | normalizedPaths.js:408:38:408:48 | req.query.x | semmle.label | req.query.x |
 | normalizedPaths.js:408:38:408:59 | req.que ... it('/') | semmle.label | req.que ... it('/') |
+| normalizedPaths.js:412:7:412:46 | path | semmle.label | path |
+| normalizedPaths.js:412:14:412:46 | pathMod ... uery.x) | semmle.label | pathMod ... uery.x) |
+| normalizedPaths.js:412:35:412:45 | req.query.x | semmle.label | req.query.x |
+| normalizedPaths.js:415:19:415:22 | path | semmle.label | path |
+| normalizedPaths.js:426:21:426:24 | path | semmle.label | path |
 | other-fs-libraries.js:9:7:9:48 | path | semmle.label | path |
 | other-fs-libraries.js:9:14:9:37 | url.par ... , true) | semmle.label | url.par ... , true) |
 | other-fs-libraries.js:9:14:9:43 | url.par ... ).query | semmle.label | url.par ... ).query |
@@ -760,6 +765,10 @@ edges
 | normalizedPaths.js:407:45:407:66 | req.que ... it('/') | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) | provenance | Config |
 | normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:38:408:59 | req.que ... it('/') | provenance | Config |
 | normalizedPaths.js:408:38:408:59 | req.que ... it('/') | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | provenance | Config |
+| normalizedPaths.js:412:7:412:46 | path | normalizedPaths.js:415:19:415:22 | path | provenance |  |
+| normalizedPaths.js:412:7:412:46 | path | normalizedPaths.js:426:21:426:24 | path | provenance |  |
+| normalizedPaths.js:412:14:412:46 | pathMod ... uery.x) | normalizedPaths.js:412:7:412:46 | path | provenance |  |
+| normalizedPaths.js:412:35:412:45 | req.query.x | normalizedPaths.js:412:14:412:46 | pathMod ... uery.x) | provenance | Config |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:11:19:11:22 | path | provenance |  |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:12:27:12:30 | path | provenance |  |
 | other-fs-libraries.js:9:7:9:48 | path | other-fs-libraries.js:13:24:13:27 | path | provenance |  |
@@ -1023,6 +1032,8 @@ subpaths
 | normalizedPaths.js:399:21:399:24 | path | normalizedPaths.js:385:35:385:45 | req.query.x | normalizedPaths.js:399:21:399:24 | path | This path depends on a $@. | normalizedPaths.js:385:35:385:45 | req.query.x | user-provided value |
 | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) | normalizedPaths.js:407:45:407:55 | req.query.x | normalizedPaths.js:407:19:407:67 | pathMod ... t('/')) | This path depends on a $@. | normalizedPaths.js:407:45:407:55 | req.query.x | user-provided value |
 | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | normalizedPaths.js:408:38:408:48 | req.query.x | normalizedPaths.js:408:19:408:60 | pathMod ... t('/')) | This path depends on a $@. | normalizedPaths.js:408:38:408:48 | req.query.x | user-provided value |
+| normalizedPaths.js:415:19:415:22 | path | normalizedPaths.js:412:35:412:45 | req.query.x | normalizedPaths.js:415:19:415:22 | path | This path depends on a $@. | normalizedPaths.js:412:35:412:45 | req.query.x | user-provided value |
+| normalizedPaths.js:426:21:426:24 | path | normalizedPaths.js:412:35:412:45 | req.query.x | normalizedPaths.js:426:21:426:24 | path | This path depends on a $@. | normalizedPaths.js:412:35:412:45 | req.query.x | user-provided value |
 | other-fs-libraries.js:11:19:11:22 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:11:19:11:22 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |
 | other-fs-libraries.js:12:27:12:30 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:12:27:12:30 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |
 | other-fs-libraries.js:13:24:13:27 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:13:24:13:27 | path | This path depends on a $@. | other-fs-libraries.js:9:24:9:30 | req.url | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/IndirectCommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/IndirectCommandInjection.expected
@@ -94,27 +94,19 @@ edges
 | command-line-parameter-command-injection.js:71:20:71:40 | require ... ').argv | command-line-parameter-command-injection.js:71:6:71:16 | [...taint4] | provenance |  |
 | command-line-parameter-command-injection.js:72:22:72:27 | taint4 | command-line-parameter-command-injection.js:72:10:72:27 | "cmd.sh " + taint4 | provenance |  |
 | command-line-parameter-command-injection.js:76:8:76:35 | argv | command-line-parameter-command-injection.js:79:31:79:34 | argv | provenance |  |
-| command-line-parameter-command-injection.js:76:8:76:35 | argv [ArrayElement] | command-line-parameter-command-injection.js:79:31:79:34 | argv [ArrayElement] | provenance |  |
 | command-line-parameter-command-injection.js:76:15:76:26 | process.argv | command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) | provenance |  |
-| command-line-parameter-command-injection.js:76:15:76:26 | process.argv | command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) [ArrayElement] | provenance |  |
 | command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) | command-line-parameter-command-injection.js:76:8:76:35 | argv | provenance |  |
-| command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) [ArrayElement] | command-line-parameter-command-injection.js:76:8:76:35 | argv [ArrayElement] | provenance |  |
 | command-line-parameter-command-injection.js:79:22:79:35 | minimist(argv) | command-line-parameter-command-injection.js:79:10:79:39 | "cmd.sh ... gv).foo | provenance |  |
-| command-line-parameter-command-injection.js:79:31:79:34 | argv | command-line-parameter-command-injection.js:79:22:79:35 | minimist(argv) | provenance | Config |
-| command-line-parameter-command-injection.js:79:31:79:34 | argv [ArrayElement] | command-line-parameter-command-injection.js:79:22:79:35 | minimist(argv) | provenance | Config |
+| command-line-parameter-command-injection.js:79:31:79:34 | argv | command-line-parameter-command-injection.js:79:22:79:35 | minimist(argv) | provenance |  |
 | command-line-parameter-command-injection.js:82:22:82:50 | subarg( ... ice(2)) | command-line-parameter-command-injection.js:82:10:82:54 | "cmd.sh ... 2)).foo | provenance |  |
 | command-line-parameter-command-injection.js:82:29:82:40 | process.argv | command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) | provenance |  |
-| command-line-parameter-command-injection.js:82:29:82:40 | process.argv | command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) [ArrayElement] | provenance |  |
-| command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) | command-line-parameter-command-injection.js:82:22:82:50 | subarg( ... ice(2)) | provenance | Config |
-| command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) [ArrayElement] | command-line-parameter-command-injection.js:82:22:82:50 | subarg( ... ice(2)) | provenance | Config |
+| command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) | command-line-parameter-command-injection.js:82:22:82:50 | subarg( ... ice(2)) | provenance |  |
 | command-line-parameter-command-injection.js:85:22:85:55 | yargsPa ... ice(2)) | command-line-parameter-command-injection.js:85:10:85:59 | "cmd.sh ... 2)).foo | provenance |  |
 | command-line-parameter-command-injection.js:85:34:85:45 | process.argv | command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) | provenance |  |
-| command-line-parameter-command-injection.js:85:34:85:45 | process.argv | command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) [ArrayElement] | provenance |  |
-| command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) | command-line-parameter-command-injection.js:85:22:85:55 | yargsPa ... ice(2)) | provenance | Config |
-| command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) [ArrayElement] | command-line-parameter-command-injection.js:85:22:85:55 | yargsPa ... ice(2)) | provenance | Config |
+| command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) | command-line-parameter-command-injection.js:85:22:85:55 | yargsPa ... ice(2)) | provenance |  |
 | command-line-parameter-command-injection.js:88:6:88:37 | flags | command-line-parameter-command-injection.js:89:22:89:26 | flags | provenance |  |
 | command-line-parameter-command-injection.js:88:14:88:37 | args.pa ... s.argv) | command-line-parameter-command-injection.js:88:6:88:37 | flags | provenance |  |
-| command-line-parameter-command-injection.js:88:25:88:36 | process.argv | command-line-parameter-command-injection.js:88:14:88:37 | args.pa ... s.argv) | provenance | Config |
+| command-line-parameter-command-injection.js:88:25:88:36 | process.argv | command-line-parameter-command-injection.js:88:14:88:37 | args.pa ... s.argv) | provenance |  |
 | command-line-parameter-command-injection.js:89:22:89:26 | flags | command-line-parameter-command-injection.js:89:10:89:30 | "cmd.sh ... ags.foo | provenance |  |
 | command-line-parameter-command-injection.js:91:6:91:38 | flags | command-line-parameter-command-injection.js:92:22:92:26 | flags | provenance |  |
 | command-line-parameter-command-injection.js:91:14:91:38 | require ... .spec}) | command-line-parameter-command-injection.js:91:6:91:38 | flags | provenance |  |
@@ -245,24 +237,19 @@ nodes
 | command-line-parameter-command-injection.js:72:10:72:27 | "cmd.sh " + taint4 | semmle.label | "cmd.sh " + taint4 |
 | command-line-parameter-command-injection.js:72:22:72:27 | taint4 | semmle.label | taint4 |
 | command-line-parameter-command-injection.js:76:8:76:35 | argv | semmle.label | argv |
-| command-line-parameter-command-injection.js:76:8:76:35 | argv [ArrayElement] | semmle.label | argv [ArrayElement] |
 | command-line-parameter-command-injection.js:76:15:76:26 | process.argv | semmle.label | process.argv |
 | command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) | semmle.label | process ... lice(2) |
-| command-line-parameter-command-injection.js:76:15:76:35 | process ... lice(2) [ArrayElement] | semmle.label | process ... lice(2) [ArrayElement] |
 | command-line-parameter-command-injection.js:79:10:79:39 | "cmd.sh ... gv).foo | semmle.label | "cmd.sh ... gv).foo |
 | command-line-parameter-command-injection.js:79:22:79:35 | minimist(argv) | semmle.label | minimist(argv) |
 | command-line-parameter-command-injection.js:79:31:79:34 | argv | semmle.label | argv |
-| command-line-parameter-command-injection.js:79:31:79:34 | argv [ArrayElement] | semmle.label | argv [ArrayElement] |
 | command-line-parameter-command-injection.js:82:10:82:54 | "cmd.sh ... 2)).foo | semmle.label | "cmd.sh ... 2)).foo |
 | command-line-parameter-command-injection.js:82:22:82:50 | subarg( ... ice(2)) | semmle.label | subarg( ... ice(2)) |
 | command-line-parameter-command-injection.js:82:29:82:40 | process.argv | semmle.label | process.argv |
 | command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) | semmle.label | process ... lice(2) |
-| command-line-parameter-command-injection.js:82:29:82:49 | process ... lice(2) [ArrayElement] | semmle.label | process ... lice(2) [ArrayElement] |
 | command-line-parameter-command-injection.js:85:10:85:59 | "cmd.sh ... 2)).foo | semmle.label | "cmd.sh ... 2)).foo |
 | command-line-parameter-command-injection.js:85:22:85:55 | yargsPa ... ice(2)) | semmle.label | yargsPa ... ice(2)) |
 | command-line-parameter-command-injection.js:85:34:85:45 | process.argv | semmle.label | process.argv |
 | command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) | semmle.label | process ... lice(2) |
-| command-line-parameter-command-injection.js:85:34:85:54 | process ... lice(2) [ArrayElement] | semmle.label | process ... lice(2) [ArrayElement] |
 | command-line-parameter-command-injection.js:88:6:88:37 | flags | semmle.label | flags |
 | command-line-parameter-command-injection.js:88:14:88:37 | args.pa ... s.argv) | semmle.label | args.pa ... s.argv) |
 | command-line-parameter-command-injection.js:88:25:88:36 | process.argv | semmle.label | process.argv |

--- a/javascript/ql/test/query-tests/Security/CWE-089/local-threat-source/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/local-threat-source/SqlInjection.expected
@@ -1,17 +1,12 @@
 nodes
-| test.js:4:5:4:29 | temp |
-| test.js:4:12:4:22 | process.env |
-| test.js:4:12:4:22 | process.env |
-| test.js:4:12:4:29 | process.env['foo'] |
-| test.js:7:14:7:61 | 'SELECT ...  + temp |
-| test.js:7:14:7:61 | 'SELECT ...  + temp |
-| test.js:7:58:7:61 | temp |
+| test.js:4:5:4:29 | temp | semmle.label | temp |
+| test.js:4:12:4:22 | process.env | semmle.label | process.env |
+| test.js:7:14:7:61 | 'SELECT ...  + temp | semmle.label | 'SELECT ...  + temp |
+| test.js:7:58:7:61 | temp | semmle.label | temp |
 edges
-| test.js:4:5:4:29 | temp | test.js:7:58:7:61 | temp |
-| test.js:4:12:4:22 | process.env | test.js:4:12:4:29 | process.env['foo'] |
-| test.js:4:12:4:22 | process.env | test.js:4:12:4:29 | process.env['foo'] |
-| test.js:4:12:4:29 | process.env['foo'] | test.js:4:5:4:29 | temp |
-| test.js:7:58:7:61 | temp | test.js:7:14:7:61 | 'SELECT ...  + temp |
-| test.js:7:58:7:61 | temp | test.js:7:14:7:61 | 'SELECT ...  + temp |
+| test.js:4:5:4:29 | temp | test.js:7:58:7:61 | temp | provenance |  |
+| test.js:4:12:4:22 | process.env | test.js:4:5:4:29 | temp | provenance |  |
+| test.js:7:58:7:61 | temp | test.js:7:14:7:61 | 'SELECT ...  + temp | provenance |  |
+subpaths
 #select
 | test.js:7:14:7:61 | 'SELECT ...  + temp | test.js:4:12:4:22 | process.env | test.js:7:14:7:61 | 'SELECT ...  + temp | This query string depends on a $@. | test.js:4:12:4:22 | process.env | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-117/LogInjection.expected
@@ -64,6 +64,14 @@ edges
 | logInjectionBad.js:87:5:94:5 | functio ... ;\\n    } [username] | logInjectionBad.js:91:26:91:33 | username | provenance |  |
 | logInjectionBad.js:96:5:103:5 | functio ... ;\\n    } [username] | logInjectionBad.js:99:26:99:33 | username | provenance |  |
 | logInjectionBad.js:105:5:118:5 | functio ... ;\\n    } [username] | logInjectionBad.js:113:37:113:44 | username | provenance |  |
+| logInjectionBad.js:122:9:122:58 | username | logInjectionBad.js:123:20:123:27 | username | provenance |  |
+| logInjectionBad.js:122:20:122:43 | url.par ... , true) | logInjectionBad.js:122:9:122:58 | username | provenance |  |
+| logInjectionBad.js:122:30:122:36 | req.url | logInjectionBad.js:122:20:122:43 | url.par ... , true) | provenance |  |
+| logInjectionBad.js:123:9:123:46 | otherStr | logInjectionBad.js:124:17:124:24 | otherStr | provenance |  |
+| logInjectionBad.js:123:20:123:27 | username | logInjectionBad.js:123:20:123:43 | usernam ... (/.*/g) | provenance |  |
+| logInjectionBad.js:123:20:123:43 | usernam ... (/.*/g) | logInjectionBad.js:123:9:123:46 | otherStr | provenance |  |
+| logInjectionBad.js:128:20:128:43 | url.par ... , true) | logInjectionBad.js:129:42:129:50 | RegExp.$1 | provenance |  |
+| logInjectionBad.js:128:30:128:36 | req.url | logInjectionBad.js:128:20:128:43 | url.par ... , true) | provenance |  |
 nodes
 | logInjectionBad.js:7:25:7:32 | username | semmle.label | username |
 | logInjectionBad.js:8:38:8:45 | username | semmle.label | username |
@@ -134,6 +142,16 @@ nodes
 | logInjectionBad.js:99:26:99:33 | username | semmle.label | username |
 | logInjectionBad.js:105:5:118:5 | functio ... ;\\n    } [username] | semmle.label | functio ... ;\\n    } [username] |
 | logInjectionBad.js:113:37:113:44 | username | semmle.label | username |
+| logInjectionBad.js:122:9:122:58 | username | semmle.label | username |
+| logInjectionBad.js:122:20:122:43 | url.par ... , true) | semmle.label | url.par ... , true) |
+| logInjectionBad.js:122:30:122:36 | req.url | semmle.label | req.url |
+| logInjectionBad.js:123:9:123:46 | otherStr | semmle.label | otherStr |
+| logInjectionBad.js:123:20:123:27 | username | semmle.label | username |
+| logInjectionBad.js:123:20:123:43 | usernam ... (/.*/g) | semmle.label | usernam ... (/.*/g) |
+| logInjectionBad.js:124:17:124:24 | otherStr | semmle.label | otherStr |
+| logInjectionBad.js:128:20:128:43 | url.par ... , true) | semmle.label | url.par ... , true) |
+| logInjectionBad.js:128:30:128:36 | req.url | semmle.label | req.url |
+| logInjectionBad.js:129:42:129:50 | RegExp.$1 | semmle.label | RegExp.$1 |
 subpaths
 | logInjectionBad.js:28:24:28:31 | username | logInjectionBad.js:7:25:7:32 | username | logInjectionBad.js:8:38:8:45 | username | logInjectionBad.js:28:9:28:32 | exceptional return of check_u ... ername) |
 #select
@@ -158,3 +176,5 @@ subpaths
 | logInjectionBad.js:91:26:91:33 | username | logInjectionBad.js:72:23:72:29 | req.url | logInjectionBad.js:91:26:91:33 | username | Log entry depends on a $@. | logInjectionBad.js:72:23:72:29 | req.url | user-provided value |
 | logInjectionBad.js:99:26:99:33 | username | logInjectionBad.js:72:23:72:29 | req.url | logInjectionBad.js:99:26:99:33 | username | Log entry depends on a $@. | logInjectionBad.js:72:23:72:29 | req.url | user-provided value |
 | logInjectionBad.js:113:37:113:44 | username | logInjectionBad.js:72:23:72:29 | req.url | logInjectionBad.js:113:37:113:44 | username | Log entry depends on a $@. | logInjectionBad.js:72:23:72:29 | req.url | user-provided value |
+| logInjectionBad.js:124:17:124:24 | otherStr | logInjectionBad.js:122:30:122:36 | req.url | logInjectionBad.js:124:17:124:24 | otherStr | Log entry depends on a $@. | logInjectionBad.js:122:30:122:36 | req.url | user-provided value |
+| logInjectionBad.js:129:42:129:50 | RegExp.$1 | logInjectionBad.js:128:30:128:36 | req.url | logInjectionBad.js:129:42:129:50 | RegExp.$1 | Log entry depends on a $@. | logInjectionBad.js:128:30:128:36 | req.url | user-provided value |


### PR DESCRIPTION
`speculativeTaintStep` is a mandatory part of the data flow interface now, resulting in compilation errors when merging in `main`.

It's not a priority to get this working, so just providing a bare-bones implementation that's slightly better than `none()`.