### PR TITLE
C#: Add `html-injection` sinks for Blazor `MarkupString`

### DIFF
--- a/csharp/ql/lib/change-notes/2024-12-12-add-markupstring-as-html-injection-sink.md
+++ b/csharp/ql/lib/change-notes/2024-12-12-add-markupstring-as-html-injection-sink.md
@@ -1,4 +1,4 @@
 ---
 category: minorAnalysis
 ---
-* Added the constructor of `Microsoft.AspNetCore.Components.MarkupString` as an `html-injection` sink. This will help catch cross-site scripting resulting from using `MarkupString`. 
+* Added the constructor and explicit cast operator of `Microsoft.AspNetCore.Components.MarkupString` as an `html-injection` sink. This will help catch cross-site scripting resulting from using `MarkupString`. 

--- a/csharp/ql/lib/change-notes/2024-12-12-add-markupstring-as-html-injection-sink.md
+++ b/csharp/ql/lib/change-notes/2024-12-12-add-markupstring-as-html-injection-sink.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added the constructor of `Microsoft.AspNetCore.Components.MarkupString` as an `html-injection` sink. This will help catch cross-site scripting resulting from using `MarkupString`. 

--- a/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
@@ -10,3 +10,9 @@ extensions:
       extensible: summaryModel
     data:
       - ["Microsoft.AspNetCore.Components", "NagivationManager", True, "ToAbsoluteUri", "(System.String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: sinkModel
+    data:
+      - ["Microsoft.AspNetCore.Components", "MarkupString", False, "MarkupString", "(System.String)", "", "Argument[0]", "html-injection", "manual"]
+      - ["Microsoft.AspNetCore.Components", "MarkupString", False, "op_Explicit", "(System.String)", "", "Argument[0]", "html-injection", "manual"]


### PR DESCRIPTION
Adds `html-injection` sinks for the [`MarkupString`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.markupstring?view=aspnetcore-9.0) class from Blazor's `Microsoft.AspNetCore.Components` library.

`MarkupString` does not escape HTML tags in the string, so it is a potential XSS sink.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
~- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.~
~- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.~
~- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.~

#### Internal query authors only

~- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).~
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
~- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).~
