### PR TITLE
Rust: Never skip assignment LHS in data flow

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -855,6 +855,12 @@ module RustDataFlow implements InputSig<Location> {
     node instanceof Node::ClosureParameterNode
   }
 
+  predicate neverSkipInPathGraph(Node node) {
+    node.getCfgNode() = any(LetStmtCfgNode s).getPat()
+    or
+    node.getCfgNode() = any(AssignmentExprCfgNode a).getLhs()
+  }
+
   class DataFlowExpr = ExprCfgNode;
 
   /** Gets the node corresponding to `e`. */

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -859,6 +859,11 @@ module RustDataFlow implements InputSig<Location> {
     node.getCfgNode() = any(LetStmtCfgNode s).getPat()
     or
     node.getCfgNode() = any(AssignmentExprCfgNode a).getLhs()
+    or
+    exists(MatchExprCfgNode match |
+      node.asExpr() = match.getScrutinee() or
+      node.asExpr() = match.getArmPat(_)
+    )
   }
 
   class DataFlowExpr = ExprCfgNode;

--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
@@ -1,6 +1,7 @@
 models
 edges
-| main.rs:9:13:9:19 | ...: ... | main.rs:9:30:14:1 | { ... } | provenance |  |
+| main.rs:9:13:9:19 | ...: ... | main.rs:10:11:10:11 | s | provenance |  |
+| main.rs:10:11:10:11 | s | main.rs:9:30:14:1 | { ... } | provenance |  |
 | main.rs:21:9:21:9 | s | main.rs:22:10:22:10 | s | provenance |  |
 | main.rs:21:13:21:21 | source(...) | main.rs:21:9:21:9 | s | provenance |  |
 | main.rs:26:9:26:9 | s | main.rs:27:22:27:22 | s | provenance |  |
@@ -14,6 +15,7 @@ edges
 nodes
 | main.rs:9:13:9:19 | ...: ... | semmle.label | ...: ... |
 | main.rs:9:30:14:1 | { ... } | semmle.label | { ... } |
+| main.rs:10:11:10:11 | s | semmle.label | s |
 | main.rs:17:10:17:18 | source(...) | semmle.label | source(...) |
 | main.rs:21:9:21:9 | s | semmle.label | s |
 | main.rs:21:13:21:21 | source(...) | semmle.label | source(...) |

--- a/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/barrier/inline-flow.expected
@@ -1,22 +1,30 @@
 models
 edges
 | main.rs:9:13:9:19 | ...: ... | main.rs:9:30:14:1 | { ... } | provenance |  |
-| main.rs:21:13:21:21 | source(...) | main.rs:22:10:22:10 | s | provenance |  |
-| main.rs:26:13:26:21 | source(...) | main.rs:27:22:27:22 | s | provenance |  |
-| main.rs:27:13:27:23 | sanitize(...) | main.rs:28:10:28:10 | s | provenance |  |
+| main.rs:21:9:21:9 | s | main.rs:22:10:22:10 | s | provenance |  |
+| main.rs:21:13:21:21 | source(...) | main.rs:21:9:21:9 | s | provenance |  |
+| main.rs:26:9:26:9 | s | main.rs:27:22:27:22 | s | provenance |  |
+| main.rs:26:13:26:21 | source(...) | main.rs:26:9:26:9 | s | provenance |  |
+| main.rs:27:9:27:9 | s | main.rs:28:10:28:10 | s | provenance |  |
+| main.rs:27:13:27:23 | sanitize(...) | main.rs:27:9:27:9 | s | provenance |  |
 | main.rs:27:22:27:22 | s | main.rs:9:13:9:19 | ...: ... | provenance |  |
 | main.rs:27:22:27:22 | s | main.rs:27:13:27:23 | sanitize(...) | provenance |  |
-| main.rs:32:13:32:21 | source(...) | main.rs:33:10:33:10 | s | provenance |  |
+| main.rs:32:9:32:9 | s | main.rs:33:10:33:10 | s | provenance |  |
+| main.rs:32:13:32:21 | source(...) | main.rs:32:9:32:9 | s | provenance |  |
 nodes
 | main.rs:9:13:9:19 | ...: ... | semmle.label | ...: ... |
 | main.rs:9:30:14:1 | { ... } | semmle.label | { ... } |
 | main.rs:17:10:17:18 | source(...) | semmle.label | source(...) |
+| main.rs:21:9:21:9 | s | semmle.label | s |
 | main.rs:21:13:21:21 | source(...) | semmle.label | source(...) |
 | main.rs:22:10:22:10 | s | semmle.label | s |
+| main.rs:26:9:26:9 | s | semmle.label | s |
 | main.rs:26:13:26:21 | source(...) | semmle.label | source(...) |
+| main.rs:27:9:27:9 | s | semmle.label | s |
 | main.rs:27:13:27:23 | sanitize(...) | semmle.label | sanitize(...) |
 | main.rs:27:22:27:22 | s | semmle.label | s |
 | main.rs:28:10:28:10 | s | semmle.label | s |
+| main.rs:32:9:32:9 | s | semmle.label | s |
 | main.rs:32:13:32:21 | source(...) | semmle.label | source(...) |
 | main.rs:33:10:33:10 | s | semmle.label | s |
 subpaths

--- a/rust/ql/test/library-tests/dataflow/closures/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/closures/inline-flow.expected
@@ -3,11 +3,14 @@ edges
 | main.rs:11:20:11:52 | if cond {...} else {...} | main.rs:12:10:12:16 | f(...) | provenance |  |
 | main.rs:11:30:11:39 | source(...) | main.rs:11:20:11:52 | if cond {...} else {...} | provenance |  |
 | main.rs:16:20:16:23 | ... | main.rs:18:18:18:21 | data | provenance |  |
-| main.rs:22:13:22:22 | source(...) | main.rs:23:13:23:13 | a | provenance |  |
+| main.rs:22:9:22:9 | a | main.rs:23:13:23:13 | a | provenance |  |
+| main.rs:22:13:22:22 | source(...) | main.rs:22:9:22:9 | a | provenance |  |
 | main.rs:23:13:23:13 | a | main.rs:16:20:16:23 | ... | provenance |  |
 | main.rs:27:20:27:23 | ... | main.rs:28:9:32:9 | if cond {...} else {...} | provenance |  |
-| main.rs:33:13:33:22 | source(...) | main.rs:34:21:34:21 | a | provenance |  |
-| main.rs:34:13:34:22 | f(...) | main.rs:35:10:35:10 | b | provenance |  |
+| main.rs:33:9:33:9 | a | main.rs:34:21:34:21 | a | provenance |  |
+| main.rs:33:13:33:22 | source(...) | main.rs:33:9:33:9 | a | provenance |  |
+| main.rs:34:9:34:9 | b | main.rs:35:10:35:10 | b | provenance |  |
+| main.rs:34:13:34:22 | f(...) | main.rs:34:9:34:9 | b | provenance |  |
 | main.rs:34:21:34:21 | a | main.rs:27:20:27:23 | ... | provenance |  |
 | main.rs:34:21:34:21 | a | main.rs:34:13:34:22 | f(...) | provenance |  |
 | main.rs:42:16:42:25 | source(...) | main.rs:44:5:44:5 | [post] f [captured capt] | provenance |  |
@@ -20,11 +23,14 @@ nodes
 | main.rs:12:10:12:16 | f(...) | semmle.label | f(...) |
 | main.rs:16:20:16:23 | ... | semmle.label | ... |
 | main.rs:18:18:18:21 | data | semmle.label | data |
+| main.rs:22:9:22:9 | a | semmle.label | a |
 | main.rs:22:13:22:22 | source(...) | semmle.label | source(...) |
 | main.rs:23:13:23:13 | a | semmle.label | a |
 | main.rs:27:20:27:23 | ... | semmle.label | ... |
 | main.rs:28:9:32:9 | if cond {...} else {...} | semmle.label | if cond {...} else {...} |
+| main.rs:33:9:33:9 | a | semmle.label | a |
 | main.rs:33:13:33:22 | source(...) | semmle.label | source(...) |
+| main.rs:34:9:34:9 | b | semmle.label | b |
 | main.rs:34:13:34:22 | f(...) | semmle.label | f(...) |
 | main.rs:34:21:34:21 | a | semmle.label | a |
 | main.rs:35:10:35:10 | b | semmle.label | b |

--- a/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
@@ -2,16 +2,21 @@ models
 edges
 | main.rs:12:28:14:1 | { ... } | main.rs:17:13:17:23 | get_data(...) | provenance |  |
 | main.rs:13:5:13:13 | source(...) | main.rs:12:28:14:1 | { ... } | provenance |  |
-| main.rs:17:13:17:23 | get_data(...) | main.rs:18:10:18:10 | a | provenance |  |
+| main.rs:17:9:17:9 | a | main.rs:18:10:18:10 | a | provenance |  |
+| main.rs:17:13:17:23 | get_data(...) | main.rs:17:9:17:9 | a | provenance |  |
 | main.rs:21:12:21:17 | ...: i64 | main.rs:22:10:22:10 | n | provenance |  |
-| main.rs:26:13:26:21 | source(...) | main.rs:27:13:27:13 | a | provenance |  |
+| main.rs:26:9:26:9 | a | main.rs:27:13:27:13 | a | provenance |  |
+| main.rs:26:13:26:21 | source(...) | main.rs:26:9:26:9 | a | provenance |  |
 | main.rs:27:13:27:13 | a | main.rs:21:12:21:17 | ...: i64 | provenance |  |
 | main.rs:30:17:30:22 | ...: i64 | main.rs:30:32:32:1 | { ... } | provenance |  |
-| main.rs:35:13:35:21 | source(...) | main.rs:36:26:36:26 | a | provenance |  |
-| main.rs:36:13:36:27 | pass_through(...) | main.rs:37:10:37:10 | b | provenance |  |
+| main.rs:35:9:35:9 | a | main.rs:36:26:36:26 | a | provenance |  |
+| main.rs:35:13:35:21 | source(...) | main.rs:35:9:35:9 | a | provenance |  |
+| main.rs:36:9:36:9 | b | main.rs:37:10:37:10 | b | provenance |  |
+| main.rs:36:13:36:27 | pass_through(...) | main.rs:36:9:36:9 | b | provenance |  |
 | main.rs:36:26:36:26 | a | main.rs:30:17:30:22 | ...: i64 | provenance |  |
 | main.rs:36:26:36:26 | a | main.rs:36:13:36:27 | pass_through(...) | provenance |  |
