### PR TITLE
Swift: Fix makeIterator() models

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Array.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Array.qll
@@ -36,6 +36,7 @@ private class ArraySummaries extends SummaryModelCsv {
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[-1].CollectionElement;Argument[0].Parameter[0].CollectionElement;taint",
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[0].Parameter[0].CollectionElement;Argument[-1].CollectionElement;taint",
         ";Array;true;withUnsafeMutableBytes(_:);;;Argument[0].ReturnValue;ReturnValue;value",
+        ";Array;true;makeIterator();;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;value",
         ";ContiguousArray;true;withUnsafeBufferPointer(_:);;;Argument[-1];Argument[0].Parameter[0].CollectionElement;taint",
         ";ContiguousArray;true;withUnsafeBufferPointer(_:);;;Argument[-1].CollectionElement;Argument[0].Parameter[0].CollectionElement;value",
         ";ContiguousArray;true;withUnsafeBufferPointer(_:);;;Argument[0].ReturnValue;ReturnValue;value",

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Collection.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Collection.qll
@@ -44,6 +44,7 @@ private class CollectionSummaries extends SummaryModelCsv {
         ";Collection;true;trimmingPrefix(_:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;value",
         ";Collection;true;trimmingPrefix(while:);;;Argument[-1];ReturnValue;taint",
         ";Collection;true;trimmingPrefix(while:);;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;value",
+        ";Collection;true;makeIterator();;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;value",
         ";RangeReplaceableCollection;true;init(_:);;;Argument[0];ReturnValue.CollectionElement;taint",
         ";RangeReplaceableCollection;true;init(_:);;;Argument[0].CollectionElement;ReturnValue.CollectionElement;value",
         ";RangeReplaceableCollection;true;init(repeating:count:);;;Argument[0];ReturnValue.CollectionElement;value",

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Dictionary.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/Dictionary.qll
@@ -21,7 +21,8 @@ private class DictionarySummaries extends SummaryModelCsv {
       [
         ";Dictionary;true;updateValue(_:forKey:);;;Argument[0];Argument[-1].CollectionElement.TupleElement[1];value",
         ";Dictionary;true;updateValue(_:forKey:);;;Argument[1];Argument[-1].CollectionElement.TupleElement[0];value",
-        ";Dictionary;true;updateValue(_:forKey:);;;Argument[-1].CollectionElement.TupleElement[1];ReturnValue.OptionalSome;value"
+        ";Dictionary;true;updateValue(_:forKey:);;;Argument[-1].CollectionElement.TupleElement[1];ReturnValue.OptionalSome;value",
+        ";Dictionary;true;makeIterator();;;Argument[-1].CollectionElement;ReturnValue.CollectionElement;value",
       ]
   }
 }

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -135,9 +135,15 @@ edges
 | test2.swift:69:10:69:10 | key | test2.swift:70:19:70:19 | key | provenance |  |
 | test2.swift:69:25:69:25 | call to makeIterator() [Collection element, Tuple element at index 0] | test2.swift:69:5:69:5 | $generator [Collection element, Tuple element at index 0] | provenance |  |
 | test2.swift:69:25:69:25 | d4 [Collection element, Tuple element at index 0] | test2.swift:69:25:69:25 | call to makeIterator() [Collection element, Tuple element at index 0] | provenance |  |
+| test2.swift:76:14:76:47 | [...] [Collection element] | test2.swift:78:14:78:14 | a1 [Collection element] | provenance |  |
 | test2.swift:76:14:76:47 | [...] [Collection element] | test2.swift:82:19:82:19 | a1 [Collection element] | provenance |  |
 | test2.swift:76:14:76:47 | [...] [Collection element] | test2.swift:84:20:84:20 | a1 [Collection element] | provenance |  |
 | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:76:14:76:47 | [...] [Collection element] | provenance |  |
+| test2.swift:78:5:78:5 | $v$generator [Collection element] | test2.swift:78:5:78:5 | call to next() [some:0] | provenance |  |
+| test2.swift:78:5:78:5 | call to next() [some:0] | test2.swift:78:9:78:9 | v | provenance |  |
+| test2.swift:78:9:78:9 | v | test2.swift:79:19:79:19 | v | provenance |  |
+| test2.swift:78:14:78:14 | a1 [Collection element] | test2.swift:78:14:78:14 | call to makeIterator() [Collection element] | provenance |  |
+| test2.swift:78:14:78:14 | call to makeIterator() [Collection element] | test2.swift:78:5:78:5 | $v$generator [Collection element] | provenance |  |
 | test2.swift:82:19:82:19 | a1 [Collection element] | test2.swift:82:19:82:24 | ...[...] | provenance |  |
 | test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | test2.swift:84:5:84:5 | call to next() [some:0, Tuple element at index 1] | provenance |  |
 | test2.swift:84:5:84:5 | call to next() [some:0, Tuple element at index 1] | test2.swift:84:9:84:15 | (...) [Tuple element at index 1] | provenance |  |
@@ -146,9 +152,15 @@ edges
 | test2.swift:84:20:84:20 | a1 [Collection element] | test2.swift:84:20:84:34 | call to enumerated() [Collection element, Tuple element at index 1] | provenance |  |
 | test2.swift:84:20:84:34 | call to enumerated() [Collection element, Tuple element at index 1] | test2.swift:84:20:84:34 | call to makeIterator() [Collection element, Tuple element at index 1] | provenance |  |
 | test2.swift:84:20:84:34 | call to makeIterator() [Collection element, Tuple element at index 1] | test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:93:5:93:5 | [post] a2 [Collection element] | test2.swift:95:14:95:14 | a2 [Collection element] | provenance |  |
 | test2.swift:93:5:93:5 | [post] a2 [Collection element] | test2.swift:99:19:99:19 | a2 [Collection element] | provenance |  |
 | test2.swift:93:5:93:5 | [post] a2 [Collection element] | test2.swift:101:20:101:20 | a2 [Collection element] | provenance |  |
 | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:93:5:93:5 | [post] a2 [Collection element] | provenance |  |
+| test2.swift:95:5:95:5 | $v$generator [Collection element] | test2.swift:95:5:95:5 | call to next() [some:0] | provenance |  |
+| test2.swift:95:5:95:5 | call to next() [some:0] | test2.swift:95:9:95:9 | v | provenance |  |
+| test2.swift:95:9:95:9 | v | test2.swift:96:19:96:19 | v | provenance |  |
+| test2.swift:95:14:95:14 | a2 [Collection element] | test2.swift:95:14:95:14 | call to makeIterator() [Collection element] | provenance |  |
+| test2.swift:95:14:95:14 | call to makeIterator() [Collection element] | test2.swift:95:5:95:5 | $v$generator [Collection element] | provenance |  |
 | test2.swift:99:19:99:19 | a2 [Collection element] | test2.swift:99:19:99:24 | ...[...] | provenance |  |
 | test2.swift:101:5:101:5 | $generator [Collection element, Tuple element at index 1] | test2.swift:101:5:101:5 | call to next() [some:0, Tuple element at index 1] | provenance |  |
 | test2.swift:101:5:101:5 | call to next() [some:0, Tuple element at index 1] | test2.swift:101:9:101:15 | (...) [Tuple element at index 1] | provenance |  |
@@ -712,9 +724,15 @@ edges
 | test.swift:849:19:849:24 | v | test.swift:850:15:850:15 | v | provenance |  |
 | test.swift:856:29:856:40 | args [Collection element] | test.swift:859:15:859:15 | args [Collection element] | provenance |  |
 | test.swift:856:29:856:40 | args [Collection element] | test.swift:860:15:860:15 | args [Collection element] | provenance |  |
+| test.swift:856:29:856:40 | args [Collection element] | test.swift:862:16:862:16 | args [Collection element] | provenance |  |
 | test.swift:856:29:856:40 | args [Collection element] | test.swift:867:15:867:15 | args [Collection element] | provenance |  |
 | test.swift:859:15:859:15 | args [Collection element] | test.swift:859:15:859:21 | ...[...] | provenance |  |
 | test.swift:860:15:860:15 | args [Collection element] | test.swift:860:15:860:21 | ...[...] | provenance |  |
+| test.swift:862:5:862:5 | $arg$generator [Collection element] | test.swift:862:5:862:5 | call to next() [some:0] | provenance |  |
+| test.swift:862:5:862:5 | call to next() [some:0] | test.swift:862:9:862:9 | arg | provenance |  |
+| test.swift:862:9:862:9 | arg | test.swift:863:19:863:19 | arg | provenance |  |
+| test.swift:862:16:862:16 | args [Collection element] | test.swift:862:16:862:16 | call to makeIterator() [Collection element] | provenance |  |
+| test.swift:862:16:862:16 | call to makeIterator() [Collection element] | test.swift:862:5:862:5 | $arg$generator [Collection element] | provenance |  |
 | test.swift:866:21:866:29 | enter #keyPath(...) [Collection element] | test.swift:866:27:866:29 | KeyPathComponent | provenance |  |
 | test.swift:866:27:866:29 | KeyPathComponent | test.swift:866:21:866:29 | exit #keyPath(...) | provenance |  |
 | test.swift:867:15:867:15 | args [Collection element] | test.swift:866:21:866:29 | enter #keyPath(...) [Collection element] | provenance |  |
@@ -908,6 +926,12 @@ nodes
 | test2.swift:70:19:70:19 | key | semmle.label | key |
 | test2.swift:76:14:76:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
 | test2.swift:76:30:76:46 | call to source(_:) | semmle.label | call to source(_:) |
+| test2.swift:78:5:78:5 | $v$generator [Collection element] | semmle.label | $v$generator [Collection element] |
+| test2.swift:78:5:78:5 | call to next() [some:0] | semmle.label | call to next() [some:0] |
+| test2.swift:78:9:78:9 | v | semmle.label | v |
+| test2.swift:78:14:78:14 | a1 [Collection element] | semmle.label | a1 [Collection element] |
+| test2.swift:78:14:78:14 | call to makeIterator() [Collection element] | semmle.label | call to makeIterator() [Collection element] |
+| test2.swift:79:19:79:19 | v | semmle.label | v |
 | test2.swift:82:19:82:19 | a1 [Collection element] | semmle.label | a1 [Collection element] |
 | test2.swift:82:19:82:24 | ...[...] | semmle.label | ...[...] |
 | test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | semmle.label | $generator [Collection element, Tuple element at index 1] |
@@ -920,6 +944,12 @@ nodes
 | test2.swift:86:19:86:19 | v | semmle.label | v |
 | test2.swift:93:5:93:5 | [post] a2 [Collection element] | semmle.label | [post] a2 [Collection element] |
 | test2.swift:93:13:93:29 | call to source(_:) | semmle.label | call to source(_:) |
+| test2.swift:95:5:95:5 | $v$generator [Collection element] | semmle.label | $v$generator [Collection element] |
+| test2.swift:95:5:95:5 | call to next() [some:0] | semmle.label | call to next() [some:0] |
+| test2.swift:95:9:95:9 | v | semmle.label | v |
+| test2.swift:95:14:95:14 | a2 [Collection element] | semmle.label | a2 [Collection element] |
+| test2.swift:95:14:95:14 | call to makeIterator() [Collection element] | semmle.label | call to makeIterator() [Collection element] |
+| test2.swift:96:19:96:19 | v | semmle.label | v |
 | test2.swift:99:19:99:19 | a2 [Collection element] | semmle.label | a2 [Collection element] |
 | test2.swift:99:19:99:24 | ...[...] | semmle.label | ...[...] |
 | test2.swift:101:5:101:5 | $generator [Collection element, Tuple element at index 1] | semmle.label | $generator [Collection element, Tuple element at index 1] |
@@ -1518,6 +1548,12 @@ nodes
 | test.swift:859:15:859:21 | ...[...] | semmle.label | ...[...] |
 | test.swift:860:15:860:15 | args [Collection element] | semmle.label | args [Collection element] |
 | test.swift:860:15:860:21 | ...[...] | semmle.label | ...[...] |
+| test.swift:862:5:862:5 | $arg$generator [Collection element] | semmle.label | $arg$generator [Collection element] |
+| test.swift:862:5:862:5 | call to next() [some:0] | semmle.label | call to next() [some:0] |
+| test.swift:862:9:862:9 | arg | semmle.label | arg |
+| test.swift:862:16:862:16 | args [Collection element] | semmle.label | args [Collection element] |
+| test.swift:862:16:862:16 | call to makeIterator() [Collection element] | semmle.label | call to makeIterator() [Collection element] |
+| test.swift:863:19:863:19 | arg | semmle.label | arg |
 | test.swift:866:21:866:29 | enter #keyPath(...) [Collection element] | semmle.label | enter #keyPath(...) [Collection element] |
 | test.swift:866:21:866:29 | exit #keyPath(...) | semmle.label | exit #keyPath(...) |
 | test.swift:866:27:866:29 | KeyPathComponent | semmle.label | KeyPathComponent |
@@ -1661,8 +1697,10 @@ subpaths
 | test2.swift:53:15:53:28 | ... ??(_:_:) ... | test2.swift:46:17:46:33 | call to source(_:) | test2.swift:53:15:53:28 | ... ??(_:_:) ... | result |
 | test2.swift:54:15:54:24 | ...! | test2.swift:46:17:46:33 | call to source(_:) | test2.swift:54:15:54:24 | ...! | result |
 | test2.swift:70:19:70:19 | key | test2.swift:60:8:60:24 | call to source(_:) | test2.swift:70:19:70:19 | key | result |
+| test2.swift:79:19:79:19 | v | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:79:19:79:19 | v | result |
 | test2.swift:82:19:82:24 | ...[...] | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:82:19:82:24 | ...[...] | result |
 | test2.swift:86:19:86:19 | v | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:86:19:86:19 | v | result |
+| test2.swift:96:19:96:19 | v | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:96:19:96:19 | v | result |
 | test2.swift:99:19:99:24 | ...[...] | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:99:19:99:24 | ...[...] | result |
 | test2.swift:103:19:103:19 | v | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:103:19:103:19 | v | result |
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
@@ -1789,6 +1827,7 @@ subpaths
 | test.swift:850:15:850:15 | v | test.swift:872:18:872:25 | call to source() | test.swift:850:15:850:15 | v | result |
 | test.swift:859:15:859:21 | ...[...] | test.swift:873:24:873:31 | call to source() | test.swift:859:15:859:21 | ...[...] | result |
 | test.swift:860:15:860:21 | ...[...] | test.swift:873:24:873:31 | call to source() | test.swift:860:15:860:21 | ...[...] | result |
+| test.swift:863:19:863:19 | arg | test.swift:873:24:873:31 | call to source() | test.swift:863:19:863:19 | arg | result |
 | test.swift:867:15:867:38 | \\...[...] | test.swift:873:24:873:31 | call to source() | test.swift:867:15:867:38 | \\...[...] | result |
 | test.swift:880:19:880:19 | elem | test.swift:877:21:877:28 | call to source() | test.swift:880:19:880:19 | elem | result |
 | test.swift:884:15:884:31 | ...! | test.swift:877:21:877:28 | call to source() | test.swift:884:15:884:31 | ...! | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlow.expected
@@ -135,6 +135,28 @@ edges
 | test2.swift:69:10:69:10 | key | test2.swift:70:19:70:19 | key | provenance |  |
 | test2.swift:69:25:69:25 | call to makeIterator() [Collection element, Tuple element at index 0] | test2.swift:69:5:69:5 | $generator [Collection element, Tuple element at index 0] | provenance |  |
 | test2.swift:69:25:69:25 | d4 [Collection element, Tuple element at index 0] | test2.swift:69:25:69:25 | call to makeIterator() [Collection element, Tuple element at index 0] | provenance |  |
+| test2.swift:76:14:76:47 | [...] [Collection element] | test2.swift:82:19:82:19 | a1 [Collection element] | provenance |  |
+| test2.swift:76:14:76:47 | [...] [Collection element] | test2.swift:84:20:84:20 | a1 [Collection element] | provenance |  |
+| test2.swift:76:30:76:46 | call to source(_:) | test2.swift:76:14:76:47 | [...] [Collection element] | provenance |  |
+| test2.swift:82:19:82:19 | a1 [Collection element] | test2.swift:82:19:82:24 | ...[...] | provenance |  |
+| test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | test2.swift:84:5:84:5 | call to next() [some:0, Tuple element at index 1] | provenance |  |
+| test2.swift:84:5:84:5 | call to next() [some:0, Tuple element at index 1] | test2.swift:84:9:84:15 | (...) [Tuple element at index 1] | provenance |  |
+| test2.swift:84:9:84:15 | (...) [Tuple element at index 1] | test2.swift:84:14:84:14 | v | provenance |  |
+| test2.swift:84:14:84:14 | v | test2.swift:86:19:86:19 | v | provenance |  |
+| test2.swift:84:20:84:20 | a1 [Collection element] | test2.swift:84:20:84:34 | call to enumerated() [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:84:20:84:34 | call to enumerated() [Collection element, Tuple element at index 1] | test2.swift:84:20:84:34 | call to makeIterator() [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:84:20:84:34 | call to makeIterator() [Collection element, Tuple element at index 1] | test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:93:5:93:5 | [post] a2 [Collection element] | test2.swift:99:19:99:19 | a2 [Collection element] | provenance |  |
+| test2.swift:93:5:93:5 | [post] a2 [Collection element] | test2.swift:101:20:101:20 | a2 [Collection element] | provenance |  |
+| test2.swift:93:13:93:29 | call to source(_:) | test2.swift:93:5:93:5 | [post] a2 [Collection element] | provenance |  |
+| test2.swift:99:19:99:19 | a2 [Collection element] | test2.swift:99:19:99:24 | ...[...] | provenance |  |
+| test2.swift:101:5:101:5 | $generator [Collection element, Tuple element at index 1] | test2.swift:101:5:101:5 | call to next() [some:0, Tuple element at index 1] | provenance |  |
+| test2.swift:101:5:101:5 | call to next() [some:0, Tuple element at index 1] | test2.swift:101:9:101:15 | (...) [Tuple element at index 1] | provenance |  |
+| test2.swift:101:9:101:15 | (...) [Tuple element at index 1] | test2.swift:101:14:101:14 | v | provenance |  |
+| test2.swift:101:14:101:14 | v | test2.swift:103:19:103:19 | v | provenance |  |
+| test2.swift:101:20:101:20 | a2 [Collection element] | test2.swift:101:20:101:34 | call to enumerated() [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:101:20:101:34 | call to enumerated() [Collection element, Tuple element at index 1] | test2.swift:101:20:101:34 | call to makeIterator() [Collection element, Tuple element at index 1] | provenance |  |
+| test2.swift:101:20:101:34 | call to makeIterator() [Collection element, Tuple element at index 1] | test2.swift:101:5:101:5 | $generator [Collection element, Tuple element at index 1] | provenance |  |
 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | provenance |  |
 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | provenance |  |
 | test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 | provenance |  |
@@ -884,6 +906,30 @@ nodes
 | test2.swift:69:25:69:25 | call to makeIterator() [Collection element, Tuple element at index 0] | semmle.label | call to makeIterator() [Collection element, Tuple element at index 0] |
 | test2.swift:69:25:69:25 | d4 [Collection element, Tuple element at index 0] | semmle.label | d4 [Collection element, Tuple element at index 0] |
 | test2.swift:70:19:70:19 | key | semmle.label | key |
+| test2.swift:76:14:76:47 | [...] [Collection element] | semmle.label | [...] [Collection element] |
+| test2.swift:76:30:76:46 | call to source(_:) | semmle.label | call to source(_:) |
+| test2.swift:82:19:82:19 | a1 [Collection element] | semmle.label | a1 [Collection element] |
+| test2.swift:82:19:82:24 | ...[...] | semmle.label | ...[...] |
+| test2.swift:84:5:84:5 | $generator [Collection element, Tuple element at index 1] | semmle.label | $generator [Collection element, Tuple element at index 1] |
+| test2.swift:84:5:84:5 | call to next() [some:0, Tuple element at index 1] | semmle.label | call to next() [some:0, Tuple element at index 1] |
+| test2.swift:84:9:84:15 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test2.swift:84:14:84:14 | v | semmle.label | v |
+| test2.swift:84:20:84:20 | a1 [Collection element] | semmle.label | a1 [Collection element] |
+| test2.swift:84:20:84:34 | call to enumerated() [Collection element, Tuple element at index 1] | semmle.label | call to enumerated() [Collection element, Tuple element at index 1] |
+| test2.swift:84:20:84:34 | call to makeIterator() [Collection element, Tuple element at index 1] | semmle.label | call to makeIterator() [Collection element, Tuple element at index 1] |
+| test2.swift:86:19:86:19 | v | semmle.label | v |
+| test2.swift:93:5:93:5 | [post] a2 [Collection element] | semmle.label | [post] a2 [Collection element] |
+| test2.swift:93:13:93:29 | call to source(_:) | semmle.label | call to source(_:) |
+| test2.swift:99:19:99:19 | a2 [Collection element] | semmle.label | a2 [Collection element] |
+| test2.swift:99:19:99:24 | ...[...] | semmle.label | ...[...] |
+| test2.swift:101:5:101:5 | $generator [Collection element, Tuple element at index 1] | semmle.label | $generator [Collection element, Tuple element at index 1] |
+| test2.swift:101:5:101:5 | call to next() [some:0, Tuple element at index 1] | semmle.label | call to next() [some:0, Tuple element at index 1] |
+| test2.swift:101:9:101:15 | (...) [Tuple element at index 1] | semmle.label | (...) [Tuple element at index 1] |
+| test2.swift:101:14:101:14 | v | semmle.label | v |
+| test2.swift:101:20:101:20 | a2 [Collection element] | semmle.label | a2 [Collection element] |
+| test2.swift:101:20:101:34 | call to enumerated() [Collection element, Tuple element at index 1] | semmle.label | call to enumerated() [Collection element, Tuple element at index 1] |
+| test2.swift:101:20:101:34 | call to makeIterator() [Collection element, Tuple element at index 1] | semmle.label | call to makeIterator() [Collection element, Tuple element at index 1] |
+| test2.swift:103:19:103:19 | v | semmle.label | v |
 | test.swift:6:19:6:26 | call to source() | semmle.label | call to source() |
 | test.swift:7:15:7:15 | t1 | semmle.label | t1 |
 | test.swift:9:15:9:15 | t1 | semmle.label | t1 |
@@ -1615,6 +1661,10 @@ subpaths
 | test2.swift:53:15:53:28 | ... ??(_:_:) ... | test2.swift:46:17:46:33 | call to source(_:) | test2.swift:53:15:53:28 | ... ??(_:_:) ... | result |
 | test2.swift:54:15:54:24 | ...! | test2.swift:46:17:46:33 | call to source(_:) | test2.swift:54:15:54:24 | ...! | result |
 | test2.swift:70:19:70:19 | key | test2.swift:60:8:60:24 | call to source(_:) | test2.swift:70:19:70:19 | key | result |
+| test2.swift:82:19:82:24 | ...[...] | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:82:19:82:24 | ...[...] | result |
+| test2.swift:86:19:86:19 | v | test2.swift:76:30:76:46 | call to source(_:) | test2.swift:86:19:86:19 | v | result |
+| test2.swift:99:19:99:24 | ...[...] | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:99:19:99:24 | ...[...] | result |
+| test2.swift:103:19:103:19 | v | test2.swift:93:13:93:29 | call to source(_:) | test2.swift:103:19:103:19 | v | result |
 | test.swift:7:15:7:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:7:15:7:15 | t1 | result |
 | test.swift:9:15:9:15 | t1 | test.swift:6:19:6:26 | call to source() | test.swift:9:15:9:15 | t1 | result |
 | test.swift:10:15:10:15 | t2 | test.swift:6:19:6:26 | call to source() | test.swift:10:15:10:15 | t2 | result |

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.expected
@@ -1,3 +1,2 @@
 testFailures
-| test.swift:863:24:864:1 | // $ flow=873\n | Missing result: flow=873 |
 failures

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -161,6 +161,87 @@
 | test2.swift:69:25:69:25 | $generator | test2.swift:69:25:69:25 | SSA def($generator) |
 | test2.swift:69:25:69:25 | SSA def($generator) | test2.swift:69:5:69:5 | $generator |
 | test2.swift:69:25:69:25 | call to makeIterator() | test2.swift:69:25:69:25 | $generator |
+| test2.swift:76:9:76:9 | SSA def(a1) | test2.swift:78:14:78:14 | a1 |
+| test2.swift:76:9:76:9 | a1 | test2.swift:76:9:76:9 | SSA def(a1) |
+| test2.swift:76:14:76:47 | [...] | test2.swift:76:9:76:9 | a1 |
+| test2.swift:78:5:78:5 | $v$generator | test2.swift:78:5:78:5 | &... |
+| test2.swift:78:5:78:5 | &... | test2.swift:78:5:78:5 | $v$generator |
+| test2.swift:78:5:78:5 | [post] $v$generator | test2.swift:78:5:78:5 | &... |
+| test2.swift:78:9:78:9 | SSA def(v) | test2.swift:79:19:79:19 | v |
+| test2.swift:78:9:78:9 | v | test2.swift:78:9:78:9 | SSA def(v) |
+| test2.swift:78:14:78:14 | $v$generator | test2.swift:78:14:78:14 | SSA def($v$generator) |
+| test2.swift:78:14:78:14 | SSA def($v$generator) | test2.swift:78:5:78:5 | $v$generator |
+| test2.swift:78:14:78:14 | [post] a1 | test2.swift:81:21:81:21 | a1 |
+| test2.swift:78:14:78:14 | a1 | test2.swift:81:21:81:21 | a1 |
+| test2.swift:78:14:78:14 | call to makeIterator() | test2.swift:78:14:78:14 | $v$generator |
+| test2.swift:81:5:81:5 | $ix$generator | test2.swift:81:5:81:5 | &... |
+| test2.swift:81:5:81:5 | &... | test2.swift:81:5:81:5 | $ix$generator |
+| test2.swift:81:5:81:5 | [post] $ix$generator | test2.swift:81:5:81:5 | &... |
+| test2.swift:81:9:81:9 | SSA def(ix) | test2.swift:82:22:82:22 | ix |
+| test2.swift:81:9:81:9 | ix | test2.swift:81:9:81:9 | SSA def(ix) |
+| test2.swift:81:15:81:15 | $ix$generator | test2.swift:81:15:81:15 | SSA def($ix$generator) |
+| test2.swift:81:15:81:15 | SSA def($ix$generator) | test2.swift:81:5:81:5 | $ix$generator |
+| test2.swift:81:15:81:24 | call to makeIterator() | test2.swift:81:15:81:15 | $ix$generator |
+| test2.swift:81:21:81:21 | [post] a1 | test2.swift:82:19:82:19 | a1 |
+| test2.swift:81:21:81:21 | [post] a1 | test2.swift:84:20:84:20 | a1 |
+| test2.swift:81:21:81:21 | a1 | test2.swift:82:19:82:19 | a1 |
+| test2.swift:81:21:81:21 | a1 | test2.swift:84:20:84:20 | a1 |
+| test2.swift:82:19:82:19 | &... | test2.swift:82:19:82:19 | a1 |
+| test2.swift:82:19:82:19 | &... | test2.swift:84:20:84:20 | a1 |
+| test2.swift:82:19:82:19 | [post] a1 | test2.swift:82:19:82:19 | &... |
+| test2.swift:82:19:82:19 | a1 | test2.swift:82:19:82:19 | &... |
+| test2.swift:84:5:84:5 | $generator | test2.swift:84:5:84:5 | &... |
+| test2.swift:84:5:84:5 | &... | test2.swift:84:5:84:5 | $generator |
+| test2.swift:84:5:84:5 | [post] $generator | test2.swift:84:5:84:5 | &... |
+| test2.swift:84:10:84:10 | SSA def(ix) | test2.swift:85:19:85:19 | ix |
+| test2.swift:84:10:84:10 | ix | test2.swift:84:10:84:10 | SSA def(ix) |
+| test2.swift:84:14:84:14 | SSA def(v) | test2.swift:86:19:86:19 | v |
+| test2.swift:84:14:84:14 | v | test2.swift:84:14:84:14 | SSA def(v) |
+| test2.swift:84:20:84:20 | $generator | test2.swift:84:20:84:20 | SSA def($generator) |
+| test2.swift:84:20:84:20 | SSA def($generator) | test2.swift:84:5:84:5 | $generator |
+| test2.swift:84:20:84:34 | call to makeIterator() | test2.swift:84:20:84:20 | $generator |
+| test2.swift:91:9:91:9 | SSA def(a2) | test2.swift:93:5:93:5 | a2 |
+| test2.swift:91:9:91:9 | a2 | test2.swift:91:9:91:9 | SSA def(a2) |
+| test2.swift:91:14:91:33 | [...] | test2.swift:91:9:91:9 | a2 |
+| test2.swift:93:5:93:5 | &... | test2.swift:95:14:95:14 | a2 |
+| test2.swift:93:5:93:5 | [post] a2 | test2.swift:93:5:93:5 | &... |
+| test2.swift:93:5:93:5 | a2 | test2.swift:93:5:93:5 | &... |
+| test2.swift:95:5:95:5 | $v$generator | test2.swift:95:5:95:5 | &... |
+| test2.swift:95:5:95:5 | &... | test2.swift:95:5:95:5 | $v$generator |
+| test2.swift:95:5:95:5 | [post] $v$generator | test2.swift:95:5:95:5 | &... |
+| test2.swift:95:9:95:9 | SSA def(v) | test2.swift:96:19:96:19 | v |
+| test2.swift:95:9:95:9 | v | test2.swift:95:9:95:9 | SSA def(v) |
+| test2.swift:95:14:95:14 | $v$generator | test2.swift:95:14:95:14 | SSA def($v$generator) |
+| test2.swift:95:14:95:14 | SSA def($v$generator) | test2.swift:95:5:95:5 | $v$generator |
+| test2.swift:95:14:95:14 | [post] a2 | test2.swift:98:21:98:21 | a2 |
+| test2.swift:95:14:95:14 | a2 | test2.swift:98:21:98:21 | a2 |
+| test2.swift:95:14:95:14 | call to makeIterator() | test2.swift:95:14:95:14 | $v$generator |
+| test2.swift:98:5:98:5 | $ix$generator | test2.swift:98:5:98:5 | &... |
+| test2.swift:98:5:98:5 | &... | test2.swift:98:5:98:5 | $ix$generator |
+| test2.swift:98:5:98:5 | [post] $ix$generator | test2.swift:98:5:98:5 | &... |
+| test2.swift:98:9:98:9 | SSA def(ix) | test2.swift:99:22:99:22 | ix |
+| test2.swift:98:9:98:9 | ix | test2.swift:98:9:98:9 | SSA def(ix) |
+| test2.swift:98:15:98:15 | $ix$generator | test2.swift:98:15:98:15 | SSA def($ix$generator) |
+| test2.swift:98:15:98:15 | SSA def($ix$generator) | test2.swift:98:5:98:5 | $ix$generator |
+| test2.swift:98:15:98:24 | call to makeIterator() | test2.swift:98:15:98:15 | $ix$generator |
+| test2.swift:98:21:98:21 | [post] a2 | test2.swift:99:19:99:19 | a2 |
+| test2.swift:98:21:98:21 | [post] a2 | test2.swift:101:20:101:20 | a2 |
+| test2.swift:98:21:98:21 | a2 | test2.swift:99:19:99:19 | a2 |
+| test2.swift:98:21:98:21 | a2 | test2.swift:101:20:101:20 | a2 |
+| test2.swift:99:19:99:19 | &... | test2.swift:99:19:99:19 | a2 |
+| test2.swift:99:19:99:19 | &... | test2.swift:101:20:101:20 | a2 |
+| test2.swift:99:19:99:19 | [post] a2 | test2.swift:99:19:99:19 | &... |
+| test2.swift:99:19:99:19 | a2 | test2.swift:99:19:99:19 | &... |
+| test2.swift:101:5:101:5 | $generator | test2.swift:101:5:101:5 | &... |
+| test2.swift:101:5:101:5 | &... | test2.swift:101:5:101:5 | $generator |
+| test2.swift:101:5:101:5 | [post] $generator | test2.swift:101:5:101:5 | &... |
+| test2.swift:101:10:101:10 | SSA def(ix) | test2.swift:102:19:102:19 | ix |
+| test2.swift:101:10:101:10 | ix | test2.swift:101:10:101:10 | SSA def(ix) |
+| test2.swift:101:14:101:14 | SSA def(v) | test2.swift:103:19:103:19 | v |
+| test2.swift:101:14:101:14 | v | test2.swift:101:14:101:14 | SSA def(v) |
+| test2.swift:101:20:101:20 | $generator | test2.swift:101:20:101:20 | SSA def($generator) |
+| test2.swift:101:20:101:20 | SSA def($generator) | test2.swift:101:5:101:5 | $generator |
+| test2.swift:101:20:101:34 | call to makeIterator() | test2.swift:101:20:101:20 | $generator |
 | test.swift:5:9:5:13 | ... as ... | test.swift:5:9:5:9 | t2 |
 | test.swift:6:9:6:9 | SSA def(t1) | test.swift:7:15:7:15 | t1 |
 | test.swift:6:9:6:9 | t1 | test.swift:6:9:6:9 | SSA def(t1) |

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -860,7 +860,7 @@ func testVarargs3(_ v: Int, _ args: Int...) {
     sink(arg: args[1]) // $ flow=873
 
     for arg in args {
-        sink(arg: arg) // $ flow=873
+        sink(arg: arg) // $ MISSING: flow=873
     }
 
     let myKeyPath = \[Int][1]

--- a/swift/ql/test/library-tests/dataflow/dataflow/test.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test.swift
@@ -860,7 +860,7 @@ func testVarargs3(_ v: Int, _ args: Int...) {
     sink(arg: args[1]) // $ flow=873
 
     for arg in args {
-        sink(arg: arg) // $ MISSING: flow=873
+        sink(arg: arg) // $ flow=873
     }
 
     let myKeyPath = \[Int][1]

--- a/swift/ql/test/library-tests/dataflow/dataflow/test2.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test2.swift
@@ -76,7 +76,7 @@ func testArrays1() {
     var a1 = ["a", "b", "c", source("source5")]
 
     for v in a1 {
-        sink(arg: v) // $ MISSING: flow=source5
+        sink(arg: v) // $ flow=source5
     }
     for ix in 0 ..< a1.count {
         sink(arg: a1[ix]) // $ flow=source5
@@ -93,7 +93,7 @@ func testArrays2() {
     a2[1] = source("source6")
 
     for v in a2 {
-        sink(arg: v) // $ MISSING: flow=source6
+        sink(arg: v) // $ flow=source6
     }
     for ix in 0 ..< a2.count {
         sink(arg: a2[ix]) // $ flow=source6

--- a/swift/ql/test/library-tests/dataflow/dataflow/test2.swift
+++ b/swift/ql/test/library-tests/dataflow/dataflow/test2.swift
@@ -1,5 +1,5 @@
 func source(_ label: String) -> String { return ""; }
-func sink(arg: String) {}
+func sink<T>(arg: T) {}
 
 func testDicts() {
     let d1 = ["a": "apple", "b": "banana", "c": source("source1")]
@@ -69,5 +69,37 @@ func testDicts4() {
     for (key, value) in d4 {
         sink(arg: key) // $ flow=source4
         sink(arg: value)
+    }
+}
+
+func testArrays1() {
+    var a1 = ["a", "b", "c", source("source5")]
+
+    for v in a1 {
+        sink(arg: v) // $ MISSING: flow=source5
+    }
+    for ix in 0 ..< a1.count {
+        sink(arg: a1[ix]) // $ flow=source5
+    }
+    for (ix, v) in a1.enumerated() {
+        sink(arg: ix)
+        sink(arg: v) // $ flow=source5
+    }
+}
+
+func testArrays2() {
+    var a2 = ["a", "b", "c", "d"]
+
+    a2[1] = source("source6")
+
+    for v in a2 {
+        sink(arg: v) // $ MISSING: flow=source6
+    }
+    for ix in 0 ..< a2.count {
+        sink(arg: a2[ix]) // $ flow=source6
+    }
+    for (ix, v) in a2.enumerated() {
+        sink(arg: ix)
+        sink(arg: v) // $ flow=source6
     }
 }

--- a/swift/ql/test/query-tests/Security/CWE-020/MissingRegexAnchor.expected
+++ b/swift/ql/test/query-tests/Security/CWE-020/MissingRegexAnchor.expected
@@ -46,8 +46,9 @@
 | UnanchoredUrlRegex.swift:71:46:71:46 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:78:39:78:39 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:79:39:79:39 | https?://good.com:8080 | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
-| UnanchoredUrlRegex.swift:95:39:95:39 | https?:\\/\\/good.com\\/([0-9]+) | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
-| UnanchoredUrlRegex.swift:101:39:101:39 | example\\.com\|whatever | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:91:3:91:3 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:101:39:101:39 | https?:\\/\\/good.com\\/([0-9]+) | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:107:39:107:39 | example\\.com\|whatever | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | test.swift:56:16:56:16 | ^http://example.com | This hostname pattern may match any domain name, as it is missing a '$' or '/' at the end. |
 | test.swift:59:16:59:16 | ^http://test\\.example.com | This hostname pattern may match any domain name, as it is missing a '$' or '/' at the end. |
 | test.swift:69:16:69:16 | ^(.+\\.(?:example-a\|example-b)\\.com)/ | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |

--- a/swift/ql/test/query-tests/Security/CWE-020/MissingRegexAnchor.expected
+++ b/swift/ql/test/query-tests/Security/CWE-020/MissingRegexAnchor.expected
@@ -46,6 +46,9 @@
 | UnanchoredUrlRegex.swift:71:46:71:46 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:78:39:78:39 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:79:39:79:39 | https?://good.com:8080 | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:82:3:82:3 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:83:3:83:3 | https?:\\/\\/good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
+| UnanchoredUrlRegex.swift:84:3:84:3 | ^https?://good.com | This hostname pattern may match any domain name, as it is missing a '$' or '/' at the end. |
 | UnanchoredUrlRegex.swift:91:3:91:3 | https?://good.com | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:101:39:101:39 | https?:\\/\\/good.com\\/([0-9]+) | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |
 | UnanchoredUrlRegex.swift:107:39:107:39 | example\\.com\|whatever | When this is used as a regular expression on a URL, it may match anywhere, and arbitrary hosts may come before or after it. |

--- a/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
+++ b/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
@@ -86,6 +86,12 @@ func tests(url: String, secure: Bool) throws {
 	for trustedUrlRegex in trustedUrlRegexs {
 		if let _ = try NSRegularExpression(pattern: trustedUrlRegex).firstMatch(in: input, range: inputRange) { }
 	}
+
+	let trustedUrlRegexs2 = [
+		"https?://good.com", // BAD (missing anchor), referenced below
+	]
+	if let _ = try NSRegularExpression(pattern: trustedUrlRegexs2[0]).firstMatch(in: input, range: inputRange) { }
+
 	let notUsedUrlRegexs = [
 		"https?://good.com" // OK (not referenced)
 	]

--- a/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
+++ b/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
@@ -79,9 +79,9 @@ func tests(url: String, secure: Bool) throws {
 	_ = try NSRegularExpression(pattern: #"https?://good.com:8080"#).firstMatch(in: input, range: inputRange) // BAD (missing anchor)
 
 	let trustedUrlRegexs = [
-		"https?://good.com", // BAD (missing anchor), referenced below
-		#"https?:\/\/good.com"#, // BAD (missing anchor), referenced below
-		"^https?://good.com" // BAD (missing post-anchor), referenced below
+		"https?://good.com", // BAD (missing anchor), referenced below [NOT DETECTED]
+		#"https?:\/\/good.com"#, // BAD (missing anchor), referenced below [NOT DETECTED]
+		"^https?://good.com" // BAD (missing post-anchor), referenced below [NOT DETECTED]
 	]
 	for trustedUrlRegex in trustedUrlRegexs {
 		if let _ = try NSRegularExpression(pattern: trustedUrlRegex).firstMatch(in: input, range: inputRange) { }

--- a/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
+++ b/swift/ql/test/query-tests/Security/CWE-020/UnanchoredUrlRegex.swift
@@ -79,9 +79,9 @@ func tests(url: String, secure: Bool) throws {
 	_ = try NSRegularExpression(pattern: #"https?://good.com:8080"#).firstMatch(in: input, range: inputRange) // BAD (missing anchor)
 
 	let trustedUrlRegexs = [
-		"https?://good.com", // BAD (missing anchor), referenced below [NOT DETECTED]
-		#"https?:\/\/good.com"#, // BAD (missing anchor), referenced below [NOT DETECTED]
-		"^https?://good.com" // BAD (missing post-anchor), referenced below [NOT DETECTED]
+		"https?://good.com", // BAD (missing anchor), referenced below
+		#"https?:\/\/good.com"#, // BAD (missing anchor), referenced below
+		"^https?://good.com" // BAD (missing post-anchor), referenced below
 	]
 	for trustedUrlRegex in trustedUrlRegexs {
 		if let _ = try NSRegularExpression(pattern: trustedUrlRegex).firstMatch(in: input, range: inputRange) { }


### PR DESCRIPTION
Fix `makeIterator()` models.  We previously depended on the `Sequence.makeIterator()` model, but it appears basic `for in` loops go to `Collection.makeIterator()` now, so we need a model of that.