### PR TITLE
Java: add SHA-384 to list of secure crypto algorithms

### DIFF
--- a/java/ql/lib/semmle/code/java/security/Encryption.qll
+++ b/java/ql/lib/semmle/code/java/security/Encryption.qll
@@ -246,7 +246,7 @@ string getInsecureAlgorithmRegex() {
 string getASecureAlgorithmName() {
   result =
     [
-      "RSA", "SHA-?256", "SHA-?512", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
+      "RSA", "SHA-?(256|384|512)", "CCM", "GCM", "AES(?![^a-zA-Z](ECB|CBC/PKCS[57]Padding))",
       "Blowfish", "ECIES", "SHA3-(256|384|512)"
     ]
 }

--- a/java/ql/src/change-notes/2024-11-24-sha2.md
+++ b/java/ql/src/change-notes/2024-11-24-sha2.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added SHA-384 to the list of secure hashing algorithms. As a result the `java/potentially-weak-cryptographic-algorithm` query should no longer flag up uses of SHA-384.

--- a/java/ql/test/query-tests/security/CWE-327/semmle/tests/WeakHashing.java
+++ b/java/ql/test/query-tests/security/CWE-327/semmle/tests/WeakHashing.java
@@ -19,7 +19,7 @@ public class WeakHashing {
 
         // BAD: Using a strong hashing algorithm but with a weak default
         MessageDigest bad3 = MessageDigest.getInstance(props.getProperty("hashAlg2", "MD5"));
-        
+
         // GOOD: Using a strong hashing algorithm
         MessageDigest ok = MessageDigest.getInstance(props.getProperty("hashAlg2"));
 
@@ -28,5 +28,8 @@ public class WeakHashing {
 
         // GOOD: Using a strong hashing algorithm
         MessageDigest ok3 = MessageDigest.getInstance("SHA3-512");
+
+         // GOOD: Using a strong hashing algorithm
+        MessageDigest ok4 = MessageDigest.getInstance("SHA384");
     }
 }


### PR DESCRIPTION
### Description

Adds `SHA-384` as a secure algorithm so that the `java/potentially-weak-cryptographic-algorithm` query no longer flags it. 

Adding `SHA-384` aligns Java with [other languages](https://github.com/github/codeql/blob/f0045692a76454e00a39f318510f8e188b563cc0/python/ql/lib/semmle/python/concepts/internal/CryptoAlgorithmNames.qll#L24C27-L24C35).

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.

#### Internal query authors only

- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
