### PR TITLE
C++: Fix `forex` recursion in sign analysis

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
@@ -516,12 +516,18 @@ module SignAnalysis<DeltaSig D> {
    */
   private Sign guardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
     result = TPos() and
+    // optimised version of
+    // `forex(SemExpr bound | posBound(bound, v, pos) | posBoundOk(bound, v, pos))`
     posBoundGuardedSsaSignOk(v, pos)
     or
     result = TNeg() and
+    // optimised version of
+    // `forex(SemExpr bound | negBound(bound, v, pos) | negBoundOk(bound, v, pos))`
     negBoundGuardedSsaSignOk(v, pos)
     or
     result = TZero() and
+    // optimised version of
+    // `forex(SemExpr bound | zeroBound(bound, v, pos) | zeroBoundOk(bound, v, pos))`
     zeroBoundGuardedSsaSignOk(v, pos)
   }
 

--- a/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/rangeanalysis/new/internal/semantic/analysis/SignAnalysisCommon.qll
@@ -437,6 +437,78 @@ module SignAnalysis<DeltaSig D> {
     not hasGuard(v, pos, result)
   }
 
+  private SemExpr posBoundGetElement(int i, SemSsaVariable v, SsaReadPosition pos) {
+    result =
+      rank[i + 1](SemExpr bound, SemBasicBlock b, int blockOrder, int indexOrder |
+        posBound(bound, v, pos) and
+        b = bound.getBasicBlock() and
+        blockOrder = b.getUniqueId() and
+        bound = b.getInstruction(indexOrder)
+      |
+        bound order by blockOrder, indexOrder
+      )
+  }
+
+  private predicate posBoundOkFromIndex(int i, SemSsaVariable v, SsaReadPosition pos) {
+    i = 0 and
+    posBoundOk(posBoundGetElement(i, v, pos), v, pos)
+    or
+    posBoundOkFromIndex(i - 1, v, pos) and
+    posBoundOk(posBoundGetElement(i, v, pos), v, pos)
+  }
+
+  private predicate posBoundGuardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
+    posBoundOkFromIndex(max(int i | exists(posBoundGetElement(i, v, pos))), v, pos)
+  }
+
+  private SemExpr negBoundGetElement(int i, SemSsaVariable v, SsaReadPosition pos) {
+    result =
+      rank[i + 1](SemExpr bound, SemBasicBlock b, int blockOrder, int indexOrder |
+        negBound(bound, v, pos) and
+        b = bound.getBasicBlock() and
+        blockOrder = b.getUniqueId() and
+        bound = b.getInstruction(indexOrder)
+      |
+        bound order by blockOrder, indexOrder
+      )
+  }
+
+  private predicate negBoundOkFromIndex(int i, SemSsaVariable v, SsaReadPosition pos) {
+    i = 0 and
+    negBoundOk(negBoundGetElement(i, v, pos), v, pos)
+    or
+    negBoundOkFromIndex(i - 1, v, pos) and
+    negBoundOk(negBoundGetElement(i, v, pos), v, pos)
+  }
+
+  private predicate negBoundGuardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
+    negBoundOkFromIndex(max(int i | exists(negBoundGetElement(i, v, pos))), v, pos)
+  }
+
+  private SemExpr zeroBoundGetElement(int i, SemSsaVariable v, SsaReadPosition pos) {
+    result =
+      rank[i + 1](SemExpr bound, SemBasicBlock b, int blockOrder, int indexOrder |
+        zeroBound(bound, v, pos) and
+        b = bound.getBasicBlock() and
+        blockOrder = b.getUniqueId() and
+        bound = b.getInstruction(indexOrder)
+      |
+        bound order by blockOrder, indexOrder
+      )
+  }
+
+  private predicate zeroBoundOkFromIndex(int i, SemSsaVariable v, SsaReadPosition pos) {
+    i = 0 and
+    zeroBoundOk(zeroBoundGetElement(i, v, pos), v, pos)
+    or
+    zeroBoundOkFromIndex(i - 1, v, pos) and
+    zeroBoundOk(zeroBoundGetElement(i, v, pos), v, pos)
+  }
+
+  private predicate zeroBoundGuardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
+    zeroBoundOkFromIndex(max(int i | exists(zeroBoundGetElement(i, v, pos))), v, pos)
+  }
+
   /**
    * Gets a possible sign of `v` at read position `pos`, where a guard could have
    * ruled out the sign but does not.
@@ -444,13 +516,13 @@ module SignAnalysis<DeltaSig D> {
    */
   private Sign guardedSsaSignOk(SemSsaVariable v, SsaReadPosition pos) {
     result = TPos() and
-    forex(SemExpr bound | posBound(bound, v, pos) | posBoundOk(bound, v, pos))
+    posBoundGuardedSsaSignOk(v, pos)
     or
     result = TNeg() and
-    forex(SemExpr bound | negBound(bound, v, pos) | negBoundOk(bound, v, pos))
+    negBoundGuardedSsaSignOk(v, pos)
     or
     result = TZero() and
-    forex(SemExpr bound | zeroBound(bound, v, pos) | zeroBoundOk(bound, v, pos))
+    zeroBoundGuardedSsaSignOk(v, pos)
   }
 
   /** Gets a possible sign for `v` at `pos`. */


### PR DESCRIPTION
It's well-known that recursion through `forall`/`forex` may perform poorly. Apparently we do recursion through `forex` in the sign analysis library (which is part of the new range analysis library for C++). This results in some unfortunate tuple counts because the "range" part of the `forall`/`forex` gets joined with itself:
```ql
Tuple counts for _RangeAnalysisImpl::SignAnalysis::zeroBound/3#c119dcdb_RangeAnalysisImpl::SignAnalysis::zeroBound/3#__#antijoin_rhs/3@i4#L3#76559w2g after 1m28s:
  256000    ~900%         {4} r1 = JOIN `RangeAnalysisImpl::SignAnalysis::zeroBoundOk/3#a6688e7a#prev_delta` WITH num#Sign::TZero#65a6fcab CARTESIAN PRODUCT OUTPUT Lhs.0, Lhs.1 'arg1', Lhs.2 'arg2', Rhs.0
  251000    ~1835%        {3}    | JOIN WITH `RangeAnalysisImpl::SignAnalysis::zeroBound/3#c119dcdb` ON FIRST 3 OUTPUT Lhs.1 'arg1', Lhs.2 'arg2', Lhs.3 'arg0'
  692772000 ~2073%        {4}    | JOIN WITH `RangeAnalysisImpl::SignAnalysis::zeroBound/3#c119dcdb_120#join_rhs` ON FIRST 2 OUTPUT Rhs.2, Lhs.0 'arg1', Lhs.1 'arg2', Lhs.2 'arg0'
                          {4}    | AND NOT `RangeAnalysisImpl::SignAnalysis::zeroBoundOk/3#a6688e7a#prev`(FIRST 3)
  64314500  ~1238106%     {3}    | SCAN OUTPUT In.3 'arg0', In.1 'arg1', In.2 'arg2'
```

Luckily, there's a standard way to work around this problem by rewriting the `forall`/`forex` to recursion over integers. This PR does just that. This results in much better RA.