### PR TITLE
C++: Consider writes to arrays as uncertain

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TypeFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/TypeFlow.qll
@@ -27,8 +27,11 @@ private module Input implements TypeFlowInput<Location> {
   }
 
   private predicate hasExactSingleType(Instruction i) {
-    // The address of a variable is always a single object
-    i instanceof VariableAddressInstruction
+    // The address of a variable is always a single object (unless it's an array)
+    exists(VariableAddressInstruction vai |
+      i = vai and
+      not vai.getResultType() instanceof ArrayType
+    )
     or
     // A reference always points to a single object
     i.getResultLanguageType().hasUnspecifiedType(any(ReferenceType rt), false)

--- a/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
+++ b/cpp/ql/test/experimental/query-tests/Security/CWE/CWE-193/constant-size/ConstantSizeArrayOffByOne.expected
@@ -21,7 +21,11 @@ edges
 | test.cpp:85:21:85:36 | buf | test.cpp:87:5:87:31 | access to array | provenance | Config |
 | test.cpp:85:21:85:36 | buf | test.cpp:88:5:88:27 | access to array | provenance | Config |
 | test.cpp:85:34:85:36 | buf | test.cpp:85:21:85:36 | buf | provenance |  |
+| test.cpp:92:9:92:11 | definition of arr | test.cpp:96:13:96:18 | access to array | provenance | Config |
 | test.cpp:96:13:96:15 | arr | test.cpp:96:13:96:18 | access to array | provenance | Config |
+| test.cpp:102:9:102:11 | definition of arr | test.cpp:111:17:111:22 | access to array | provenance | Config |
+| test.cpp:102:9:102:11 | definition of arr | test.cpp:115:35:115:40 | access to array | provenance | Config |
+| test.cpp:102:9:102:11 | definition of arr | test.cpp:119:17:119:22 | access to array | provenance | Config |
 | test.cpp:111:17:111:19 | arr | test.cpp:111:17:111:22 | access to array | provenance | Config |
 | test.cpp:111:17:111:19 | arr | test.cpp:115:35:115:40 | access to array | provenance | Config |
 | test.cpp:111:17:111:19 | arr | test.cpp:119:17:119:22 | access to array | provenance | Config |
@@ -31,40 +35,54 @@ edges
 | test.cpp:119:17:119:19 | arr | test.cpp:111:17:111:22 | access to array | provenance | Config |
 | test.cpp:119:17:119:19 | arr | test.cpp:115:35:115:40 | access to array | provenance | Config |
 | test.cpp:119:17:119:19 | arr | test.cpp:119:17:119:22 | access to array | provenance | Config |
+| test.cpp:125:11:125:13 | definition of arr | test.cpp:128:9:128:14 | access to array | provenance | Config |
 | test.cpp:128:9:128:11 | arr | test.cpp:128:9:128:14 | access to array | provenance | Config |
 | test.cpp:134:25:134:27 | arr | test.cpp:136:9:136:16 | ... += ... | provenance | Config |
 | test.cpp:136:9:136:16 | ... += ... | test.cpp:136:9:136:16 | ... += ... | provenance |  |
 | test.cpp:136:9:136:16 | ... += ... | test.cpp:138:13:138:15 | arr | provenance |  |
+| test.cpp:142:10:142:13 | definition of asdf | test.cpp:143:18:143:21 | asdf | provenance |  |
 | test.cpp:143:18:143:21 | asdf | test.cpp:134:25:134:27 | arr | provenance |  |
 | test.cpp:143:18:143:21 | asdf | test.cpp:143:18:143:21 | asdf | provenance |  |
 | test.cpp:146:26:146:26 | *p | test.cpp:147:4:147:9 | -- ... | provenance |  |
+| test.cpp:154:7:154:9 | definition of buf | test.cpp:156:12:156:18 | ... + ... | provenance | Config |
 | test.cpp:156:12:156:14 | buf | test.cpp:156:12:156:18 | ... + ... | provenance | Config |
 | test.cpp:156:12:156:18 | ... + ... | test.cpp:156:12:156:18 | ... + ... | provenance |  |
 | test.cpp:156:12:156:18 | ... + ... | test.cpp:158:17:158:18 | *& ... | provenance |  |
 | test.cpp:158:17:158:18 | *& ... | test.cpp:146:26:146:26 | *p | provenance |  |
+| test.cpp:217:19:217:24 | definition of buffer | test.cpp:218:16:218:28 | buffer | provenance |  |
 | test.cpp:218:16:218:28 | buffer | test.cpp:220:5:220:11 | access to array | provenance | Config |
 | test.cpp:218:16:218:28 | buffer | test.cpp:221:5:221:11 | access to array | provenance | Config |
 | test.cpp:218:23:218:28 | buffer | test.cpp:218:16:218:28 | buffer | provenance |  |
+| test.cpp:228:10:228:14 | definition of array | test.cpp:229:17:229:29 | array | provenance |  |
 | test.cpp:229:17:229:29 | array | test.cpp:231:5:231:10 | access to array | provenance | Config |
 | test.cpp:229:17:229:29 | array | test.cpp:232:5:232:10 | access to array | provenance | Config |
 | test.cpp:229:25:229:29 | array | test.cpp:229:17:229:29 | array | provenance |  |
 | test.cpp:245:30:245:30 | p | test.cpp:261:27:261:30 | access to array | provenance | Config |
 | test.cpp:245:30:245:30 | p | test.cpp:261:27:261:30 | access to array | provenance | Config |
+| test.cpp:273:19:273:25 | definition of buffer3 | test.cpp:274:14:274:20 | buffer3 | provenance |  |
 | test.cpp:274:14:274:20 | buffer3 | test.cpp:245:30:245:30 | p | provenance |  |
 | test.cpp:274:14:274:20 | buffer3 | test.cpp:274:14:274:20 | buffer3 | provenance |  |
 | test.cpp:277:35:277:35 | p | test.cpp:278:14:278:14 | p | provenance |  |
 | test.cpp:278:14:278:14 | p | test.cpp:245:30:245:30 | p | provenance |  |
+| test.cpp:282:19:282:25 | definition of buffer1 | test.cpp:283:19:283:25 | buffer1 | provenance |  |
 | test.cpp:283:19:283:25 | buffer1 | test.cpp:277:35:277:35 | p | provenance |  |
 | test.cpp:283:19:283:25 | buffer1 | test.cpp:283:19:283:25 | buffer1 | provenance |  |
+| test.cpp:285:19:285:25 | definition of buffer2 | test.cpp:286:19:286:25 | buffer2 | provenance |  |
 | test.cpp:286:19:286:25 | buffer2 | test.cpp:277:35:277:35 | p | provenance |  |
 | test.cpp:286:19:286:25 | buffer2 | test.cpp:286:19:286:25 | buffer2 | provenance |  |
+| test.cpp:288:19:288:25 | definition of buffer3 | test.cpp:289:19:289:25 | buffer3 | provenance |  |
 | test.cpp:289:19:289:25 | buffer3 | test.cpp:277:35:277:35 | p | provenance |  |
 | test.cpp:289:19:289:25 | buffer3 | test.cpp:289:19:289:25 | buffer3 | provenance |  |
 | test.cpp:292:25:292:27 | arr | test.cpp:299:16:299:21 | access to array | provenance | Config |
+| test.cpp:305:9:305:12 | definition of arr1 | test.cpp:306:20:306:23 | arr1 | provenance |  |
 | test.cpp:306:20:306:23 | arr1 | test.cpp:292:25:292:27 | arr | provenance |  |
 | test.cpp:306:20:306:23 | arr1 | test.cpp:306:20:306:23 | arr1 | provenance |  |
+| test.cpp:308:9:308:12 | definition of arr2 | test.cpp:309:20:309:23 | arr2 | provenance |  |
 | test.cpp:309:20:309:23 | arr2 | test.cpp:292:25:292:27 | arr | provenance |  |
 | test.cpp:309:20:309:23 | arr2 | test.cpp:309:20:309:23 | arr2 | provenance |  |
+| test.cpp:314:10:314:13 | definition of temp | test.cpp:319:19:319:27 | ... + ... | provenance | Config |
+| test.cpp:314:10:314:13 | definition of temp | test.cpp:322:19:322:27 | ... + ... | provenance | Config |
+| test.cpp:314:10:314:13 | definition of temp | test.cpp:324:23:324:32 | ... + ... | provenance | Config |
 | test.cpp:319:13:319:27 | ... = ... | test.cpp:325:24:325:26 | end | provenance |  |
 | test.cpp:319:19:319:22 | temp | test.cpp:319:19:319:27 | ... + ... | provenance | Config |
 | test.cpp:319:19:319:22 | temp | test.cpp:324:23:324:32 | ... + ... | provenance | Config |
@@ -114,32 +132,39 @@ nodes
 | test.cpp:85:34:85:36 | buf | semmle.label | buf |
 | test.cpp:87:5:87:31 | access to array | semmle.label | access to array |
 | test.cpp:88:5:88:27 | access to array | semmle.label | access to array |
+| test.cpp:92:9:92:11 | definition of arr | semmle.label | definition of arr |
 | test.cpp:96:13:96:15 | arr | semmle.label | arr |
 | test.cpp:96:13:96:18 | access to array | semmle.label | access to array |
+| test.cpp:102:9:102:11 | definition of arr | semmle.label | definition of arr |
 | test.cpp:111:17:111:19 | arr | semmle.label | arr |
 | test.cpp:111:17:111:22 | access to array | semmle.label | access to array |
 | test.cpp:115:35:115:37 | arr | semmle.label | arr |
 | test.cpp:115:35:115:40 | access to array | semmle.label | access to array |
 | test.cpp:119:17:119:19 | arr | semmle.label | arr |
 | test.cpp:119:17:119:22 | access to array | semmle.label | access to array |
+| test.cpp:125:11:125:13 | definition of arr | semmle.label | definition of arr |
 | test.cpp:128:9:128:11 | arr | semmle.label | arr |
 | test.cpp:128:9:128:14 | access to array | semmle.label | access to array |
 | test.cpp:134:25:134:27 | arr | semmle.label | arr |
 | test.cpp:136:9:136:16 | ... += ... | semmle.label | ... += ... |
 | test.cpp:136:9:136:16 | ... += ... | semmle.label | ... += ... |
 | test.cpp:138:13:138:15 | arr | semmle.label | arr |
+| test.cpp:142:10:142:13 | definition of asdf | semmle.label | definition of asdf |
 | test.cpp:143:18:143:21 | asdf | semmle.label | asdf |
 | test.cpp:143:18:143:21 | asdf | semmle.label | asdf |
 | test.cpp:146:26:146:26 | *p | semmle.label | *p |
 | test.cpp:147:4:147:9 | -- ... | semmle.label | -- ... |
+| test.cpp:154:7:154:9 | definition of buf | semmle.label | definition of buf |
 | test.cpp:156:12:156:14 | buf | semmle.label | buf |
 | test.cpp:156:12:156:18 | ... + ... | semmle.label | ... + ... |
 | test.cpp:156:12:156:18 | ... + ... | semmle.label | ... + ... |
 | test.cpp:158:17:158:18 | *& ... | semmle.label | *& ... |
+| test.cpp:217:19:217:24 | definition of buffer | semmle.label | definition of buffer |
 | test.cpp:218:16:218:28 | buffer | semmle.label | buffer |
 | test.cpp:218:23:218:28 | buffer | semmle.label | buffer |
 | test.cpp:220:5:220:11 | access to array | semmle.label | access to array |
 | test.cpp:221:5:221:11 | access to array | semmle.label | access to array |
+| test.cpp:228:10:228:14 | definition of array | semmle.label | definition of array |
 | test.cpp:229:17:229:29 | array | semmle.label | array |
 | test.cpp:229:25:229:29 | array | semmle.label | array |
 | test.cpp:231:5:231:10 | access to array | semmle.label | access to array |
@@ -147,22 +172,29 @@ nodes
 | test.cpp:245:30:245:30 | p | semmle.label | p |
 | test.cpp:245:30:245:30 | p | semmle.label | p |
 | test.cpp:261:27:261:30 | access to array | semmle.label | access to array |
+| test.cpp:273:19:273:25 | definition of buffer3 | semmle.label | definition of buffer3 |
 | test.cpp:274:14:274:20 | buffer3 | semmle.label | buffer3 |
 | test.cpp:274:14:274:20 | buffer3 | semmle.label | buffer3 |
 | test.cpp:277:35:277:35 | p | semmle.label | p |
 | test.cpp:278:14:278:14 | p | semmle.label | p |
+| test.cpp:282:19:282:25 | definition of buffer1 | semmle.label | definition of buffer1 |
 | test.cpp:283:19:283:25 | buffer1 | semmle.label | buffer1 |
 | test.cpp:283:19:283:25 | buffer1 | semmle.label | buffer1 |
+| test.cpp:285:19:285:25 | definition of buffer2 | semmle.label | definition of buffer2 |
 | test.cpp:286:19:286:25 | buffer2 | semmle.label | buffer2 |
 | test.cpp:286:19:286:25 | buffer2 | semmle.label | buffer2 |
+| test.cpp:288:19:288:25 | definition of buffer3 | semmle.label | definition of buffer3 |
 | test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
 | test.cpp:289:19:289:25 | buffer3 | semmle.label | buffer3 |
 | test.cpp:292:25:292:27 | arr | semmle.label | arr |
 | test.cpp:299:16:299:21 | access to array | semmle.label | access to array |
+| test.cpp:305:9:305:12 | definition of arr1 | semmle.label | definition of arr1 |
 | test.cpp:306:20:306:23 | arr1 | semmle.label | arr1 |
 | test.cpp:306:20:306:23 | arr1 | semmle.label | arr1 |
+| test.cpp:308:9:308:12 | definition of arr2 | semmle.label | definition of arr2 |
 | test.cpp:309:20:309:23 | arr2 | semmle.label | arr2 |
 | test.cpp:309:20:309:23 | arr2 | semmle.label | arr2 |
+| test.cpp:314:10:314:13 | definition of temp | semmle.label | definition of temp |
 | test.cpp:319:13:319:27 | ... = ... | semmle.label | ... = ... |
 | test.cpp:319:19:319:22 | temp | semmle.label | temp |
 | test.cpp:319:19:319:27 | ... + ... | semmle.label | ... + ... |
@@ -187,13 +219,23 @@ subpaths
 | test.cpp:72:5:72:15 | PointerAdd: access to array | test.cpp:79:32:79:34 | buf | test.cpp:72:5:72:15 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:15:9:15:11 | buf | buf | test.cpp:72:5:72:19 | Store: ... = ... | write |
 | test.cpp:77:27:77:44 | PointerAdd: access to array | test.cpp:77:32:77:34 | buf | test.cpp:66:32:66:32 | p | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:15:9:15:11 | buf | buf | test.cpp:67:5:67:10 | Store: ... = ... | write |
 | test.cpp:88:5:88:27 | PointerAdd: access to array | test.cpp:85:34:85:36 | buf | test.cpp:88:5:88:27 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:15:9:15:11 | buf | buf | test.cpp:88:5:88:31 | Store: ... = ... | write |
+| test.cpp:128:9:128:14 | PointerAdd: access to array | test.cpp:125:11:125:13 | definition of arr | test.cpp:128:9:128:14 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:125:11:125:13 | arr | arr | test.cpp:128:9:128:18 | Store: ... = ... | write |
 | test.cpp:128:9:128:14 | PointerAdd: access to array | test.cpp:128:9:128:11 | arr | test.cpp:128:9:128:14 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:125:11:125:13 | arr | arr | test.cpp:128:9:128:18 | Store: ... = ... | write |
+| test.cpp:136:9:136:16 | PointerAdd: ... += ... | test.cpp:142:10:142:13 | definition of asdf | test.cpp:138:13:138:15 | arr | This pointer arithmetic may have an off-by-2 error allowing it to overrun $@ at this $@. | test.cpp:142:10:142:13 | asdf | asdf | test.cpp:138:12:138:15 | Load: * ... | read |
 | test.cpp:136:9:136:16 | PointerAdd: ... += ... | test.cpp:143:18:143:21 | asdf | test.cpp:138:13:138:15 | arr | This pointer arithmetic may have an off-by-2 error allowing it to overrun $@ at this $@. | test.cpp:142:10:142:13 | asdf | asdf | test.cpp:138:12:138:15 | Load: * ... | read |
+| test.cpp:156:12:156:18 | PointerAdd: ... + ... | test.cpp:154:7:154:9 | definition of buf | test.cpp:147:4:147:9 | -- ... | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:154:7:154:9 | buf | buf | test.cpp:147:3:147:13 | Store: ... = ... | write |
 | test.cpp:156:12:156:18 | PointerAdd: ... + ... | test.cpp:156:12:156:14 | buf | test.cpp:147:4:147:9 | -- ... | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:154:7:154:9 | buf | buf | test.cpp:147:3:147:13 | Store: ... = ... | write |
+| test.cpp:221:5:221:11 | PointerAdd: access to array | test.cpp:217:19:217:24 | definition of buffer | test.cpp:221:5:221:11 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:217:19:217:24 | buffer | buffer | test.cpp:221:5:221:15 | Store: ... = ... | write |
 | test.cpp:221:5:221:11 | PointerAdd: access to array | test.cpp:218:23:218:28 | buffer | test.cpp:221:5:221:11 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:217:19:217:24 | buffer | buffer | test.cpp:221:5:221:15 | Store: ... = ... | write |
+| test.cpp:232:5:232:10 | PointerAdd: access to array | test.cpp:228:10:228:14 | definition of array | test.cpp:232:5:232:10 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:228:10:228:14 | array | array | test.cpp:232:5:232:19 | Store: ... = ... | write |
 | test.cpp:232:5:232:10 | PointerAdd: access to array | test.cpp:229:25:229:29 | array | test.cpp:232:5:232:10 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:228:10:228:14 | array | array | test.cpp:232:5:232:19 | Store: ... = ... | write |
+| test.cpp:261:27:261:30 | PointerAdd: access to array | test.cpp:285:19:285:25 | definition of buffer2 | test.cpp:261:27:261:30 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:285:19:285:25 | buffer2 | buffer2 | test.cpp:261:27:261:30 | Load: access to array | read |
 | test.cpp:261:27:261:30 | PointerAdd: access to array | test.cpp:286:19:286:25 | buffer2 | test.cpp:261:27:261:30 | access to array | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:285:19:285:25 | buffer2 | buffer2 | test.cpp:261:27:261:30 | Load: access to array | read |
+| test.cpp:299:16:299:21 | PointerAdd: access to array | test.cpp:308:9:308:12 | definition of arr2 | test.cpp:299:16:299:21 | access to array | This pointer arithmetic may have an off-by-1014 error allowing it to overrun $@ at this $@. | test.cpp:308:9:308:12 | arr2 | arr2 | test.cpp:299:16:299:21 | Load: access to array | read |
 | test.cpp:299:16:299:21 | PointerAdd: access to array | test.cpp:309:20:309:23 | arr2 | test.cpp:299:16:299:21 | access to array | This pointer arithmetic may have an off-by-1014 error allowing it to overrun $@ at this $@. | test.cpp:308:9:308:12 | arr2 | arr2 | test.cpp:299:16:299:21 | Load: access to array | read |
+| test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:314:10:314:13 | definition of temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:330:13:330:24 | Store: ... = ... | write |
+| test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:314:10:314:13 | definition of temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:331:13:331:24 | Store: ... = ... | write |
+| test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:314:10:314:13 | definition of temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:333:13:333:24 | Store: ... = ... | write |
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:330:13:330:24 | Store: ... = ... | write |
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:331:13:331:24 | Store: ... = ... | write |
 | test.cpp:322:19:322:27 | PointerAdd: ... + ... | test.cpp:322:19:322:22 | temp | test.cpp:325:24:325:26 | end | This pointer arithmetic may have an off-by-1 error allowing it to overrun $@ at this $@. | test.cpp:314:10:314:13 | temp | temp | test.cpp:333:13:333:24 | Store: ... = ... | write |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -181,6 +181,10 @@ postWithInFlow
 | test.cpp:1108:4:1108:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1109:3:1109:4 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
 | test.cpp:1109:4:1109:4 | p [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:1138:3:1138:13 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:1138:5:1138:8 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:1139:3:1139:7 | * ... [post update] | PostUpdateNode should not be the target of local flow. |
+| test.cpp:1139:4:1139:7 | data [inner post update] | PostUpdateNode should not be the target of local flow. |
 viableImplInCallContextTooLarge
 uniqueParameterNodeAtPosition
 uniqueParameterNodePosition

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -326,6 +326,7 @@ irFlow
 | test.cpp:1069:9:1069:14 | call to source | test.cpp:1081:10:1081:10 | i |
 | test.cpp:1117:27:1117:34 | call to source | test.cpp:1117:27:1117:34 | call to source |
 | test.cpp:1132:11:1132:16 | call to source | test.cpp:1121:8:1121:8 | x |
+| test.cpp:1138:17:1138:22 | call to source | test.cpp:1140:8:1140:18 | * ... |
 | true_upon_entry.cpp:9:11:9:16 | call to source | true_upon_entry.cpp:13:8:13:8 | x |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test-source-sink.expected
@@ -132,6 +132,8 @@ astFlow
 | test.cpp:1069:9:1069:14 | call to source | test.cpp:1074:10:1074:10 | i |
 | test.cpp:1069:9:1069:14 | call to source | test.cpp:1082:10:1082:10 | i |
 | test.cpp:1086:12:1086:12 | a | test.cpp:1088:8:1088:9 | & ... |
+| test.cpp:1137:7:1137:10 | data | test.cpp:1140:8:1140:18 | * ... |
+| test.cpp:1138:17:1138:22 | call to source | test.cpp:1140:8:1140:18 | * ... |
 | true_upon_entry.cpp:17:11:17:16 | call to source | true_upon_entry.cpp:21:8:21:8 | x |
 | true_upon_entry.cpp:27:9:27:14 | call to source | true_upon_entry.cpp:29:8:29:8 | x |
 | true_upon_entry.cpp:33:11:33:16 | call to source | true_upon_entry.cpp:39:8:39:8 | x |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1137,5 +1137,5 @@ void test_uncertain_array(int n1, int n2) {
   int data[10];
   *(data + 1) = source();
   *data = 0;
-  sink(*(data + 1)); // $ ast=1138:17 ast=1137:7 MISSING: ir
+  sink(*(data + 1)); // $ ast=1138:17 ast=1137:7 ir
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test.cpp
@@ -1132,3 +1132,10 @@ void test_dispatch_table(int i) {
   int x = source();
   dispatch_table[i](x);
 }
+
+void test_uncertain_array(int n1, int n2) {
+  int data[10];
+  *(data + 1) = source();
+  *data = 0;
+  sink(*(data + 1)); // $ ast=1138:17 ast=1137:7 MISSING: ir
+}

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/uninitialized.expected
@@ -56,3 +56,6 @@
 | test.cpp:796:12:796:12 | a | test.cpp:798:17:798:17 | a |
 | test.cpp:1086:12:1086:12 | a | test.cpp:1087:3:1087:3 | a |
 | test.cpp:1086:12:1086:12 | a | test.cpp:1088:9:1088:9 | a |
+| test.cpp:1137:7:1137:10 | data | test.cpp:1138:5:1138:8 | data |
+| test.cpp:1137:7:1137:10 | data | test.cpp:1139:4:1139:7 | data |
+| test.cpp:1137:7:1137:10 | data | test.cpp:1140:10:1140:13 | data |


### PR DESCRIPTION
This PR fixes a bug where we were incorrectly concluding that a write such as:
```cpp
int xs[10];
*xs = 42;
```
would overwrite the entire object.

Commit-by-commit review recommended (even though the fix is extremely straightforward).