### PR TITLE
C#: Narrow pattern types

### DIFF
--- a/csharp/.vscode/launch.json
+++ b/csharp/.vscode/launch.json
@@ -75,6 +75,7 @@
             "env": {},
             "stopAtEntry": true,
             "justMyCode": false,
+            "requireExactSource": false,
             "suppressJITOptimizations": true
         },
     ]

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/Pattern.cs
@@ -28,20 +28,20 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 case DeclarationPatternSyntax declPattern:
                     // Creates a single local variable declaration.
                     {
-                        if (declPattern.Designation is VariableDesignationSyntax designation)
+                        switch (declPattern.Designation)
                         {
-                            if (cx.GetModel(syntax).GetDeclaredSymbol(designation) is ILocalSymbol symbol)
-                            {
-                                var type = symbol.GetAnnotatedType();
-                                return VariableDeclaration.Create(cx, symbol, type, declPattern.Type, cx.CreateLocation(syntax.GetLocation()), false, parent, child);
-                            }
-                            if (designation is DiscardDesignationSyntax)
-                            {
+                            case SingleVariableDesignationSyntax singleDesignation:
+                                if (cx.GetModel(syntax).GetDeclaredSymbol(singleDesignation) is ILocalSymbol symbol)
+                                {
+                                    var type = symbol.GetAnnotatedType();
+                                    return VariableDeclaration.Create(cx, symbol, type, declPattern.Type, cx.CreateLocation(syntax.GetLocation()), false, parent, child);
+                                }
+                                throw new InternalError(singleDesignation, "Unable to get the declared symbol of the declaration pattern designation.");
+                            case DiscardDesignationSyntax _:
                                 return Expressions.TypeAccess.Create(cx, declPattern.Type, parent, child);
-                            }
-                            throw new InternalError(designation, "Designation pattern not handled");
+                            default:
+                                throw new InternalError($"declaration pattern designation of type {declPattern.Designation.GetType()} is unhandled");
                         }
-                        throw new InternalError(declPattern, "Declaration pattern not handled");
                     }
 
                 case RecursivePatternSyntax recPattern:
@@ -59,7 +59,6 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                             if (cx.GetModel(syntax).GetDeclaredSymbol(varDesignation) is ILocalSymbol symbol)
                             {
                                 var type = symbol.GetAnnotatedType();
-
                                 return VariableDeclaration.Create(cx, symbol, type, null, cx.CreateLocation(syntax.GetLocation()), true, parent, child);
                             }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Patterns/RecursivePattern.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                 Expressions.TypeAccess.Create(cx, t, this, 1);
 
             // Extract the local variable declaration
-            if (syntax.Designation is VariableDesignationSyntax designation && cx.GetModel(syntax).GetDeclaredSymbol(designation) is ILocalSymbol symbol)
+            if (syntax.Designation is SingleVariableDesignationSyntax designation && cx.GetModel(syntax).GetDeclaredSymbol(designation) is ILocalSymbol symbol)
             {
                 var type = symbol.GetAnnotatedType();
 


### PR DESCRIPTION
In this PR we narrow types used for pattern matching for patterns in the extractor (when it comes to variable designation syntax). Otherwise we get a compiler warning when we update Roslyn.

DCA looks good.