### PR TITLE
C#: Add field-flow for dynamic fields

### DIFF
--- a/csharp/ql/lib/change-notes/2024-12-03-dynamic-field-flow.md
+++ b/csharp/ql/lib/change-notes/2024-12-03-dynamic-field-flow.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added support for data-flow through members accesses of objects with `dynamic` types.
+* Added support for data-flow through member accesses of objects with `dynamic` types.

--- a/csharp/ql/lib/change-notes/2024-12-03-dynamic-field-flow.md
+++ b/csharp/ql/lib/change-notes/2024-12-03-dynamic-field-flow.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added support for data-flow through members accesses of objects with `dynamic` types.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -385,13 +385,15 @@ class ContentSet extends TContentSet {
       overridesOrImplementsSourceDecl(p1, p2)
     )
     or
-    exists(Property p |
-      this.isProperty(p) and
+    exists(FieldOrProperty p |
+      this = p.getContentSet() and
       result.(DynamicPropertyContent).getName() = p.getName()
     )
     or
     this.isDynamicProperty([
-        result.(DynamicPropertyContent).getName(), result.(PropertyContent).getProperty().getName()
+        result.(DynamicPropertyContent).getName(),
+        result.(PropertyContent).getProperty().getName(),
+        result.(FieldContent).getField().getName()
       ])
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPublic.qll
@@ -239,6 +239,23 @@ class PropertyContent extends Content, TPropertyContent {
   override Location getLocation() { result = p.getLocation() }
 }
 
+/** A reference to a dynamic property. */
+class DynamicPropertyContent extends Content, TDynamicPropertyContent {
+  private DynamicProperty name;
+
+  DynamicPropertyContent() { this = TDynamicPropertyContent(name) }
+
+  /** Gets an access of this dynamic property. */
+  DynamicMemberAccess getAnAccess() { result = name.getAnAccess() }
+
+  override string toString() { result = "dynamic property " + name }
+
+  override EmptyLocation getLocation() { any() }
+
+  /** Gets the name that is referenced. */
+  string getName() { result = name }
+}
+
 /**
  * A reference to the index of an argument of a delegate call.
  */
@@ -324,6 +341,9 @@ class ContentSet extends TContentSet {
    */
   predicate isProperty(Property p) { this = TPropertyContentSet(p) }
 
+  /** Holds if this content set represents the dynamic property `name`. */
+  predicate isDynamicProperty(string name) { this = TDynamicPropertyContentSet(name) }
+
   /**
    * Holds if this content set represents the `i`th argument of a delegate call.
    */
@@ -348,6 +368,8 @@ class ContentSet extends TContentSet {
     this.isSingleton(result)
     or
     this.isProperty(result.(PropertyContent).getProperty())
+    or
+    this.isDynamicProperty(result.(DynamicPropertyContent).getName())
   }
 
   /** Gets a content that may be read from when reading from this set. */
@@ -362,6 +384,15 @@ class ContentSet extends TContentSet {
       or
       overridesOrImplementsSourceDecl(p1, p2)
     )
+    or
+    exists(Property p |
+      this.isProperty(p) and
+      result.(DynamicPropertyContent).getName() = p.getName()
+    )
+    or
+    this.isDynamicProperty([
+        result.(DynamicPropertyContent).getName(), result.(PropertyContent).getProperty().getName()
+      ])
   }
 
   /** Gets a textual representation of this content set. */
@@ -374,6 +405,11 @@ class ContentSet extends TContentSet {
     exists(Property p |
       this.isProperty(p) and
       result = "property " + p.getName()
+    )
+    or
+    exists(string name |
+      this.isDynamicProperty(name) and
+      result = "dynamic property " + name
     )
   }
 
@@ -388,5 +424,8 @@ class ContentSet extends TContentSet {
       this.isProperty(p) and
       result = p.getLocation()
     )
+    or
+    this.isDynamicProperty(_) and
+    result instanceof EmptyLocation
   }
 }

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1162,6 +1162,30 @@ edges
 | K.cs:8:22:8:22 | access to local variable o : String | K.cs:8:9:8:15 | [post] access to field Strings : String[] [element] : String | provenance |  |
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | K.cs:13:14:13:23 | access to array element | provenance |  |
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | K.cs:13:14:13:23 | access to array element | provenance |  |
+| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:18 | dynamic access to member f1 | provenance |  |
+| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:18 | dynamic access to member f1 | provenance |  |
+| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
+| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
+| L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | provenance |  |
+| L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | provenance |  |
+| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
+| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
+| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
+| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
+| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:18 | access to property f2 | provenance |  |
+| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:18 | access to property f2 | provenance |  |
+| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | provenance |  |
+| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | provenance |  |
+| L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:23:9:23:12 | [post] this access : L [property f3] : String | provenance |  |
+| L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:23:9:23:12 | [post] this access : L [property f3] : String | provenance |  |
+| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | provenance |  |
+| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | provenance |  |
+| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:18 | dynamic access to member f3 | provenance |  |
+| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:18 | dynamic access to member f3 | provenance |  |
 nodes
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
@@ -2415,6 +2439,36 @@ nodes
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | semmle.label | access to field Strings : String[] [element] : String |
 | K.cs:13:14:13:23 | access to array element | semmle.label | access to array element |
 | K.cs:13:14:13:23 | access to array element | semmle.label | access to array element |
+| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property f1] : String |
+| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property f1] : String |
+| L.cs:13:17:13:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:13:17:13:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | semmle.label | access to local variable d1 : Object [dynamic property f1] : String |
+| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | semmle.label | access to local variable d1 : Object [dynamic property f1] : String |
+| L.cs:14:14:14:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
+| L.cs:14:14:14:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
+| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property f2] : String |
+| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property f2] : String |
+| L.cs:18:17:18:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:18:17:18:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
+| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
+| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
+| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
+| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
+| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
+| L.cs:20:14:20:18 | access to property f2 | semmle.label | access to property f2 |
+| L.cs:20:14:20:18 | access to property f2 | semmle.label | access to property f2 |
+| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | semmle.label | [post] this access : L [property f3] : String |
+| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | semmle.label | [post] this access : L [property f3] : String |
+| L.cs:23:19:23:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:23:19:23:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
+| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
+| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
+| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
+| L.cs:25:14:25:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
+| L.cs:25:14:25:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
@@ -2672,3 +2726,9 @@ testFailures
 | J.cs:125:14:125:17 | (...) ... | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:125:14:125:17 | (...) ... | $@ | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |
 | K.cs:13:14:13:23 | access to array element | K.cs:7:17:7:33 | call to method Source<String> : String | K.cs:13:14:13:23 | access to array element | $@ | K.cs:7:17:7:33 | call to method Source<String> : String | call to method Source<String> : String |
 | K.cs:13:14:13:23 | access to array element | K.cs:7:17:7:33 | call to method Source<String> : String | K.cs:13:14:13:23 | access to array element | $@ | K.cs:7:17:7:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:14:14:14:18 | dynamic access to member f1 | L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:14:14:14:18 | dynamic access to member f1 | $@ | L.cs:13:17:13:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:14:14:14:18 | dynamic access to member f1 | L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:14:14:14:18 | dynamic access to member f1 | $@ | L.cs:13:17:13:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:20:14:20:18 | access to property f2 | L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:20:14:20:18 | access to property f2 | $@ | L.cs:18:17:18:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:20:14:20:18 | access to property f2 | L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:20:14:20:18 | access to property f2 | $@ | L.cs:18:17:18:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:25:14:25:18 | dynamic access to member f3 | L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:25:14:25:18 | dynamic access to member f3 | $@ | L.cs:23:19:23:35 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:25:14:25:18 | dynamic access to member f3 | L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:25:14:25:18 | dynamic access to member f3 | $@ | L.cs:23:19:23:35 | call to method Source<String> : String | call to method Source<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1192,6 +1192,24 @@ edges
 | L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | provenance |  |
 | L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:18 | dynamic access to member f1 | provenance |  |
 | L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:18 | dynamic access to member f1 | provenance |  |
