### PR TITLE
C++: Fix two bad joins in barrier guards

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2275,6 +2275,12 @@ private predicate guardControlsPhiInput(
  */
 signature predicate guardChecksSig(IRGuardCondition g, Expr e, boolean branch);
 
+bindingset[g, n]
+pragma[inline_late]
+private predicate controls(IRGuardCondition g, Node n, boolean edge) {
+  g.controls(n.getBasicBlock(), edge)
+}
+
 /**
  * Provides a set of barrier nodes for a guard that validates an expression.
  *
@@ -2318,15 +2324,17 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     exists(IRGuardCondition g, Expr e, ValueNumber value, boolean edge |
       e = value.getAnInstruction().getConvertedResultExpression() and
       result.asConvertedExpr() = e and
-      guardChecks(g, value.getAnInstruction().getConvertedResultExpression(), edge) and
-      g.controls(result.getBasicBlock(), edge)
+      guardChecks(g,
+        pragma[only_bind_into](value.getAnInstruction().getConvertedResultExpression()), edge) and
+      controls(g, result, edge)
     )
     or
     exists(
       IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input, Ssa::PhiNode phi
     |
       guardChecks(g, def.getARead().asOperand().getDef().getConvertedResultExpression(), branch) and
-      guardControlsPhiInput(g, branch, def, input, phi) and
+      guardControlsPhiInput(g, branch, def, pragma[only_bind_into](input),
+        pragma[only_bind_into](phi)) and
       result = TSsaPhiInputNode(phi, input)
     )
   }
@@ -2404,8 +2412,9 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     exists(IRGuardCondition g, Expr e, ValueNumber value, boolean edge |
       e = value.getAnInstruction().getConvertedResultExpression() and
       result.asIndirectConvertedExpr(indirectionIndex) = e and
-      guardChecks(g, value.getAnInstruction().getConvertedResultExpression(), edge) and
-      g.controls(result.getBasicBlock(), edge)
+      guardChecks(g,
+        pragma[only_bind_into](value.getAnInstruction().getConvertedResultExpression()), edge) and
+      controls(g, result, edge)
     )
     or
     exists(
@@ -2414,7 +2423,8 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
       guardChecks(g,
         def.getARead().asIndirectOperand(indirectionIndex).getDef().getConvertedResultExpression(),
         branch) and
-      guardControlsPhiInput(g, branch, def, input, phi) and
+      guardControlsPhiInput(g, branch, def, pragma[only_bind_into](input),
+        pragma[only_bind_into](phi)) and
       result = TSsaPhiInputNode(phi, input)
     )
   }
@@ -2443,17 +2453,18 @@ module InstructionBarrierGuard<instructionGuardChecksSig/3 instructionGuardCheck
   /** Gets a node that is safely guarded by the given guard check. */
   Node getABarrierNode() {
     exists(IRGuardCondition g, ValueNumber value, boolean edge, Operand use |
-      instructionGuardChecks(g, value.getAnInstruction(), edge) and
+      instructionGuardChecks(g, pragma[only_bind_into](value.getAnInstruction()), edge) and
       use = value.getAnInstruction().getAUse() and
       result.asOperand() = use and
-      g.controls(result.getBasicBlock(), edge)
+      controls(g, result, edge)
     )
     or
     exists(
       IRGuardCondition g, boolean branch, Ssa::DefinitionExt def, IRBlock input, Ssa::PhiNode phi
     |
       instructionGuardChecks(g, def.getARead().asOperand().getDef(), branch) and
-      guardControlsPhiInput(g, branch, def, input, phi) and
+      guardControlsPhiInput(g, branch, def, pragma[only_bind_into](input),
+        pragma[only_bind_into](phi)) and
       result = TSsaPhiInputNode(phi, input)
     )
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -1276,6 +1276,7 @@ class DefinitionExt extends SsaImpl::DefinitionExt {
   }
 
   /** Gets a node that represents a read of this SSA definition. */
+  pragma[nomagic]
   Node getARead() {
     exists(SourceVariable sv, IRBlock bb, int i | SsaCached::ssaDefReachesReadExt(sv, this, bb, i) |
       useToNode(bb, i, sv, result)


### PR DESCRIPTION
Observed during QA of https://github.com/github/codeql/pull/18207.

Before (on #18207):
```ql
[2024-12-06 12:46:11] Evaluated non-recursive predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@eee4e50o in 695949ms (size: 10004).
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@eee4e50o with tuple counts:
     322600    ~0%    {2} r1 = JOIN `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  483600582    ~0%    {2}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  467900586    ~0%    {2}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  467768453    ~7%    {2}    | JOIN WITH `project#ExprNodes::ExprNode.getConvertedExpr/1#dispred#04e26388_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  467773635   ~12%    {3}    | JOIN WITH `project#DataFlowUtil::Node.hasIndexInBlock/2#4ca72ac1` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0
11948631477   ~10%    {4}    | JOIN WITH `IRGuards::IRGuardCondition.controls/2#dispred#a7389eda_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2, Lhs.2
      72683  ~810%    {1}    | JOIN WITH `UnboundedWrite::lessThanOrEqual/3#4e4dda57` ON FIRST 3 OUTPUT Lhs.3
                  
     218983    ~1%    {3} r2 = SCAN DataFlowUtil::TSsaPhiInputNode#d9cd78c6 OUTPUT In.1, In.0, In.2
    5691923    ~1%    {4}    | JOIN WITH `DataFlowUtil::guardControlsPhiInput/5#50adc50d_34012#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Rhs.3, Lhs.2, Rhs.4
    9261053    ~1%    {3}    | JOIN WITH `UnboundedWrite::lessThanOrEqual/3#4e4dda57_021#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Lhs.2, Lhs.3
    5991776    ~2%    {3}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
    5991754    ~0%    {3}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
    5991738    ~1%    {3}    | JOIN WITH DataFlowUtil::OperandNode#3e3b23f6_20#join_rhs ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Rhs.1
76562240430    ~0%    {5}    | JOIN WITH `SsaInternals::ssaDefReachesReadExt/4#0fbc7cab_1023#join_rhs` ON FIRST 1 OUTPUT Rhs.2, Rhs.3, Rhs.1, Lhs.2, Lhs.1
       4324  ~184%    {1}    | JOIN WITH `SsaInternals::useToNode/4#96395582` ON FIRST 4 OUTPUT Lhs.4
                  
      77007  ~708%    {1} r3 = r1 UNION r2
                      return r3
```

After:
```ql
[2024-12-06 15:11:43] Evaluated non-recursive predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@9bfd6d2f in 456ms (size: 10004).
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@9bfd6d2f with tuple counts:
  494346    ~0%    {2} r1 = JOIN DataFlowUtil::OperandNode#3e3b23f6_20#join_rhs WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  326435    ~0%    {2}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
  132421    ~5%    {2}    | JOIN WITH `SsaInternals::DefinitionExt.getARead/0#0429944e_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
   11306   ~15%    {3}    | JOIN WITH `UnboundedWrite::lessThanOrEqual/3#4e4dda57_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1
    1757    ~7%    {2}    | JOIN WITH `DataFlowUtil::guardControlsPhiInput/5#50adc50d` ON FIRST 3 OUTPUT Rhs.4, Rhs.3
    1669    ~9%    {1}    | JOIN WITH DataFlowUtil::TSsaPhiInputNode#d9cd78c6 ON FIRST 2 OUTPUT Rhs.2
               
  138362    ~0%    {3} r2 = JOIN `UnboundedWrite::lessThanOrEqual/3#4e4dda57_102#join_rhs` WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
  138362  ~565%    {3}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
32309466  ~849%    {3}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
30802905  ~840%    {3}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
28124921  ~758%    {3}    | JOIN WITH `project#ExprNodes::ExprNode.getConvertedExpr/1#dispred#04e26388_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
28125285  ~728%    {4}    | JOIN WITH `project#DataFlowUtil::Node.hasIndexInBlock/2#4ca72ac1` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2, Lhs.0
   66856  ~684%    {1}    | JOIN WITH `IRGuards::IRGuardCondition.controls/2#dispred#a7389eda` ON FIRST 3 OUTPUT Lhs.3
               
   68525  ~567%    {1} r3 = r1 UNION r2
                   return r3
```