-| main.rs:41:13:44:6 | pass_through(...) | main.rs:45:10:45:10 | a | provenance |  |
+| main.rs:41:9:41:9 | a | main.rs:45:10:45:10 | a | provenance |  |
+| main.rs:41:13:44:6 | pass_through(...) | main.rs:41:9:41:9 | a | provenance |  |
 | main.rs:41:26:44:5 | { ... } | main.rs:30:17:30:22 | ...: i64 | provenance |  |
 | main.rs:41:26:44:5 | { ... } | main.rs:41:13:44:6 | pass_through(...) | provenance |  |
 | main.rs:43:9:43:18 | source(...) | main.rs:41:26:44:5 | { ... } | provenance |  |
@@ -19,28 +24,37 @@ edges
 | main.rs:59:31:65:5 | { ... } | main.rs:77:13:77:25 | mn.get_data(...) | provenance |  |
 | main.rs:63:13:63:21 | source(...) | main.rs:59:31:65:5 | { ... } | provenance |  |
 | main.rs:66:28:66:33 | ...: i64 | main.rs:66:43:72:5 | { ... } | provenance |  |
-| main.rs:77:13:77:25 | mn.get_data(...) | main.rs:78:10:78:10 | a | provenance |  |
-| main.rs:83:13:83:21 | source(...) | main.rs:84:16:84:16 | a | provenance |  |
+| main.rs:77:9:77:9 | a | main.rs:78:10:78:10 | a | provenance |  |
+| main.rs:77:13:77:25 | mn.get_data(...) | main.rs:77:9:77:9 | a | provenance |  |
+| main.rs:83:9:83:9 | a | main.rs:84:16:84:16 | a | provenance |  |
+| main.rs:83:13:83:21 | source(...) | main.rs:83:9:83:9 | a | provenance |  |
 | main.rs:84:16:84:16 | a | main.rs:56:23:56:28 | ...: i64 | provenance |  |
-| main.rs:89:13:89:21 | source(...) | main.rs:90:29:90:29 | a | provenance |  |
-| main.rs:90:13:90:30 | mn.data_through(...) | main.rs:91:10:91:10 | b | provenance |  |
+| main.rs:89:9:89:9 | a | main.rs:90:29:90:29 | a | provenance |  |
+| main.rs:89:13:89:21 | source(...) | main.rs:89:9:89:9 | a | provenance |  |
+| main.rs:90:9:90:9 | b | main.rs:91:10:91:10 | b | provenance |  |
+| main.rs:90:13:90:30 | mn.data_through(...) | main.rs:90:9:90:9 | b | provenance |  |
 | main.rs:90:29:90:29 | a | main.rs:66:28:66:33 | ...: i64 | provenance |  |
 | main.rs:90:29:90:29 | a | main.rs:90:13:90:30 | mn.data_through(...) | provenance |  |
 nodes
 | main.rs:12:28:14:1 | { ... } | semmle.label | { ... } |
 | main.rs:13:5:13:13 | source(...) | semmle.label | source(...) |
+| main.rs:17:9:17:9 | a | semmle.label | a |
 | main.rs:17:13:17:23 | get_data(...) | semmle.label | get_data(...) |
 | main.rs:18:10:18:10 | a | semmle.label | a |
 | main.rs:21:12:21:17 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:22:10:22:10 | n | semmle.label | n |
+| main.rs:26:9:26:9 | a | semmle.label | a |
 | main.rs:26:13:26:21 | source(...) | semmle.label | source(...) |
 | main.rs:27:13:27:13 | a | semmle.label | a |
 | main.rs:30:17:30:22 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:30:32:32:1 | { ... } | semmle.label | { ... } |
+| main.rs:35:9:35:9 | a | semmle.label | a |
 | main.rs:35:13:35:21 | source(...) | semmle.label | source(...) |
+| main.rs:36:9:36:9 | b | semmle.label | b |
 | main.rs:36:13:36:27 | pass_through(...) | semmle.label | pass_through(...) |
 | main.rs:36:26:36:26 | a | semmle.label | a |
 | main.rs:37:10:37:10 | b | semmle.label | b |
+| main.rs:41:9:41:9 | a | semmle.label | a |
 | main.rs:41:13:44:6 | pass_through(...) | semmle.label | pass_through(...) |
 | main.rs:41:26:44:5 | { ... } | semmle.label | { ... } |
 | main.rs:43:9:43:18 | source(...) | semmle.label | source(...) |
@@ -51,11 +65,15 @@ nodes
 | main.rs:63:13:63:21 | source(...) | semmle.label | source(...) |
 | main.rs:66:28:66:33 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:66:43:72:5 | { ... } | semmle.label | { ... } |
+| main.rs:77:9:77:9 | a | semmle.label | a |
 | main.rs:77:13:77:25 | mn.get_data(...) | semmle.label | mn.get_data(...) |
 | main.rs:78:10:78:10 | a | semmle.label | a |
+| main.rs:83:9:83:9 | a | semmle.label | a |
 | main.rs:83:13:83:21 | source(...) | semmle.label | source(...) |
 | main.rs:84:16:84:16 | a | semmle.label | a |
+| main.rs:89:9:89:9 | a | semmle.label | a |
 | main.rs:89:13:89:21 | source(...) | semmle.label | source(...) |
+| main.rs:90:9:90:9 | b | semmle.label | b |
 | main.rs:90:13:90:30 | mn.data_through(...) | semmle.label | mn.data_through(...) |
 | main.rs:90:29:90:29 | a | semmle.label | a |
 | main.rs:91:10:91:10 | b | semmle.label | b |

--- a/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
@@ -38,14 +38,16 @@ edges
 | main.rs:148:12:148:21 | source(...) | main.rs:147:13:150:5 | Point {...} [Point.x] | provenance |  |
 | main.rs:151:9:151:28 | Point {...} [Point.x] | main.rs:151:20:151:20 | a | provenance |  |
 | main.rs:151:20:151:20 | a | main.rs:152:10:152:10 | a | provenance |  |
-| main.rs:198:9:198:10 | s1 [Some] | main.rs:201:9:201:23 | ...::Some(...) [Some] | provenance |  |
+| main.rs:198:9:198:10 | s1 [Some] | main.rs:200:11:200:12 | s1 [Some] | provenance |  |
 | main.rs:198:14:198:37 | ...::Some(...) [Some] | main.rs:198:9:198:10 | s1 [Some] | provenance |  |
 | main.rs:198:27:198:36 | source(...) | main.rs:198:14:198:37 | ...::Some(...) [Some] | provenance |  |
+| main.rs:200:11:200:12 | s1 [Some] | main.rs:201:9:201:23 | ...::Some(...) [Some] | provenance |  |
 | main.rs:201:9:201:23 | ...::Some(...) [Some] | main.rs:201:22:201:22 | n | provenance |  |
 | main.rs:201:22:201:22 | n | main.rs:201:33:201:33 | n | provenance |  |
-| main.rs:211:9:211:10 | s1 [Some] | main.rs:214:9:214:15 | Some(...) [Some] | provenance |  |
+| main.rs:211:9:211:10 | s1 [Some] | main.rs:213:11:213:12 | s1 [Some] | provenance |  |
 | main.rs:211:14:211:29 | Some(...) [Some] | main.rs:211:9:211:10 | s1 [Some] | provenance |  |
 | main.rs:211:19:211:28 | source(...) | main.rs:211:14:211:29 | Some(...) [Some] | provenance |  |
+| main.rs:213:11:213:12 | s1 [Some] | main.rs:214:9:214:15 | Some(...) [Some] | provenance |  |
 | main.rs:214:9:214:15 | Some(...) [Some] | main.rs:214:14:214:14 | n | provenance |  |
 | main.rs:214:14:214:14 | n | main.rs:214:25:214:25 | n | provenance |  |
 | main.rs:224:9:224:10 | s1 [Some] | main.rs:225:10:225:11 | s1 [Some] | provenance |  |
@@ -64,36 +66,44 @@ edges
 | main.rs:241:9:241:10 | i1 | main.rs:243:10:243:11 | i1 | provenance |  |
 | main.rs:241:14:241:15 | s1 [Ok] | main.rs:241:14:241:16 | TryExpr | provenance |  |
 | main.rs:241:14:241:16 | TryExpr | main.rs:241:9:241:10 | i1 | provenance |  |
-| main.rs:256:9:256:10 | s1 [A] | main.rs:259:9:259:25 | ...::A(...) [A] | provenance |  |
-| main.rs:256:9:256:10 | s1 [A] | main.rs:263:9:263:25 | ...::A(...) [A] | provenance |  |
+| main.rs:256:9:256:10 | s1 [A] | main.rs:258:11:258:12 | s1 [A] | provenance |  |
 | main.rs:256:14:256:39 | ...::A(...) [A] | main.rs:256:9:256:10 | s1 [A] | provenance |  |
 | main.rs:256:29:256:38 | source(...) | main.rs:256:14:256:39 | ...::A(...) [A] | provenance |  |
+| main.rs:258:11:258:12 | s1 [A] | main.rs:259:9:259:25 | ...::A(...) [A] | provenance |  |
+| main.rs:258:11:258:12 | s1 [A] | main.rs:262:11:262:12 | s1 [A] | provenance |  |
 | main.rs:259:9:259:25 | ...::A(...) [A] | main.rs:259:24:259:24 | n | provenance |  |
 | main.rs:259:24:259:24 | n | main.rs:259:35:259:35 | n | provenance |  |
+| main.rs:262:11:262:12 | s1 [A] | main.rs:263:9:263:25 | ...::A(...) [A] | provenance |  |
 | main.rs:263:9:263:25 | ...::A(...) [A] | main.rs:263:24:263:24 | n | provenance |  |
 | main.rs:263:24:263:24 | n | main.rs:263:55:263:55 | n | provenance |  |
-| main.rs:274:9:274:10 | s1 [A] | main.rs:277:9:277:12 | A(...) [A] | provenance |  |
-| main.rs:274:9:274:10 | s1 [A] | main.rs:281:9:281:12 | A(...) [A] | provenance |  |
+| main.rs:274:9:274:10 | s1 [A] | main.rs:276:11:276:12 | s1 [A] | provenance |  |
 | main.rs:274:14:274:26 | A(...) [A] | main.rs:274:9:274:10 | s1 [A] | provenance |  |
 | main.rs:274:16:274:25 | source(...) | main.rs:274:14:274:26 | A(...) [A] | provenance |  |
