### PR TITLE
Go: Fix some spurious results in ExternalFlowInheritance tests

### DIFF
--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/test_fields.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/test_fields.go
@@ -6,12 +6,12 @@ import (
 
 func TestFieldsP1(t test.P1) {
 	a := t.SourceField
-	t.SinkField = a // $ P1[f] P1[t] ql_P1 SPURIOUS: ql_S1
+	t.SinkField = a // $ P1[f] P1[t] ql_P1
 }
 
 func TestFieldsS1(t test.S1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[f] S1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[f] S1[t] ql_S1
 }
 
 func TestFieldsSEmbedI1(t test.SEmbedI1) {
@@ -31,22 +31,22 @@ func TestFieldsPImplEmbedI1(t test.PImplEmbedI1) {
 
 func TestFieldsSEmbedP1(t test.SEmbedP1) {
 	a := t.SourceField
-	t.SinkField = a // $ P1[t] SEmbedP1[t] ql_P1 SPURIOUS: ql_S1
+	t.SinkField = a // $ P1[t] SEmbedP1[t] ql_P1
 }
 
 func TestFieldsSEmbedS1(t test.SEmbedS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1
 }
 
 func TestFieldsSEmbedPtrP1(t test.SEmbedPtrP1) {
 	a := t.SourceField
-	t.SinkField = a // $ P1[t] SEmbedPtrP1[t] ql_P1 SPURIOUS: ql_S1
+	t.SinkField = a // $ P1[t] SEmbedPtrP1[t] ql_P1
 }
 
 func TestFieldsSEmbedPtrS1(t test.SEmbedPtrS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1
 }
 
 func TestFieldsSImplEmbedS1(t test.SImplEmbedS1) {
@@ -61,25 +61,25 @@ func TestFieldsSEmbedSEmbedI1(t test.SEmbedSEmbedI1) {
 
 func TestFieldsSEmbedSEmbedS1(t test.SEmbedSEmbedS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1
 }
 
 func TestFieldsSEmbedSEmbedPtrS1(t test.SEmbedSEmbedPtrS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1
 }
 
 func TestFieldsSEmbedPtrSEmbedS1(t test.SEmbedPtrSEmbedS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedS1[t] ql_S1
 }
 
 func TestFieldsSEmbedPtrSEmbedPtrS1(t test.SEmbedPtrSEmbedPtrS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] SEmbedPtrS1[t] ql_S1
 }
 
 func TestFieldsSEmbedS1AndSEmbedS1(t test.SEmbedS1AndSEmbedS1) {
 	a := t.SourceField
-	t.SinkField = a // $ S1[t] ql_S1 SPURIOUS: ql_P1
+	t.SinkField = a // $ S1[t] ql_S1
 }

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/vendor/github.com/nonexistent/test/stub.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalFlowInheritance/vendor/github.com/nonexistent/test/stub.go
@@ -17,8 +17,9 @@ type I2 interface {
 
 // A struct type implementing I1
 type S1 struct {
-	SourceField string
-	SinkField   string
+	SourceField   string
+	SinkField     string
+	UniqueFieldS1 int // this only exists to make this struct type different from other struct types
 }
 
 func (t S1) Source() interface{} {
@@ -33,8 +34,9 @@ func (t S1) Step(val interface{}) interface{} {
 
 // A struct type whose pointer type implements I1
 type P1 struct {
-	SourceField string
-	SinkField   string
+	SourceField   string
+	SinkField     string
+	UniqueFieldP1 int // this only exists to make this struct type different from other struct types
 }
 
 func (t *P1) Source() interface{} {
@@ -48,7 +50,9 @@ func (t *P1) Step(val interface{}) interface{} {
 }
 
 // A struct type implementing I2
-type S2 struct{}
+type S2 struct {
+	UniqueFieldS2 int // this only exists to make this struct type different from other struct types
+}
 
 func (t S2) Source() interface{} {
 	return nil
@@ -80,8 +84,9 @@ func (t *P2) ExtraMethodI2() {}
 // A struct type embedding I1
 type SEmbedI1 struct {
 	I1
-	SourceField string
-	SinkField   string
+	SourceField         string
+	SinkField           string
+	UniqueFieldSEmbedI1 int // this only exists to make this struct type different from other struct types
 }
 
 // A struct type embedding I2
@@ -103,8 +108,9 @@ type IEmbedI2 interface {
 // methods of the embedded field are not promoted.
 type SImplEmbedI1 struct {
 	I1
-	SourceField string
-	SinkField   string
+	SourceField             string
+	SinkField               string
+	UniqueFieldSImplEmbedI1 int // this only exists to make this struct type different from other struct types
 }
 
 func (t SImplEmbedI1) Source() interface{} {
@@ -119,7 +125,10 @@ func (t SImplEmbedI1) Step(val interface{}) interface{} {
 
 // A struct type embedding I2 and separately implementing its methods, so the
 // methods of the embedded field are not promoted.
-type SImplEmbedI2 struct{ I2 }
+type SImplEmbedI2 struct {
+	I2
+	UniqueFieldSImplEmbedI2 int // this only exists to make this struct type different from other struct types
+}
 
 func (t SImplEmbedI2) Source() interface{} {
 	return nil
@@ -137,8 +146,9 @@ func (t SImplEmbedI2) ExtraMethodI2() {}
 // pointer type, so the methods of the embedded field are not promoted.
 type PImplEmbedI1 struct {
 	I1
-	SourceField string
-	SinkField   string
+	SourceField             string
+	SinkField               string
+	UniqueFieldPImplEmbedI1 int // this only exists to make this struct type different from other struct types
 }
 
 func (t *PImplEmbedI1) Source() interface{} {
@@ -195,8 +205,9 @@ type SEmbedPtrP2 struct{ *P2 }
 // fields, so the methods and fields of the embedded field are not promoted.
 type SImplEmbedS1 struct {
 	S1
-	SourceField string
-	SinkField   string
+	SourceField             string
+	SinkField               string
+	UniqueFieldSImplEmbedS1 int // this only exists to make this struct type different from other struct types
 }
 
 func (t *SImplEmbedS1) Source() interface{} {
@@ -211,7 +222,10 @@ func (t *SImplEmbedS1) Step(val interface{}) interface{} {
 
 // A struct type embedding S2 and separately implementing I2's methods, so the
 // methods of the embedded field are not promoted.
-type SImplEmbedS2 struct{ S2 }
+type SImplEmbedS2 struct {
+	S2
+	UniqueFieldSImplEmbedS2 int // this only exists to make this struct type different from other struct types
+}
 
 func (t *SImplEmbedS2) Source() interface{} {
 	return nil
@@ -228,8 +242,9 @@ func (t *SImplEmbedS2) ExtraMethodI2() {}
 // A struct type embedding SEmbedI1
 type SEmbedSEmbedI1 struct {
 	SEmbedI1
-	SourceField string
-	SinkField   string
+	SourceField               string
+	SinkField                 string
+	UniqueFieldSEmbedSEmbedI1 int // this only exists to make this struct type different from other struct types
 }
 
 // A struct type embedding SEmbedS1
@@ -248,4 +263,5 @@ type SEmbedPtrSEmbedPtrS1 struct{ *SEmbedPtrS1 }
 type SEmbedS1AndSEmbedS1 struct {
 	S1
 	SEmbedS1
+	UniqueFieldSEmbedS1AndSEmbedS1 int // this only exists to make this struct type different from other struct types
 }


### PR DESCRIPTION
Trivial change to some tests to fix some spurious results.