### PR TITLE
C++: Fix FPs in cpp/badly-bounded-write caused by extraction errors

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -25,7 +25,8 @@ from BufferWrite bw, int destSize
 where
   bw.hasExplicitLimit() and // has an explicit size limit
   destSize = max(getBufferSize(bw.getDest(), _)) and
-  bw.getExplicitLimit() > destSize // but it's larger than the destination
+  bw.getExplicitLimit() > destSize and // but it's larger than the destination
+  not bw.getDest().getUnderlyingType().stripType() instanceof ErroneousType // destSize may be incorrect
 select bw,
   "This '" + bw.getBWDesc() + "' operation is limited to " + bw.getExplicitLimit() +
     " bytes but the destination is only " + destSize + " bytes."

--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -26,7 +26,7 @@ where
   bw.hasExplicitLimit() and // has an explicit size limit
   destSize = max(getBufferSize(bw.getDest(), _)) and
   bw.getExplicitLimit() > destSize and // but it's larger than the destination
-  not bw.getDest().getUnderlyingType().stripType() instanceof ErroneousType // destSize may be incorrect
+  not bw.getDest().getType().stripType() instanceof ErroneousType // destSize may be incorrect
 select bw,
   "This '" + bw.getBWDesc() + "' operation is limited to " + bw.getExplicitLimit() +
     " bytes but the destination is only " + destSize + " bytes."

--- a/cpp/ql/src/change-notes/2024-12-05-badly-bounded-write.md
+++ b/cpp/ql/src/change-notes/2024-12-05-badly-bounded-write.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The "Badly bounded write" query (`cpp/badly-bounded-write`) query no longer produces results if there is an extraction error in the type of the output buffer.

--- a/cpp/ql/src/change-notes/2024-12-05-badly-bounded-write.md
+++ b/cpp/ql/src/change-notes/2024-12-05-badly-bounded-write.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* The "Badly bounded write" query (`cpp/badly-bounded-write`) query no longer produces results if there is an extraction error in the type of the output buffer.
+* The "Badly bounded write" query (`cpp/badly-bounded-write`) no longer produces results if there is an extraction error in the type of the output buffer.

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
@@ -1,3 +1,2 @@
-| errors.c:10:5:10:12 | call to swprintf | This 'call to swprintf' operation is limited to 12 bytes but the destination is only 3 bytes. |
 | tests.c:43:3:43:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |
 | tests.c:46:3:46:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/BadlyBoundedWrite.expected
@@ -1,2 +1,3 @@
+| errors.c:10:5:10:12 | call to swprintf | This 'call to swprintf' operation is limited to 12 bytes but the destination is only 3 bytes. |
 | tests.c:43:3:43:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |
 | tests.c:46:3:46:10 | call to snprintf | This 'call to snprintf' operation is limited to 111 bytes but the destination is only 110 bytes. |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/errors.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-120/semmle/tests/errors.c
@@ -1,0 +1,11 @@
+// semmle-extractor-options: --expect_errors
+
+typedef unsigned long size_t;
+typedef int wchar_t;
+
+int swprintf(wchar_t *s, size_t n, const wchar_t *format, ...);
+
+void test_extraction_errors() {
+    WCHAR buffer[3];
+    swprintf(buffer, 3, L"abc");
+}


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
