### PR TITLE
KE2: Put 'callable' into 'StmtParent'

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
@@ -3792,12 +3792,12 @@ OLD: KE1
         }
     */
 
-    abstract inner class StmtExprParent {
+    abstract inner class StmtExprParent(val callable: Label<out DbCallable>) {
         abstract fun stmt(e: KtExpression): StmtParent
         abstract fun expr(e: KtExpression): ExprParent
     }
 
-    inner class StmtParent(val parent: Label<out DbStmtparent>, val idx: Int, val callable: Label<out DbCallable>) : StmtExprParent() {
+    inner class StmtParent(val parent: Label<out DbStmtparent>, val idx: Int, callable: Label<out DbCallable>) : StmtExprParent(callable) {
         override fun stmt(e: KtExpression) = this
 
         override fun expr(e: KtExpression) =
@@ -3810,8 +3810,8 @@ OLD: KE1
         val parent: Label<out DbExprparent>,
         val idx: Int,
         val enclosingStmt: Label<out DbStmt>,
-        val callable: Label<out DbCallable>
-    ) : StmtExprParent() {
+        callable: Label<out DbCallable>
+    ) : StmtExprParent(callable) {
         override fun stmt(e: KtExpression): StmtParent {
             val id = tw.getFreshIdLabel<DbStmtexpr>()
             val et = e.expressionType

--- a/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/KotlinFileExtractor.kt
@@ -3793,25 +3793,26 @@ OLD: KE1
     */
 
     abstract inner class StmtExprParent {
-        abstract fun stmt(e: KtExpression, callable: Label<out DbCallable>): StmtParent
-        abstract fun expr(e: KtExpression, callable: Label<out DbCallable>): ExprParent
+        abstract fun stmt(e: KtExpression): StmtParent
+        abstract fun expr(e: KtExpression): ExprParent
     }
 
-    inner class StmtParent(val parent: Label<out DbStmtparent>, val idx: Int) : StmtExprParent() {
-        override fun stmt(e: KtExpression, callable: Label<out DbCallable>) = this
+    inner class StmtParent(val parent: Label<out DbStmtparent>, val idx: Int, val callable: Label<out DbCallable>) : StmtExprParent() {
+        override fun stmt(e: KtExpression) = this
 
-        override fun expr(e: KtExpression, callable: Label<out DbCallable>) =
+        override fun expr(e: KtExpression) =
             extractExpressionStmt(tw.getLocation(e), parent, idx, callable).let { id ->
-                ExprParent(id, 0, id)
+                ExprParent(id, 0, id, callable)
             }
     }
 
     inner class ExprParent(
         val parent: Label<out DbExprparent>,
         val idx: Int,
-        val enclosingStmt: Label<out DbStmt>
+        val enclosingStmt: Label<out DbStmt>,
+        val callable: Label<out DbCallable>
     ) : StmtExprParent() {
-        override fun stmt(e: KtExpression, callable: Label<out DbCallable>): StmtParent {
+        override fun stmt(e: KtExpression): StmtParent {
             val id = tw.getFreshIdLabel<DbStmtexpr>()
             val et = e.expressionType
             val type = useType(et)
@@ -3819,10 +3820,10 @@ OLD: KE1
             tw.writeExprs_stmtexpr(id, type.javaResult.id, parent, idx)
             tw.writeExprsKotlinType(id, type.kotlinResult.id)
             extractExprContext(id, locId, callable, enclosingStmt)
-            return StmtParent(id, 0)
+            return StmtParent(id, 0, callable)
         }
 
-        override fun expr(e: KtExpression, callable: Label<out DbCallable>): ExprParent {
+        override fun expr(e: KtExpression): ExprParent {
             return this
         }
     }

--- a/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
@@ -61,7 +61,7 @@ fun KotlinFileExtractor.extractFunctionLiteral(
         addModifiers(ids.function, "override")
     }
 
-    val exprParent = parent.expr(e, callable)
+    val exprParent = parent.expr(e)
     val idLambdaExpr = tw.getFreshIdLabel<DbLambdaexpr>()
     tw.writeExprs_lambdaexpr(
         idLambdaExpr,

--- a/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
@@ -40,7 +40,6 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
 context(KaSession)
 fun KotlinFileExtractor.extractFunctionLiteral(
     e: KtFunctionLiteral,
-    callable: Label<out DbCallable>,
     parent: StmtExprParent
 ): Label<out DbExpr> {
 
@@ -70,7 +69,7 @@ fun KotlinFileExtractor.extractFunctionLiteral(
         exprParent.idx
     )
     tw.writeExprsKotlinType(idLambdaExpr, ids.type.kotlinResult.id)
-    extractExprContext(idLambdaExpr, locId, callable, exprParent.enclosingStmt)
+    extractExprContext(idLambdaExpr, locId, exprParent.callable, exprParent.enclosingStmt)
     tw.writeCallableBinding(idLambdaExpr, ids.constructor)
 
     // todo: fix hard coded block body of lambda

--- a/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.utils.mapToIndex
 context(KaSession)
 fun KotlinFileExtractor.extractMethodCall(
     call: KtCallExpression,
-    enclosingCallable: Label<out DbCallable>,
     stmtExprParent: StmtExprParent
 ): Label<out DbExpr> {
     val callTarget = call.resolveCallTarget() as? KaSimpleFunctionCall?
@@ -63,7 +62,7 @@ fun KotlinFileExtractor.extractMethodCall(
         target,
         tw.getLocation(call),
         call.expressionType!!,
-        enclosingCallable,
+        stmtExprParent.callable,
         exprParent.parent,
         exprParent.idx,
         exprParent.enclosingStmt,

--- a/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
@@ -57,7 +57,7 @@ fun KotlinFileExtractor.extractMethodCall(
     val extensionReceiver = if (target.isExtension) qualifier else null
     val dispatchReceiver = if (!target.isExtension) qualifier else null
 
-    val exprParent = stmtExprParent.expr(call, enclosingCallable)
+    val exprParent = stmtExprParent.expr(call)
 
     val callId = extractRawMethodAccess(
         target,


### PR DESCRIPTION
This came up because I wanted `StmtParent` to be able to emit an errorexpr/errorstmt, when the expr/stmt is null. However, it didn't know what callable to use. And actually, by putting the callable in this class, we can avoid passing it around everywhere as a separate parameter.

The `KotlinFileExtractor.kt` changes are the essence of this PR; everything else is just making it compile and removing redundant arguments.