+| main.rs:276:11:276:12 | s1 [A] | main.rs:277:9:277:12 | A(...) [A] | provenance |  |
+| main.rs:276:11:276:12 | s1 [A] | main.rs:280:11:280:12 | s1 [A] | provenance |  |
 | main.rs:277:9:277:12 | A(...) [A] | main.rs:277:11:277:11 | n | provenance |  |
 | main.rs:277:11:277:11 | n | main.rs:277:22:277:22 | n | provenance |  |
+| main.rs:280:11:280:12 | s1 [A] | main.rs:281:9:281:12 | A(...) [A] | provenance |  |
 | main.rs:281:9:281:12 | A(...) [A] | main.rs:281:11:281:11 | n | provenance |  |
 | main.rs:281:11:281:11 | n | main.rs:281:29:281:29 | n | provenance |  |
-| main.rs:295:9:295:10 | s1 [C] | main.rs:300:9:300:38 | ...::C {...} [C] | provenance |  |
-| main.rs:295:9:295:10 | s1 [C] | main.rs:304:9:304:38 | ...::C {...} [C] | provenance |  |
+| main.rs:295:9:295:10 | s1 [C] | main.rs:299:11:299:12 | s1 [C] | provenance |  |
 | main.rs:295:14:297:5 | ...::C {...} [C] | main.rs:295:9:295:10 | s1 [C] | provenance |  |
 | main.rs:296:18:296:27 | source(...) | main.rs:295:14:297:5 | ...::C {...} [C] | provenance |  |
+| main.rs:299:11:299:12 | s1 [C] | main.rs:300:9:300:38 | ...::C {...} [C] | provenance |  |
+| main.rs:299:11:299:12 | s1 [C] | main.rs:303:11:303:12 | s1 [C] | provenance |  |
 | main.rs:300:9:300:38 | ...::C {...} [C] | main.rs:300:36:300:36 | n | provenance |  |
 | main.rs:300:36:300:36 | n | main.rs:300:48:300:48 | n | provenance |  |
+| main.rs:303:11:303:12 | s1 [C] | main.rs:304:9:304:38 | ...::C {...} [C] | provenance |  |
 | main.rs:304:9:304:38 | ...::C {...} [C] | main.rs:304:36:304:36 | n | provenance |  |
 | main.rs:304:36:304:36 | n | main.rs:304:81:304:81 | n | provenance |  |
-| main.rs:315:9:315:10 | s1 [C] | main.rs:320:9:320:24 | C {...} [C] | provenance |  |
-| main.rs:315:9:315:10 | s1 [C] | main.rs:324:9:324:24 | C {...} [C] | provenance |  |
+| main.rs:315:9:315:10 | s1 [C] | main.rs:319:11:319:12 | s1 [C] | provenance |  |
 | main.rs:315:14:317:5 | C {...} [C] | main.rs:315:9:315:10 | s1 [C] | provenance |  |
 | main.rs:316:18:316:27 | source(...) | main.rs:315:14:317:5 | C {...} [C] | provenance |  |
+| main.rs:319:11:319:12 | s1 [C] | main.rs:320:9:320:24 | C {...} [C] | provenance |  |
+| main.rs:319:11:319:12 | s1 [C] | main.rs:323:11:323:12 | s1 [C] | provenance |  |
 | main.rs:320:9:320:24 | C {...} [C] | main.rs:320:22:320:22 | n | provenance |  |
 | main.rs:320:22:320:22 | n | main.rs:320:34:320:34 | n | provenance |  |
+| main.rs:323:11:323:12 | s1 [C] | main.rs:324:9:324:24 | C {...} [C] | provenance |  |
 | main.rs:324:9:324:24 | C {...} [C] | main.rs:324:22:324:22 | n | provenance |  |
 | main.rs:324:22:324:22 | n | main.rs:324:53:324:53 | n | provenance |  |
 | main.rs:336:9:336:12 | arr1 [array[]] | main.rs:337:14:337:17 | arr1 [array[]] | provenance |  |
@@ -113,9 +123,10 @@ edges
 | main.rs:350:23:350:32 | source(...) | main.rs:350:16:350:33 | [...] [array[]] | provenance |  |
 | main.rs:351:9:351:10 | n1 | main.rs:352:14:352:15 | n1 | provenance |  |
 | main.rs:351:15:351:18 | arr1 [array[]] | main.rs:351:9:351:10 | n1 | provenance |  |
-| main.rs:362:9:362:12 | arr1 [array[]] | main.rs:364:9:364:17 | SlicePat [array[]] | provenance |  |
+| main.rs:362:9:362:12 | arr1 [array[]] | main.rs:363:11:363:14 | arr1 [array[]] | provenance |  |
 | main.rs:362:16:362:33 | [...] [array[]] | main.rs:362:9:362:12 | arr1 [array[]] | provenance |  |
 | main.rs:362:23:362:32 | source(...) | main.rs:362:16:362:33 | [...] [array[]] | provenance |  |
+| main.rs:363:11:363:14 | arr1 [array[]] | main.rs:364:9:364:17 | SlicePat [array[]] | provenance |  |
 | main.rs:364:9:364:17 | SlicePat [array[]] | main.rs:364:10:364:10 | a | provenance |  |
 | main.rs:364:9:364:17 | SlicePat [array[]] | main.rs:364:13:364:13 | b | provenance |  |
 | main.rs:364:9:364:17 | SlicePat [array[]] | main.rs:364:16:364:16 | c | provenance |  |
@@ -181,12 +192,14 @@ nodes
 | main.rs:198:9:198:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:198:14:198:37 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
 | main.rs:198:27:198:36 | source(...) | semmle.label | source(...) |
+| main.rs:200:11:200:12 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:201:9:201:23 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
 | main.rs:201:22:201:22 | n | semmle.label | n |
 | main.rs:201:33:201:33 | n | semmle.label | n |
 | main.rs:211:9:211:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:211:14:211:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:211:19:211:28 | source(...) | semmle.label | source(...) |
+| main.rs:213:11:213:12 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:214:9:214:15 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:214:14:214:14 | n | semmle.label | n |
 | main.rs:214:25:214:25 | n | semmle.label | n |
@@ -212,36 +225,44 @@ nodes
 | main.rs:256:9:256:10 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:256:14:256:39 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:256:29:256:38 | source(...) | semmle.label | source(...) |
+| main.rs:258:11:258:12 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:259:9:259:25 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:259:24:259:24 | n | semmle.label | n |
 | main.rs:259:35:259:35 | n | semmle.label | n |
+| main.rs:262:11:262:12 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:263:9:263:25 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:263:24:263:24 | n | semmle.label | n |
 | main.rs:263:55:263:55 | n | semmle.label | n |
 | main.rs:274:9:274:10 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:274:14:274:26 | A(...) [A] | semmle.label | A(...) [A] |
 | main.rs:274:16:274:25 | source(...) | semmle.label | source(...) |
+| main.rs:276:11:276:12 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:277:9:277:12 | A(...) [A] | semmle.label | A(...) [A] |
 | main.rs:277:11:277:11 | n | semmle.label | n |
 | main.rs:277:22:277:22 | n | semmle.label | n |
+| main.rs:280:11:280:12 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:281:9:281:12 | A(...) [A] | semmle.label | A(...) [A] |
 | main.rs:281:11:281:11 | n | semmle.label | n |
 | main.rs:281:29:281:29 | n | semmle.label | n |
 | main.rs:295:9:295:10 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:295:14:297:5 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:296:18:296:27 | source(...) | semmle.label | source(...) |
+| main.rs:299:11:299:12 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:300:9:300:38 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:300:36:300:36 | n | semmle.label | n |
 | main.rs:300:48:300:48 | n | semmle.label | n |
+| main.rs:303:11:303:12 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:304:9:304:38 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:304:36:304:36 | n | semmle.label | n |
 | main.rs:304:81:304:81 | n | semmle.label | n |
 | main.rs:315:9:315:10 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:315:14:317:5 | C {...} [C] | semmle.label | C {...} [C] |
 | main.rs:316:18:316:27 | source(...) | semmle.label | source(...) |
+| main.rs:319:11:319:12 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:320:9:320:24 | C {...} [C] | semmle.label | C {...} [C] |
 | main.rs:320:22:320:22 | n | semmle.label | n |
 | main.rs:320:34:320:34 | n | semmle.label | n |
+| main.rs:323:11:323:12 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:324:9:324:24 | C {...} [C] | semmle.label | C {...} [C] |
 | main.rs:324:22:324:22 | n | semmle.label | n |
 | main.rs:324:53:324:53 | n | semmle.label | n |
@@ -268,6 +289,7 @@ nodes
 | main.rs:362:9:362:12 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:362:16:362:33 | [...] [array[]] | semmle.label | [...] [array[]] |
 | main.rs:362:23:362:32 | source(...) | semmle.label | source(...) |
+| main.rs:363:11:363:14 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:364:9:364:17 | SlicePat [array[]] | semmle.label | SlicePat [array[]] |
 | main.rs:364:10:364:10 | a | semmle.label | a |
 | main.rs:364:13:364:13 | b | semmle.label | b |

--- a/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
@@ -1,91 +1,120 @@
 models
 | 1 | Summary: lang:core; <crate::option::Option>::unwrap; Argument[self].Variant[crate::option::Option::Some(0)]; ReturnValue; value |
 edges
