### PR TITLE
Dataflow: Remove tracked types from Access Paths, track tainted object type, and tweak type pruning.

### DIFF
--- a/csharp/ql/lib/change-notes/2024-12-04-dataflow-type-pruning-tweak.md
+++ b/csharp/ql/lib/change-notes/2024-12-04-dataflow-type-pruning-tweak.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The data flow library has been updated to track types in a slightly different way: The type of the tainted data (which may be stored into fields, etc.) is tracked more precisely, while the types of intermediate containers for nested contents is tracked less precisely. This may have a slight effect on false positives for complex flow paths.

--- a/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/collections/CollectionFlow.expected
@@ -249,9 +249,9 @@ edges
 | CollectionFlow.cs:308:9:308:12 | [post] access to local variable list : List<T> [element, property Key] : A | CollectionFlow.cs:309:9:309:12 | access to local variable list : List<T> [element, property Key] : A | provenance |  |
 | CollectionFlow.cs:308:18:308:47 | object creation of type KeyValuePair<A,Int32> : KeyValuePair<T,T> [property Key] : A | CollectionFlow.cs:308:9:308:12 | [post] access to local variable list : List<T> [element, property Key] : A | provenance | MaD:3 |
 | CollectionFlow.cs:308:43:308:43 | access to local variable a : A | CollectionFlow.cs:308:18:308:47 | object creation of type KeyValuePair<A,Int32> : KeyValuePair<T,T> [property Key] : A | provenance | MaD:13 |
-| CollectionFlow.cs:309:9:309:12 | access to local variable list : List<T> [element, property Key] : A | CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<T,T> [property Key] : A | provenance | MaD:18 |
-| CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<T,T> [property Key] : A | CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | provenance |  |
-| CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | CollectionFlow.cs:311:18:311:24 | access to property Key | provenance |  |
+| CollectionFlow.cs:309:9:309:12 | access to local variable list : List<T> [element, property Key] : A | CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<A,Int32> [property Key] : A | provenance | MaD:18 |
+| CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<A,Int32> [property Key] : A | CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<A,Int32> [property Key] : A | provenance |  |
+| CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<A,Int32> [property Key] : A | CollectionFlow.cs:311:18:311:24 | access to property Key | provenance |  |
 | CollectionFlow.cs:328:32:328:38 | element : A | CollectionFlow.cs:328:55:328:61 | access to parameter element : A | provenance |  |
 | CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | provenance |  |
 | CollectionFlow.cs:328:55:328:61 | access to parameter element : A | CollectionFlow.cs:328:44:328:48 | [post] access to parameter array : A[] [element] : A | provenance |  |
@@ -559,8 +559,8 @@ nodes
 | CollectionFlow.cs:308:18:308:47 | object creation of type KeyValuePair<A,Int32> : KeyValuePair<T,T> [property Key] : A | semmle.label | object creation of type KeyValuePair<A,Int32> : KeyValuePair<T,T> [property Key] : A |
 | CollectionFlow.cs:308:43:308:43 | access to local variable a : A | semmle.label | access to local variable a : A |
 | CollectionFlow.cs:309:9:309:12 | access to local variable list : List<T> [element, property Key] : A | semmle.label | access to local variable list : List<T> [element, property Key] : A |
-| CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<T,T> [property Key] : A | semmle.label | kvp : KeyValuePair<T,T> [property Key] : A |
-| CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<T,T> [property Key] : A | semmle.label | access to parameter kvp : KeyValuePair<T,T> [property Key] : A |
+| CollectionFlow.cs:309:21:309:23 | kvp : KeyValuePair<A,Int32> [property Key] : A | semmle.label | kvp : KeyValuePair<A,Int32> [property Key] : A |
+| CollectionFlow.cs:311:18:311:20 | access to parameter kvp : KeyValuePair<A,Int32> [property Key] : A | semmle.label | access to parameter kvp : KeyValuePair<A,Int32> [property Key] : A |
 | CollectionFlow.cs:311:18:311:24 | access to property Key | semmle.label | access to property Key |
 | CollectionFlow.cs:328:23:328:27 | array [Return] : A[] [element] : A | semmle.label | array [Return] : A[] [element] : A |
 | CollectionFlow.cs:328:32:328:38 | element : A | semmle.label | element : A |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -812,10 +812,10 @@ edges
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:33:19:33:19 | a : A [field FieldA] : Object | provenance |  |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | provenance |  |
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | H.cs:106:16:106:40 | call to method Transform : B [field FieldB] : Object | provenance |  |
-| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | provenance |  |
-| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | provenance |  |
-| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | provenance |  |
-| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | provenance |  |
+| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | provenance |  |
+| H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | provenance |  |
+| H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | provenance |  |
+| H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | provenance |  |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | provenance |  |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | H.cs:113:31:113:31 | access to local variable a : A [field FieldA] : Object | provenance |  |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | provenance |  |
@@ -908,14 +908,14 @@ edges
 | H.cs:165:17:165:27 | (...) ... : B | H.cs:165:13:165:13 | access to local variable b : B | provenance |  |
 | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | H.cs:165:13:165:13 | access to local variable b : B [field FieldB] : Object | provenance |  |
 | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | H.cs:165:13:165:13 | access to local variable b : B [field FieldB] : Object | provenance |  |
-| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | provenance |  |
-| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | provenance |  |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | provenance |  |
+| H.cs:165:20:165:20 | access to local variable a : A [field FieldA, field FieldB] : Object | H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | provenance |  |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B | provenance |  |
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | H.cs:165:20:165:27 | access to field FieldA : B | provenance |  |
 | H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B | provenance |  |
 | H.cs:165:20:165:27 | access to field FieldA : B | H.cs:165:17:165:27 | (...) ... : B | provenance |  |
-| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | provenance |  |
-| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | provenance |  |
+| H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | provenance |  |
+| H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | H.cs:165:17:165:27 | (...) ... : B [field FieldB] : Object | provenance |  |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB | provenance |  |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | H.cs:167:14:167:21 | access to field FieldB | provenance |  |
 | I.cs:5:12:5:12 | this [Return] : I [field Field1] : Object | I.cs:21:13:21:19 | object creation of type I : I [field Field1] : Object | provenance |  |
@@ -2033,8 +2033,8 @@ nodes
 | H.cs:106:26:106:39 | (...) ... : A [field FieldA] : Object | semmle.label | (...) ... : A [field FieldA] : Object |
 | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp : B [field FieldB, field FieldA] : Object |
 | H.cs:106:29:106:32 | access to local variable temp : B [field FieldB, field FieldA] : Object | semmle.label | access to local variable temp : B [field FieldB, field FieldA] : Object |
-| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | semmle.label | access to field FieldB : A [field FieldA] : Object |
-| H.cs:106:29:106:39 | access to field FieldB : A [field FieldA] : Object | semmle.label | access to field FieldB : A [field FieldA] : Object |
+| H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | semmle.label | access to field FieldB : Object [field FieldA] : Object |
+| H.cs:106:29:106:39 | access to field FieldB : Object [field FieldA] : Object | semmle.label | access to field FieldB : Object [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:112:9:112:9 | [post] access to local variable a : A [field FieldA] : Object | semmle.label | [post] access to local variable a : A [field FieldA] : Object |
 | H.cs:112:20:112:36 | call to method Source<Object> : Object | semmle.label | call to method Source<Object> : Object |
@@ -2133,8 +2133,8 @@ nodes
 | H.cs:165:20:165:20 | access to local variable a : A [field FieldA] : B | semmle.label | access to local variable a : A [field FieldA] : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
 | H.cs:165:20:165:27 | access to field FieldA : B | semmle.label | access to field FieldA : B |
-| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | semmle.label | access to field FieldA : B [field FieldB] : Object |
-| H.cs:165:20:165:27 | access to field FieldA : B [field FieldB] : Object | semmle.label | access to field FieldA : B [field FieldB] : Object |
+| H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | semmle.label | access to field FieldA : Object [field FieldB] : Object |
+| H.cs:165:20:165:27 | access to field FieldA : Object [field FieldB] : Object | semmle.label | access to field FieldA : Object [field FieldB] : Object |
 | H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
 | H.cs:166:14:166:14 | access to local variable b | semmle.label | access to local variable b |
 | H.cs:167:14:167:14 | access to local variable b : B [field FieldB] : Object | semmle.label | access to local variable b : B [field FieldB] : Object |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -136,8 +136,8 @@ edges
 | Capture.cs:334:9:334:30 | access to local function CapturingLocalFunction : CapturingLocalFunction [captured x] : String | Capture.cs:332:42:332:62 | access to local function CapturedLocalFunction : CapturedLocalFunction [captured x] : String | provenance |  |
 | Capture.cs:339:17:339:30 | "taint source" : String | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | provenance |  |
 | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | provenance |  |
-| Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | Capture.cs:341:45:341:45 | access to local variable x | provenance |  |
-| Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | provenance |  |
+| Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | Capture.cs:341:45:341:45 | access to local variable x | provenance |  |
+| Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
@@ -639,7 +639,7 @@ nodes
 | Capture.cs:339:17:339:30 | "taint source" : String | semmle.label | "taint source" : String |
 | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | semmle.label | (...) => ... : (...) => ... [captured x] : String |
 | Capture.cs:341:45:341:45 | access to local variable x | semmle.label | access to local variable x |
-| Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | semmle.label | access to local variable capturedLambda : (...) => ... [captured x] : String |
+| Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | semmle.label | access to local variable capturedLambda : Action [captured x] : String |
 | Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | semmle.label | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | semmle.label | a : (...) => ... [captured s] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -146,8 +146,8 @@ edges
 | Capture.cs:334:9:334:30 | access to local function CapturingLocalFunction : CapturingLocalFunction [captured x] : String | Capture.cs:332:42:332:62 | access to local function CapturedLocalFunction : CapturedLocalFunction [captured x] : String | provenance |  |
 | Capture.cs:339:17:339:30 | "taint source" : String | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | provenance |  |
 | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | provenance |  |
-| Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | Capture.cs:341:45:341:45 | access to local variable x | provenance |  |
-| Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | provenance |  |
+| Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | Capture.cs:341:45:341:45 | access to local variable x | provenance |  |
+| Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured s] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | Capture.cs:352:9:352:9 | access to parameter a : (...) => ... [captured sink39] : String | provenance |  |
@@ -709,7 +709,7 @@ nodes
 | Capture.cs:339:17:339:30 | "taint source" : String | semmle.label | "taint source" : String |
 | Capture.cs:341:33:341:46 | (...) => ... : (...) => ... [captured x] : String | semmle.label | (...) => ... : (...) => ... [captured x] : String |
 | Capture.cs:341:45:341:45 | access to local variable x | semmle.label | access to local variable x |
-| Capture.cs:343:40:343:53 | access to local variable capturedLambda : (...) => ... [captured x] : String | semmle.label | access to local variable capturedLambda : (...) => ... [captured x] : String |
+| Capture.cs:343:40:343:53 | access to local variable capturedLambda : Action [captured x] : String | semmle.label | access to local variable capturedLambda : Action [captured x] : String |
 | Capture.cs:345:9:345:23 | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String | semmle.label | access to local variable capturingLambda : Action [captured capturedLambda, captured x] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured s] : String | semmle.label | a : (...) => ... [captured s] : String |
 | Capture.cs:350:34:350:34 | a : (...) => ... [captured sink39] : String | semmle.label | a : (...) => ... [captured sink39] : String |

--- a/java/ql/lib/change-notes/2024-12-04-dataflow-type-pruning-tweak.md
+++ b/java/ql/lib/change-notes/2024-12-04-dataflow-type-pruning-tweak.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The data flow library has been updated to track types in a slightly different way: The type of the tainted data (which may be stored into fields, etc.) is tracked more precisely, while the types of intermediate containers for nested contents is tracked less precisely. This may have a slight effect on false positives for complex flow paths.

--- a/java/ql/test/library-tests/dataflow/capture/inlinetest.expected
+++ b/java/ql/test/library-tests/dataflow/capture/inlinetest.expected
@@ -12,12 +12,12 @@ edges
 | B.java:13:5:13:6 | l1 : ArrayList [<element>] : String | B.java:13:16:13:16 | e : String | provenance | MaD:1 |
 | B.java:13:5:13:6 | l1 : ArrayList [<element>] : String | B.java:13:16:13:29 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | provenance | MaD:1 |
 | B.java:13:16:13:16 | e : String | B.java:13:28:13:28 | e : String | provenance |  |
-| B.java:13:16:13:29 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | B.java:13:16:13:29 | List<String> l2 : ArrayList [<element>] : String | provenance |  |
-| B.java:13:16:13:29 | List<String> l2 : ArrayList [<element>] : String | B.java:14:10:14:11 | l2 : ArrayList [<element>] : String | provenance |  |
+| B.java:13:16:13:29 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | B.java:13:16:13:29 | List<String> l2 : List [<element>] : String | provenance |  |
+| B.java:13:16:13:29 | List<String> l2 : List [<element>] : String | B.java:14:10:14:11 | l2 : List [<element>] : String | provenance |  |
 | B.java:13:21:13:22 | l2 [post update] : ArrayList [<element>] : String | B.java:13:21:13:22 | this : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | provenance |  |
 | B.java:13:21:13:22 | this : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | B.java:13:16:13:29 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | provenance |  |
 | B.java:13:28:13:28 | e : String | B.java:13:21:13:22 | l2 [post update] : ArrayList [<element>] : String | provenance | MaD:2 |
-| B.java:14:10:14:11 | l2 : ArrayList [<element>] : String | B.java:14:10:14:18 | get(...) | provenance | MaD:3 |
+| B.java:14:10:14:11 | l2 : List [<element>] : String | B.java:14:10:14:18 | get(...) | provenance | MaD:3 |
 | B.java:22:26:22:26 | x : String | B.java:22:68:22:68 | x : String | provenance |  |
 | B.java:22:56:22:60 | other [post update] : B [bf1] : String | B.java:22:56:22:60 | this : new Consumer<String>(...) { ... } [B other, bf1] : String | provenance |  |
 | B.java:22:56:22:60 | this : new Consumer<String>(...) { ... } [B other, bf1] : String | B.java:22:26:22:71 | parameter this [Return] : new Consumer<String>(...) { ... } [B other, bf1] : String | provenance |  |
@@ -33,10 +33,10 @@ edges
 | B.java:39:5:39:7 | inp : HashMap [<map.key>] : String | B.java:39:18:39:20 | key : String | provenance | MaD:4 |
 | B.java:39:5:39:7 | inp : HashMap [<map.value>] : String | B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | provenance | MaD:5 |
 | B.java:39:5:39:7 | inp : HashMap [<map.value>] : String | B.java:39:23:39:27 | value : String | provenance | MaD:5 |
-| B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | B.java:39:17:39:56 | out : HashMap [<map.key>] : String | provenance |  |
-| B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | B.java:39:17:39:56 | out : HashMap [<map.value>] : String | provenance |  |
-| B.java:39:17:39:56 | out : HashMap [<map.key>] : String | B.java:38:48:38:70 | out [Return] : HashMap [<map.key>] : String | provenance |  |
-| B.java:39:17:39:56 | out : HashMap [<map.value>] : String | B.java:38:48:38:70 | out [Return] : HashMap [<map.value>] : String | provenance |  |
+| B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | B.java:39:17:39:56 | out : Map [<map.key>] : String | provenance |  |
+| B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | B.java:39:17:39:56 | out : Map [<map.value>] : String | provenance |  |
+| B.java:39:17:39:56 | out : Map [<map.key>] : String | B.java:38:48:38:70 | out [Return] : Map [<map.key>] : String | provenance |  |
+| B.java:39:17:39:56 | out : Map [<map.value>] : String | B.java:38:48:38:70 | out [Return] : Map [<map.value>] : String | provenance |  |
 | B.java:39:18:39:20 | key : String | B.java:39:43:39:45 | key : String | provenance |  |
 | B.java:39:23:39:27 | value : String | B.java:39:48:39:52 | value : String | provenance |  |
 | B.java:39:35:39:37 | out [post update] : HashMap [<map.key>] : String | B.java:39:35:39:37 | this : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | provenance |  |
@@ -94,30 +94,30 @@ edges
 | B.java:103:5:103:6 | l2 [post update] : ArrayList [<element>, <element>] : String | B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | provenance |  |
 | B.java:103:12:103:13 | l1 : ArrayList [<element>] : String | B.java:103:5:103:6 | l2 [post update] : ArrayList [<element>, <element>] : String | provenance | MaD:2 |
 | B.java:104:16:104:32 | source(...) : String | B.java:107:16:111:6 | String s : String | provenance |  |
-| B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | B.java:107:16:107:16 | l : ArrayList [<element>] : String | provenance | MaD:1 |
+| B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | B.java:107:16:107:16 | l : List [<element>] : String | provenance | MaD:1 |
 | B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | provenance | MaD:1 |
-| B.java:107:16:107:16 | l : ArrayList [<element>] : String | B.java:107:21:107:21 | l : ArrayList [<element>] : String | provenance |  |
+| B.java:107:16:107:16 | l : List [<element>] : String | B.java:107:21:107:21 | l : List [<element>] : String | provenance |  |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | provenance | MaD:1 |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | provenance | heuristic-callback |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String | provenance | MaD:1 |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String | provenance | heuristic-callback |
-| B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | B.java:107:16:111:6 | List<String> out1 : ArrayList [<element>] : String | provenance |  |
-| B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | B.java:107:16:111:6 | List<String> out2 : ArrayList [<element>] : String | provenance |  |
-| B.java:107:16:111:6 | List<String> out1 : ArrayList [<element>] : String | B.java:112:10:112:13 | out1 : ArrayList [<element>] : String | provenance |  |
-| B.java:107:16:111:6 | List<String> out2 : ArrayList [<element>] : String | B.java:113:10:113:13 | out2 : ArrayList [<element>] : String | provenance |  |
+| B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | B.java:107:16:111:6 | List<String> out1 : List [<element>] : String | provenance |  |
+| B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | B.java:107:16:111:6 | List<String> out2 : List [<element>] : String | provenance |  |
+| B.java:107:16:111:6 | List<String> out1 : List [<element>] : String | B.java:112:10:112:13 | out1 : List [<element>] : String | provenance |  |
+| B.java:107:16:111:6 | List<String> out2 : List [<element>] : String | B.java:113:10:113:13 | out2 : List [<element>] : String | provenance |  |
 | B.java:107:16:111:6 | String s : String | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | provenance |  |
 | B.java:107:16:111:6 | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:31:111:5 | this : new Consumer<List<String>>(...) { ... } [String s] : String | provenance |  |
-| B.java:107:21:107:21 | l : ArrayList [<element>] : String | B.java:107:31:107:31 | x : String | provenance | MaD:1 |
-| B.java:107:21:107:21 | l : ArrayList [<element>] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | provenance | MaD:1 |
+| B.java:107:21:107:21 | l : List [<element>] : String | B.java:107:31:107:31 | x : String | provenance | MaD:1 |
+| B.java:107:21:107:21 | l : List [<element>] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | provenance | MaD:1 |
 | B.java:107:31:107:31 | x : String | B.java:109:16:109:16 | x : String | provenance |  |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | provenance | MaD:1 |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | provenance | heuristic-callback |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | provenance | MaD:1 |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | provenance | heuristic-callback |
-| B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | B.java:107:31:111:5 | List<String> out1 : ArrayList [<element>] : String | provenance |  |
-| B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | B.java:107:31:111:5 | List<String> out2 : ArrayList [<element>] : String | provenance |  |
-| B.java:107:31:111:5 | List<String> out1 : ArrayList [<element>] : String | B.java:107:31:111:5 | this : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | provenance |  |
-| B.java:107:31:111:5 | List<String> out2 : ArrayList [<element>] : String | B.java:107:31:111:5 | this : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | provenance |  |
+| B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | B.java:107:31:111:5 | List<String> out1 : List [<element>] : String | provenance |  |
+| B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | B.java:107:31:111:5 | List<String> out2 : List [<element>] : String | provenance |  |
+| B.java:107:31:111:5 | List<String> out1 : List [<element>] : String | B.java:107:31:111:5 | this : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | provenance |  |
+| B.java:107:31:111:5 | List<String> out2 : List [<element>] : String | B.java:107:31:111:5 | this : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | provenance |  |
 | B.java:107:31:111:5 | String s : String | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | provenance |  |
 | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | B.java:108:12:108:12 | this : new Consumer<String>(...) { ... } [String s] : String | provenance |  |
 | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | B.java:110:16:110:16 | this : new Consumer<String>(...) { ... } [String s] : String | provenance |  |
@@ -132,8 +132,8 @@ edges
 | B.java:110:7:110:10 | this : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | B.java:107:31:111:5 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | provenance |  |
 | B.java:110:16:110:16 | s : String | B.java:110:7:110:10 | out2 [post update] : ArrayList [<element>] : String | provenance | MaD:2 |
 | B.java:110:16:110:16 | this : new Consumer<String>(...) { ... } [String s] : String | B.java:110:16:110:16 | s : String | provenance |  |
-| B.java:112:10:112:13 | out1 : ArrayList [<element>] : String | B.java:112:10:112:20 | get(...) | provenance | MaD:3 |
-| B.java:113:10:113:13 | out2 : ArrayList [<element>] : String | B.java:113:10:113:20 | get(...) | provenance | MaD:3 |
+| B.java:112:10:112:13 | out1 : List [<element>] : String | B.java:112:10:112:20 | get(...) | provenance | MaD:3 |
+| B.java:113:10:113:13 | out2 : List [<element>] : String | B.java:113:10:113:20 | get(...) | provenance | MaD:3 |
 | B.java:126:19:126:22 | parameter this [Return] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:136:5:136:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
 | B.java:127:9:127:10 | l1 [post update] : ArrayList [<element>] : String | B.java:127:9:127:10 | this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
 | B.java:127:9:127:10 | this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:126:19:126:22 | parameter this [Return] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
@@ -144,14 +144,14 @@ edges
 | B.java:131:16:131:17 | l1 : ArrayList [<element>] : String | B.java:131:16:131:24 | get(...) : String | provenance | MaD:3 |
 | B.java:131:16:131:17 | this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:131:16:131:17 | l1 : ArrayList [<element>] : String | provenance |  |
 | B.java:131:16:131:24 | get(...) : String | B.java:131:9:131:10 | l2 [post update] : ArrayList [<element>] : String | provenance | MaD:2 |
-| B.java:136:5:136:5 | List<String> l1 : ArrayList [<element>] : String | B.java:137:5:137:5 | List<String> l1 : ArrayList [<element>] : String | provenance |  |
-| B.java:136:5:136:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:136:5:136:5 | List<String> l1 : ArrayList [<element>] : String | provenance |  |
-| B.java:137:5:137:5 | List<String> l1 : ArrayList [<element>] : String | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
-| B.java:137:5:137:5 | List<String> l2 : ArrayList [<element>] : String | B.java:138:10:138:11 | l2 : ArrayList [<element>] : String | provenance |  |
+| B.java:136:5:136:5 | List<String> l1 : List [<element>] : String | B.java:137:5:137:5 | List<String> l1 : List [<element>] : String | provenance |  |
+| B.java:136:5:136:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:136:5:136:5 | List<String> l1 : List [<element>] : String | provenance |  |
+| B.java:137:5:137:5 | List<String> l1 : List [<element>] : String | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
+| B.java:137:5:137:5 | List<String> l2 : List [<element>] : String | B.java:138:10:138:11 | l2 : List [<element>] : String | provenance |  |
 | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:130:19:130:22 | parameter this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | provenance |  |
 | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:137:5:137:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String | provenance | MaD:3 |
-| B.java:137:5:137:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String | B.java:137:5:137:5 | List<String> l2 : ArrayList [<element>] : String | provenance |  |
-| B.java:138:10:138:11 | l2 : ArrayList [<element>] : String | B.java:138:10:138:18 | get(...) | provenance | MaD:3 |
+| B.java:137:5:137:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String | B.java:137:5:137:5 | List<String> l2 : List [<element>] : String | provenance |  |
+| B.java:138:10:138:11 | l2 : List [<element>] : String | B.java:138:10:138:18 | get(...) | provenance | MaD:3 |
 | B.java:142:16:142:31 | source(...) : String | B.java:148:17:148:29 | String s : String | provenance |  |
 | B.java:145:7:145:13 | parameter this : MyLocal [String s] : String | B.java:145:28:145:28 | this : MyLocal [String s] : String | provenance |  |
 | B.java:145:19:145:22 | this [post update] : MyLocal [f] : String | B.java:145:7:145:13 | parameter this [Return] : MyLocal [f] : String | provenance |  |
@@ -204,11 +204,11 @@ edges
 | B.java:175:5:175:6 | String s2 : String | B.java:175:5:175:6 | m1 : MyLocal [String s2] : String | provenance |  |
 | B.java:175:5:175:6 | m1 : MyLocal [String s2] : String | B.java:162:12:162:15 | parameter this : MyLocal [String s2] : String | provenance |  |
 | B.java:175:5:175:6 | m1 : MyLocal [f] : String | B.java:162:12:162:15 | parameter this : MyLocal [f] : String | provenance |  |
-| B.java:177:5:177:6 | List<String> l : ArrayList [<element>] : String | B.java:178:10:178:11 | List<String> l : ArrayList [<element>] : String | provenance |  |
-| B.java:177:5:177:6 | m1 [post update] : MyLocal [List<String> l, <element>] : String | B.java:177:5:177:6 | List<String> l : ArrayList [<element>] : String | provenance |  |
+| B.java:177:5:177:6 | List<String> l : List [<element>] : String | B.java:178:10:178:11 | List<String> l : List [<element>] : String | provenance |  |
+| B.java:177:5:177:6 | m1 [post update] : MyLocal [List<String> l, <element>] : String | B.java:177:5:177:6 | List<String> l : List [<element>] : String | provenance |  |
 | B.java:177:12:177:27 | source(...) : String | B.java:166:16:166:23 | s : String | provenance |  |
 | B.java:177:12:177:27 | source(...) : String | B.java:177:5:177:6 | m1 [post update] : MyLocal [List<String> l, <element>] : String | provenance | MaD:2 |
