### PR TITLE
C++: Actually check function names in MaD

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -794,6 +794,7 @@ private Element interpretElement0(
   (
     // Non-member functions
     elementSpec(namespace, type, subtypes, name, signature, _) and
+    funcHasQualifiedName(result, namespace, name) and
     subtypes = false and
     type = "" and
     (

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -793,7 +793,6 @@ private Element interpretElement0(
 ) {
   (
     // Non-member functions
-    elementSpec(namespace, type, subtypes, name, signature, _) and
     funcHasQualifiedName(result, namespace, name) and
     subtypes = false and
     type = "" and
@@ -801,21 +800,20 @@ private Element interpretElement0(
       elementSpecMatchesSignature(result, namespace, type, subtypes, name, signature)
       or
       signature = "" and
-      elementSpec(namespace, type, subtypes, name, "", _) and
-      funcHasQualifiedName(result, namespace, name)
+      elementSpec(namespace, type, subtypes, name, signature, _)
     )
     or
     // Member functions
     exists(Class namedClass, Class classWithMethod |
+      hasClassAndName(classWithMethod, result, name) and
+      classHasQualifiedName(namedClass, namespace, type)
+    |
       (
-        elementSpecMatchesSignature(result, namespace, type, subtypes, name, signature) and
-        hasClassAndName(classWithMethod, result, name)
+        elementSpecMatchesSignature(result, namespace, type, subtypes, name, signature)
         or
         signature = "" and
-        elementSpec(namespace, type, subtypes, name, "", _) and
-        hasClassAndName(classWithMethod, result, name)
+        elementSpec(namespace, type, subtypes, name, "", _)
       ) and
-      classHasQualifiedName(namedClass, namespace, type) and
       (
         // member declared in the named type or a subtype of it
         subtypes = true and

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
@@ -165,3 +165,9 @@ void test_format() {
   auto s2 = std::format(string::source());
   sink(s2); // $ ir MISSING: ast
 }
+
+void test(std::format_string s) {
+  int x = source();
+  int y = std::same_signature_as_format_but_different_name(s, x);
+  sink(y); // $ SPURIOUS: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/format.cpp
@@ -169,5 +169,5 @@ void test_format() {
 void test(std::format_string s) {
   int x = source();
   int y = std::same_signature_as_format_but_different_name(s, x);
-  sink(y); // $ SPURIOUS: ir
+  sink(y); // clean
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -451,6 +451,9 @@ WARNING: module 'TaintTracking' has been deprecated and may be removed in future
 | format.cpp:162:24:162:27 | {} | format.cpp:162:24:162:27 | call to basic_format_string | TAINT |
 | format.cpp:165:13:165:23 | call to format | format.cpp:166:8:166:9 | s2 |  |
 | format.cpp:165:25:165:38 | call to source | format.cpp:165:25:165:40 | call to basic_format_string | TAINT |
+| format.cpp:169:30:169:30 | s | format.cpp:171:60:171:60 | s |  |
+| format.cpp:170:11:170:16 | call to source | format.cpp:171:63:171:63 | x |  |
+| format.cpp:171:11:171:58 | call to same_signature_as_format_but_different_name | format.cpp:172:8:172:8 | y |  |
 | map.cpp:21:28:21:28 | call to pair | map.cpp:23:2:23:2 | a |  |
 | map.cpp:21:28:21:28 | call to pair | map.cpp:24:7:24:7 | a |  |
 | map.cpp:21:28:21:28 | call to pair | map.cpp:25:7:25:7 | a |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.h
@@ -676,4 +676,9 @@ namespace std {
 	using format_string = basic_format_string<char>; // simplified from `char, std::type_identity_t<Args>...`
 
 	template<class... Args> string format( format_string fmt, Args&&... args );
+
+	// This function has the same signature as `format`, but a different name. It should NOT be able to use
+	// the model for `format`.
+	template <typename... Args>
+	int same_signature_as_format_but_different_name(format_string, Args &&...args);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_mad-signatures.expected
@@ -265,6 +265,8 @@ signatureMatches
 | stl.h:678:33:678:38 | format | (format_string,Args &&) |  | format<Args> | 0 |
 | stl.h:678:33:678:38 | format | (format_string,Args &&) |  | format<Args> | 1 |
 | stl.h:678:33:678:38 | format | (format_string,Args &&) |  | format<Args> | 1 |
+| stl.h:683:6:683:48 | same_signature_as_format_but_different_name | (format_string,Args &&) |  | format<Args> | 0 |
+| stl.h:683:6:683:48 | same_signature_as_format_but_different_name | (format_string,Args &&) |  | format<Args> | 1 |
 getSignatureParameterName
 | (InputIt,InputIt) | deque | assign<InputIt> | 0 | func:0 |
 | (InputIt,InputIt) | deque | assign<InputIt> | 1 | func:0 |
@@ -729,6 +731,8 @@ getParameterTypeName
 | stl.h:678:33:678:38 | format | 0 | format_string |
 | stl.h:678:33:678:38 | format | 1 | func:0 && |
 | stl.h:678:33:678:38 | format | 1 | func:0 && |
+| stl.h:683:6:683:48 | same_signature_as_format_but_different_name | 0 | format_string |
+| stl.h:683:6:683:48 | same_signature_as_format_but_different_name | 1 | func:0 && |
 | stringstream.cpp:18:6:18:9 | sink | 0 | const basic_ostream> & |
 | stringstream.cpp:21:6:21:9 | sink | 0 | const basic_istream> & |
 | stringstream.cpp:24:6:24:9 | sink | 0 | const basic_iostream> & |


### PR DESCRIPTION
This PR fixes quite an embarrassing bug: We forgot to check the function name when matching MaD models with `Function`s when dealing with non-member functions 😱

That's ... quite bad. Luckily, there are several reasons for why this went unnoticed for 4 months:
- The only non-member models we have is `boost::asio::buffer` and `std::format`
- We were still correctly validating the signature, which meant that very few spurious functions were being matched.

Commit-by-commit review recommended. The last commit is just a cleanup of the conjuncts.