-| main.rs:19:13:19:21 | source(...) | main.rs:20:10:20:10 | s | provenance |  |
-| main.rs:24:13:24:21 | source(...) | main.rs:27:10:27:10 | c | provenance |  |
-| main.rs:31:13:31:21 | source(...) | main.rs:36:10:36:10 | b | provenance |  |
-| main.rs:45:15:45:23 | source(...) | main.rs:47:10:47:10 | b | provenance |  |
-| main.rs:53:9:53:17 | source(...) | main.rs:54:10:54:10 | i | provenance |  |
-| main.rs:94:13:94:26 | TupleExpr [tuple.0] | main.rs:95:10:95:10 | a [tuple.0] | provenance |  |
+| main.rs:19:9:19:9 | s | main.rs:20:10:20:10 | s | provenance |  |
+| main.rs:19:13:19:21 | source(...) | main.rs:19:9:19:9 | s | provenance |  |
+| main.rs:24:9:24:9 | a | main.rs:26:9:26:9 | c | provenance |  |
+| main.rs:24:13:24:21 | source(...) | main.rs:24:9:24:9 | a | provenance |  |
+| main.rs:26:9:26:9 | c | main.rs:27:10:27:10 | c | provenance |  |
+| main.rs:31:9:31:9 | a | main.rs:32:9:32:9 | b | provenance |  |
+| main.rs:31:13:31:21 | source(...) | main.rs:31:9:31:9 | a | provenance |  |
+| main.rs:32:9:32:9 | b | main.rs:36:10:36:10 | b | provenance |  |
+| main.rs:44:9:44:9 | b | main.rs:47:10:47:10 | b | provenance |  |
+| main.rs:45:15:45:23 | source(...) | main.rs:44:9:44:9 | b | provenance |  |
+| main.rs:53:5:53:5 | i | main.rs:54:10:54:10 | i | provenance |  |
+| main.rs:53:9:53:17 | source(...) | main.rs:53:5:53:5 | i | provenance |  |
+| main.rs:94:9:94:9 | a [tuple.0] | main.rs:95:10:95:10 | a [tuple.0] | provenance |  |
+| main.rs:94:13:94:26 | TupleExpr [tuple.0] | main.rs:94:9:94:9 | a [tuple.0] | provenance |  |
 | main.rs:94:14:94:22 | source(...) | main.rs:94:13:94:26 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:95:10:95:10 | a [tuple.0] | main.rs:95:10:95:12 | a.0 | provenance |  |
-| main.rs:108:17:108:31 | TupleExpr [tuple.1] | main.rs:110:10:110:10 | a [tuple.1] | provenance |  |
+| main.rs:108:9:108:13 | a [tuple.1] | main.rs:110:10:110:10 | a [tuple.1] | provenance |  |
+| main.rs:108:17:108:31 | TupleExpr [tuple.1] | main.rs:108:9:108:13 | a [tuple.1] | provenance |  |
 | main.rs:108:21:108:30 | source(...) | main.rs:108:17:108:31 | TupleExpr [tuple.1] | provenance |  |
 | main.rs:110:10:110:10 | a [tuple.1] | main.rs:110:10:110:12 | a.1 | provenance |  |
 | main.rs:111:5:111:5 | [post] a [tuple.0] | main.rs:112:5:112:5 | a [tuple.0] | provenance |  |
 | main.rs:111:11:111:20 | source(...) | main.rs:111:5:111:5 | [post] a [tuple.0] | provenance |  |
 | main.rs:112:5:112:5 | a [tuple.0] | main.rs:113:10:113:10 | a [tuple.0] | provenance |  |
 | main.rs:113:10:113:10 | a [tuple.0] | main.rs:113:10:113:12 | a.0 | provenance |  |
-| main.rs:118:13:118:27 | TupleExpr [tuple.1] | main.rs:119:14:119:14 | a [tuple.1] | provenance |  |
+| main.rs:118:9:118:9 | a [tuple.1] | main.rs:119:14:119:14 | a [tuple.1] | provenance |  |
+| main.rs:118:13:118:27 | TupleExpr [tuple.1] | main.rs:118:9:118:9 | a [tuple.1] | provenance |  |
 | main.rs:118:17:118:26 | source(...) | main.rs:118:13:118:27 | TupleExpr [tuple.1] | provenance |  |
-| main.rs:119:13:119:18 | TupleExpr [tuple.0, tuple.1] | main.rs:121:10:121:10 | b [tuple.0, tuple.1] | provenance |  |
+| main.rs:119:9:119:9 | b [tuple.0, tuple.1] | main.rs:121:10:121:10 | b [tuple.0, tuple.1] | provenance |  |
+| main.rs:119:13:119:18 | TupleExpr [tuple.0, tuple.1] | main.rs:119:9:119:9 | b [tuple.0, tuple.1] | provenance |  |
 | main.rs:119:14:119:14 | a [tuple.1] | main.rs:119:13:119:18 | TupleExpr [tuple.0, tuple.1] | provenance |  |
 | main.rs:121:10:121:10 | b [tuple.0, tuple.1] | main.rs:121:10:121:12 | b.0 [tuple.1] | provenance |  |
 | main.rs:121:10:121:12 | b.0 [tuple.1] | main.rs:121:10:121:15 | ... .1 | provenance |  |
-| main.rs:147:13:150:5 | Point {...} [Point.x] | main.rs:151:9:151:28 | Point {...} [Point.x] | provenance |  |
+| main.rs:147:9:147:9 | p [Point.x] | main.rs:151:9:151:28 | Point {...} [Point.x] | provenance |  |
+| main.rs:147:13:150:5 | Point {...} [Point.x] | main.rs:147:9:147:9 | p [Point.x] | provenance |  |
 | main.rs:148:12:148:21 | source(...) | main.rs:147:13:150:5 | Point {...} [Point.x] | provenance |  |
 | main.rs:151:9:151:28 | Point {...} [Point.x] | main.rs:151:20:151:20 | a | provenance |  |
 | main.rs:151:20:151:20 | a | main.rs:152:10:152:10 | a | provenance |  |
-| main.rs:198:14:198:37 | ...::Some(...) [Some] | main.rs:201:9:201:23 | ...::Some(...) [Some] | provenance |  |
+| main.rs:198:9:198:10 | s1 [Some] | main.rs:201:9:201:23 | ...::Some(...) [Some] | provenance |  |
+| main.rs:198:14:198:37 | ...::Some(...) [Some] | main.rs:198:9:198:10 | s1 [Some] | provenance |  |
 | main.rs:198:27:198:36 | source(...) | main.rs:198:14:198:37 | ...::Some(...) [Some] | provenance |  |
 | main.rs:201:9:201:23 | ...::Some(...) [Some] | main.rs:201:22:201:22 | n | provenance |  |
 | main.rs:201:22:201:22 | n | main.rs:201:33:201:33 | n | provenance |  |
-| main.rs:211:14:211:29 | Some(...) [Some] | main.rs:214:9:214:15 | Some(...) [Some] | provenance |  |
+| main.rs:211:9:211:10 | s1 [Some] | main.rs:214:9:214:15 | Some(...) [Some] | provenance |  |
+| main.rs:211:14:211:29 | Some(...) [Some] | main.rs:211:9:211:10 | s1 [Some] | provenance |  |
 | main.rs:211:19:211:28 | source(...) | main.rs:211:14:211:29 | Some(...) [Some] | provenance |  |
 | main.rs:214:9:214:15 | Some(...) [Some] | main.rs:214:14:214:14 | n | provenance |  |
 | main.rs:214:14:214:14 | n | main.rs:214:25:214:25 | n | provenance |  |
-| main.rs:224:14:224:29 | Some(...) [Some] | main.rs:225:10:225:11 | s1 [Some] | provenance |  |
+| main.rs:224:9:224:10 | s1 [Some] | main.rs:225:10:225:11 | s1 [Some] | provenance |  |
+| main.rs:224:14:224:29 | Some(...) [Some] | main.rs:224:9:224:10 | s1 [Some] | provenance |  |
 | main.rs:224:19:224:28 | source(...) | main.rs:224:14:224:29 | Some(...) [Some] | provenance |  |
 | main.rs:225:10:225:11 | s1 [Some] | main.rs:225:10:225:20 | s1.unwrap(...) | provenance | MaD:1 |
-| main.rs:229:14:229:29 | Some(...) [Some] | main.rs:231:14:231:15 | s1 [Some] | provenance |  |
+| main.rs:229:9:229:10 | s1 [Some] | main.rs:231:14:231:15 | s1 [Some] | provenance |  |
+| main.rs:229:14:229:29 | Some(...) [Some] | main.rs:229:9:229:10 | s1 [Some] | provenance |  |
 | main.rs:229:19:229:28 | source(...) | main.rs:229:14:229:29 | Some(...) [Some] | provenance |  |
+| main.rs:231:9:231:10 | i1 | main.rs:232:10:232:11 | i1 | provenance |  |
 | main.rs:231:14:231:15 | s1 [Some] | main.rs:231:14:231:16 | TryExpr | provenance |  |
-| main.rs:231:14:231:16 | TryExpr | main.rs:232:10:232:11 | i1 | provenance |  |
-| main.rs:238:32:238:45 | Ok(...) [Ok] | main.rs:241:14:241:15 | s1 [Ok] | provenance |  |
+| main.rs:231:14:231:16 | TryExpr | main.rs:231:9:231:10 | i1 | provenance |  |
+| main.rs:238:9:238:10 | s1 [Ok] | main.rs:241:14:241:15 | s1 [Ok] | provenance |  |
+| main.rs:238:32:238:45 | Ok(...) [Ok] | main.rs:238:9:238:10 | s1 [Ok] | provenance |  |
 | main.rs:238:35:238:44 | source(...) | main.rs:238:32:238:45 | Ok(...) [Ok] | provenance |  |
+| main.rs:241:9:241:10 | i1 | main.rs:243:10:243:11 | i1 | provenance |  |
 | main.rs:241:14:241:15 | s1 [Ok] | main.rs:241:14:241:16 | TryExpr | provenance |  |
-| main.rs:241:14:241:16 | TryExpr | main.rs:243:10:243:11 | i1 | provenance |  |
-| main.rs:256:14:256:39 | ...::A(...) [A] | main.rs:259:9:259:25 | ...::A(...) [A] | provenance |  |
-| main.rs:256:14:256:39 | ...::A(...) [A] | main.rs:263:9:263:25 | ...::A(...) [A] | provenance |  |
+| main.rs:241:14:241:16 | TryExpr | main.rs:241:9:241:10 | i1 | provenance |  |
+| main.rs:256:9:256:10 | s1 [A] | main.rs:259:9:259:25 | ...::A(...) [A] | provenance |  |
+| main.rs:256:9:256:10 | s1 [A] | main.rs:263:9:263:25 | ...::A(...) [A] | provenance |  |
+| main.rs:256:14:256:39 | ...::A(...) [A] | main.rs:256:9:256:10 | s1 [A] | provenance |  |
 | main.rs:256:29:256:38 | source(...) | main.rs:256:14:256:39 | ...::A(...) [A] | provenance |  |
 | main.rs:259:9:259:25 | ...::A(...) [A] | main.rs:259:24:259:24 | n | provenance |  |
 | main.rs:259:24:259:24 | n | main.rs:259:35:259:35 | n | provenance |  |
 | main.rs:263:9:263:25 | ...::A(...) [A] | main.rs:263:24:263:24 | n | provenance |  |
 | main.rs:263:24:263:24 | n | main.rs:263:55:263:55 | n | provenance |  |
