### PR TITLE
Remove deprecated `InlineExpectationsTest` class-based API

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.expected
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test-indirect.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/asExpr/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/asExpr/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/guard-condition-regression-test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/has-parameter-flow-out.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/has-parameter-flow-out.expected
@@ -1,3 +1,1 @@
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (has-parameter-flow-out.ql:5,18-61)
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-number-of-outnodes.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-number-of-outnodes.expected
@@ -1,3 +1,1 @@
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (test-number-of-outnodes.ql:5,18-61)
-failures
-testFailures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_argument_flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_argument_flow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_self_parameter_flow.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/type-bugs.expected
@@ -52,4 +52,3 @@ incorrectBaseType
 | test.cpp:854:10:854:36 | * ... | Expected 'Node.getType()' to be const int, but it was int |
 | test.cpp:867:10:867:30 | * ... | Expected 'Node.getType()' to be const int, but it was int |
 | test.cpp:1098:52:1098:53 | *& ... | Expected 'Node.getType()' to be char, but it was char * |
-failures

--- a/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/external-models/flow.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 edges
 | asio_streams.cpp:56:18:56:23 | [summary param] *0 in buffer | asio_streams.cpp:56:18:56:23 | [summary] to write: ReturnValue in buffer | provenance | MaD:10 |
 | asio_streams.cpp:87:34:87:44 | read_until output argument | asio_streams.cpp:91:7:91:17 | recv_buffer | provenance | Src:MaD:2  |

