### PR TITLE
Java: add File.getName as a path injection sanitizer

### DIFF
--- a/java/ql/lib/change-notes/2024-12-06-file-getname.md
+++ b/java/ql/lib/change-notes/2024-12-06-file-getname.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added `java.io.File.getName()` as a path injection sanitizer.

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -333,3 +333,18 @@ private Method getSourceMethod(Method m) {
   not exists(Method src | m = src.getKotlinParameterDefaultsProxy()) and
   result = m
 }
+
+/**
+ * A sanitizer that protects against path injection vulnerabilities
+ * by extracting the final component of the user provided path.
+ *
+ * TODO: convert this class to models-as-data if sanitizer support is added
+ */
+private class FileGetNameSanitizer extends PathInjectionSanitizer {
+  FileGetNameSanitizer() {
+    exists(MethodCall mc |
+      mc.getMethod().hasQualifiedName("java.io", "File", "getName") and
+      this.asExpr() = mc
+    )
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
@@ -71,4 +71,19 @@ public class TaintedPath {
             fileLine = fileReader.readLine();
         }
     }
+
+    public void sendUserFileGood4(Socket sock, String user) throws IOException {
+        BufferedReader filenameReader =
+                new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
+        String filename = filenameReader.readLine();
+        File file = new File(filename);
+        String baseName = file.getName();
+        // GOOD: only use the final component of the user provided path
+        BufferedReader fileReader = new BufferedReader(new FileReader(baseName));
+        String fileLine = fileReader.readLine();
+        while (fileLine != null) {
+            sock.getOutputStream().write(fileLine.getBytes());
+            fileLine = fileReader.readLine();
+        }
+    }
 }


### PR DESCRIPTION
Adds `java.io.File.getName` as a path injection sanitizer. 

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.

#### Internal query authors only

- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