+| L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
+| L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
+| L.cs:38:17:38:33 | call to method Source<String> : String | L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | provenance |  |
+| L.cs:38:17:38:33 | call to method Source<String> : String | L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | provenance |  |
+| L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | provenance |  |
+| L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | provenance |  |
+| L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | provenance |  |
+| L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | provenance |  |
+| L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | L.cs:40:14:40:18 | access to field f2 | provenance |  |
+| L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | L.cs:40:14:40:18 | access to field f2 | provenance |  |
+| L.cs:43:9:43:12 | [post] this access : L [field f3] : String | L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | provenance |  |
+| L.cs:43:9:43:12 | [post] this access : L [field f3] : String | L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | provenance |  |
+| L.cs:43:19:43:35 | call to method Source<String> : String | L.cs:43:9:43:12 | [post] this access : L [field f3] : String | provenance |  |
+| L.cs:43:19:43:35 | call to method Source<String> : String | L.cs:43:9:43:12 | [post] this access : L [field f3] : String | provenance |  |
+| L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | provenance |  |
+| L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | provenance |  |
+| L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | L.cs:45:14:45:18 | dynamic access to member f3 | provenance |  |
+| L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | L.cs:45:14:45:18 | dynamic access to member f3 | provenance |  |
 nodes
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
@@ -2483,6 +2501,28 @@ nodes
 | L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | semmle.label | access to local variable d4 : Object [dynamic property f1] : String |
 | L.cs:34:14:34:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
 | L.cs:34:14:34:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