-| main.rs:274:14:274:26 | A(...) [A] | main.rs:277:9:277:12 | A(...) [A] | provenance |  |
-| main.rs:274:14:274:26 | A(...) [A] | main.rs:281:9:281:12 | A(...) [A] | provenance |  |
+| main.rs:274:9:274:10 | s1 [A] | main.rs:277:9:277:12 | A(...) [A] | provenance |  |
+| main.rs:274:9:274:10 | s1 [A] | main.rs:281:9:281:12 | A(...) [A] | provenance |  |
+| main.rs:274:14:274:26 | A(...) [A] | main.rs:274:9:274:10 | s1 [A] | provenance |  |
 | main.rs:274:16:274:25 | source(...) | main.rs:274:14:274:26 | A(...) [A] | provenance |  |
 | main.rs:277:9:277:12 | A(...) [A] | main.rs:277:11:277:11 | n | provenance |  |
 | main.rs:277:11:277:11 | n | main.rs:277:22:277:22 | n | provenance |  |
 | main.rs:281:9:281:12 | A(...) [A] | main.rs:281:11:281:11 | n | provenance |  |
 | main.rs:281:11:281:11 | n | main.rs:281:29:281:29 | n | provenance |  |
-| main.rs:295:14:297:5 | ...::C {...} [C] | main.rs:300:9:300:38 | ...::C {...} [C] | provenance |  |
-| main.rs:295:14:297:5 | ...::C {...} [C] | main.rs:304:9:304:38 | ...::C {...} [C] | provenance |  |
+| main.rs:295:9:295:10 | s1 [C] | main.rs:300:9:300:38 | ...::C {...} [C] | provenance |  |
+| main.rs:295:9:295:10 | s1 [C] | main.rs:304:9:304:38 | ...::C {...} [C] | provenance |  |
+| main.rs:295:14:297:5 | ...::C {...} [C] | main.rs:295:9:295:10 | s1 [C] | provenance |  |
 | main.rs:296:18:296:27 | source(...) | main.rs:295:14:297:5 | ...::C {...} [C] | provenance |  |
 | main.rs:300:9:300:38 | ...::C {...} [C] | main.rs:300:36:300:36 | n | provenance |  |
 | main.rs:300:36:300:36 | n | main.rs:300:48:300:48 | n | provenance |  |
 | main.rs:304:9:304:38 | ...::C {...} [C] | main.rs:304:36:304:36 | n | provenance |  |
 | main.rs:304:36:304:36 | n | main.rs:304:81:304:81 | n | provenance |  |
-| main.rs:315:14:317:5 | C {...} [C] | main.rs:320:9:320:24 | C {...} [C] | provenance |  |
-| main.rs:315:14:317:5 | C {...} [C] | main.rs:324:9:324:24 | C {...} [C] | provenance |  |
+| main.rs:315:9:315:10 | s1 [C] | main.rs:320:9:320:24 | C {...} [C] | provenance |  |
+| main.rs:315:9:315:10 | s1 [C] | main.rs:324:9:324:24 | C {...} [C] | provenance |  |
+| main.rs:315:14:317:5 | C {...} [C] | main.rs:315:9:315:10 | s1 [C] | provenance |  |
 | main.rs:316:18:316:27 | source(...) | main.rs:315:14:317:5 | C {...} [C] | provenance |  |
 | main.rs:320:9:320:24 | C {...} [C] | main.rs:320:22:320:22 | n | provenance |  |
 | main.rs:320:22:320:22 | n | main.rs:320:34:320:34 | n | provenance |  |
 | main.rs:324:9:324:24 | C {...} [C] | main.rs:324:22:324:22 | n | provenance |  |
 | main.rs:324:22:324:22 | n | main.rs:324:53:324:53 | n | provenance |  |
-| main.rs:336:16:336:33 | [...] [array[]] | main.rs:337:14:337:17 | arr1 [array[]] | provenance |  |
+| main.rs:336:9:336:12 | arr1 [array[]] | main.rs:337:14:337:17 | arr1 [array[]] | provenance |  |
+| main.rs:336:16:336:33 | [...] [array[]] | main.rs:336:9:336:12 | arr1 [array[]] | provenance |  |
 | main.rs:336:23:336:32 | source(...) | main.rs:336:16:336:33 | [...] [array[]] | provenance |  |
+| main.rs:337:9:337:10 | n1 | main.rs:338:10:338:11 | n1 | provenance |  |
 | main.rs:337:14:337:17 | arr1 [array[]] | main.rs:337:14:337:20 | arr1[2] | provenance |  |
-| main.rs:337:14:337:20 | arr1[2] | main.rs:338:10:338:11 | n1 | provenance |  |
-| main.rs:340:16:340:31 | [...; 10] [array[]] | main.rs:341:14:341:17 | arr2 [array[]] | provenance |  |
+| main.rs:337:14:337:20 | arr1[2] | main.rs:337:9:337:10 | n1 | provenance |  |
+| main.rs:340:9:340:12 | arr2 [array[]] | main.rs:341:14:341:17 | arr2 [array[]] | provenance |  |
+| main.rs:340:16:340:31 | [...; 10] [array[]] | main.rs:340:9:340:12 | arr2 [array[]] | provenance |  |
 | main.rs:340:17:340:26 | source(...) | main.rs:340:16:340:31 | [...; 10] [array[]] | provenance |  |
+| main.rs:341:9:341:10 | n2 | main.rs:342:10:342:11 | n2 | provenance |  |
 | main.rs:341:14:341:17 | arr2 [array[]] | main.rs:341:14:341:20 | arr2[4] | provenance |  |
-| main.rs:341:14:341:20 | arr2[4] | main.rs:342:10:342:11 | n2 | provenance |  |
-| main.rs:350:16:350:33 | [...] [array[]] | main.rs:351:15:351:18 | arr1 [array[]] | provenance |  |
+| main.rs:341:14:341:20 | arr2[4] | main.rs:341:9:341:10 | n2 | provenance |  |
+| main.rs:350:9:350:12 | arr1 [array[]] | main.rs:351:15:351:18 | arr1 [array[]] | provenance |  |
+| main.rs:350:16:350:33 | [...] [array[]] | main.rs:350:9:350:12 | arr1 [array[]] | provenance |  |
 | main.rs:350:23:350:32 | source(...) | main.rs:350:16:350:33 | [...] [array[]] | provenance |  |
 | main.rs:351:9:351:10 | n1 | main.rs:352:14:352:15 | n1 | provenance |  |
 | main.rs:351:15:351:18 | arr1 [array[]] | main.rs:351:9:351:10 | n1 | provenance |  |
-| main.rs:362:16:362:33 | [...] [array[]] | main.rs:364:9:364:17 | SlicePat [array[]] | provenance |  |
+| main.rs:362:9:362:12 | arr1 [array[]] | main.rs:364:9:364:17 | SlicePat [array[]] | provenance |  |
+| main.rs:362:16:362:33 | [...] [array[]] | main.rs:362:9:362:12 | arr1 [array[]] | provenance |  |
 | main.rs:362:23:362:32 | source(...) | main.rs:362:16:362:33 | [...] [array[]] | provenance |  |
 | main.rs:364:9:364:17 | SlicePat [array[]] | main.rs:364:10:364:10 | a | provenance |  |
 | main.rs:364:9:364:17 | SlicePat [array[]] | main.rs:364:13:364:13 | b | provenance |  |
@@ -96,25 +125,35 @@ edges
 | main.rs:376:5:376:11 | [post] mut_arr [array[]] | main.rs:377:13:377:19 | mut_arr [array[]] | provenance |  |
 | main.rs:376:5:376:11 | [post] mut_arr [array[]] | main.rs:379:10:379:16 | mut_arr [array[]] | provenance |  |
 | main.rs:376:18:376:27 | source(...) | main.rs:376:5:376:11 | [post] mut_arr [array[]] | provenance |  |
+| main.rs:377:9:377:9 | d | main.rs:378:10:378:10 | d | provenance |  |
 | main.rs:377:13:377:19 | mut_arr [array[]] | main.rs:377:13:377:22 | mut_arr[1] | provenance |  |
-| main.rs:377:13:377:22 | mut_arr[1] | main.rs:378:10:378:10 | d | provenance |  |
+| main.rs:377:13:377:22 | mut_arr[1] | main.rs:377:9:377:9 | d | provenance |  |
 | main.rs:379:10:379:16 | mut_arr [array[]] | main.rs:379:10:379:19 | mut_arr[0] | provenance |  |
 nodes
 | main.rs:15:10:15:18 | source(...) | semmle.label | source(...) |
+| main.rs:19:9:19:9 | s | semmle.label | s |
 | main.rs:19:13:19:21 | source(...) | semmle.label | source(...) |
 | main.rs:20:10:20:10 | s | semmle.label | s |
+| main.rs:24:9:24:9 | a | semmle.label | a |
 | main.rs:24:13:24:21 | source(...) | semmle.label | source(...) |
+| main.rs:26:9:26:9 | c | semmle.label | c |
 | main.rs:27:10:27:10 | c | semmle.label | c |
+| main.rs:31:9:31:9 | a | semmle.label | a |
 | main.rs:31:13:31:21 | source(...) | semmle.label | source(...) |
+| main.rs:32:9:32:9 | b | semmle.label | b |
 | main.rs:36:10:36:10 | b | semmle.label | b |
+| main.rs:44:9:44:9 | b | semmle.label | b |
 | main.rs:45:15:45:23 | source(...) | semmle.label | source(...) |
 | main.rs:47:10:47:10 | b | semmle.label | b |
+| main.rs:53:5:53:5 | i | semmle.label | i |
 | main.rs:53:9:53:17 | source(...) | semmle.label | source(...) |
 | main.rs:54:10:54:10 | i | semmle.label | i |
+| main.rs:94:9:94:9 | a [tuple.0] | semmle.label | a [tuple.0] |
 | main.rs:94:13:94:26 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | main.rs:94:14:94:22 | source(...) | semmle.label | source(...) |
 | main.rs:95:10:95:10 | a [tuple.0] | semmle.label | a [tuple.0] |
 | main.rs:95:10:95:12 | a.0 | semmle.label | a.0 |
+| main.rs:108:9:108:13 | a [tuple.1] | semmle.label | a [tuple.1] |
 | main.rs:108:17:108:31 | TupleExpr [tuple.1] | semmle.label | TupleExpr [tuple.1] |
 | main.rs:108:21:108:30 | source(...) | semmle.label | source(...) |
 | main.rs:110:10:110:10 | a [tuple.1] | semmle.label | a [tuple.1] |
