### PR TITLE
C#: Remove false-positive reflection calls in dataflow

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowDispatch.qll
@@ -424,7 +424,11 @@ class NonDelegateDataFlowCall extends DataFlowCall, TNonDelegateCall {
   Callable getATarget(boolean static) {
     result = dc.getADynamicTarget().getUnboundDeclaration() and static = false
     or
-    result = dc.getAStaticTarget().getUnboundDeclaration() and static = true
+    result = dc.getAStaticTarget().getUnboundDeclaration() and
+    static = true and
+    // In reflection calls, _all_ methods with matching names and arities are considered
+    // static targets, so we need to exclude them
+    not dc.isReflection()
   }
 
   override ControlFlow::Nodes::ElementNode getControlFlowNode() { result = cfn }

--- a/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dispatch/Dispatch.qll
@@ -52,7 +52,21 @@ class DispatchCall extends Internal::TDispatchCall {
   }
 
   /** Holds if this call uses reflection. */
-  predicate isReflection() { this instanceof Internal::TDispatchReflectionCall }
+  predicate isReflection() {
+    this instanceof Internal::TDispatchReflectionCall
+    or
+    this instanceof Internal::TDispatchDynamicElementAccess
+    or
+    this instanceof Internal::TDispatchDynamicMemberAccess
+    or
+    this instanceof Internal::TDispatchDynamicMethodCall
+    or
+    this instanceof Internal::TDispatchDynamicOperatorCall
+    or
+    this instanceof Internal::TDispatchDynamicEventAccess
+    or
+    this instanceof Internal::TDispatchDynamicObjectCreation
+  }
 }
 
 /** Internal implementation details. */


### PR DESCRIPTION
When debugging a data flow performance issue, I noticed that we may have incorrect flow out of calls using reflection. 

The data flow library uses the `Dispatch.qll` library to resolve calls, and this library distinguishes between the static target and dynamic targets of calls; for reflection-based calls, any method with matching name and arity is considered a static target, and this is then refined based on type information when calculating dynamic call targets. This means that "static target" of reflection calls is overly broad, and should not be used in data flow.