### PR TITLE
KE2: Add warnings-as-error to build system, but commented out for now

### DIFF
--- a/java/kotlin-extractor2/BUILD.bazel
+++ b/java/kotlin-extractor2/BUILD.bazel
@@ -10,6 +10,8 @@ kt_javac_options(
 kt_kotlinc_options(
     name = "kotlinc-options",
     x_context_receivers = True,
+    # TODO:
+    # warn = "error",
     # if needed, see https://bazelbuild.github.io/rules_kotlin/kotlin.html#kt_kotlinc_options for available options
 )
 


### PR DESCRIPTION
Once we get closer to completion, it will be useful to have this on.
