### PR TITLE
Rust: Change `&String` to `&str`

### DIFF
--- a/rust/ast-generator/src/main.rs
+++ b/rust/ast-generator/src/main.rs
@@ -14,24 +14,26 @@ fn project_root() -> PathBuf {
     PathBuf::from(dir).parent().unwrap().to_owned()
 }
 
-fn class_name(type_name: &String) -> String {
-    match type_name.as_str() {
-        "BinExpr" => "BinaryExpr".to_owned(),
-        "ElseBranch" => "Expr".to_owned(),
-        "Fn" => "Function".to_owned(),
-        "Literal" => "LiteralExpr".to_owned(),
-        "Type" => "TypeRef".to_owned(),
-        _ => type_name.to_owned(),
-    }
+fn class_name(type_name: &str) -> String {
+    let name = match type_name {
+        "BinExpr" => "BinaryExpr",
+        "ElseBranch" => "Expr",
+        "Fn" => "Function",
+        "Literal" => "LiteralExpr",
+        "Type" => "TypeRef",
+        _ => type_name,
+    };
+    name.to_owned()
 }
 
-fn property_name(type_name: &String, field_name: &String) -> String {
-    match (type_name.as_str(), field_name.as_str()) {
-        ("Path", "segment") => "part".to_owned(),
-        (_, "then_branch") => "then".to_owned(),
-        (_, "else_branch") => "else_".to_owned(),
-        _ => field_name.to_owned(),
-    }
+fn property_name(type_name: &str, field_name: &str) -> String {
+    let name = match (type_name, field_name) {
+        ("Path", "segment") => "part",
+        (_, "then_branch") => "then",
+        (_, "else_branch") => "else_",
+        _ => field_name,
+    };
+    name.to_owned()
 }
 
 fn to_lower_snake_case(s: &str) -> String {
@@ -61,7 +63,7 @@ fn write_schema(
 
     for node in &grammar.enums {
         let super_classses = if let Some(cls) = super_types.get(&node.name) {
-            let super_classes: Vec<String> = cls.iter().map(class_name).collect();
+            let super_classes: Vec<String> = cls.iter().map(|s| class_name(s)).collect();
             super_classes.join(",")
         } else {
             "AstNode".to_owned()
@@ -76,7 +78,7 @@ fn write_schema(
     }
     for node in &grammar.nodes {
         let super_classses = if let Some(cls) = super_types.get(&node.name) {
-            let super_classes: Vec<String> = cls.iter().map(class_name).collect();
+            let super_classes: Vec<String> = cls.iter().map(|s| class_name(s)).collect();
             super_classes.join(",")
         } else {
             "AstNode".to_owned()


### PR DESCRIPTION
Changes the parameters of `class_name` and `property_name` from `&String` to the [more idiomatic](https://doc.rust-lang.org/std/string/struct.String.html#deref) `&str`.