### PR TITLE
C++: Fix two more dataflow-related joins

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1237,12 +1237,14 @@ module IsUnreachableInCall {
     int getValue() { result = value }
   }
 
-  pragma[nomagic]
+  bindingset[right]
+  pragma[inline_late]
   private predicate ensuresEq(Operand left, Operand right, int k, IRBlock block, boolean areEqual) {
     any(G::IRGuardCondition guard).ensuresEq(left, right, k, block, areEqual)
   }
 
-  pragma[nomagic]
+  bindingset[right]
+  pragma[inline_late]
   private predicate ensuresLt(Operand left, Operand right, int k, IRBlock block, boolean areEqual) {
     any(G::IRGuardCondition guard).ensuresLt(left, right, k, block, areEqual)
   }

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2290,9 +2290,11 @@ private predicate controls(IRGuardCondition g, Node n, boolean edge) {
 module BarrierGuard<guardChecksSig/3 guardChecks> {
   bindingset[value, n]
   pragma[inline_late]
-  private predicate convertedExprHasValueNumber(Expr e, ValueNumber value, Node n) {
-    e = value.getAnInstruction().getConvertedResultExpression() and
-    n.asConvertedExpr() = e
+  private predicate convertedExprHasValueNumber(ValueNumber value, Node n) {
+    exists(Expr e |
+      e = value.getAnInstruction().getConvertedResultExpression() and
+      n.asConvertedExpr() = e
+    )
   }
 
   /**
@@ -2328,8 +2330,8 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
    * NOTE: If an indirect expression is tracked, use `getAnIndirectBarrierNode` instead.
    */
   Node getABarrierNode() {
-    exists(IRGuardCondition g, Expr e, ValueNumber value, boolean edge |
-      convertedExprHasValueNumber(e, value, result) and
+    exists(IRGuardCondition g, ValueNumber value, boolean edge |
+      convertedExprHasValueNumber(value, result) and
       guardChecks(g,
         pragma[only_bind_into](value.getAnInstruction().getConvertedResultExpression()), edge) and
       controls(g, result, edge)
@@ -2383,10 +2385,12 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
   bindingset[value, n]
   pragma[inline_late]
   private predicate indirectConvertedExprHasValueNumber(
-    Expr e, int indirectionIndex, ValueNumber value, Node n
+    int indirectionIndex, ValueNumber value, Node n
   ) {
-    e = value.getAnInstruction().getConvertedResultExpression() and
-    n.asIndirectConvertedExpr(indirectionIndex) = e
+    exists(Expr e |
+      e = value.getAnInstruction().getConvertedResultExpression() and
+      n.asIndirectConvertedExpr(indirectionIndex) = e
+    )
   }
 
   /**
@@ -2424,8 +2428,8 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
    * NOTE: If a non-indirect expression is tracked, use `getABarrierNode` instead.
    */
   Node getAnIndirectBarrierNode(int indirectionIndex) {
-    exists(IRGuardCondition g, Expr e, ValueNumber value, boolean edge |
-      indirectConvertedExprHasValueNumber(e, indirectionIndex, value, result) and
+    exists(IRGuardCondition g, ValueNumber value, boolean edge |
+      indirectConvertedExprHasValueNumber(indirectionIndex, value, result) and
       guardChecks(g,
         pragma[only_bind_into](value.getAnInstruction().getConvertedResultExpression()), edge) and
       controls(g, result, edge)
@@ -2466,16 +2470,18 @@ private EdgeKind getConditionalEdge(boolean branch) {
 module InstructionBarrierGuard<instructionGuardChecksSig/3 instructionGuardChecks> {
   bindingset[value, n]
   pragma[inline_late]
-  private predicate operandHasValueNumber(Operand use, ValueNumber value, Node n) {
-    use = value.getAnInstruction().getAUse() and
-    n.asOperand() = use
+  private predicate operandHasValueNumber(ValueNumber value, Node n) {
+    exists(Operand use |
+      use = value.getAnInstruction().getAUse() and
+      n.asOperand() = use
+    )
   }
 
   /** Gets a node that is safely guarded by the given guard check. */
   Node getABarrierNode() {
-    exists(IRGuardCondition g, ValueNumber value, boolean edge, Operand use |
+    exists(IRGuardCondition g, ValueNumber value, boolean edge |
       instructionGuardChecks(g, pragma[only_bind_into](value.getAnInstruction()), edge) and
-      operandHasValueNumber(use, value, result) and
+      operandHasValueNumber(value, result) and
       controls(g, result, edge)
     )
     or

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2275,7 +2275,7 @@ private predicate guardControlsPhiInput(
  */
 signature predicate guardChecksSig(IRGuardCondition g, Expr e, boolean branch);
 
-bindingset[g, n]
+bindingset[g]
 pragma[inline_late]
 private predicate controls(IRGuardCondition g, Node n, boolean edge) {
   g.controls(n.getBasicBlock(), edge)
@@ -2288,6 +2288,13 @@ private predicate controls(IRGuardCondition g, Node n, boolean edge) {
  * in data flow and taint tracking.
  */
 module BarrierGuard<guardChecksSig/3 guardChecks> {
+  bindingset[value, n]
+  pragma[inline_late]
+  private predicate convertedExprHasValueNumber(Expr e, ValueNumber value, Node n) {
+    e = value.getAnInstruction().getConvertedResultExpression() and
+    n.asConvertedExpr() = e
+  }
+
   /**
    * Gets an expression node that is safely guarded by the given guard check.
    *
@@ -2322,8 +2329,7 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
    */
   Node getABarrierNode() {
     exists(IRGuardCondition g, Expr e, ValueNumber value, boolean edge |
-      e = value.getAnInstruction().getConvertedResultExpression() and
-      result.asConvertedExpr() = e and
+      convertedExprHasValueNumber(e, value, result) and
       guardChecks(g,
         pragma[only_bind_into](value.getAnInstruction().getConvertedResultExpression()), edge) and
       controls(g, result, edge)

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -51,6 +51,7 @@ class ValueNumber extends TValueNumber {
   /**
    * Gets an `Operand` whose definition is exact and has this value number.
    */
+  pragma[nomagic]
   final Operand getAUse() { this = valueNumber(result.getDef()) }
 
   final string getKind() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -51,6 +51,7 @@ class ValueNumber extends TValueNumber {
   /**
    * Gets an `Operand` whose definition is exact and has this value number.
    */
+  pragma[nomagic]
   final Operand getAUse() { this = valueNumber(result.getDef()) }
 
   final string getKind() {

--- a/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -51,6 +51,7 @@ class ValueNumber extends TValueNumber {
   /**
    * Gets an `Operand` whose definition is exact and has this value number.
    */
+  pragma[nomagic]
   final Operand getAUse() { this = valueNumber(result.getDef()) }
 
   final string getKind() {


### PR DESCRIPTION
The join order fix in https://github.com/github/codeql/pull/18233 turned out to be slightly incomplete. This can actually be seen in the 'after' tuple counts, but I decided to ignore it since I couldn't find a repository where it was too bad 🙈

Well, jokes on me, because there was actually a repository where this happened (thanks for flagging this up to me, @jketema):
```ql
[2024-12-17 14:53:19] Evaluated non-recursive predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@37a2adb9 in 266575ms (evaluation was halted due to CancellationException).
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@37a2adb9 with tuple counts:
    2067749       ~0%    {2} r1 = JOIN DataFlowUtil::OperandNode#3e3b23f6_20#join_rhs WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
    1269345       ~2%    {2}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
     481892       ~2%    {2}    | JOIN WITH `SsaInternals::DefinitionExt.getARead/0#0429944e_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
   29735623      ~70%    {3}    | JOIN WITH `UnboundedWrite::lessThanOrEqual/3#4e4dda57_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1
    1471195   ~11490%    {2}    | JOIN WITH `DataFlowUtil::guardControlsPhiInput/5#50adc50d` ON FIRST 3 OUTPUT Rhs.4, Rhs.3
    1440561   ~11292%    {1}    | JOIN WITH DataFlowUtil::TSsaPhiInputNode#d9cd78c6 ON FIRST 2 OUTPUT Rhs.2
                     
    3299500     ~705%    {3} r2 = JOIN `UnboundedWrite::lessThanOrEqual/3#4e4dda57_102#join_rhs` WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
    3294500    ~3478%    {3}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
20015752673    ~3597%    {3}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
20014034357    ~3405%    {3}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
20013966490    ~4007%    {3}    | JOIN WITH `project#ExprNodes::ExprNode.getConvertedExpr/1#dispred#04e26388_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
20013961855    ~3810%    {4}    | JOIN WITH `project#DataFlowUtil::Node.hasIndexInBlock/2#4ca72ac1` ON FIRST 1 OUTPUT Lhs.1, Rhs.1, Lhs.2, Lhs.0
      22500    ~2307%    {1}    | JOIN WITH `IRGuards::IRGuardCondition.controls/2#dispred#a7389eda` ON FIRST 3 OUTPUT Lhs.3
                     
    1463061  ~156413%    {1} r3 = r1 UNION r2
                         return r3
```
(I stopped the run before it was finished)

This PR fixes that join by ordering the `IRGuards::IRGuardCondition.controls` join before the second join with `ValueNumberingInternal::tvalueNumber` which is clearly better:

```ql
Evaluated relational algebra for predicate DataFlowUtil::BarrierGuard<UnboundedWrite::lessThanOrEqual>::getABarrierNode/0#fcc0c149@32b236qn with tuple counts:
    2067749      ~1%    {2} r1 = JOIN DataFlowUtil::OperandNode#3e3b23f6_20#join_rhs WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
    1269345      ~0%    {2}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
     481892      ~1%    {2}    | JOIN WITH `SsaInternals::DefinitionExt.getARead/0#0429944e_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
   29735623     ~74%    {3}    | JOIN WITH `UnboundedWrite::lessThanOrEqual/3#4e4dda57_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1
    1471329  ~11826%    {2}    | JOIN WITH `DataFlowUtil::guardControlsPhiInput/5#50adc50d` ON FIRST 3 OUTPUT Rhs.4, Rhs.3
    1441442  ~11783%    {1}    | JOIN WITH DataFlowUtil::TSsaPhiInputNode#d9cd78c6 ON FIRST 2 OUTPUT Rhs.2
                    
   59515338      ~0%    {3} r2 = SCAN `UnboundedWrite::lessThanOrEqual/3#4e4dda57` OUTPUT In.0, In.2, In.1
    9908538      ~0%    {2}    | JOIN WITH `IRGuards::IRGuardCondition.controls/2#dispred#a7389eda_021#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Lhs.2
  364723786      ~0%    {2}    | JOIN WITH `project#DataFlowUtil::Node.hasIndexInBlock/2#4ca72ac1_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
  362546872      ~1%    {2}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
  362546213   ~4197%    {2}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
    1654638     ~23%    {3}    | JOIN WITH `project#ExprNodes::ExprNode.getConvertedExpr/1#dispred#04e26388` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
    1290054      ~6%    {3}    | JOIN WITH `Instruction::Instruction.getConvertedResultExpression/0#dispred#f9cfafab_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.2, Lhs.1
      24183      ~4%    {1}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 2 OUTPUT Lhs.2
                    
    1465625   ~4008%    {1} r3 = r1 UNION r2
                        return r3
```
Ideally, I would have liked to order the joins with `ExprNode.getConvertedExpr` before the join with `Node.hasIndexInBlock`, but I couldn't quite make that work out. In any case, this join order is still much better than before.

The same project also showed an unfortunate materialization of `ensuresEq`:
```ql
[2024-12-17 15:04:03] Evaluated non-recursive predicate DataFlowPrivate::ensuresEq/5#44fb628b@559ac42h in 17131ms (size: 181724202).
Evaluated relational algebra for predicate DataFlowPrivate::ensuresEq/5#44fb628b@559ac42h with tuple counts:
[2024-12-17 15:03:48] Evaluated non-recursive predicate DataFlowPrivate::ensuresLt/5#598de9e7_10234#join_rhs@1c1067or in 1817ms (size: 12553976).
Evaluated relational algebra for predicate DataFlowPrivate::ensuresLt/5#598de9e7_10234#join_rhs@1c1067or with tuple counts:
  12553976  ~2%    {5} r1 = SCAN `DataFlowPrivate::ensuresLt/5#598de9e7` OUTPUT In.1, In.0, In.2, In.3, In.4
                   return r1
...
[2024-12-17 15:04:03] Evaluated non-recursive predicate DataFlowPrivate::ensuresEq/5#44fb628b@559ac42h in 17131ms (size: 181724202).
Evaluated relational algebra for predicate DataFlowPrivate::ensuresEq/5#44fb628b@559ac42h with tuple counts:
  181734680  ~4%    {5} r1 = JOIN `_IRGuards::IRGuardCondition.valueControls/2#eb6b9b19_ValueNumberingInternal::tvalueNumber/1#f03b58f9#shared` WITH `IRGuards::Cached::compares_eq/6#511a0d6d_051234#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Rhs.3, Rhs.4, Lhs.2, Rhs.5
                    return r1
```
Both of these have been removed in f35155854706ce6c1886ed4975e7622e048068b9.