### PR TITLE
C#: Only extract public and protected members from metadata.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/CodeAnalysisExtensions/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/CodeAnalysisExtensions/SymbolExtensions.cs
@@ -663,11 +663,11 @@ namespace Semmle.Extraction.CSharp
             }
             if (symbol is IMethodSymbol method)
             {
-                return method.ExplicitInterfaceImplementations.Any(m => m.ContainingType.DeclaredAccessibility == Accessibility.Public);
+                return method.ExplicitInterfaceImplementations.Any(m => m.ContainingType.ShouldExtractSymbol());
             }
             if (symbol is IPropertySymbol property)
             {
-                return property.ExplicitInterfaceImplementations.Any(m => m.ContainingType.DeclaredAccessibility == Accessibility.Public);
+                return property.ExplicitInterfaceImplementations.Any(m => m.ContainingType.ShouldExtractSymbol());
             }
             return false;
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -101,7 +101,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 }
             }
 
-            if (Symbol.OverriddenMethod is not null)
+            if (Symbol.OverriddenMethod is not null && Symbol.OverriddenMethod.ShouldExtractSymbol())
             {
                 trapFile.overrides(this, Method.Create(Context, Symbol.OverriddenMethod));
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -225,7 +225,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         /// <summary>
-        /// Called to extract all members and nested types.
+        /// Called to extract members and nested types.
         /// This is called on each member of a namespace,
         /// in either source code or an assembly.
         /// </summary>
@@ -236,7 +236,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 Context.BindComments(this, l);
             }
 
-            foreach (var member in Symbol.GetMembers())
+            foreach (var member in Symbol.GetMembers().ExtractionCandidates())
             {
                 switch (member.Kind)
                 {
@@ -262,16 +262,16 @@ namespace Semmle.Extraction.CSharp.Entities
 
                 var members = new List<ISymbol>();
 
-                foreach (var member in Symbol.GetMembers())
+                foreach (var member in Symbol.GetMembers().ExtractionCandidates())
                     members.Add(member);
-                foreach (var member in Symbol.GetTypeMembers())
+                foreach (var member in Symbol.GetTypeMembers().ExtractionCandidates())
                     members.Add(member);
 
                 // Mono extractor puts all BASE interface members as members of the current interface.
 
                 if (Symbol.TypeKind == TypeKind.Interface)
                 {
-                    foreach (var baseInterface in Symbol.Interfaces)
+                    foreach (var baseInterface in Symbol.Interfaces.ExtractionCandidates())
                     {
                         foreach (var member in baseInterface.GetMembers())
                             members.Add(member);
@@ -285,10 +285,10 @@ namespace Semmle.Extraction.CSharp.Entities
                     Context.CreateEntity(member);
                 }
 
-                if (Symbol.BaseType is not null)
+                if (Symbol.BaseType is not null && Symbol.BaseType.ShouldExtractSymbol())
                     Create(Context, Symbol.BaseType).PopulateGenerics();
 
-                foreach (var i in Symbol.Interfaces)
+                foreach (var i in Symbol.Interfaces.ExtractionCandidates())
                 {
                     Create(Context, i).PopulateGenerics();
                 }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -285,7 +285,7 @@ namespace Semmle.Extraction.CSharp.Entities
                     Context.CreateEntity(member);
                 }
 
-                if (Symbol.BaseType is not null && Symbol.BaseType.ShouldExtractSymbol())
+                if (Symbol.BaseType is not null)
                     Create(Context, Symbol.BaseType).PopulateGenerics();
 
                 foreach (var i in Symbol.Interfaces.ExtractionCandidates())

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Analyser.cs
@@ -269,7 +269,7 @@ namespace Semmle.Extraction.CSharp
                 AnalyseNamespace(cx, memberNamespace);
             }
 
-            foreach (var memberType in ns.GetTypeMembers())
+            foreach (var memberType in ns.GetTypeMembers().ExtractionCandidates())
             {
                 Entities.Type.Create(cx, memberType).ExtractRecursive();
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Extractor/Extractor.cs
@@ -549,7 +549,6 @@ namespace Semmle.Extraction.CSharp
                         compilerArguments.CompilationOptions
                             .WithAssemblyIdentityComparer(DesktopAssemblyIdentityComparer.Default)
                             .WithStrongNameProvider(new DesktopStrongNameProvider(compilerArguments.KeyFileSearchPaths))
-                            .WithMetadataImportOptions(MetadataImportOptions.All)
                         );
                 },
                 (compilation, options) => analyser.EndInitialize(compilerArguments, options, compilation, cwd, args),