+| L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d5 : Object [dynamic property f2] : String |
+| L.cs:38:9:38:10 | [post] access to local variable d5 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d5 : Object [dynamic property f2] : String |
+| L.cs:38:17:38:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:38:17:38:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | semmle.label | access to local variable l5 : L [dynamic property f2] : String |
+| L.cs:39:11:39:12 | access to local variable l5 : L [dynamic property f2] : String | semmle.label | access to local variable l5 : L [dynamic property f2] : String |
+| L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
+| L.cs:39:16:39:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
+| L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | semmle.label | access to local variable l5 : L [dynamic property f2] : String |
+| L.cs:40:14:40:15 | access to local variable l5 : L [dynamic property f2] : String | semmle.label | access to local variable l5 : L [dynamic property f2] : String |
+| L.cs:40:14:40:18 | access to field f2 | semmle.label | access to field f2 |
+| L.cs:40:14:40:18 | access to field f2 | semmle.label | access to field f2 |
+| L.cs:43:9:43:12 | [post] this access : L [field f3] : String | semmle.label | [post] this access : L [field f3] : String |
+| L.cs:43:9:43:12 | [post] this access : L [field f3] : String | semmle.label | [post] this access : L [field f3] : String |
+| L.cs:43:19:43:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:43:19:43:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | semmle.label | access to local variable d6 : L [field f3] : String |
+| L.cs:44:17:44:18 | access to local variable d6 : L [field f3] : String | semmle.label | access to local variable d6 : L [field f3] : String |
+| L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | semmle.label | access to local variable d6 : L [field f3] : String |
+| L.cs:45:14:45:15 | access to local variable d6 : L [field f3] : String | semmle.label | access to local variable d6 : L [field f3] : String |
+| L.cs:45:14:45:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
+| L.cs:45:14:45:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
@@ -2748,3 +2788,7 @@ testFailures
 | L.cs:29:14:29:18 | dynamic access to member p3 | L.cs:27:19:27:35 | call to method Source<String> : String | L.cs:29:14:29:18 | dynamic access to member p3 | $@ | L.cs:27:19:27:35 | call to method Source<String> : String | call to method Source<String> : String |
 | L.cs:34:14:34:18 | dynamic access to member f1 | L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:34:14:34:18 | dynamic access to member f1 | $@ | L.cs:33:17:33:33 | call to method Source<String> : String | call to method Source<String> : String |
 | L.cs:34:14:34:18 | dynamic access to member f1 | L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:34:14:34:18 | dynamic access to member f1 | $@ | L.cs:33:17:33:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:40:14:40:18 | access to field f2 | L.cs:38:17:38:33 | call to method Source<String> : String | L.cs:40:14:40:18 | access to field f2 | $@ | L.cs:38:17:38:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:40:14:40:18 | access to field f2 | L.cs:38:17:38:33 | call to method Source<String> : String | L.cs:40:14:40:18 | access to field f2 | $@ | L.cs:38:17:38:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:45:14:45:18 | dynamic access to member f3 | L.cs:43:19:43:35 | call to method Source<String> : String | L.cs:45:14:45:18 | dynamic access to member f3 | $@ | L.cs:43:19:43:35 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:45:14:45:18 | dynamic access to member f3 | L.cs:43:19:43:35 | call to method Source<String> : String | L.cs:45:14:45:18 | dynamic access to member f3 | $@ | L.cs:43:19:43:35 | call to method Source<String> : String | call to method Source<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -1162,30 +1162,36 @@ edges
 | K.cs:8:22:8:22 | access to local variable o : String | K.cs:8:9:8:15 | [post] access to field Strings : String[] [element] : String | provenance |  |
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | K.cs:13:14:13:23 | access to array element | provenance |  |
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | K.cs:13:14:13:23 | access to array element | provenance |  |
-| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
-| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
-| L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
-| L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | provenance |  |
-| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:18 | dynamic access to member f1 | provenance |  |
-| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | L.cs:14:14:14:18 | dynamic access to member f1 | provenance |  |
-| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
-| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | provenance |  |
-| L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | provenance |  |
-| L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | provenance |  |
-| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
-| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
-| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
-| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | provenance |  |
-| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:18 | access to property f2 | provenance |  |
-| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | L.cs:20:14:20:18 | access to property f2 | provenance |  |
-| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | provenance |  |
-| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | provenance |  |
-| L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:23:9:23:12 | [post] this access : L [property f3] : String | provenance |  |
-| L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:23:9:23:12 | [post] this access : L [property f3] : String | provenance |  |
-| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | provenance |  |
-| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | provenance |  |
-| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:18 | dynamic access to member f3 | provenance |  |
-| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | L.cs:25:14:25:18 | dynamic access to member f3 | provenance |  |
+| L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | provenance |  |
+| L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | provenance |  |
+| L.cs:17:17:17:33 | call to method Source<String> : String | L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | provenance |  |
+| L.cs:17:17:17:33 | call to method Source<String> : String | L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | provenance |  |
+| L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | L.cs:18:14:18:18 | dynamic access to member p1 | provenance |  |
+| L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | L.cs:18:14:18:18 | dynamic access to member p1 | provenance |  |
+| L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | provenance |  |
+| L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | provenance |  |
+| L.cs:22:17:22:33 | call to method Source<String> : String | L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | provenance |  |
+| L.cs:22:17:22:33 | call to method Source<String> : String | L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | provenance |  |
+| L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | provenance |  |
+| L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | provenance |  |
+| L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | provenance |  |
+| L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | provenance |  |
+| L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | L.cs:24:14:24:18 | access to property p2 | provenance |  |
+| L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | L.cs:24:14:24:18 | access to property p2 | provenance |  |
+| L.cs:27:9:27:12 | [post] this access : L [property p3] : String | L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | provenance |  |
+| L.cs:27:9:27:12 | [post] this access : L [property p3] : String | L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | provenance |  |
+| L.cs:27:19:27:35 | call to method Source<String> : String | L.cs:27:9:27:12 | [post] this access : L [property p3] : String | provenance |  |
+| L.cs:27:19:27:35 | call to method Source<String> : String | L.cs:27:9:27:12 | [post] this access : L [property p3] : String | provenance |  |
+| L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | provenance |  |
+| L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | provenance |  |
+| L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | L.cs:29:14:29:18 | dynamic access to member p3 | provenance |  |
+| L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | L.cs:29:14:29:18 | dynamic access to member p3 | provenance |  |
+| L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | provenance |  |
+| L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:18 | dynamic access to member f1 | provenance |  |
+| L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | L.cs:34:14:34:18 | dynamic access to member f1 | provenance |  |
 nodes
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
 | A.cs:5:13:5:13 | access to local variable c : C | semmle.label | access to local variable c : C |
