### PR TITLE
JS: Add class harness to recover localFieldStep edges

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/AdditionalFlowInternal.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/AdditionalFlowInternal.qll
@@ -9,6 +9,14 @@ DataFlow::Node getSynthesizedNode(AstNode node, string tag) {
   result = TGenericSynthesizedNode(node, tag, _)
 }
 
+DataFlowCallable getSynthesizedCallable(AstNode node, string tag) {
+  result = MkGenericSynthesizedCallable(node, tag)
+}
+
+DataFlowCall getSynthesizedCall(AstNode node, string tag) {
+  result = MkGenericSynthesizedCall(node, tag, _)
+}
+
 /**
  * An extension to `AdditionalFlowStep` with additional internal-only predicates.
  */
@@ -22,6 +30,10 @@ class AdditionalFlowInternal extends DataFlow::AdditionalFlowStep {
    */
   predicate needsSynthesizedNode(AstNode node, string tag, DataFlowCallable container) { none() }
 
+  predicate needsSynthesizedCallable(AstNode node, string tag) { none() }
+
+  predicate needsSynthesizedCall(AstNode node, string tag, DataFlowCallable container) { none() }
+
   /**
    * Holds if `node` should only permit flow of values stored in `contents`.
    */
@@ -31,4 +43,10 @@ class AdditionalFlowInternal extends DataFlow::AdditionalFlowStep {
    * Holds if `node` should not permit flow of values stored in `contents`.
    */
   predicate clearsContent(DataFlow::Node node, DataFlow::ContentSet contents) { none() }
+
+  predicate argument(DataFlowCall call, ArgumentPosition pos, DataFlow::Node value) { none() }
+
+  predicate postUpdate(DataFlow::Node pre, DataFlow::Node post) { none() }
+
+  predicate viableCallable(DataFlowCall call, DataFlowCallable target) { none() }
 }

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AllFlowSummaries.qll
@@ -11,3 +11,4 @@ private import Promises
 private import Sets
 private import Strings
 private import DynamicImportStep
+private import ClassHarness

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/ClassHarness.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/ClassHarness.qll
@@ -1,0 +1,104 @@
+/**
+ * Contains flow for the "class harness", which facilitates flow from constructor to methods in a class.
+ */
+
+private import javascript
+private import semmle.javascript.dataflow.internal.DataFlowNode
+private import semmle.javascript.dataflow.internal.AdditionalFlowInternal
+private import semmle.javascript.dataflow.internal.DataFlowPrivate
+
+/**
+ * Synthesizes a callable for each class, which invokes the class constructor and every
+ * instance method with the same value of `this`.
+ *
+ * This ensures flow between methods in a class when the source originated "within the class",
+ * but not when the flow into the field came from an argument.
+ *
+ * For example:
+ * ```js
+ * class C {
+ *   constructor(arg) {
+ *     this.x = sourceOfTaint();
+ *     this.y = arg;
+ *   }
+ *   method() {
+ *     sink(this.x); // sourceOfTaint() flows here
+ *     sink(this.y); // but 'arg' does not flow here (only through real call sites)
+ *   }
+ * }
+ * ```
+ *
+ * The class harness for a class `C` can roughly be thought of as the following code:
+ * ```js
+ * function classHarness() {
+ *   var c = new C();
+ *   while (true) {
+ *     // call an arbitrary instance methods in the loop
+ *     c.arbitraryInstaceMethod();
+ *   }
+ * }
+ * ```
+ *
+ * This is realized with the following data flow graph:
+ * ```
+ * [Call to constructor]
+ *     |
+ *     | post-update for 'this' argument
+ *     V
+ * [Data flow node]   <----------------------+
+ *     |                                     |
+ *     | 'this' argument                     | post-update for 'this' argument
+ *     V                                     |
+ *  [Call to an instance method]  -----------+
+ * ```
+ */
+class ClassHarnessModel extends AdditionalFlowInternal {
+  override predicate needsSynthesizedCallable(AstNode node, string tag) {
+    node instanceof Function and
+    not node instanceof ArrowFunctionExpr and // can't be called with 'new'
+    not node.getTopLevel().isExterns() and // we don't need harnesses in externs
+    tag = "class-harness"
+  }
+
+  override predicate needsSynthesizedCall(AstNode node, string tag, DataFlowCallable container) {
+    container = getSynthesizedCallable(node, "class-harness") and
+    tag = ["class-harness-constructor-call", "class-harness-method-call"]
+  }
+
+  override predicate needsSynthesizedNode(AstNode node, string tag, DataFlowCallable container) {
+    // We synthesize two nodes, but note that `class-harness-constructor-this-arg` never actually has any
+    // ingoing flow, we just need it to specify which post-update node to use for that argument.
+    container = getSynthesizedCallable(node, "class-harness") and
+    tag = ["class-harness-constructor-this-arg", "class-harness-method-this-arg"]
+  }
+
+  override predicate argument(DataFlowCall call, ArgumentPosition pos, DataFlow::Node value) {
+    pos.isThis() and
+    exists(Function f |
+      call = getSynthesizedCall(f, "class-harness-constructor-call") and
+      value = getSynthesizedNode(f, "class-harness-constructor-this-arg")
+      or
+      call = getSynthesizedCall(f, "class-harness-method-call") and
+      value = getSynthesizedNode(f, "class-harness-method-this-arg")
+    )
+  }
+
+  override predicate postUpdate(DataFlow::Node pre, DataFlow::Node post) {
+    exists(Function f |
+      pre =
+        getSynthesizedNode(f,
+          ["class-harness-constructor-this-arg", "class-harness-method-this-arg"]) and
+      post = getSynthesizedNode(f, "class-harness-method-this-arg")
+    )
+  }
+
+  override predicate viableCallable(DataFlowCall call, DataFlowCallable target) {
+    exists(DataFlow::ClassNode cls, Function f | f = cls.getConstructor().getFunction() |
+      call = getSynthesizedCall(f, "class-harness-constructor-call") and
+      target.asSourceCallable() = f
+      or
+      call = getSynthesizedCall(f, "class-harness-method-call") and
+      target.asSourceCallable() = cls.getAnInstanceMember().getFunction()
+    )
+  }
+}

--- a/javascript/ql/test/library-tests/TripleDot/class-harness.js
+++ b/javascript/ql/test/library-tests/TripleDot/class-harness.js
@@ -6,7 +6,7 @@ function h1() {
             this.x = source("h1.1")
         }
         method() {
-            sink(this.x); // $ MISSING: hasValueFlow=h1.1
+            sink(this.x); // $ hasValueFlow=h1.1
         }
     }
 }
