### PR TITLE
C#: Clean up dependencies Newtonsoft.Json.

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/BUILD.bazel
@@ -17,6 +17,5 @@ codeql_csharp_binary(
         "//csharp/extractor/Semmle.Extraction.CSharp.Standalone:bin/Semmle.Extraction.CSharp.Standalone",
         "//csharp/extractor/Semmle.Util",
         "@paket.main//microsoft.build",
-        "@paket.main//newtonsoft.json",
     ],
 )

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/paket.references
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/paket.references
@@ -1,2 +1,1 @@
-Newtonsoft.Json
 Microsoft.Build

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
@@ -11,10 +11,10 @@ codeql_csharp_library(
     ]),
     allow_unsafe_blocks = True,
     internals_visible_to = ["Semmle.Extraction.Tests"],
-    nowarn = ["CA1822"],
     visibility = ["//csharp:__subpackages__"],
     deps = [
         "//csharp/extractor/Semmle.Extraction.CSharp",
         "//csharp/extractor/Semmle.Util",
+        "@paket.main//newtonsoft.json",
     ],
 )

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/paket.references
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/paket.references
@@ -1,0 +1,1 @@
+Newtonsoft.Json


### PR DESCRIPTION
Besides cleaning up the dependencies for `Newtonsoft.Json` we also remove `nowarn` from `Build.bazel` in the Dependency fetching project, as it appears to override what is in the project file. Note that in the project file the *default* `NoWarn` is included, which also includes the *global* *default* `NoWarn` for warning 1701 and 1702 (We got a 1702 compiler warning for the dependency fetching project).
This was the last remaining compiler warning.