### PR TITLE
Include paths on pull_request event trigger for compile-queries.yml workflow

### DIFF
--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -8,10 +8,10 @@ on:
       - "codeql-cli-*"
   pull_request:
     paths:
-      - '*.ql'
-      - '*.qll'
+      - '**.ql'
+      - '**.qll'
       - '**/qlpack.yml'
-      - '*.dbscheme'
+      - '**.dbscheme'
 
 permissions:
   contents: read

--- a/.github/workflows/compile-queries.yml
+++ b/.github/workflows/compile-queries.yml
@@ -7,6 +7,11 @@ on:
       - "rc/*"
       - "codeql-cli-*"
   pull_request:
+    paths:
+      - '*.ql'
+      - '*.qll'
+      - '**/qlpack.yml'
+      - '*.dbscheme'
 
 permissions:
   contents: read


### PR DESCRIPTION
Avoid running `compile-queries.yml` workflow on changes unrelated to queries (in particular on Kotlin extractor changes).