### PR TITLE
KE2: Remove the fakeOverride code

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/comments/CommentExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/comments/CommentExtractor.kt
@@ -44,10 +44,7 @@ open class CommentExtractor(
             }
         if (existingLabel == null) {
             // Sometimes we don't extract elements.
-            // The actual extractor logic is a bit more nuanced than
-            // just "isFake", but just checking isFake is good enough
-            // to not bother with a warning.
-            if (element !is IrDeclarationWithVisibility || !fileExtractor.isFake(element)) {
+            if (element !is IrDeclarationWithVisibility) {
                 logger.warn("Couldn't get existing label for $label")
             }
             return null

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
@@ -2598,20 +2598,6 @@ private fun KotlinFileExtractor.extractConstant(
                         fun trySub(t: IrType, context: TypeContext) =
                             if (typeSub == null) t else typeSub(t, context, pluginContext)
 
-                        // Force extraction of this function even if this is a fake override --
-                        // This happens in the case where a functional interface inherits its only
-                        // abstract member,
-                        // which usually we wouldn't extract, but in this case we're effectively using
-                        // it as a template
-                        // for the real function we're extracting that will implement this interface,
-                        // and it serves fine
-                        // for that purpose. By contrast if we looked through the fake to the underlying
-                        // abstract method
-                        // we would need to compose generic type substitutions -- for example, if we're
-                        // implementing
-                        // T UnaryOperator<T>.apply(T t) here, we would need to compose substitutions so
-                        // we can implement
-                        // the real underlying R Function<T, R>.apply(T t).
                         forceExtractFunction(
                             samMember,
                             classId,

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Function.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Function.kt
@@ -334,26 +334,7 @@ fun KotlinFileExtractor.extractFunction(
 ): Label<out DbCallable> {
     /*
     OLD: KE1
-            if (isFake(f)) {
-                if (needsInterfaceForwarder(f)) {
-                    return makeInterfaceForwarder(
-                        f,
-                        parentId,
-                        extractBody,
-                        extractMethodAndParameterTypeAccesses,
-                        typeSubstitution,
-                        classTypeArgsIncludingOuterClasses
-                    )
-                } else {
-                    return null
-                }
-            } else {
-                // Work around an apparent bug causing redeclarations of `fun toString(): String`
-                // specifically in interfaces loaded from Java classes show up like fake overrides.
-                val overriddenVisibility =
-                    if (f.isFakeOverride && isJavaBinaryObjectMethodRedeclaration(f))
-                        OverriddenFunctionAttributes(visibility = DescriptorVisibilities.PUBLIC)
-                    else null
+                val overriddenVisibility = null
     */
     return forceExtractFunction(
         f,

--- a/java/kotlin-extractor2/src/main/kotlin/utils/IrVisitorLookup.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/utils/IrVisitorLookup.kt
@@ -6,7 +6,6 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrFile
-import org.jetbrains.kotlin.ir.util.isFakeOverride
 import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 
 class IrVisitorLookup(
@@ -21,12 +20,6 @@ class IrVisitorLookup(
 
         if (!location.intersects(elementLocation)) {
             // No need to visit children.
-            return
-        }
-
-        if (element is IrDeclaration && element.isFakeOverride) {
-            // These aren't extracted, so we don't expect anything to exist
-            // to which we could ascribe a comment.
             return
         }
 


### PR DESCRIPTION
As far as I can see, the analysis API isn't giving us fake overrides.
