### PR TITLE
Rust: Add % of files extracted without errors to summary stats.

### DIFF
--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -5,6 +5,7 @@
 | Files extracted - total | 5 |
 | Files extracted - with errors | 1 |
 | Files extracted - without errors | 4 |
+| Files extracted - without errors % | 100 |
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - data flow | 0 |

--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -5,7 +5,7 @@
 | Files extracted - total | 5 |
 | Files extracted - with errors | 1 |
 | Files extracted - without errors | 4 |
-| Files extracted - without errors % | 100 |
+| Files extracted - without errors % | 80 |
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - data flow | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -5,6 +5,7 @@
 | Files extracted - total | 4 |
 | Files extracted - with errors | 0 |
 | Files extracted - without errors | 4 |
+| Files extracted - without errors % | 100 |
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - data flow | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -5,6 +5,7 @@
 | Files extracted - total | 4 |
 | Files extracted - with errors | 0 |
 | Files extracted - without errors | 4 |
+| Files extracted - without errors % | 100 |
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - data flow | 0 |

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -32,6 +32,11 @@ where
   key = "Files extracted - without errors" and
   value = count(SuccessfullyExtractedFile f | exists(f.getRelativePath()))
   or
+  key = "Files extracted - without errors %" and
+  value =
+    (count(SuccessfullyExtractedFile f | exists(f.getRelativePath())) * 100) /
+      count(ExtractedFile f | exists(f.getRelativePath()))
+  or
   key = "Lines of code extracted" and value = getLinesOfCode()
   or
   key = "Lines of user code extracted" and value = getLinesOfUserCode()

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -5,6 +5,7 @@
 | Files extracted - total | 7 |
 | Files extracted - with errors | 3 |
 | Files extracted - without errors | 4 |
+| Files extracted - without errors % | 57 |
 | Inconsistencies - AST | 0 |
 | Inconsistencies - CFG | 0 |
 | Inconsistencies - data flow | 0 |


### PR DESCRIPTION
Add % of files extracted without errors to summary stats.  Requested by @redsun82 .
- I don't think the `exists(f.getRelativePath())` part makes any difference right now, but let me know if you have a preference about it.
- the 57% number for the test is rather low, reflecting some odd stuff we're doing there.  On `openvmm` I get 91%.
- the number is rounded to an `int`, because I'm not confident I can output a float or string and pick it up in DCA.  Again, if this is a problem please say and I'll look into what I can do.