### PR TITLE
Swift: Fix for OptionSet and BinaryInteger models

### DIFF
--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
@@ -12,10 +12,11 @@ private import codeql.swift.dataflow.FlowSteps
  */
 private class RawRepresentableSummaries extends SummaryModelCsv {
   override predicate row(string row) {
-    row = [
-      ";RawRepresentable;true;init(rawValue:);;;Argument[0];ReturnValue;taint",
-      ";OptionSet;true;init(rawValue:);;;Argument[0];ReturnValue;taint"
-    ]
+    row =
+      [
+        ";RawRepresentable;true;init(rawValue:);;;Argument[0];ReturnValue;taint",
+        ";OptionSet;true;init(rawValue:);;;Argument[0];ReturnValue;taint"
+      ]
   }
 }
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/RawRepresentable.qll
@@ -12,7 +12,10 @@ private import codeql.swift.dataflow.FlowSteps
  */
 private class RawRepresentableSummaries extends SummaryModelCsv {
   override predicate row(string row) {
-    row = ";RawRepresentable;true;init(rawValue:);;;Argument[0];ReturnValue;taint"
+    row = [
+      ";RawRepresentable;true;init(rawValue:);;;Argument[0];ReturnValue;taint",
+      ";OptionSet;true;init(rawValue:);;;Argument[0];ReturnValue;taint"
+    ]
   }
 }
 

--- a/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
+++ b/swift/ql/lib/codeql/swift/frameworks/StandardLibrary/String.qll
@@ -167,7 +167,7 @@ private class StringFieldsInheritTaint extends TaintInheritingContent,
             "precomposedStringWithCompatibilityMapping", "removingPercentEncoding"
           ]
         or
-        namedTypeDecl.getFullName() = "CustomStringConvertible" and
+        namedTypeDecl.getFullName() = ["CustomStringConvertible", "BinaryInteger"] and
         fieldDecl.getName() = "description"
         or
         namedTypeDecl.getFullName() = "CustomDebugStringConvertible" and

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
@@ -1,4 +1,2 @@
 testFailures
-| optionset.swift:60:49:61:1 | // $ tainted=60\n | Missing result: tainted=60 |
-| optionset.swift:65:58:66:1 | // $ tainted=65\n | Missing result: tainted=65 |
 failures

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
@@ -1,5 +1,4 @@
 testFailures
 | optionset.swift:60:49:61:1 | // $ tainted=60\n | Missing result: tainted=60 |
 | optionset.swift:65:58:66:1 | // $ tainted=65\n | Missing result: tainted=65 |
-| string.swift:599:35:600:1 | // $ tainted=599\n | Missing result: tainted=599 |
 failures


### PR DESCRIPTION
Small fix for the `OptionSet` and `BinaryInteger` models for Swift 6.  I'm particularly displeased with this one as there doesn't seem to be much reason why `BinaryInteger` would apparently not derive from `CustomStringConvertible` any more (hence needing its own model of `.description`), though it does remind me of some of the changes in https://github.com/github/codeql/pull/17989 to integral type models.  Similarly for `OptionSet`, either it's been divorced from `RawRepresentable` or for some reason we're not extracting the association correctly any more.

In any case, all of the test regressions I'm aware of are now fixed.