### PR TITLE
C#: Add summary for `Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelper::TypeCheck<T>`

### DIFF
--- a/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.CompilerServices.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.CompilerServices.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/csharp-all
+      extensible: summaryModel
+    data:
+      - ["Microsoft.AspNetCore.Components.CompilerServices", "RuntimeHelpers", False, "TypeCheck<T>", "(T)", "", "Argument[0]", "ReturnValue", "value", "manual"]

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -164,6 +164,7 @@
 | Microsoft.AspNetCore.Components.CompilerServices;RuntimeHelpers;InvokeAsynchronousDelegate;(System.Action);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.CompilerServices;RuntimeHelpers;InvokeAsynchronousDelegate;(System.Func<System.Threading.Tasks.Task>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.CompilerServices;RuntimeHelpers;InvokeSynchronousDelegate;(System.Action);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
+| Microsoft.AspNetCore.Components.CompilerServices;RuntimeHelpers;TypeCheck<T>;(T);Argument[0];ReturnValue;value;manual |
 | Microsoft.AspNetCore.Components.Forms.Mapping;FormValueMappingContext;set_MapErrorToContainer;(System.Action<System.String,System.Object>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Forms.Mapping;FormValueMappingContext;set_OnError;(System.Action<System.String,System.FormattableString,System.String>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Forms;EditContext;GetValidationMessages;(System.Linq.Expressions.Expression<System.Func<System.Object>>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |


### PR DESCRIPTION
Blazor has a static class named `RuntimeHelpers` [(source)](https://github.com/dotnet/aspnetcore/blob/c70204ae3c91d2b48fa6d9b92b62265f368421b4/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs) which provides some methods which help the compiler with callbacks and type checking.

I will model the other `RuntimeHelpers` methods in a subsequent PR, but I need to investigate them further as I model dataflow through Blazor components. `TypeCheck<T>` is an identity function to help with type checking.

Since the [`TypeCheck<T>`](https://github.com/dotnet/aspnetcore/blob/c70204ae3c91d2b48fa6d9b92b62265f368421b4/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs#L20) method is [not to be used directly in application code](https://github.com/dotnet/aspnetcore/blob/c70204ae3c91d2b48fa6d9b92b62265f368421b4/src/Components/Components/src/CompilerServices/RuntimeHelpers.cs#L15), no change note should be necessary.

### Pull Request checklist

#### All query authors

~- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.~
~- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.~
