### PR TITLE
Add script and VSCode task for creating change notes

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,14 +40,32 @@
             "problemMatcher": []
         },
         {
-            "label": "Create change note",
+            "label": "Create query change note",
             "type": "process",
             "command": "python3",
             "args": [
                 "misc/scripts/create-change-note.py",
                 "${input:language}",
+                "src",
                 "${input:name}",
-                "${input:category}"
+                "${input:categoryQuery}"
+            ],
+            "presentation": {
+                "reveal": "never",
+                "close": true
+            },
+            "problemMatcher": []
+        },
+                {
+            "label": "Create library change note",
+            "type": "process",
+            "command": "python3",
+            "args": [
+                "misc/scripts/create-change-note.py",
+                "${input:language}",
+                "lib",
+                "${input:name}",
+                "${input:categoryLibrary}"
             ],
             "presentation": {
                 "reveal": "never",
@@ -70,25 +88,42 @@
                 "csharp",
                 "python",
                 "ruby",
+                "rust",
                 "swift",
             ]
         },
         {
             "type": "promptString",
             "id": "name",
-            "description": "Name"
+            "description": "Short name (kebab-case)"
         },
         {
             "type": "pickString",
-            "id": "category",
-            "description": "Category",
+            "id": "categoryQuery",
+            "description": "Category (query change)",
             "options":
             [
-                "minorAnalysis",
-                "newQuery",
-                "fix",
-                "majorAnalysis",
                 "breaking",
+                "deprecated",
+                "newQuery",
+                "queryMetadata",
+                "majorAnalysis",
+                "minorAnalysis",
+                "fix",
+            ]
+        },
+                {
+            "type": "pickString",
+            "id": "categoryLibrary",
+            "description": "Category (library change)",
+            "options":
+            [
+                "breaking",
+                "deprecated",
+                "feature",
+                "majorAnalysis",
+                "minorAnalysis",
+                "fix",
             ]
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,58 @@
                 "command": "${config:python.pythonPath}",
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Create change note",
+            "type": "process",
+            "command": "python3",
+            "args": [
+                "misc/scripts/create-change-note.py",
+                "${input:language}",
+                "${input:name}",
+                "${input:category}"
+            ],
+            "presentation": {
+                "reveal": "never",
+                "close": true
+            },
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "type": "pickString",
+            "id": "language",
+            "description": "Language",
+            "options":
+            [
+                "go",
+                "java",
+                "javascript",
+                "cpp",
+                "csharp",
+                "python",
+                "ruby",
+                "swift",
+            ]
+        },
+        {
+            "type": "promptString",
+            "id": "name",
+            "description": "Name"
+        },
+        {
+            "type": "pickString",
+            "id": "category",
+            "description": "Category",
+            "options":
+            [
+                "minorAnalysis",
+                "newQuery",
+                "fix",
+                "majorAnalysis",
+                "breaking",
+            ]
         }
     ]
 }

--- a/misc/scripts/create-change-note.py
+++ b/misc/scripts/create-change-note.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+# Creates a change note and opens it in VSCode for editing.
+
+# Expects to receive the following arguments:
+# - What language the change note is for
+# - The name of the change note (in kebab-case)
+# - The category of the change.
+
+# The change note will be created in the `{language}/ql/lib/change-notes` directory.
+
+# The format of the change note filename is `{current_date}-{change_note_name}.md` with the date in
+# the format `YYYY-MM-DD`.
+
+import sys
+import os
+
+# Read the given arguments
+language = sys.argv[1]
+change_note_name = sys.argv[2]
+change_category = sys.argv[3]
+
+# Find the root of the repository. The current script should be located in `misc/scripts`.
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Go to the repo root
+os.chdir(root)
+
+# Abort if the output directory doesn't exist
+if not os.path.exists(f"{language}/ql/lib/change-notes"):
+    print(f"Output directory {language}/ql/lib/change-notes does not exist")
+    sys.exit(1)
+
+# Get the current date
+import datetime
+current_date = datetime.datetime.now().strftime("%Y-%m-%d")
+
+# Create the change note file
+change_note_file = f"{language}/ql/lib/change-notes/{current_date}-{change_note_name}.md"
+
+change_note = f"""
+---
+category: {change_category}
+---
+* """.lstrip()
+
+with open(change_note_file, "w") as f:
+    f.write(change_note)
+
+# Open the change note file in VSCode, reusing the existing window if possible
+os.system(f"code -r {change_note_file}")

--- a/misc/scripts/create-change-note.py
+++ b/misc/scripts/create-change-note.py
@@ -4,6 +4,7 @@
 
 # Expects to receive the following arguments:
 # - What language the change note is for
+# - Whether it's a query or library change (the string `src` or `lib`)
 # - The name of the change note (in kebab-case)
 # - The category of the change.
 
@@ -17,8 +18,9 @@ import os
 
 # Read the given arguments
 language = sys.argv[1]
-change_note_name = sys.argv[2]
-change_category = sys.argv[3]
+subdir = sys.argv[2]
+change_note_name = sys.argv[3]
+change_category = sys.argv[4]
 
 # Find the root of the repository. The current script should be located in `misc/scripts`.
 root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -26,9 +28,11 @@ root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # Go to the repo root
 os.chdir(root)
 
+output_dir = f"{language}/ql/{subdir}/change-notes"
+
 # Abort if the output directory doesn't exist
-if not os.path.exists(f"{language}/ql/lib/change-notes"):
-    print(f"Output directory {language}/ql/lib/change-notes does not exist")
+if not os.path.exists(output_dir):
+    print(f"Output directory {output_dir} does not exist")
     sys.exit(1)
 
 # Get the current date
@@ -36,7 +40,7 @@ import datetime
 current_date = datetime.datetime.now().strftime("%Y-%m-%d")
 
 # Create the change note file
-change_note_file = f"{language}/ql/lib/change-notes/{current_date}-{change_note_name}.md"
+change_note_file = f"{output_dir}/{current_date}-{change_note_name}.md"
 
 change_note = f"""
 ---

--- a/misc/scripts/create-change-note.py
+++ b/misc/scripts/create-change-note.py
@@ -8,7 +8,7 @@
 # - The name of the change note (in kebab-case)
 # - The category of the change.
 
-# The change note will be created in the `{language}/ql/lib/change-notes` directory.
+# The change note will be created in the `{language}/ql/{subdir}/change-notes` directory, where `subdir` is either `src` or `lib`.
 
 # The format of the change note filename is `{current_date}-{change_note_name}.md` with the date in
 # the format `YYYY-MM-DD`.


### PR DESCRIPTION
Adds a VSCode Task (accessible from the "Run Task" menu) for creating change notes, prompting the user for the language, name, and category of the change.

The language options presented are based on the existing occurrences of `change-notes` folders in the repo. There are more such files (in particular every shared library has a `change-notes` directory), but it seemed to me that the language change notes are the ones that are most common, and so in an effort to not clutter the list too much, I only included the languages.

The selection of categories is based on existing usage -- more specifically the result of grepping for occurrences of `'^category: '` in the repo. It's possible there are more change categories that could be added.

Hopefully this should make it more convenient to create change notes from within VSCode.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
