### PR TITLE
C++: Fix more FPs with extraction errors on cpp/wrong-type-format-arguments

### DIFF
--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -171,6 +171,10 @@ where
   not arg.isAffectedByMacro() and
   not arg.isFromUninstantiatedTemplate(_) and
   not actual.getUnspecifiedType() instanceof ErroneousType and
+  not (
+    expected instanceof PointerType and
+    actual.getUnspecifiedType().(PointerType).getBaseType() instanceof ErroneousType
+  ) and
   not arg.(Call).mayBeFromImplicitlyDeclaredFunction()
 select arg,
   "This format specifier for type '" + expected.getName() + "' does not match the argument type '" +

--- a/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Format/WrongTypeFormatArguments.ql
@@ -170,11 +170,7 @@ where
   ) and
   not arg.isAffectedByMacro() and
   not arg.isFromUninstantiatedTemplate(_) and
-  not actual.getUnspecifiedType() instanceof ErroneousType and
-  not (
-    expected instanceof PointerType and
-    actual.getUnspecifiedType().(PointerType).getBaseType() instanceof ErroneousType
-  ) and
+  not actual.stripType() instanceof ErroneousType and
   not arg.(Call).mayBeFromImplicitlyDeclaredFunction()
 select arg,
   "This format specifier for type '" + expected.getName() + "' does not match the argument type '" +

--- a/cpp/ql/src/change-notes/2024-12-05-wrong-type-format-args.md
+++ b/cpp/ql/src/change-notes/2024-12-05-wrong-type-format-args.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The "Wrong type of arguments to formatting function" query (`cpp/wrong-type-format-argument`) query no longer produces results when a string type has an extraction error.
+* The "Wrong type of arguments to formatting function" query (`cpp/wrong-type-format-argument`) no longer produces results when an argument type has an extraction error.

--- a/cpp/ql/src/change-notes/2024-12-05-wrong-type-format-args.md
+++ b/cpp/ql/src/change-notes/2024-12-05-wrong-type-format-args.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Wrong type of arguments to formatting function" query (`cpp/wrong-type-format-argument`) query no longer produces results when a string type has an extraction error.

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/WrongTypeFormatArguments.expected
@@ -1,2 +1,1 @@
 | tests.c:7:18:7:18 | 1 | This format specifier for type 'char *' does not match the argument type 'int'. |
-| tests.c:11:18:11:20 | str | This format specifier for type 'char *' does not match the argument type '<error-type> *'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/WrongTypeFormatArguments.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/WrongTypeFormatArguments.expected
@@ -1,1 +1,2 @@
 | tests.c:7:18:7:18 | 1 | This format specifier for type 'char *' does not match the argument type 'int'. |
+| tests.c:11:18:11:20 | str | This format specifier for type 'char *' does not match the argument type '<error-type> *'. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/tests.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Format/WrongTypeFormatArguments/Buildless/tests.c
@@ -3,9 +3,10 @@
 int printf(const char * format, ...);
 int fprintf();
 
-void f() {
+void f(UNKNOWN_CHAR * str) {
     printf("%s", 1); // BAD
     printf("%s", implicit_function()); // GOOD - we should ignore the type
     sprintf(0, "%s", ""); // GOOD
     fprintf(0, "%s", ""); // GOOD
+    printf("%s", str); // GOOD - erroneous type is ignored
 }


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
