### PR TITLE
C++: Add word missing from change note

### DIFF
--- a/cpp/ql/lib/CHANGELOG.md
+++ b/cpp/ql/lib/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Deprecated APIs
 
-* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
+* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing.NonThrowingFunction`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
 
 ## 2.1.1
 

--- a/cpp/ql/lib/CHANGELOG.md
+++ b/cpp/ql/lib/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Deprecated APIs
 
-* The `NonThrowing` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
+* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
 
 ## 2.1.1
 

--- a/cpp/ql/lib/change-notes/released/3.0.0.md
+++ b/cpp/ql/lib/change-notes/released/3.0.0.md
@@ -6,4 +6,4 @@
 
 ### Deprecated APIs
 
-* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
+* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing.NonThrowingFunction`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.

--- a/cpp/ql/lib/change-notes/released/3.0.0.md
+++ b/cpp/ql/lib/change-notes/released/3.0.0.md
@@ -6,4 +6,4 @@
 
 ### Deprecated APIs
 
-* The `NonThrowing` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.
+* The `NonThrowingFunction` class (`semmle.code.cpp.models.interfaces.NonThrowing`) has been deprecated. Please use the `NonCppThrowingFunction` class instead.


### PR DESCRIPTION
I don't think it's worth propagating this to all the places where the change note has been copied, but at least this is correct now going forward.