@@ -2439,36 +2445,44 @@ nodes
 | K.cs:13:14:13:20 | access to field Strings : String[] [element] : String | semmle.label | access to field Strings : String[] [element] : String |
 | K.cs:13:14:13:23 | access to array element | semmle.label | access to array element |
 | K.cs:13:14:13:23 | access to array element | semmle.label | access to array element |
-| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property f1] : String |
-| L.cs:13:9:13:10 | [post] access to local variable d1 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property f1] : String |
-| L.cs:13:17:13:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:13:17:13:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | semmle.label | access to local variable d1 : Object [dynamic property f1] : String |
-| L.cs:14:14:14:15 | access to local variable d1 : Object [dynamic property f1] : String | semmle.label | access to local variable d1 : Object [dynamic property f1] : String |
-| L.cs:14:14:14:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
-| L.cs:14:14:14:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
-| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property f2] : String |
-| L.cs:18:9:18:10 | [post] access to local variable d2 : Object [dynamic property f2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property f2] : String |
-| L.cs:18:17:18:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:18:17:18:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
-| L.cs:19:11:19:12 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
-| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
-| L.cs:19:16:19:17 | (...) ... : L [dynamic property f2] : String | semmle.label | (...) ... : L [dynamic property f2] : String |
-| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
-| L.cs:20:14:20:15 | access to local variable l2 : L [dynamic property f2] : String | semmle.label | access to local variable l2 : L [dynamic property f2] : String |
-| L.cs:20:14:20:18 | access to property f2 | semmle.label | access to property f2 |
-| L.cs:20:14:20:18 | access to property f2 | semmle.label | access to property f2 |
-| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | semmle.label | [post] this access : L [property f3] : String |
-| L.cs:23:9:23:12 | [post] this access : L [property f3] : String | semmle.label | [post] this access : L [property f3] : String |
-| L.cs:23:19:23:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:23:19:23:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
-| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
-| L.cs:24:17:24:18 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
-| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
-| L.cs:25:14:25:15 | access to local variable d3 : L [property f3] : String | semmle.label | access to local variable d3 : L [property f3] : String |
-| L.cs:25:14:25:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
-| L.cs:25:14:25:18 | dynamic access to member f3 | semmle.label | dynamic access to member f3 |
+| L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property p1] : String |
+| L.cs:17:9:17:10 | [post] access to local variable d1 : Object [dynamic property p1] : String | semmle.label | [post] access to local variable d1 : Object [dynamic property p1] : String |
+| L.cs:17:17:17:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:17:17:17:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | semmle.label | access to local variable d1 : Object [dynamic property p1] : String |
+| L.cs:18:14:18:15 | access to local variable d1 : Object [dynamic property p1] : String | semmle.label | access to local variable d1 : Object [dynamic property p1] : String |
+| L.cs:18:14:18:18 | dynamic access to member p1 | semmle.label | dynamic access to member p1 |
+| L.cs:18:14:18:18 | dynamic access to member p1 | semmle.label | dynamic access to member p1 |
+| L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property p2] : String |
+| L.cs:22:9:22:10 | [post] access to local variable d2 : Object [dynamic property p2] : String | semmle.label | [post] access to local variable d2 : Object [dynamic property p2] : String |
+| L.cs:22:17:22:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:22:17:22:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | semmle.label | access to local variable l2 : L [dynamic property p2] : String |
+| L.cs:23:11:23:12 | access to local variable l2 : L [dynamic property p2] : String | semmle.label | access to local variable l2 : L [dynamic property p2] : String |
+| L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | semmle.label | (...) ... : L [dynamic property p2] : String |
+| L.cs:23:16:23:17 | (...) ... : L [dynamic property p2] : String | semmle.label | (...) ... : L [dynamic property p2] : String |
+| L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | semmle.label | access to local variable l2 : L [dynamic property p2] : String |
+| L.cs:24:14:24:15 | access to local variable l2 : L [dynamic property p2] : String | semmle.label | access to local variable l2 : L [dynamic property p2] : String |
+| L.cs:24:14:24:18 | access to property p2 | semmle.label | access to property p2 |
+| L.cs:24:14:24:18 | access to property p2 | semmle.label | access to property p2 |
+| L.cs:27:9:27:12 | [post] this access : L [property p3] : String | semmle.label | [post] this access : L [property p3] : String |
+| L.cs:27:9:27:12 | [post] this access : L [property p3] : String | semmle.label | [post] this access : L [property p3] : String |
+| L.cs:27:19:27:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:27:19:27:35 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | semmle.label | access to local variable d3 : L [property p3] : String |
+| L.cs:28:17:28:18 | access to local variable d3 : L [property p3] : String | semmle.label | access to local variable d3 : L [property p3] : String |
+| L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | semmle.label | access to local variable d3 : L [property p3] : String |
+| L.cs:29:14:29:15 | access to local variable d3 : L [property p3] : String | semmle.label | access to local variable d3 : L [property p3] : String |
+| L.cs:29:14:29:18 | dynamic access to member p3 | semmle.label | dynamic access to member p3 |
+| L.cs:29:14:29:18 | dynamic access to member p3 | semmle.label | dynamic access to member p3 |
+| L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d4 : Object [dynamic property f1] : String |
+| L.cs:33:9:33:10 | [post] access to local variable d4 : Object [dynamic property f1] : String | semmle.label | [post] access to local variable d4 : Object [dynamic property f1] : String |
+| L.cs:33:17:33:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:33:17:33:33 | call to method Source<String> : String | semmle.label | call to method Source<String> : String |
+| L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | semmle.label | access to local variable d4 : Object [dynamic property f1] : String |
+| L.cs:34:14:34:15 | access to local variable d4 : Object [dynamic property f1] : String | semmle.label | access to local variable d4 : Object [dynamic property f1] : String |
+| L.cs:34:14:34:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
+| L.cs:34:14:34:18 | dynamic access to member f1 | semmle.label | dynamic access to member f1 |
 subpaths
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
 | A.cs:6:24:6:24 | access to local variable c : C | A.cs:147:32:147:32 | c : C | A.cs:149:20:149:27 | object creation of type B : B [field c] : C | A.cs:6:17:6:25 | call to method Make : B [field c] : C |