@@ -17,7 +17,7 @@ function h2() {
             this.x = source("h2.1")
         }
         method2() {
-            sink(this.x); // $ MISSING: hasValueFlow=h2.1
+            sink(this.x); // $ hasValueFlow=h2.1
         }
     }
 }

--- a/javascript/ql/test/library-tests/TripleDot/class-harness.js
+++ b/javascript/ql/test/library-tests/TripleDot/class-harness.js
@@ -1,0 +1,40 @@
+import 'dummy';
+
+function h1() {
+    class C {
+        constructor(arg) {
+            this.x = source("h1.1")
+        }
+        method() {
+            sink(this.x); // $ MISSING: hasValueFlow=h1.1
+        }
+    }
+}
+
+function h2() {
+    class C {
+        method1() {
+            this.x = source("h2.1")
+        }
+        method2() {
+            sink(this.x); // $ MISSING: hasValueFlow=h2.1
+        }
+    }
+}
+
+function h3() {
+    class C {
+        constructor(arg) {
+            this.x = arg;
+        }
+        method1() {
+            sink(this.x); // $ hasValueFlow=h3.2
+        }
+        method2() {
+            sink(this.x); // $ hasValueFlow=h3.3
+        }
+    }
+    new C(source("h3.1"));
+    new C(source("h3.2")).method1();
+    new C(source("h3.3")).method2();
+}


### PR DESCRIPTION
Synthesizes a callable for each class, which invokes the class constructor and every
instance method with the same value of `this`.

This ensures flow between methods in a class when the source originated "within the class",
but not when the flow into the field came from an argument.

For example:
```js
class C {
  constructor(arg) {
    this.x = sourceOfTaint();
    this.y = arg;
  }
  method() {
    sink(this.x); // sourceOfTaint() flows here
    sink(this.y); // but 'arg' does not flow here (only through real call sites)
  }
}
```

The class harness for a class `C` can roughly be thought of as the following code:
```js
function classHarness() {
  var c = new C();
  while (true) {
    // call an arbitrary instance methods in the loop
    c.arbitraryInstaceMethod();
  }
}
```

This is realized with the following data flow graph:
```
[Call to constructor]
    |
    | post-update for 'this' argument
    V
[Data flow node]   <----------------------+
    |                                     |
    | 'this' argument                     | post-update for 'this' argument
    V                                     |
 [Call to an instance method]  -----------+
```

[Evaluation](https://github.com/github/codeql-dca-main/issues/25372) shows an 85% slowdown in vscode, so more work is needed before this can be merged.