--- a/csharp/ql/lib/change-notes/2024-12-03-public-protected-reference.md
+++ b/csharp/ql/lib/change-notes/2024-12-03-public-protected-reference.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Only extract *public* and *protected* members from reference assemblies. This yields an approximate average speed-up of around 10% for extraction and query execution.
+* Only extract *public* and *protected* members from reference assemblies. This yields an approximate average speed-up of around 10% for extraction and query execution. Custom MaD rows using `Field`-based summaries may need to be changed to `SyntheticField`-based flows if they reference private fields.

--- a/csharp/ql/lib/change-notes/2024-12-03-public-protected-reference.md
+++ b/csharp/ql/lib/change-notes/2024-12-03-public-protected-reference.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Only extract *public* and *protected* members from reference assemblies. This yields an approximate average speed-up of around 10% for extraction and query execution.

--- a/csharp/ql/test/library-tests/conversion/operator/Operator.expected
+++ b/csharp/ql/test/library-tests/conversion/operator/Operator.expected
@@ -21,7 +21,6 @@
 | Int32 | Decimal |
 | Int32 | Index |
 | Int32 | Int128 |
-| Int32 | MetadataToken |
 | Int32 | NFloat |
 | Int64 | Decimal |
 | Int64 | Int128 |
@@ -29,7 +28,6 @@
 | IntPtr | Int128 |
 | IntPtr | NFloat |
 | Memory`1 | ReadOnlyMemory<T> |
-| MetadataToken | Int32 |
 | NFloat | Double |
 | SByte | Decimal |
 | SByte | Half |
@@ -59,4 +57,3 @@
 | UIntPtr | Int128 |
 | UIntPtr | NFloat |
 | UIntPtr | UInt128 |
-| UnixFileMode | Nullable<UnixFileMode> |

--- a/csharp/ql/test/library-tests/conversion/reftype/RefType.expected
+++ b/csharp/ql/test/library-tests/conversion/reftype/RefType.expected
@@ -183,8 +183,6 @@
 | IReadOnlyList<T4> | dynamic |
 | Int16[] | Object |
 | Int16[] | dynamic |
-| Int32[,] | Object |
-| Int32[,] | dynamic |
 | Int32[] | Object |
 | Int32[] | dynamic |
 | Int64[] | Object |
@@ -223,8 +221,6 @@
 | T5 | C1 |
 | T5 | Object |
 | T5 | dynamic |
-| UInt16[][] | Object |
-| UInt16[][] | dynamic |
 | UInt32[] | Object |
 | UInt32[] | dynamic |
 | UInt64[] | Object |
@@ -283,7 +279,6 @@
 | null | IReadOnlyList<T3> |
 | null | IReadOnlyList<T4> |
 | null | Int16[] |
-| null | Int32[,] |
 | null | Int32[] |
 | null | Int64[] |
 | null | Object |
@@ -294,7 +289,6 @@
 | null | T4 |
 | null | T4[] |
 | null | T5 |
-| null | UInt16[][] |
 | null | UInt32[] |
 | null | UInt64[] |
 | null | dynamic |

--- a/csharp/ql/test/library-tests/csharp9/FunctionPointer.expected
+++ b/csharp/ql/test/library-tests/csharp9/FunctionPointer.expected
@@ -1,68 +1,33 @@
 type
 | file://:0:0:0:0 | delegate* default<A,B> | B | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<B,A> | A | DefaultCallingConvention |
-| file://:0:0:0:0 | delegate* default<Byte ref,Void> | Void | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 in,Int32 ref> | ref int | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 ref readonly> | readonly int | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<Int32*,Void*> | Void* | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<Int32> | int | DefaultCallingConvention |
-| file://:0:0:0:0 | delegate* default<IntPtr,Byte ref,PortableTailCallFrame*,Void> | Void | DefaultCallingConvention |
-| file://:0:0:0:0 | delegate* default<Object,Void> | Void | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<T,Int32> | int | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* default<Void*,Int32*> | int* | DefaultCallingConvention |
-| file://:0:0:0:0 | delegate* default<Void*,Object> | object | DefaultCallingConvention |
 | file://:0:0:0:0 | delegate* stdcall<Int32 ref,Object out,T,Void> | Void | StdCallCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | Void | UnmanagedCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<Char*,IntPtr,Void> | Void | UnmanagedCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<Int32,PosixSignal,Int32> | int | UnmanagedCallingConvention |
 | file://:0:0:0:0 | delegate* unmanaged<IntPtr,Int32> | int | UnmanagedCallingConvention |
 | file://:0:0:0:0 | delegate* unmanaged<IntPtr,Void> | Void | UnmanagedCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<NoGCRegionCallbackFinalizerWorkItem*,Void> | Void | UnmanagedCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Byte*,Void> | Void | UnmanagedCallingConvention |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | Void | UnmanagedCallingConvention |
 | file://:0:0:0:0 | delegate* unmanaged<Void> | Void | UnmanagedCallingConvention |
 unmanagedCallingConvention
 parameter
 | file://:0:0:0:0 | delegate* default<A,B> | 0 | file://:0:0:0:0 |  | A |
 | file://:0:0:0:0 | delegate* default<B,A> | 0 | file://:0:0:0:0 |  | B |
-| file://:0:0:0:0 | delegate* default<Byte ref,Void> | 0 | file://:0:0:0:0 |  | ref byte! |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 in,Int32 ref> | 0 | file://:0:0:0:0 |  | ref int! |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 in,Int32 ref> | 1 | file://:0:0:0:0 | `1 | out object? |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 in,Int32 ref> | 2 | file://:0:0:0:0 | `2 | readonly int! |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 ref readonly> | 0 | file://:0:0:0:0 |  | ref int! |
 | file://:0:0:0:0 | delegate* default<Int32 ref,Object out,Int32 ref readonly> | 1 | file://:0:0:0:0 | `1 | out object? |
 | file://:0:0:0:0 | delegate* default<Int32*,Void*> | 0 | file://:0:0:0:0 |  | int*! |
