### PR TITLE
KE2: Remove some unnecessary !!s

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/Expression.kt
@@ -649,7 +649,7 @@ private fun KotlinFileExtractor.extractExpression(
             is KtIsExpression -> {
 
                 val locId = tw.getLocation(e)
-                val type = useType(e.expressionType!!)
+                val type = useType(e.expressionType)
                 val exprParent = parent.expr(e)
 
                 val id: Label<out DbExpr>
@@ -673,7 +673,7 @@ private fun KotlinFileExtractor.extractExpression(
 
             is KtBinaryExpressionWithTypeRHS -> {
                 val locId = tw.getLocation(e)
-                val type = useType(e.expressionType!!)
+                val type = useType(e.expressionType)
                 val exprParent = parent.expr(e)
 
                 val id: Label<out DbExpr>


### PR DESCRIPTION
`useType` already handles null types, and extracts an error type for them.

The error also includes info about where that came from via the `with` stack, although we might want to make that finer grained in future.
