### PR TITLE
KE2: Don't actually deprecate WhenBranch.getCondition() yet

### DIFF
--- a/java/ql/lib/semmle/code/java/Expr.qll
+++ b/java/ql/lib/semmle/code/java/Expr.qll
@@ -2603,7 +2603,7 @@ class WhenBranch extends Stmt, @whenbranch {
    *
    * Gets the condition of this branch.
    */
-  deprecated Expr getCondition() {
+  /* TODO: deprecated */ Expr getCondition() {
     result = this.getCondition(0).(WhenBranchConditionWithExpression).getExpression()
   }
 


### PR DESCRIPTION
It makes a lot of noise in the CFG QLL, that we aren't fixing yet