### PR TITLE
C#: Shorten test target names to make Windows happy.

### DIFF
--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -74,8 +74,9 @@ test_suite(
     name = "unit-tests",
     tags = ["csharp"],
     tests = [
-        "//csharp/autobuilder/Semmle.Autobuild.CSharp.Tests:t",
-        "//csharp/autobuilder/Semmle.Autobuild.Cpp.Tests:t",
-        "//csharp/extractor/Semmle.Extraction.Tests:t",
+        "//csharp/autobuilder/Semmle.Autobuild.CSharp.Tests:acst",
+        "//csharp/autobuilder/Semmle.Autobuild.Cpp.Tests:acpt",
+        "//csharp/extractor/Semmle.Extraction.Tests:et",
+        "//csharp/extractor/Semmle.Util.Tests:ut",
     ],
 )

--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -77,6 +77,7 @@ test_suite(
         "//csharp/autobuilder/Semmle.Autobuild.CSharp.Tests:acst",
         "//csharp/autobuilder/Semmle.Autobuild.Cpp.Tests:acpt",
         "//csharp/extractor/Semmle.Extraction.Tests:et",
-        "//csharp/extractor/Semmle.Util.Tests:ut",
+        # this test suite currently fails, disable for now
+        # "//csharp/extractor/Semmle.Util.Tests:ut",
     ],
 )

--- a/csharp/BUILD.bazel
+++ b/csharp/BUILD.bazel
@@ -74,8 +74,8 @@ test_suite(
     name = "unit-tests",
     tags = ["csharp"],
     tests = [
-        "//csharp/autobuilder/Semmle.Autobuild.CSharp.Tests",
-        "//csharp/autobuilder/Semmle.Autobuild.Cpp.Tests",
-        "//csharp/extractor/Semmle.Extraction.Tests",
+        "//csharp/autobuilder/Semmle.Autobuild.CSharp.Tests:t",
+        "//csharp/autobuilder/Semmle.Autobuild.Cpp.Tests:t",
+        "//csharp/extractor/Semmle.Extraction.Tests:t",
     ],
 )

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
@@ -4,7 +4,8 @@ load(
 )
 
 codeql_xunit_test(
-    name = "Semmle.Autobuild.CSharp.Tests",
+    # short name as we run into long path limitations on Windows
+    name = "t",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp.Tests/BUILD.bazel
@@ -5,7 +5,7 @@ load(
 
 codeql_xunit_test(
     # short name as we run into long path limitations on Windows
-    name = "t",
+    name = "acst",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
@@ -4,7 +4,8 @@ load(
 )
 
 codeql_xunit_test(
-    name = "Semmle.Autobuild.Cpp.Tests",
+    # short name as we run into long path limitations on Windows
+    name = "t",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
+++ b/csharp/autobuilder/Semmle.Autobuild.Cpp.Tests/BUILD.bazel
@@ -5,7 +5,7 @@ load(
 
 codeql_xunit_test(
     # short name as we run into long path limitations on Windows
-    name = "t",
+    name = "acpt",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
@@ -10,7 +10,7 @@ codeql_csharp_library(
         "SourceGenerators/**/*.cs",
     ]),
     allow_unsafe_blocks = True,
-    internals_visible_to = ["t"],
+    internals_visible_to = ["et"],
     visibility = ["//csharp:__subpackages__"],
     deps = [
         "//csharp/extractor/Semmle.Extraction.CSharp",

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/BUILD.bazel
@@ -10,7 +10,7 @@ codeql_csharp_library(
         "SourceGenerators/**/*.cs",
     ]),
     allow_unsafe_blocks = True,
-    internals_visible_to = ["Semmle.Extraction.Tests"],
+    internals_visible_to = ["t"],
     visibility = ["//csharp:__subpackages__"],
     deps = [
         "//csharp/extractor/Semmle.Extraction.CSharp",

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
@@ -8,7 +8,7 @@ codeql_csharp_library(
     srcs = glob([
         "*.cs",
     ]),
-    internals_visible_to = ["t"],
+    internals_visible_to = ["et"],
     visibility = ["//csharp:__subpackages__"],
     deps = [
         "//csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching",

--- a/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.CSharp.StubGenerator/BUILD.bazel
@@ -8,7 +8,7 @@ codeql_csharp_library(
     srcs = glob([
         "*.cs",
     ]),
-    internals_visible_to = ["Semmle.Extraction.Tests"],
+    internals_visible_to = ["t"],
     visibility = ["//csharp:__subpackages__"],
     deps = [
         "//csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching",

--- a/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
@@ -4,7 +4,8 @@ load(
 )
 
 codeql_xunit_test(
-    name = "Semmle.Extraction.Tests",
+    # short name as we run into long path limitations on Windows
+    name = "t",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
+++ b/csharp/extractor/Semmle.Extraction.Tests/BUILD.bazel
@@ -5,7 +5,7 @@ load(
 
 codeql_xunit_test(
     # short name as we run into long path limitations on Windows
-    name = "t",
+    name = "et",
     srcs = glob([
         "*.cs",
     ]),

--- a/csharp/extractor/Semmle.Util.Tests/BUILD.bazel
+++ b/csharp/extractor/Semmle.Util.Tests/BUILD.bazel
@@ -4,7 +4,8 @@ load(
 )
 
 codeql_xunit_test(
-    name = "Semmle.Util.Tests",
+    # short name as we run into long path limitations on Windows
+    name = "ut",
     srcs = glob([
         "*.cs",
     ]),


### PR DESCRIPTION
With this, we can finally re-enable the C# unit tests on Windows (no more bazel errors about path length limitations).

The target name appears 3/4 times in the relevant path, so shortening it from the original names to "t" fixes our long-path problem.
