### PR TITLE
KE2: extractExpression always returns an ID

### DIFF
--- a/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/FunctionalInterface.kt
@@ -1,5 +1,5 @@
 import com.github.codeql.*
-import com.github.codeql.KotlinFileExtractor.StmtExprParent
+import com.github.codeql.KotlinFileExtractor.ExprParent
 import com.github.codeql.utils.type
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
 context(KaSession)
 fun KotlinFileExtractor.extractFunctionLiteral(
     e: KtFunctionLiteral,
-    parent: StmtExprParent
+    exprParent: ExprParent
 ): Label<out DbExpr> {
 
     val locId = tw.getLocation(e)
@@ -60,7 +60,6 @@ fun KotlinFileExtractor.extractFunctionLiteral(
         addModifiers(ids.function, "override")
     }
 
-    val exprParent = parent.expr(e)
     val idLambdaExpr = tw.getFreshIdLabel<DbLambdaexpr>()
     tw.writeExprs_lambdaexpr(
         idLambdaExpr,

--- a/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
+++ b/java/kotlin-extractor2/src/main/kotlin/entities/MethodCall.kt
@@ -1,6 +1,6 @@
 package com.github.codeql
 
-import com.github.codeql.KotlinFileExtractor.StmtExprParent
+import com.github.codeql.KotlinFileExtractor.ExprParent
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.resolution.KaSimpleFunctionCall
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.utils.mapToIndex
 context(KaSession)
 fun KotlinFileExtractor.extractMethodCall(
     call: KtCallExpression,
-    stmtExprParent: StmtExprParent
+    parent: ExprParent
 ): Label<out DbExpr> {
     val callTarget = call.resolveCallTarget() as? KaSimpleFunctionCall?
     val target = callTarget?.symbol
@@ -56,16 +56,14 @@ fun KotlinFileExtractor.extractMethodCall(
     val extensionReceiver = if (target.isExtension) qualifier else null
     val dispatchReceiver = if (!target.isExtension) qualifier else null
 
-    val exprParent = stmtExprParent.expr(call)
-
     val callId = extractRawMethodAccess(
         target,
         tw.getLocation(call),
         call.expressionType!!,
-        stmtExprParent.callable,
-        exprParent.parent,
-        exprParent.idx,
-        exprParent.enclosingStmt,
+        parent.callable,
+        parent.parent,
+        parent.idx,
+        parent.enclosingStmt,
         dispatchReceiver,
         extensionReceiver,
         args


### PR DESCRIPTION
It used to sometimes return null, which could mean either it extracted a statement or it failed to extract an expression. Also, what it returned didn't take into account any ExprStmt or StmtExpr wrappers.

Now, it will always return an ID of the type that it StmtExprParent corresponds to.

The essence of the changes is in `KotlinFileExtractor.kt`; the rest is just switching to the new interface.