### PR TITLE
Add query to ensure predicates starting with 'get' return a value

### DIFF
--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -26,9 +26,7 @@ predicate hasReturnType(Predicate pred) { exists(pred.getReturnType()) }
 /**
  * Checks if a predicate is an alias using getAlias().
  */
-predicate isAlias(Predicate pred) {
-  pred instanceof ClasslessPredicate and exists(pred.(ClasslessPredicate).getAlias())
-}
+predicate isAlias(Predicate pred) { exists(pred.(ClasslessPredicate).getAlias()) }
 
 from Predicate pred
 where

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -1,6 +1,6 @@
 /**
- * @name Predicates starting with "get" should return a value
- * @description Checks if predicates that start with "get" actually return a value.
+ * @name Predicates starting with "get" or "as" should return a value
+ * @description Checks if predicates that start with "get" or "as" actually return a value.
  * @kind problem
  * @problem.severity warning
  * @id ql/predicates-get-should-return-value
@@ -13,7 +13,7 @@ import ql
 import codeql_ql.ast.Ast
 
 /**
- * Identifies predicates whose names start with "get" followed by an uppercase letter.
+ * Identifies predicates whose names start with "get", "as" followed by an uppercase letter.
  * This ensures that only predicates like "getValue" are matched, excluding names like "getter".
  */
 predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("(get|as)[A-Z].*") }

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -21,18 +21,17 @@ predicate isGetPredicate(Predicate pred, string prefix) {
 }
 
 /**
- * Checks if a predicate has a return type.
+ * Checks if a predicate has a return type. This is phrased negatively to not flag unresolved aliases.
  */
-predicate hasReturnType(Predicate pred) { exists(pred.getReturnTypeExpr()) }
-
-/**
- * Checks if a predicate is an alias using getAlias().
- */
-predicate isAlias(Predicate pred) { exists(pred.(ClasslessPredicate).getAlias()) }
+predicate hasNoReturnType(Predicate pred) {
+  not exists(pred.getReturnTypeExpr()) and
+  not pred.(ClasslessPredicate).getAlias() instanceof PredicateExpr
+  or
+  hasNoReturnType(pred.(ClasslessPredicate).getAlias().(PredicateExpr).getResolvedPredicate())
+}
 
 from Predicate pred, string prefix
 where
   isGetPredicate(pred, prefix) and
-  not hasReturnType(pred) and
-  not isAlias(pred)
+  hasNoReturnType(pred)
 select pred, "This predicate starts with '" + prefix + "' but does not return a value."

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -21,9 +21,7 @@ predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("get[A-Z].
 /**
  * Checks if a predicate has a return type.
  */
-predicate hasReturnType(Predicate pred) {
-  exists(Type returnType | pred.getReturnType() = returnType)
-}
+predicate hasReturnType(Predicate pred) { exists(pred.getReturnType()) }
 
 /**
  * Checks if a predicate is an alias using getAlias().

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -1,0 +1,40 @@
+/**
+ * @name Predicates starting with "get" should return a value
+ * @description Checks if predicates that start with "get" actually return a value.
+ * @kind problem
+ * @problem.severity warning
+ * @id ql/predicates-get-should-return-value
+ * @tags correctness
+ *       maintainability
+ * @precision high
+ */
+
+import ql
+import codeql_ql.ast.Ast
+
+/**
+ * Identifies predicates whose names start with "get" followed by an uppercase letter.
+ * This ensures that only predicates like "getValue" are matched, excluding names like "getter".
+ */
+predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("get[A-Z].*") }
+
+/**
+ * Checks if a predicate has a return type.
+ */
+predicate hasReturnType(Predicate pred) {
+  exists(Type returnType | pred.getReturnType() = returnType)
+}
+
+/**
+ * Checks if a predicate is an alias using getAlias().
+ */
+predicate isAlias(Predicate pred) {
+  pred instanceof ClasslessPredicate and exists(pred.(ClasslessPredicate).getAlias())
+}
+
+from Predicate pred
+where
+  isGetPredicate(pred) and
+  not hasReturnType(pred) and
+  not isAlias(pred)
+select pred, "This predicate starts with 'get' but does not return a value."

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -16,7 +16,7 @@ import codeql_ql.ast.Ast
  * Identifies predicates whose names start with "get" followed by an uppercase letter.
  * This ensures that only predicates like "getValue" are matched, excluding names like "getter".
  */
-predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("get[A-Z].*") }
+predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("(get|as)[A-Z].*") }
 
 /**
  * Checks if a predicate has a return type.

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -21,7 +21,7 @@ predicate isGetPredicate(Predicate pred) { pred.getName().regexpMatch("(get|as)[
 /**
  * Checks if a predicate has a return type.
  */
-predicate hasReturnType(Predicate pred) { exists(pred.getReturnType()) }
+predicate hasReturnType(Predicate pred) { exists(pred.getReturnTypeExpr()) }
 
 /**
  * Checks if a predicate is an alias using getAlias().

--- a/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
+++ b/ql/ql/src/queries/style/ValidatePredicateGetReturns.ql
@@ -28,9 +28,21 @@ predicate hasReturnType(Predicate pred) { exists(pred.getReturnType()) }
  */
 predicate isAlias(Predicate pred) { exists(pred.(ClasslessPredicate).getAlias()) }
 
+/**
+ * Returns "get" if the predicate name starts with "get", otherwise "as".
+ */
+string getPrefix(Predicate pred) {
+  if pred.getName().matches("get%")
+  then result = "get"
+  else
+    if pred.getName().matches("as%")
+    then result = "as"
+    else result = ""
+}
+
 from Predicate pred
 where
   isGetPredicate(pred) and
   not hasReturnType(pred) and
   not isAlias(pred)