@@ -124,42 +163,53 @@ nodes
 | main.rs:112:5:112:5 | a [tuple.0] | semmle.label | a [tuple.0] |
 | main.rs:113:10:113:10 | a [tuple.0] | semmle.label | a [tuple.0] |
 | main.rs:113:10:113:12 | a.0 | semmle.label | a.0 |
+| main.rs:118:9:118:9 | a [tuple.1] | semmle.label | a [tuple.1] |
 | main.rs:118:13:118:27 | TupleExpr [tuple.1] | semmle.label | TupleExpr [tuple.1] |
 | main.rs:118:17:118:26 | source(...) | semmle.label | source(...) |
+| main.rs:119:9:119:9 | b [tuple.0, tuple.1] | semmle.label | b [tuple.0, tuple.1] |
 | main.rs:119:13:119:18 | TupleExpr [tuple.0, tuple.1] | semmle.label | TupleExpr [tuple.0, tuple.1] |
 | main.rs:119:14:119:14 | a [tuple.1] | semmle.label | a [tuple.1] |
 | main.rs:121:10:121:10 | b [tuple.0, tuple.1] | semmle.label | b [tuple.0, tuple.1] |
 | main.rs:121:10:121:12 | b.0 [tuple.1] | semmle.label | b.0 [tuple.1] |
 | main.rs:121:10:121:15 | ... .1 | semmle.label | ... .1 |
+| main.rs:147:9:147:9 | p [Point.x] | semmle.label | p [Point.x] |
 | main.rs:147:13:150:5 | Point {...} [Point.x] | semmle.label | Point {...} [Point.x] |
 | main.rs:148:12:148:21 | source(...) | semmle.label | source(...) |
 | main.rs:151:9:151:28 | Point {...} [Point.x] | semmle.label | Point {...} [Point.x] |
 | main.rs:151:20:151:20 | a | semmle.label | a |
 | main.rs:152:10:152:10 | a | semmle.label | a |
+| main.rs:198:9:198:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:198:14:198:37 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
 | main.rs:198:27:198:36 | source(...) | semmle.label | source(...) |
 | main.rs:201:9:201:23 | ...::Some(...) [Some] | semmle.label | ...::Some(...) [Some] |
 | main.rs:201:22:201:22 | n | semmle.label | n |
 | main.rs:201:33:201:33 | n | semmle.label | n |
+| main.rs:211:9:211:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:211:14:211:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:211:19:211:28 | source(...) | semmle.label | source(...) |
 | main.rs:214:9:214:15 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:214:14:214:14 | n | semmle.label | n |
 | main.rs:214:25:214:25 | n | semmle.label | n |
+| main.rs:224:9:224:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:224:14:224:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:224:19:224:28 | source(...) | semmle.label | source(...) |
 | main.rs:225:10:225:11 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:225:10:225:20 | s1.unwrap(...) | semmle.label | s1.unwrap(...) |
+| main.rs:229:9:229:10 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:229:14:229:29 | Some(...) [Some] | semmle.label | Some(...) [Some] |
 | main.rs:229:19:229:28 | source(...) | semmle.label | source(...) |
+| main.rs:231:9:231:10 | i1 | semmle.label | i1 |
 | main.rs:231:14:231:15 | s1 [Some] | semmle.label | s1 [Some] |
 | main.rs:231:14:231:16 | TryExpr | semmle.label | TryExpr |
 | main.rs:232:10:232:11 | i1 | semmle.label | i1 |
+| main.rs:238:9:238:10 | s1 [Ok] | semmle.label | s1 [Ok] |
 | main.rs:238:32:238:45 | Ok(...) [Ok] | semmle.label | Ok(...) [Ok] |
 | main.rs:238:35:238:44 | source(...) | semmle.label | source(...) |
+| main.rs:241:9:241:10 | i1 | semmle.label | i1 |
 | main.rs:241:14:241:15 | s1 [Ok] | semmle.label | s1 [Ok] |
 | main.rs:241:14:241:16 | TryExpr | semmle.label | TryExpr |
 | main.rs:243:10:243:11 | i1 | semmle.label | i1 |
+| main.rs:256:9:256:10 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:256:14:256:39 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:256:29:256:38 | source(...) | semmle.label | source(...) |
 | main.rs:259:9:259:25 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
@@ -168,6 +218,7 @@ nodes
 | main.rs:263:9:263:25 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:263:24:263:24 | n | semmle.label | n |
 | main.rs:263:55:263:55 | n | semmle.label | n |
+| main.rs:274:9:274:10 | s1 [A] | semmle.label | s1 [A] |
 | main.rs:274:14:274:26 | A(...) [A] | semmle.label | A(...) [A] |
 | main.rs:274:16:274:25 | source(...) | semmle.label | source(...) |
 | main.rs:277:9:277:12 | A(...) [A] | semmle.label | A(...) [A] |
@@ -176,6 +227,7 @@ nodes
 | main.rs:281:9:281:12 | A(...) [A] | semmle.label | A(...) [A] |
 | main.rs:281:11:281:11 | n | semmle.label | n |
 | main.rs:281:29:281:29 | n | semmle.label | n |
+| main.rs:295:9:295:10 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:295:14:297:5 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:296:18:296:27 | source(...) | semmle.label | source(...) |
 | main.rs:300:9:300:38 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
@@ -184,6 +236,7 @@ nodes
 | main.rs:304:9:304:38 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:304:36:304:36 | n | semmle.label | n |
 | main.rs:304:81:304:81 | n | semmle.label | n |
+| main.rs:315:9:315:10 | s1 [C] | semmle.label | s1 [C] |
 | main.rs:315:14:317:5 | C {...} [C] | semmle.label | C {...} [C] |
 | main.rs:316:18:316:27 | source(...) | semmle.label | source(...) |
 | main.rs:320:9:320:24 | C {...} [C] | semmle.label | C {...} [C] |
@@ -192,21 +245,27 @@ nodes
 | main.rs:324:9:324:24 | C {...} [C] | semmle.label | C {...} [C] |
 | main.rs:324:22:324:22 | n | semmle.label | n |
 | main.rs:324:53:324:53 | n | semmle.label | n |
+| main.rs:336:9:336:12 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:336:16:336:33 | [...] [array[]] | semmle.label | [...] [array[]] |
 | main.rs:336:23:336:32 | source(...) | semmle.label | source(...) |
+| main.rs:337:9:337:10 | n1 | semmle.label | n1 |
 | main.rs:337:14:337:17 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:337:14:337:20 | arr1[2] | semmle.label | arr1[2] |
 | main.rs:338:10:338:11 | n1 | semmle.label | n1 |
+| main.rs:340:9:340:12 | arr2 [array[]] | semmle.label | arr2 [array[]] |
 | main.rs:340:16:340:31 | [...; 10] [array[]] | semmle.label | [...; 10] [array[]] |
 | main.rs:340:17:340:26 | source(...) | semmle.label | source(...) |
+| main.rs:341:9:341:10 | n2 | semmle.label | n2 |
 | main.rs:341:14:341:17 | arr2 [array[]] | semmle.label | arr2 [array[]] |
 | main.rs:341:14:341:20 | arr2[4] | semmle.label | arr2[4] |
 | main.rs:342:10:342:11 | n2 | semmle.label | n2 |
+| main.rs:350:9:350:12 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:350:16:350:33 | [...] [array[]] | semmle.label | [...] [array[]] |
 | main.rs:350:23:350:32 | source(...) | semmle.label | source(...) |
 | main.rs:351:9:351:10 | n1 | semmle.label | n1 |
 | main.rs:351:15:351:18 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:352:14:352:15 | n1 | semmle.label | n1 |
+| main.rs:362:9:362:12 | arr1 [array[]] | semmle.label | arr1 [array[]] |
 | main.rs:362:16:362:33 | [...] [array[]] | semmle.label | [...] [array[]] |
 | main.rs:362:23:362:32 | source(...) | semmle.label | source(...) |
 | main.rs:364:9:364:17 | SlicePat [array[]] | semmle.label | SlicePat [array[]] |
@@ -218,6 +277,7 @@ nodes
 | main.rs:367:18:367:18 | c | semmle.label | c |
 | main.rs:376:5:376:11 | [post] mut_arr [array[]] | semmle.label | [post] mut_arr [array[]] |
 | main.rs:376:18:376:27 | source(...) | semmle.label | source(...) |
+| main.rs:377:9:377:9 | d | semmle.label | d |
 | main.rs:377:13:377:19 | mut_arr [array[]] | semmle.label | mut_arr [array[]] |
 | main.rs:377:13:377:22 | mut_arr[1] | semmle.label | mut_arr[1] |
 | main.rs:378:10:378:10 | d | semmle.label | d |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -10,98 +10,142 @@ models
 | 9 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
 | 10 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
 edges
-| main.rs:15:13:15:21 | source(...) | main.rs:16:19:16:19 | s | provenance |  |
-| main.rs:15:13:15:21 | source(...) | main.rs:16:19:16:19 | s | provenance |  |
+| main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
+| main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
+| main.rs:15:13:15:21 | source(...) | main.rs:15:9:15:9 | s | provenance |  |
+| main.rs:15:13:15:21 | source(...) | main.rs:15:9:15:9 | s | provenance |  |
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
-| main.rs:25:13:25:22 | source(...) | main.rs:26:17:26:17 | s | provenance |  |
+| main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
+| main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
 | main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:1 |
-| main.rs:40:13:40:21 | source(...) | main.rs:41:27:41:27 | s | provenance |  |
-| main.rs:40:13:40:21 | source(...) | main.rs:41:27:41:27 | s | provenance |  |
-| main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:42:22:42:23 | e1 [A] | provenance |  |
-| main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:42:22:42:23 | e1 [A] | provenance |  |
+| main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
+| main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
+| main.rs:40:13:40:21 | source(...) | main.rs:40:9:40:9 | s | provenance |  |
+| main.rs:40:13:40:21 | source(...) | main.rs:40:9:40:9 | s | provenance |  |
+| main.rs:41:9:41:10 | e1 [A] | main.rs:42:22:42:23 | e1 [A] | provenance |  |
+| main.rs:41:9:41:10 | e1 [A] | main.rs:42:22:42:23 | e1 [A] | provenance |  |
+| main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
+| main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:6 |
 | main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:6 |