-| B.java:178:10:178:11 | List<String> l : ArrayList [<element>] : String | B.java:178:10:178:11 | m2 : MyLocal [List<String> l, <element>] : String | provenance |  |
+| B.java:178:10:178:11 | List<String> l : List [<element>] : String | B.java:178:10:178:11 | m2 : MyLocal [List<String> l, <element>] : String | provenance |  |
 | B.java:178:10:178:11 | m2 : MyLocal [List<String> l, <element>] : String | B.java:169:14:169:16 | parameter this : MyLocal [List<String> l, <element>] : String | provenance |  |
 | B.java:178:10:178:11 | m2 : MyLocal [List<String> l, <element>] : String | B.java:178:10:178:17 | get(...) | provenance | MaD:3 |
 | B.java:203:16:203:42 | source(...) : String | B.java:212:5:212:6 | String s : String | provenance |  |
@@ -220,17 +220,17 @@ edges
 | B.java:207:15:207:42 | source(...) : String | B.java:207:7:207:9 | out [post update] : ArrayList [<element>] : String | provenance | MaD:2 |
 | B.java:209:19:211:5 | parameter this : new Runnable(...) { ... } [String s] : String | B.java:210:7:210:8 | this : new Runnable(...) { ... } [String s] : String | provenance |  |
 | B.java:209:19:211:5 | parameter this [Return] : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:212:5:212:6 | r2 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | provenance |  |
-| B.java:210:7:210:8 | List<String> out : ArrayList [<element>] : String | B.java:210:7:210:8 | this : new Runnable(...) { ... } [List<String> out, <element>] : String | provenance |  |
+| B.java:210:7:210:8 | List<String> out : List [<element>] : String | B.java:210:7:210:8 | this : new Runnable(...) { ... } [List<String> out, <element>] : String | provenance |  |
 | B.java:210:7:210:8 | String s : String | B.java:210:7:210:8 | r1 : new Runnable(...) { ... } [String s] : String | provenance |  |
 | B.java:210:7:210:8 | r1 : new Runnable(...) { ... } [String s] : String | B.java:205:19:208:5 | parameter this : new Runnable(...) { ... } [String s] : String | provenance |  |
-| B.java:210:7:210:8 | r1 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:210:7:210:8 | List<String> out : ArrayList [<element>] : String | provenance |  |
+| B.java:210:7:210:8 | r1 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:210:7:210:8 | List<String> out : List [<element>] : String | provenance |  |
 | B.java:210:7:210:8 | this : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:209:19:211:5 | parameter this [Return] : new Runnable(...) { ... } [List<String> out, <element>] : String | provenance |  |
 | B.java:210:7:210:8 | this : new Runnable(...) { ... } [String s] : String | B.java:210:7:210:8 | String s : String | provenance |  |
-| B.java:212:5:212:6 | List<String> out : ArrayList [<element>] : String | B.java:213:10:213:12 | out : ArrayList [<element>] : String | provenance |  |
+| B.java:212:5:212:6 | List<String> out : List [<element>] : String | B.java:213:10:213:12 | out : List [<element>] : String | provenance |  |
 | B.java:212:5:212:6 | String s : String | B.java:212:5:212:6 | r2 : new Runnable(...) { ... } [String s] : String | provenance |  |
 | B.java:212:5:212:6 | r2 : new Runnable(...) { ... } [String s] : String | B.java:209:19:211:5 | parameter this : new Runnable(...) { ... } [String s] : String | provenance |  |
-| B.java:212:5:212:6 | r2 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:212:5:212:6 | List<String> out : ArrayList [<element>] : String | provenance |  |
-| B.java:213:10:213:12 | out : ArrayList [<element>] : String | B.java:213:10:213:19 | get(...) | provenance | MaD:3 |
+| B.java:212:5:212:6 | r2 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | B.java:212:5:212:6 | List<String> out : List [<element>] : String | provenance |  |
+| B.java:213:10:213:12 | out : List [<element>] : String | B.java:213:10:213:19 | get(...) | provenance | MaD:3 |
 | B.java:231:16:231:28 | source(...) : String | B.java:247:5:247:18 | String s : String | provenance |  |
 | B.java:235:7:235:14 | parameter this : MyLocal2 [String s] : String | B.java:238:15:238:15 | this : MyLocal2 [String s] : String | provenance |  |
 | B.java:238:9:238:9 | l [post update] : ArrayList [<element>] : String | B.java:238:9:238:9 | this : MyLocal2 [List<String> l, <element>] : String | provenance |  |
@@ -243,17 +243,17 @@ edges
 | B.java:241:16:241:16 | l : ArrayList [<element>] : String | B.java:241:16:241:23 | get(...) : String | provenance | MaD:3 |
 | B.java:241:16:241:16 | this : MyLocal2 [List<String> l, <element>] : String | B.java:241:16:241:16 | l : ArrayList [<element>] : String | provenance |  |
 | B.java:241:16:241:23 | get(...) : String | B.java:241:9:241:10 | l2 [post update] : ArrayList [<element>] : String | provenance | MaD:2 |
-| B.java:247:5:247:18 | List<String> l2 : ArrayList [<element>] : String | B.java:249:10:249:11 | l2 : ArrayList [<element>] : String | provenance |  |
-| B.java:247:5:247:18 | List<String> l : ArrayList [<element>] : String | B.java:248:10:248:10 | l : ArrayList [<element>] : String | provenance |  |
+| B.java:247:5:247:18 | List<String> l2 : List [<element>] : String | B.java:249:10:249:11 | l2 : List [<element>] : String | provenance |  |
+| B.java:247:5:247:18 | List<String> l : List [<element>] : String | B.java:248:10:248:10 | l : List [<element>] : String | provenance |  |
 | B.java:247:5:247:18 | String s : String | B.java:247:5:247:18 | new MyLocal2(...) [pre constructor] : MyLocal2 [String s] : String | provenance |  |
 | B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | B.java:240:12:240:14 | parameter this : MyLocal2 [List<String> l, <element>] : String | provenance |  |
-| B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | B.java:247:5:247:18 | List<String> l : ArrayList [<element>] : String | provenance |  |
+| B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | B.java:247:5:247:18 | List<String> l : List [<element>] : String | provenance |  |
 | B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | B.java:247:5:247:18 | new MyLocal2(...) [post update] : MyLocal2 [List<String> l2, <element>] : String | provenance | MaD:3 |
-| B.java:247:5:247:18 | new MyLocal2(...) [post update] : MyLocal2 [List<String> l2, <element>] : String | B.java:247:5:247:18 | List<String> l2 : ArrayList [<element>] : String | provenance |  |
+| B.java:247:5:247:18 | new MyLocal2(...) [post update] : MyLocal2 [List<String> l2, <element>] : String | B.java:247:5:247:18 | List<String> l2 : List [<element>] : String | provenance |  |
 | B.java:247:5:247:18 | new MyLocal2(...) [pre constructor] : MyLocal2 [String s] : String | B.java:235:7:235:14 | parameter this : MyLocal2 [String s] : String | provenance |  |
 | B.java:247:5:247:18 | new MyLocal2(...) [pre constructor] : MyLocal2 [String s] : String | B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | provenance | MaD:2 |
-| B.java:248:10:248:10 | l : ArrayList [<element>] : String | B.java:248:10:248:17 | get(...) | provenance | MaD:3 |
-| B.java:249:10:249:11 | l2 : ArrayList [<element>] : String | B.java:249:10:249:18 | get(...) | provenance | MaD:3 |
+| B.java:248:10:248:10 | l : List [<element>] : String | B.java:248:10:248:17 | get(...) | provenance | MaD:3 |
+| B.java:249:10:249:11 | l2 : List [<element>] : String | B.java:249:10:249:18 | get(...) | provenance | MaD:3 |
 | B.java:254:16:254:29 | source(...) : String | B.java:261:5:261:18 | String s : String | provenance |  |
 | B.java:255:11:255:18 | parameter this : MyLocal3 [String s] : String | B.java:255:11:255:18 | this <.method> : MyLocal3 [String s] : String | provenance |  |
 | B.java:255:11:255:18 | parameter this : MyLocal3 [String s] : String | B.java:256:18:256:18 | this : MyLocal3 [String s] : String | provenance |  |
@@ -300,12 +300,12 @@ nodes
 | B.java:13:5:13:6 | l1 : ArrayList [<element>] : String | semmle.label | l1 : ArrayList [<element>] : String |
 | B.java:13:16:13:16 | e : String | semmle.label | e : String |
 | B.java:13:16:13:29 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | semmle.label | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String |
-| B.java:13:16:13:29 | List<String> l2 : ArrayList [<element>] : String | semmle.label | List<String> l2 : ArrayList [<element>] : String |
+| B.java:13:16:13:29 | List<String> l2 : List [<element>] : String | semmle.label | List<String> l2 : List [<element>] : String |
 | B.java:13:16:13:29 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | semmle.label | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String |
 | B.java:13:21:13:22 | l2 [post update] : ArrayList [<element>] : String | semmle.label | l2 [post update] : ArrayList [<element>] : String |
 | B.java:13:21:13:22 | this : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String | semmle.label | this : new Consumer<String>(...) { ... } [List<String> l2, <element>] : String |
 | B.java:13:28:13:28 | e : String | semmle.label | e : String |
-| B.java:14:10:14:11 | l2 : ArrayList [<element>] : String | semmle.label | l2 : ArrayList [<element>] : String |
+| B.java:14:10:14:11 | l2 : List [<element>] : String | semmle.label | l2 : List [<element>] : String |
 | B.java:14:10:14:18 | get(...) | semmle.label | get(...) |
 | B.java:22:26:22:26 | x : String | semmle.label | x : String |
 | B.java:22:26:22:71 | parameter this [Return] : new Consumer<String>(...) { ... } [B other, bf1] : String | semmle.label | parameter this [Return] : new Consumer<String>(...) { ... } [B other, bf1] : String |
@@ -319,14 +319,14 @@ nodes
 | B.java:34:10:34:18 | other.bf1 | semmle.label | other.bf1 |
 | B.java:38:23:38:45 | inp : HashMap [<map.key>] : String | semmle.label | inp : HashMap [<map.key>] : String |
 | B.java:38:23:38:45 | inp : HashMap [<map.value>] : String | semmle.label | inp : HashMap [<map.value>] : String |
-| B.java:38:48:38:70 | out [Return] : HashMap [<map.key>] : String | semmle.label | out [Return] : HashMap [<map.key>] : String |
-| B.java:38:48:38:70 | out [Return] : HashMap [<map.value>] : String | semmle.label | out [Return] : HashMap [<map.value>] : String |
+| B.java:38:48:38:70 | out [Return] : Map [<map.key>] : String | semmle.label | out [Return] : Map [<map.key>] : String |
+| B.java:38:48:38:70 | out [Return] : Map [<map.value>] : String | semmle.label | out [Return] : Map [<map.value>] : String |
 | B.java:39:5:39:7 | inp : HashMap [<map.key>] : String | semmle.label | inp : HashMap [<map.key>] : String |
 | B.java:39:5:39:7 | inp : HashMap [<map.value>] : String | semmle.label | inp : HashMap [<map.value>] : String |
 | B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | semmle.label | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String |
 | B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | semmle.label | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String |
-| B.java:39:17:39:56 | out : HashMap [<map.key>] : String | semmle.label | out : HashMap [<map.key>] : String |
-| B.java:39:17:39:56 | out : HashMap [<map.value>] : String | semmle.label | out : HashMap [<map.value>] : String |
+| B.java:39:17:39:56 | out : Map [<map.key>] : String | semmle.label | out : Map [<map.key>] : String |
+| B.java:39:17:39:56 | out : Map [<map.value>] : String | semmle.label | out : Map [<map.value>] : String |
 | B.java:39:17:39:56 | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | semmle.label | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String |
 | B.java:39:17:39:56 | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | semmle.label | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String |
 | B.java:39:18:39:20 | key : String | semmle.label | key : String |
@@ -390,23 +390,23 @@ nodes
 | B.java:103:12:103:13 | l1 : ArrayList [<element>] : String | semmle.label | l1 : ArrayList [<element>] : String |
 | B.java:104:16:104:32 | source(...) : String | semmle.label | source(...) : String |
 | B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | semmle.label | l2 : ArrayList [<element>, <element>] : String |
-| B.java:107:16:107:16 | l : ArrayList [<element>] : String | semmle.label | l : ArrayList [<element>] : String |
+| B.java:107:16:107:16 | l : List [<element>] : String | semmle.label | l : List [<element>] : String |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | semmle.label | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String |
 | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | semmle.label | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String |
 | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | semmle.label | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String |
-| B.java:107:16:111:6 | List<String> out1 : ArrayList [<element>] : String | semmle.label | List<String> out1 : ArrayList [<element>] : String |
-| B.java:107:16:111:6 | List<String> out2 : ArrayList [<element>] : String | semmle.label | List<String> out2 : ArrayList [<element>] : String |
+| B.java:107:16:111:6 | List<String> out1 : List [<element>] : String | semmle.label | List<String> out1 : List [<element>] : String |
+| B.java:107:16:111:6 | List<String> out2 : List [<element>] : String | semmle.label | List<String> out2 : List [<element>] : String |
 | B.java:107:16:111:6 | String s : String | semmle.label | String s : String |
 | B.java:107:16:111:6 | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String | semmle.label | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String |
 | B.java:107:16:111:6 | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | semmle.label | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String |
 | B.java:107:16:111:6 | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | semmle.label | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String |
-| B.java:107:21:107:21 | l : ArrayList [<element>] : String | semmle.label | l : ArrayList [<element>] : String |
+| B.java:107:21:107:21 | l : List [<element>] : String | semmle.label | l : List [<element>] : String |
 | B.java:107:31:107:31 | x : String | semmle.label | x : String |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | semmle.label | ...->... : new Consumer<String>(...) { ... } [String s] : String |
 | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | semmle.label | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String |
 | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | semmle.label | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String |
-| B.java:107:31:111:5 | List<String> out1 : ArrayList [<element>] : String | semmle.label | List<String> out1 : ArrayList [<element>] : String |
-| B.java:107:31:111:5 | List<String> out2 : ArrayList [<element>] : String | semmle.label | List<String> out2 : ArrayList [<element>] : String |
+| B.java:107:31:111:5 | List<String> out1 : List [<element>] : String | semmle.label | List<String> out1 : List [<element>] : String |
+| B.java:107:31:111:5 | List<String> out2 : List [<element>] : String | semmle.label | List<String> out2 : List [<element>] : String |
 | B.java:107:31:111:5 | String s : String | semmle.label | String s : String |
 | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | semmle.label | parameter this : new Consumer<String>(...) { ... } [String s] : String |
 | B.java:107:31:111:5 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | semmle.label | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String |
@@ -423,9 +423,9 @@ nodes
 | B.java:110:7:110:10 | this : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | semmle.label | this : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String |
 | B.java:110:16:110:16 | s : String | semmle.label | s : String |
 | B.java:110:16:110:16 | this : new Consumer<String>(...) { ... } [String s] : String | semmle.label | this : new Consumer<String>(...) { ... } [String s] : String |
-| B.java:112:10:112:13 | out1 : ArrayList [<element>] : String | semmle.label | out1 : ArrayList [<element>] : String |
+| B.java:112:10:112:13 | out1 : List [<element>] : String | semmle.label | out1 : List [<element>] : String |
 | B.java:112:10:112:20 | get(...) | semmle.label | get(...) |
-| B.java:113:10:113:13 | out2 : ArrayList [<element>] : String | semmle.label | out2 : ArrayList [<element>] : String |
+| B.java:113:10:113:13 | out2 : List [<element>] : String | semmle.label | out2 : List [<element>] : String |
 | B.java:113:10:113:20 | get(...) | semmle.label | get(...) |
 | B.java:126:19:126:22 | parameter this [Return] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | semmle.label | parameter this [Return] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String |
 | B.java:127:9:127:10 | l1 [post update] : ArrayList [<element>] : String | semmle.label | l1 [post update] : ArrayList [<element>] : String |
@@ -438,13 +438,13 @@ nodes
 | B.java:131:16:131:17 | l1 : ArrayList [<element>] : String | semmle.label | l1 : ArrayList [<element>] : String |
 | B.java:131:16:131:17 | this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | semmle.label | this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String |
 | B.java:131:16:131:24 | get(...) : String | semmle.label | get(...) : String |
-| B.java:136:5:136:5 | List<String> l1 : ArrayList [<element>] : String | semmle.label | List<String> l1 : ArrayList [<element>] : String |
+| B.java:136:5:136:5 | List<String> l1 : List [<element>] : String | semmle.label | List<String> l1 : List [<element>] : String |
 | B.java:136:5:136:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | semmle.label | r [post update] : new TwoRuns(...) { ... } [List<String> l1, <element>] : String |
-| B.java:137:5:137:5 | List<String> l1 : ArrayList [<element>] : String | semmle.label | List<String> l1 : ArrayList [<element>] : String |
-| B.java:137:5:137:5 | List<String> l2 : ArrayList [<element>] : String | semmle.label | List<String> l2 : ArrayList [<element>] : String |
+| B.java:137:5:137:5 | List<String> l1 : List [<element>] : String | semmle.label | List<String> l1 : List [<element>] : String |
+| B.java:137:5:137:5 | List<String> l2 : List [<element>] : String | semmle.label | List<String> l2 : List [<element>] : String |
 | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | semmle.label | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String |
 | B.java:137:5:137:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String | semmle.label | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String |
-| B.java:138:10:138:11 | l2 : ArrayList [<element>] : String | semmle.label | l2 : ArrayList [<element>] : String |
+| B.java:138:10:138:11 | l2 : List [<element>] : String | semmle.label | l2 : List [<element>] : String |
 | B.java:138:10:138:18 | get(...) | semmle.label | get(...) |
 | B.java:142:16:142:31 | source(...) : String | semmle.label | source(...) : String |
 | B.java:145:7:145:13 | parameter this : MyLocal [String s] : String | semmle.label | parameter this : MyLocal [String s] : String |
@@ -499,10 +499,10 @@ nodes
 | B.java:175:5:175:6 | String s2 : String | semmle.label | String s2 : String |
 | B.java:175:5:175:6 | m1 : MyLocal [String s2] : String | semmle.label | m1 : MyLocal [String s2] : String |
 | B.java:175:5:175:6 | m1 : MyLocal [f] : String | semmle.label | m1 : MyLocal [f] : String |
-| B.java:177:5:177:6 | List<String> l : ArrayList [<element>] : String | semmle.label | List<String> l : ArrayList [<element>] : String |
+| B.java:177:5:177:6 | List<String> l : List [<element>] : String | semmle.label | List<String> l : List [<element>] : String |
 | B.java:177:5:177:6 | m1 [post update] : MyLocal [List<String> l, <element>] : String | semmle.label | m1 [post update] : MyLocal [List<String> l, <element>] : String |
 | B.java:177:12:177:27 | source(...) : String | semmle.label | source(...) : String |
-| B.java:178:10:178:11 | List<String> l : ArrayList [<element>] : String | semmle.label | List<String> l : ArrayList [<element>] : String |
+| B.java:178:10:178:11 | List<String> l : List [<element>] : String | semmle.label | List<String> l : List [<element>] : String |
 | B.java:178:10:178:11 | m2 : MyLocal [List<String> l, <element>] : String | semmle.label | m2 : MyLocal [List<String> l, <element>] : String |
 | B.java:178:10:178:17 | get(...) | semmle.label | get(...) |
 | B.java:203:16:203:42 | source(...) : String | semmle.label | source(...) : String |
@@ -515,17 +515,17 @@ nodes
 | B.java:207:15:207:42 | source(...) : String | semmle.label | source(...) : String |
 | B.java:209:19:211:5 | parameter this : new Runnable(...) { ... } [String s] : String | semmle.label | parameter this : new Runnable(...) { ... } [String s] : String |
 | B.java:209:19:211:5 | parameter this [Return] : new Runnable(...) { ... } [List<String> out, <element>] : String | semmle.label | parameter this [Return] : new Runnable(...) { ... } [List<String> out, <element>] : String |
-| B.java:210:7:210:8 | List<String> out : ArrayList [<element>] : String | semmle.label | List<String> out : ArrayList [<element>] : String |
+| B.java:210:7:210:8 | List<String> out : List [<element>] : String | semmle.label | List<String> out : List [<element>] : String |
 | B.java:210:7:210:8 | String s : String | semmle.label | String s : String |
 | B.java:210:7:210:8 | r1 : new Runnable(...) { ... } [String s] : String | semmle.label | r1 : new Runnable(...) { ... } [String s] : String |
 | B.java:210:7:210:8 | r1 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | semmle.label | r1 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String |
 | B.java:210:7:210:8 | this : new Runnable(...) { ... } [List<String> out, <element>] : String | semmle.label | this : new Runnable(...) { ... } [List<String> out, <element>] : String |
 | B.java:210:7:210:8 | this : new Runnable(...) { ... } [String s] : String | semmle.label | this : new Runnable(...) { ... } [String s] : String |
-| B.java:212:5:212:6 | List<String> out : ArrayList [<element>] : String | semmle.label | List<String> out : ArrayList [<element>] : String |
+| B.java:212:5:212:6 | List<String> out : List [<element>] : String | semmle.label | List<String> out : List [<element>] : String |
 | B.java:212:5:212:6 | String s : String | semmle.label | String s : String |
 | B.java:212:5:212:6 | r2 : new Runnable(...) { ... } [String s] : String | semmle.label | r2 : new Runnable(...) { ... } [String s] : String |
 | B.java:212:5:212:6 | r2 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String | semmle.label | r2 [post update] : new Runnable(...) { ... } [List<String> out, <element>] : String |
-| B.java:213:10:213:12 | out : ArrayList [<element>] : String | semmle.label | out : ArrayList [<element>] : String |
+| B.java:213:10:213:12 | out : List [<element>] : String | semmle.label | out : List [<element>] : String |
 | B.java:213:10:213:19 | get(...) | semmle.label | get(...) |
 | B.java:231:16:231:28 | source(...) : String | semmle.label | source(...) : String |
 | B.java:235:7:235:14 | parameter this : MyLocal2 [String s] : String | semmle.label | parameter this : MyLocal2 [String s] : String |
@@ -541,15 +541,15 @@ nodes
 | B.java:241:16:241:16 | l : ArrayList [<element>] : String | semmle.label | l : ArrayList [<element>] : String |
 | B.java:241:16:241:16 | this : MyLocal2 [List<String> l, <element>] : String | semmle.label | this : MyLocal2 [List<String> l, <element>] : String |
 | B.java:241:16:241:23 | get(...) : String | semmle.label | get(...) : String |
-| B.java:247:5:247:18 | List<String> l2 : ArrayList [<element>] : String | semmle.label | List<String> l2 : ArrayList [<element>] : String |
-| B.java:247:5:247:18 | List<String> l : ArrayList [<element>] : String | semmle.label | List<String> l : ArrayList [<element>] : String |
+| B.java:247:5:247:18 | List<String> l2 : List [<element>] : String | semmle.label | List<String> l2 : List [<element>] : String |
+| B.java:247:5:247:18 | List<String> l : List [<element>] : String | semmle.label | List<String> l : List [<element>] : String |
 | B.java:247:5:247:18 | String s : String | semmle.label | String s : String |
 | B.java:247:5:247:18 | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String | semmle.label | new MyLocal2(...) : MyLocal2 [List<String> l, <element>] : String |
 | B.java:247:5:247:18 | new MyLocal2(...) [post update] : MyLocal2 [List<String> l2, <element>] : String | semmle.label | new MyLocal2(...) [post update] : MyLocal2 [List<String> l2, <element>] : String |
 | B.java:247:5:247:18 | new MyLocal2(...) [pre constructor] : MyLocal2 [String s] : String | semmle.label | new MyLocal2(...) [pre constructor] : MyLocal2 [String s] : String |
-| B.java:248:10:248:10 | l : ArrayList [<element>] : String | semmle.label | l : ArrayList [<element>] : String |
+| B.java:248:10:248:10 | l : List [<element>] : String | semmle.label | l : List [<element>] : String |
 | B.java:248:10:248:17 | get(...) | semmle.label | get(...) |
-| B.java:249:10:249:11 | l2 : ArrayList [<element>] : String | semmle.label | l2 : ArrayList [<element>] : String |
+| B.java:249:10:249:11 | l2 : List [<element>] : String | semmle.label | l2 : List [<element>] : String |
 | B.java:249:10:249:18 | get(...) | semmle.label | get(...) |
 | B.java:254:16:254:29 | source(...) : String | semmle.label | source(...) : String |
 | B.java:255:11:255:18 | parameter this : MyLocal3 [String s] : String | semmle.label | parameter this : MyLocal3 [String s] : String |
@@ -595,11 +595,11 @@ subpaths
 | B.java:30:14:30:24 | source(...) : String | B.java:22:26:22:26 | x : String | B.java:22:26:22:71 | parameter this [Return] : new Consumer<String>(...) { ... } [B other, bf1] : String | B.java:30:5:30:5 | f [post update] : new Consumer<String>(...) { ... } [B other, bf1] : String |
 | B.java:39:5:39:7 | inp : HashMap [<map.key>] : String | B.java:39:18:39:20 | key : String | B.java:39:17:39:56 | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String | B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.key>] : String |
 | B.java:39:5:39:7 | inp : HashMap [<map.value>] : String | B.java:39:23:39:27 | value : String | B.java:39:17:39:56 | parameter this [Return] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String | B.java:39:17:39:56 | ...->... [post update] : new BiConsumer<String,String>(...) { ... } [out, <map.value>] : String |
