### PR TITLE
C++: Fix a FP in cpp/wrong-number-format-arguments caused by an extraction error

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongNumberOfFormatArguments.ql
@@ -44,7 +44,8 @@ where
   ) and
   // A typical problem is that string literals are concatenated, but if one of the string
   // literals is an undefined macro, then this just leads to a syntax error.
-  not exists(SyntaxError e | e.affects(fl))
+  not exists(SyntaxError e | e.affects(fl)) and
+  not ffc.getArgument(_) instanceof ErrorExpr
 select ffc,
   "Format for " + ffcName + " expects " + expected.toString() + " arguments but given " +
     given.toString()

--- a/cpp/ql/src/change-notes/2024-12-05-wrong-number-format-arguments.md
+++ b/cpp/ql/src/change-notes/2024-12-05-wrong-number-format-arguments.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Too few arguments to formatting function" query (`cpp/wrong-number-format-arguments`) query no longer produces results if an argument has an extraction error.

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -5,7 +5,6 @@
 | macros.cpp:14:2:14:37 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:21:2:21:36 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:32:2:32:25 | call to printf | Format for printf (in a macro expansion) expects 1 arguments but given 0 |
-| syntax_errors.c:8:5:8:10 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:9:2:9:7 | call to printf | Format for printf expects 1 arguments but given 0 |
 | test.c:12:2:12:7 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:15:2:15:7 | call to printf | Format for printf expects 3 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -5,6 +5,7 @@
 | macros.cpp:14:2:14:37 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:21:2:21:36 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:32:2:32:25 | call to printf | Format for printf (in a macro expansion) expects 1 arguments but given 0 |
+| syntax_errors.c:15:5:15:10 | call to printf | Format for printf expects 2 arguments but given 0 |
 | test.c:9:2:9:7 | call to printf | Format for printf expects 1 arguments but given 0 |
 | test.c:12:2:12:7 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:15:2:15:7 | call to printf | Format for printf expects 3 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/WrongNumberOfFormatArguments.expected
@@ -5,6 +5,7 @@
 | macros.cpp:14:2:14:37 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:21:2:21:36 | call to printf | Format for printf (in a macro expansion) expects 4 arguments but given 3 |
 | macros.cpp:32:2:32:25 | call to printf | Format for printf (in a macro expansion) expects 1 arguments but given 0 |
+| syntax_errors.c:8:5:8:10 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:9:2:9:7 | call to printf | Format for printf expects 1 arguments but given 0 |
 | test.c:12:2:12:7 | call to printf | Format for printf expects 2 arguments but given 1 |
 | test.c:15:2:15:7 | call to printf | Format for printf expects 3 arguments but given 2 |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/syntax_errors.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/syntax_errors.c
@@ -3,5 +3,9 @@
 extern int printf(const char *fmt, ...);
 
 void test_syntax_error() {
-    printf("Error code %d: " FMT_MSG, 0, "");
+    printf("Error code %d: " UNDEFINED_MACRO, 0, "");
+
+    printf("%d%d",
+        (UNDEFINED_MACRO)1,
+        (UNDEFINED_MACRO)2);
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/syntax_errors.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongNumberOfFormatArguments/syntax_errors.c
@@ -3,9 +3,16 @@
 extern int printf(const char *fmt, ...);
 
 void test_syntax_error() {
+    // GOOD
     printf("Error code %d: " UNDEFINED_MACRO, 0, "");
 
+    // GOOD
     printf("%d%d",
         (UNDEFINED_MACRO)1,
         (UNDEFINED_MACRO)2);
+
+    // GOOD [FALSE POSITIVE]
+    printf("%d%d"
+        UNDEFINED_MACRO,
+        1, 2);
 }


### PR DESCRIPTION
Commit-by-commit review encouraged. It's a fairly small fix that removes a grand total of one FP on [DCA](https://github.com/github/codeql-dca-main/blob/data/calumgrant/pr-18194-99efff__nightly-buildle__nightly/reports/alert-comparison.md).

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
