### PR TITLE
JS: Added taint-step String.prototype.toWellFormed ES2023 feature

### DIFF
--- a/javascript/ql/lib/change-notes/2024-11-20-ES2023-string-protytpe-toWellFormed.md
+++ b/javascript/ql/lib/change-notes/2024-11-20-ES2023-string-protytpe-toWellFormed.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added taint-steps for `String.prototype.toWellFormed`.

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -612,7 +612,7 @@ module TaintTracking {
                 "italics", "link", "padEnd", "padStart", "repeat", "replace", "replaceAll", "slice",
                 "small", "split", "strike", "sub", "substr", "substring", "sup",
                 "toLocaleLowerCase", "toLocaleUpperCase", "toLowerCase", "toUpperCase", "trim",
-                "trimLeft", "trimRight"
+                "trimLeft", "trimRight", "toWellFormed"
               ]
             or
             // sorted, interesting, properties of Object.prototype

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -209,6 +209,10 @@ typeInferenceMismatch
 | static-capture-groups.js:2:17:2:24 | source() | static-capture-groups.js:27:14:27:22 | RegExp.$1 |
 | static-capture-groups.js:32:17:32:24 | source() | static-capture-groups.js:38:10:38:18 | RegExp.$1 |
 | static-capture-groups.js:42:12:42:19 | source() | static-capture-groups.js:43:14:43:22 | RegExp.$1 |
+| string-immutable-operations.js:2:13:2:20 | source() | string-immutable-operations.js:3:10:3:25 | x.toWellFormed() |
+| string-immutable-operations.js:2:13:2:20 | source() | string-immutable-operations.js:6:10:6:20 | wellFormedX |
+| string-immutable-operations.js:2:13:2:20 | source() | string-immutable-operations.js:9:10:9:26 | concatWellFormedX |
+| string-immutable-operations.js:11:10:11:17 | source() | string-immutable-operations.js:11:10:11:32 | source( ... ormed() |
 | string-replace.js:3:13:3:20 | source() | string-replace.js:14:10:14:13 | data |
 | string-replace.js:3:13:3:20 | source() | string-replace.js:18:10:18:13 | data |
 | string-replace.js:3:13:3:20 | source() | string-replace.js:21:6:21:41 | safe(). ...  taint) |

--- a/javascript/ql/test/library-tests/TaintTracking/string-immutable-operations.js
+++ b/javascript/ql/test/library-tests/TaintTracking/string-immutable-operations.js
@@ -1,12 +1,12 @@
 function test() {
     let x = source();
-    sink(x.toWellFormed()); // NOT OK -- Currently not tainted, but should be
+    sink(x.toWellFormed()); // NOT OK
 
     const wellFormedX = x.toWellFormed();
-    sink(wellFormedX); // NOT OK -- Currently not tainted, but should be
+    sink(wellFormedX); // NOT OK
 
     const concatWellFormedX = "/" + wellFormedX + "!";
-    sink(concatWellFormedX); // NOT OK -- Currently not tainted, but should be
+    sink(concatWellFormedX); // NOT OK
 
-    sink(source().toWellFormed()); // NOT OK -- Currently not tainted, but should be
+    sink(source().toWellFormed()); // NOT OK
 }

--- a/javascript/ql/test/library-tests/TaintTracking/string-immutable-operations.js
+++ b/javascript/ql/test/library-tests/TaintTracking/string-immutable-operations.js
@@ -1,0 +1,12 @@
+function test() {
+    let x = source();
+    sink(x.toWellFormed()); // NOT OK -- Currently not tainted, but should be
+
+    const wellFormedX = x.toWellFormed();
+    sink(wellFormedX); // NOT OK -- Currently not tainted, but should be
+
+    const concatWellFormedX = "/" + wellFormedX + "!";
+    sink(concatWellFormedX); // NOT OK -- Currently not tainted, but should be
+
+    sink(source().toWellFormed()); // NOT OK -- Currently not tainted, but should be
+}


### PR DESCRIPTION
Added `String.prototype.toWellFormed` to [`StringManipulationTaintStep`](https://github.com/github/codeql/blob/afc2d3e6d25f24d6111072b555357151b3684222/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll#L601).

The DCA run times look fine, and no new meta alerts have appeared, which is expected due to the `String.prototype.toWellFormed` novelty.