-| B.java:46:13:46:14 | m1 : HashMap [<map.key>] : String | B.java:38:23:38:45 | inp : HashMap [<map.key>] : String | B.java:38:48:38:70 | out [Return] : HashMap [<map.key>] : String | B.java:46:17:46:18 | m2 [post update] : HashMap [<map.key>] : String |
-| B.java:46:13:46:14 | m1 : HashMap [<map.value>] : String | B.java:38:23:38:45 | inp : HashMap [<map.value>] : String | B.java:38:48:38:70 | out [Return] : HashMap [<map.value>] : String | B.java:46:17:46:18 | m2 [post update] : HashMap [<map.value>] : String |
-| B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | B.java:107:16:107:16 | l : ArrayList [<element>] : String | B.java:107:16:111:6 | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String |
+| B.java:46:13:46:14 | m1 : HashMap [<map.key>] : String | B.java:38:23:38:45 | inp : HashMap [<map.key>] : String | B.java:38:48:38:70 | out [Return] : Map [<map.key>] : String | B.java:46:17:46:18 | m2 [post update] : HashMap [<map.key>] : String |
+| B.java:46:13:46:14 | m1 : HashMap [<map.value>] : String | B.java:38:23:38:45 | inp : HashMap [<map.value>] : String | B.java:38:48:38:70 | out [Return] : Map [<map.value>] : String | B.java:46:17:46:18 | m2 [post update] : HashMap [<map.value>] : String |
+| B.java:107:5:107:6 | l2 : ArrayList [<element>, <element>] : String | B.java:107:16:107:16 | l : List [<element>] : String | B.java:107:16:111:6 | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out1, <element>] : String |
 | B.java:107:16:111:6 | ...->... : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | parameter this : new Consumer<List<String>>(...) { ... } [String s] : String | B.java:107:16:111:6 | parameter this [Return] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String | B.java:107:16:111:6 | ...->... [post update] : new Consumer<List<String>>(...) { ... } [List<String> out2, <element>] : String |
-| B.java:107:21:107:21 | l : ArrayList [<element>] : String | B.java:107:31:107:31 | x : String | B.java:107:31:111:5 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String |
+| B.java:107:21:107:21 | l : List [<element>] : String | B.java:107:31:107:31 | x : String | B.java:107:31:111:5 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out1, <element>] : String |
 | B.java:107:31:111:5 | ...->... : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | parameter this : new Consumer<String>(...) { ... } [String s] : String | B.java:107:31:111:5 | parameter this [Return] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String | B.java:107:31:111:5 | ...->... [post update] : new Consumer<String>(...) { ... } [List<String> out2, <element>] : String |
 | B.java:137:5:137:5 | r : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:130:19:130:22 | parameter this : new TwoRuns(...) { ... } [List<String> l1, <element>] : String | B.java:130:19:130:22 | parameter this [Return] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String | B.java:137:5:137:5 | r [post update] : new TwoRuns(...) { ... } [List<String> l2, <element>] : String |
 | B.java:148:17:148:29 | new MyLocal(...) [pre constructor] : MyLocal [String s] : String | B.java:145:7:145:13 | parameter this : MyLocal [String s] : String | B.java:145:7:145:13 | parameter this [Return] : MyLocal [f] : String | B.java:148:17:148:29 | new MyLocal(...) : MyLocal [f] : String |

--- a/java/ql/test/library-tests/frameworks/android/intent/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/intent/test.expected
@@ -184,96 +184,50 @@ edges
 | Test.java:22:44:22:45 | it : Set [<element>] : String | Test.java:22:44:22:56 | iterator(...) : Iterator [<element>] : String | provenance | MaD:179 |
 | Test.java:22:44:22:56 | iterator(...) : Iterator [<element>] : String | Test.java:22:44:22:63 | next(...) : String | provenance | MaD:180 |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | provenance | MaD:34 |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | provenance | MaD:34 |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | provenance | MaD:34 |
 | Test.java:24:19:24:30 | b : BaseBundle [<map.key>] : String | Test.java:24:42:24:42 | b : BaseBundle [<map.key>] : String | provenance |  |
 | Test.java:24:19:24:30 | b : Bundle [<map.key>] : Object | Test.java:24:42:24:42 | b : Bundle [<map.key>] : Object | provenance |  |
@@ -303,27 +257,19 @@ edges
 | Test.java:41:65:41:72 | source(...) : String | Test.java:28:29:28:36 | k : String | provenance |  |
 | Test.java:41:65:41:72 | source(...) : String | Test.java:41:45:41:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:42:21:42:22 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:13 |
 | Test.java:42:21:42:22 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:13 |
 | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:43:9:43:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:48:16:48:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:49:21:49:22 | in : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:48:24:48:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:48:16:48:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:48:45:48:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | Test.java:48:24:48:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:178 |
 | Test.java:48:67:48:74 | source(...) : Object | Test.java:48:45:48:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | provenance | MaD:176 |
 | Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:49:21:49:22 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:14 |
 | Test.java:49:21:49:22 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:14 |
 | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | Test.java:50:9:50:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:55:13:55:25 | (...)... : Uri | Test.java:56:27:56:28 | in : Uri | provenance |  |
 | Test.java:55:18:55:25 | source(...) : Object | Test.java:55:13:55:25 | (...)... : Uri | provenance |  |
@@ -348,35 +294,23 @@ edges
 | Test.java:83:22:83:43 | (...)... : CharSequence | Test.java:84:37:84:38 | in : CharSequence | provenance |  |
 | Test.java:83:36:83:43 | source(...) : Object | Test.java:83:22:83:43 | (...)... : CharSequence | provenance |  |
 | Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:84:37:84:38 | in : CharSequence | Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance | MaD:17 |
 | Test.java:84:37:84:38 | in : CharSequence | Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance | MaD:17 |
 | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | Test.java:85:9:85:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:90:22:90:43 | (...)... : IntentSender | Test.java:91:43:91:44 | in : IntentSender | provenance |  |
 | Test.java:90:36:90:43 | source(...) : Object | Test.java:90:22:90:43 | (...)... : IntentSender | provenance |  |
 | Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
-| Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
-| Test.java:91:43:91:44 | in : IntentSender | Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance | MaD:17 |
 | Test.java:91:43:91:44 | in : IntentSender | Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance | MaD:17 |
 | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender | Test.java:92:9:92:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
-| Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | provenance |  |
-| Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender | provenance | MaD:34 |
 | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender | provenance | MaD:34 |
 | Test.java:97:16:97:31 | (...)... : Intent | Test.java:98:31:98:32 | in : Intent | provenance |  |
 | Test.java:97:24:97:31 | source(...) : Object | Test.java:97:16:97:31 | (...)... : Intent | provenance |  |
 | Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:98:31:98:32 | in : Intent | Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance | MaD:17 |
 | Test.java:98:31:98:32 | in : Intent | Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance | MaD:17 |
 | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent | Test.java:99:9:99:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | provenance |  |
-| Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent | provenance | MaD:34 |
 | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent | provenance | MaD:34 |
 | Test.java:104:16:104:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:105:10:105:11 | in : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:104:24:104:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:104:16:104:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
@@ -504,25 +438,17 @@ edges
 | Test.java:244:16:244:31 | (...)... : String | Test.java:245:38:245:39 | in : String | provenance |  |
 | Test.java:244:24:244:31 | source(...) : Object | Test.java:244:16:244:31 | (...)... : String | provenance |  |
 | Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:245:38:245:39 | in : String | Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:45 |
 | Test.java:245:38:245:39 | in : String | Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:45 |
 | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:246:9:246:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:251:19:251:37 | (...)... : ArrayList | Test.java:252:44:252:45 | in : ArrayList | provenance |  |
 | Test.java:251:30:251:37 | source(...) : Object | Test.java:251:19:251:37 | (...)... : ArrayList | provenance |  |
 | Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:252:44:252:45 | in : ArrayList | Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:46 |
 | Test.java:252:44:252:45 | in : ArrayList | Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:46 |
 | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | Test.java:253:9:253:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:258:16:258:31 | (...)... : Intent | Test.java:259:10:259:11 | in : Intent | provenance |  |
 | Test.java:258:24:258:31 | source(...) : Object | Test.java:258:16:258:31 | (...)... : Intent | provenance |  |
@@ -623,554 +549,362 @@ edges
 | Test.java:426:16:426:31 | (...)... : String | Test.java:427:17:427:18 | in : String | provenance |  |
 | Test.java:426:24:426:31 | source(...) : Object | Test.java:426:16:426:31 | (...)... : String | provenance |  |
 | Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:427:17:427:18 | in : String | Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:427:17:427:18 | in : String | Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:428:9:428:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:433:16:433:31 | (...)... : String | Test.java:434:17:434:18 | in : String | provenance |  |
 | Test.java:433:24:433:31 | source(...) : Object | Test.java:433:16:433:31 | (...)... : String | provenance |  |
 | Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:434:17:434:18 | in : String | Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:434:17:434:18 | in : String | Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:435:9:435:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:440:16:440:31 | (...)... : String | Test.java:441:17:441:18 | in : String | provenance |  |
 | Test.java:440:24:440:31 | source(...) : Object | Test.java:440:16:440:31 | (...)... : String | provenance |  |
 | Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:441:17:441:18 | in : String | Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:441:17:441:18 | in : String | Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:442:9:442:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:447:16:447:31 | (...)... : String | Test.java:448:17:448:18 | in : String | provenance |  |
 | Test.java:447:24:447:31 | source(...) : Object | Test.java:447:16:447:31 | (...)... : String | provenance |  |
 | Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:448:17:448:18 | in : String | Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:448:17:448:18 | in : String | Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:449:9:449:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:454:16:454:31 | (...)... : String | Test.java:455:17:455:18 | in : String | provenance |  |
 | Test.java:454:24:454:31 | source(...) : Object | Test.java:454:16:454:31 | (...)... : String | provenance |  |
 | Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:455:17:455:18 | in : String | Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:455:17:455:18 | in : String | Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:456:9:456:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:461:16:461:31 | (...)... : String | Test.java:462:17:462:18 | in : String | provenance |  |
 | Test.java:461:24:461:31 | source(...) : Object | Test.java:461:16:461:31 | (...)... : String | provenance |  |
 | Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:462:17:462:18 | in : String | Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:462:17:462:18 | in : String | Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:463:9:463:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:468:16:468:31 | (...)... : String | Test.java:469:17:469:18 | in : String | provenance |  |
 | Test.java:468:24:468:31 | source(...) : Object | Test.java:468:16:468:31 | (...)... : String | provenance |  |
 | Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:469:17:469:18 | in : String | Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:469:17:469:18 | in : String | Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:470:9:470:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:475:16:475:31 | (...)... : String | Test.java:476:17:476:18 | in : String | provenance |  |
 | Test.java:475:24:475:31 | source(...) : Object | Test.java:475:16:475:31 | (...)... : String | provenance |  |
 | Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:476:17:476:18 | in : String | Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:476:17:476:18 | in : String | Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:477:9:477:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:482:16:482:31 | (...)... : String | Test.java:483:17:483:18 | in : String | provenance |  |
 | Test.java:482:24:482:31 | source(...) : Object | Test.java:482:16:482:31 | (...)... : String | provenance |  |
 | Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:483:17:483:18 | in : String | Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:483:17:483:18 | in : String | Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:484:9:484:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:489:16:489:31 | (...)... : String | Test.java:490:17:490:18 | in : String | provenance |  |
 | Test.java:489:24:489:31 | source(...) : Object | Test.java:489:16:489:31 | (...)... : String | provenance |  |
 | Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:490:17:490:18 | in : String | Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:490:17:490:18 | in : String | Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:491:9:491:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:496:16:496:31 | (...)... : String | Test.java:497:17:497:18 | in : String | provenance |  |
 | Test.java:496:24:496:31 | source(...) : Object | Test.java:496:16:496:31 | (...)... : String | provenance |  |
 | Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:497:17:497:18 | in : String | Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:497:17:497:18 | in : String | Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:498:9:498:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:503:16:503:31 | (...)... : String | Test.java:504:17:504:18 | in : String | provenance |  |
 | Test.java:503:24:503:31 | source(...) : Object | Test.java:503:16:503:31 | (...)... : String | provenance |  |
 | Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:504:17:504:18 | in : String | Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:504:17:504:18 | in : String | Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:505:9:505:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:510:16:510:31 | (...)... : String | Test.java:511:17:511:18 | in : String | provenance |  |
 | Test.java:510:24:510:31 | source(...) : Object | Test.java:510:16:510:31 | (...)... : String | provenance |  |
 | Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:511:17:511:18 | in : String | Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:511:17:511:18 | in : String | Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:512:9:512:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:517:16:517:31 | (...)... : String | Test.java:518:17:518:18 | in : String | provenance |  |
 | Test.java:517:24:517:31 | source(...) : Object | Test.java:517:16:517:31 | (...)... : String | provenance |  |
 | Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:518:17:518:18 | in : String | Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:518:17:518:18 | in : String | Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:519:9:519:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:524:16:524:31 | (...)... : String | Test.java:525:17:525:18 | in : String | provenance |  |
 | Test.java:524:24:524:31 | source(...) : Object | Test.java:524:16:524:31 | (...)... : String | provenance |  |
 | Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:525:17:525:18 | in : String | Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:525:17:525:18 | in : String | Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:526:9:526:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:531:16:531:31 | (...)... : String | Test.java:532:17:532:18 | in : String | provenance |  |
 | Test.java:531:24:531:31 | source(...) : Object | Test.java:531:16:531:31 | (...)... : String | provenance |  |
 | Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:532:17:532:18 | in : String | Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:532:17:532:18 | in : String | Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:533:9:533:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:538:16:538:31 | (...)... : String | Test.java:539:17:539:18 | in : String | provenance |  |
 | Test.java:538:24:538:31 | source(...) : Object | Test.java:538:16:538:31 | (...)... : String | provenance |  |
 | Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:539:17:539:18 | in : String | Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:539:17:539:18 | in : String | Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:540:9:540:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:545:16:545:31 | (...)... : String | Test.java:546:17:546:18 | in : String | provenance |  |
 | Test.java:545:24:545:31 | source(...) : Object | Test.java:545:16:545:31 | (...)... : String | provenance |  |
 | Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:546:17:546:18 | in : String | Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:546:17:546:18 | in : String | Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:547:9:547:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:552:16:552:31 | (...)... : String | Test.java:553:17:553:18 | in : String | provenance |  |
 | Test.java:552:24:552:31 | source(...) : Object | Test.java:552:16:552:31 | (...)... : String | provenance |  |
 | Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:553:17:553:18 | in : String | Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:553:17:553:18 | in : String | Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:554:9:554:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:559:16:559:31 | (...)... : String | Test.java:560:17:560:18 | in : String | provenance |  |
 | Test.java:559:24:559:31 | source(...) : Object | Test.java:559:16:559:31 | (...)... : String | provenance |  |
 | Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:560:17:560:18 | in : String | Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:560:17:560:18 | in : String | Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:561:9:561:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:566:16:566:31 | (...)... : String | Test.java:567:17:567:18 | in : String | provenance |  |
 | Test.java:566:24:566:31 | source(...) : Object | Test.java:566:16:566:31 | (...)... : String | provenance |  |
 | Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:567:17:567:18 | in : String | Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:567:17:567:18 | in : String | Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:568:9:568:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:573:16:573:31 | (...)... : String | Test.java:574:17:574:18 | in : String | provenance |  |
 | Test.java:573:24:573:31 | source(...) : Object | Test.java:573:16:573:31 | (...)... : String | provenance |  |
 | Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:574:17:574:18 | in : String | Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:574:17:574:18 | in : String | Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:575:9:575:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:580:16:580:31 | (...)... : String | Test.java:581:17:581:18 | in : String | provenance |  |
 | Test.java:580:24:580:31 | source(...) : Object | Test.java:580:16:580:31 | (...)... : String | provenance |  |
 | Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:581:17:581:18 | in : String | Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:581:17:581:18 | in : String | Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:582:9:582:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:587:16:587:31 | (...)... : String | Test.java:588:17:588:18 | in : String | provenance |  |
 | Test.java:587:24:587:31 | source(...) : Object | Test.java:587:16:587:31 | (...)... : String | provenance |  |
 | Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:588:17:588:18 | in : String | Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:588:17:588:18 | in : String | Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:48 |
 | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:589:9:589:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:594:17:594:33 | (...)... : short[] | Test.java:595:31:595:32 | in : short[] | provenance |  |
 | Test.java:594:26:594:33 | source(...) : Object | Test.java:594:17:594:33 | (...)... : short[] | provenance |  |
 | Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:595:31:595:32 | in : short[] | Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance | MaD:49 |
 | Test.java:595:31:595:32 | in : short[] | Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance | MaD:49 |
 | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] | Test.java:596:9:596:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | provenance |  |
-| Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] | provenance | MaD:34 |
 | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] | provenance | MaD:34 |
 | Test.java:601:15:601:29 | (...)... : Number | Test.java:602:31:602:32 | in : Number | provenance |  |
 | Test.java:601:22:601:29 | source(...) : Object | Test.java:601:15:601:29 | (...)... : Number | provenance |  |
 | Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:602:31:602:32 | in : Number | Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:602:31:602:32 | in : Number | Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:603:9:603:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:608:16:608:31 | (...)... : long[] | Test.java:609:31:609:32 | in : long[] | provenance |  |
 | Test.java:608:24:608:31 | source(...) : Object | Test.java:608:16:608:31 | (...)... : long[] | provenance |  |
 | Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
-| Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
-| Test.java:609:31:609:32 | in : long[] | Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance | MaD:49 |
 | Test.java:609:31:609:32 | in : long[] | Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance | MaD:49 |
 | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] | Test.java:610:9:610:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
-| Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | provenance |  |
-| Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] | provenance | MaD:34 |
 | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] | provenance | MaD:34 |
 | Test.java:615:14:615:27 | (...)... : Number | Test.java:616:31:616:32 | in : Number | provenance |  |
 | Test.java:615:20:615:27 | source(...) : Object | Test.java:615:14:615:27 | (...)... : Number | provenance |  |
 | Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:616:31:616:32 | in : Number | Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:616:31:616:32 | in : Number | Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:617:9:617:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:622:15:622:29 | (...)... : int[] | Test.java:623:31:623:32 | in : int[] | provenance |  |
 | Test.java:622:22:622:29 | source(...) : Object | Test.java:622:15:622:29 | (...)... : int[] | provenance |  |
 | Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:623:31:623:32 | in : int[] | Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance | MaD:49 |
 | Test.java:623:31:623:32 | in : int[] | Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance | MaD:49 |
 | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] | Test.java:624:9:624:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | provenance |  |
-| Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] | provenance | MaD:34 |
 | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] | provenance | MaD:34 |
 | Test.java:629:13:629:25 | (...)... : Number | Test.java:630:31:630:32 | in : Number | provenance |  |
 | Test.java:629:18:629:25 | source(...) : Object | Test.java:629:13:629:25 | (...)... : Number | provenance |  |
 | Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:630:31:630:32 | in : Number | Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:630:31:630:32 | in : Number | Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:631:9:631:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:636:17:636:33 | (...)... : float[] | Test.java:637:31:637:32 | in : float[] | provenance |  |
 | Test.java:636:26:636:33 | source(...) : Object | Test.java:636:17:636:33 | (...)... : float[] | provenance |  |
 | Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
-| Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
-| Test.java:637:31:637:32 | in : float[] | Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance | MaD:49 |
 | Test.java:637:31:637:32 | in : float[] | Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance | MaD:49 |
 | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] | Test.java:638:9:638:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
-| Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | provenance |  |
-| Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] | provenance | MaD:34 |
 | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] | provenance | MaD:34 |
 | Test.java:643:15:643:29 | (...)... : Number | Test.java:644:31:644:32 | in : Number | provenance |  |
 | Test.java:643:22:643:29 | source(...) : Object | Test.java:643:15:643:29 | (...)... : Number | provenance |  |
 | Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:644:31:644:32 | in : Number | Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:644:31:644:32 | in : Number | Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:645:9:645:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:650:18:650:35 | (...)... : double[] | Test.java:651:31:651:32 | in : double[] | provenance |  |
 | Test.java:650:28:650:35 | source(...) : Object | Test.java:650:18:650:35 | (...)... : double[] | provenance |  |
 | Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:651:31:651:32 | in : double[] | Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance | MaD:49 |
 | Test.java:651:31:651:32 | in : double[] | Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance | MaD:49 |
 | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] | Test.java:652:9:652:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | provenance |  |
-| Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] | provenance | MaD:34 |
 | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] | provenance | MaD:34 |
 | Test.java:657:16:657:31 | (...)... : Number | Test.java:658:31:658:32 | in : Number | provenance |  |
 | Test.java:657:24:657:31 | source(...) : Object | Test.java:657:16:657:31 | (...)... : Number | provenance |  |
 | Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:658:31:658:32 | in : Number | Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:658:31:658:32 | in : Number | Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:659:9:659:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:664:16:664:31 | (...)... : char[] | Test.java:665:31:665:32 | in : char[] | provenance |  |
 | Test.java:664:24:664:31 | source(...) : Object | Test.java:664:16:664:31 | (...)... : char[] | provenance |  |
 | Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
-| Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
-| Test.java:665:31:665:32 | in : char[] | Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance | MaD:49 |
 | Test.java:665:31:665:32 | in : char[] | Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance | MaD:49 |
 | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] | Test.java:666:9:666:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
-| Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | provenance |  |
-| Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] | provenance | MaD:34 |
 | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] | provenance | MaD:34 |
 | Test.java:671:14:671:27 | (...)... : Number | Test.java:672:31:672:32 | in : Number | provenance |  |
 | Test.java:671:20:671:27 | source(...) : Object | Test.java:671:14:671:27 | (...)... : Number | provenance |  |
 | Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:672:31:672:32 | in : Number | Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:672:31:672:32 | in : Number | Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:673:9:673:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:678:16:678:31 | (...)... : byte[] | Test.java:679:31:679:32 | in : byte[] | provenance |  |
 | Test.java:678:24:678:31 | source(...) : Object | Test.java:678:16:678:31 | (...)... : byte[] | provenance |  |
 | Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:679:31:679:32 | in : byte[] | Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance | MaD:49 |
 | Test.java:679:31:679:32 | in : byte[] | Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance | MaD:49 |
 | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] | Test.java:680:9:680:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | provenance |  |
-| Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] | provenance | MaD:34 |
 | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] | provenance | MaD:34 |
 | Test.java:685:14:685:27 | (...)... : Number | Test.java:686:31:686:32 | in : Number | provenance |  |
 | Test.java:685:20:685:27 | source(...) : Object | Test.java:685:14:685:27 | (...)... : Number | provenance |  |
 | Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:686:31:686:32 | in : Number | Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:686:31:686:32 | in : Number | Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | provenance | MaD:49 |
 | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | Test.java:687:9:687:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | provenance |  |
-| Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | provenance | MaD:34 |
 | Test.java:692:19:692:37 | (...)... : boolean[] | Test.java:693:31:693:32 | in : boolean[] | provenance |  |
 | Test.java:692:30:692:37 | source(...) : Object | Test.java:692:19:692:37 | (...)... : boolean[] | provenance |  |
 | Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
-| Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
-| Test.java:693:31:693:32 | in : boolean[] | Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance | MaD:49 |
 | Test.java:693:31:693:32 | in : boolean[] | Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance | MaD:49 |
 | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] | Test.java:694:9:694:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
-| Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | provenance |  |
-| Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] | provenance | MaD:34 |
 | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] | provenance | MaD:34 |
 | Test.java:699:17:699:33 | (...)... : Boolean | Test.java:700:31:700:32 | in : Boolean | provenance |  |
 | Test.java:699:26:699:33 | source(...) : Object | Test.java:699:17:699:33 | (...)... : Boolean | provenance |  |
 | Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:700:31:700:32 | in : Boolean | Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance | MaD:49 |
 | Test.java:700:31:700:32 | in : Boolean | Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance | MaD:49 |
 | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean | Test.java:701:9:701:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | provenance |  |
-| Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean | provenance | MaD:34 |
 | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean | provenance | MaD:34 |
 | Test.java:706:18:706:35 | (...)... : String[] | Test.java:707:31:707:32 | in : String[] | provenance |  |
 | Test.java:706:28:706:35 | source(...) : Object | Test.java:706:18:706:35 | (...)... : String[] | provenance |  |
 | Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:707:31:707:32 | in : String[] | Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance | MaD:49 |
 | Test.java:707:31:707:32 | in : String[] | Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance | MaD:49 |
 | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] | Test.java:708:9:708:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | provenance |  |
-| Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] | provenance | MaD:34 |
 | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] | provenance | MaD:34 |
 | Test.java:713:16:713:31 | (...)... : String | Test.java:714:31:714:32 | in : String | provenance |  |
 | Test.java:713:24:713:31 | source(...) : Object | Test.java:713:16:713:31 | (...)... : String | provenance |  |
 | Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:714:31:714:32 | in : String | Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | Test.java:714:31:714:32 | in : String | Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String | Test.java:715:9:715:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String | provenance | MaD:34 |
 | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String | provenance | MaD:34 |
 | Test.java:720:22:720:43 | (...)... : Serializable | Test.java:721:31:721:32 | in : Serializable | provenance |  |
 | Test.java:720:36:720:43 | source(...) : Object | Test.java:720:22:720:43 | (...)... : Serializable | provenance |  |
 | Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:721:31:721:32 | in : Serializable | Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance | MaD:49 |
 | Test.java:721:31:721:32 | in : Serializable | Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance | MaD:49 |
 | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable | Test.java:722:9:722:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | provenance |  |
-| Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable | provenance | MaD:34 |
 | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable | provenance | MaD:34 |
 | Test.java:727:22:727:43 | (...)... : Parcelable[] | Test.java:728:31:728:32 | in : Parcelable[] | provenance |  |
 | Test.java:727:36:727:43 | source(...) : Object | Test.java:727:22:727:43 | (...)... : Parcelable[] | provenance |  |
 | Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
-| Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
-| Test.java:728:31:728:32 | in : Parcelable[] | Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance | MaD:49 |
 | Test.java:728:31:728:32 | in : Parcelable[] | Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance | MaD:49 |
 | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] | Test.java:729:9:729:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
-| Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | provenance |  |
-| Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] | provenance | MaD:34 |
 | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] | provenance | MaD:34 |
 | Test.java:734:20:734:39 | (...)... : Parcelable | Test.java:735:31:735:32 | in : Parcelable | provenance |  |
 | Test.java:734:32:734:39 | source(...) : Object | Test.java:734:20:734:39 | (...)... : Parcelable | provenance |  |
 | Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:735:31:735:32 | in : Parcelable | Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance | MaD:49 |
 | Test.java:735:31:735:32 | in : Parcelable | Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance | MaD:49 |
 | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable | Test.java:736:9:736:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | provenance |  |
-| Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable | provenance | MaD:34 |
 | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable | provenance | MaD:34 |
 | Test.java:741:24:741:47 | (...)... : CharSequence[] | Test.java:742:31:742:32 | in : CharSequence[] | provenance |  |
 | Test.java:741:40:741:47 | source(...) : Object | Test.java:741:24:741:47 | (...)... : CharSequence[] | provenance |  |
 | Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
-| Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
-| Test.java:742:31:742:32 | in : CharSequence[] | Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance | MaD:49 |
 | Test.java:742:31:742:32 | in : CharSequence[] | Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance | MaD:49 |
 | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] | Test.java:743:9:743:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
-| Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | provenance |  |
-| Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] | provenance | MaD:34 |
 | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] | provenance | MaD:34 |
 | Test.java:748:22:748:43 | (...)... : CharSequence | Test.java:749:31:749:32 | in : CharSequence | provenance |  |
 | Test.java:748:36:748:43 | source(...) : Object | Test.java:748:22:748:43 | (...)... : CharSequence | provenance |  |
 | Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:749:31:749:32 | in : CharSequence | Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance | MaD:49 |
 | Test.java:749:31:749:32 | in : CharSequence | Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance | MaD:49 |
 | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | Test.java:750:9:750:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | provenance |  |
-| Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | provenance | MaD:34 |
 | Test.java:755:16:755:31 | (...)... : Bundle | Test.java:756:31:756:32 | in : Bundle | provenance |  |
 | Test.java:755:24:755:31 | source(...) : Object | Test.java:755:16:755:31 | (...)... : Bundle | provenance |  |
 | Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
-| Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
-| Test.java:756:31:756:32 | in : Bundle | Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance | MaD:49 |
 | Test.java:756:31:756:32 | in : Bundle | Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance | MaD:49 |
 | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle | Test.java:757:9:757:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
-| Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | provenance |  |
-| Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle | provenance | MaD:34 |
 | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle | provenance | MaD:34 |
 | Test.java:762:16:762:31 | (...)... : Intent | Test.java:763:10:763:11 | in : Intent | provenance |  |
 | Test.java:762:24:762:31 | source(...) : Object | Test.java:762:16:762:31 | (...)... : Intent | provenance |  |
@@ -1181,26 +915,18 @@ edges
 | Test.java:769:44:769:51 | source(...) : String | Test.java:28:29:28:36 | k : String | provenance |  |
 | Test.java:769:44:769:51 | source(...) : String | Test.java:769:24:769:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:770:18:770:19 | in : Bundle [<map.key>] : String | Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:51 |
 | Test.java:770:18:770:19 | in : Bundle [<map.key>] : String | Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:51 |
 | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:771:9:771:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:776:16:776:54 | (...)... : Bundle [<map.value>] : Object | Test.java:777:18:777:19 | in : Bundle [<map.value>] : Object | provenance |  |
 | Test.java:776:24:776:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | Test.java:776:16:776:54 | (...)... : Bundle [<map.value>] : Object | provenance |  |
 | Test.java:776:46:776:53 | source(...) : Object | Test.java:776:24:776:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | provenance | MaD:176 |
 | Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:777:18:777:19 | in : Bundle [<map.value>] : Object | Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:52 |
 | Test.java:777:18:777:19 | in : Bundle [<map.value>] : Object | Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:52 |
 | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | Test.java:778:9:778:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:783:16:783:31 | (...)... : Intent | Test.java:784:10:784:11 | in : Intent | provenance |  |
 | Test.java:783:24:783:31 | source(...) : Object | Test.java:783:16:783:31 | (...)... : Intent | provenance |  |
@@ -1212,27 +938,19 @@ edges
 | Test.java:790:65:790:72 | source(...) : String | Test.java:28:29:28:36 | k : String | provenance |  |
 | Test.java:790:65:790:72 | source(...) : String | Test.java:790:45:790:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:791:18:791:19 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:54 |
 | Test.java:791:18:791:19 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:54 |
 | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:792:9:792:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:797:16:797:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:798:18:798:19 | in : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:797:24:797:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:797:16:797:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:797:45:797:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | Test.java:797:24:797:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:178 |
 | Test.java:797:67:797:74 | source(...) : Object | Test.java:797:45:797:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | provenance | MaD:176 |
 | Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:798:18:798:19 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:55 |
 | Test.java:798:18:798:19 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:55 |
 | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | Test.java:799:9:799:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:804:16:804:31 | (...)... : Intent | Test.java:805:10:805:11 | in : Intent | provenance |  |
 | Test.java:804:24:804:31 | source(...) : Object | Test.java:804:16:804:31 | (...)... : Intent | provenance |  |
@@ -1241,14 +959,10 @@ edges
 | Test.java:811:16:811:31 | (...)... : String | Test.java:812:33:812:34 | in : String | provenance |  |
 | Test.java:811:24:811:31 | source(...) : Object | Test.java:811:16:811:31 | (...)... : String | provenance |  |
 | Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:812:33:812:34 | in : String | Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:57 |
 | Test.java:812:33:812:34 | in : String | Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:57 |
 | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:813:9:813:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:818:16:818:31 | (...)... : Intent | Test.java:819:10:819:11 | in : Intent | provenance |  |
 | Test.java:818:24:818:31 | source(...) : Object | Test.java:818:16:818:31 | (...)... : Intent | provenance |  |
@@ -1257,25 +971,17 @@ edges
 | Test.java:825:16:825:31 | (...)... : String | Test.java:826:36:826:37 | in : String | provenance |  |
 | Test.java:825:24:825:31 | source(...) : Object | Test.java:825:16:825:31 | (...)... : String | provenance |  |
 | Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:826:36:826:37 | in : String | Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:59 |
 | Test.java:826:36:826:37 | in : String | Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:59 |
 | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:827:9:827:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:832:19:832:37 | (...)... : ArrayList | Test.java:833:42:833:43 | in : ArrayList | provenance |  |
 | Test.java:832:30:832:37 | source(...) : Object | Test.java:832:19:832:37 | (...)... : ArrayList | provenance |  |
 | Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:833:42:833:43 | in : ArrayList | Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:60 |
 | Test.java:833:42:833:43 | in : ArrayList | Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:60 |
 | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | Test.java:834:9:834:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:839:16:839:31 | (...)... : Intent | Test.java:840:10:840:11 | in : Intent | provenance |  |
 | Test.java:839:24:839:31 | source(...) : Object | Test.java:839:16:839:31 | (...)... : Intent | provenance |  |
@@ -1284,25 +990,17 @@ edges
 | Test.java:846:16:846:31 | (...)... : String | Test.java:847:32:847:33 | in : String | provenance |  |
 | Test.java:846:24:846:31 | source(...) : Object | Test.java:846:16:846:31 | (...)... : String | provenance |  |
 | Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:847:32:847:33 | in : String | Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:62 |
 | Test.java:847:32:847:33 | in : String | Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:62 |
 | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:848:9:848:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:853:19:853:37 | (...)... : ArrayList | Test.java:854:38:854:39 | in : ArrayList | provenance |  |
 | Test.java:853:30:853:37 | source(...) : Object | Test.java:853:19:853:37 | (...)... : ArrayList | provenance |  |
 | Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:854:38:854:39 | in : ArrayList | Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:63 |
 | Test.java:854:38:854:39 | in : ArrayList | Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance | MaD:63 |
 | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | Test.java:855:9:855:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | provenance |  |
-| Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | provenance | MaD:34 |
 | Test.java:860:16:860:31 | (...)... : Intent | Test.java:861:10:861:11 | in : Intent | provenance |  |
 | Test.java:860:24:860:31 | source(...) : Object | Test.java:860:16:860:31 | (...)... : Intent | provenance |  |
@@ -1313,26 +1011,18 @@ edges
 | Test.java:867:44:867:51 | source(...) : String | Test.java:28:29:28:36 | k : String | provenance |  |
 | Test.java:867:44:867:51 | source(...) : String | Test.java:867:24:867:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:868:22:868:23 | in : Bundle [<map.key>] : String | Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:65 |
 | Test.java:868:22:868:23 | in : Bundle [<map.key>] : String | Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:65 |
 | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:869:9:869:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:874:16:874:54 | (...)... : Bundle [<map.value>] : Object | Test.java:875:22:875:23 | in : Bundle [<map.value>] : Object | provenance |  |
 | Test.java:874:24:874:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | Test.java:874:16:874:54 | (...)... : Bundle [<map.value>] : Object | provenance |  |
 | Test.java:874:46:874:53 | source(...) : Object | Test.java:874:24:874:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | provenance | MaD:176 |
 | Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:875:22:875:23 | in : Bundle [<map.value>] : Object | Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:66 |
 | Test.java:875:22:875:23 | in : Bundle [<map.value>] : Object | Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:66 |
 | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | Test.java:876:9:876:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:881:16:881:31 | (...)... : Intent | Test.java:882:10:882:11 | in : Intent | provenance |  |
 | Test.java:881:24:881:31 | source(...) : Object | Test.java:881:16:881:31 | (...)... : Intent | provenance |  |
@@ -1344,27 +1034,19 @@ edges
 | Test.java:888:65:888:72 | source(...) : String | Test.java:28:29:28:36 | k : String | provenance |  |
 | Test.java:888:65:888:72 | source(...) : String | Test.java:888:45:888:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:889:22:889:23 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:68 |
 | Test.java:889:22:889:23 | in : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | provenance | MaD:68 |
 | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | provenance |  |
 | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:890:9:890:40 | getMapKey(...) | provenance | MaD:98 |
 | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | provenance | MaD:34 |
 | Test.java:895:16:895:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:896:22:896:23 | in : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:895:24:895:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:895:16:895:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
 | Test.java:895:45:895:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | Test.java:895:24:895:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:178 |
 | Test.java:895:67:895:74 | source(...) : Object | Test.java:895:45:895:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | provenance | MaD:176 |
 | Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:896:22:896:23 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:69 |
 | Test.java:896:22:896:23 | in : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | provenance | MaD:69 |
 | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | Test.java:897:9:897:42 | getMapValue(...) | provenance | MaD:175 |
 | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | provenance |  |
-| Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | provenance | MaD:34 |
 | Test.java:902:16:902:31 | (...)... : Intent | Test.java:903:10:903:11 | in : Intent | provenance |  |
 | Test.java:902:24:902:31 | source(...) : Object | Test.java:902:16:902:31 | (...)... : Intent | provenance |  |
@@ -2001,430 +1683,164 @@ edges
 | Test.java:1759:4:1759:6 | out [post update] : Intent | Test.java:1760:9:1760:11 | out | provenance |  |
 | Test.java:1759:19:1759:20 | in : String | Test.java:1759:4:1759:6 | out [post update] : Intent | provenance | MaD:89 |
 | TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:18:37:18:64 | (...)... : String | TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:18:37:18:64 | (...)... : String | TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:18:37:18:64 | (...)... : String | TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:18:46:18:64 | source(...) : Object | TestStartActivityToGetIntent.java:18:37:18:64 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:23:37:23:69 | (...)... : String | TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:23:37:23:69 | (...)... : String | TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:23:37:23:69 | (...)... : String | TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:23:46:23:69 | source(...) : Object | TestStartActivityToGetIntent.java:23:37:23:69 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
-| TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
-| TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
 | TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:29:37:29:71 | (...)... : String | TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:29:37:29:71 | (...)... : String | TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:29:37:29:71 | (...)... : String | TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:29:46:29:71 | source(...) : Object | TestStartActivityToGetIntent.java:29:37:29:71 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$AnotherActivity |
-| TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$AnotherActivity |
-| TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$AnotherActivity |
 | TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:35:37:35:64 | (...)... : String | TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:35:37:35:64 | (...)... : String | TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:35:37:35:64 | (...)... : String | TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:35:46:35:64 | source(...) : Object | TestStartActivityToGetIntent.java:35:37:35:64 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:40:37:40:69 | (...)... : String | TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:40:37:40:69 | (...)... : String | TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:40:37:40:69 | (...)... : String | TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:40:46:40:69 | source(...) : Object | TestStartActivityToGetIntent.java:40:37:40:69 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
-| TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
-| TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance | android.content.Activity.startActivities()+TestStartActivityToGetIntent$SomeActivity |
 | TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:52:37:52:71 | (...)... : String | TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:52:37:52:71 | (...)... : String | TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:52:37:52:71 | (...)... : String | TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:52:46:52:71 | source(...) : Object | TestStartActivityToGetIntent.java:52:37:52:71 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:57:37:57:70 | (...)... : String | TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:57:37:57:70 | (...)... : String | TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:57:37:57:70 | (...)... : String | TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:57:46:57:70 | source(...) : Object | TestStartActivityToGetIntent.java:57:37:57:70 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:62:37:62:69 | (...)... : String | TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:62:37:62:69 | (...)... : String | TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:62:37:62:69 | (...)... : String | TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:62:46:62:69 | source(...) : Object | TestStartActivityToGetIntent.java:62:37:62:69 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:67:37:67:71 | (...)... : String | TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:67:37:67:71 | (...)... : String | TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:67:37:67:71 | (...)... : String | TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:67:46:67:71 | source(...) : Object | TestStartActivityToGetIntent.java:67:37:67:71 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:72:37:72:70 | (...)... : String | TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:72:37:72:70 | (...)... : String | TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:72:37:72:70 | (...)... : String | TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:72:46:72:70 | source(...) : Object | TestStartActivityToGetIntent.java:72:37:72:70 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:79:37:79:60 | (...)... : String | TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartActivityToGetIntent.java:79:37:79:60 | (...)... : String | TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:79:37:79:60 | (...)... : String | TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartActivityToGetIntent.java:79:46:79:60 | source(...) : Object | TestStartActivityToGetIntent.java:79:37:79:60 | (...)... : String | provenance |  |
 | TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:51 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:51 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:95:18:95:51 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:51 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:51 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | TestStartActivityToGetIntent.java:102:18:102:51 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:18:37:18:59 | (...)... : String | TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:18:37:18:59 | (...)... : String | TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:18:37:18:59 | (...)... : String | TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:18:46:18:59 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:18:37:18:59 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:23:37:23:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:23:37:23:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:23:37:23:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:23:46:23:67 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:23:37:23:67 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:28:37:28:69 | (...)... : String | TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:28:37:28:69 | (...)... : String | TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:28:37:28:69 | (...)... : String | TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:28:46:28:69 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:28:37:28:69 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:33:37:33:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:33:37:33:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:33:37:33:67 | (...)... : String | TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:33:46:33:67 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:33:37:33:67 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:38:37:38:75 | (...)... : String | TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:38:37:38:75 | (...)... : String | TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:38:37:38:75 | (...)... : String | TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:38:46:38:75 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:38:37:38:75 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:43:37:43:66 | (...)... : String | TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:43:37:43:66 | (...)... : String | TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:43:37:43:66 | (...)... : String | TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:43:46:43:66 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:43:37:43:66 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:48:37:48:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:48:37:48:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:48:37:48:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:48:46:48:74 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:48:37:48:74 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:53:37:53:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:53:37:53:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:53:37:53:74 | (...)... : String | TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:53:46:53:74 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:53:37:53:74 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:58:37:58:82 | (...)... : String | TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:58:37:58:82 | (...)... : String | TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:58:37:58:82 | (...)... : String | TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:58:46:58:82 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:58:37:58:82 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:65:37:65:60 | (...)... : String | TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartBroadcastReceiverToIntent.java:65:37:65:60 | (...)... : String | TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:65:37:65:60 | (...)... : String | TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartBroadcastReceiverToIntent.java:65:46:65:60 | source(...) : Object | TestStartBroadcastReceiverToIntent.java:65:37:65:60 | (...)... : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartBroadcastReceiverToIntent.java:82:18:82:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:19:37:19:59 | (...)... : String | TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:19:37:19:59 | (...)... : String | TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:19:37:19:59 | (...)... : String | TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:19:46:19:59 | source(...) : Object | TestStartServiceToIntent.java:19:37:19:59 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:24:37:24:67 | (...)... : String | TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:24:37:24:67 | (...)... : String | TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:24:37:24:67 | (...)... : String | TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:24:46:24:67 | source(...) : Object | TestStartServiceToIntent.java:24:37:24:67 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:29:37:29:68 | (...)... : String | TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:29:37:29:68 | (...)... : String | TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:29:37:29:68 | (...)... : String | TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:29:46:29:68 | source(...) : Object | TestStartServiceToIntent.java:29:37:29:68 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:34:37:34:60 | (...)... : String | TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:34:37:34:60 | (...)... : String | TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:34:37:34:60 | (...)... : String | TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:34:46:34:60 | source(...) : Object | TestStartServiceToIntent.java:34:37:34:60 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:39:37:39:71 | (...)... : String | TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:39:37:39:71 | (...)... : String | TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:39:37:39:71 | (...)... : String | TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:39:46:39:71 | source(...) : Object | TestStartServiceToIntent.java:39:37:39:71 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:46:37:46:60 | (...)... : String | TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
-| TestStartServiceToIntent.java:46:37:46:60 | (...)... : String | TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:46:37:46:60 | (...)... : String | TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | provenance | MaD:49 |
 | TestStartServiceToIntent.java:46:46:46:60 | source(...) : Object | TestStartServiceToIntent.java:46:37:46:60 | (...)... : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:63:18:63:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:68:18:68:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:74:18:74:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:80:18:80:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:86:18:86:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:46 | getStringExtra(...) | provenance | MaD:43 |
-| TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:46 | getStringExtra(...) | provenance | MaD:43 |
 | TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | TestStartServiceToIntent.java:91:18:91:46 | getStringExtra(...) | provenance | MaD:43 |
 nodes
 | Test.java:22:19:22:32 | it : Set [<element>] : String | semmle.label | it : Set [<element>] : String |
