### PR TITLE
C++: Fix FPs to cpp/return-stack-allocated-memory

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/ReturnStackAllocatedMemory.ql
@@ -92,6 +92,8 @@ class ReturnStackAllocatedMemoryConfig extends MustFlowConfiguration {
     or
     node2.(PointerOffsetInstruction).getLeftOperand() = node1
   }
+
+  override predicate isBarrier(Instruction n) { n.getResultType() instanceof ErroneousType }
 }
 
 from

--- a/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Memory Management/ReturnStackAllocatedMemory/test.cpp
@@ -1,4 +1,4 @@
-// semmle-extractor-options: -std=c++14
+// semmle-extractor-options: -std=c++14 --expect_errors
 class MyClass
 {
 public:
@@ -248,4 +248,9 @@ char* test_strdupa(const char* s) {
 void* test_strndupa(const char* s, size_t size) {
 	char* s2 = strndupa(s, size);
 	return s2; // BAD
+}
+
+UNKNOWN_TYPE test_error_type() {
+	UNKNOWN_TYPE x;
+	return x; // GOOD: Don't report error types
 }


### PR DESCRIPTION
### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