-| file://:0:0:0:0 | delegate* default<IntPtr,Byte ref,PortableTailCallFrame*,Void> | 0 | file://:0:0:0:0 |  | IntPtr! |
-| file://:0:0:0:0 | delegate* default<IntPtr,Byte ref,PortableTailCallFrame*,Void> | 1 | file://:0:0:0:0 | `1 | ref byte! |
-| file://:0:0:0:0 | delegate* default<IntPtr,Byte ref,PortableTailCallFrame*,Void> | 2 | file://:0:0:0:0 | `2 | PortableTailCallFrame*! |
-| file://:0:0:0:0 | delegate* default<Object,Void> | 0 | file://:0:0:0:0 |  | object |
 | file://:0:0:0:0 | delegate* default<T,Int32> | 0 | file://:0:0:0:0 |  | T |
 | file://:0:0:0:0 | delegate* default<Void*,Int32*> | 0 | file://:0:0:0:0 |  | Void*! |
-| file://:0:0:0:0 | delegate* default<Void*,Object> | 0 | file://:0:0:0:0 |  | Void*! |
 | file://:0:0:0:0 | delegate* stdcall<Int32 ref,Object out,T,Void> | 0 | file://:0:0:0:0 |  | ref int! |
 | file://:0:0:0:0 | delegate* stdcall<Int32 ref,Object out,T,Void> | 1 | file://:0:0:0:0 | `1 | out object? |
 | file://:0:0:0:0 | delegate* stdcall<Int32 ref,Object out,T,Void> | 2 | file://:0:0:0:0 | `2 | T |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 0 | file://:0:0:0:0 |  | byte*! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 1 | file://:0:0:0:0 | `1 | int! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 2 | file://:0:0:0:0 | `2 | byte! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 3 | file://:0:0:0:0 | `3 | long! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 4 | file://:0:0:0:0 | `4 | long! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 5 | file://:0:0:0:0 | `5 | EVENT_FILTER_DESCRIPTOR*! |
-| file://:0:0:0:0 | delegate* unmanaged<Byte*,Int32,Byte,Int64,Int64,EVENT_FILTER_DESCRIPTOR*,Void*,Void> | 6 | file://:0:0:0:0 | `6 | Void*! |
-| file://:0:0:0:0 | delegate* unmanaged<Char*,IntPtr,Void> | 0 | file://:0:0:0:0 |  | char*! |
-| file://:0:0:0:0 | delegate* unmanaged<Char*,IntPtr,Void> | 1 | file://:0:0:0:0 | `1 | IntPtr! |
-| file://:0:0:0:0 | delegate* unmanaged<Int32,PosixSignal,Int32> | 0 | file://:0:0:0:0 |  | int! |
-| file://:0:0:0:0 | delegate* unmanaged<Int32,PosixSignal,Int32> | 1 | file://:0:0:0:0 | `1 | PosixSignal! |
 | file://:0:0:0:0 | delegate* unmanaged<IntPtr,Int32> | 0 | file://:0:0:0:0 |  | IntPtr! |
 | file://:0:0:0:0 | delegate* unmanaged<IntPtr,Void> | 0 | file://:0:0:0:0 |  | IntPtr! |
-| file://:0:0:0:0 | delegate* unmanaged<NoGCRegionCallbackFinalizerWorkItem*,Void> | 0 | file://:0:0:0:0 |  | NoGCRegionCallbackFinalizerWorkItem*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Byte*,Void> | 0 | file://:0:0:0:0 |  | Void*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Byte*,Void> | 1 | file://:0:0:0:0 | `1 | byte*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | 0 | file://:0:0:0:0 |  | Void*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | 1 | file://:0:0:0:0 | `1 | Void*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | 2 | file://:0:0:0:0 | `2 | Void*! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | 3 | file://:0:0:0:0 | `3 | GCConfigurationType! |
-| file://:0:0:0:0 | delegate* unmanaged<Void*,Void*,Void*,GCConfigurationType,Int64,Void> | 4 | file://:0:0:0:0 | `4 | long! |
 invocation
 | FunctionPointer.cs:17:21:17:43 | function pointer call |
 | FunctionPointer.cs:23:13:23:44 | function pointer call |