@@ -2432,142 +1848,73 @@ nodes
 | Test.java:22:44:22:56 | iterator(...) : Iterator [<element>] : String | semmle.label | iterator(...) : Iterator [<element>] : String |
 | Test.java:22:44:22:63 | next(...) : String | semmle.label | next(...) : String |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Boolean |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Boolean |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Intent |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Intent |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Serializable |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Serializable |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : byte[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : byte[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : char[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : char[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : double[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : double[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : float[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : float[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : int[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : int[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : long[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : long[] |
 | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : short[] |
-| Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : short[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Boolean |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Boolean |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Bundle |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Bundle |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Serializable |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : Serializable |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : String[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : byte[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : byte[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : char[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : char[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : double[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : double[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : float[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : float[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : int[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : int[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : long[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : long[] |
-| Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : short[] |
 | Test.java:23:45:23:45 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | i : Intent [android.content.Intent.extras, <map.value>] : short[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | semmle.label | getExtras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | semmle.label | getExtras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | semmle.label | getExtras(...) : Bundle [<map.value>] : Boolean |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | semmle.label | getExtras(...) : Bundle [<map.value>] : Boolean |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | semmle.label | getExtras(...) : Bundle [<map.value>] : Bundle |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | semmle.label | getExtras(...) : Bundle [<map.value>] : Bundle |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | semmle.label | getExtras(...) : Bundle [<map.value>] : CharSequence |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | semmle.label | getExtras(...) : Bundle [<map.value>] : CharSequence |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | semmle.label | getExtras(...) : Bundle [<map.value>] : CharSequence[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | semmle.label | getExtras(...) : Bundle [<map.value>] : CharSequence[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | semmle.label | getExtras(...) : Bundle [<map.value>] : Intent |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | semmle.label | getExtras(...) : Bundle [<map.value>] : Intent |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | semmle.label | getExtras(...) : Bundle [<map.value>] : IntentSender |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | semmle.label | getExtras(...) : Bundle [<map.value>] : IntentSender |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | semmle.label | getExtras(...) : Bundle [<map.value>] : Number |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | semmle.label | getExtras(...) : Bundle [<map.value>] : Number |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | semmle.label | getExtras(...) : Bundle [<map.value>] : Object |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | semmle.label | getExtras(...) : Bundle [<map.value>] : Object |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | semmle.label | getExtras(...) : Bundle [<map.value>] : Parcelable |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | semmle.label | getExtras(...) : Bundle [<map.value>] : Parcelable |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | semmle.label | getExtras(...) : Bundle [<map.value>] : Parcelable[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | semmle.label | getExtras(...) : Bundle [<map.value>] : Parcelable[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | semmle.label | getExtras(...) : Bundle [<map.value>] : Serializable |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | semmle.label | getExtras(...) : Bundle [<map.value>] : Serializable |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | semmle.label | getExtras(...) : Bundle [<map.value>] : String[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | semmle.label | getExtras(...) : Bundle [<map.value>] : String[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | semmle.label | getExtras(...) : Bundle [<map.value>] : boolean[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | semmle.label | getExtras(...) : Bundle [<map.value>] : boolean[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | semmle.label | getExtras(...) : Bundle [<map.value>] : byte[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | semmle.label | getExtras(...) : Bundle [<map.value>] : byte[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | semmle.label | getExtras(...) : Bundle [<map.value>] : char[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | semmle.label | getExtras(...) : Bundle [<map.value>] : char[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | semmle.label | getExtras(...) : Bundle [<map.value>] : double[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | semmle.label | getExtras(...) : Bundle [<map.value>] : double[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | semmle.label | getExtras(...) : Bundle [<map.value>] : float[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | semmle.label | getExtras(...) : Bundle [<map.value>] : float[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | semmle.label | getExtras(...) : Bundle [<map.value>] : int[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | semmle.label | getExtras(...) : Bundle [<map.value>] : int[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | semmle.label | getExtras(...) : Bundle [<map.value>] : long[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | semmle.label | getExtras(...) : Bundle [<map.value>] : long[] |
-| Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | semmle.label | getExtras(...) : Bundle [<map.value>] : short[] |
 | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | semmle.label | getExtras(...) : Bundle [<map.value>] : short[] |
 | Test.java:24:19:24:30 | b : BaseBundle [<map.key>] : String | semmle.label | b : BaseBundle [<map.key>] : String |
 | Test.java:24:19:24:30 | b : Bundle [<map.key>] : Object | semmle.label | b : Bundle [<map.key>] : Object |
@@ -2603,22 +1950,18 @@ nodes
 | Test.java:41:45:41:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | semmle.label | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:41:65:41:72 | source(...) : String | semmle.label | source(...) : String |
 | Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:42:10:42:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | new Intent(...) : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:42:21:42:22 | in : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | in : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:43:9:43:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:48:16:48:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:48:24:48:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:48:45:48:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | semmle.label | newBundleWithMapValue(...) : Bundle [<map.value>] : Object |
 | Test.java:48:67:48:74 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:49:10:49:23 | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | new Intent(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:49:21:49:22 | in : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | in : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:50:9:50:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Object |
-| Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:55:13:55:25 | (...)... : Uri | semmle.label | (...)... : Uri |
 | Test.java:55:18:55:25 | source(...) : Object | semmle.label | source(...) : Object |
@@ -2645,29 +1988,23 @@ nodes
 | Test.java:83:22:83:43 | (...)... : CharSequence | semmle.label | (...)... : CharSequence |
 | Test.java:83:36:83:43 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
-| Test.java:84:10:84:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:84:37:84:38 | in : CharSequence | semmle.label | in : CharSequence |
 | Test.java:85:9:85:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
 | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
-| Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:90:22:90:43 | (...)... : IntentSender | semmle.label | (...)... : IntentSender |
 | Test.java:90:36:90:43 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
 | Test.java:91:10:91:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
 | Test.java:91:43:91:44 | in : IntentSender | semmle.label | in : IntentSender |
 | Test.java:92:9:92:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : IntentSender |
 | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
-| Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender |
 | Test.java:97:16:97:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:97:24:97:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:98:10:98:45 | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | createChooser(...) : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:98:31:98:32 | in : Intent | semmle.label | in : Intent |
 | Test.java:99:9:99:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Intent |
-| Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Intent |
 | Test.java:104:16:104:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:104:24:104:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
@@ -2810,20 +2147,16 @@ nodes
 | Test.java:244:16:244:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:244:24:244:31 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:245:4:245:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:245:38:245:39 | in : String | semmle.label | in : String |
 | Test.java:246:9:246:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:251:19:251:37 | (...)... : ArrayList | semmle.label | (...)... : ArrayList |
 | Test.java:251:30:251:37 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:252:4:252:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:252:44:252:45 | in : ArrayList | semmle.label | in : ArrayList |
 | Test.java:253:9:253:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
-| Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:258:16:258:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:258:24:258:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -2948,434 +2281,338 @@ nodes
 | Test.java:426:16:426:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:426:24:426:31 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:427:4:427:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:427:17:427:18 | in : String | semmle.label | in : String |
 | Test.java:428:9:428:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:433:16:433:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:433:24:433:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:434:4:434:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:434:17:434:18 | in : String | semmle.label | in : String |
 | Test.java:435:9:435:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:440:16:440:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:440:24:440:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:441:4:441:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:441:17:441:18 | in : String | semmle.label | in : String |
 | Test.java:442:9:442:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:447:16:447:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:447:24:447:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:448:4:448:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:448:17:448:18 | in : String | semmle.label | in : String |
 | Test.java:449:9:449:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:454:16:454:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:454:24:454:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:455:4:455:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:455:17:455:18 | in : String | semmle.label | in : String |
 | Test.java:456:9:456:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:461:16:461:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:461:24:461:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:462:4:462:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:462:17:462:18 | in : String | semmle.label | in : String |
 | Test.java:463:9:463:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:468:16:468:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:468:24:468:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:469:4:469:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:469:17:469:18 | in : String | semmle.label | in : String |
 | Test.java:470:9:470:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:475:16:475:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:475:24:475:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:476:4:476:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:476:17:476:18 | in : String | semmle.label | in : String |
 | Test.java:477:9:477:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:482:16:482:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:482:24:482:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:483:4:483:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:483:17:483:18 | in : String | semmle.label | in : String |
 | Test.java:484:9:484:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:489:16:489:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:489:24:489:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:490:4:490:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:490:17:490:18 | in : String | semmle.label | in : String |
 | Test.java:491:9:491:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:496:16:496:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:496:24:496:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:497:4:497:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:497:17:497:18 | in : String | semmle.label | in : String |
 | Test.java:498:9:498:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:503:16:503:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:503:24:503:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:504:4:504:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:504:17:504:18 | in : String | semmle.label | in : String |
 | Test.java:505:9:505:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:510:16:510:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:510:24:510:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:511:4:511:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:511:17:511:18 | in : String | semmle.label | in : String |
 | Test.java:512:9:512:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:517:16:517:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:517:24:517:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:518:4:518:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:518:17:518:18 | in : String | semmle.label | in : String |
 | Test.java:519:9:519:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:524:16:524:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:524:24:524:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:525:4:525:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:525:17:525:18 | in : String | semmle.label | in : String |
 | Test.java:526:9:526:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:531:16:531:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:531:24:531:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:532:4:532:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:532:17:532:18 | in : String | semmle.label | in : String |
 | Test.java:533:9:533:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:538:16:538:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:538:24:538:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:539:4:539:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:539:17:539:18 | in : String | semmle.label | in : String |
 | Test.java:540:9:540:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:545:16:545:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:545:24:545:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:546:4:546:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:546:17:546:18 | in : String | semmle.label | in : String |
 | Test.java:547:9:547:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:552:16:552:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:552:24:552:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:553:4:553:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:553:17:553:18 | in : String | semmle.label | in : String |
 | Test.java:554:9:554:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:559:16:559:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:559:24:559:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:560:4:560:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:560:17:560:18 | in : String | semmle.label | in : String |
 | Test.java:561:9:561:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:566:16:566:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:566:24:566:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:567:4:567:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:567:17:567:18 | in : String | semmle.label | in : String |
 | Test.java:568:9:568:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:573:16:573:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:573:24:573:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:574:4:574:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:574:17:574:18 | in : String | semmle.label | in : String |
 | Test.java:575:9:575:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:580:16:580:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:580:24:580:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:581:4:581:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:581:17:581:18 | in : String | semmle.label | in : String |
 | Test.java:582:9:582:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:587:16:587:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:587:24:587:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:588:4:588:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:588:17:588:18 | in : String | semmle.label | in : String |
 | Test.java:589:9:589:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:594:17:594:33 | (...)... : short[] | semmle.label | (...)... : short[] |
 | Test.java:594:26:594:33 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] |
 | Test.java:595:4:595:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : short[] |
 | Test.java:595:31:595:32 | in : short[] | semmle.label | in : short[] |
 | Test.java:596:9:596:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : short[] |
 | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : short[] |
-| Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : short[] |
 | Test.java:601:15:601:29 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:601:22:601:29 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:602:4:602:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:602:31:602:32 | in : Number | semmle.label | in : Number |
 | Test.java:603:9:603:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:608:16:608:31 | (...)... : long[] | semmle.label | (...)... : long[] |
 | Test.java:608:24:608:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] |
 | Test.java:609:4:609:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : long[] |
 | Test.java:609:31:609:32 | in : long[] | semmle.label | in : long[] |
 | Test.java:610:9:610:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : long[] |
 | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : long[] |
-| Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : long[] |
 | Test.java:615:14:615:27 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:615:20:615:27 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:616:4:616:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:616:31:616:32 | in : Number | semmle.label | in : Number |
 | Test.java:617:9:617:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:622:15:622:29 | (...)... : int[] | semmle.label | (...)... : int[] |
 | Test.java:622:22:622:29 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] |
 | Test.java:623:4:623:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : int[] |
 | Test.java:623:31:623:32 | in : int[] | semmle.label | in : int[] |
 | Test.java:624:9:624:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : int[] |
 | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : int[] |
-| Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : int[] |
 | Test.java:629:13:629:25 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:629:18:629:25 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:630:4:630:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:630:31:630:32 | in : Number | semmle.label | in : Number |
 | Test.java:631:9:631:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:636:17:636:33 | (...)... : float[] | semmle.label | (...)... : float[] |
 | Test.java:636:26:636:33 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] |
 | Test.java:637:4:637:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : float[] |
 | Test.java:637:31:637:32 | in : float[] | semmle.label | in : float[] |
 | Test.java:638:9:638:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : float[] |
 | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : float[] |
-| Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : float[] |
 | Test.java:643:15:643:29 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:643:22:643:29 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:644:4:644:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:644:31:644:32 | in : Number | semmle.label | in : Number |
 | Test.java:645:9:645:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:650:18:650:35 | (...)... : double[] | semmle.label | (...)... : double[] |
 | Test.java:650:28:650:35 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] |
 | Test.java:651:4:651:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : double[] |
 | Test.java:651:31:651:32 | in : double[] | semmle.label | in : double[] |
 | Test.java:652:9:652:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : double[] |
 | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : double[] |
-| Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : double[] |
 | Test.java:657:16:657:31 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:657:24:657:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:658:4:658:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:658:31:658:32 | in : Number | semmle.label | in : Number |
 | Test.java:659:9:659:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:664:16:664:31 | (...)... : char[] | semmle.label | (...)... : char[] |
 | Test.java:664:24:664:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] |
 | Test.java:665:4:665:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : char[] |
 | Test.java:665:31:665:32 | in : char[] | semmle.label | in : char[] |
 | Test.java:666:9:666:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : char[] |
 | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : char[] |
-| Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : char[] |
 | Test.java:671:14:671:27 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:671:20:671:27 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:672:4:672:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:672:31:672:32 | in : Number | semmle.label | in : Number |
 | Test.java:673:9:673:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:678:16:678:31 | (...)... : byte[] | semmle.label | (...)... : byte[] |
 | Test.java:678:24:678:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] |
 | Test.java:679:4:679:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : byte[] |
 | Test.java:679:31:679:32 | in : byte[] | semmle.label | in : byte[] |
 | Test.java:680:9:680:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : byte[] |
 | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : byte[] |
-| Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : byte[] |
 | Test.java:685:14:685:27 | (...)... : Number | semmle.label | (...)... : Number |
 | Test.java:685:20:685:27 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:686:4:686:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:686:31:686:32 | in : Number | semmle.label | in : Number |
 | Test.java:687:9:687:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Number |
 | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
-| Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Number |
 | Test.java:692:19:692:37 | (...)... : boolean[] | semmle.label | (...)... : boolean[] |
 | Test.java:692:30:692:37 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
 | Test.java:693:4:693:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
 | Test.java:693:31:693:32 | in : boolean[] | semmle.label | in : boolean[] |
 | Test.java:694:9:694:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : boolean[] |
 | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
-| Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] |
 | Test.java:699:17:699:33 | (...)... : Boolean | semmle.label | (...)... : Boolean |
 | Test.java:699:26:699:33 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean |
 | Test.java:700:4:700:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Boolean |
 | Test.java:700:31:700:32 | in : Boolean | semmle.label | in : Boolean |
 | Test.java:701:9:701:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Boolean |
 | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Boolean |
-| Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Boolean |
 | Test.java:706:18:706:35 | (...)... : String[] | semmle.label | (...)... : String[] |
 | Test.java:706:28:706:35 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] |
 | Test.java:707:4:707:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String[] |
 | Test.java:707:31:707:32 | in : String[] | semmle.label | in : String[] |
 | Test.java:708:9:708:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : String[] |
 | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : String[] |
-| Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : String[] |
 | Test.java:713:16:713:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:713:24:713:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | Test.java:714:4:714:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | Test.java:714:31:714:32 | in : String | semmle.label | in : String |
 | Test.java:715:9:715:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : String |
 | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : String |
-| Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : String |
 | Test.java:720:22:720:43 | (...)... : Serializable | semmle.label | (...)... : Serializable |
 | Test.java:720:36:720:43 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable |
 | Test.java:721:4:721:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Serializable |
 | Test.java:721:31:721:32 | in : Serializable | semmle.label | in : Serializable |
 | Test.java:722:9:722:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Serializable |
 | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Serializable |
-| Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Serializable |
 | Test.java:727:22:727:43 | (...)... : Parcelable[] | semmle.label | (...)... : Parcelable[] |
 | Test.java:727:36:727:43 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
 | Test.java:728:4:728:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
 | Test.java:728:31:728:32 | in : Parcelable[] | semmle.label | in : Parcelable[] |
 | Test.java:729:9:729:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] |
 | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
-| Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] |
 | Test.java:734:20:734:39 | (...)... : Parcelable | semmle.label | (...)... : Parcelable |
 | Test.java:734:32:734:39 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
 | Test.java:735:4:735:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
 | Test.java:735:31:735:32 | in : Parcelable | semmle.label | in : Parcelable |
 | Test.java:736:9:736:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Parcelable |
 | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
-| Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable |
 | Test.java:741:24:741:47 | (...)... : CharSequence[] | semmle.label | (...)... : CharSequence[] |
 | Test.java:741:40:741:47 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
 | Test.java:742:4:742:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
 | Test.java:742:31:742:32 | in : CharSequence[] | semmle.label | in : CharSequence[] |
 | Test.java:743:9:743:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] |
 | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
-| Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] |
 | Test.java:748:22:748:43 | (...)... : CharSequence | semmle.label | (...)... : CharSequence |
 | Test.java:748:36:748:43 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:749:4:749:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:749:31:749:32 | in : CharSequence | semmle.label | in : CharSequence |
 | Test.java:750:9:750:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
 | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
-| Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence |
 | Test.java:755:16:755:31 | (...)... : Bundle | semmle.label | (...)... : Bundle |
 | Test.java:755:24:755:31 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:756:4:756:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:756:31:756:32 | in : Bundle | semmle.label | in : Bundle |
 | Test.java:757:9:757:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Bundle |
-| Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Bundle |
 | Test.java:762:16:762:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:762:24:762:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3386,21 +2623,17 @@ nodes
 | Test.java:769:24:769:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | semmle.label | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:769:44:769:51 | source(...) : String | semmle.label | source(...) : String |
 | Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:770:4:770:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:770:18:770:19 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:771:9:771:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:776:16:776:54 | (...)... : Bundle [<map.value>] : Object | semmle.label | (...)... : Bundle [<map.value>] : Object |
 | Test.java:776:24:776:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | semmle.label | newBundleWithMapValue(...) : Bundle [<map.value>] : Object |
 | Test.java:776:46:776:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:777:4:777:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:777:18:777:19 | in : Bundle [<map.value>] : Object | semmle.label | in : Bundle [<map.value>] : Object |
 | Test.java:778:9:778:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Object |
-| Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:783:16:783:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:783:24:783:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3412,22 +2645,18 @@ nodes
 | Test.java:790:45:790:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | semmle.label | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:790:65:790:72 | source(...) : String | semmle.label | source(...) : String |
 | Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:791:4:791:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:791:18:791:19 | in : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | in : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:792:9:792:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:797:16:797:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:797:24:797:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:797:45:797:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | semmle.label | newBundleWithMapValue(...) : Bundle [<map.value>] : Object |
 | Test.java:797:67:797:74 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:798:4:798:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:798:18:798:19 | in : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | in : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:799:9:799:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Object |
-| Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:804:16:804:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:804:24:804:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3437,11 +2666,9 @@ nodes
 | Test.java:811:16:811:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:811:24:811:31 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:812:4:812:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:812:33:812:34 | in : String | semmle.label | in : String |
 | Test.java:813:9:813:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:818:16:818:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:818:24:818:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3451,20 +2678,16 @@ nodes
 | Test.java:825:16:825:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:825:24:825:31 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:826:4:826:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:826:36:826:37 | in : String | semmle.label | in : String |
 | Test.java:827:9:827:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:832:19:832:37 | (...)... : ArrayList | semmle.label | (...)... : ArrayList |
 | Test.java:832:30:832:37 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:833:4:833:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:833:42:833:43 | in : ArrayList | semmle.label | in : ArrayList |
 | Test.java:834:9:834:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
-| Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:839:16:839:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:839:24:839:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3474,20 +2697,16 @@ nodes
 | Test.java:846:16:846:31 | (...)... : String | semmle.label | (...)... : String |
 | Test.java:846:24:846:31 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:847:4:847:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:847:32:847:33 | in : String | semmle.label | in : String |
 | Test.java:848:9:848:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:853:19:853:37 | (...)... : ArrayList | semmle.label | (...)... : ArrayList |
 | Test.java:853:30:853:37 | source(...) : Object | semmle.label | source(...) : Object |
-| Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:854:4:854:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:854:38:854:39 | in : ArrayList | semmle.label | in : ArrayList |
 | Test.java:855:9:855:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
-| Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList |
 | Test.java:860:16:860:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:860:24:860:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3498,21 +2717,17 @@ nodes
 | Test.java:867:24:867:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | semmle.label | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:867:44:867:51 | source(...) : String | semmle.label | source(...) : String |
 | Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:868:4:868:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:868:22:868:23 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:869:9:869:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:874:16:874:54 | (...)... : Bundle [<map.value>] : Object | semmle.label | (...)... : Bundle [<map.value>] : Object |
 | Test.java:874:24:874:54 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | semmle.label | newBundleWithMapValue(...) : Bundle [<map.value>] : Object |
 | Test.java:874:46:874:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:875:4:875:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:875:22:875:23 | in : Bundle [<map.value>] : Object | semmle.label | in : Bundle [<map.value>] : Object |
 | Test.java:876:9:876:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Object |
-| Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:881:16:881:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:881:24:881:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -3524,22 +2739,18 @@ nodes
 | Test.java:888:45:888:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String | semmle.label | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:888:65:888:72 | source(...) : String | semmle.label | source(...) : String |
 | Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
-| Test.java:889:4:889:6 | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:889:22:889:23 | in : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | in : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:890:9:890:40 | getMapKey(...) | semmle.label | getMapKey(...) |
 | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | semmle.label | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Intent [android.content.Intent.extras, <map.key>] : String |
 | Test.java:895:16:895:76 | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | (...)... : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:895:24:895:76 | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | newWithIntent_extras(...) : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:895:45:895:75 | newBundleWithMapValue(...) : Bundle [<map.value>] : Object | semmle.label | newBundleWithMapValue(...) : Bundle [<map.value>] : Object |
 | Test.java:895:67:895:74 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
-| Test.java:896:4:896:6 | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out [post update] : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:896:22:896:23 | in : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | in : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:897:9:897:42 | getMapValue(...) | semmle.label | getMapValue(...) |
 | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object | semmle.label | getIntent_extras(...) : Bundle [<map.value>] : Object |
-| Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | semmle.label | out : Intent [android.content.Intent.extras, <map.value>] : Object |
 | Test.java:902:16:902:31 | (...)... : Intent | semmle.label | (...)... : Intent |
 | Test.java:902:24:902:31 | source(...) : Object | semmle.label | source(...) : Object |
@@ -4250,474 +3461,254 @@ nodes
 | Test.java:1759:19:1759:20 | in : String | semmle.label | in : String |
 | Test.java:1760:9:1760:11 | out | semmle.label | out |
 | TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:18:37:18:64 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:18:46:18:64 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:23:37:23:69 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:23:46:23:69 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:24:32:24:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:24:46:24:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:25:33:25:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:29:37:29:71 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:29:46:29:71 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:30:32:30:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:30:46:30:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:31:33:31:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:35:13:35:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:35:37:35:64 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:35:46:35:64 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:36:31:36:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:40:13:40:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:40:37:40:69 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:40:46:40:69 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:41:32:41:52 | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | {...} : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:41:46:41:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:42:33:42:39 | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String | semmle.label | intents : Intent[] [[], android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:52:13:52:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:52:37:52:71 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:52:46:52:71 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:53:40:53:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:57:13:57:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:57:37:57:70 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:57:46:57:70 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:58:39:58:44 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:62:13:62:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:62:37:62:69 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:62:46:62:69 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:63:43:63:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:67:13:67:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:67:37:67:71 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:67:46:67:71 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:68:46:68:51 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:72:13:72:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:72:37:72:70 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:72:46:72:70 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:73:49:73:54 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:79:13:79:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:79:37:79:60 | (...)... : String | semmle.label | (...)... : String |
 | TestStartActivityToGetIntent.java:79:46:79:60 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:80:31:80:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:95:18:95:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:95:18:95:51 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartActivityToGetIntent.java:102:18:102:28 | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | getIntent(...) : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartActivityToGetIntent.java:102:18:102:51 | getStringExtra(...) | semmle.label | getStringExtra(...) |
-| TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:18:13:18:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:18:37:18:59 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:18:46:18:59 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:19:31:19:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:23:13:23:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:23:37:23:67 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:23:46:23:67 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:24:37:24:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:28:13:28:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:28:37:28:69 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:28:46:28:69 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:29:54:29:59 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:33:13:33:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:33:37:33:67 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:33:46:33:67 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:34:38:34:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:38:13:38:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:38:37:38:75 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:38:46:38:75 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:39:44:39:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:43:13:43:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:43:37:43:66 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:43:46:43:66 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:44:37:44:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:48:13:48:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:48:37:48:74 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:48:46:48:74 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:49:43:49:48 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:53:13:53:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:53:37:53:74 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:53:46:53:74 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:54:44:54:49 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:58:13:58:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:58:37:58:82 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:58:46:58:82 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:59:50:59:55 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:65:13:65:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:65:37:65:60 | (...)... : String | semmle.label | (...)... : String |
 | TestStartBroadcastReceiverToIntent.java:65:46:65:60 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:66:31:66:36 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:81:48:81:60 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:82:18:82:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartBroadcastReceiverToIntent.java:82:18:82:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
-| TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:19:13:19:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:19:37:19:59 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:19:46:19:59 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:20:29:20:34 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:24:13:24:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:24:37:24:67 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:24:46:24:67 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:25:35:25:40 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:29:13:29:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:29:37:29:68 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:29:46:29:68 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:30:37:30:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:34:13:34:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:34:37:34:60 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:34:46:34:60 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:35:30:35:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:39:13:39:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:39:37:39:71 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:39:46:39:71 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:40:40:40:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:46:13:46:18 | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent [post update] : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:46:37:46:60 | (...)... : String | semmle.label | (...)... : String |
 | TestStartServiceToIntent.java:46:46:46:60 | source(...) : Object | semmle.label | source(...) : Object |
 | TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:47:30:47:35 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:62:29:62:41 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:63:18:63:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:63:18:63:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:67:35:67:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:68:18:68:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:68:18:68:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:73:31:73:43 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:74:18:74:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:74:18:74:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:79:33:79:45 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:80:18:80:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:80:18:80:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:85:30:85:42 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:86:18:86:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:86:18:86:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 | TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:90:35:90:47 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
-| TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:91:18:91:23 | intent : Intent [android.content.Intent.extras, <map.value>] : String | semmle.label | intent : Intent [android.content.Intent.extras, <map.value>] : String |
 | TestStartServiceToIntent.java:91:18:91:46 | getStringExtra(...) | semmle.label | getStringExtra(...) |
 subpaths
 | Test.java:41:65:41:72 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:41:45:41:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:43:9:43:40 | getMapKey(...) |
 | Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:43:36:43:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:43:19:43:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:50:38:50:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:50:21:50:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:57:17:57:19 | out : Intent [android.content.Intent.data] : Uri | Test.java:32:14:32:26 | intent : Intent [android.content.Intent.data] : Uri | Test.java:32:38:32:53 | getData(...) : Uri | Test.java:57:9:57:20 | getData(...) |
 | Test.java:64:17:64:19 | out : Intent [android.content.Intent.data] : Uri | Test.java:32:14:32:26 | intent : Intent [android.content.Intent.data] : Uri | Test.java:32:38:32:53 | getData(...) : Uri | Test.java:64:9:64:20 | getData(...) |
 | Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
-| Test.java:85:38:85:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | Test.java:85:21:85:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
 | Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender |
-| Test.java:92:38:92:40 | out : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : IntentSender | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : IntentSender | Test.java:92:21:92:41 | getIntent_extras(...) : Bundle [<map.value>] : IntentSender |
-| Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent |
 | Test.java:99:38:99:40 | out : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Intent | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Intent | Test.java:99:21:99:41 | getIntent_extras(...) : Bundle [<map.value>] : Intent |
 | Test.java:146:43:146:50 | source(...) : Uri | Test.java:27:28:27:35 | data : Uri | Test.java:27:47:27:71 | new Intent(...) : Intent [android.content.Intent.data] : Uri | Test.java:146:24:146:51 | newWithIntent_data(...) : Intent [android.content.Intent.data] : Uri |
 | Test.java:153:43:153:50 | source(...) : Uri | Test.java:27:28:27:35 | data : Uri | Test.java:27:47:27:71 | new Intent(...) : Intent [android.content.Intent.data] : Uri | Test.java:153:24:153:51 | newWithIntent_data(...) : Intent [android.content.Intent.data] : Uri |
 | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:246:9:246:40 | getMapKey(...) |
 | Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:246:36:246:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:246:19:246:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:253:38:253:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:253:21:253:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:428:9:428:40 | getMapKey(...) |
 | Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:428:36:428:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:428:19:428:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:435:9:435:40 | getMapKey(...) |
-| Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:435:36:435:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:435:19:435:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:442:9:442:40 | getMapKey(...) |
 | Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:442:36:442:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:442:19:442:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:449:9:449:40 | getMapKey(...) |
-| Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:449:36:449:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:449:19:449:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:456:9:456:40 | getMapKey(...) |
 | Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:456:36:456:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:456:19:456:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:463:9:463:40 | getMapKey(...) |
-| Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:463:36:463:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:463:19:463:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:470:9:470:40 | getMapKey(...) |
 | Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:470:36:470:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:470:19:470:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:477:9:477:40 | getMapKey(...) |
-| Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:477:36:477:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:477:19:477:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:484:9:484:40 | getMapKey(...) |
 | Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:484:36:484:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:484:19:484:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:491:9:491:40 | getMapKey(...) |
-| Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:491:36:491:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:491:19:491:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:498:9:498:40 | getMapKey(...) |
 | Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:498:36:498:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:498:19:498:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:505:9:505:40 | getMapKey(...) |
-| Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:505:36:505:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:505:19:505:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:512:9:512:40 | getMapKey(...) |
 | Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:512:36:512:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:512:19:512:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:519:9:519:40 | getMapKey(...) |
-| Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:519:36:519:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:519:19:519:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:526:9:526:40 | getMapKey(...) |
 | Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:526:36:526:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:526:19:526:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:533:9:533:40 | getMapKey(...) |
-| Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:533:36:533:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:533:19:533:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:540:9:540:40 | getMapKey(...) |
 | Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:540:36:540:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:540:19:540:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:547:9:547:40 | getMapKey(...) |
-| Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:547:36:547:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:547:19:547:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:554:9:554:40 | getMapKey(...) |
 | Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:554:36:554:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:554:19:554:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:561:9:561:40 | getMapKey(...) |
-| Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:561:36:561:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:561:19:561:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:568:9:568:40 | getMapKey(...) |
 | Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:568:36:568:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:568:19:568:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:575:9:575:40 | getMapKey(...) |
-| Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:575:36:575:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:575:19:575:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:582:9:582:40 | getMapKey(...) |
 | Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:582:36:582:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:582:19:582:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:589:9:589:40 | getMapKey(...) |
 | Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:589:36:589:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:589:19:589:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] |
 | Test.java:596:38:596:40 | out : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : short[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : short[] | Test.java:596:21:596:41 | getIntent_extras(...) : Bundle [<map.value>] : short[] |
 | Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:603:38:603:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:603:21:603:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] |
 | Test.java:610:38:610:40 | out : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : long[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : long[] | Test.java:610:21:610:41 | getIntent_extras(...) : Bundle [<map.value>] : long[] |
 | Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:617:38:617:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:617:21:617:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] |
 | Test.java:624:38:624:40 | out : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : int[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : int[] | Test.java:624:21:624:41 | getIntent_extras(...) : Bundle [<map.value>] : int[] |
 | Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:631:38:631:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:631:21:631:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] |
 | Test.java:638:38:638:40 | out : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : float[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : float[] | Test.java:638:21:638:41 | getIntent_extras(...) : Bundle [<map.value>] : float[] |
 | Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:645:38:645:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:645:21:645:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] |
 | Test.java:652:38:652:40 | out : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : double[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : double[] | Test.java:652:21:652:41 | getIntent_extras(...) : Bundle [<map.value>] : double[] |
 | Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:659:38:659:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:659:21:659:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] |
 | Test.java:666:38:666:40 | out : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : char[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : char[] | Test.java:666:21:666:41 | getIntent_extras(...) : Bundle [<map.value>] : char[] |
 | Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:673:38:673:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:673:21:673:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] |
 | Test.java:680:38:680:40 | out : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : byte[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : byte[] | Test.java:680:21:680:41 | getIntent_extras(...) : Bundle [<map.value>] : byte[] |
 | Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:687:38:687:40 | out : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Number | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Number | Test.java:687:21:687:41 | getIntent_extras(...) : Bundle [<map.value>] : Number |
-| Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] |
 | Test.java:694:38:694:40 | out : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : boolean[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : boolean[] | Test.java:694:21:694:41 | getIntent_extras(...) : Bundle [<map.value>] : boolean[] |
 | Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean |
-| Test.java:701:38:701:40 | out : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Boolean | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Boolean | Test.java:701:21:701:41 | getIntent_extras(...) : Bundle [<map.value>] : Boolean |
-| Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] |
 | Test.java:708:38:708:40 | out : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String[] | Test.java:708:21:708:41 | getIntent_extras(...) : Bundle [<map.value>] : String[] |
 | Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String |
-| Test.java:715:38:715:40 | out : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : String | Test.java:715:21:715:41 | getIntent_extras(...) : Bundle [<map.value>] : String |
-| Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable |
 | Test.java:722:38:722:40 | out : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Serializable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Serializable | Test.java:722:21:722:41 | getIntent_extras(...) : Bundle [<map.value>] : Serializable |
 | Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] |
-| Test.java:729:38:729:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable[] | Test.java:729:21:729:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable[] |
-| Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable |
 | Test.java:736:38:736:40 | out : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Parcelable | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Parcelable | Test.java:736:21:736:41 | getIntent_extras(...) : Bundle [<map.value>] : Parcelable |
 | Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] |
-| Test.java:743:38:743:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence[] | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence[] | Test.java:743:21:743:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence[] |
 | Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
-| Test.java:750:38:750:40 | out : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : CharSequence | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : CharSequence | Test.java:750:21:750:41 | getIntent_extras(...) : Bundle [<map.value>] : CharSequence |
-| Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle |
 | Test.java:757:38:757:40 | out : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Bundle | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Bundle | Test.java:757:21:757:41 | getIntent_extras(...) : Bundle [<map.value>] : Bundle |
 | Test.java:769:44:769:51 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:769:24:769:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:771:9:771:40 | getMapKey(...) |
 | Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:771:36:771:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:771:19:771:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:778:38:778:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:778:21:778:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:790:65:790:72 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:790:45:790:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:792:9:792:40 | getMapKey(...) |
 | Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:792:36:792:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:792:19:792:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:799:38:799:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:799:21:799:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:813:9:813:40 | getMapKey(...) |
 | Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:813:36:813:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:813:19:813:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
 | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:827:9:827:40 | getMapKey(...) |
 | Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:827:36:827:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:827:19:827:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:834:38:834:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:834:21:834:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:848:9:848:40 | getMapKey(...) |
 | Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:848:36:848:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:848:19:848:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:855:38:855:40 | out : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : ArrayList | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : ArrayList | Test.java:855:21:855:41 | getIntent_extras(...) : Bundle [<map.value>] : ArrayList |
 | Test.java:867:44:867:51 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:867:24:867:52 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:869:9:869:40 | getMapKey(...) |
 | Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:869:36:869:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:869:19:869:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:876:38:876:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:876:21:876:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:888:65:888:72 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:888:45:888:73 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String | Test.java:24:19:24:30 | b : Bundle [<map.key>] : String | Test.java:24:42:24:69 | next(...) : String | Test.java:890:9:890:40 | getMapKey(...) |
 | Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:890:36:890:38 | out : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.key>] : String | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.key>] : String | Test.java:890:19:890:39 | getIntent_extras(...) : Bundle [<map.key>] : String |
-| Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:897:38:897:40 | out : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:26:23:33 | i : Intent [android.content.Intent.extras, <map.value>] : Object | Test.java:23:45:23:57 | getExtras(...) : Bundle [<map.value>] : Object | Test.java:897:21:897:41 | getIntent_extras(...) : Bundle [<map.value>] : Object |
 | Test.java:1064:52:1064:59 | source(...) : String | Test.java:28:29:28:36 | k : String | Test.java:28:89:28:89 | b : Bundle [<map.key>] : String | Test.java:1064:32:1064:60 | newBundleWithMapKey(...) : Bundle [<map.key>] : String |
 | Test.java:1066:20:1066:22 | out : Set [<element>] : String | Test.java:22:19:22:32 | it : Set [<element>] : String | Test.java:22:44:22:63 | next(...) : String | Test.java:1066:9:1066:23 | getElement(...) |

--- a/java/ql/test/library-tests/frameworks/android/notification/test.expected
+++ b/java/ql/test/library-tests/frameworks/android/notification/test.expected
@@ -223,10 +223,7 @@ edges
 | Test.java:79:46:79:53 | source(...) : Object | Test.java:26:30:26:43 | element : Object | provenance |  |
 | Test.java:79:46:79:53 | source(...) : Object | Test.java:79:25:79:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
 | Test.java:80:18:80:19 | in : Bundle [<map.key>] : String | Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:4 |
-| Test.java:80:18:80:19 | in : Bundle [<map.key>] : String | Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:4 |
-| Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:81:26:81:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:11 |
 | Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:81:26:81:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:11 |
 | Test.java:81:26:81:40 | getExtras(...) : Bundle [<map.key>] : String | Test.java:81:9:81:41 | getMapKeyDefault(...) | provenance | MaD:194 |
 | Test.java:88:16:88:56 | (...)... : Bundle [<map.value>] : String | Test.java:89:18:89:19 | in : Bundle [<map.value>] : String | provenance |  |
@@ -234,10 +231,7 @@ edges
 | Test.java:88:48:88:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:88:48:88:55 | source(...) : Object | Test.java:88:25:88:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:89:18:89:19 | in : Bundle [<map.value>] : String | Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:5 |
-| Test.java:89:18:89:19 | in : Bundle [<map.value>] : String | Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:5 |
-| Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:90:28:90:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:11 |
 | Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:90:28:90:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:11 |
 | Test.java:90:28:90:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:90:28:90:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:90:9:90:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -254,15 +248,9 @@ edges
 | Test.java:112:48:112:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:112:48:112:55 | source(...) : Object | Test.java:112:25:112:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:113:22:113:23 | in : Bundle [<map.value>] : String | Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:5 |
 | Test.java:113:22:113:23 | in : Bundle [<map.value>] : String | Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:5 |
 | Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:8 |
-| Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:8 |
-| Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:8 |
 | Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | Test.java:115:28:115:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:17 |
 | Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | Test.java:115:28:115:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:17 |
 | Test.java:115:28:115:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:115:28:115:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:115:9:115:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -319,10 +307,7 @@ edges
 | Test.java:206:46:206:53 | source(...) : Object | Test.java:26:30:26:43 | element : Object | provenance |  |
 | Test.java:206:46:206:53 | source(...) : Object | Test.java:206:25:206:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
 | Test.java:207:18:207:19 | in : Bundle [<map.key>] : String | Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:32 |
-| Test.java:207:18:207:19 | in : Bundle [<map.key>] : String | Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:32 |
-| Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:208:26:208:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:39 |
 | Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:208:26:208:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:39 |
 | Test.java:208:26:208:40 | getExtras(...) : Bundle [<map.key>] : String | Test.java:208:9:208:41 | getMapKeyDefault(...) | provenance | MaD:194 |
 | Test.java:214:16:214:56 | (...)... : Bundle [<map.value>] : String | Test.java:215:18:215:19 | in : Bundle [<map.value>] : String | provenance |  |
@@ -330,10 +315,7 @@ edges
 | Test.java:214:48:214:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:214:48:214:55 | source(...) : Object | Test.java:214:25:214:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:215:18:215:19 | in : Bundle [<map.value>] : String | Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:33 |
-| Test.java:215:18:215:19 | in : Bundle [<map.value>] : String | Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:33 |
-| Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:216:28:216:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:39 |
 | Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:216:28:216:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:39 |
 | Test.java:216:28:216:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:216:28:216:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:216:9:216:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -354,15 +336,9 @@ edges
 | Test.java:244:48:244:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:244:48:244:55 | source(...) : Object | Test.java:244:25:244:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:245:22:245:23 | in : Bundle [<map.value>] : String | Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:33 |
 | Test.java:245:22:245:23 | in : Bundle [<map.value>] : String | Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:33 |
 | Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:36 |
-| Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:36 |
-| Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:36 |
 | Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | provenance |  |
-| Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | provenance |  |
-| Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | Test.java:247:28:247:37 | out.extras : Bundle [<map.value>] : String | provenance |  |
 | Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | Test.java:247:28:247:37 | out.extras : Bundle [<map.value>] : String | provenance |  |
 | Test.java:247:28:247:37 | out.extras : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:247:28:247:37 | out.extras : Bundle [<map.value>] : String | Test.java:247:9:247:38 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -722,10 +698,7 @@ edges
 | Test.java:851:46:851:53 | source(...) : Object | Test.java:26:30:26:43 | element : Object | provenance |  |
 | Test.java:851:46:851:53 | source(...) : Object | Test.java:851:25:851:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
 | Test.java:852:18:852:19 | in : Bundle [<map.key>] : String | Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:110 |
-| Test.java:852:18:852:19 | in : Bundle [<map.key>] : String | Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:110 |
-| Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:853:26:853:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:117 |
 | Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:853:26:853:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:117 |
 | Test.java:853:26:853:40 | getExtras(...) : Bundle [<map.key>] : String | Test.java:853:9:853:41 | getMapKeyDefault(...) | provenance | MaD:194 |
 | Test.java:858:16:858:56 | (...)... : Bundle [<map.value>] : String | Test.java:859:18:859:19 | in : Bundle [<map.value>] : String | provenance |  |
@@ -733,10 +706,7 @@ edges
 | Test.java:858:48:858:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:858:48:858:55 | source(...) : Object | Test.java:858:25:858:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:859:18:859:19 | in : Bundle [<map.value>] : String | Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:111 |
-| Test.java:859:18:859:19 | in : Bundle [<map.value>] : String | Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:111 |
-| Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:860:28:860:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:117 |
 | Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:860:28:860:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:117 |
 | Test.java:860:28:860:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:860:28:860:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:860:9:860:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -749,15 +719,9 @@ edges
 | Test.java:873:48:873:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:873:48:873:55 | source(...) : Object | Test.java:873:25:873:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:874:22:874:23 | in : Bundle [<map.value>] : String | Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:111 |
 | Test.java:874:22:874:23 | in : Bundle [<map.value>] : String | Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:111 |
 | Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:114 |
-| Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:114 |
-| Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | provenance | MaD:114 |
 | Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | Test.java:876:28:876:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:123 |
 | Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | Test.java:876:28:876:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:123 |
 | Test.java:876:28:876:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:876:28:876:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:876:9:876:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -858,10 +822,7 @@ edges
 | Test.java:1042:46:1042:53 | source(...) : Object | Test.java:26:30:26:43 | element : Object | provenance |  |
 | Test.java:1042:46:1042:53 | source(...) : Object | Test.java:1042:25:1042:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | provenance | MaD:105 |
 | Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
-| Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | provenance |  |
 | Test.java:1043:18:1043:19 | in : Bundle [<map.key>] : String | Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:134 |
-| Test.java:1043:18:1043:19 | in : Bundle [<map.key>] : String | Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | provenance | MaD:134 |
-| Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:1044:26:1044:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:141 |
 | Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | Test.java:1044:26:1044:40 | getExtras(...) : Bundle [<map.key>] : String | provenance | MaD:141 |
 | Test.java:1044:26:1044:40 | getExtras(...) : Bundle [<map.key>] : String | Test.java:1044:9:1044:41 | getMapKeyDefault(...) | provenance | MaD:194 |
 | Test.java:1049:16:1049:56 | (...)... : Bundle [<map.value>] : String | Test.java:1050:18:1050:19 | in : Bundle [<map.value>] : String | provenance |  |
@@ -869,10 +830,7 @@ edges
 | Test.java:1049:48:1049:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:1049:48:1049:55 | source(...) : Object | Test.java:1049:25:1049:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
 | Test.java:1050:18:1050:19 | in : Bundle [<map.value>] : String | Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:135 |
-| Test.java:1050:18:1050:19 | in : Bundle [<map.value>] : String | Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:135 |
-| Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1051:28:1051:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:141 |
 | Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1051:28:1051:42 | getExtras(...) : Bundle [<map.value>] : String | provenance | MaD:141 |
 | Test.java:1051:28:1051:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:1051:28:1051:42 | getExtras(...) : Bundle [<map.value>] : String | Test.java:1051:9:1051:43 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -889,15 +847,9 @@ edges
 | Test.java:1071:48:1071:55 | source(...) : Object | Test.java:32:32:32:45 | element : Object | provenance |  |
 | Test.java:1071:48:1071:55 | source(...) : Object | Test.java:1071:25:1071:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | provenance | MaD:106 |
 | Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | provenance |  |
-| Test.java:1072:22:1072:23 | in : Bundle [<map.value>] : String | Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:135 |
 | Test.java:1072:22:1072:23 | in : Bundle [<map.value>] : String | Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | provenance | MaD:135 |
 | Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:138 |
-| Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:138 |
-| Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | provenance | MaD:138 |
 | Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | provenance |  |
-| Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | provenance |  |
-| Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | Test.java:1074:28:1074:37 | out.extras : Bundle [<map.value>] : String | provenance |  |
 | Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | Test.java:1074:28:1074:37 | out.extras : Bundle [<map.value>] : String | provenance |  |
 | Test.java:1074:28:1074:37 | out.extras : Bundle [<map.value>] : String | Test.java:22:28:22:43 | container : Bundle [<map.value>] : String | provenance |  |
 | Test.java:1074:28:1074:37 | out.extras : Bundle [<map.value>] : String | Test.java:1074:9:1074:38 | getMapValueDefault(...) | provenance | MaD:104 |
@@ -1174,20 +1126,16 @@ nodes
 | Test.java:79:25:79:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | semmle.label | newWithMapKeyDefault(...) : Bundle [<map.key>] : String |
 | Test.java:79:46:79:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
-| Test.java:80:4:80:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:80:18:80:19 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:81:9:81:41 | getMapKeyDefault(...) | semmle.label | getMapKeyDefault(...) |
-| Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:81:26:81:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:81:26:81:40 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
 | Test.java:88:16:88:56 | (...)... : Bundle [<map.value>] : String | semmle.label | (...)... : Bundle [<map.value>] : String |
 | Test.java:88:25:88:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:88:48:88:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:89:4:89:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:89:18:89:19 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:90:9:90:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:90:28:90:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:90:28:90:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:95:37:95:74 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1204,14 +1152,10 @@ nodes
 | Test.java:112:25:112:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:112:48:112:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:113:4:113:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:113:22:113:23 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:114:10:114:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | build(...) : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:114:10:114:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | build(...) : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:115:9:115:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:115:28:115:30 | out : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:115:28:115:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:120:37:120:74 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1278,20 +1222,16 @@ nodes
 | Test.java:206:25:206:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | semmle.label | newWithMapKeyDefault(...) : Bundle [<map.key>] : String |
 | Test.java:206:46:206:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
-| Test.java:207:4:207:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:207:18:207:19 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:208:9:208:41 | getMapKeyDefault(...) | semmle.label | getMapKeyDefault(...) |
-| Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:208:26:208:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:208:26:208:40 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
 | Test.java:214:16:214:56 | (...)... : Bundle [<map.value>] : String | semmle.label | (...)... : Bundle [<map.value>] : String |
 | Test.java:214:25:214:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:214:48:214:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:215:4:215:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:215:18:215:19 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:216:9:216:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:216:28:216:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:216:28:216:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:221:30:221:60 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1313,14 +1253,10 @@ nodes
 | Test.java:244:25:244:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:244:48:244:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:245:4:245:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:245:22:245:23 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:246:10:246:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | semmle.label | build(...) : Notification [extras, <map.value>] : String |
 | Test.java:246:10:246:24 | build(...) : Notification [extras, <map.value>] : String | semmle.label | build(...) : Notification [extras, <map.value>] : String |
 | Test.java:247:9:247:38 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | semmle.label | out : Notification [extras, <map.value>] : String |
 | Test.java:247:28:247:30 | out : Notification [extras, <map.value>] : String | semmle.label | out : Notification [extras, <map.value>] : String |
 | Test.java:247:28:247:37 | out.extras : Bundle [<map.value>] : String | semmle.label | out.extras : Bundle [<map.value>] : String |
 | Test.java:252:30:252:60 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1765,20 +1701,16 @@ nodes
 | Test.java:851:25:851:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | semmle.label | newWithMapKeyDefault(...) : Bundle [<map.key>] : String |
 | Test.java:851:46:851:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
-| Test.java:852:4:852:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:852:18:852:19 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:853:9:853:41 | getMapKeyDefault(...) | semmle.label | getMapKeyDefault(...) |
-| Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:853:26:853:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:853:26:853:40 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
 | Test.java:858:16:858:56 | (...)... : Bundle [<map.value>] : String | semmle.label | (...)... : Bundle [<map.value>] : String |
 | Test.java:858:25:858:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:858:48:858:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:859:4:859:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:859:18:859:19 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:860:9:860:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:860:28:860:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:860:28:860:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:865:43:865:86 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1790,14 +1722,10 @@ nodes
 | Test.java:873:25:873:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:873:48:873:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:874:4:874:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:874:22:874:23 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:875:10:875:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | build(...) : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:875:10:875:24 | build(...) : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | build(...) : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:876:9:876:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:876:28:876:30 | out : Action [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Action [android.content.Intent.extras, <map.value>] : String |
 | Test.java:876:28:876:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:881:43:881:86 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1919,20 +1847,16 @@ nodes
 | Test.java:1042:25:1042:54 | newWithMapKeyDefault(...) : Bundle [<map.key>] : String | semmle.label | newWithMapKeyDefault(...) : Bundle [<map.key>] : String |
 | Test.java:1042:46:1042:53 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
-| Test.java:1043:4:1043:6 | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:1043:18:1043:19 | in : Bundle [<map.key>] : String | semmle.label | in : Bundle [<map.key>] : String |
 | Test.java:1044:9:1044:41 | getMapKeyDefault(...) | semmle.label | getMapKeyDefault(...) |
-| Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:1044:26:1044:28 | out : Builder [android.content.Intent.extras, <map.key>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.key>] : String |
 | Test.java:1044:26:1044:40 | getExtras(...) : Bundle [<map.key>] : String | semmle.label | getExtras(...) : Bundle [<map.key>] : String |
 | Test.java:1049:16:1049:56 | (...)... : Bundle [<map.value>] : String | semmle.label | (...)... : Bundle [<map.value>] : String |
 | Test.java:1049:25:1049:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:1049:48:1049:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:1050:4:1050:6 | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:1050:18:1050:19 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:1051:9:1051:43 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:1051:28:1051:30 | out : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | out : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:1051:28:1051:42 | getExtras(...) : Bundle [<map.value>] : String | semmle.label | getExtras(...) : Bundle [<map.value>] : String |
 | Test.java:1056:36:1056:72 | (...)... : Builder | semmle.label | (...)... : Builder |
@@ -1949,14 +1873,10 @@ nodes
 | Test.java:1071:25:1071:56 | newWithMapValueDefault(...) : Bundle [<map.value>] : String | semmle.label | newWithMapValueDefault(...) : Bundle [<map.value>] : String |
 | Test.java:1071:48:1071:55 | source(...) : Object | semmle.label | source(...) : Object |
 | Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:1072:4:1072:10 | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder [post update] : Builder [android.content.Intent.extras, <map.value>] : String |
 | Test.java:1072:22:1072:23 | in : Bundle [<map.value>] : String | semmle.label | in : Bundle [<map.value>] : String |
 | Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:1073:10:1073:16 | builder : Builder [android.content.Intent.extras, <map.value>] : String | semmle.label | builder : Builder [android.content.Intent.extras, <map.value>] : String |
-| Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | semmle.label | build(...) : Notification [extras, <map.value>] : String |
 | Test.java:1073:10:1073:24 | build(...) : Notification [extras, <map.value>] : String | semmle.label | build(...) : Notification [extras, <map.value>] : String |
 | Test.java:1074:9:1074:38 | getMapValueDefault(...) | semmle.label | getMapValueDefault(...) |
-| Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | semmle.label | out : Notification [extras, <map.value>] : String |
 | Test.java:1074:28:1074:30 | out : Notification [extras, <map.value>] : String | semmle.label | out : Notification [extras, <map.value>] : String |
 | Test.java:1074:28:1074:37 | out.extras : Bundle [<map.value>] : String | semmle.label | out.extras : Bundle [<map.value>] : String |
 | Test.java:1079:36:1079:72 | (...)... : Builder | semmle.label | (...)... : Builder |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1533,11 +1533,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           )
           or
           // read
-          exists(Typ t0, Ap ap0, Content c |
-            fwdFlowRead(t0, ap0, c, _, node, state, cc, summaryCtx) and
-            fwdFlowConsCand(t0, ap0, c, t, ap) and
-            apa = getApprox(ap)
-          )
+          fwdFlowRead(_, _, _, _, node, t, ap, state, cc, summaryCtx) and
+          apa = getApprox(ap)
           or
           // flow into a callable without summary context
           fwdFlowInNoFlowThrough(node, apa, state, cc, t, ap) and
@@ -1676,7 +1673,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         }
 
         pragma[nomagic]
-        private predicate fwdFlowRead(
+        private predicate fwdFlowRead0(
           Typ t, Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
           SummaryCtx summaryCtx
         ) {
@@ -1687,6 +1684,15 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             apc = getHeadContent(ap) and
             readStepCand0(node1, apc, c, node2)
           )
+        }
+
+        pragma[nomagic]
+        private predicate fwdFlowRead(
+          NodeEx node1, Typ t1, Ap ap1, Content c, NodeEx node2, Typ t2, Ap ap2, FlowState state,
+          Cc cc, SummaryCtx summaryCtx
+        ) {
+          fwdFlowRead0(t1, ap1, c, node1, node2, state, cc, summaryCtx) and
+          fwdFlowConsCand(t1, ap1, c, t2, ap2)
         }
 
         pragma[nomagic]
@@ -2127,10 +2133,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate readStepFwd(NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2) {
-          exists(Typ t1 |
-            fwdFlowRead(t1, ap1, c, n1, n2, _, _, _) and
-            fwdFlowConsCand(t1, ap1, c, _, ap2)
-          )
+          fwdFlowRead(n1, _, ap1, c, n2, _, ap2, _, _, _)
         }
 
         pragma[nomagic]
@@ -3200,10 +3203,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             )
             or
             // read
-            exists(NodeEx mid, Typ t0, Ap ap0, Content c |
+            exists(NodeEx mid, Typ t0, Ap ap0 |
               pn1 = TPathNodeMid(mid, state, cc, summaryCtx, t0, ap0) and
-              fwdFlowRead(t0, ap0, c, mid, node, state, cc, summaryCtx) and
-              fwdFlowConsCand(t0, ap0, c, t, ap) and
+              fwdFlowRead(mid, t0, ap0, _, node, t, ap, state, cc, summaryCtx) and
               label = "" and
               isStoreStep = false
             )

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1410,8 +1410,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         bindingset[node, ap, isStoreStep]
         predicate stepFilter(NodeEx node, Ap ap, boolean isStoreStep);
 
-        bindingset[typ, contentType]
-        predicate typecheckStore(Typ typ, DataFlowType contentType);
+        bindingset[t1, t2]
+        predicate typecheck(Typ t1, Typ t2);
 
         default predicate enableTypeFlow() { any() }
       }
@@ -1641,7 +1641,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             not inBarrier(node2, state) and
             PrevStage::storeStepCand(node1, apa1, c, node2, contentType, containerType) and
             t2 = getTyp(containerType) and
-            typecheckStore(t1, contentType)
+            // We need to typecheck stores here, since reverse flow through a getter
+            // might have a different type here compared to inside the getter.
+            typecheck(t1, getTyp(contentType))
           )
         }
 
@@ -3742,8 +3744,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       bindingset[node, ap, isStoreStep]
       predicate stepFilter(NodeEx node, Ap ap, boolean isStoreStep) { any() }
 
-      bindingset[typ, contentType]
-      predicate typecheckStore(Typ typ, DataFlowType contentType) { any() }
+      bindingset[t1, t2]
+      predicate typecheck(Typ t1, Typ t2) { any() }
 
       predicate enableTypeFlow() { none() }
     }
@@ -3855,8 +3857,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       bindingset[node, ap, isStoreStep]
       predicate stepFilter(NodeEx node, Ap ap, boolean isStoreStep) { any() }
 
-      bindingset[typ, contentType]
-      predicate typecheckStore(Typ typ, DataFlowType contentType) { any() }
+      bindingset[t1, t2]
+      predicate typecheck(Typ t1, Typ t2) { any() }
     }
 
     private module Stage3 = MkStage<Stage2>::Stage<Stage3Param>;
@@ -3975,12 +3977,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         if clearExceptStore(node, ap) then isStoreStep = true else any()
       }
 
-      bindingset[typ, contentType]
-      predicate typecheckStore(Typ typ, DataFlowType contentType) {
-        // We need to typecheck stores here, since reverse flow through a getter
-        // might have a different type here compared to inside the getter.
-        compatibleTypesFilter(typ, contentType)
-      }
+      bindingset[t1, t2]
+      predicate typecheck(Typ t1, Typ t2) { compatibleTypesFilter(t1, t2) }
     }
 
     private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;
@@ -4227,10 +4225,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         if clearExceptStore(node, ap) then isStoreStep = true else any()
       }
 
-      bindingset[typ, contentType]
-      predicate typecheckStore(Typ typ, DataFlowType contentType) {
-        compatibleTypesFilter(typ, contentType)
-      }
+      bindingset[t1, t2]
+      predicate typecheck(Typ t1, Typ t2) { compatibleTypesFilter(t1, t2) }
     }
 
     private module Stage5 = MkStage<Stage4>::Stage<Stage5Param>;
@@ -4426,10 +4422,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         if clearExceptStore(node, ap) then isStoreStep = true else any()
       }
 
-      bindingset[typ, contentType]
-      predicate typecheckStore(Typ typ, DataFlowType contentType) {
-        compatibleTypesFilter(typ, contentType)
-      }
+      bindingset[t1, t2]
+      predicate typecheck(Typ t1, Typ t2) { compatibleTypesFilter(t1, t2) }
     }
 
     module Stage6 = MkStage<Stage5>::Stage<Stage6Param>;

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3931,7 +3931,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
     private module Stage4Param implements MkStage<Stage3>::StageParam {
       private module PrevStage = Stage3;
 
-      class Typ = DataFlowType;
+      class Typ = Unit;
 
       class Ap = AccessPathFront;
 
@@ -3939,7 +3939,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       PrevStage::Ap getApprox(Ap ap) { result = ap.toApprox() }
 
-      Typ getTyp(DataFlowType t) { result = t }
+      Typ getTyp(DataFlowType t) { any() }
 
       bindingset[c, tail]
       Ap apCons(Content c, Ap tail) { result.getHead() = c and exists(tail) }
@@ -3964,9 +3964,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         NodeEx node1, FlowState state1, NodeEx node2, FlowState state2, boolean preservesValue,
         Typ t, LocalCc lcc, string label
       ) {
-        Stage3Param::localFlowBigStep(node1, state1, node2, state2, preservesValue, t, _, label) and
+        Stage3Param::localFlowBigStep(node1, state1, node2, state2, preservesValue, _, _, label) and
         PrevStage::revFlow(node1, pragma[only_bind_into](state1), _) and
         PrevStage::revFlow(node2, pragma[only_bind_into](state2), _) and
+        exists(t) and
         exists(lcc)
       }
 
@@ -4015,7 +4016,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       predicate filter(NodeEx node, FlowState state, Typ t0, Ap ap, Typ t) {
         exists(state) and
         not clear(node, ap) and
-        strengthenType(node, t0, t) and
+        t0 = t and
         (
           notExpectsContent(node)
           or
@@ -4029,7 +4030,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       bindingset[t1, t2]
-      predicate typecheck(Typ t1, Typ t2) { compatibleTypesFilter(t1, t2) }
+      predicate typecheck(Typ t1, Typ t2) { any() }
     }
 
     private module Stage4 = MkStage<Stage3>::Stage<Stage4Param>;

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1419,6 +1419,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       module Stage<StageParam Param> implements StageSig {
         import Param
 
+        private module TypOption = Option<Typ>;
+
+        private class TypOption = TypOption::Option;
+
         /* Begin: Stage logic. */
         pragma[nomagic]
         private Typ getNodeTyp(NodeEx node) {
@@ -1472,16 +1476,17 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
          */
         pragma[nomagic]
         additional predicate fwdFlow(
-          NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa
+          NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa,
+          TypOption stored
         ) {
-          fwdFlow1(node, state, cc, summaryCtx, _, t, ap, apa)
+          fwdFlow1(node, state, cc, summaryCtx, _, t, ap, apa, stored)
         }
 
         private predicate fwdFlow1(
           NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Typ t, Ap ap,
-          ApApprox apa
+          ApApprox apa, TypOption stored
         ) {
-          fwdFlow0(node, state, cc, summaryCtx, t0, ap, apa) and
+          fwdFlow0(node, state, cc, summaryCtx, t0, ap, apa, stored) and
           PrevStage::revFlow(node, state, apa) and
           filter(node, state, t0, ap, t) and
           (
@@ -1496,17 +1501,19 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlow0(
-          NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa
+          NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa,
+          TypOption stored
         ) {
           sourceNode(node, state) and
           (if hasSourceCallCtx() then cc = ccSomeCall() else cc = ccNone()) and
           summaryCtx = TSummaryCtxNone() and
           t = getNodeTyp(node) and
           ap instanceof ApNil and
-          apa = getApprox(ap)
+          apa = getApprox(ap) and
+          stored.isNone()
           or
           exists(NodeEx mid, FlowState state0, Typ t0, LocalCc localCc |
-            fwdFlow(mid, state0, cc, summaryCtx, t0, ap, apa) and
+            fwdFlow(mid, state0, cc, summaryCtx, t0, ap, apa, stored) and
             localCc = getLocalCc(cc)
           |
             localStep(mid, state0, node, state, true, _, localCc, _) and
@@ -1516,23 +1523,23 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             ap instanceof ApNil
           )
           or
-          fwdFlowJump(node, state, t, ap, apa) and
+          fwdFlowJump(node, state, t, ap, apa, stored) and
           cc = ccNone() and
           summaryCtx = TSummaryCtxNone()
           or
           // store
           exists(Content c, Ap ap0 |
-            fwdFlowStore(_, _, ap0, c, t, node, state, cc, summaryCtx) and
+            fwdFlowStore(_, _, ap0, _, c, t, stored, node, state, cc, summaryCtx) and
             ap = apCons(c, ap0) and
             apa = getApprox(ap)
           )
           or
           // read
-          fwdFlowRead(_, _, _, _, node, t, ap, state, cc, summaryCtx) and
+          fwdFlowRead(_, _, _, _, _, node, t, ap, stored, state, cc, summaryCtx) and
           apa = getApprox(ap)
           or
           // flow into a callable without summary context
-          fwdFlowInNoFlowThrough(node, apa, state, cc, t, ap) and
+          fwdFlowInNoFlowThrough(node, apa, state, cc, t, ap, stored) and
           summaryCtx = TSummaryCtxNone() and
           // When the call contexts of source and sink needs to match then there's
           // never any reason to enter a callable except to find a summary. See also
@@ -1540,18 +1547,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           not Config::getAFeature() instanceof FeatureEqualSourceSinkCallContext
           or
           // flow into a callable with summary context (non-linear recursion)
-          fwdFlowInFlowThrough(node, apa, state, cc, t, ap) and
-          summaryCtx = TSummaryCtxSome(node, state, t, ap)
+          fwdFlowInFlowThrough(node, apa, state, cc, t, ap, stored) and
+          summaryCtx = TSummaryCtxSome(node, state, t, ap, stored)
           or
           // flow out of a callable
-          fwdFlowOut(_, _, node, state, cc, summaryCtx, t, ap, apa)
+          fwdFlowOut(_, _, node, state, cc, summaryCtx, t, ap, apa, stored)
           or
           // flow through a callable
           exists(
             DataFlowCall call, CcCall ccc, RetNodeEx ret, boolean allowsFieldFlow,
             ApApprox innerArgApa
           |
-            fwdFlowThrough(call, cc, state, ccc, summaryCtx, t, ap, apa, ret, innerArgApa) and
+            fwdFlowThrough(call, cc, state, ccc, summaryCtx, t, ap, apa, stored, ret, innerArgApa) and
             flowThroughOutOfCall(call, ccc, ret, node, allowsFieldFlow, innerArgApa, apa) and
             not inBarrier(node, state) and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
@@ -1560,8 +1567,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         private newtype TSummaryCtx =
           TSummaryCtxNone() or
-          TSummaryCtxSome(ParamNodeEx p, FlowState state, Typ t, Ap ap) {
-            fwdFlowInFlowThrough(p, _, state, _, t, ap)
+          TSummaryCtxSome(ParamNodeEx p, FlowState state, Typ t, Ap ap, TypOption stored) {
+            fwdFlowInFlowThrough(p, _, state, _, t, ap, stored)
           }
 
         /**
@@ -1589,33 +1596,44 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           private FlowState state;
           private Typ t;
           private Ap ap;
+          private TypOption stored;
 
-          SummaryCtxSome() { this = TSummaryCtxSome(p, state, t, ap) }
+          SummaryCtxSome() { this = TSummaryCtxSome(p, state, t, ap, stored) }
 
           ParamNodeEx getParamNode() { result = p }
 
           private string ppTyp() { result = t.toString() and result != "" }
 
-          override string toString() { result = p + concat(" : " + this.ppTyp()) + " " + ap }
+          private string ppStored() {
+            exists(string ppt | ppt = stored.toString() |
+              if stored.isNone() or ppt = "" then result = "" else result = " : " + ppt
+            )
+          }
+
+          override string toString() {
+            result = p + concat(" : " + this.ppTyp()) + " " + ap + this.ppStored()
+          }
 
           override Location getLocation() { result = p.getLocation() }
         }
 
-        private predicate fwdFlowJump(NodeEx node, FlowState state, Typ t, Ap ap, ApApprox apa) {
+        private predicate fwdFlowJump(
+          NodeEx node, FlowState state, Typ t, Ap ap, ApApprox apa, TypOption stored
+        ) {
           exists(NodeEx mid |
-            fwdFlow(mid, state, _, _, t, ap, apa) and
+            fwdFlow(mid, state, _, _, t, ap, apa, stored) and
             jumpStepEx(mid, node)
           )
           or
           exists(NodeEx mid |
-            fwdFlow(mid, state, _, _, _, ap, apa) and
+            fwdFlow(mid, state, _, _, _, ap, apa, stored) and
             additionalJumpStep(mid, node, _) and
             t = getNodeTyp(node) and
             ap instanceof ApNil
           )
           or
           exists(NodeEx mid, FlowState state0 |
-            fwdFlow(mid, state0, _, _, _, ap, apa) and
+            fwdFlow(mid, state0, _, _, _, ap, apa, stored) and
             additionalJumpStateStep(mid, state0, node, state, _) and
             t = getNodeTyp(node) and
             ap instanceof ApNil
@@ -1624,18 +1642,19 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowStore(
-          NodeEx node1, Typ t1, Ap ap1, Content c, Typ t2, NodeEx node2, FlowState state, Cc cc,
-          SummaryCtx summaryCtx
+          NodeEx node1, Typ t1, Ap ap1, TypOption stored1, Content c, Typ t2, TypOption stored2,
+          NodeEx node2, FlowState state, Cc cc, SummaryCtx summaryCtx
         ) {
           exists(DataFlowType contentType, DataFlowType containerType, ApApprox apa1 |
-            fwdFlow(node1, state, cc, summaryCtx, t1, ap1, apa1) and
+            fwdFlow(node1, state, cc, summaryCtx, t1, ap1, apa1, stored1) and
             not outBarrier(node1, state) and
             not inBarrier(node2, state) and
             PrevStage::storeStepCand(node1, apa1, c, node2, contentType, containerType) and
             t2 = getTyp(containerType) and
             // We need to typecheck stores here, since reverse flow through a getter
             // might have a different type here compared to inside the getter.
-            typecheck(t1, getTyp(contentType))
+            typecheck(t1, getTyp(contentType)) and
+            if ap1 instanceof ApNil then stored2.asSome() = t1 else stored2 = stored1
           )
         }
 
@@ -1646,7 +1665,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
          */
         pragma[nomagic]
         private predicate fwdFlowConsCand(Typ t2, Ap cons, Content c, Typ t1, Ap tail) {
-          fwdFlowStore(_, t1, tail, c, t2, _, _, _, _) and
+          fwdFlowStore(_, t1, tail, _, c, t2, _, _, _, _, _) and
           cons = apCons(c, tail)
         }
 
@@ -1664,11 +1683,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowRead0(
-          Typ t, Ap ap, Content c, NodeEx node1, NodeEx node2, FlowState state, Cc cc,
-          SummaryCtx summaryCtx
+          Typ t, Ap ap, TypOption stored, Content c, NodeEx node1, NodeEx node2, FlowState state,
+          Cc cc, SummaryCtx summaryCtx
         ) {
           exists(ApHeadContent apc |
-            fwdFlow(node1, state, cc, summaryCtx, t, ap, _) and
+            fwdFlow(node1, state, cc, summaryCtx, t, ap, _, stored) and
             not outBarrier(node1, state) and
             not inBarrier(node2, state) and
             apc = getHeadContent(ap) and
@@ -1678,19 +1697,28 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowRead(
-          NodeEx node1, Typ t1, Ap ap1, Content c, NodeEx node2, Typ t2, Ap ap2, FlowState state,
-          Cc cc, SummaryCtx summaryCtx
+          NodeEx node1, Typ t1, Ap ap1, TypOption stored1, Content c, NodeEx node2, Typ t2, Ap ap2,
+          TypOption stored2, FlowState state, Cc cc, SummaryCtx summaryCtx
         ) {
-          fwdFlowRead0(t1, ap1, c, node1, node2, state, cc, summaryCtx) and
-          fwdFlowConsCand(t1, ap1, c, t2, ap2)
+          exists(Typ ct1, Typ ct2 |
+            fwdFlowRead0(t1, ap1, stored1, c, node1, node2, state, cc, summaryCtx) and
+            fwdFlowConsCand(ct1, ap1, c, ct2, ap2) and
+            typecheck(t1, ct1) and
+            typecheck(t2, ct2) and
+            if ap2 instanceof ApNil
+            then stored2.isNone() and stored1.asSome() = t2
+            else (
+              stored2 = stored1 and t2 = getNodeTyp(node2)
+            )
+          )
         }
 
         pragma[nomagic]
         private predicate fwdFlowIntoArg(
           ArgNodeEx arg, FlowState state, Cc outercc, SummaryCtx summaryCtx, Typ t, Ap ap,
-          boolean emptyAp, ApApprox apa, boolean cc
+          boolean emptyAp, ApApprox apa, TypOption stored, boolean cc
         ) {
-          fwdFlow(arg, state, outercc, summaryCtx, t, ap, apa) and
+          fwdFlow(arg, state, outercc, summaryCtx, t, ap, apa, stored) and
           (if instanceofCcCall(outercc) then cc = true else cc = false) and
           if ap instanceof ApNil then emptyAp = true else emptyAp = false
         }
@@ -1797,9 +1825,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           private predicate fwdFlowInCand(
             DataFlowCall call, ArgNodeEx arg, FlowState state, Cc outercc, DataFlowCallable inner,
             ParamNodeEx p, SummaryCtx summaryCtx, Typ t, Ap ap, boolean emptyAp, ApApprox apa,
-            boolean cc
+            TypOption stored, boolean cc
           ) {
-            fwdFlowIntoArg(arg, state, outercc, summaryCtx, t, ap, emptyAp, apa, cc) and
+            fwdFlowIntoArg(arg, state, outercc, summaryCtx, t, ap, emptyAp, apa, stored, cc) and
             (
               inner = viableImplCallContextReducedInlineLate(call, arg, outercc)
               or
@@ -1813,10 +1841,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           pragma[inline]
           private predicate fwdFlowInCandTypeFlowDisabled(
             DataFlowCall call, ArgNodeEx arg, FlowState state, Cc outercc, DataFlowCallable inner,
-            ParamNodeEx p, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, boolean cc
+            ParamNodeEx p, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, TypOption stored,
+            boolean cc
           ) {
             not enableTypeFlow() and
-            fwdFlowInCand(call, arg, state, outercc, inner, p, summaryCtx, t, ap, _, apa, cc)
+            fwdFlowInCand(call, arg, state, outercc, inner, p, summaryCtx, t, ap, _, apa, stored, cc)
           }
 
           pragma[nomagic]
@@ -1825,7 +1854,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             boolean emptyAp, ApApprox apa, boolean cc
           ) {
             enableTypeFlow() and
-            fwdFlowInCand(call, arg, _, outercc, inner, p, _, _, _, emptyAp, apa, cc)
+            fwdFlowInCand(call, arg, _, outercc, inner, p, _, _, _, emptyAp, apa, _, cc)
           }
 
           pragma[nomagic]
@@ -1851,16 +1880,16 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           predicate fwdFlowIn(
             DataFlowCall call, ArgNodeEx arg, DataFlowCallable inner, ParamNodeEx p,
             FlowState state, Cc outercc, CcCall innercc, SummaryCtx summaryCtx, Typ t, Ap ap,
-            ApApprox apa, boolean cc
+            ApApprox apa, TypOption stored, boolean cc
           ) {
             // type flow disabled: linear recursion
             fwdFlowInCandTypeFlowDisabled(call, arg, state, outercc, inner, p, summaryCtx, t, ap,
-              apa, cc) and
+              apa, stored, cc) and
             fwdFlowInValidEdgeTypeFlowDisabled(call, inner, innercc, pragma[only_bind_into](cc))
             or
             // type flow enabled: non-linear recursion
             exists(boolean emptyAp |
-              fwdFlowIntoArg(arg, state, outercc, summaryCtx, t, ap, emptyAp, apa, cc) and
+              fwdFlowIntoArg(arg, state, outercc, summaryCtx, t, ap, emptyAp, apa, stored, cc) and
               fwdFlowInValidEdgeTypeFlowEnabled(call, arg, outercc, inner, p, innercc, emptyAp, apa,
                 cc)
             )
@@ -1873,9 +1902,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowInNoFlowThrough(
-          ParamNodeEx p, ApApprox apa, FlowState state, CcCall innercc, Typ t, Ap ap
+          ParamNodeEx p, ApApprox apa, FlowState state, CcCall innercc, Typ t, Ap ap,
+          TypOption stored
         ) {
-          FwdFlowInNoThrough::fwdFlowIn(_, _, _, p, state, _, innercc, _, t, ap, apa, _)
+          FwdFlowInNoThrough::fwdFlowIn(_, _, _, p, state, _, innercc, _, t, ap, apa, stored, _)
         }
 
         private predicate top() { any() }
@@ -1884,9 +1914,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowInFlowThrough(
-          ParamNodeEx p, ApApprox apa, FlowState state, CcCall innercc, Typ t, Ap ap
+          ParamNodeEx p, ApApprox apa, FlowState state, CcCall innercc, Typ t, Ap ap,
+          TypOption stored
         ) {
-          FwdFlowInThrough::fwdFlowIn(_, _, _, p, state, _, innercc, _, t, ap, apa, _)
+          FwdFlowInThrough::fwdFlowIn(_, _, _, p, state, _, innercc, _, t, ap, apa, stored, _)
         }
 
         pragma[nomagic]
@@ -1928,11 +1959,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[nomagic]
         private predicate fwdFlowIntoRet(
           RetNodeEx ret, FlowState state, CcNoCall cc, SummaryCtx summaryCtx, Typ t, Ap ap,
-          ApApprox apa
+          ApApprox apa, TypOption stored
         ) {
           instanceofCcNoCall(cc) and
           not outBarrier(ret, state) and
-          fwdFlow(ret, state, cc, summaryCtx, t, ap, apa)
+          fwdFlow(ret, state, cc, summaryCtx, t, ap, apa, stored)
         }
 
         pragma[nomagic]
@@ -1940,7 +1971,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           DataFlowCall call, RetNodeEx ret, CcNoCall innercc, DataFlowCallable inner, NodeEx out,
           ApApprox apa, boolean allowsFieldFlow
         ) {
-          fwdFlowIntoRet(ret, _, innercc, _, _, _, apa) and
+          fwdFlowIntoRet(ret, _, innercc, _, _, _, apa, _) and
           inner = ret.getEnclosingCallable() and
           (
             call = viableImplCallContextReducedReverseInlineLate(inner, innercc) and
@@ -1964,10 +1995,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[inline]
         private predicate fwdFlowOut(
           DataFlowCall call, DataFlowCallable inner, NodeEx out, FlowState state, CcNoCall outercc,
-          SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa
+          SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, TypOption stored
         ) {
           exists(RetNodeEx ret, CcNoCall innercc, boolean allowsFieldFlow |
-            fwdFlowIntoRet(ret, state, innercc, summaryCtx, t, ap, apa) and
+            fwdFlowIntoRet(ret, state, innercc, summaryCtx, t, ap, apa, stored) and
             fwdFlowOutValidEdge(call, ret, innercc, inner, out, outercc, apa, allowsFieldFlow) and
             not inBarrier(out, state) and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
@@ -1984,47 +2015,52 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           pragma[nomagic]
           private predicate dataFlowTakenCallEdgeIn0(
             DataFlowCall call, DataFlowCallable c, ParamNodeEx p, FlowState state, CcCall innercc,
-            Typ t, Ap ap, boolean cc
+            Typ t, Ap ap, TypOption stored, boolean cc
           ) {
-            FwdFlowInNoThrough::fwdFlowIn(call, _, c, p, state, _, innercc, _, t, ap, _, cc)
+            FwdFlowInNoThrough::fwdFlowIn(call, _, c, p, state, _, innercc, _, t, ap, _, stored, cc)
             or
-            FwdFlowInThrough::fwdFlowIn(call, _, c, p, state, _, innercc, _, t, ap, _, cc)
+            FwdFlowInThrough::fwdFlowIn(call, _, c, p, state, _, innercc, _, t, ap, _, stored, cc)
           }
 
           pragma[nomagic]
-          private predicate fwdFlow1Param(ParamNodeEx p, FlowState state, CcCall cc, Typ t0, Ap ap) {
+          private predicate fwdFlow1Param(
+            ParamNodeEx p, FlowState state, CcCall cc, Typ t0, Ap ap, TypOption stored
+          ) {
             instanceofCcCall(cc) and
-            fwdFlow1(p, state, cc, _, t0, _, ap, _)
+            fwdFlow1(p, state, cc, _, t0, _, ap, _, stored)
           }
 
           pragma[nomagic]
           predicate dataFlowTakenCallEdgeIn(DataFlowCall call, DataFlowCallable c, boolean cc) {
-            exists(ParamNodeEx p, FlowState state, CcCall innercc, Typ t, Ap ap |
-              dataFlowTakenCallEdgeIn0(call, c, p, state, innercc, t, ap, cc) and
-              fwdFlow1Param(p, state, innercc, t, ap)
+            exists(ParamNodeEx p, FlowState state, CcCall innercc, Typ t, Ap ap, TypOption stored |
+              dataFlowTakenCallEdgeIn0(call, c, p, state, innercc, t, ap, stored, cc) and
+              fwdFlow1Param(p, state, innercc, t, ap, stored)
             )
           }
 
           pragma[nomagic]
           private predicate dataFlowTakenCallEdgeOut0(
-            DataFlowCall call, DataFlowCallable c, NodeEx node, FlowState state, Cc cc, Typ t, Ap ap
+            DataFlowCall call, DataFlowCallable c, NodeEx node, FlowState state, Cc cc, Typ t,
+            Ap ap, TypOption stored
           ) {
-            fwdFlowOut(call, c, node, state, cc, _, t, ap, _)
+            fwdFlowOut(call, c, node, state, cc, _, t, ap, _, stored)
           }
 
           pragma[nomagic]
-          private predicate fwdFlow1Out(NodeEx node, FlowState state, Cc cc, Typ t0, Ap ap) {
+          private predicate fwdFlow1Out(
+            NodeEx node, FlowState state, Cc cc, Typ t0, Ap ap, TypOption stored
+          ) {
             exists(ApApprox apa |
-              fwdFlow1(node, state, cc, _, t0, _, ap, apa) and
+              fwdFlow1(node, state, cc, _, t0, _, ap, apa, stored) and
               PrevStage::callEdgeReturn(_, _, _, _, node, _, apa)
             )
           }
 
           pragma[nomagic]
           predicate dataFlowTakenCallEdgeOut(DataFlowCall call, DataFlowCallable c) {
-            exists(NodeEx node, FlowState state, Cc cc, Typ t, Ap ap |
-              dataFlowTakenCallEdgeOut0(call, c, node, state, cc, t, ap) and
-              fwdFlow1Out(node, state, cc, t, ap)
+            exists(NodeEx node, FlowState state, Cc cc, Typ t, Ap ap, TypOption stored |
+              dataFlowTakenCallEdgeOut0(call, c, node, state, cc, t, ap, stored) and
+              fwdFlow1Out(node, state, cc, t, ap, stored)
             )
           }
 
@@ -2038,7 +2074,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             or
             exists(NodeEx node |
               cc = false and
-              fwdFlowJump(node, _, _, _, _) and
+              fwdFlowJump(node, _, _, _, _, _) and
               c = node.getEnclosingCallable()
             )
           }
@@ -2057,14 +2093,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[nomagic]
         private predicate fwdFlowRetFromArg(
           RetNodeEx ret, FlowState state, CcCall ccc, SummaryCtxSome summaryCtx, ApApprox argApa,
-          Typ t, Ap ap, ApApprox apa
+          Typ t, Ap ap, ApApprox apa, TypOption stored
         ) {
           exists(ReturnKindExt kind, ParamNodeEx p, Ap argAp |
             instanceofCcCall(ccc) and
             fwdFlow(pragma[only_bind_into](ret), state, ccc, summaryCtx, t, ap,
-              pragma[only_bind_into](apa)) and
+              pragma[only_bind_into](apa), stored) and
             summaryCtx =
-              TSummaryCtxSome(pragma[only_bind_into](p), _, _, pragma[only_bind_into](argAp)) and
+              TSummaryCtxSome(pragma[only_bind_into](p), _, _, pragma[only_bind_into](argAp), _) and
             not outBarrier(ret, state) and
             kind = ret.getKind() and
             parameterFlowThroughAllowed(p, kind) and
@@ -2076,27 +2112,29 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[inline]
         private predicate fwdFlowThrough0(
           DataFlowCall call, ArgNodeEx arg, Cc cc, FlowState state, CcCall ccc,
-          SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, RetNodeEx ret,
+          SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, TypOption stored, RetNodeEx ret,
           SummaryCtxSome innerSummaryCtx, ApApprox innerArgApa
         ) {
-          fwdFlowRetFromArg(ret, state, ccc, innerSummaryCtx, innerArgApa, t, ap, apa) and
+          fwdFlowRetFromArg(ret, state, ccc, innerSummaryCtx, innerArgApa, t, ap, apa, stored) and
           fwdFlowIsEntered(call, arg, cc, ccc, summaryCtx, innerSummaryCtx)
         }
 
         pragma[nomagic]
         private predicate fwdFlowThrough(
           DataFlowCall call, Cc cc, FlowState state, CcCall ccc, SummaryCtx summaryCtx, Typ t,
-          Ap ap, ApApprox apa, RetNodeEx ret, ApApprox innerArgApa
+          Ap ap, ApApprox apa, TypOption stored, RetNodeEx ret, ApApprox innerArgApa
         ) {
-          fwdFlowThrough0(call, _, cc, state, ccc, summaryCtx, t, ap, apa, ret, _, innerArgApa)
+          fwdFlowThrough0(call, _, cc, state, ccc, summaryCtx, t, ap, apa, stored, ret, _,
+            innerArgApa)
         }
 
         pragma[nomagic]
         private predicate fwdFlowIsEntered0(
           DataFlowCall call, ArgNodeEx arg, Cc cc, CcCall innerCc, SummaryCtx summaryCtx,
-          ParamNodeEx p, FlowState state, Typ t, Ap ap
+          ParamNodeEx p, FlowState state, Typ t, Ap ap, TypOption stored
         ) {
-          FwdFlowInThrough::fwdFlowIn(call, arg, _, p, state, cc, innerCc, summaryCtx, t, ap, _, _)
+          FwdFlowInThrough::fwdFlowIn(call, arg, _, p, state, cc, innerCc, summaryCtx, t, ap, _,
+            stored, _)
         }
 
         /**
@@ -2108,22 +2146,22 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           DataFlowCall call, ArgNodeEx arg, Cc cc, CcCall innerCc, SummaryCtx summaryCtx,
           SummaryCtxSome innerSummaryCtx
         ) {
-          exists(ParamNodeEx p, FlowState state, Typ t, Ap ap |
-            fwdFlowIsEntered0(call, arg, cc, innerCc, summaryCtx, p, state, t, ap) and
-            innerSummaryCtx = TSummaryCtxSome(p, state, t, ap)
+          exists(ParamNodeEx p, FlowState state, Typ t, Ap ap, TypOption stored |
+            fwdFlowIsEntered0(call, arg, cc, innerCc, summaryCtx, p, state, t, ap, stored) and
+            innerSummaryCtx = TSummaryCtxSome(p, state, t, ap, stored)
           )
         }
 
         pragma[nomagic]
         private predicate storeStepFwd(NodeEx node1, Ap ap1, Content c, NodeEx node2, Ap ap2) {
-          fwdFlowStore(node1, _, ap1, c, _, node2, _, _, _) and
+          fwdFlowStore(node1, _, ap1, _, c, _, _, node2, _, _, _) and
           ap2 = apCons(c, ap1) and
           readStepFwd(_, ap2, c, _, _)
         }
 
         pragma[nomagic]
         private predicate readStepFwd(NodeEx n1, Ap ap1, Content c, NodeEx n2, Ap ap2) {
-          fwdFlowRead(n1, _, ap1, c, n2, _, ap2, _, _, _)
+          fwdFlowRead(n1, _, ap1, _, c, n2, _, ap2, _, _, _, _)
         }
 
         pragma[nomagic]
@@ -2131,17 +2169,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           DataFlowCall call, FlowState state, CcCall ccc, Ap ap, ApApprox apa, RetNodeEx ret,
           SummaryCtxSome innerSummaryCtx, ApApprox innerArgApa
         ) {
-          fwdFlowThrough0(call, _, _, state, ccc, _, _, ap, apa, ret, innerSummaryCtx, innerArgApa)
+          fwdFlowThrough0(call, _, _, state, ccc, _, _, ap, apa, _, ret, innerSummaryCtx,
+            innerArgApa)
         }
 
         pragma[nomagic]
         private predicate returnFlowsThrough(
           RetNodeEx ret, ReturnPosition pos, FlowState state, CcCall ccc, ParamNodeEx p, Typ argT,
-          Ap argAp, ApApprox argApa, Ap ap
+          Ap argAp, ApApprox argApa, TypOption argStored, Ap ap
         ) {
           exists(DataFlowCall call, ApApprox apa, boolean allowsFieldFlow |
-            returnFlowsThrough0(call, state, ccc, ap, apa, ret, TSummaryCtxSome(p, _, argT, argAp),
-              argApa) and
+            returnFlowsThrough0(call, state, ccc, ap, apa, ret,
+              TSummaryCtxSome(p, _, argT, argAp, argStored), argApa) and
             flowThroughOutOfCall(call, ccc, ret, _, allowsFieldFlow, argApa, apa) and
             pos = ret.getReturnPosition() and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
@@ -2152,12 +2191,13 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         private predicate flowThroughIntoCall(
           DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, boolean allowsFieldFlow, Ap argAp, Ap ap
         ) {
-          exists(ApApprox argApa, Typ argT |
+          exists(ApApprox argApa, Typ argT, TypOption argStored |
             returnFlowsThrough(_, _, _, _, pragma[only_bind_into](p), pragma[only_bind_into](argT),
-              pragma[only_bind_into](argAp), pragma[only_bind_into](argApa), ap) and
+              pragma[only_bind_into](argAp), pragma[only_bind_into](argApa),
+              pragma[only_bind_into](argStored), ap) and
             flowIntoCallApaTaken(call, _, pragma[only_bind_into](arg), p, allowsFieldFlow, argApa) and
             fwdFlow(arg, _, _, _, pragma[only_bind_into](argT), pragma[only_bind_into](argAp),
-              pragma[only_bind_into](argApa)) and
+              pragma[only_bind_into](argApa), pragma[only_bind_into](argStored)) and
             if allowsFieldFlow = false then argAp instanceof ApNil else any()
           )
         }
@@ -2168,7 +2208,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         ) {
           exists(ApApprox apa, boolean allowsFieldFlow |
             flowIntoCallApaTaken(call, c, arg, p, allowsFieldFlow, apa) and
-            fwdFlow(arg, _, _, _, _, ap, apa) and
+            fwdFlow(arg, _, _, _, _, ap, apa, _) and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
           )
         }
@@ -2180,7 +2220,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         ) {
           exists(ApApprox apa, boolean allowsFieldFlow |
             PrevStage::callEdgeReturn(call, c, ret, _, out, allowsFieldFlow, apa) and
-            fwdFlow(ret, _, _, _, _, ap, apa) and
+            fwdFlow(ret, _, _, _, _, ap, apa, _) and
             pos = ret.getReturnPosition() and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
           |
@@ -2203,14 +2243,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           NodeEx node, FlowState state, ReturnCtx returnCtx, ApOption returnAp, Ap ap
         ) {
           revFlow0(node, state, returnCtx, returnAp, ap) and
-          fwdFlow(node, state, _, _, _, ap, _)
+          fwdFlow(node, state, _, _, _, ap, _, _)
         }
 
         pragma[nomagic]
         private predicate revFlow0(
           NodeEx node, FlowState state, ReturnCtx returnCtx, ApOption returnAp, Ap ap
         ) {
-          fwdFlow(node, state, _, _, _, ap, _) and
+          fwdFlow(node, state, _, _, _, ap, _, _) and
           sinkNode(node, state) and
           (
             if hasSinkCallCtx()
@@ -2261,7 +2301,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           // flow out of a callable
           exists(ReturnPosition pos |
             revFlowOut(_, node, pos, state, _, _, _, ap) and
-            if returnFlowsThrough(node, pos, state, _, _, _, _, _, ap)
+            if returnFlowsThrough(node, pos, state, _, _, _, _, _, _, ap)
             then (
               returnCtx = TReturnCtxMaybeFlowThrough(pos) and
               returnAp = apSome(ap)
@@ -2338,7 +2378,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
           predicate dataFlowNonCallEntry(DataFlowCallable c, boolean cc) {
             exists(NodeEx node, FlowState state, ApNil nil |
-              fwdFlow(node, state, _, _, _, nil, _) and
+              fwdFlow(node, state, _, _, _, nil, _, _) and
               sinkNode(node, state) and
               (if hasSinkCallCtx() then cc = true else cc = false) and
               c = node.getEnclosingCallable()
@@ -2423,7 +2463,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         ) {
           exists(RetNodeEx ret, FlowState state, CcCall ccc |
             revFlowOut(call, ret, pos, state, returnCtx, _, returnAp, ap) and
-            returnFlowsThrough(ret, pos, state, ccc, _, _, _, _, ap) and
+            returnFlowsThrough(ret, pos, state, ccc, _, _, _, _, _, ap) and
             matchesCall(ccc, call)
           )
         }
@@ -2492,7 +2532,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[nomagic]
         predicate parameterMayFlowThrough(ParamNodeEx p, Ap ap) {
           exists(ReturnPosition pos |
-            returnFlowsThrough(_, pos, _, _, p, _, ap, _, _) and
+            returnFlowsThrough(_, pos, _, _, p, _, ap, _, _, _) and
             parameterFlowsThroughRev(p, ap, pos, _)
           )
         }
@@ -2502,7 +2542,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           exists(Ap ap0 |
             parameterMayFlowThrough(p, _) and
             revFlow(n, state, TReturnCtxMaybeFlowThrough(_), _, ap0) and
-            fwdFlow(n, state, any(CcCall ccc), TSummaryCtxSome(p, _, _, ap), _, ap0, _)
+            fwdFlow(n, state, any(CcCall ccc), TSummaryCtxSome(p, _, _, ap, _), _, ap0, _, _)
           )
         }
 
@@ -2521,7 +2561,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[nomagic]
         predicate returnMayFlowThrough(RetNodeEx ret, Ap argAp, Ap ap, ReturnKindExt kind) {
           exists(ParamNodeEx p, ReturnPosition pos |
-            returnFlowsThrough(ret, pos, _, _, p, _, argAp, _, ap) and
+            returnFlowsThrough(ret, pos, _, _, p, _, argAp, _, _, ap) and
             parameterFlowsThroughRev(p, argAp, pos, ap) and
             kind = pos.getKind()
           )
@@ -2795,8 +2835,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
          */
         additional module Graph {
           private newtype TPathNode =
-            TPathNodeMid(NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap) {
-              fwdFlow(node, state, cc, summaryCtx, t, ap, _) and
+            TPathNodeMid(
+              NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap,
+              TypOption stored
+            ) {
+              fwdFlow(node, state, cc, summaryCtx, t, ap, _, stored) and
               revFlow(node, state, _, _, ap)
             } or
             TPathNodeSink(NodeEx node, FlowState state) {
@@ -2937,8 +2980,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             SummaryCtx summaryCtx;
             Typ t;
             Ap ap;
+            TypOption stored;
 
-            PathNodeMid() { this = TPathNodeMid(node, state, cc, summaryCtx, t, ap) }
+            PathNodeMid() { this = TPathNodeMid(node, state, cc, summaryCtx, t, ap, stored) }
 
             override NodeEx getNodeEx() { result = node }
 
@@ -3006,6 +3050,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
               )
             }
 
+            private string ppStored() {
+              exists(string ppt | ppt = stored.toString() |
+                if stored.isNone() or ppt = "" then result = "" else result = " : " + ppt
+              )
+            }
+
             private string ppCtx() { result = " <" + cc + ">" }
 
             private string ppSummaryCtx() {
@@ -3015,7 +3065,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
               result = " <" + summaryCtx + ">"
             }
 
-            override string toString() { result = node.toString() + this.ppType() + this.ppAp() }
+            override string toString() {
+              result = node.toString() + this.ppType() + this.ppAp() + this.ppStored()
+            }
 
             /**
              * Gets a textual representation of this element, including a textual
@@ -3023,7 +3075,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
              */
             string toStringWithContext() {
               result =
-                node.toString() + this.ppType() + this.ppAp() + this.ppCtx() + this.ppSummaryCtx()
+                node.toString() + this.ppType() + this.ppAp() + this.ppStored() + this.ppCtx() +
+                  this.ppSummaryCtx()
             }
 
             override predicate isSource() {
@@ -3093,41 +3146,43 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           pragma[nomagic]
           private predicate fwdFlowInStep(
             ArgNodeEx arg, ParamNodeEx p, FlowState state, Cc outercc, CcCall innercc,
-            SummaryCtx outerSummaryCtx, SummaryCtx innerSummaryCtx, Typ t, Ap ap
+            SummaryCtx outerSummaryCtx, SummaryCtx innerSummaryCtx, Typ t, Ap ap, TypOption stored
           ) {
             FwdFlowInNoThrough::fwdFlowIn(_, arg, _, p, state, outercc, innercc, outerSummaryCtx, t,
-              ap, _, _) and
+              ap, _, stored, _) and
             innerSummaryCtx = TSummaryCtxNone()
             or
             FwdFlowInThrough::fwdFlowIn(_, arg, _, p, state, outercc, innercc, outerSummaryCtx, t,
-              ap, _, _) and
-            innerSummaryCtx = TSummaryCtxSome(p, state, t, ap)
+              ap, _, stored, _) and
+            innerSummaryCtx = TSummaryCtxSome(p, state, t, ap, stored)
           }
 
           pragma[nomagic]
           private predicate fwdFlowThroughStep0(
             DataFlowCall call, ArgNodeEx arg, Cc cc, FlowState state, CcCall ccc,
-            SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, RetNodeEx ret,
+            SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa, TypOption stored, RetNodeEx ret,
             SummaryCtxSome innerSummaryCtx, ApApprox innerArgApa
           ) {
-            fwdFlowThrough0(call, arg, cc, state, ccc, summaryCtx, t, ap, apa, ret, innerSummaryCtx,
-              innerArgApa)
+            fwdFlowThrough0(call, arg, cc, state, ccc, summaryCtx, t, ap, apa, stored, ret,
+              innerSummaryCtx, innerArgApa)
           }
 
-          bindingset[node, state, cc, summaryCtx, t, ap]
+          bindingset[node, state, cc, summaryCtx, t, ap, stored]
           pragma[inline_late]
           private PathNodeImpl mkPathNode(
-            NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap
+            NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap,
+            TypOption stored
           ) {
-            result = TPathNodeMid(node, state, cc, summaryCtx, t, ap)
+            result = TPathNodeMid(node, state, cc, summaryCtx, t, ap, stored)
           }
 
           private PathNodeImpl typeStrengthenToPathNode(
-            NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap
+            NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap,
+            TypOption stored
           ) {
             exists(Typ t |
-              fwdFlow1(node, state, cc, summaryCtx, t0, t, ap, _) and
-              result = TPathNodeMid(node, state, cc, summaryCtx, t, ap)
+              fwdFlow1(node, state, cc, summaryCtx, t0, t, ap, _, stored) and
+              result = TPathNodeMid(node, state, cc, summaryCtx, t, ap, stored)
             )
           }
 
@@ -3135,32 +3190,34 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           private predicate fwdFlowThroughStep1(
             PathNodeImpl pn1, PathNodeImpl pn2, PathNodeImpl pn3, DataFlowCall call, Cc cc,
             FlowState state, CcCall ccc, SummaryCtx summaryCtx, Typ t, Ap ap, ApApprox apa,
-            RetNodeEx ret, ApApprox innerArgApa
+            TypOption stored, RetNodeEx ret, ApApprox innerArgApa
           ) {
             exists(
               FlowState state0, ArgNodeEx arg, SummaryCtxSome innerSummaryCtx, ParamNodeEx p,
-              Typ innerArgT, Ap innerArgAp
+              Typ innerArgT, Ap innerArgAp, TypOption innerArgStored
             |
-              fwdFlowThroughStep0(call, arg, cc, state, ccc, summaryCtx, t, ap, apa, ret,
+              fwdFlowThroughStep0(call, arg, cc, state, ccc, summaryCtx, t, ap, apa, stored, ret,
                 innerSummaryCtx, innerArgApa) and
-              innerSummaryCtx = TSummaryCtxSome(p, state0, innerArgT, innerArgAp) and
-              pn1 = mkPathNode(arg, state0, cc, summaryCtx, innerArgT, innerArgAp) and
-              pn2 = typeStrengthenToPathNode(p, state0, ccc, innerSummaryCtx, innerArgT, innerArgAp) and
-              pn3 = mkPathNode(ret, state, ccc, innerSummaryCtx, t, ap)
+              innerSummaryCtx = TSummaryCtxSome(p, state0, innerArgT, innerArgAp, innerArgStored) and
+              pn1 = mkPathNode(arg, state0, cc, summaryCtx, innerArgT, innerArgAp, innerArgStored) and
+              pn2 =
+                typeStrengthenToPathNode(p, state0, ccc, innerSummaryCtx, innerArgT, innerArgAp,
+                  innerArgStored) and
+              pn3 = mkPathNode(ret, state, ccc, innerSummaryCtx, t, ap, stored)
             )
           }
 
           pragma[nomagic]
           private predicate fwdFlowThroughStep2(
             PathNodeImpl pn1, PathNodeImpl pn2, PathNodeImpl pn3, NodeEx node, Cc cc,
-            FlowState state, SummaryCtx summaryCtx, Typ t, Ap ap
+            FlowState state, SummaryCtx summaryCtx, Typ t, Ap ap, TypOption stored
           ) {
             exists(
               DataFlowCall call, CcCall ccc, RetNodeEx ret, boolean allowsFieldFlow,
               ApApprox innerArgApa, ApApprox apa
             |
-              fwdFlowThroughStep1(pn1, pn2, pn3, call, cc, state, ccc, summaryCtx, t, ap, apa, ret,
-                innerArgApa) and
+              fwdFlowThroughStep1(pn1, pn2, pn3, call, cc, state, ccc, summaryCtx, t, ap, apa,
+                stored, ret, innerArgApa) and
               flowThroughOutOfCall(call, ccc, ret, node, allowsFieldFlow, innerArgApa, apa) and
               not inBarrier(node, state) and
               if allowsFieldFlow = false then ap instanceof ApNil else any()
@@ -3169,10 +3226,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
           private predicate localStep(
             PathNodeImpl pn1, NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t,
-            Ap ap, string label, boolean isStoreStep
+            Ap ap, TypOption stored, string label, boolean isStoreStep
           ) {
             exists(NodeEx mid, FlowState state0, Typ t0, LocalCc localCc |
-              pn1 = TPathNodeMid(mid, state0, cc, summaryCtx, t0, ap) and
+              pn1 = TPathNodeMid(mid, state0, cc, summaryCtx, t0, ap, stored) and
               localCc = getLocalCc(cc) and
               isStoreStep = false
             |
@@ -3184,18 +3241,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             )
             or
             // store
-            exists(NodeEx mid, Content c, Typ t0, Ap ap0 |
-              pn1 = TPathNodeMid(mid, state, cc, summaryCtx, t0, ap0) and
-              fwdFlowStore(mid, t0, ap0, c, t, node, state, cc, summaryCtx) and
+            exists(NodeEx mid, Content c, Typ t0, Ap ap0, TypOption stored0 |
+              pn1 = TPathNodeMid(mid, state, cc, summaryCtx, t0, ap0, stored0) and
+              fwdFlowStore(mid, t0, ap0, stored0, c, t, stored, node, state, cc, summaryCtx) and
               ap = apCons(c, ap0) and
               label = "" and
               isStoreStep = true
             )
             or
             // read
-            exists(NodeEx mid, Typ t0, Ap ap0 |
-              pn1 = TPathNodeMid(mid, state, cc, summaryCtx, t0, ap0) and
-              fwdFlowRead(mid, t0, ap0, _, node, t, ap, state, cc, summaryCtx) and
+            exists(NodeEx mid, Typ t0, Ap ap0, TypOption stored0 |
+              pn1 = TPathNodeMid(mid, state, cc, summaryCtx, t0, ap0, stored0) and
+              fwdFlowRead(mid, t0, ap0, stored0, _, node, t, ap, stored, state, cc, summaryCtx) and
               label = "" and
               isStoreStep = false
             )
@@ -3204,10 +3261,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           private predicate localStep(PathNodeImpl pn1, PathNodeImpl pn2, string label) {
             exists(
               NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap,
-              boolean isStoreStep
+              TypOption stored, boolean isStoreStep
             |
-              localStep(pn1, node, state, cc, summaryCtx, t0, ap, label, isStoreStep) and
-              pn2 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap) and
+              localStep(pn1, node, state, cc, summaryCtx, t0, ap, stored, label, isStoreStep) and
+              pn2 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap, stored) and
               stepFilter(node, ap, isStoreStep)
             )
             or
@@ -3235,11 +3292,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
           private predicate nonLocalStep(
             PathNodeImpl pn1, NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t,
-            Ap ap, string label
+            Ap ap, TypOption stored, string label
           ) {
             // jump
             exists(NodeEx mid, FlowState state0, Typ t0 |
-              pn1 = TPathNodeMid(mid, state0, _, _, t0, ap) and
+              pn1 = TPathNodeMid(mid, state0, _, _, t0, ap, stored) and
               cc = ccNone() and
               summaryCtx = TSummaryCtxNone()
             |
@@ -3264,15 +3321,16 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             or
             // flow into a callable
             exists(ArgNodeEx arg, Cc outercc, SummaryCtx outerSummaryCtx |
-              pn1 = TPathNodeMid(arg, state, outercc, outerSummaryCtx, t, ap) and
-              fwdFlowInStep(arg, node, state, outercc, cc, outerSummaryCtx, summaryCtx, t, ap) and
+              pn1 = TPathNodeMid(arg, state, outercc, outerSummaryCtx, t, ap, stored) and
+              fwdFlowInStep(arg, node, state, outercc, cc, outerSummaryCtx, summaryCtx, t, ap,
+                stored) and
               label = ""
             )
             or
             // flow out of a callable
             exists(RetNodeEx ret, CcNoCall innercc, boolean allowsFieldFlow, ApApprox apa |
-              pn1 = TPathNodeMid(ret, state, innercc, summaryCtx, t, ap) and
-              fwdFlowIntoRet(ret, state, innercc, summaryCtx, t, ap, apa) and
+              pn1 = TPathNodeMid(ret, state, innercc, summaryCtx, t, ap, stored) and
+              fwdFlowIntoRet(ret, state, innercc, summaryCtx, t, ap, apa, stored) and
               fwdFlowOutValidEdge(_, ret, innercc, _, node, cc, apa, allowsFieldFlow) and
               not inBarrier(node, state) and
               label = "" and
@@ -3281,9 +3339,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           }
 
           private predicate nonLocalStep(PathNodeImpl pn1, PathNodeImpl pn2, string label) {
-            exists(NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap |
-              nonLocalStep(pn1, node, state, cc, summaryCtx, t0, ap, label) and
-              pn2 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap) and
+            exists(
+              NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap,
+              TypOption stored
+            |
+              nonLocalStep(pn1, node, state, cc, summaryCtx, t0, ap, stored, label) and
+              pn2 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap, stored) and
               stepFilter(node, ap, false)
             )
           }
@@ -3298,10 +3359,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           ) {
             exists(
               NodeEx node, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t0, Ap ap,
-              PathNodeImpl out0
+              TypOption stored, PathNodeImpl out0
             |
-              fwdFlowThroughStep2(arg, par, ret, node, cc, state, summaryCtx, t0, ap) and
-              out0 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap) and
+              fwdFlowThroughStep2(arg, par, ret, node, cc, state, summaryCtx, t0, ap, stored) and
+              out0 = typeStrengthenToPathNode(node, state, cc, summaryCtx, t0, ap, stored) and
               stepFilter(node, ap, false)
             |
               out = out0 or out = out0.(PathNodeMid).projectToSink(_)
@@ -3573,14 +3634,13 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           int tfnodes, int tftuples
         ) {
           fwd = true and
-          nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, _, _)) and
+          nodes = count(NodeEx node | fwdFlow(node, _, _, _, _, _, _, _)) and
           fields = count(Content f0 | fwdConsCand(f0, _)) and
           conscand = count(Content f0, Ap ap | fwdConsCand(f0, ap)) and
-          states = count(FlowState state | fwdFlow(_, state, _, _, _, _, _)) and
+          states = count(FlowState state | fwdFlow(_, state, _, _, _, _, _, _)) and
           tuples =
-            count(NodeEx n, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap |
-              fwdFlow(n, state, cc, summaryCtx, t, ap, _)
-            ) and
+            count(NodeEx n, FlowState state, Cc cc, SummaryCtx summaryCtx, Typ t, Ap ap,
+              TypOption stored | fwdFlow(n, state, cc, summaryCtx, t, ap, _, stored)) and
           calledges =
             count(DataFlowCall call, DataFlowCallable c |
               FwdTypeFlowInput::dataFlowTakenCallEdgeIn(call, c, _) or

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1423,6 +1423,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         private class TypOption = TypOption::Option;
 
+        private string ppStored(TypOption stored) {
+          exists(string ppt | ppt = stored.toString() |
+            if stored.isNone() or ppt = "" then result = "" else result = " : " + ppt
+          )
+        }
+
         /* Begin: Stage logic. */
         pragma[nomagic]
         private Typ getNodeTyp(NodeEx node) {
@@ -1604,14 +1610,8 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
           private string ppTyp() { result = t.toString() and result != "" }
 
-          private string ppStored() {
-            exists(string ppt | ppt = stored.toString() |
-              if stored.isNone() or ppt = "" then result = "" else result = " : " + ppt
-            )
-          }
-
           override string toString() {
-            result = p + concat(" : " + this.ppTyp()) + " " + ap + this.ppStored()
+            result = p + concat(" : " + this.ppTyp()) + " " + ap + ppStored(stored)
           }
 
           override Location getLocation() { result = p.getLocation() }
@@ -3050,12 +3050,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
               )
             }
 
-            private string ppStored() {
-              exists(string ppt | ppt = stored.toString() |
-                if stored.isNone() or ppt = "" then result = "" else result = " : " + ppt
-              )
-            }
-
             private string ppCtx() { result = " <" + cc + ">" }
 
             private string ppSummaryCtx() {
@@ -3066,7 +3060,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             }
 
             override string toString() {
-              result = node.toString() + this.ppType() + this.ppAp() + this.ppStored()
+              result = node.toString() + this.ppType() + this.ppAp() + ppStored(stored)
             }
 
             /**
@@ -3075,7 +3069,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
              */
             string toStringWithContext() {
               result =
-                node.toString() + this.ppType() + this.ppAp() + this.ppStored() + this.ppCtx() +
+                node.toString() + this.ppType() + this.ppAp() + ppStored(stored) + this.ppCtx() +
                   this.ppSummaryCtx()
             }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -891,6 +891,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       nodeDataFlowType(this.asNode(), result)
       or
       nodeDataFlowType(this.asParamReturnNode(), result)
+      or
+      isTopType(result) and this.isImplicitReadNode(_)
     }
 
     pragma[inline]


### PR DESCRIPTION
This PR changes how type pruning is done in the data flow library. The primary change is that access paths no longer carry information about tracked types. On its own, this is a precision reduction, so it's combined with a separate precision improvement in that we now track the type of the originally tainted object - this corresponds to the innermost type in an access path, if available, prior to this PR. These two changes mostly balance each other in terms of overall precision, but of course they also affect performance. For Java on MRVA top 1000, this effect was slightly negative with two projects having big degradations in terms of number of computed tuples in certain queries. However, without types in access paths, this now allows other changes, so this PR contains a third tweak that postpones type pruning until stage 5. And this latter tweak regains the lost performance and then some, so the overall effect looks like a net win on almost all of MRVA top 1000.

I also checked impact on C# MRVA top 1000, but there the effects were negligible. And other languages are likely even less affected, since this only deals with type pruning, which isn't used much beyond Java and C#.

Commit-by-commit review is encouraged. The first two commits are simple refactorings. And the subsequent 3 commits implement the 3 changes described above. 