### PR TITLE
KE2: restore basic function label construction

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/entities/Function.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Function.kt
@@ -149,7 +149,7 @@ fun KotlinUsesExtractor.getFunctionLabel(
     prefix: String = "callable"
 ): String {
 
-    val allParamTypes = (extensionParamType?.let { listOf(it) } ?: listOf()) + parameterTypes
+    val allParamTypes = listOfNotNull(extensionParamType) + parameterTypes
 
     /* OLD: KE1
     val substitutionMap =
@@ -165,10 +165,8 @@ fun KotlinUsesExtractor.getFunctionLabel(
         }
      */
     val getIdForFunctionLabel = { it: IndexedValue<KaType> ->
-        // Kotlin rewrites certain Java collections types adding additional generic
-        // constraints-- for example,
-        // Collection.remove(Object) because Collection.remove(Collection::E) in the Kotlin
-        // universe.
+        // Kotlin rewrites certain Java collections types adding additional generic constraints-- for example,
+        // Collection.remove(Object) becomes Collection.remove(Collection::E) in the Kotlin universe.
         // If this has happened, erase the type again to get the correct Java signature.
         val maybeAmendedForCollections = it.value
         /* OLD: KE1


### PR DESCRIPTION
Restore the basics of function label construction from parameter, return and extension receiver types.

Restoration of generics, variances, type substition etc still to do.