-select pred, "This predicate starts with 'get' but does not return a value."
+select pred, "This predicate starts with '" + getPrefix(pred) + "' but does not return a value."

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
@@ -1,3 +1,6 @@
 | test.qll:4:11:4:18 | ClasslessPredicate getValue | This predicate starts with 'get' but does not return a value. |
 | test.qll:25:11:25:28 | ClasslessPredicate getImplementation2 | This predicate starts with 'get' but does not return a value. |
+| test.qll:28:11:28:19 | ClasslessPredicate getAlias2 | This predicate starts with 'get' but does not return a value. |
 | test.qll:31:11:31:17 | ClasslessPredicate asValue | This predicate starts with 'as' but does not return a value. |
+| test.qll:48:11:48:19 | ClasslessPredicate getAlias4 | This predicate starts with 'get' but does not return a value. |
+| test.qll:61:11:61:22 | ClasslessPredicate getDistance2 | This predicate starts with 'get' but does not return a value. |

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
@@ -1,0 +1,2 @@
+| test.qll:4:11:4:18 | ClasslessPredicate getValue | This predicate starts with 'get' but does not return a value. |
+| test.qll:25:11:25:28 | ClasslessPredicate getImplementation2 | This predicate starts with 'get' but does not return a value. |

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
@@ -1,2 +1,3 @@
 | test.qll:4:11:4:18 | ClasslessPredicate getValue | This predicate starts with 'get' but does not return a value. |
 | test.qll:25:11:25:28 | ClasslessPredicate getImplementation2 | This predicate starts with 'get' but does not return a value. |
+| test.qll:31:11:31:17 | ClasslessPredicate asValue | This predicate starts with 'get' but does not return a value. |

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.expected
@@ -1,3 +1,3 @@
 | test.qll:4:11:4:18 | ClasslessPredicate getValue | This predicate starts with 'get' but does not return a value. |
 | test.qll:25:11:25:28 | ClasslessPredicate getImplementation2 | This predicate starts with 'get' but does not return a value. |
-| test.qll:31:11:31:17 | ClasslessPredicate asValue | This predicate starts with 'get' but does not return a value. |
+| test.qll:31:11:31:17 | ClasslessPredicate asValue | This predicate starts with 'as' but does not return a value. |

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.qlref
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/ValidatePredicateGetReturns.qlref
@@ -1,0 +1,1 @@
+queries/style/ValidatePredicateGetReturns.ql

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
@@ -24,7 +24,7 @@ predicate retrieveValue() { none() }
 // NOT OK -- starts with get and does not return value
 predicate getImplementation2() { none() }
 
-// OK -- is an alias
+// NOT OK -- is an alias for a predicate which does not have a return value
 predicate getAlias2 = getImplementation2/0;
 
 // NOT OK -- starts with as and does not return value
@@ -40,3 +40,28 @@ string asString() { result = "string" }
 HiddenType getInjectableCompositeActionNode() {
   exists(HiddenType hidden | result = hidden.toString())
 }
+
+// OK
+predicate implementation4() { none() }
+
+// NOT OK -- is an alias
+predicate getAlias4 = implementation4/0;
+
+// OK -- is an alias
+predicate alias5 = implementation4/0;
+
+int root() { none() }
+
+predicate edge(int x, int y) { none() }
+
+// OK -- Higher-order predicate
+int getDistance(int x) = shortestDistances(root/0, edge/2)(_, x, result)
+
+// NOT OK -- Higher-order predicate that does not return a value even though has 'get' in the name
+predicate getDistance2(int x, int y) = shortestDistances(root/0, edge/2)(_, x, y)
+
+// OK
+predicate unresolvedAlias = unresolved/0;
+
+// OK -- unresolved alias
+predicate getUnresolvedAlias = unresolved/0;

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
@@ -1,0 +1,28 @@
+import ql
+
+// NOT OK -- Predicate starts with "get" but does not return a value
+predicate getValue() { none() }
+
+// OK -- starts with get and returns a value
+string getData() { result = "data" }
+
+// OK -- starts with get but followed by a lowercase letter, probably should be ignored
+predicate getterFunction() { none() }
+
+// OK -- starts with get and returns a value
+string getImplementation() { result = "implementation" }
+
+// OK -- is an alias
+predicate getAlias = getImplementation/0;
+
+// OK -- Starts with "get" but followed by a lowercase letter, probably be ignored
+predicate getvalue() { none() }
+
+// OK -- Does not start with "get", should be ignored
+predicate retrieveValue() { none() }
+
+// NOT OK -- starts with get and does not return value
+predicate getImplementation2() { none() }
+
+// OK -- is an alias
+predicate getAlias2 = getImplementation2/0;

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
@@ -26,3 +26,12 @@ predicate getImplementation2() { none() }
 
 // OK -- is an alias
 predicate getAlias2 = getImplementation2/0;
+
+// NOT OK -- starts with as and does not return value
+predicate asValue() { none() }
+
+// OK -- starts with as but followed by a lowercase letter, probably should be ignored
+predicate assessment() { none() }
+
+// OK -- starts with as and returns a value
+string asString() { result = "string" }

--- a/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
+++ b/ql/ql/test/queries/style/ValidatePredicateGetReturns/test.qll
@@ -35,3 +35,8 @@ predicate assessment() { none() }
 
 // OK -- starts with as and returns a value
 string asString() { result = "string" }
+
+// OK -- starts with get and returns a value
+HiddenType getInjectableCompositeActionNode() {
+  exists(HiddenType hidden | result = hidden.toString())
+}


### PR DESCRIPTION
This PR adds a new query to ensure that predicates starting with 'get' actually return a value. It includes the query definition, expected test results, and test cases to validate the functionality. 