### PR TITLE
KE2: Start switching to having separate Kt* and Ka*Symbol methods

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
@@ -305,24 +305,38 @@ OLD: KE1
                 is KaNamedFunctionSymbol -> {
                     val parentId = useDeclarationParentOf(declaration, false)?.cast<DbReftype>()
                     if (parentId != null) {
-                        extractFunction(
-                            declaration,
-                            parentId,
-                            /*
-                            OLD: KE1
-                                                        extractBody = extractFunctionBodies,
-                                                        extractMethodAndParameterTypeAccesses = extractFunctionBodies,
-                                                        extractAnnotations = extractAnnotations,
-                                                        null,
-                                                        listOf()
-                            */
-                        )
-                    } else
+                        // TODO: Float this PSI further up
+                        val func = declaration.psi as? KtFunction
+                        if (func == null) {
+                            extractFunctionSymbol(
+                                declaration,
+                                parentId,
+                                /*
+                                OLD: KE1
+                                                            extractBody = extractFunctionBodies,
+                                                            extractMethodAndParameterTypeAccesses = extractFunctionBodies,
+                                                            extractAnnotations = extractAnnotations,
+                                                            null,
+                                                            listOf()
+                                */
+                            )
+                        } else {
+                            extractFunction(
+                                func,
+                                parentId,
+                                /*
+                                OLD: KE1
+                                                            extractBody = extractFunctionBodies,
+                                                            extractMethodAndParameterTypeAccesses = extractFunctionBodies,
+                                                            extractAnnotations = extractAnnotations,
+                                                            null,
+                                                            listOf()
+                                */
+                            )
+                        }
+                    } else {
                         Unit
-                    /*
-                    OLD: KE1
-                                        Unit
-                    */
+                    }
                 }
                 /*
                 OLD: KE1

--- a/java/kotlin-extractor2/src/main/kotlin/entities/Class.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Class.kt
@@ -77,7 +77,8 @@ fun KotlinFileExtractor.extractClassSource(
                                 it
                             )
                         } else {
-                            extractFunction(
+                            // TODO: Should this be extractFunction?
+                            extractFunctionSymbol(
                                 getter,
                                 id,
                                 /* OLD: KE1

--- a/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
@@ -426,7 +426,8 @@ private fun KotlinFileExtractor.extractGeneratedClass(
         )
 
     // Extract local function as a member
-    extractFunction(
+    // TODO: Should this be extractFunction?
+    extractFunctionSymbol(
         localFunction,
         id,
         /*


### PR DESCRIPTION
This gives us
```
fun KotlinFileExtractor.extractFunction(
    f: KtFunction,
```
for when extracting source files (which also extracts the body, for example), and
```
fun KotlinFileExtractor.extractFunctionSymbol(
    f: KaFunctionSymbol,
```
when extracting external functions.

Currently this means that  `extractDeclaration` has to call one or the other depending on whether the PSI for the function is available, but ultimately there would be an `extractDeclaration` that has a `KtDeclaration` that calls `extractFunction`, and `extractDeclarationSymbol` that has a `KaDeclarationSymbol` that calls `extractFunctionSymbol`.

On the plus side, this "feels" more correct to me. Before this PR, if we have a symbol that corresponds to a source function, then theoretically `.psi` will be non-null; and if we've got our "is external" check right, then we'll never get non-null `.psi` for an external method, but it feels like it could be a source of bugs and inconsistencies.

On the other hand, we'll need both an `extractDeclaration` (that extracts the source entities of source classes) and an `extractDeclarationSymbol` (that extracts the info available from the symbol only, when we have an external class), and they'll both have essentially the same logic and the same cases.

Any thoughts on which is the better way to go?