### PR TITLE
C#: Use dedicated lock type where applicable.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/NugetPackageRestorer.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -264,7 +263,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             var isWindows = fileContent.UseWindowsForms || fileContent.UseWpf;
 
-            var sync = new object();
+            var sync = new Lock();
             var projectGroups = projects.GroupBy(Path.GetDirectoryName);
             Parallel.ForEach(projectGroups, new ParallelOptions { MaxDegreeOfParallelism = DependencyManager.Threads }, projectGroup =>
             {
@@ -346,7 +345,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             compilationInfoContainer.CompilationInfos.Add(("Fallback nuget restore", notYetDownloadedPackages.Count.ToString()));
 
             var successCount = 0;
-            var sync = new object();
+            var sync = new Lock();
 
             Parallel.ForEach(notYetDownloadedPackages, new ParallelOptions { MaxDegreeOfParallelism = DependencyManager.Threads }, package =>
             {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Options.cs
@@ -1,8 +1,6 @@
+using System;
 using System.IO;
 using Semmle.Util;
-using Semmle.Util.Logging;
-using Semmle.Extraction.CSharp.DependencyFetching;
-using System;
 
 namespace Semmle.Extraction.CSharp.Standalone
 {

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Program.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Program.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using Semmle.Util.Logging;
-using Semmle.Extraction.CSharp.DependencyFetching;
-
 namespace Semmle.Extraction.CSharp.Standalone
 {
     public class Program

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/ExtractionContext.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/ExtractionContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using Semmle.Util.Logging;
 using CompilationInfo = (string key, string value);
 
@@ -38,7 +39,7 @@ namespace Semmle.Extraction.CSharp
         // to handle pathological cases.
         private const int maxErrors = 1000;
 
-        private readonly object mutex = new object();
+        private readonly Lock mutex = new();
 
         public void Message(Message msg)
         {

--- a/csharp/extractor/Semmle.Util/Logging/PidStreamWriter.cs
+++ b/csharp/extractor/Semmle.Util/Logging/PidStreamWriter.cs
@@ -1,5 +1,5 @@
 using System.IO;
-using System.Diagnostics;
+using System.Threading;
 
 namespace Semmle.Util.Logging
 {
@@ -33,6 +33,6 @@ namespace Semmle.Util.Logging
             WriteLine(format is null ? format : string.Format(format, args));
         }
 
-        private readonly object mutex = new object();
+        private readonly Lock mutex = new();
     }
 }

--- a/csharp/extractor/Testrunner/Testrunner.cs
+++ b/csharp/extractor/Testrunner/Testrunner.cs
@@ -14,7 +14,7 @@ using System;
 /// </summary>
 public class Testrunner
 {
-    private static readonly object ConsoleLock = new();
+    private static readonly Lock ConsoleLock = new();
 
     private static readonly ManualResetEvent Finished = new(false);
 


### PR DESCRIPTION
As of C# 13 there is a dedicated *lock* object type for threat synchronization: https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#new-lock-object
This *should* perform slightly better than just locking on another object type.

In this PR we use the new `Lock` type for sync locks where applicable.