--- a/cpp/ql/test/library-tests/dataflow/fields/flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/flow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/interpretElement.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/interpretElement.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/models-as-data/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/models-as-data/taint.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/parameters-without-defs/test.expected
+++ b/cpp/ql/test/library-tests/dataflow/parameters-without-defs/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/smart-pointers-taint/taint.expected
@@ -2,5 +2,3 @@ WARNING: module 'DataFlow' has been deprecated and may be removed in future (tai
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (taint.ql:7,24-32)
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (taint.ql:11,22-30)
 WARNING: module 'TaintTracking' has been deprecated and may be removed in future (taint.ql:19,20-33)
-failures
-testFailures

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/local-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/local-flow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/source-sink-tests/remote-flow.expected
+++ b/cpp/ql/test/library-tests/dataflow/source-sink-tests/remote-flow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -3,5 +3,3 @@ WARNING: module 'DataFlow' has been deprecated and may be removed in future (tai
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (taint.ql:61,22-30)
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (taint.ql:68,25-33)
 WARNING: module 'TaintTracking' has been deprecated and may be removed in future (taint.ql:73,20-33)
-testFailures
-failures

--- a/cpp/ql/test/library-tests/ir/modulus-analysis/ModulusAnalysis.expected
+++ b/cpp/ql/test/library-tests/ir/modulus-analysis/ModulusAnalysis.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/ir/range-analysis/Overflow.expected
+++ b/cpp/ql/test/library-tests/ir/range-analysis/Overflow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/ir/range-analysis/RangeAnalysis.expected
+++ b/cpp/ql/test/library-tests/ir/range-analysis/RangeAnalysis.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/ir/sign-analysis/SignAnalysis.expected
+++ b/cpp/ql/test/library-tests/ir/sign-analysis/SignAnalysis.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/library-tests/ir/types/irtypes.expected
+++ b/cpp/ql/test/library-tests/ir/types/irtypes.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/AllocationToInvalidPointer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/AllocationToInvalidPointer.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerToDereference.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-193/InvalidPointerToDereference.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/experimental/CWE-522-DecompressionBombs/DecompressionBombTest.expected
+++ b/go/ql/test/experimental/CWE-522-DecompressionBombs/DecompressionBombTest.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.expected
+++ b/go/ql/test/experimental/frameworks/CleverGo/HeaderWrite.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.expected
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpRedirect.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.expected
+++ b/go/ql/test/experimental/frameworks/CleverGo/HttpResponseBody.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/CleverGo/RemoteSources.expected
+++ b/go/ql/test/experimental/frameworks/CleverGo/RemoteSources.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.expected
+++ b/go/ql/test/experimental/frameworks/Fiber/HeaderWrite.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/Fiber/Redirect.expected
+++ b/go/ql/test/experimental/frameworks/Fiber/Redirect.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/Fiber/RemoteFlowSources.expected
+++ b/go/ql/test/experimental/frameworks/Fiber/RemoteFlowSources.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/experimental/frameworks/Fiber/ResponseBody.expected
+++ b/go/ql/test/experimental/frameworks/Fiber/ResponseBody.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/library-tests/semmle/go/Function/isVariadic.expected
+++ b/go/ql/test/library-tests/semmle/go/Function/isVariadic.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/ImplementsComparable.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.expected
+++ b/go/ql/test/library-tests/semmle/go/Types/SignatureType_isVariadic.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.expected
+++ b/go/ql/test/library-tests/semmle/go/concepts/HTTP/Handler.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.expected
+++ b/go/ql/test/library-tests/semmle/go/concepts/LoggerCall/LoggerCall.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I1_subtypes_false.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I1_subtypes_false.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I2_subtypes_false.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I2_subtypes_false.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_I2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_IEmbedI1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_IEmbedI1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_IEmbedI2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_IEmbedI2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_PImplEmbedI1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_PImplEmbedI1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_PImplEmbedI2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_PImplEmbedI2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_S1_subtypes_false.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_S1_subtypes_false.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_S1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_S1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedI1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedI1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedI2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedI2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedP1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedP1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedP2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedP2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrP1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrP1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrP2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrP2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrS1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrS1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrS2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedPtrS2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedS1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedS1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedS2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SEmbedS2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedI1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedI1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedI2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedI2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedS1_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedS1_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedS2_subtypes_true.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/mad_SImplEmbedS2_subtypes_true.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_I1.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_I1.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_P1.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_P1.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_S1.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/ql_S1.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/PromotedMethods/DataFlowConfig.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/environment/test.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/environment/test.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/file/test.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/file/test.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/stdin/source.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/stdin/source.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Afero/Query.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Afero/Query.expected
@@ -1,3 +1,2 @@
 invalidModelRow
 testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/BeegoOrm/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/BeegoOrm/QueryString.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/CouchbaseV1/test.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/ElazarlGoproxy/test.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/EscapeFunction.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/EscapeFunction.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/FileSystemAccess.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/FileSystemAccess.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/OpenRedirect.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/OpenRedirect.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/RemoteFlowSources.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/RemoteFlowSources.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/SSRF.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/SSRF.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/Xss.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fasthttp/Xss.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Fiber/Query.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Fiber/Query.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoKit/RemoteFlowSources.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoKit/RemoteFlowSources.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/GoMicro/gomicro.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/GoMicro/gomicro.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Iris/Query.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Iris/Query.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/K8sIoClientGo/SecretInterfaceSource.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Macaron/Sources.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Macaron/Sources.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/NoSQL/Query.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Revel/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/Gorm/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/Gorm/QueryString.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/QueryString.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/Sqlx/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/Sqlx/QueryString.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/bun/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/bun/QueryString.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/gogf/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/gogf/QueryString.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/SQL/gorqlite/QueryString.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/SQL/gorqlite/QueryString.expected
@@ -1,3 +1,2 @@
 testFailures
 invalidModelRow
-failures

--- a/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/StdlibTaintFlow/test.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/Yaml/tests.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/library-tests/semmle/go/frameworks/gqlgen/gqlgen.expected
+++ b/go/ql/test/library-tests/semmle/go/frameworks/gqlgen/gqlgen.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
+++ b/go/ql/test/query-tests/Security/CWE-681/IncorrectIntegerConversion.expected
@@ -1,3 +1,2 @@
-failures
 invalidModelRow
 testFailures

--- a/java/ql/integration-tests/kotlin/all-platforms/default-parameter-mad-flow/test.expected
+++ b/java/ql/integration-tests/kotlin/all-platforms/default-parameter-mad-flow/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/library-tests/dataflow/callback-dispatch/test.expected
+++ b/java/ql/test/library-tests/dataflow/callback-dispatch/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.expected
+++ b/java/ql/test/library-tests/dataflow/entrypoint-types/EntryPointTypesTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
+++ b/java/ql/test/library-tests/dataflow/flowfeature/flow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/library-tests/dataflow/state/test.expected
+++ b/java/ql/test/library-tests/dataflow/state/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/dataflow/taintsources/local.expected
+++ b/java/ql/test/library-tests/dataflow/taintsources/local.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/dataflow/taintsources/remote.expected
+++ b/java/ql/test/library-tests/dataflow/taintsources/remote.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/dataflow/taintsources/reversedns.expected
+++ b/java/ql/test/library-tests/dataflow/taintsources/reversedns.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.expected
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxRs.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.expected
+++ b/java/ql/test/library-tests/frameworks/JaxWs/JaxWsEndpoint.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/android/taint-database/flowSteps.expected
+++ b/java/ql/test/library-tests/frameworks/android/taint-database/flowSteps.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/android/taint-database/sinks.expected
+++ b/java/ql/test/library-tests/frameworks/android/taint-database/sinks.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/guava/handwritten/flow.expected
+++ b/java/ql/test/library-tests/frameworks/guava/handwritten/flow.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/jms/FlowTest.expected
+++ b/java/ql/test/library-tests/frameworks/jms/FlowTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/jms/RemoteSourcesTest.expected
+++ b/java/ql/test/library-tests/frameworks/jms/RemoteSourcesTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/frameworks/rabbitmq/SourceTest.expected
+++ b/java/ql/test/library-tests/frameworks/rabbitmq/SourceTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/neutrals/neutralsinks/NeutralSinksTest.expected
+++ b/java/ql/test/library-tests/neutrals/neutralsinks/NeutralSinksTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/library-tests/xml/XMLTest.expected
+++ b/java/ql/test/library-tests/xml/XMLTest.expected
@@ -1,4 +1,2 @@
-testFailures
 | test.xml:4:5:4:32 | attribute=value | Unexpected result: hasXmlResult |
 | test.xml:5:29:5:52 |  $ hasXmlResult  | Missing result: hasXmlResult |
-failures

--- a/java/ql/test/query-tests/security/CWE-023/semmle/tests/PartialPathTraversalFromRemoteTest.expected
+++ b/java/ql/test/query-tests/security/CWE-023/semmle/tests/PartialPathTraversalFromRemoteTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-074/JndiInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-074/XsltInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-089/semmle/examples/springjdbc.expected
+++ b/java/ql/test/query-tests/security/CWE-089/semmle/examples/springjdbc.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/ApkInstallationTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/ApkInstallationTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/GroovyInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/JexlInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/MvelInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/SpelInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-094/TemplateInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-1204/StaticInitializationVectorTest.expected
+++ b/java/ql/test/query-tests/security/CWE-1204/StaticInitializationVectorTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-200/semmle/tests/SensitiveNotification/test.expected
+++ b/java/ql/test/query-tests/security/CWE-200/semmle/tests/SensitiveNotification/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-200/semmle/tests/SensitiveTextView/test.expected
+++ b/java/ql/test/query-tests/security/CWE-200/semmle/tests/SensitiveTextView/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-273/UnsafeCertTrustTest.expected
+++ b/java/ql/test/query-tests/security/CWE-273/UnsafeCertTrustTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-287/InsecureKeys/Test1/InsecureKeys.expected
+++ b/java/ql/test/query-tests/security/CWE-287/InsecureKeys/Test1/InsecureKeys.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-287/InsecureKeys/Test2/InsecureKeys.expected
+++ b/java/ql/test/query-tests/security/CWE-287/InsecureKeys/Test2/InsecureKeys.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-287/InsecureLocalAuth/InsecureLocalAuth.expected
+++ b/java/ql/test/query-tests/security/CWE-287/InsecureLocalAuth/InsecureLocalAuth.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test1/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test2/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test3/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test4/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test5/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/AndroidMissingCertificatePinning/Test5/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/ImproperWebVeiwCertificateValidation/test.expected
+++ b/java/ql/test/query-tests/security/CWE-295/ImproperWebVeiwCertificateValidation/test.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-295/InsecureTrustManager/InsecureTrustManagerTest.expected
+++ b/java/ql/test/query-tests/security/CWE-295/InsecureTrustManager/InsecureTrustManagerTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-297/InsecureJavaMailTest.expected
+++ b/java/ql/test/query-tests/security/CWE-297/InsecureJavaMailTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageAndroidDatabaseTest.expected
+++ b/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageAndroidDatabaseTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageAndroidFilesystemTest.expected
+++ b/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageAndroidFilesystemTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageSharedPrefsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-312/android/CleartextStorage/CleartextStorageSharedPrefsTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-326/InsufficientKeySizeTest.expected
+++ b/java/ql/test/query-tests/security/CWE-326/InsufficientKeySizeTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-330/InsecureRandomnessTest.expected
+++ b/java/ql/test/query-tests/security/CWE-330/InsecureRandomnessTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-347/MissingJWTSignatureCheckTest.expected
+++ b/java/ql/test/query-tests/security/CWE-347/MissingJWTSignatureCheckTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-352/SpringCsrfProtectionTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-470/FragmentInjectionInPreferenceActivityTest.expected
+++ b/java/ql/test/query-tests/security/CWE-470/FragmentInjectionInPreferenceActivityTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-489/debuggable-attribute/DebuggableAttributeEnabledTest.expected
+++ b/java/ql/test/query-tests/security/CWE-489/debuggable-attribute/DebuggableAttributeEnabledTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
+++ b/java/ql/test/query-tests/security/CWE-502/UnsafeDeserialization.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-522/InsecureBasicAuthTest.expected
+++ b/java/ql/test/query-tests/security/CWE-522/InsecureBasicAuthTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-522/InsecureLdapAuthTest.expected
+++ b/java/ql/test/query-tests/security/CWE-522/InsecureLdapAuthTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-524/SensitiveKeyboardCache.expected
+++ b/java/ql/test/query-tests/security/CWE-524/SensitiveKeyboardCache.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-643/XPathInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-643/XPathInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-730/PolynomialReDoS.expected
+++ b/java/ql/test/query-tests/security/CWE-730/PolynomialReDoS.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-730/ReDoS.expected
+++ b/java/ql/test/query-tests/security/CWE-730/ReDoS.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-730/RegexInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.expected
+++ b/java/ql/test/query-tests/security/CWE-749/UnsafeAndroidAccessTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsApiCall.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsComparison.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsComparison.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedCredentialsSourceCall.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedPasswordField.expected
+++ b/java/ql/test/query-tests/security/CWE-798/semmle/tests/HardcodedPasswordField.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypassTest.expected
+++ b/java/ql/test/query-tests/security/CWE-807/semmle/tests/ConditionalBypassTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.expected
+++ b/java/ql/test/query-tests/security/CWE-917/OgnlInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-918/RequestForgery.expected
+++ b/java/ql/test/query-tests/security/CWE-918/RequestForgery.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-925/ImproperIntentVerification.expected
+++ b/java/ql/test/query-tests/security/CWE-925/ImproperIntentVerification.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-926/ImplicitlyExportedAndroidComponentTest.expected
+++ b/java/ql/test/query-tests/security/CWE-926/ImplicitlyExportedAndroidComponentTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-926/incomplete_provider_permissions/ContentProviderIncompletePermissionsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-926/incomplete_provider_permissions/ContentProviderIncompletePermissionsTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
+++ b/java/ql/test/query-tests/security/CWE-927/ImplicitPendingIntentsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.expected
+++ b/java/ql/test/query-tests/security/CWE-927/SensitiveResultReceiver.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
+++ b/javascript/ql/test/library-tests/EndpointNaming/EndpointNaming.expected
@@ -5,4 +5,3 @@ ambiguousPreferredPredecessor
 | pack2/main.js:1:1:3:1 | def moduleImport("pack2").getMember("exports").getMember("MainClass").getInstance() |
 ambiguousSinkName
 ambiguousFunctionName
-failures

--- a/javascript/ql/test/library-tests/threat-models/sources/TestSources.expected
+++ b/javascript/ql/test/library-tests/threat-models/sources/TestSources.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/experimental/import-resolution/importflow.expected
+++ b/python/ql/test/experimental/import-resolution/importflow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/experimental/import-resolution/imports.expected
+++ b/python/ql/test/experimental/import-resolution/imports.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/experimental/library-tests/CallGraph-implicit-init/InlineCallGraphTest.expected
+++ b/python/ql/test/experimental/library-tests/CallGraph-implicit-init/InlineCallGraphTest.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 debug_callableNotUnique
 pointsTo_found_typeTracker_notFound
 typeTracker_found_pointsTo_notFound

--- a/python/ql/test/experimental/library-tests/CallGraph-imports/InlineCallGraphTest.expected
+++ b/python/ql/test/experimental/library-tests/CallGraph-imports/InlineCallGraphTest.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 debug_callableNotUnique
 pointsTo_found_typeTracker_notFound
 typeTracker_found_pointsTo_notFound

--- a/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.expected
+++ b/python/ql/test/experimental/library-tests/CallGraph/InlineCallGraphTest.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 debug_callableNotUnique
 pointsTo_found_typeTracker_notFound
 | code/class_attr_assign.py:10:9:10:27 | ControlFlowNode for Attribute() | my_func |

--- a/python/ql/test/experimental/meta/inline-taint-test-demo/InlineTaintTest.expected
+++ b/python/ql/test/experimental/meta/inline-taint-test-demo/InlineTaintTest.expected
@@ -5,4 +5,3 @@ untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 | taint_test.py:37:24:37:40 | taint_test.py:37 | ERROR, you should add `# $ MISSING: tainted` annotation | should_be_tainted |
 testFailures
 | taint_test.py:41:20:41:21 | ts | Fixed missing result: tainted |
-failures

--- a/python/ql/test/experimental/query-tests/Security/CWE-022-UnsafeUnpacking/DataflowQueryTest.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-022-UnsafeUnpacking/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/experimental/query-tests/Security/CWE-074-RemoteCommandExecution/ConceptsTest.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-074-RemoteCommandExecution/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/experimental/query-tests/Security/CWE-074-RemoteCommandExecution/DataflowQueryTest.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-074-RemoteCommandExecution/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/experimental/query-tests/Security/CWE-409/DataflowQueryTest.expected
+++ b/python/ql/test/experimental/query-tests/Security/CWE-409/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/ApiGraphs/py2/use.expected
+++ b/python/ql/test/library-tests/ApiGraphs/py2/use.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/InlineExpectationsTest/missing-relevant-tag/Test.expected
+++ b/python/ql/test/library-tests/InlineExpectationsTest/missing-relevant-tag/Test.expected
@@ -1,4 +1,2 @@
-testFailures
 | test.py:1:1:1:3 | foo | Tag mismatch: Actual result with tag 'foo' that is not part of getARelevantTag() |
 | test.py:4:1:4:3 | foo | Tag mismatch: Actual result with tag 'foo' that is not part of getARelevantTag() |
-failures

--- a/python/ql/test/library-tests/dataflow/basic/localFlowStepTest.expected
+++ b/python/ql/test/library-tests/dataflow/basic/localFlowStepTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/basic/maximalFlowTest.expected
+++ b/python/ql/test/library-tests/dataflow/basic/maximalFlowTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/calls/DataFlowCallTest.expected
+++ b/python/ql/test/library-tests/dataflow/calls/DataFlowCallTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/coverage-py2/argumentRoutingTest.expected
+++ b/python/ql/test/library-tests/dataflow/coverage-py2/argumentRoutingTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/coverage-py3/argumentRoutingTest.expected
+++ b/python/ql/test/library-tests/dataflow/coverage-py3/argumentRoutingTest.expected
@@ -1,6 +1,4 @@
-testFailures
 | classes.py:54:44:54:107 | Comment #$ arg1="with_length_hint" func=With_length_hint.__length_hint__ | Missing result: arg1="with_length_hint" |
 | classes.py:54:44:54:107 | Comment #$ arg1="with_length_hint" func=With_length_hint.__length_hint__ | Missing result: func=With_length_hint.__length_hint__ |
 | classes.py:71:32:71:77 | Comment #$ arg1="with_index" func=With_index.__index__ | Missing result: arg1="with_index" |
 | classes.py:71:32:71:77 | Comment #$ arg1="with_index" func=With_index.__index__ | Missing result: func=With_index.__index__ |
-failures

--- a/python/ql/test/library-tests/dataflow/coverage/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/coverage/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/coverage/argumentRoutingTest.expected
+++ b/python/ql/test/library-tests/dataflow/coverage/argumentRoutingTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/exceptions/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/exceptions/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/fieldflow/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/fieldflow/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/fieldflow/UnresolvedCalls.expected
+++ b/python/ql/test/library-tests/dataflow/fieldflow/UnresolvedCalls.expected
@@ -1,6 +1,4 @@
-testFailures
 | test.py:4:17:4:60 | ControlFlowNode for Attribute() | Unexpected result: unresolved_call=os.path.dirname(..) |
 | test.py:4:33:4:59 | ControlFlowNode for Attribute() | Unexpected result: unresolved_call=os.path.dirname(..) |
 | test_dict.py:4:17:4:60 | ControlFlowNode for Attribute() | Unexpected result: unresolved_call=os.path.dirname(..) |
 | test_dict.py:4:33:4:59 | ControlFlowNode for Attribute() | Unexpected result: unresolved_call=os.path.dirname(..) |
-failures

--- a/python/ql/test/library-tests/dataflow/global-flow/accesses.expected
+++ b/python/ql/test/library-tests/dataflow/global-flow/accesses.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/global-or-captured-vars/test.expected
+++ b/python/ql/test/library-tests/dataflow/global-or-captured-vars/test.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/match/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/match/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/model-summaries/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/model-summaries/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/model-summaries/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/model-summaries/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/module-initialization/localFlow.expected
+++ b/python/ql/test/library-tests/dataflow/module-initialization/localFlow.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/path-graph/PathNodes.expected
+++ b/python/ql/test/library-tests/dataflow/path-graph/PathNodes.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/sensitive-data/TestSensitiveDataSources.expected
+++ b/python/ql/test/library-tests/dataflow/sensitive-data/TestSensitiveDataSources.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/summaries/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/summaries/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/summaries/NormalTaintTrackingTest.expected
+++ b/python/ql/test/library-tests/dataflow/summaries/NormalTaintTrackingTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/commonSanitizer/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/commonSanitizer/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/customSanitizer/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/customSanitizer/InlineTaintTest.expected
@@ -1,7 +1,6 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures
 isSanitizer
 | test.py:21:39:21:39 | ControlFlowNode for s |
 | test.py:34:39:34:39 | ControlFlowNode for s |

--- a/python/ql/test/library-tests/dataflow/tainttracking/defaultAdditionalTaintStep-py3/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/defaultAdditionalTaintStep-py3/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/defaultAdditionalTaintStep/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/defaultAdditionalTaintStep/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/generator-flow/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/generator-flow/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/generator-flow/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/generator-flow/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/isinstance/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/isinstance/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/tainttracking/unwanted-global-flow/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/dataflow/tainttracking/unwanted-global-flow/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/typetracking-summaries/tracked.expected
+++ b/python/ql/test/library-tests/dataflow/typetracking-summaries/tracked.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/typetracking/tracked.expected
+++ b/python/ql/test/library-tests/dataflow/typetracking/tracked.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/typetracking_imports/tracked.expected
+++ b/python/ql/test/library-tests/dataflow/typetracking_imports/tracked.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/dataflow/variable-capture/CaptureTest.expected
+++ b/python/ql/test/library-tests/dataflow/variable-capture/CaptureTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/essa/ssa-compute/UseUse.expected
+++ b/python/ql/test/library-tests/essa/ssa-compute/UseUse.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aioch/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aioch/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiofile/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiofile/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiofiles/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiofiles/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiohttp/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiohttp/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiohttp/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiohttp/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiomysql/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiomysql/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiopg/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiopg/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/aiosqlite/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/aiosqlite/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/anyio/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/anyio/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/asyncpg/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/asyncpg/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/asyncpg/MaDTest.expected
+++ b/python/ql/test/library-tests/frameworks/asyncpg/MaDTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/baize/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/baize/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/bottle/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/bottle/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/bottle/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/bottle/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/cassandra-driver/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/cassandra-driver/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/cherrypy/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/cherrypy/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/clickhouse_driver/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/clickhouse_driver/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/crypto/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/crypto/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/cryptodome/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/cryptodome/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/cryptography/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/cryptography/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/cx_Oracle/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/cx_Oracle/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/dill/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/dill/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/django-orm/NormalDataflowTest.expected
+++ b/python/ql/test/library-tests/frameworks/django-orm/NormalDataflowTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/django-v1/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/django-v1/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/django-v2-v3/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/django-v2-v3/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/django-v2-v3/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/django-v2-v3/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/django/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/django/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/fabric/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/fabric/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/fabric/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/fabric/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/fastapi/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/fastapi/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/fastapi/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/fastapi/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask_admin/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask_admin/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask_admin/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask_admin/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask_sqlalchemy/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask_sqlalchemy/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/flask_sqlalchemy/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/flask_sqlalchemy/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/gradio/source_test.expected
+++ b/python/ql/test/library-tests/frameworks/gradio/source_test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/httpx/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/httpx/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/idna/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/idna/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/idna/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/idna/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/internal-ql-helpers/PoorMansFunctionResolutionTest.expected
+++ b/python/ql/test/library-tests/frameworks/internal-ql-helpers/PoorMansFunctionResolutionTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/invoke/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/invoke/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/jmespath/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/jmespath/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/jmespath/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/jmespath/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/joblib/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/joblib/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/jsonpickle/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/jsonpickle/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/libtaxii/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/libtaxii/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/lxml/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/lxml/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/markupsafe/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/markupsafe/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/markupsafe/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/markupsafe/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/multidict/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/multidict/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/multidict/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/multidict/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/mysql-connector-python/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/mysql-connector-python/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/mysqldb/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/mysqldb/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/numpy/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/numpy/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/oracledb/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/oracledb/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pandas/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pandas/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/paramiko/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/paramiko/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/peewee/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/peewee/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/peewee/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/peewee/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pexpect/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pexpect/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/phoenixdb/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/phoenixdb/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/psycopg/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pycurl/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pycurl/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pymssql/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pymssql/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pymysql/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pymysql/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pyodbc/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pyodbc/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pyramid/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/pyramid/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/pyramid/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/pyramid/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/requests/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/requests/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/requests/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/requests/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/rest_framework/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/rest_framework/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/rest_framework/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/rest_framework/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/rsa/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/rsa/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/rsa/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/rsa/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/ruamel.yaml/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/ruamel.yaml/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/sanic/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/sanic/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/serverless/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/serverless/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/simplejson/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/simplejson/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/simplejson/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/simplejson/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/sqlalchemy/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/sqlalchemy/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/sqlalchemy/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/sqlalchemy/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/starlette/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/starlette/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/stdlib-py2/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/stdlib-py2/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/stdlib-py3/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/stdlib-py3/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/stdlib/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/stdlib/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/stdlib/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/stdlib/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/streamlit/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/streamlit/rfs-test.expected
+++ b/python/ql/test/library-tests/frameworks/streamlit/rfs-test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/toml/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/toml/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/torch/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/torch/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/tornado/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/tornado/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/tornado/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/tornado/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/twisted/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/twisted/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/twisted/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/twisted/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/ujson/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/ujson/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/ujson/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/ujson/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/urllib/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/urllib/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/urllib3/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/urllib3/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/xmltodict/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/xmltodict/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/yaml/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/yaml/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/yarl/ConceptsTest.expected
+++ b/python/ql/test/library-tests/frameworks/yarl/ConceptsTest.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/frameworks/yarl/InlineTaintTest.expected
+++ b/python/ql/test/library-tests/frameworks/yarl/InlineTaintTest.expected
@@ -1,4 +1,3 @@
 argumentToEnsureNotTaintedNotMarkedAsSpurious
 untaintedArgumentToEnsureTaintedNotMarkedAsMissing
 testFailures
-failures

--- a/python/ql/test/library-tests/regex/SubstructureTests.expected
+++ b/python/ql/test/library-tests/regex/SubstructureTests.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/library-tests/regexparser/Locations.expected
+++ b/python/ql/test/library-tests/regexparser/Locations.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.expected
+++ b/python/ql/test/query-tests/Functions/ModificationOfParameterWithDefault/test.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/query-tests/Security/CWE-022-PathInjection/DataflowQueryTest.expected
+++ b/python/ql/test/query-tests/Security/CWE-022-PathInjection/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/query-tests/Security/CWE-078-CommandInjection/DataflowQueryTest.expected
+++ b/python/ql/test/query-tests/Security/CWE-078-CommandInjection/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/DataflowQueryTest.expected
+++ b/python/ql/test/query-tests/Security/CWE-078-UnsafeShellCommandConstruction/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/python/ql/test/query-tests/Security/CWE-209-StackTraceExposure/ExceptionInfo.expected
+++ b/python/ql/test/query-tests/Security/CWE-209-StackTraceExposure/ExceptionInfo.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/python/ql/test/query-tests/Security/CWE-943-NoSqlInjection/DataflowQueryTest.expected
+++ b/python/ql/test/query-tests/Security/CWE-943-NoSqlInjection/DataflowQueryTest.expected
@@ -1,3 +1,2 @@
 missingAnnotationOnSink
 testFailures
-failures

--- a/ruby/ql/test/library-tests/concepts/CryptographicOperation.expected
+++ b/ruby/ql/test/library-tests/concepts/CryptographicOperation.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
+++ b/ruby/ql/test/library-tests/dataflow/api-graphs/VerifyApiGraphExpectations.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/type-tracking-array-flow.expected
@@ -1,4 +1,3 @@
-testFailures
 | array_flow.rb:107:10:107:13 | ...[...] | Unexpected result: hasValueFlow=11.2 |
 | array_flow.rb:179:28:179:46 | # $ hasValueFlow=19 | Missing result: hasValueFlow=19 |
 | array_flow.rb:180:28:180:46 | # $ hasValueFlow=19 | Missing result: hasValueFlow=19 |
@@ -65,4 +64,3 @@ testFailures
 | array_flow.rb:1626:19:1626:70 | # $ hasValueFlow=136.2 $ SPURIOUS hasValueFlow=136.1 | Missing result: hasValueFlow=136.2 |
 | array_flow.rb:1627:19:1627:40 | # $ hasValueFlow=136.1 | Missing result: hasValueFlow=136.1 |
 | array_flow.rb:1699:13:1699:32 | # $ hasValueFlow=143 | Missing result: hasValueFlow=143 |
-failures

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 newStyleBarrierGuards
 | barrier-guards.rb:3:16:4:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:4:5:4:7 | foo |

--- a/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/TypeTrackingInlineTest.expected
@@ -1,4 +1,3 @@
-testFailures
 | blocks.rb:4:10:4:10 | r | Fixed missing result: hasValueFlow=1 |
 | captured_variables.rb:50:10:50:10 | x | Fixed missing result: hasValueFlow=2 |
 | captured_variables.rb:68:25:68:68 | # $ hasValueFlow=3 $ MISSING: hasValueFlow=4 | Missing result: hasValueFlow=3 |
@@ -30,4 +29,3 @@ testFailures
 | instance_variables.rb:114:23:114:41 | # $ hasValueFlow=28 | Missing result: hasValueFlow=28 |
 | instance_variables.rb:117:23:117:41 | # $ hasValueFlow=29 | Missing result: hasValueFlow=29 |
 | instance_variables.rb:120:23:120:41 | # $ hasValueFlow=30 | Missing result: hasValueFlow=30 |
-failures

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/type-tracking-hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/type-tracking-hash-flow.expected
@@ -1,4 +1,3 @@
-testFailures
 | hash_flow.rb:65:21:65:40 | # $ hasValueFlow=3.3 | Missing result: hasValueFlow=3.3 |
 | hash_flow.rb:66:21:66:49 | # $ SPURIOUS hasValueFlow=3.3 | Missing result: hasValueFlow=3.3 |
 | hash_flow.rb:117:10:117:17 | ...[...] | Unexpected result: hasValueFlow=7.1 |
@@ -21,4 +20,3 @@ testFailures
 | hash_flow.rb:779:10:779:14 | ...[...] | Unexpected result: hasValueFlow=46.3 |
 | hash_flow.rb:781:10:781:17 | ...[...] | Unexpected result: hasValueFlow=46.1 |
 | hash_flow.rb:784:10:784:17 | ...[...] | Unexpected result: hasValueFlow=46.3 |
-failures

--- a/ruby/ql/test/query-tests/experimental/improper-memoization/ImproperMemoization.expected
+++ b/ruby/ql/test/query-tests/experimental/improper-memoization/ImproperMemoization.expected
@@ -1,4 +1,3 @@
-failures
 testFailures
 | improper_memoization.rb:100:1:104:3 | m14 | Unexpected result: result=BAD |
 #select

--- a/ruby/ql/test/query-tests/security/cwe-116/IncompleteMultiCharacterSanitization/IncompleteMultiCharacterSanitization.expected
+++ b/ruby/ql/test/query-tests/security/cwe-116/IncompleteMultiCharacterSanitization/IncompleteMultiCharacterSanitization.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/ruby/ql/test/query-tests/security/cwe-300/InsecureDependency.expected
+++ b/ruby/ql/test/query-tests/security/cwe-300/InsecureDependency.expected
@@ -1,4 +1,3 @@
-failures
 testFailures
 #select
 | Gemfile:2:8:2:28 | "http://rubygems.org" | Dependency source URL uses the unencrypted protocol HTTP. Use HTTPS instead. |

--- a/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
+++ b/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 edges
 | insecure_download.rb:31:5:31:7 | url | insecure_download.rb:33:15:33:17 | url | provenance |  |
 | insecure_download.rb:31:5:31:7 | url | insecure_download.rb:33:15:33:17 | url | provenance |  |

--- a/rust/ql/test/library-tests/variables/variables.expected
+++ b/rust/ql/test/library-tests/variables/variables.expected
@@ -1,5 +1,4 @@
 testFailures
-failures
 variable
 | variables.rs:3:14:3:14 | s |
 | variables.rs:7:14:7:14 | i |

--- a/rust/ql/test/query-tests/security/CWE-089/SqlSinks.expected
+++ b/rust/ql/test/query-tests/security/CWE-089/SqlSinks.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/shared/util/change-notes/2024-12-03-remove-deprected-inline-expecation-test-classes.md
+++ b/shared/util/change-notes/2024-12-03-remove-deprected-inline-expecation-test-classes.md
@@ -1,0 +1,4 @@
+---
+category: breaking
+---
+* Deleted the old deprecated inline expectation test API that was based on the `InlineExpectationsTest` class.

--- a/shared/util/codeql/util/test/InlineExpectationsTest.qll
+++ b/shared/util/codeql/util/test/InlineExpectationsTest.qll
@@ -500,55 +500,6 @@ module Make<InlineExpectationsTestSig Impl> {
     }
   }
 
-  deprecated private module LegacyImpl implements TestSig {
-    string getARelevantTag() { result = any(InlineExpectationsTest t).getARelevantTag() }
-
-    predicate hasActualResult(Impl::Location location, string element, string tag, string value) {
-      any(InlineExpectationsTest t).hasActualResult(location, element, tag, value)
-    }
-
-    predicate hasOptionalResult(Impl::Location location, string element, string tag, string value) {
-      any(InlineExpectationsTest t).hasOptionalResult(location, element, tag, value)
-    }
-  }
-
-  /**
-   * DEPRECATED: Use the InlineExpectationsTest module.
-   *
-   * The base class for tests with inline expectations. The test extends this class to provide the actual
-   * results of the query, which are then compared with the expected results in comments to produce a
-   * list of failure messages that point out where the actual results differ from the expected
-   * results.
-   */
-  abstract deprecated class InlineExpectationsTest extends string {
-    bindingset[this]
-    InlineExpectationsTest() { any() }
-
-    abstract string getARelevantTag();
-
-    abstract predicate hasActualResult(
-      Impl::Location location, string element, string tag, string value
-    );
-
-    predicate hasOptionalResult(Impl::Location location, string element, string tag, string value) {
-      none()
-    }
-  }
-
-  deprecated import MakeTest<LegacyImpl> as LegacyTest
-
-  deprecated query predicate failures = LegacyTest::testFailures/2;
-
-  deprecated class ActualResult = LegacyTest::ActualTestResult;
-
-  deprecated class GoodExpectation = LegacyTest::GoodTestExpectation;
-
-  deprecated class FalsePositiveExpectation = LegacyTest::FalsePositiveTestExpectation;
-
-  deprecated class FalseNegativeExpectation = LegacyTest::FalseNegativeTestExpectation;
-
-  deprecated class InvalidExpectation = LegacyTest::InvalidTestExpectation;
-
   /**
    * Holds if the expectation `tag=value` is found in one or more expectation comments.
    *

--- a/swift/ql/test/library-tests/dataflow/capture/FlowInline.expected
+++ b/swift/ql/test/library-tests/dataflow/capture/FlowInline.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/DataFlowInline.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.expected
+++ b/swift/ql/test/library-tests/dataflow/flowsources/FlowSourcesInline.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/core/TaintInline.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
+++ b/swift/ql/test/library-tests/dataflow/taint/libraries/TaintInline.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/library-tests/regex/regex.expected
+++ b/swift/ql/test/library-tests/regex/regex.expected
@@ -1,2 +1,0 @@
-testFailures
-failures

--- a/swift/ql/test/query-tests/Security/CWE-022/PathInjection/PathInjectionTest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-022/PathInjection/PathInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/query-tests/Security/CWE-312/CleartextLoggingTest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-312/CleartextLoggingTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-611/XXETest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures

--- a/swift/ql/test/query-tests/Security/CWE-946/PredicateInjectionTest.expected
+++ b/swift/ql/test/query-tests/Security/CWE-946/PredicateInjectionTest.expected
@@ -1,2 +1,0 @@
-failures
-testFailures


### PR DESCRIPTION
This has been deprecated for 17 months.
