### PR TITLE
Python: Model additional flow steps for the lxml framework

### DIFF
--- a/python/ql/lib/change-notes/2024-12-11-lxml-flowsteps.md
+++ b/python/ql/lib/change-notes/2024-12-11-lxml-flowsteps.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+- Additional taint steps through methods of `lxml.etree.Element` and `lxml.etree.ElementTree` objects from the `lxml` PyPI package have been modeled. 

--- a/python/ql/lib/semmle/python/frameworks/Lxml.qll
+++ b/python/ql/lib/semmle/python/frameworks/Lxml.qll
@@ -387,6 +387,15 @@ module Lxml {
   module ElementTree {
     API::Node classRef() { result = etreeRef().getMember("ElementTree") }
 
+    /**
+     * A source of instances of `lxml.etree.ElementTree` instances, extend this class to model new instances.
+     *
+     * This can include instantiations of the class, return values from function
+     * calls, or a special parameter that will be set when functions are called by an external
+     * library.
+     *
+     * Use the predicate `ElementTree::instance()` to get references to instances of `lxml.etree.ElementTree` instances.
+     */
     abstract class InstanceSource extends DataFlow::LocalSourceNode { }
 
     /** Gets a reference to an `lxml.etree.ElementTree` instance.` */
@@ -397,7 +406,7 @@ module Lxml {
       exists(DataFlow::TypeTracker t2 | result = instance(t2).track(t2, t))
     }
 
-    /** Gets a reference to an `lxml.etree.ElementTree` parsers instance. */
+    /** Gets a reference to an `lxml.etree.ElementTree` instance. */
     DataFlow::Node instance() { instance(DataFlow::TypeTracker::end()).flowsTo(result) }
 
     /** An `ElementTree` instantiated directly. */
@@ -439,7 +448,9 @@ module Lxml {
 
   /** A call to serialise xml to a string */
   private class XmlEncoding extends Encoding::Range, DataFlow::CallCfgNode {
-    XmlEncoding() { this = etreeRef().getMember("tostring").getACall() }
+    XmlEncoding() {
+      this = etreeRef().getMember(["tostring", "tostringlist", "tounicode"]).getACall()
+    }
 
     override DataFlow::Node getAnInput() {
       result = [this.getArg(0), this.getArgByName("element_or_tree")]

--- a/python/ql/lib/semmle/python/frameworks/Lxml.qll
+++ b/python/ql/lib/semmle/python/frameworks/Lxml.qll
@@ -320,13 +320,13 @@ module Lxml {
     override DataFlow::Node getAPathArgument() { result = this.getAnInput() }
   }
 
-  /** Provides models for instances of the `lxml.etree.Element` class. */
+  /** Provides models for the `lxml.etree.Element` class. */
   module Element {
     /** Gets a reference to the `Element` class. */
     API::Node classRef() { result = etreeRef().getMember(["Element", "_Element"]) }
 
     /**
-     * A source of instances of `lxml.etree.Element` instances, extend this class to model new instances.
+     * A source of `lxml.etree.Element` instances, extend this class to model new instances.
      *
      * This can include instantiations of the class, return values from function
      * calls, or a special parameter that will be set when functions are called by an external
@@ -408,7 +408,7 @@ module Lxml {
         |
           call.calls(nodeFrom,
             // We consider a node to be tainted if there could be taint anywhere in the element tree;
-            // So sibling nodes (e.g. `getnext`) are also tainted.
+            // so sibling nodes (e.g. `getnext`) are also tainted.
             // This ensures nodes like `elem[0].getnext()` are tracked.
             [
               "cssselect", "find", "findall", "findtext", "get", "getchildren", "getiterator",
@@ -425,13 +425,13 @@ module Lxml {
     }
   }
 
-  /** Provides models for instances of the `lxml.etree.ElementTree` class. */
+  /** Provides models for the `lxml.etree.ElementTree` class. */
   module ElementTree {
     /** Gets a reference to the `ElementTree` class. */
     API::Node classRef() { result = etreeRef().getMember(["ElementTree", "_ElementTree"]) }
 
     /**
-     * A source of instances of `lxml.etree.ElementTree` instances, extend this class to model new instances.
+     * A source of `lxml.etree.ElementTree` instances; extend this class to model new instances.
      *
      * This can include instantiations of the class, return values from function
      * calls, or a special parameter that will be set when functions are called by an external
@@ -452,7 +452,7 @@ module Lxml {
       ElementTreeInstance() { this = classRef().getAnInstance() }
     }
 
-    /** The result of a parst operation that returns an `ElementTree`. */
+    /** The result of a parse operation that returns an `ElementTree`. */
     private class ParseResult extends InstanceSource {
       ParseResult() { this = etreeRef().getMember("parse").getReturn() }
     }

--- a/python/ql/lib/semmle/python/frameworks/Lxml.qll
+++ b/python/ql/lib/semmle/python/frameworks/Lxml.qll
@@ -322,7 +322,17 @@ module Lxml {
     /** Gets a reference to the `Element` class. */
     API::Node classRef() { result = etreeRef().getMember(["Element", "_Element"]) }
 
+    /**
+     * A source of instances of `lxml.etree.Element` instances, extend this class to model new instances.
+     *
+     * This can include instantiations of the class, return values from function
+     * calls, or a special parameter that will be set when functions are called by an external
+     * library.
+     *
+     * Use the predicate `Element::instance()` to get references to instances of `lxml.etree.ElementTree` instances.
+     */
     abstract class InstanceSource instanceof API::Node {
+      /** Gets a textual representation of this element. */
       string toString() { result = super.toString() }
     }
 
@@ -410,6 +420,7 @@ module Lxml {
 
   /** Provides models for instances of the `lxml.etree.ElementTree` class. */
   module ElementTree {
+    /** Gets a reference to the `ElementTree` class. */
     API::Node classRef() { result = etreeRef().getMember(["ElementTree", "_ElementTree"]) }
 
     /**
@@ -422,6 +433,7 @@ module Lxml {
      * Use the predicate `ElementTree::instance()` to get references to instances of `lxml.etree.ElementTree` instances.
      */
     abstract class InstanceSource instanceof API::Node {
+      /** Gets a textual representation of this element. */
       string toString() { result = super.toString() }
     }
 

--- a/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.expected
@@ -1,0 +1,4 @@
+argumentToEnsureNotTaintedNotMarkedAsSpurious
+untaintedArgumentToEnsureTaintedNotMarkedAsMissing
+testFailures
+failures

--- a/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.ql
+++ b/python/ql/test/library-tests/frameworks/lxml/InlineTaintTest.ql
@@ -1,0 +1,2 @@
+import experimental.meta.InlineTaintTest
+import MakeInlineTaintTest<TestTaintTrackingConfig>

--- a/python/ql/test/library-tests/frameworks/lxml/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/lxml/taint_test.py
@@ -32,6 +32,7 @@ def test():
         elem,  # $ tainted
         ET.tostring(elem),  # $ tainted encodeFormat=XML encodeInput=elem encodeOutput=ET.tostring(..)
         ET.tostringlist(elem),  # $ tainted encodeFormat=XML encodeInput=elem encodeOutput=ET.tostringlist(..)
+        ET.tounicode(elem), # $ tainted encodeFormat=XML encodeInput=elem encodeOutput=ET.tounicode(..)
         elem.attrib,  # $ tainted
         elem.base,  # $ tainted
         elem.nsmap,  # $ tainted
@@ -82,7 +83,7 @@ def test():
         )
 
     buf = io.StringIO(src)
-    tree = ET.parse(buf) # $ decodeFormat=XML decodeInput=buf xmlVuln='XXE' decodeOutput=ET.parse(..) SPURIOUS:getAPathArgument=buf # Spurious as this is used as a file-like objectt, not a path 
+    tree = ET.parse(buf) # $ decodeFormat=XML decodeInput=buf xmlVuln='XXE' decodeOutput=ET.parse(..) SPURIOUS:getAPathArgument=buf # Spurious as this is used as a file-like object, not a path 
     ensure_tainted(
         tree,  # $ tainted
         tree.getroot().text,  # $ tainted
@@ -94,6 +95,7 @@ def test():
         next(tree.iter()).text,  # $ MISSING:tainted
         tree.iterfind("b"),  # $ tainted
         next(tree.iterfind("b")).text,  # $ MISSING:tainted
+        tree.xpath("b")[0].text,  # $ tainted getXPath="b"
     )
 
     (elem2, ids) = ET.XMLID(src) # $ decodeFormat=XML decodeInput=src xmlVuln='XXE' decodeOutput=ET.XMLID(..)

--- a/python/ql/test/library-tests/frameworks/lxml/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/lxml/taint_test.py
@@ -138,15 +138,15 @@ def test():
     def func2(x):
         return x 
 
-    def func3(x) -> ET.Element:
+    def func3(x) -> ET.ElementTree:
         return x
 
     ensure_tainted(
         func2(tree), # $ tainted
-        func2(tree).text, # $ MISSING:tainted - type tracking not tracked through flow preserving calls
-        func3(tree).text, # $ MISSING:tainted - this includes if there is a type hint annotation on the return
+        func2(tree).getroot().text, # $ MISSING:tainted - type tracking not tracked through flow preserving calls
+        func3(tree).getroot().text, # $ MISSING:tainted - this includes if there is a type hint annotation on the return
         typing.cast(ET.ElementTree, tree), # $ tainted
-        typing.cast(ET.ElementTree, tree).text, # $ MISSING:tainted - this includes for flow summary models
+        typing.cast(ET.ElementTree, tree).getroot().text, # $ MISSING:tainted - this includes for flow summary models
 
     )
     

--- a/python/ql/test/library-tests/frameworks/lxml/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/lxml/taint_test.py
@@ -1,5 +1,6 @@
 import lxml.etree as ET
 import io
+import typing
 
 def ensure_tainted(*args):
     print("ensure_tainted: ", *args)
@@ -133,6 +134,21 @@ def test():
         )
 
     func(tree2)
+
+    def func2(x):
+        return x 
+
+    def func3(x) -> ET.Element:
+        return x
+
+    ensure_tainted(
+        func2(tree), # $ tainted
+        func2(tree).text, # $ MISSING:tainted - type tracking not tracked through flow preserving calls
+        func3(tree).text, # $ MISSING:tainted - this includes if there is a type hint annotation on the return
+        typing.cast(ET.ElementTree, tree), # $ tainted
+        typing.cast(ET.ElementTree, tree).text, # $ MISSING:tainted - this includes for flow summary models
+
+    )
     
 
 test()

--- a/python/ql/test/library-tests/frameworks/lxml/taint_test.py
+++ b/python/ql/test/library-tests/frameworks/lxml/taint_test.py
@@ -1,0 +1,103 @@
+import lxml.etree as ET
+
+def ensure_tainted(*args):
+    pass 
+
+TAINTED_STRING = "<a><b></b></a>"
+src = TAINTED_STRING
+
+def test():
+    ensure_tainted(
+        src, # $ tainted
+        ET.fromstring(src),  # $ tainted
+        ET.XML(src),  # $ tainted
+        ET.HTML(src),  # $ tainted
+        ET.fromstringlist([src]),  # $ tainted
+        ET.XMLID(src),  # $ tainted
+        ET.XMLDTD(src),  # $ tainted
+    )
+
+
+    parser = ET.XmlParser()
+    parser.feed(src)
+    ensure_tainted(parser.close()),  # $ tainted
+
+    parser2 = ET.get_default_parser()
+    parser.feed(data=src)
+    ensure_tainted(parser2.close()),  # $ tainted
+
+    elem = ET.XML(src)
+    ensure_tainted(
+        elem,  # $ tainted
+        ET.tostring(elem),  # $ tainted
+        ET.tostringlist(elem),  # $ tainted
+        elem.attrib,  # $ tainted
+        elem.base,  # $ tainted
+        elem.nsmap,  # $ tainted
+        elem.prefix,  # $ tainted
+        elem.tag,  # $ tainted
+        elem.tail,  # $ tainted
+        elem.text,  # $ tainted
+        elem[0],  # $ tainted
+        elem[0].text,  # $ tainted
+        elem.cssselect("b"),  # $ tainted
+        elem.cssselect("b")[0].text,  # $ tainted
+        elem.find("b").text,  # $ tainted
+        elem.findall("b"),  # $ tainted
+        list(elem.findall("b"))[0].text,  # $ tainted
+        elem.get("at"),  # $ tainted
+        elem.getchildren(),  # $ tainted
+        list(elem.getchildren())[0].text,  # $ tainted,
+        elem.getiterator(),  # $ tainted
+        list(elem.getiterator())[0].text,  # $ tainted
+        elem.getnext().text,  # $ tainted
+        elem.getparent().text,  # $ tainted
+        elem.getprevious().text,  # $ tainted
+        elem.getroottree(),  # $ tainted
+        elem.getroottree().getroot().text,  # $ tainted
+        elem.items(),  # $ tainted
+        list(elem.items())[0].text,  # $ tainted
+        elem.iter(),  # $ tainted
+        list(elem.iter())[0].text,  # $ tainted
+        elem.iterancestors(),  # $ tainted
+        list(elem.iterancestors())[0].text,  # $ tainted
+        elem.iterchildren(), # $ tainted
+        list(elem.iterchildren())[0].text,  # $ tainted
+        elem.iterdecendants(),  # $ tainted
+        list(elem.iterdecendants())[0].text,  # $ tainted
+        elem.iterfind(),  # $ tainted
+        list(elem.iterfind())[0].text,  # $ tainted
+        elem.itersiblings(),  # $ tainted
+        list(elem.itersiblings())[0].text,  # $ tainted
+        elem.itertext(),  # $ tainted
+        list(elem.itertext())[0].text,  # $ tainted
+        elem.keys(),  # $ tainted
+        elem.values(),  # $ tainted
+        elem.xpath("b"),  # $ tainted
+        list(elem.xpath("b"))[0].text,  # $ tainted
+    )
+
+    for ch in elem:
+        ensure_tainted(
+            ch,  # $ tainted
+            ch.text  # $ tainted
+        )
+
+    tree = ET.parse(src)
+    ensure_tainted(
+        tree,  # $ tainted
+        tree.getroot().text,  # $ tainted
+        tree.find("a").text,  # $ tainted
+        tree.findall("a"),  # $ tainted
+        list(tree.findall("a"))[0].text,  # $ tainted
+        tree.getiterator(),  # $ tainted
+        list(tree.getiterator())[0].text,  # $ tainted
+        tree.iter(),  # $ tainted
+        list(tree.iter())[0].text,  # $ tainted
+        tree.iterfind(),  # $ tainted
+        list(tree.iterfind())[0].text,  # $ tainted
+    )
+
+    
+
+test()

--- a/shared/threat-models/ext/supported-threat-models.model.yml
+++ b/shared/threat-models/ext/supported-threat-models.model.yml
@@ -4,4 +4,3 @@ extensions:
       extensible: threatModelConfiguration
     data:
       - ["default", true, -2147483648] # The "default" threat model is included by default
-      - ["all", true, 1]

--- a/shared/threat-models/ext/supported-threat-models.model.yml
+++ b/shared/threat-models/ext/supported-threat-models.model.yml
@@ -4,3 +4,4 @@ extensions:
       extensible: threatModelConfiguration
     data:
       - ["default", true, -2147483648] # The "default" threat model is included by default
+      - ["all", true, 1]


### PR DESCRIPTION
Models additional flow steps for `Element` and `ElementTree` objects from the `lxml.etree` module, to track taint through parsed XML elements. 