@@ -2726,9 +2740,11 @@ testFailures
 | J.cs:125:14:125:17 | (...) ... | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | J.cs:125:14:125:17 | (...) ... | $@ | J.cs:119:20:119:34 | call to method Source<Int32> : Int32 | call to method Source<Int32> : Int32 |
 | K.cs:13:14:13:23 | access to array element | K.cs:7:17:7:33 | call to method Source<String> : String | K.cs:13:14:13:23 | access to array element | $@ | K.cs:7:17:7:33 | call to method Source<String> : String | call to method Source<String> : String |
 | K.cs:13:14:13:23 | access to array element | K.cs:7:17:7:33 | call to method Source<String> : String | K.cs:13:14:13:23 | access to array element | $@ | K.cs:7:17:7:33 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:14:14:14:18 | dynamic access to member f1 | L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:14:14:14:18 | dynamic access to member f1 | $@ | L.cs:13:17:13:33 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:14:14:14:18 | dynamic access to member f1 | L.cs:13:17:13:33 | call to method Source<String> : String | L.cs:14:14:14:18 | dynamic access to member f1 | $@ | L.cs:13:17:13:33 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:20:14:20:18 | access to property f2 | L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:20:14:20:18 | access to property f2 | $@ | L.cs:18:17:18:33 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:20:14:20:18 | access to property f2 | L.cs:18:17:18:33 | call to method Source<String> : String | L.cs:20:14:20:18 | access to property f2 | $@ | L.cs:18:17:18:33 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:25:14:25:18 | dynamic access to member f3 | L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:25:14:25:18 | dynamic access to member f3 | $@ | L.cs:23:19:23:35 | call to method Source<String> : String | call to method Source<String> : String |