--- a/csharp/ql/test/library-tests/tuples/tuples.expected
+++ b/csharp/ql/test/library-tests/tuples/tuples.expected
@@ -8,13 +8,11 @@ members2
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | Equals(object, IEqualityComparer) |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | GetHashCode() |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | GetHashCode(IEqualityComparer) |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | Item1 |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | Item2 |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | Item[int] |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | Length |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | ToString() |
-| tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | ToStringEnd() |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | ValueTuple() |
 | tuple.cs:7:17:7:22 | (Int32,Int32) | ValueTuple<int, int> | ValueTuple(int, int) |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | CompareTo((int, int, int, int, int, int, int)) |
@@ -25,7 +23,6 @@ members2
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Equals(object, IEqualityComparer) |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | GetHashCode() |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | GetHashCode(IEqualityComparer) |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Item1 |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Item2 |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Item3 |
@@ -36,7 +33,6 @@ members2
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Item[int] |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | Length |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | ToString() |
-| tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | ToStringEnd() |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | ValueTuple() |
 | tuple.cs:12:17:12:37 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int> | ValueTuple(int, int, int, int, int, int, int) |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | CompareTo((int, int, int, int, int, int, int, int)) |
@@ -47,7 +43,6 @@ members2
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Equals(object, IEqualityComparer) |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | GetHashCode() |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | GetHashCode(IEqualityComparer) |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Item1 |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Item2 |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Item3 |
@@ -60,7 +55,6 @@ members2
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Length |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | Rest |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | ToString() |
-| tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | ToStringEnd() |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | ValueTuple() |
 | tuple.cs:15:17:15:40 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int)> | ValueTuple(int, int, int, int, int, int, int, (int)) |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | CompareTo((int, int, int, int, int, int, int, int, int, int)) |
@@ -71,7 +65,6 @@ members2
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Equals(object, IEqualityComparer) |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | GetHashCode() |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | GetHashCode(IEqualityComparer) |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | GetHashCodeCore(IEqualityComparer) |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Item1 |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Item2 |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Item3 |
@@ -86,6 +79,5 @@ members2
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Length |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | Rest |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | ToString() |
-| tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | ToStringEnd() |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | ValueTuple() |
 | tuple.cs:18:17:18:47 | (Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32,Int32) | ValueTuple<int, int, int, int, int, int, int, (int, int, int)> | ValueTuple(int, int, int, int, int, int, int, (int, int, int)) |


### PR DESCRIPTION
In this PR we change how much information we extract from reference assemblies.
Prior to this PR all symbols (also private an internal) were extracted from the reference assemblies even though not all of them are accessible outside the assemblies (e.g. it is not possible to call a private method outside the assembly).

With this PR, we only extract *public* and *protected* members ("effectively" public members and types) from the reference assemblies.

There is one identified drawback with this approach, which was identified by DCA:
- If a project exposes its internals to another project and if the project that exposes its internals is referenced as a dll (and not by source), then we get missing call targets (and thereby unknown expression types). This happens in a few cases in our DCA suite (two projects from traced extraction were investigated)
  - Roslyn makes use of some dll's which were originally implemented in VB (this was mostly in tests).
  - Powershell makes use of one project, which is referenced by dll and which gives us eight missing call targets. The eight extra missing call targets are also due `InternalsVisible` (in this case internals from [Microsoft.Management.Infrastructure](https://github.com/PowerShell/MMI/blob/cf32fc695b32c2eae848b693395c09222fe1d2ae/src/Microsoft.Management.Infrastructure/AssemblyInfo.cs) are made accessible to `System.Management.Automation`, which is declared in the powershell project).


Making solutions in production code using `InternalsVisible` in an anti-pattern (note that we only get an issue in case internals are in reference assemblies). Furthermore, the "increase" in the number of missing call targets and expressions with unknown types for the buildless extractions are negligible.

The advantages are
- DCA identifies a 10% overall speedup of analysis time.
- DCA identified an approximately DB reduction of around 10%.
- For .NET 9 we avoid DB inconsistencies (failing DB check) when including some of the standard Microsoft reference DLLs that have conflicting internal declarations (this will otherwise have to be fixed in another way) <-- This was the original motivation to look into this.

DCA doesn't show any alert changes to the security related queries.
IMO the advantages outweigh the drawbacks.

@hvitved @tamasvajk : What do you think?