-| main.rs:53:13:53:21 | source(...) | main.rs:54:26:54:26 | s | provenance |  |
-| main.rs:53:13:53:21 | source(...) | main.rs:54:26:54:26 | s | provenance |  |
-| main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
-| main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
+| main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
+| main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
+| main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
+| main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
+| main.rs:54:9:54:10 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
+| main.rs:54:9:54:10 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
+| main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
+| main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:10 |
 | main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:10 |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
 | main.rs:57:22:57:22 | i | main.rs:57:33:57:33 | i | provenance |  |
 | main.rs:57:22:57:22 | i | main.rs:57:33:57:33 | i | provenance |  |
-| main.rs:72:13:72:21 | source(...) | main.rs:73:40:73:40 | s | provenance |  |
-| main.rs:72:13:72:21 | source(...) | main.rs:73:40:73:40 | s | provenance |  |
-| main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:74:24:74:25 | e1 [C] | provenance |  |
-| main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:74:24:74:25 | e1 [C] | provenance |  |
+| main.rs:72:9:72:9 | s | main.rs:73:40:73:40 | s | provenance |  |
+| main.rs:72:9:72:9 | s | main.rs:73:40:73:40 | s | provenance |  |
+| main.rs:72:13:72:21 | source(...) | main.rs:72:9:72:9 | s | provenance |  |
+| main.rs:72:13:72:21 | source(...) | main.rs:72:9:72:9 | s | provenance |  |
+| main.rs:73:9:73:10 | e1 [C] | main.rs:74:24:74:25 | e1 [C] | provenance |  |
+| main.rs:73:9:73:10 | e1 [C] | main.rs:74:24:74:25 | e1 [C] | provenance |  |
+| main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
+| main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:5 |
 | main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:5 |
-| main.rs:85:13:85:21 | source(...) | main.rs:86:28:86:28 | s | provenance |  |
-| main.rs:85:13:85:21 | source(...) | main.rs:86:28:86:28 | s | provenance |  |
-| main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
-| main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
+| main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
+| main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
+| main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
+| main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
+| main.rs:86:9:86:10 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
+| main.rs:86:9:86:10 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
+| main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
+| main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:9 |
 | main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:9 |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
 | main.rs:89:35:89:35 | i | main.rs:89:47:89:47 | i | provenance |  |
 | main.rs:89:35:89:35 | i | main.rs:89:47:89:47 | i | provenance |  |
-| main.rs:104:13:104:21 | source(...) | main.rs:106:17:106:17 | s | provenance |  |
-| main.rs:104:13:104:21 | source(...) | main.rs:106:17:106:17 | s | provenance |  |
-| main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | provenance |  |
-| main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | provenance |  |
+| main.rs:104:9:104:9 | s | main.rs:106:17:106:17 | s | provenance |  |
+| main.rs:104:9:104:9 | s | main.rs:106:17:106:17 | s | provenance |  |
+| main.rs:104:13:104:21 | source(...) | main.rs:104:9:104:9 | s | provenance |  |
+| main.rs:104:13:104:21 | source(...) | main.rs:104:9:104:9 | s | provenance |  |
+| main.rs:105:9:105:17 | my_struct [MyStruct.field1] | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | provenance |  |
+| main.rs:105:9:105:17 | my_struct [MyStruct.field1] | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | provenance |  |
+| main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
+| main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:3 |
 | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:3 |
-| main.rs:138:13:138:21 | source(...) | main.rs:139:29:139:29 | s | provenance |  |
-| main.rs:138:13:138:21 | source(...) | main.rs:139:29:139:29 | s | provenance |  |
+| main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
+| main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
+| main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
+| main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
 | main.rs:139:28:139:30 | [...] [array[]] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:2 |
 | main.rs:139:28:139:30 | [...] [array[]] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:2 |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [array[]] | provenance |  |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [array[]] | provenance |  |
-| main.rs:148:13:148:21 | source(...) | main.rs:149:33:149:33 | s | provenance |  |
-| main.rs:148:13:148:21 | source(...) | main.rs:149:33:149:33 | s | provenance |  |
-| main.rs:149:15:149:34 | set_array_element(...) [array[]] | main.rs:150:10:150:12 | arr [array[]] | provenance |  |
-| main.rs:149:15:149:34 | set_array_element(...) [array[]] | main.rs:150:10:150:12 | arr [array[]] | provenance |  |
+| main.rs:148:9:148:9 | s | main.rs:149:33:149:33 | s | provenance |  |
+| main.rs:148:9:148:9 | s | main.rs:149:33:149:33 | s | provenance |  |
+| main.rs:148:13:148:21 | source(...) | main.rs:148:9:148:9 | s | provenance |  |
+| main.rs:148:13:148:21 | source(...) | main.rs:148:9:148:9 | s | provenance |  |
+| main.rs:149:9:149:11 | arr [array[]] | main.rs:150:10:150:12 | arr [array[]] | provenance |  |
+| main.rs:149:9:149:11 | arr [array[]] | main.rs:150:10:150:12 | arr [array[]] | provenance |  |
+| main.rs:149:15:149:34 | set_array_element(...) [array[]] | main.rs:149:9:149:11 | arr [array[]] | provenance |  |
+| main.rs:149:15:149:34 | set_array_element(...) [array[]] | main.rs:149:9:149:11 | arr [array[]] | provenance |  |
 | main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [array[]] | provenance | MaD:7 |
 | main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [array[]] | provenance | MaD:7 |
 | main.rs:150:10:150:12 | arr [array[]] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:150:10:150:12 | arr [array[]] | main.rs:150:10:150:15 | arr[0] | provenance |  |
-| main.rs:159:13:159:22 | source(...) | main.rs:160:14:160:14 | s | provenance |  |
-| main.rs:159:13:159:22 | source(...) | main.rs:160:14:160:14 | s | provenance |  |
-| main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:161:28:161:28 | t [tuple.0] | provenance |  |
-| main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:161:28:161:28 | t [tuple.0] | provenance |  |
+| main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
+| main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
+| main.rs:159:13:159:22 | source(...) | main.rs:159:9:159:9 | s | provenance |  |
+| main.rs:159:13:159:22 | source(...) | main.rs:159:9:159:9 | s | provenance |  |
+| main.rs:160:9:160:9 | t [tuple.0] | main.rs:161:28:161:28 | t [tuple.0] | provenance |  |
+| main.rs:160:9:160:9 | t [tuple.0] | main.rs:161:28:161:28 | t [tuple.0] | provenance |  |
+| main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
+| main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:4 |
 | main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:4 |
-| main.rs:172:13:172:22 | source(...) | main.rs:173:31:173:31 | s | provenance |  |
-| main.rs:172:13:172:22 | source(...) | main.rs:173:31:173:31 | s | provenance |  |
-| main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
-| main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
+| main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
+| main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
+| main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
+| main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
+| main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
+| main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
+| main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
+| main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
 | main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:8 |
 | main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:8 |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 nodes
+| main.rs:15:9:15:9 | s | semmle.label | s |
+| main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:13:15:21 | source(...) | semmle.label | source(...) |
 | main.rs:15:13:15:21 | source(...) | semmle.label | source(...) |
 | main.rs:16:10:16:20 | identity(...) | semmle.label | identity(...) |
 | main.rs:16:10:16:20 | identity(...) | semmle.label | identity(...) |
 | main.rs:16:19:16:19 | s | semmle.label | s |
 | main.rs:16:19:16:19 | s | semmle.label | s |
+| main.rs:25:9:25:9 | s | semmle.label | s |
 | main.rs:25:13:25:22 | source(...) | semmle.label | source(...) |
 | main.rs:26:10:26:18 | coerce(...) | semmle.label | coerce(...) |
 | main.rs:26:17:26:17 | s | semmle.label | s |
+| main.rs:40:9:40:9 | s | semmle.label | s |
+| main.rs:40:9:40:9 | s | semmle.label | s |
 | main.rs:40:13:40:21 | source(...) | semmle.label | source(...) |
 | main.rs:40:13:40:21 | source(...) | semmle.label | source(...) |
+| main.rs:41:9:41:10 | e1 [A] | semmle.label | e1 [A] |
+| main.rs:41:9:41:10 | e1 [A] | semmle.label | e1 [A] |
 | main.rs:41:14:41:28 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:41:14:41:28 | ...::A(...) [A] | semmle.label | ...::A(...) [A] |
 | main.rs:41:27:41:27 | s | semmle.label | s |
@@ -110,8 +154,12 @@ nodes
 | main.rs:42:10:42:24 | get_var_pos(...) | semmle.label | get_var_pos(...) |
 | main.rs:42:22:42:23 | e1 [A] | semmle.label | e1 [A] |
 | main.rs:42:22:42:23 | e1 [A] | semmle.label | e1 [A] |
+| main.rs:53:9:53:9 | s | semmle.label | s |
+| main.rs:53:9:53:9 | s | semmle.label | s |
 | main.rs:53:13:53:21 | source(...) | semmle.label | source(...) |
 | main.rs:53:13:53:21 | source(...) | semmle.label | source(...) |
+| main.rs:54:9:54:10 | e1 [B] | semmle.label | e1 [B] |
+| main.rs:54:9:54:10 | e1 [B] | semmle.label | e1 [B] |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | semmle.label | set_var_pos(...) [B] |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | semmle.label | set_var_pos(...) [B] |
 | main.rs:54:26:54:26 | s | semmle.label | s |
@@ -122,8 +170,12 @@ nodes
 | main.rs:57:22:57:22 | i | semmle.label | i |
 | main.rs:57:33:57:33 | i | semmle.label | i |
 | main.rs:57:33:57:33 | i | semmle.label | i |
+| main.rs:72:9:72:9 | s | semmle.label | s |
+| main.rs:72:9:72:9 | s | semmle.label | s |
 | main.rs:72:13:72:21 | source(...) | semmle.label | source(...) |
 | main.rs:72:13:72:21 | source(...) | semmle.label | source(...) |
+| main.rs:73:9:73:10 | e1 [C] | semmle.label | e1 [C] |
+| main.rs:73:9:73:10 | e1 [C] | semmle.label | e1 [C] |
 | main.rs:73:14:73:42 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:73:14:73:42 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
 | main.rs:73:40:73:40 | s | semmle.label | s |
@@ -132,8 +184,12 @@ nodes
 | main.rs:74:10:74:26 | get_var_field(...) | semmle.label | get_var_field(...) |
 | main.rs:74:24:74:25 | e1 [C] | semmle.label | e1 [C] |
 | main.rs:74:24:74:25 | e1 [C] | semmle.label | e1 [C] |
