### PR TITLE
Data flow: Remove unused column from `flowThroughOutOfCall`

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -1440,13 +1440,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate flowThroughOutOfCall(
-          DataFlowCall call, CcCall ccc, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow
+          DataFlowCall call, RetNodeEx ret, NodeEx out, boolean allowsFieldFlow
         ) {
           exists(ReturnKindExt kind |
             PrevStage::callEdgeReturn(call, _, ret, kind, out, allowsFieldFlow) and
             PrevStage::callMayFlowThroughRev(call) and
-            PrevStage::returnMayFlowThrough(ret, kind) and
-            matchesCall(ccc, call)
+            PrevStage::returnMayFlowThrough(ret, kind)
           )
         }
 
@@ -1568,9 +1567,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           apa = getApprox(ap)
           or
           // flow through a callable
-          exists(DataFlowCall call, CcCall ccc, RetNodeEx ret, boolean allowsFieldFlow |
-            fwdFlowThrough(call, cc, state, ccc, summaryCtx, t, ap, stored, ret) and
-            flowThroughOutOfCall(call, ccc, ret, node, allowsFieldFlow) and
+          exists(DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow |
+            fwdFlowThrough(call, cc, state, summaryCtx, t, ap, stored, ret) and
+            flowThroughOutOfCall(call, ret, node, allowsFieldFlow) and
             apa = getApprox(ap) and
             not inBarrier(node, state) and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
@@ -2098,10 +2097,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate fwdFlowThrough(
-          DataFlowCall call, Cc cc, FlowState state, CcCall ccc, SummaryCtx summaryCtx, Typ t,
-          Ap ap, TypOption stored, RetNodeEx ret
+          DataFlowCall call, Cc cc, FlowState state, SummaryCtx summaryCtx, Typ t, Ap ap,
+          TypOption stored, RetNodeEx ret
         ) {
-          fwdFlowThrough0(call, _, cc, state, ccc, summaryCtx, t, ap, stored, ret, _)
+          fwdFlowThrough0(call, _, cc, state, _, summaryCtx, t, ap, stored, ret, _)
         }
 
         pragma[nomagic]
@@ -2156,7 +2155,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           exists(DataFlowCall call, boolean allowsFieldFlow |
             returnFlowsThrough0(call, state, ccc, ap, ret,
               TSummaryCtxSome(p, _, argT, argAp, argStored)) and
-            flowThroughOutOfCall(call, ccc, ret, _, allowsFieldFlow) and
+            flowThroughOutOfCall(call, ret, _, allowsFieldFlow) and
             pos = ret.getReturnPosition() and
             if allowsFieldFlow = false then ap instanceof ApNil else any()
           )
@@ -3155,12 +3154,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           pragma[nomagic]
           private predicate fwdFlowThroughStep1(
             PathNodeImpl pn1, PathNodeImpl pn2, PathNodeImpl pn3, DataFlowCall call, Cc cc,
-            FlowState state, CcCall ccc, SummaryCtx summaryCtx, Typ t, Ap ap, TypOption stored,
-            RetNodeEx ret
+            FlowState state, SummaryCtx summaryCtx, Typ t, Ap ap, TypOption stored, RetNodeEx ret
           ) {
             exists(
               FlowState state0, ArgNodeEx arg, SummaryCtxSome innerSummaryCtx, ParamNodeEx p,
-              Typ innerArgT, Ap innerArgAp, TypOption innerArgStored
+              Typ innerArgT, Ap innerArgAp, TypOption innerArgStored, CcCall ccc
             |
               fwdFlowThroughStep0(call, arg, cc, state, ccc, summaryCtx, t, ap, stored, ret,
                 innerSummaryCtx) and
@@ -3178,10 +3176,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             PathNodeImpl pn1, PathNodeImpl pn2, PathNodeImpl pn3, NodeEx node, Cc cc,
             FlowState state, SummaryCtx summaryCtx, Typ t, Ap ap, TypOption stored
           ) {
-            exists(DataFlowCall call, CcCall ccc, RetNodeEx ret, boolean allowsFieldFlow |
-              fwdFlowThroughStep1(pn1, pn2, pn3, call, cc, state, ccc, summaryCtx, t, ap, stored,
-                ret) and
-              flowThroughOutOfCall(call, ccc, ret, node, allowsFieldFlow) and
+            exists(DataFlowCall call, RetNodeEx ret, boolean allowsFieldFlow |
+              fwdFlowThroughStep1(pn1, pn2, pn3, call, cc, state, summaryCtx, t, ap, stored, ret) and
+              flowThroughOutOfCall(call, ret, node, allowsFieldFlow) and
               not inBarrier(node, state) and
               if allowsFieldFlow = false then ap instanceof ApNil else any()
             )


### PR DESCRIPTION
I noticed in a run that `flowThroughOutOfCall` may have a large fan-out when joining `call` with `ccc` through `matchesCall`:

```
[2024-12-10 20:37:27] Evaluated non-recursive predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage2::flowThroughOutOfCall/7#306bfe26@3d1aaa28 in 3916ms (size: 109177854).
Evaluated relational algebra for predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage2::flowThroughOutOfCall/7#306bfe26@3d1aaa28 with tuple counts:
           153181   ~8%    {2} r1 = JOIN `DataFlowImplCommon::DataFlowCallEx.projectToCall/0#dispred#c63e421f` WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::callMayFlowThroughRev/1#05c410c1` ON FIRST 1 OUTPUT Lhs.0, Lhs.1
           291231   ~5%    {8}    | JOIN WITH `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::callEdgeReturn/7#10c89f93` ON FIRST 1 OUTPUT Rhs.1, Rhs.5, Rhs.5, Rhs.2, Lhs.0, Lhs.1, Rhs.3, Rhs.4
           289311   ~0%    {7}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::returnMayFlowThrough/4#6a6483e2` ON FIRST 4 OUTPUT Lhs.5, Lhs.4, Lhs.0, Lhs.6, Lhs.7, Lhs.1, Lhs.1
        108888543   ~1%    {7}    | JOIN WITH `project#DataFlowImplCommon::Cached::CachedCallContextSensitivity::getSpecificCallContextCall/2#2f40f4a2` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6
                       
          1362219   ~3%    {1} r2 = SCAN `DataFlowImplCommon::DataFlowCallEx.projectToCall/0#dispred#c63e421f` OUTPUT In.0
          1362219   ~3%    {1}    | STREAM DEDUP
           153181   ~1%    {1}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::callMayFlowThroughRev/1#05c410c1` ON FIRST 1 OUTPUT Lhs.0
           291231   ~2%    {7}    | JOIN WITH `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::callEdgeReturn/7#10c89f93` ON FIRST 1 OUTPUT Rhs.1, Rhs.5, Rhs.5, Rhs.2, Lhs.0, Rhs.3, Rhs.4
           289311   ~1%    {6}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::CsharpDataFlow>::Impl<ExternalLocationSink::LocalFileOutputStreamFlow::C>::Stage1::returnMayFlowThrough/4#6a6483e2` ON FIRST 4 OUTPUT Lhs.4, Lhs.0, Lhs.5, Lhs.6, Lhs.1, Lhs.1
           289311   ~4%    {7}    | JOIN WITH `num#DataFlowImplCommon::CallContextSensitivity<Cached::CachedCallContextSensitivity::CallContextSensitivityInput>::TSomeCall#b6cffc7d` CARTESIAN PRODUCT OUTPUT Lhs.0, Rhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                       
        109177854   ~1%    {7} r3 = r1 UNION r2
                           return r3
```

I turns out that the column is actually not needed, since all predicates that join against `flowThroughOutOfCall` already have both `call` and `ccc`, so those should already match.

DCA shows a nice speedup for the C# project `mono`.