### PR TITLE
C#: Add `js-interop` sinks for `Microsoft.JSInterop.IJSRuntime`

### DIFF
--- a/csharp/ql/lib/change-notes/2024-11-26-model-microsoft.jsinterop.ijsruntime.md
+++ b/csharp/ql/lib/change-notes/2024-11-26-model-microsoft.jsinterop.ijsruntime.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+* Added `js-interop` sinks for the `InvokeAsync` and `InvokeVoidAsync` methods of `Microsoft.JSInterop.IJSRuntime`, which can run arbitrary JavaScript. 
+

--- a/csharp/ql/lib/ext/Microsoft.JSInterop.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.JSInterop.model.yml
@@ -3,5 +3,5 @@ extensions:
       pack: codeql/csharp-all
       extensible: sinkModel
     data:
-      - ["Microsoft.JSInterop", "JSRuntimeExtensions", True, "InvokeAsync", "", "", "Argument[1]", "js-injection", "manual"]
+      - ["Microsoft.JSInterop", "JSRuntimeExtensions", True, "InvokeAsync<TValue>", "", "", "Argument[1]", "js-injection", "manual"]
       - ["Microsoft.JSInterop", "JSRuntimeExtensions", True, "InvokeVoidAsync", "", "", "Argument[1]", "js-injection", "manual"]

--- a/csharp/ql/lib/ext/Microsoft.JSInterop.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.JSInterop.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sinkModel
+    data:
+      - ["Microsoft.JSInterop", "JSRuntimeExtensions", True, "InvokeAsync", "", "", "Argument[1]", "js-injection", "manual"]
+      - ["Microsoft.JSInterop", "JSRuntimeExtensions", True, "InvokeVoidAsync", "", "", "Argument[1]", "js-injection", "manual"]


### PR DESCRIPTION
Adds `js-injection` sink models for the extensions methods for the `Microsoft.JSInterop.IJSRuntime` interface, which can run arbitrary JS.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
~- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.~
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
~- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.~

#### Internal query authors only

~- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).~
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
~- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).~