+| main.rs:85:9:85:9 | s | semmle.label | s |
+| main.rs:85:9:85:9 | s | semmle.label | s |
 | main.rs:85:13:85:21 | source(...) | semmle.label | source(...) |
 | main.rs:85:13:85:21 | source(...) | semmle.label | source(...) |
+| main.rs:86:9:86:10 | e1 [D] | semmle.label | e1 [D] |
+| main.rs:86:9:86:10 | e1 [D] | semmle.label | e1 [D] |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | semmle.label | set_var_field(...) [D] |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | semmle.label | set_var_field(...) [D] |
 | main.rs:86:28:86:28 | s | semmle.label | s |
@@ -144,8 +200,12 @@ nodes
 | main.rs:89:35:89:35 | i | semmle.label | i |
 | main.rs:89:47:89:47 | i | semmle.label | i |
 | main.rs:89:47:89:47 | i | semmle.label | i |
+| main.rs:104:9:104:9 | s | semmle.label | s |
+| main.rs:104:9:104:9 | s | semmle.label | s |
 | main.rs:104:13:104:21 | source(...) | semmle.label | source(...) |
 | main.rs:104:13:104:21 | source(...) | semmle.label | source(...) |
+| main.rs:105:9:105:17 | my_struct [MyStruct.field1] | semmle.label | my_struct [MyStruct.field1] |
+| main.rs:105:9:105:17 | my_struct [MyStruct.field1] | semmle.label | my_struct [MyStruct.field1] |
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | semmle.label | MyStruct {...} [MyStruct.field1] |
 | main.rs:106:17:106:17 | s | semmle.label | s |
@@ -154,6 +214,8 @@ nodes
 | main.rs:109:10:109:36 | get_struct_field(...) | semmle.label | get_struct_field(...) |
 | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | semmle.label | my_struct [MyStruct.field1] |
 | main.rs:109:27:109:35 | my_struct [MyStruct.field1] | semmle.label | my_struct [MyStruct.field1] |
+| main.rs:138:9:138:9 | s | semmle.label | s |
+| main.rs:138:9:138:9 | s | semmle.label | s |
 | main.rs:138:13:138:21 | source(...) | semmle.label | source(...) |
 | main.rs:138:13:138:21 | source(...) | semmle.label | source(...) |
 | main.rs:139:10:139:31 | get_array_element(...) | semmle.label | get_array_element(...) |
@@ -162,8 +224,12 @@ nodes
 | main.rs:139:28:139:30 | [...] [array[]] | semmle.label | [...] [array[]] |
 | main.rs:139:29:139:29 | s | semmle.label | s |
 | main.rs:139:29:139:29 | s | semmle.label | s |
+| main.rs:148:9:148:9 | s | semmle.label | s |
+| main.rs:148:9:148:9 | s | semmle.label | s |
 | main.rs:148:13:148:21 | source(...) | semmle.label | source(...) |
 | main.rs:148:13:148:21 | source(...) | semmle.label | source(...) |
+| main.rs:149:9:149:11 | arr [array[]] | semmle.label | arr [array[]] |
+| main.rs:149:9:149:11 | arr [array[]] | semmle.label | arr [array[]] |
 | main.rs:149:15:149:34 | set_array_element(...) [array[]] | semmle.label | set_array_element(...) [array[]] |
 | main.rs:149:15:149:34 | set_array_element(...) [array[]] | semmle.label | set_array_element(...) [array[]] |
 | main.rs:149:33:149:33 | s | semmle.label | s |
@@ -172,8 +238,12 @@ nodes
 | main.rs:150:10:150:12 | arr [array[]] | semmle.label | arr [array[]] |
 | main.rs:150:10:150:15 | arr[0] | semmle.label | arr[0] |
 | main.rs:150:10:150:15 | arr[0] | semmle.label | arr[0] |
+| main.rs:159:9:159:9 | s | semmle.label | s |
+| main.rs:159:9:159:9 | s | semmle.label | s |
 | main.rs:159:13:159:22 | source(...) | semmle.label | source(...) |
 | main.rs:159:13:159:22 | source(...) | semmle.label | source(...) |
+| main.rs:160:9:160:9 | t [tuple.0] | semmle.label | t [tuple.0] |
+| main.rs:160:9:160:9 | t [tuple.0] | semmle.label | t [tuple.0] |
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | main.rs:160:14:160:14 | s | semmle.label | s |
@@ -182,8 +252,12 @@ nodes
 | main.rs:161:10:161:29 | get_tuple_element(...) | semmle.label | get_tuple_element(...) |
 | main.rs:161:28:161:28 | t [tuple.0] | semmle.label | t [tuple.0] |
 | main.rs:161:28:161:28 | t [tuple.0] | semmle.label | t [tuple.0] |
+| main.rs:172:9:172:9 | s | semmle.label | s |
+| main.rs:172:9:172:9 | s | semmle.label | s |
 | main.rs:172:13:172:22 | source(...) | semmle.label | source(...) |
 | main.rs:172:13:172:22 | source(...) | semmle.label | source(...) |
+| main.rs:173:9:173:9 | t [tuple.1] | semmle.label | t [tuple.1] |
+| main.rs:173:9:173:9 | t [tuple.1] | semmle.label | t [tuple.1] |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | semmle.label | set_tuple_element(...) [tuple.1] |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | semmle.label | set_tuple_element(...) [tuple.1] |
 | main.rs:173:31:173:31 | s | semmle.label | s |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -35,12 +35,14 @@ edges
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
-| main.rs:54:9:54:10 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
-| main.rs:54:9:54:10 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
+| main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
+| main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:10 |
 | main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:10 |
+| main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
+| main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
 | main.rs:57:22:57:22 | i | main.rs:57:33:57:33 | i | provenance |  |
@@ -61,12 +63,14 @@ edges
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
-| main.rs:86:9:86:10 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
-| main.rs:86:9:86:10 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
+| main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
+| main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:9 |
 | main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:9 |
+| main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
+| main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
 | main.rs:89:35:89:35 | i | main.rs:89:47:89:47 | i | provenance |  |
@@ -164,6 +168,8 @@ nodes
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | semmle.label | set_var_pos(...) [B] |
 | main.rs:54:26:54:26 | s | semmle.label | s |
 | main.rs:54:26:54:26 | s | semmle.label | s |
+| main.rs:55:11:55:12 | e1 [B] | semmle.label | e1 [B] |
+| main.rs:55:11:55:12 | e1 [B] | semmle.label | e1 [B] |
 | main.rs:57:9:57:23 | ...::B(...) [B] | semmle.label | ...::B(...) [B] |
 | main.rs:57:9:57:23 | ...::B(...) [B] | semmle.label | ...::B(...) [B] |
 | main.rs:57:22:57:22 | i | semmle.label | i |
@@ -194,6 +200,8 @@ nodes
 | main.rs:86:14:86:29 | set_var_field(...) [D] | semmle.label | set_var_field(...) [D] |
 | main.rs:86:28:86:28 | s | semmle.label | s |
 | main.rs:86:28:86:28 | s | semmle.label | s |
+| main.rs:87:11:87:12 | e1 [D] | semmle.label | e1 [D] |
+| main.rs:87:11:87:12 | e1 [D] | semmle.label | e1 [D] |
 | main.rs:89:9:89:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
 | main.rs:89:9:89:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
 | main.rs:89:35:89:35 | i | semmle.label | i |

--- a/rust/ql/test/library-tests/dataflow/taint/inline-taint-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/taint/inline-taint-flow.expected
@@ -1,18 +1,28 @@
 models
 edges
-| main.rs:12:13:12:22 | source(...) | main.rs:13:10:13:14 | ... + ... | provenance |  |
-| main.rs:17:13:17:22 | source(...) | main.rs:18:10:18:11 | - ... | provenance |  |
-| main.rs:22:13:22:22 | source(...) | main.rs:24:10:24:17 | b as i64 | provenance |  |
-| main.rs:53:19:53:28 | source(...) | main.rs:54:14:54:19 | arr[1] | provenance |  |
+| main.rs:12:9:12:9 | a | main.rs:13:10:13:14 | ... + ... | provenance |  |
+| main.rs:12:13:12:22 | source(...) | main.rs:12:9:12:9 | a | provenance |  |
+| main.rs:17:9:17:9 | a | main.rs:18:10:18:11 | - ... | provenance |  |
+| main.rs:17:13:17:22 | source(...) | main.rs:17:9:17:9 | a | provenance |  |
+| main.rs:22:9:22:9 | a | main.rs:23:9:23:9 | b | provenance |  |
+| main.rs:22:13:22:22 | source(...) | main.rs:22:9:22:9 | a | provenance |  |
+| main.rs:23:9:23:9 | b | main.rs:24:10:24:17 | b as i64 | provenance |  |
+| main.rs:53:13:53:15 | arr | main.rs:54:14:54:19 | arr[1] | provenance |  |
+| main.rs:53:19:53:28 | source(...) | main.rs:53:13:53:15 | arr | provenance |  |
 | main.rs:69:9:69:12 | [post] arr2 [array[]] | main.rs:70:14:70:17 | arr2 | provenance |  |
 | main.rs:69:19:69:28 | source(...) | main.rs:69:9:69:12 | [post] arr2 [array[]] | provenance |  |
 nodes
+| main.rs:12:9:12:9 | a | semmle.label | a |
 | main.rs:12:13:12:22 | source(...) | semmle.label | source(...) |
 | main.rs:13:10:13:14 | ... + ... | semmle.label | ... + ... |
+| main.rs:17:9:17:9 | a | semmle.label | a |
 | main.rs:17:13:17:22 | source(...) | semmle.label | source(...) |
 | main.rs:18:10:18:11 | - ... | semmle.label | - ... |
+| main.rs:22:9:22:9 | a | semmle.label | a |
 | main.rs:22:13:22:22 | source(...) | semmle.label | source(...) |
+| main.rs:23:9:23:9 | b | semmle.label | b |
 | main.rs:24:10:24:17 | b as i64 | semmle.label | b as i64 |
+| main.rs:53:13:53:15 | arr | semmle.label | arr |
 | main.rs:53:19:53:28 | source(...) | semmle.label | source(...) |
 | main.rs:54:14:54:19 | arr[1] | semmle.label | arr[1] |
 | main.rs:69:9:69:12 | [post] arr2 [array[]] | semmle.label | [post] arr2 [array[]] |


### PR DESCRIPTION
Always including the left-hand side of an assignment in data flow path graphs make it easier to follow flow. The same goes for scrutinee and patterns in `match` expressions.