-| L.cs:25:14:25:18 | dynamic access to member f3 | L.cs:23:19:23:35 | call to method Source<String> : String | L.cs:25:14:25:18 | dynamic access to member f3 | $@ | L.cs:23:19:23:35 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:18:14:18:18 | dynamic access to member p1 | L.cs:17:17:17:33 | call to method Source<String> : String | L.cs:18:14:18:18 | dynamic access to member p1 | $@ | L.cs:17:17:17:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:18:14:18:18 | dynamic access to member p1 | L.cs:17:17:17:33 | call to method Source<String> : String | L.cs:18:14:18:18 | dynamic access to member p1 | $@ | L.cs:17:17:17:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:24:14:24:18 | access to property p2 | L.cs:22:17:22:33 | call to method Source<String> : String | L.cs:24:14:24:18 | access to property p2 | $@ | L.cs:22:17:22:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:24:14:24:18 | access to property p2 | L.cs:22:17:22:33 | call to method Source<String> : String | L.cs:24:14:24:18 | access to property p2 | $@ | L.cs:22:17:22:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:29:14:29:18 | dynamic access to member p3 | L.cs:27:19:27:35 | call to method Source<String> : String | L.cs:29:14:29:18 | dynamic access to member p3 | $@ | L.cs:27:19:27:35 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:29:14:29:18 | dynamic access to member p3 | L.cs:27:19:27:35 | call to method Source<String> : String | L.cs:29:14:29:18 | dynamic access to member p3 | $@ | L.cs:27:19:27:35 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:34:14:34:18 | dynamic access to member f1 | L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:34:14:34:18 | dynamic access to member f1 | $@ | L.cs:33:17:33:33 | call to method Source<String> : String | call to method Source<String> : String |
+| L.cs:34:14:34:18 | dynamic access to member f1 | L.cs:33:17:33:33 | call to method Source<String> : String | L.cs:34:14:34:18 | dynamic access to member f1 | $@ | L.cs:33:17:33:33 | call to method Source<String> : String | call to method Source<String> : String |

--- a/csharp/ql/test/library-tests/dataflow/fields/L.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/L.cs
@@ -1,0 +1,31 @@
+using System;
+
+public class L
+{
+    public string f1 { get; set; }
+    public string f2 { get; set; }
+    public string f3 { get; set; }
+
+    private void M1()
+    {
+        // dynamic write followed by dynamic read
+        dynamic d1 = this;
+        d1.f1 = Source<string>(1);
+        Sink(d1.f1); // $ MISSING: hasValueFlow=1
+
+        // dynamic write followed by static read
+        dynamic d2 = this;
+        d2.f2 = Source<string>(2);
+        L l2 = d2;
+        Sink(l2.f2); // $ MISSING: hasValueFlow=2
+
+        // static write followed by dynamic read
+        this.f3 = Source<string>(3);
+        dynamic d3 = this;
+        Sink(d3.f3); // $ MISSING: hasValueFlow=3
+    }
+
+    public static void Sink(object o) { }
+
+    static T Source<T>(object source) => throw null;
+}

