### PR TITLE
Misc: Look up remote name instead of using `origin` in `misc/prepare-db-upgrade.sh`

### DIFF
--- a/misc/scripts/prepare-db-upgrade.sh
+++ b/misc/scripts/prepare-db-upgrade.sh
@@ -30,10 +30,10 @@ EOF
   exit "${exit_code}"
 }
 
-# default for prev_hash: the main branch of the remote for 'github/semmle-code'.
+# default for prev_hash: the main branch of the remote for 'github/codeql'.
 # This works out as a dynamic lookup of the hash of the file in the main branch
 # of the repo.
-prev_hash=$(git remote -v | grep 'github/semmle-code\.git (fetch)$' | cut -f1)/main
+prev_hash=$(git remote -v | grep 'github/codeql\.git (fetch)$' | cut -f1)/main
 
 while [ $# -gt 0 ]; do
   case "$1" in

--- a/misc/scripts/prepare-db-upgrade.sh
+++ b/misc/scripts/prepare-db-upgrade.sh
@@ -30,7 +30,10 @@ EOF
   exit "${exit_code}"
 }
 
-prev_hash="origin/main"
+# default for prev_hash: the main branch of the remote for 'github/semmle-code'.
+# This works out as a dynamic lookup of the hash of the file in the main branch
+# of the repo.
+prev_hash=$(git remote -v | grep 'github/semmle-code\.git (fetch)$' | cut -f1)/main
 
 while [ $# -gt 0 ]; do
   case "$1" in


### PR DESCRIPTION
My upstream remote is called `upstream`, not `origin`, as recommended in the internal readme. This bites me every time I have to make a db upgrade script, which is infrequently enough that I always forget in between. @esbena kindly came up with this solution.