--- a/csharp/ql/test/library-tests/dataflow/fields/L.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/L.cs
@@ -2,27 +2,47 @@ using System;
 
 public class L
 {
-    public string f1 { get; set; }
-    public string f2 { get; set; }
-    public string f3 { get; set; }
+    public string p1 { get; set; }
+    public string p2 { get; set; }
+    public string p3 { get; set; }
+    
+    private string f1;
+    private string f2;
+    private string f3;
 
     private void M1()
     {
-        // dynamic write followed by dynamic read
+        // dynamic property write followed by dynamic property read
         dynamic d1 = this;
-        d1.f1 = Source<string>(1);
-        Sink(d1.f1); // $ hasValueFlow=1
+        d1.p1 = Source<string>(1);
+        Sink(d1.p1); // $ hasValueFlow=1
 
-        // dynamic write followed by static read
+        // dynamic property write followed by static property read
         dynamic d2 = this;
-        d2.f2 = Source<string>(2);
+        d2.p2 = Source<string>(2);
         L l2 = d2;
-        Sink(l2.f2); // $ hasValueFlow=2
+        Sink(l2.p2); // $ hasValueFlow=2
 
-        // static write followed by dynamic read
-        this.f3 = Source<string>(3);
+        // static property write followed by dynamic property read
+        this.p3 = Source<string>(3);
         dynamic d3 = this;
-        Sink(d3.f3); // $ hasValueFlow=3
+        Sink(d3.p3); // $ hasValueFlow=3
+
+        // dynamic property write followed by dynamic field read
+        dynamic d4 = this;
+        d4.f1 = Source<string>(4);
+        Sink(d4.f1); // $ hasValueFlow=4
+
+        // dynamic property write followed by static field read
+        dynamic d5 = this;
+        d5.f2 = Source<string>(5);
+        L l5 = d5;
+        Sink(l5.f2); // $ MISSING: hasValueFlow=5
+
+        // static field write followed by dynamic property read
+        this.f3 = Source<string>(6);
+        dynamic d6 = this;
+        Sink(d6.f3); // $ MISSING: hasValueFlow=6
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/L.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/L.cs
@@ -37,12 +37,12 @@ public class L
         dynamic d5 = this;
         d5.f2 = Source<string>(5);
         L l5 = d5;
-        Sink(l5.f2); // $ MISSING: hasValueFlow=5
+        Sink(l5.f2); // $ hasValueFlow=5
 
         // static field write followed by dynamic property read
         this.f3 = Source<string>(6);
         dynamic d6 = this;
-        Sink(d6.f3); // $ MISSING: hasValueFlow=6
+        Sink(d6.f3); // $ hasValueFlow=6
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/L.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/L.cs
@@ -11,18 +11,18 @@ public class L
         // dynamic write followed by dynamic read
         dynamic d1 = this;
         d1.f1 = Source<string>(1);
-        Sink(d1.f1); // $ MISSING: hasValueFlow=1
+        Sink(d1.f1); // $ hasValueFlow=1
 
         // dynamic write followed by static read
         dynamic d2 = this;
         d2.f2 = Source<string>(2);
         L l2 = d2;
-        Sink(l2.f2); // $ MISSING: hasValueFlow=2
+        Sink(l2.f2); // $ hasValueFlow=2
 
         // static write followed by dynamic read
         this.f3 = Source<string>(3);
         dynamic d3 = this;
-        Sink(d3.f3); // $ MISSING: hasValueFlow=3
+        Sink(d3.f3); // $ hasValueFlow=3
     }
 
     public static void Sink(object o) { }


### PR DESCRIPTION
This PR adds a new kind of `Content` to track flow through dynamic members. For example:
```csharp
dynamic d = ...;
d.Foo = Source();
Sink(d.Foo);
```
since `d` is a `dynamic` the property access `Foo` is not a `FieldOrPropertyAccess` and thus needs special handling.