### PR TITLE
Ruby: Track types in data flow

### DIFF
--- a/ruby/ql/consistency-queries/DataFlowConsistency.ql
+++ b/ruby/ql/consistency-queries/DataFlowConsistency.ql
@@ -44,6 +44,14 @@ private module Input implements InputSig<Location, RubyDataFlow> {
       n.getASplit() instanceof Split::ConditionalCompletionSplit
     )
   }
+
+  predicate uniqueTypeExclude(Node n) {
+    n =
+      any(DataFlow::CallNode call |
+        Private::isStandardNewCall(call.getExprNode(), _, _) and
+        not call.getReceiver().asExpr().getExpr() instanceof ConstantReadAccess
+      )
+  }
 }
 
 import MakeConsistency<Location, RubyDataFlow, RubyTaintTracking, Input>

--- a/ruby/ql/lib/change-notes/2024-12-20-data-flow-types.md
+++ b/ruby/ql/lib/change-notes/2024-12-20-data-flow-types.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Types are now being tracked in data flow, but only when the type of an object is obvious from the context. For example, `C.new` has guaranteed type `C`, while in `def add(x, y) { x + y }` we cannot assign a type to `x + y` (it could, for instance, be both `String` and `Integer`). Tracking types allows us to remove false-positive results when type incompatibility can be established.

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -237,7 +237,7 @@ class NormalCall extends DataFlowCall, TNormalCall {
  * need to track the `View` instance (2) into the receiver of the adjusted method
  * call, in order to figure out that the call target is in fact `view.html.erb`.
  */
-private module ViewComponentRenderModeling {
+module ViewComponentRenderModeling {
   private import codeql.ruby.frameworks.ViewComponent
 
   private class RenderMethod extends SummarizedCallable, LibraryCallableToIncludeInTypeTracking {
@@ -333,74 +333,13 @@ private predicate selfInModule(SelfVariable self, Module m) {
 
 /** Holds if `self` belongs to method `method` inside module `m`. */
 pragma[nomagic]
-private predicate selfInMethod(SelfVariable self, MethodBase method, Module m) {
+predicate selfInMethod(SelfVariable self, MethodBase method, Module m) {
   exists(ModuleBase encl |
     method = self.getDeclaringScope() and
     encl = method.getEnclosingModule() and
     if encl instanceof SingletonClass
     then m = encl.getEnclosingModule().getModule()
     else m = encl.getModule()
-  )
-}
-
-/** Holds if `self` belongs to the top-level. */
-pragma[nomagic]
-private predicate selfInToplevel(SelfVariable self, Module m) {
-  ViewComponentRenderModeling::selfInErbToplevel(self, m)
-  or
-  not ViewComponentRenderModeling::selfInErbToplevel(self, _) and
-  self.getDeclaringScope() instanceof Toplevel and
-  m = Module::TResolved("Object")
-}
-
-/**
- * Holds if SSA definition `def` belongs to a variable introduced via pattern
- * matching on type `m`. For example, in
- *
- * ```rb
- * case object
- *   in C => c then c.foo
- * end
- * ```
- *
- * the SSA definition for `c` is introduced by matching on `C`.
- */
-private predicate asModulePattern(SsaDefinitionExtNode def, Module m) {
-  exists(AsPattern ap |
-    m = Module::resolveConstantReadAccess(ap.getPattern()) and
-    def.getDefinitionExt().(Ssa::WriteDefinition).getWriteAccess().getAstNode() =
-      ap.getVariableAccess()
-  )
-}
-
-/**
- * Holds if `read1` and `read2` are adjacent reads of SSA definition `def`,
- * and `read2` is checked to have type `m`. For example, in
- *
- * ```rb
- * case object
- *   when C then object.foo
- * end
- * ```
- *
- * the two reads of `object` are adjacent, and the second is checked to have type `C`.
- */
-private predicate hasAdjacentTypeCheckedReads(
-  Ssa::Definition def, CfgNodes::ExprCfgNode read1, CfgNodes::ExprCfgNode read2, Module m
-) {
-  exists(
-    CfgNodes::ExprCfgNode pattern, ConditionBlock cb, CfgNodes::ExprNodes::CaseExprCfgNode case
-  |
-    m = Module::resolveConstantReadAccess(pattern.getExpr()) and
-    cb.getLastNode() = pattern and
-    cb.controls(read2.getBasicBlock(),
-      any(SuccessorTypes::MatchingSuccessor match | match.getValue() = true)) and
-    def.hasAdjacentReads(read1, read2) and
-    case.getValue() = read1
-  |
-    pattern = case.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
-    or
-    pattern = case.getBranch(_).(CfgNodes::ExprNodes::InClauseCfgNode).getPattern()
   )
 }
 
@@ -638,7 +577,7 @@ private predicate hasUserDefinedNew(Module m) {
  * `self.new` on `m`.
  */
 pragma[nomagic]
-private predicate isStandardNewCall(RelevantCall new, Module m, boolean exact) {
+predicate isStandardNewCall(RelevantCall new, Module m, boolean exact) {
   exists(DataFlow::LocalSourceNode sourceNode |
     flowsToMethodCallReceiver(TNormalCall(new), sourceNode, "new") and
     // `m` should not have a user-defined `self.new` method
@@ -667,106 +606,11 @@ private predicate localFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, 
 }
 
 private module TrackInstanceInput implements CallGraphConstruction::InputSig {
-  pragma[nomagic]
-  private predicate isInstanceNoCall(DataFlow::Node n, Module tp, boolean exact) {
-    n.asExpr().getExpr() instanceof NilLiteral and
-    tp = Module::TResolved("NilClass") and
-    exact = true
-    or
-    n.asExpr().getExpr().(BooleanLiteral).isFalse() and
-    tp = Module::TResolved("FalseClass") and
-    exact = true
-    or
-    n.asExpr().getExpr().(BooleanLiteral).isTrue() and
-    tp = Module::TResolved("TrueClass") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof IntegerLiteral and
-    tp = Module::TResolved("Integer") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof FloatLiteral and
-    tp = Module::TResolved("Float") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof RationalLiteral and
-    tp = Module::TResolved("Rational") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof ComplexLiteral and
-    tp = Module::TResolved("Complex") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof StringlikeLiteral and
-    tp = Module::TResolved("String") and
-    exact = true
-    or
-    n.asExpr() instanceof CfgNodes::ExprNodes::ArrayLiteralCfgNode and
-    tp = Module::TResolved("Array") and
-    exact = true
-    or
-    n.asExpr() instanceof CfgNodes::ExprNodes::HashLiteralCfgNode and
-    tp = Module::TResolved("Hash") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof MethodBase and
-    tp = Module::TResolved("Symbol") and
-    exact = true
-    or
-    n.asParameter() instanceof BlockParameter and
-    tp = Module::TResolved("Proc") and
-    exact = true
-    or
-    n.asExpr().getExpr() instanceof Lambda and
-    tp = Module::TResolved("Proc") and
-    exact = true
-    or
-    // `self` reference in method or top-level (but not in module or singleton method,
-    // where instance methods cannot be called; only singleton methods)
-    n =
-      any(SelfLocalSourceNode self |
-        exists(MethodBase m |
-          selfInMethod(self.getVariable(), m, tp) and
-          not m instanceof SingletonMethod and
-          if m.getEnclosingModule() instanceof Toplevel then exact = true else exact = false
-        )
-        or
-        selfInToplevel(self.getVariable(), tp) and
-        exact = true
-      )
-    or
-    // `in C => c then c.foo`
-    asModulePattern(n, tp) and
-    exact = false
-    or
-    // `case object when C then object.foo`
-    hasAdjacentTypeCheckedReads(_, _, n.asExpr(), tp) and
-    exact = false
-  }
-
-  pragma[nomagic]
-  private predicate isInstanceCall(DataFlow::Node n, Module tp, boolean exact) {
-    isStandardNewCall(n.asExpr(), tp, exact)
-  }
-
-  /** Holds if `n` is an instance of type `tp`. */
-  pragma[inline]
-  private predicate isInstance(DataFlow::Node n, Module tp, boolean exact) {
-    isInstanceNoCall(n, tp, exact)
-    or
-    isInstanceCall(n, tp, exact)
-  }
-
-  pragma[nomagic]
-  private predicate hasAdjacentTypeCheckedReads(DataFlow::Node node) {
-    hasAdjacentTypeCheckedReads(_, _, node.asExpr(), _)
-  }
-
   newtype State = additional MkState(Module m, Boolean exact)
 
   predicate start(DataFlow::Node start, State state) {
     exists(Module tp, boolean exact | state = MkState(tp, exact) |
-      isInstance(start, tp, exact)
+      TypeInference::hasType(start, tp, exact)
       or
       exists(Module m |
         (if m.isClass() then tp = Module::TResolved("Class") else tp = Module::TResolved("Module")) and
@@ -785,14 +629,19 @@ private module TrackInstanceInput implements CallGraphConstruction::InputSig {
   }
 
   pragma[nomagic]
+  private predicate hasAdjacentTypeCheckedRead(DataFlow::Node node) {
+    TypeInference::hasAdjacentTypeCheckedRead(node.asExpr(), _)
+  }
+
+  pragma[nomagic]
   predicate stepNoCall(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, StepSummary summary) {
     smallStepNoCall(nodeFrom, nodeTo, summary)
     or
     // We exclude steps into type checked variables. For those, we instead rely on the
     // type being checked against
     localFlowStep(nodeFrom, nodeTo, summary) and
-    not hasAdjacentTypeCheckedReads(nodeTo) and
-    not asModulePattern(nodeTo, _)
+    not hasAdjacentTypeCheckedRead(nodeTo) and
+    not TypeInference::asModulePattern(nodeTo.(SsaDefinitionExtNode).getDefinitionExt(), _)
   }
 
   predicate stepCall(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, StepSummary summary) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -93,6 +93,14 @@ module SsaFlow {
     result = TSelfToplevelParameterNode(p.asToplevelSelf())
   }
 
+  ParameterNodeImpl toParameterNodeImpl(SsaDefinitionExtNode node) {
+    exists(SsaImpl::WriteDefinition def, SsaImpl::ParameterExt p |
+      def = node.getDefinitionExt() and
+      result = toParameterNode(p) and
+      p.isInitializedBy(def)
+    )
+  }
+
   Impl::Node asNode(Node n) {
     n = TSsaNode(result)
     or
@@ -694,7 +702,9 @@ private module Cached {
 
   cached
   newtype TDataFlowType =
+    TModuleDataFlowType(Module m) or
     TLambdaDataFlowType(Callable c) { c = any(LambdaSelfReferenceNode n).getCallable() } or
+    TCollectionType() or
     TUnknownDataFlowType()
 }
 
@@ -1883,21 +1893,83 @@ predicate expectsContent(Node n, ContentSet c) {
 }
 
 class DataFlowType extends TDataFlowType {
-  string toString() { result = "" }
+  string toString() {
+    exists(Module m |
+      this = TModuleDataFlowType(m) and
+      result = m.toString()
+    )
+    or
+    this = TLambdaDataFlowType(_) and result = "[lambda]"
+    or
+    this = TCollectionType() and result = "[collection]"
+    or
+    this = TUnknownDataFlowType() and
+    result = ""
+  }
+
+  predicate isUnknown() { this = TUnknownDataFlowType() }
+
+  Location getLocation() {
+    exists(Module m |
+      this = TModuleDataFlowType(m) and
+      result = m.getLocation()
+    )
+    or
+    exists(Callable c | this = TLambdaDataFlowType(c) and result = c.getLocation())
+  }
 }
+
+pragma[nomagic]
+private predicate isProcClass(DataFlowType t) {
+  t = TModuleDataFlowType(any(TypeInference::ProcClass m))
+}
+
+pragma[nomagic]
+private predicate isArrayClass(DataFlowType t) {
+  t = TModuleDataFlowType(any(TypeInference::ArrayClass m).getADescendent())
+}
+
+pragma[nomagic]
+private predicate isHashClass(DataFlowType t) {
+  t = TModuleDataFlowType(any(TypeInference::HashClass m).getADescendent())
+}
+
+private predicate isCollectionClass(DataFlowType t) { isArrayClass(t) or isHashClass(t) }
 
 predicate typeStrongerThan(DataFlowType t1, DataFlowType t2) {
-  t1 != TUnknownDataFlowType() and
-  t2 = TUnknownDataFlowType()
+  not t1.isUnknown() and
+  t2.isUnknown()
+  or
+  exists(Module m1, Module m2 |
+    t1 = TModuleDataFlowType(m1) and
+    t2 = TModuleDataFlowType(m2) and
+    m1.getAnImmediateAncestor+() = m2
+  )
+  or
+  t1 instanceof TLambdaDataFlowType and
+  isProcClass(t2)
 }
 
-private predicate mustHaveLambdaType(ExprNode n, Callable c) {
+private predicate mustHaveLambdaType(Node n, Callable c) {
   exists(VariableCapture::ClosureExpr ce, CfgNodes::ExprCfgNode e |
     e = n.asExpr() and ce.hasBody(c)
   |
     e = ce or
     ce.hasAliasedAccess(e)
   )
+  or
+  n.(CaptureNode).getSynthesizedCaptureNode().isInstanceAccess() and
+  c = n.(CaptureNode).getSynthesizedCaptureNode().getEnclosingCallable()
+}
+
+private predicate mustHaveCollectionType(Node n, DataFlowType t) {
+  exists(ContentSet c | readStep(n, c, _) or storeStep(_, c, n) or expectsContent(n, c) |
+    c.isElement() and
+    t = TCollectionType()
+  ) and
+  not n instanceof SynthHashSplatOrSplatArgumentNode and
+  not n instanceof SynthHashSplatParameterNode and
+  not n instanceof SynthSplatParameterNode
 }
 
 predicate localMustFlowStep(Node node1, Node node2) { none() }
@@ -1911,15 +1983,40 @@ DataFlowType getNodeType(Node n) {
     result = TLambdaDataFlowType(c)
   )
   or
+  mustHaveCollectionType(n, result)
+  or
   not n instanceof LambdaSelfReferenceNode and
   not mustHaveLambdaType(n, _) and
-  result = TUnknownDataFlowType()
+  not mustHaveCollectionType(n, _) and
+  (
+    TypeInference::hasModuleType(n, result)
+    or
+    not TypeInference::hasModuleType(n, _) and
+    result.isUnknown()
+  )
 }
 
-pragma[inline]
+pragma[nomagic]
 private predicate compatibleTypesNonSymRefl(DataFlowType t1, DataFlowType t2) {
-  t1 != TUnknownDataFlowType() and
-  t2 = TUnknownDataFlowType()
+  not t1.isUnknown() and
+  t2.isUnknown()
+  or
+  t1 instanceof TLambdaDataFlowType and
+  isProcClass(t2)
+  or
+  t1 instanceof TCollectionType and
+  isCollectionClass(t2)
+}
+
+pragma[nomagic]
+private predicate compatibleModuleTypes(TModuleDataFlowType t1, TModuleDataFlowType t2) {
+  exists(Module m1, Module m2, Module m3 |
+    t1 = TModuleDataFlowType(m1) and
+    t2 = TModuleDataFlowType(m2)
+  |
+    m3.getAnAncestor() = m1 and
+    m3.getAnAncestor() = m2
+  )
 }
 
 /**
@@ -1932,6 +2029,8 @@ predicate compatibleTypes(DataFlowType t1, DataFlowType t2) {
   compatibleTypesNonSymRefl(t1, t2)
   or
   compatibleTypesNonSymRefl(t2, t1)
+  or
+  compatibleModuleTypes(t1, t2)
 }
 
 abstract class PostUpdateNodeImpl extends Node {
@@ -1991,7 +2090,11 @@ private import PostUpdateNodes
 
 /** A node that performs a type cast. */
 class CastNode extends Node {
-  CastNode() { none() }
+  CastNode() {
+    TypeInference::hasAdjacentTypeCheckedRead(this.asExpr(), _)
+    or
+    TypeInference::asModulePattern(this.(SsaDefinitionNode).getDefinition(), _)
+  }
 }
 
 /**
@@ -2190,4 +2293,246 @@ class AdditionalJumpStep extends Unit {
    * Holds if data can flow from `pred` to `succ` in a way that discards call contexts.
    */
   abstract predicate step(Node pred, Node succ);
+}
+
+/** Provides logic for assigning types to data flow nodes. */
+module TypeInference {
+  private import codeql.ruby.ast.internal.Module
+  private import DataFlowDispatch
+
+  /** The built-in `Proc` class. */
+  class ProcClass extends Module {
+    ProcClass() { this = TResolved("Proc") }
+  }
+
+  /** The built-in `Array` class. */
+  class ArrayClass extends Module {
+    ArrayClass() { this = TResolved("Array") }
+  }
+
+  /** The built-in `Hash` class. */
+  class HashClass extends Module {
+    HashClass() { this = TResolved("Hash") }
+  }
+
+  /** The built-in `String` class. */
+  class StringClass extends Module {
+    StringClass() { this = TResolved("String") }
+  }
+
+  /** Holds if `self` belongs to the top-level. */
+  pragma[nomagic]
+  private predicate selfInToplevel(SelfVariable self, Module m) {
+    ViewComponentRenderModeling::selfInErbToplevel(self, m)
+    or
+    not ViewComponentRenderModeling::selfInErbToplevel(self, _) and
+    self.getDeclaringScope() instanceof Toplevel and
+    m = TResolved("Object")
+  }
+
+  /**
+   * Holds if SSA definition `def` belongs to a variable introduced via pattern
+   * matching on type `m`. For example, in
+   *
+   * ```rb
+   * case object
+   *   in C => c then c.foo
+   * end
+   * ```
+   *
+   * the SSA definition for `c` is introduced by matching on `C`.
+   */
+  predicate asModulePattern(Ssa::WriteDefinition def, Module m) {
+    exists(AsPattern ap |
+      m = resolveConstantReadAccess(ap.getPattern()) and
+      def.getWriteAccess().getAstNode() = ap.getVariableAccess()
+    )
+  }
+
+  /**
+   * Holds if `caseRead` and `read` are reads of SSA definition `def`,
+   * and `read` is checked to have type `m`. For example, in
+   *
+   * ```rb
+   * case object
+   *   when C then object.foo
+   * end
+   * ```
+   *
+   * the second read of `object` is known to have type `C`.
+   */
+  private predicate hasTypeCheckedRead(
+    Ssa::Definition def, CfgNodes::ExprCfgNode caseRead, CfgNodes::ExprCfgNode read, Module m
+  ) {
+    exists(
+      CfgNodes::ExprCfgNode pattern, ConditionBlock cb, CfgNodes::ExprNodes::CaseExprCfgNode case
+    |
+      m = resolveConstantReadAccess(pattern.getExpr()) and
+      cb.getLastNode() = pattern and
+      cb.controls(read.getBasicBlock(),
+        any(SuccessorTypes::MatchingSuccessor match | match.getValue() = true)) and
+      caseRead = def.getARead() and
+      read = def.getARead() and
+      case.getValue() = caseRead
+    |
+      pattern = case.getBranch(_).(CfgNodes::ExprNodes::WhenClauseCfgNode).getPattern(_)
+      or
+      pattern = case.getBranch(_).(CfgNodes::ExprNodes::InClauseCfgNode).getPattern()
+    )
+  }
+
+  predicate hasAdjacentTypeCheckedRead(CfgNodes::ExprCfgNode read, Module m) {
+    exists(Ssa::Definition def, CfgNodes::ExprCfgNode caseRead |
+      hasTypeCheckedRead(def, caseRead, read, m) and
+      def.hasAdjacentReads(caseRead, read)
+    )
+  }
+
+  private predicate isTypeCheckedRead(CfgNodes::ExprCfgNode read, Module m) {
+    exists(Ssa::Definition def |
+      hasTypeCheckedRead(def, _, read, m) and
+      // could in principle be checked against a new type
+      not exists(CfgNodes::ExprCfgNode innerCaseRead |
+        hasTypeCheckedRead(def, _, innerCaseRead, m) and
+        hasTypeCheckedRead(def, innerCaseRead, read, _)
+      )
+    )
+  }
+
+  pragma[nomagic]
+  private predicate selfInMethodOrToplevelHasType(SelfVariable self, Module tp, boolean exact) {
+    exists(MethodBase m |
+      selfInMethod(self, m, tp) and
+      not m instanceof SingletonMethod and
+      if m.getEnclosingModule() instanceof Toplevel then exact = true else exact = false
+    )
+    or
+    selfInToplevel(self, tp) and
+    exact = true
+  }
+
+  pragma[nomagic]
+  private predicate parameterNodeHasType(ParameterNodeImpl p, Module tp, boolean exact) {
+    exists(ParameterPosition pos |
+      p.isParameterOf(_, pos) and
+      exact = true
+    |
+      (pos.isSplat(_) or pos.isSynthSplat(_)) and
+      tp instanceof ArrayClass
+      or
+      (pos.isHashSplat() or pos.isSynthHashSplat()) and
+      tp instanceof HashClass
+    )
+    or
+    selfInMethodOrToplevelHasType(p.(SelfParameterNodeImpl).getSelfVariable(), tp, exact)
+  }
+
+  pragma[nomagic]
+  private predicate ssaDefHasType(SsaDefinitionExtNode def, Module tp, boolean exact) {
+    exists(ParameterNodeImpl p |
+      parameterNodeHasType(p, tp, exact) and
+      p = SsaFlow::toParameterNodeImpl(def)
+    )
+    or
+    selfInMethodOrToplevelHasType(def.getVariable(), tp, exact)
+    or
+    asModulePattern(def.getDefinitionExt(), tp) and
+    exact = false
+  }
+
+  pragma[nomagic]
+  private predicate hasTypeNoCall(Node n, Module tp, boolean exact) {
+    n.asExpr().getExpr() instanceof NilLiteral and
+    tp = TResolved("NilClass") and
+    exact = true
+    or
+    n.asExpr().getExpr().(BooleanLiteral).isFalse() and
+    tp = TResolved("FalseClass") and
+    exact = true
+    or
+    n.asExpr().getExpr().(BooleanLiteral).isTrue() and
+    tp = TResolved("TrueClass") and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof IntegerLiteral and
+    tp = TResolved("Integer") and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof FloatLiteral and
+    tp = TResolved("Float") and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof RationalLiteral and
+    tp = TResolved("Rational") and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof ComplexLiteral and
+    tp = TResolved("Complex") and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof StringlikeLiteral and
+    tp instanceof StringClass and
+    exact = true
+    or
+    (
+      n.asExpr() instanceof CfgNodes::ExprNodes::ArrayLiteralCfgNode or
+      n instanceof SynthSplatArgumentNode
+    ) and
+    tp instanceof ArrayClass and
+    exact = true
+    or
+    (
+      n.asExpr() instanceof CfgNodes::ExprNodes::HashLiteralCfgNode
+      or
+      n instanceof SynthHashSplatArgumentNode
+    ) and
+    tp instanceof HashClass and
+    exact = true
+    or
+    n.asExpr().getExpr() instanceof MethodBase and
+    tp = TResolved("Symbol") and
+    exact = true
+    or
+    (
+      n.asParameter() instanceof BlockParameter
+      or
+      n instanceof BlockParameterNode
+      or
+      n.asExpr().getExpr() instanceof Lambda
+    ) and
+    tp instanceof ProcClass and
+    exact = true
+    or
+    parameterNodeHasType(n, tp, exact)
+    or
+    exists(SsaDefinitionExtNode def | ssaDefHasType(def, tp, exact) |
+      n = def or
+      n.asExpr() =
+        any(CfgNodes::ExprCfgNode read |
+          read = def.getDefinitionExt().getARead() and
+          not isTypeCheckedRead(read, _) // could in principle be checked against a new type
+        )
+    )
+    or
+    // `case object when C then object.foo`
+    isTypeCheckedRead(n.asExpr(), tp) and
+    exact = false
+  }
+
+  pragma[nomagic]
+  private predicate hasTypeCall(Node n, Module tp, boolean exact) {
+    isStandardNewCall(n.asExpr(), tp, exact)
+  }
+
+  pragma[inline]
+  predicate hasType(Node n, Module tp, boolean exact) {
+    hasTypeNoCall(n, tp, exact)
+    or
+    hasTypeCall(n, tp, exact)
+  }
+
+  pragma[nomagic]
+  predicate hasModuleType(Node n, DataFlowType t) {
+    exists(Module tp | t = TModuleDataFlowType(tp) | hasType(n, tp, _))
+  }
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -727,6 +727,25 @@ class ContentSet extends TContentSet {
     this = TElementContentOfTypeContent(type, true)
   }
 
+  /**
+   * Holds if this content set represents an element in a collection (array or hash).
+   */
+  predicate isElement() {
+    this.isSingleton(any(Content::ElementContent c))
+    or
+    this.isAnyElement()
+    or
+    this.isKnownOrUnknownElement(any(Content::KnownElementContent c))
+    or
+    this.isElementLowerBound(_)
+    or
+    this.isElementLowerBoundOrUnknown(_)
+    or
+    this.isElementOfType(_)
+    or
+    this.isElementOfTypeOrUnknown(_)
+  }
+
   /** Gets a textual representation of this content set. */
   string toString() {
     exists(Content c |

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -117,14 +117,11 @@ private module Cached {
     // Although flow through collections is modeled precisely using stores/reads, we still
     // allow flow out of a _tainted_ collection. This is needed in order to support taint-
     // tracking configurations where the source is a collection.
-    exists(DataFlow::ContentSet c | readStep(nodeFrom, c, nodeTo) |
-      c.isSingleton(any(DataFlow::Content::ElementContent ec))
-      or
-      c.isKnownOrUnknownElement(_)
-      or
-      c.isAnyElement()
-    ) and
-    model = ""
+    exists(DataFlow::ContentSet c |
+      readStep(nodeFrom, c, nodeTo) and
+      c.isElement() and
+      model = ""
+    )
   }
 
   cached

--- a/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/array-flow/array-flow.expected
@@ -1,2979 +1,2979 @@
 models
 edges
-| array_flow.rb:2:5:2:5 | a [element 0] | array_flow.rb:3:10:3:10 | a [element 0] | provenance |  |
-| array_flow.rb:2:5:2:5 | a [element 0] | array_flow.rb:5:10:5:10 | a [element 0] | provenance |  |
-| array_flow.rb:2:9:2:20 | * ... [element 0] | array_flow.rb:2:5:2:5 | a [element 0] | provenance |  |
-| array_flow.rb:2:10:2:20 | call to source | array_flow.rb:2:9:2:20 | * ... [element 0] | provenance |  |
-| array_flow.rb:3:10:3:10 | a [element 0] | array_flow.rb:3:10:3:13 | ...[...] | provenance |  |
-| array_flow.rb:5:10:5:10 | a [element 0] | array_flow.rb:5:10:5:13 | ...[...] | provenance |  |
-| array_flow.rb:9:5:9:5 | a [element 1] | array_flow.rb:11:10:11:10 | a [element 1] | provenance |  |
-| array_flow.rb:9:5:9:5 | a [element 1] | array_flow.rb:13:10:13:10 | a [element 1] | provenance |  |
-| array_flow.rb:9:9:9:25 | call to [] [element 1] | array_flow.rb:9:5:9:5 | a [element 1] | provenance |  |
-| array_flow.rb:9:13:9:21 | call to source | array_flow.rb:9:9:9:25 | call to [] [element 1] | provenance |  |
-| array_flow.rb:11:10:11:10 | a [element 1] | array_flow.rb:11:10:11:13 | ...[...] | provenance |  |
-| array_flow.rb:13:10:13:10 | a [element 1] | array_flow.rb:13:10:13:13 | ...[...] | provenance |  |
-| array_flow.rb:17:5:17:5 | a [element] | array_flow.rb:18:10:18:10 | a [element] | provenance |  |
-| array_flow.rb:17:5:17:5 | a [element] | array_flow.rb:19:10:19:10 | a [element] | provenance |  |
-| array_flow.rb:17:5:17:5 | a [element] | array_flow.rb:21:19:21:19 | a [element] | provenance |  |
-| array_flow.rb:17:9:17:33 | call to new [element] | array_flow.rb:17:5:17:5 | a [element] | provenance |  |
-| array_flow.rb:17:22:17:32 | call to source | array_flow.rb:17:9:17:33 | call to new [element] | provenance |  |
-| array_flow.rb:18:10:18:10 | a [element] | array_flow.rb:18:10:18:13 | ...[...] | provenance |  |
-| array_flow.rb:19:10:19:10 | a [element] | array_flow.rb:19:10:19:13 | ...[...] | provenance |  |
-| array_flow.rb:21:5:21:5 | b [element] | array_flow.rb:22:10:22:10 | b [element] | provenance |  |
-| array_flow.rb:21:5:21:5 | b [element] | array_flow.rb:23:10:23:10 | b [element] | provenance |  |
-| array_flow.rb:21:9:21:20 | call to new [element] | array_flow.rb:21:5:21:5 | b [element] | provenance |  |
-| array_flow.rb:21:19:21:19 | a [element] | array_flow.rb:21:9:21:20 | call to new [element] | provenance |  |
-| array_flow.rb:22:10:22:10 | b [element] | array_flow.rb:22:10:22:13 | ...[...] | provenance |  |
-| array_flow.rb:23:10:23:10 | b [element] | array_flow.rb:23:10:23:13 | ...[...] | provenance |  |
-| array_flow.rb:25:5:25:5 | c [element] | array_flow.rb:28:10:28:10 | c [element] | provenance |  |
-| array_flow.rb:25:5:25:5 | c [element] | array_flow.rb:29:10:29:10 | c [element] | provenance |  |
-| array_flow.rb:25:9:27:7 | call to new [element] | array_flow.rb:25:5:25:5 | c [element] | provenance |  |
-| array_flow.rb:26:9:26:19 | call to source | array_flow.rb:25:9:27:7 | call to new [element] | provenance |  |
-| array_flow.rb:28:10:28:10 | c [element] | array_flow.rb:28:10:28:13 | ...[...] | provenance |  |
-| array_flow.rb:29:10:29:10 | c [element] | array_flow.rb:29:10:29:13 | ...[...] | provenance |  |
-| array_flow.rb:33:5:33:5 | a [element 0] | array_flow.rb:34:27:34:27 | a [element 0] | provenance |  |
-| array_flow.rb:33:9:33:22 | call to [] [element 0] | array_flow.rb:33:5:33:5 | a [element 0] | provenance |  |
-| array_flow.rb:33:10:33:18 | call to source | array_flow.rb:33:9:33:22 | call to [] [element 0] | provenance |  |
-| array_flow.rb:34:5:34:5 | b [element 0] | array_flow.rb:35:10:35:10 | b [element 0] | provenance |  |
-| array_flow.rb:34:9:34:28 | call to try_convert [element 0] | array_flow.rb:34:5:34:5 | b [element 0] | provenance |  |
-| array_flow.rb:34:27:34:27 | a [element 0] | array_flow.rb:34:9:34:28 | call to try_convert [element 0] | provenance |  |
-| array_flow.rb:35:10:35:10 | b [element 0] | array_flow.rb:35:10:35:13 | ...[...] | provenance |  |
-| array_flow.rb:40:5:40:5 | a [element 0] | array_flow.rb:42:9:42:9 | a [element 0] | provenance |  |
-| array_flow.rb:40:9:40:24 | call to [] [element 0] | array_flow.rb:40:5:40:5 | a [element 0] | provenance |  |
-| array_flow.rb:40:10:40:20 | call to source | array_flow.rb:40:9:40:24 | call to [] [element 0] | provenance |  |
-| array_flow.rb:41:5:41:5 | b [element 2] | array_flow.rb:42:13:42:13 | b [element 2] | provenance |  |
-| array_flow.rb:41:9:41:27 | call to [] [element 2] | array_flow.rb:41:5:41:5 | b [element 2] | provenance |  |
-| array_flow.rb:41:16:41:26 | call to source | array_flow.rb:41:9:41:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:42:5:42:5 | c [element] | array_flow.rb:43:10:43:10 | c [element] | provenance |  |
-| array_flow.rb:42:5:42:5 | c [element] | array_flow.rb:44:10:44:10 | c [element] | provenance |  |
-| array_flow.rb:42:9:42:9 | a [element 0] | array_flow.rb:42:9:42:13 | ... & ... [element] | provenance |  |
-| array_flow.rb:42:9:42:13 | ... & ... [element] | array_flow.rb:42:5:42:5 | c [element] | provenance |  |
-| array_flow.rb:42:13:42:13 | b [element 2] | array_flow.rb:42:9:42:13 | ... & ... [element] | provenance |  |
-| array_flow.rb:43:10:43:10 | c [element] | array_flow.rb:43:10:43:13 | ...[...] | provenance |  |
-| array_flow.rb:44:10:44:10 | c [element] | array_flow.rb:44:10:44:13 | ...[...] | provenance |  |
-| array_flow.rb:48:5:48:5 | a [element 0] | array_flow.rb:49:9:49:9 | a [element 0] | provenance |  |
-| array_flow.rb:48:9:48:22 | call to [] [element 0] | array_flow.rb:48:5:48:5 | a [element 0] | provenance |  |
-| array_flow.rb:48:10:48:18 | call to source | array_flow.rb:48:9:48:22 | call to [] [element 0] | provenance |  |
-| array_flow.rb:49:5:49:5 | b [element] | array_flow.rb:50:10:50:10 | b [element] | provenance |  |
-| array_flow.rb:49:5:49:5 | b [element] | array_flow.rb:51:10:51:10 | b [element] | provenance |  |
-| array_flow.rb:49:9:49:9 | a [element 0] | array_flow.rb:49:9:49:13 | ... * ... [element] | provenance |  |
-| array_flow.rb:49:9:49:13 | ... * ... [element] | array_flow.rb:49:5:49:5 | b [element] | provenance |  |
-| array_flow.rb:50:10:50:10 | b [element] | array_flow.rb:50:10:50:13 | ...[...] | provenance |  |
-| array_flow.rb:51:10:51:10 | b [element] | array_flow.rb:51:10:51:13 | ...[...] | provenance |  |
-| array_flow.rb:55:5:55:5 | a [element 0] | array_flow.rb:57:9:57:9 | a [element 0] | provenance |  |
-| array_flow.rb:55:9:55:24 | call to [] [element 0] | array_flow.rb:55:5:55:5 | a [element 0] | provenance |  |
-| array_flow.rb:55:10:55:20 | call to source | array_flow.rb:55:9:55:24 | call to [] [element 0] | provenance |  |
-| array_flow.rb:56:5:56:5 | b [element 1] | array_flow.rb:57:13:57:13 | b [element 1] | provenance |  |
-| array_flow.rb:56:9:56:24 | call to [] [element 1] | array_flow.rb:56:5:56:5 | b [element 1] | provenance |  |
-| array_flow.rb:56:13:56:23 | call to source | array_flow.rb:56:9:56:24 | call to [] [element 1] | provenance |  |
-| array_flow.rb:57:5:57:5 | c [element 0] | array_flow.rb:58:10:58:10 | c [element 0] | provenance |  |
-| array_flow.rb:57:5:57:5 | c [element] | array_flow.rb:58:10:58:10 | c [element] | provenance |  |
-| array_flow.rb:57:5:57:5 | c [element] | array_flow.rb:59:10:59:10 | c [element] | provenance |  |
-| array_flow.rb:57:9:57:9 | a [element 0] | array_flow.rb:57:9:57:13 | ... + ... [element 0] | provenance |  |
-| array_flow.rb:57:9:57:13 | ... + ... [element 0] | array_flow.rb:57:5:57:5 | c [element 0] | provenance |  |
-| array_flow.rb:57:9:57:13 | ... + ... [element] | array_flow.rb:57:5:57:5 | c [element] | provenance |  |
-| array_flow.rb:57:13:57:13 | b [element 1] | array_flow.rb:57:9:57:13 | ... + ... [element] | provenance |  |
-| array_flow.rb:58:10:58:10 | c [element 0] | array_flow.rb:58:10:58:13 | ...[...] | provenance |  |
-| array_flow.rb:58:10:58:10 | c [element] | array_flow.rb:58:10:58:13 | ...[...] | provenance |  |
-| array_flow.rb:59:10:59:10 | c [element] | array_flow.rb:59:10:59:13 | ...[...] | provenance |  |
-| array_flow.rb:63:5:63:5 | a [element 0] | array_flow.rb:65:9:65:9 | a [element 0] | provenance |  |
-| array_flow.rb:63:9:63:24 | call to [] [element 0] | array_flow.rb:63:5:63:5 | a [element 0] | provenance |  |
-| array_flow.rb:63:10:63:20 | call to source | array_flow.rb:63:9:63:24 | call to [] [element 0] | provenance |  |
-| array_flow.rb:65:5:65:5 | c [element] | array_flow.rb:66:10:66:10 | c [element] | provenance |  |
-| array_flow.rb:65:5:65:5 | c [element] | array_flow.rb:67:10:67:10 | c [element] | provenance |  |
-| array_flow.rb:65:9:65:9 | a [element 0] | array_flow.rb:65:9:65:13 | ... - ... [element] | provenance |  |
-| array_flow.rb:65:9:65:13 | ... - ... [element] | array_flow.rb:65:5:65:5 | c [element] | provenance |  |
-| array_flow.rb:66:10:66:10 | c [element] | array_flow.rb:66:10:66:13 | ...[...] | provenance |  |
-| array_flow.rb:67:10:67:10 | c [element] | array_flow.rb:67:10:67:13 | ...[...] | provenance |  |
-| array_flow.rb:71:5:71:5 | a [element 0] | array_flow.rb:72:9:72:9 | a [element 0] | provenance |  |
-| array_flow.rb:71:5:71:5 | a [element 0] | array_flow.rb:73:10:73:10 | a [element 0] | provenance |  |
-| array_flow.rb:71:9:71:24 | call to [] [element 0] | array_flow.rb:71:5:71:5 | a [element 0] | provenance |  |
-| array_flow.rb:71:10:71:20 | call to source | array_flow.rb:71:9:71:24 | call to [] [element 0] | provenance |  |
-| array_flow.rb:72:5:72:5 | b [element 0] | array_flow.rb:75:10:75:10 | b [element 0] | provenance |  |
-| array_flow.rb:72:5:72:5 | b [element] | array_flow.rb:75:10:75:10 | b [element] | provenance |  |
-| array_flow.rb:72:5:72:5 | b [element] | array_flow.rb:76:10:76:10 | b [element] | provenance |  |
-| array_flow.rb:72:9:72:9 | [post] a [element] | array_flow.rb:73:10:73:10 | a [element] | provenance |  |
-| array_flow.rb:72:9:72:9 | [post] a [element] | array_flow.rb:74:10:74:10 | a [element] | provenance |  |
-| array_flow.rb:72:9:72:9 | a [element 0] | array_flow.rb:72:9:72:24 | ... << ... [element 0] | provenance |  |
-| array_flow.rb:72:9:72:24 | ... << ... [element 0] | array_flow.rb:72:5:72:5 | b [element 0] | provenance |  |
-| array_flow.rb:72:9:72:24 | ... << ... [element] | array_flow.rb:72:5:72:5 | b [element] | provenance |  |
-| array_flow.rb:72:14:72:24 | call to source | array_flow.rb:72:9:72:9 | [post] a [element] | provenance |  |
-| array_flow.rb:72:14:72:24 | call to source | array_flow.rb:72:9:72:24 | ... << ... [element] | provenance |  |
-| array_flow.rb:73:10:73:10 | a [element 0] | array_flow.rb:73:10:73:13 | ...[...] | provenance |  |
-| array_flow.rb:73:10:73:10 | a [element] | array_flow.rb:73:10:73:13 | ...[...] | provenance |  |
-| array_flow.rb:74:10:74:10 | a [element] | array_flow.rb:74:10:74:13 | ...[...] | provenance |  |
-| array_flow.rb:75:10:75:10 | b [element 0] | array_flow.rb:75:10:75:13 | ...[...] | provenance |  |
-| array_flow.rb:75:10:75:10 | b [element] | array_flow.rb:75:10:75:13 | ...[...] | provenance |  |
-| array_flow.rb:76:10:76:10 | b [element] | array_flow.rb:76:10:76:13 | ...[...] | provenance |  |
-| array_flow.rb:80:5:80:5 | a [element 1] | array_flow.rb:81:15:81:15 | a [element 1] | provenance |  |
-| array_flow.rb:80:9:80:25 | call to [] [element 1] | array_flow.rb:80:5:80:5 | a [element 1] | provenance |  |
-| array_flow.rb:80:13:80:21 | call to source | array_flow.rb:80:9:80:25 | call to [] [element 1] | provenance |  |
+| array_flow.rb:2:5:2:5 | a : [collection] [element 0] | array_flow.rb:3:10:3:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:2:5:2:5 | a : [collection] [element 0] | array_flow.rb:5:10:5:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:2:9:2:20 | * ... : [collection] [element 0] | array_flow.rb:2:5:2:5 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:2:10:2:20 | call to source | array_flow.rb:2:9:2:20 | * ... : [collection] [element 0] | provenance |  |
+| array_flow.rb:3:10:3:10 | a : [collection] [element 0] | array_flow.rb:3:10:3:13 | ...[...] | provenance |  |
+| array_flow.rb:5:10:5:10 | a : [collection] [element 0] | array_flow.rb:5:10:5:13 | ...[...] | provenance |  |
+| array_flow.rb:9:5:9:5 | a : Array [element 1] | array_flow.rb:11:10:11:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:9:5:9:5 | a : Array [element 1] | array_flow.rb:13:10:13:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:9:9:9:25 | call to [] : Array [element 1] | array_flow.rb:9:5:9:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:9:13:9:21 | call to source | array_flow.rb:9:9:9:25 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:11:10:11:10 | a : Array [element 1] | array_flow.rb:11:10:11:13 | ...[...] | provenance |  |
+| array_flow.rb:13:10:13:10 | a : Array [element 1] | array_flow.rb:13:10:13:13 | ...[...] | provenance |  |
+| array_flow.rb:17:5:17:5 | a : [collection] [element] | array_flow.rb:18:10:18:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:17:5:17:5 | a : [collection] [element] | array_flow.rb:19:10:19:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:17:5:17:5 | a : [collection] [element] | array_flow.rb:21:19:21:19 | a : [collection] [element] | provenance |  |
+| array_flow.rb:17:9:17:33 | call to new : [collection] [element] | array_flow.rb:17:5:17:5 | a : [collection] [element] | provenance |  |
+| array_flow.rb:17:22:17:32 | call to source | array_flow.rb:17:9:17:33 | call to new : [collection] [element] | provenance |  |
+| array_flow.rb:18:10:18:10 | a : [collection] [element] | array_flow.rb:18:10:18:13 | ...[...] | provenance |  |
+| array_flow.rb:19:10:19:10 | a : [collection] [element] | array_flow.rb:19:10:19:13 | ...[...] | provenance |  |
+| array_flow.rb:21:5:21:5 | b : [collection] [element] | array_flow.rb:22:10:22:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:21:5:21:5 | b : [collection] [element] | array_flow.rb:23:10:23:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:21:9:21:20 | call to new : [collection] [element] | array_flow.rb:21:5:21:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:21:19:21:19 | a : [collection] [element] | array_flow.rb:21:9:21:20 | call to new : [collection] [element] | provenance |  |
+| array_flow.rb:22:10:22:10 | b : [collection] [element] | array_flow.rb:22:10:22:13 | ...[...] | provenance |  |
+| array_flow.rb:23:10:23:10 | b : [collection] [element] | array_flow.rb:23:10:23:13 | ...[...] | provenance |  |
+| array_flow.rb:25:5:25:5 | c : [collection] [element] | array_flow.rb:28:10:28:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:25:5:25:5 | c : [collection] [element] | array_flow.rb:29:10:29:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:25:9:27:7 | call to new : [collection] [element] | array_flow.rb:25:5:25:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:26:9:26:19 | call to source | array_flow.rb:25:9:27:7 | call to new : [collection] [element] | provenance |  |
+| array_flow.rb:28:10:28:10 | c : [collection] [element] | array_flow.rb:28:10:28:13 | ...[...] | provenance |  |
+| array_flow.rb:29:10:29:10 | c : [collection] [element] | array_flow.rb:29:10:29:13 | ...[...] | provenance |  |
+| array_flow.rb:33:5:33:5 | a : Array [element 0] | array_flow.rb:34:27:34:27 | a : Array [element 0] | provenance |  |
+| array_flow.rb:33:9:33:22 | call to [] : Array [element 0] | array_flow.rb:33:5:33:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:33:10:33:18 | call to source | array_flow.rb:33:9:33:22 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:34:5:34:5 | b : Array [element 0] | array_flow.rb:35:10:35:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:34:9:34:28 | call to try_convert : Array [element 0] | array_flow.rb:34:5:34:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:34:27:34:27 | a : Array [element 0] | array_flow.rb:34:9:34:28 | call to try_convert : Array [element 0] | provenance |  |
+| array_flow.rb:35:10:35:10 | b : Array [element 0] | array_flow.rb:35:10:35:13 | ...[...] | provenance |  |
+| array_flow.rb:40:5:40:5 | a : Array [element 0] | array_flow.rb:42:9:42:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:40:9:40:24 | call to [] : Array [element 0] | array_flow.rb:40:5:40:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:40:10:40:20 | call to source | array_flow.rb:40:9:40:24 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:41:5:41:5 | b : Array [element 2] | array_flow.rb:42:13:42:13 | b : Array [element 2] | provenance |  |
+| array_flow.rb:41:9:41:27 | call to [] : Array [element 2] | array_flow.rb:41:5:41:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:41:16:41:26 | call to source | array_flow.rb:41:9:41:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:42:5:42:5 | c : [collection] [element] | array_flow.rb:43:10:43:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:42:5:42:5 | c : [collection] [element] | array_flow.rb:44:10:44:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:42:9:42:9 | a : Array [element 0] | array_flow.rb:42:9:42:13 | ... & ... : [collection] [element] | provenance |  |
+| array_flow.rb:42:9:42:13 | ... & ... : [collection] [element] | array_flow.rb:42:5:42:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:42:13:42:13 | b : Array [element 2] | array_flow.rb:42:9:42:13 | ... & ... : [collection] [element] | provenance |  |
+| array_flow.rb:43:10:43:10 | c : [collection] [element] | array_flow.rb:43:10:43:13 | ...[...] | provenance |  |
+| array_flow.rb:44:10:44:10 | c : [collection] [element] | array_flow.rb:44:10:44:13 | ...[...] | provenance |  |
+| array_flow.rb:48:5:48:5 | a : Array [element 0] | array_flow.rb:49:9:49:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:48:9:48:22 | call to [] : Array [element 0] | array_flow.rb:48:5:48:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:48:10:48:18 | call to source | array_flow.rb:48:9:48:22 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:49:5:49:5 | b : [collection] [element] | array_flow.rb:50:10:50:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:49:5:49:5 | b : [collection] [element] | array_flow.rb:51:10:51:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:49:9:49:9 | a : Array [element 0] | array_flow.rb:49:9:49:13 | ... * ... : [collection] [element] | provenance |  |
+| array_flow.rb:49:9:49:13 | ... * ... : [collection] [element] | array_flow.rb:49:5:49:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:50:10:50:10 | b : [collection] [element] | array_flow.rb:50:10:50:13 | ...[...] | provenance |  |
+| array_flow.rb:51:10:51:10 | b : [collection] [element] | array_flow.rb:51:10:51:13 | ...[...] | provenance |  |
+| array_flow.rb:55:5:55:5 | a : Array [element 0] | array_flow.rb:57:9:57:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:55:9:55:24 | call to [] : Array [element 0] | array_flow.rb:55:5:55:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:55:10:55:20 | call to source | array_flow.rb:55:9:55:24 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:56:5:56:5 | b : Array [element 1] | array_flow.rb:57:13:57:13 | b : Array [element 1] | provenance |  |
+| array_flow.rb:56:9:56:24 | call to [] : Array [element 1] | array_flow.rb:56:5:56:5 | b : Array [element 1] | provenance |  |
+| array_flow.rb:56:13:56:23 | call to source | array_flow.rb:56:9:56:24 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:57:5:57:5 | c : Array [element 0] | array_flow.rb:58:10:58:10 | c : Array [element 0] | provenance |  |
+| array_flow.rb:57:5:57:5 | c : [collection] [element] | array_flow.rb:58:10:58:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:57:5:57:5 | c : [collection] [element] | array_flow.rb:59:10:59:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:57:9:57:9 | a : Array [element 0] | array_flow.rb:57:9:57:13 | ... + ... : Array [element 0] | provenance |  |
+| array_flow.rb:57:9:57:13 | ... + ... : Array [element 0] | array_flow.rb:57:5:57:5 | c : Array [element 0] | provenance |  |
+| array_flow.rb:57:9:57:13 | ... + ... : [collection] [element] | array_flow.rb:57:5:57:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:57:13:57:13 | b : Array [element 1] | array_flow.rb:57:9:57:13 | ... + ... : [collection] [element] | provenance |  |
+| array_flow.rb:58:10:58:10 | c : Array [element 0] | array_flow.rb:58:10:58:13 | ...[...] | provenance |  |
+| array_flow.rb:58:10:58:10 | c : [collection] [element] | array_flow.rb:58:10:58:13 | ...[...] | provenance |  |
+| array_flow.rb:59:10:59:10 | c : [collection] [element] | array_flow.rb:59:10:59:13 | ...[...] | provenance |  |
+| array_flow.rb:63:5:63:5 | a : Array [element 0] | array_flow.rb:65:9:65:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:63:9:63:24 | call to [] : Array [element 0] | array_flow.rb:63:5:63:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:63:10:63:20 | call to source | array_flow.rb:63:9:63:24 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:65:5:65:5 | c : [collection] [element] | array_flow.rb:66:10:66:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:65:5:65:5 | c : [collection] [element] | array_flow.rb:67:10:67:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:65:9:65:9 | a : Array [element 0] | array_flow.rb:65:9:65:13 | ... - ... : [collection] [element] | provenance |  |
+| array_flow.rb:65:9:65:13 | ... - ... : [collection] [element] | array_flow.rb:65:5:65:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:66:10:66:10 | c : [collection] [element] | array_flow.rb:66:10:66:13 | ...[...] | provenance |  |
+| array_flow.rb:67:10:67:10 | c : [collection] [element] | array_flow.rb:67:10:67:13 | ...[...] | provenance |  |
+| array_flow.rb:71:5:71:5 | a : Array [element 0] | array_flow.rb:72:9:72:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:71:5:71:5 | a : Array [element 0] | array_flow.rb:73:10:73:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:71:9:71:24 | call to [] : Array [element 0] | array_flow.rb:71:5:71:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:71:10:71:20 | call to source | array_flow.rb:71:9:71:24 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:72:5:72:5 | b : Array [element 0] | array_flow.rb:75:10:75:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:72:5:72:5 | b : [collection] [element] | array_flow.rb:75:10:75:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:72:5:72:5 | b : [collection] [element] | array_flow.rb:76:10:76:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:72:9:72:9 | [post] a : [collection] [element] | array_flow.rb:73:10:73:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:72:9:72:9 | [post] a : [collection] [element] | array_flow.rb:74:10:74:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:72:9:72:9 | a : Array [element 0] | array_flow.rb:72:9:72:24 | ... << ... : Array [element 0] | provenance |  |
+| array_flow.rb:72:9:72:24 | ... << ... : Array [element 0] | array_flow.rb:72:5:72:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:72:9:72:24 | ... << ... : [collection] [element] | array_flow.rb:72:5:72:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:72:14:72:24 | call to source | array_flow.rb:72:9:72:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:72:14:72:24 | call to source | array_flow.rb:72:9:72:24 | ... << ... : [collection] [element] | provenance |  |
+| array_flow.rb:73:10:73:10 | a : Array [element 0] | array_flow.rb:73:10:73:13 | ...[...] | provenance |  |
+| array_flow.rb:73:10:73:10 | a : [collection] [element] | array_flow.rb:73:10:73:13 | ...[...] | provenance |  |
+| array_flow.rb:74:10:74:10 | a : [collection] [element] | array_flow.rb:74:10:74:13 | ...[...] | provenance |  |
+| array_flow.rb:75:10:75:10 | b : Array [element 0] | array_flow.rb:75:10:75:13 | ...[...] | provenance |  |
+| array_flow.rb:75:10:75:10 | b : [collection] [element] | array_flow.rb:75:10:75:13 | ...[...] | provenance |  |
+| array_flow.rb:76:10:76:10 | b : [collection] [element] | array_flow.rb:76:10:76:13 | ...[...] | provenance |  |
+| array_flow.rb:80:5:80:5 | a : Array [element 1] | array_flow.rb:81:15:81:15 | a : Array [element 1] | provenance |  |
+| array_flow.rb:80:9:80:25 | call to [] : Array [element 1] | array_flow.rb:80:5:80:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:80:13:80:21 | call to source | array_flow.rb:80:9:80:25 | call to [] : Array [element 1] | provenance |  |
 | array_flow.rb:81:8:81:8 | c | array_flow.rb:83:10:83:10 | c | provenance |  |
-| array_flow.rb:81:15:81:15 | a [element 1] | array_flow.rb:81:8:81:8 | c | provenance |  |
-| array_flow.rb:88:5:88:5 | a [element 1] | array_flow.rb:89:9:89:9 | a [element 1] | provenance |  |
-| array_flow.rb:88:9:88:26 | call to [] [element 1] | array_flow.rb:88:5:88:5 | a [element 1] | provenance |  |
-| array_flow.rb:88:13:88:22 | call to source | array_flow.rb:88:9:88:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:89:5:89:5 | b [element 1] | array_flow.rb:91:10:91:10 | b [element 1] | provenance |  |
-| array_flow.rb:89:5:89:5 | b [element 1] | array_flow.rb:92:10:92:10 | b [element 1] | provenance |  |
-| array_flow.rb:89:9:89:9 | a [element 1] | array_flow.rb:89:9:89:15 | ...[...] [element 1] | provenance |  |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] | array_flow.rb:89:5:89:5 | b [element 1] | provenance |  |
-| array_flow.rb:91:10:91:10 | b [element 1] | array_flow.rb:91:10:91:13 | ...[...] | provenance |  |
-| array_flow.rb:92:10:92:10 | b [element 1] | array_flow.rb:92:10:92:13 | ...[...] | provenance |  |
-| array_flow.rb:96:5:96:5 | a [element 1] | array_flow.rb:97:9:97:9 | a [element 1] | provenance |  |
-| array_flow.rb:96:9:96:26 | call to [] [element 1] | array_flow.rb:96:5:96:5 | a [element 1] | provenance |  |
-| array_flow.rb:96:13:96:22 | call to source | array_flow.rb:96:9:96:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:97:5:97:5 | b [element 1] | array_flow.rb:99:10:99:10 | b [element 1] | provenance |  |
-| array_flow.rb:97:5:97:5 | b [element 1] | array_flow.rb:101:10:101:10 | b [element 1] | provenance |  |
-| array_flow.rb:97:9:97:9 | a [element 1] | array_flow.rb:97:9:97:15 | ...[...] [element 1] | provenance |  |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] | array_flow.rb:97:5:97:5 | b [element 1] | provenance |  |
-| array_flow.rb:99:10:99:10 | b [element 1] | array_flow.rb:99:10:99:13 | ...[...] | provenance |  |
-| array_flow.rb:101:10:101:10 | b [element 1] | array_flow.rb:101:10:101:13 | ...[...] | provenance |  |
-| array_flow.rb:103:5:103:5 | a [element 1] | array_flow.rb:104:9:104:9 | a [element 1] | provenance |  |
-| array_flow.rb:103:9:103:39 | call to [] [element 1] | array_flow.rb:103:5:103:5 | a [element 1] | provenance |  |
-| array_flow.rb:103:13:103:24 | call to source | array_flow.rb:103:9:103:39 | call to [] [element 1] | provenance |  |
-| array_flow.rb:104:5:104:5 | b [element 1] | array_flow.rb:106:10:106:10 | b [element 1] | provenance |  |
-| array_flow.rb:104:9:104:9 | a [element 1] | array_flow.rb:104:9:104:16 | ...[...] [element 1] | provenance |  |
-| array_flow.rb:104:9:104:16 | ...[...] [element 1] | array_flow.rb:104:5:104:5 | b [element 1] | provenance |  |
-| array_flow.rb:106:10:106:10 | b [element 1] | array_flow.rb:106:10:106:13 | ...[...] | provenance |  |
-| array_flow.rb:109:5:109:5 | a [element 1] | array_flow.rb:110:9:110:9 | a [element 1] | provenance |  |
-| array_flow.rb:109:5:109:5 | a [element 1] | array_flow.rb:114:9:114:9 | a [element 1] | provenance |  |
-| array_flow.rb:109:5:109:5 | a [element 3] | array_flow.rb:110:9:110:9 | a [element 3] | provenance |  |
-| array_flow.rb:109:5:109:5 | a [element 3] | array_flow.rb:114:9:114:9 | a [element 3] | provenance |  |
-| array_flow.rb:109:9:109:42 | call to [] [element 1] | array_flow.rb:109:5:109:5 | a [element 1] | provenance |  |
-| array_flow.rb:109:9:109:42 | call to [] [element 3] | array_flow.rb:109:5:109:5 | a [element 3] | provenance |  |
-| array_flow.rb:109:13:109:24 | call to source | array_flow.rb:109:9:109:42 | call to [] [element 1] | provenance |  |
-| array_flow.rb:109:30:109:41 | call to source | array_flow.rb:109:9:109:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:110:5:110:5 | b [element] | array_flow.rb:111:10:111:10 | b [element] | provenance |  |
-| array_flow.rb:110:5:110:5 | b [element] | array_flow.rb:112:10:112:10 | b [element] | provenance |  |
-| array_flow.rb:110:9:110:9 | a [element 1] | array_flow.rb:110:9:110:18 | ...[...] [element] | provenance |  |
-| array_flow.rb:110:9:110:9 | a [element 3] | array_flow.rb:110:9:110:18 | ...[...] [element] | provenance |  |
-| array_flow.rb:110:9:110:18 | ...[...] [element] | array_flow.rb:110:5:110:5 | b [element] | provenance |  |
-| array_flow.rb:111:10:111:10 | b [element] | array_flow.rb:111:10:111:13 | ...[...] | provenance |  |
-| array_flow.rb:112:10:112:10 | b [element] | array_flow.rb:112:10:112:13 | ...[...] | provenance |  |
-| array_flow.rb:114:5:114:5 | b [element] | array_flow.rb:115:10:115:10 | b [element] | provenance |  |
-| array_flow.rb:114:5:114:5 | b [element] | array_flow.rb:116:10:116:10 | b [element] | provenance |  |
-| array_flow.rb:114:9:114:9 | a [element 1] | array_flow.rb:114:9:114:19 | ...[...] [element] | provenance |  |
-| array_flow.rb:114:9:114:9 | a [element 3] | array_flow.rb:114:9:114:19 | ...[...] [element] | provenance |  |
-| array_flow.rb:114:9:114:19 | ...[...] [element] | array_flow.rb:114:5:114:5 | b [element] | provenance |  |
-| array_flow.rb:115:10:115:10 | b [element] | array_flow.rb:115:10:115:13 | ...[...] | provenance |  |
-| array_flow.rb:116:10:116:10 | b [element] | array_flow.rb:116:10:116:13 | ...[...] | provenance |  |
-| array_flow.rb:121:5:121:5 | [post] a [element] | array_flow.rb:122:10:122:10 | a [element] | provenance |  |
-| array_flow.rb:121:5:121:5 | [post] a [element] | array_flow.rb:123:10:123:10 | a [element] | provenance |  |
-| array_flow.rb:121:5:121:5 | [post] a [element] | array_flow.rb:124:10:124:10 | a [element] | provenance |  |
-| array_flow.rb:121:15:121:24 | call to source | array_flow.rb:121:5:121:5 | [post] a [element] | provenance |  |
-| array_flow.rb:122:10:122:10 | a [element] | array_flow.rb:122:10:122:13 | ...[...] | provenance |  |
-| array_flow.rb:123:10:123:10 | a [element] | array_flow.rb:123:10:123:13 | ...[...] | provenance |  |
-| array_flow.rb:124:10:124:10 | a [element] | array_flow.rb:124:10:124:13 | ...[...] | provenance |  |
-| array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:130:10:130:10 | a [element] | provenance |  |
-| array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:131:10:131:10 | a [element] | provenance |  |
-| array_flow.rb:129:5:129:5 | [post] a [element] | array_flow.rb:132:10:132:10 | a [element] | provenance |  |
-| array_flow.rb:129:15:129:32 | call to [] [element 1] | array_flow.rb:129:5:129:5 | [post] a [element] | provenance |  |
-| array_flow.rb:129:19:129:28 | call to source | array_flow.rb:129:15:129:32 | call to [] [element 1] | provenance |  |
-| array_flow.rb:130:10:130:10 | a [element] | array_flow.rb:130:10:130:13 | ...[...] | provenance |  |
-| array_flow.rb:131:10:131:10 | a [element] | array_flow.rb:131:10:131:13 | ...[...] | provenance |  |
-| array_flow.rb:132:10:132:10 | a [element] | array_flow.rb:132:10:132:13 | ...[...] | provenance |  |
-| array_flow.rb:137:5:137:5 | [post] a [element] | array_flow.rb:138:10:138:10 | a [element] | provenance |  |
-| array_flow.rb:137:5:137:5 | [post] a [element] | array_flow.rb:139:10:139:10 | a [element] | provenance |  |
-| array_flow.rb:137:5:137:5 | [post] a [element] | array_flow.rb:140:10:140:10 | a [element] | provenance |  |
-| array_flow.rb:137:15:137:24 | call to source | array_flow.rb:137:5:137:5 | [post] a [element] | provenance |  |
-| array_flow.rb:138:10:138:10 | a [element] | array_flow.rb:138:10:138:13 | ...[...] | provenance |  |
-| array_flow.rb:139:10:139:10 | a [element] | array_flow.rb:139:10:139:13 | ...[...] | provenance |  |
-| array_flow.rb:140:10:140:10 | a [element] | array_flow.rb:140:10:140:13 | ...[...] | provenance |  |
-| array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:146:10:146:10 | a [element] | provenance |  |
-| array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:147:10:147:10 | a [element] | provenance |  |
-| array_flow.rb:145:5:145:5 | [post] a [element] | array_flow.rb:148:10:148:10 | a [element] | provenance |  |
-| array_flow.rb:145:15:145:32 | call to [] [element 1] | array_flow.rb:145:5:145:5 | [post] a [element] | provenance |  |
-| array_flow.rb:145:19:145:28 | call to source | array_flow.rb:145:15:145:32 | call to [] [element 1] | provenance |  |
-| array_flow.rb:146:10:146:10 | a [element] | array_flow.rb:146:10:146:13 | ...[...] | provenance |  |
-| array_flow.rb:147:10:147:10 | a [element] | array_flow.rb:147:10:147:13 | ...[...] | provenance |  |
-| array_flow.rb:148:10:148:10 | a [element] | array_flow.rb:148:10:148:13 | ...[...] | provenance |  |
-| array_flow.rb:152:5:152:5 | a [element 2] | array_flow.rb:153:5:153:5 | a [element 2] | provenance |  |
-| array_flow.rb:152:9:152:26 | call to [] [element 2] | array_flow.rb:152:5:152:5 | a [element 2] | provenance |  |
-| array_flow.rb:152:16:152:25 | call to source | array_flow.rb:152:9:152:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:153:5:153:5 | a [element 2] | array_flow.rb:153:16:153:16 | x | provenance |  |
+| array_flow.rb:81:15:81:15 | a : Array [element 1] | array_flow.rb:81:8:81:8 | c | provenance |  |
+| array_flow.rb:88:5:88:5 | a : Array [element 1] | array_flow.rb:89:9:89:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:88:9:88:26 | call to [] : Array [element 1] | array_flow.rb:88:5:88:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:88:13:88:22 | call to source | array_flow.rb:88:9:88:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:89:5:89:5 | b : [collection] [element 1] | array_flow.rb:91:10:91:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:89:5:89:5 | b : [collection] [element 1] | array_flow.rb:92:10:92:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:89:9:89:9 | a : Array [element 1] | array_flow.rb:89:9:89:15 | ...[...] : [collection] [element 1] | provenance |  |
+| array_flow.rb:89:9:89:15 | ...[...] : [collection] [element 1] | array_flow.rb:89:5:89:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:91:10:91:10 | b : [collection] [element 1] | array_flow.rb:91:10:91:13 | ...[...] | provenance |  |
+| array_flow.rb:92:10:92:10 | b : [collection] [element 1] | array_flow.rb:92:10:92:13 | ...[...] | provenance |  |
+| array_flow.rb:96:5:96:5 | a : Array [element 1] | array_flow.rb:97:9:97:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:96:9:96:26 | call to [] : Array [element 1] | array_flow.rb:96:5:96:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:96:13:96:22 | call to source | array_flow.rb:96:9:96:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:97:5:97:5 | b : [collection] [element 1] | array_flow.rb:99:10:99:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:97:5:97:5 | b : [collection] [element 1] | array_flow.rb:101:10:101:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:97:9:97:9 | a : Array [element 1] | array_flow.rb:97:9:97:15 | ...[...] : [collection] [element 1] | provenance |  |
+| array_flow.rb:97:9:97:15 | ...[...] : [collection] [element 1] | array_flow.rb:97:5:97:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:99:10:99:10 | b : [collection] [element 1] | array_flow.rb:99:10:99:13 | ...[...] | provenance |  |
+| array_flow.rb:101:10:101:10 | b : [collection] [element 1] | array_flow.rb:101:10:101:13 | ...[...] | provenance |  |
+| array_flow.rb:103:5:103:5 | a : Array [element 1] | array_flow.rb:104:9:104:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:103:9:103:39 | call to [] : Array [element 1] | array_flow.rb:103:5:103:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:103:13:103:24 | call to source | array_flow.rb:103:9:103:39 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:104:5:104:5 | b : [collection] [element 1] | array_flow.rb:106:10:106:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:104:9:104:9 | a : Array [element 1] | array_flow.rb:104:9:104:16 | ...[...] : [collection] [element 1] | provenance |  |
+| array_flow.rb:104:9:104:16 | ...[...] : [collection] [element 1] | array_flow.rb:104:5:104:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:106:10:106:10 | b : [collection] [element 1] | array_flow.rb:106:10:106:13 | ...[...] | provenance |  |
+| array_flow.rb:109:5:109:5 | a : Array [element 1] | array_flow.rb:110:9:110:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:109:5:109:5 | a : Array [element 1] | array_flow.rb:114:9:114:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:109:5:109:5 | a : Array [element 3] | array_flow.rb:110:9:110:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:109:5:109:5 | a : Array [element 3] | array_flow.rb:114:9:114:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:109:9:109:42 | call to [] : Array [element 1] | array_flow.rb:109:5:109:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:109:9:109:42 | call to [] : Array [element 3] | array_flow.rb:109:5:109:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:109:13:109:24 | call to source | array_flow.rb:109:9:109:42 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:109:30:109:41 | call to source | array_flow.rb:109:9:109:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:110:5:110:5 | b : [collection] [element] | array_flow.rb:111:10:111:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:110:5:110:5 | b : [collection] [element] | array_flow.rb:112:10:112:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:110:9:110:9 | a : Array [element 1] | array_flow.rb:110:9:110:18 | ...[...] : [collection] [element] | provenance |  |
+| array_flow.rb:110:9:110:9 | a : Array [element 3] | array_flow.rb:110:9:110:18 | ...[...] : [collection] [element] | provenance |  |
+| array_flow.rb:110:9:110:18 | ...[...] : [collection] [element] | array_flow.rb:110:5:110:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:111:10:111:10 | b : [collection] [element] | array_flow.rb:111:10:111:13 | ...[...] | provenance |  |
+| array_flow.rb:112:10:112:10 | b : [collection] [element] | array_flow.rb:112:10:112:13 | ...[...] | provenance |  |
+| array_flow.rb:114:5:114:5 | b : [collection] [element] | array_flow.rb:115:10:115:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:114:5:114:5 | b : [collection] [element] | array_flow.rb:116:10:116:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:114:9:114:9 | a : Array [element 1] | array_flow.rb:114:9:114:19 | ...[...] : [collection] [element] | provenance |  |
+| array_flow.rb:114:9:114:9 | a : Array [element 3] | array_flow.rb:114:9:114:19 | ...[...] : [collection] [element] | provenance |  |
+| array_flow.rb:114:9:114:19 | ...[...] : [collection] [element] | array_flow.rb:114:5:114:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:115:10:115:10 | b : [collection] [element] | array_flow.rb:115:10:115:13 | ...[...] | provenance |  |
+| array_flow.rb:116:10:116:10 | b : [collection] [element] | array_flow.rb:116:10:116:13 | ...[...] | provenance |  |
+| array_flow.rb:121:5:121:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:122:10:122:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:121:5:121:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:123:10:123:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:121:5:121:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:124:10:124:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:121:15:121:24 | call to source | array_flow.rb:121:5:121:5 | [post] a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:122:10:122:10 | a : [collection] [element] : [collection] | array_flow.rb:122:10:122:13 | ...[...] | provenance |  |
+| array_flow.rb:123:10:123:10 | a : [collection] [element] : [collection] | array_flow.rb:123:10:123:13 | ...[...] | provenance |  |
+| array_flow.rb:124:10:124:10 | a : [collection] [element] : [collection] | array_flow.rb:124:10:124:13 | ...[...] | provenance |  |
+| array_flow.rb:129:5:129:5 | [post] a : [collection] [element] | array_flow.rb:130:10:130:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:129:5:129:5 | [post] a : [collection] [element] | array_flow.rb:131:10:131:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:129:5:129:5 | [post] a : [collection] [element] | array_flow.rb:132:10:132:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:129:15:129:32 | call to [] : Array [element 1] | array_flow.rb:129:5:129:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:129:19:129:28 | call to source | array_flow.rb:129:15:129:32 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:130:10:130:10 | a : [collection] [element] | array_flow.rb:130:10:130:13 | ...[...] | provenance |  |
+| array_flow.rb:131:10:131:10 | a : [collection] [element] | array_flow.rb:131:10:131:13 | ...[...] | provenance |  |
+| array_flow.rb:132:10:132:10 | a : [collection] [element] | array_flow.rb:132:10:132:13 | ...[...] | provenance |  |
+| array_flow.rb:137:5:137:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:138:10:138:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:137:5:137:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:139:10:139:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:137:5:137:5 | [post] a : [collection] [element] : [collection] | array_flow.rb:140:10:140:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:137:15:137:24 | call to source | array_flow.rb:137:5:137:5 | [post] a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:138:10:138:10 | a : [collection] [element] : [collection] | array_flow.rb:138:10:138:13 | ...[...] | provenance |  |
+| array_flow.rb:139:10:139:10 | a : [collection] [element] : [collection] | array_flow.rb:139:10:139:13 | ...[...] | provenance |  |
+| array_flow.rb:140:10:140:10 | a : [collection] [element] : [collection] | array_flow.rb:140:10:140:13 | ...[...] | provenance |  |
+| array_flow.rb:145:5:145:5 | [post] a : [collection] [element] | array_flow.rb:146:10:146:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:145:5:145:5 | [post] a : [collection] [element] | array_flow.rb:147:10:147:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:145:5:145:5 | [post] a : [collection] [element] | array_flow.rb:148:10:148:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:145:15:145:32 | call to [] : Array [element 1] | array_flow.rb:145:5:145:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:145:19:145:28 | call to source | array_flow.rb:145:15:145:32 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:146:10:146:10 | a : [collection] [element] | array_flow.rb:146:10:146:13 | ...[...] | provenance |  |
+| array_flow.rb:147:10:147:10 | a : [collection] [element] | array_flow.rb:147:10:147:13 | ...[...] | provenance |  |
+| array_flow.rb:148:10:148:10 | a : [collection] [element] | array_flow.rb:148:10:148:13 | ...[...] | provenance |  |
+| array_flow.rb:152:5:152:5 | a : Array [element 2] | array_flow.rb:153:5:153:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:152:9:152:26 | call to [] : Array [element 2] | array_flow.rb:152:5:152:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:152:16:152:25 | call to source | array_flow.rb:152:9:152:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:153:5:153:5 | a : Array [element 2] | array_flow.rb:153:16:153:16 | x | provenance |  |
 | array_flow.rb:153:16:153:16 | x | array_flow.rb:154:14:154:14 | x | provenance |  |
-| array_flow.rb:159:5:159:5 | a [element 2] | array_flow.rb:160:5:160:5 | a [element 2] | provenance |  |
-| array_flow.rb:159:9:159:26 | call to [] [element 2] | array_flow.rb:159:5:159:5 | a [element 2] | provenance |  |
-| array_flow.rb:159:16:159:25 | call to source | array_flow.rb:159:9:159:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:160:5:160:5 | a [element 2] | array_flow.rb:160:16:160:16 | x | provenance |  |
+| array_flow.rb:159:5:159:5 | a : Array [element 2] | array_flow.rb:160:5:160:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:159:9:159:26 | call to [] : Array [element 2] | array_flow.rb:159:5:159:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:159:16:159:25 | call to source | array_flow.rb:159:9:159:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:160:5:160:5 | a : Array [element 2] | array_flow.rb:160:16:160:16 | x | provenance |  |
 | array_flow.rb:160:16:160:16 | x | array_flow.rb:161:14:161:14 | x | provenance |  |
-| array_flow.rb:166:5:166:5 | a [element 0] | array_flow.rb:167:9:167:9 | a [element 0] | provenance |  |
-| array_flow.rb:166:5:166:5 | a [element 0] | array_flow.rb:168:10:168:10 | a [element 0] | provenance |  |
-| array_flow.rb:166:9:166:25 | call to [] [element 0] | array_flow.rb:166:5:166:5 | a [element 0] | provenance |  |
-| array_flow.rb:166:10:166:21 | call to source | array_flow.rb:166:9:166:25 | call to [] [element 0] | provenance |  |
-| array_flow.rb:167:5:167:5 | b [element 0] | array_flow.rb:170:10:170:10 | b [element 0] | provenance |  |
-| array_flow.rb:167:5:167:5 | b [element] | array_flow.rb:170:10:170:10 | b [element] | provenance |  |
-| array_flow.rb:167:5:167:5 | b [element] | array_flow.rb:171:10:171:10 | b [element] | provenance |  |
-| array_flow.rb:167:9:167:9 | [post] a [element] | array_flow.rb:168:10:168:10 | a [element] | provenance |  |
-| array_flow.rb:167:9:167:9 | [post] a [element] | array_flow.rb:169:10:169:10 | a [element] | provenance |  |
-| array_flow.rb:167:9:167:9 | a [element 0] | array_flow.rb:167:9:167:44 | call to append [element 0] | provenance |  |
-| array_flow.rb:167:9:167:44 | call to append [element 0] | array_flow.rb:167:5:167:5 | b [element 0] | provenance |  |
-| array_flow.rb:167:9:167:44 | call to append [element] | array_flow.rb:167:5:167:5 | b [element] | provenance |  |
-| array_flow.rb:167:18:167:29 | call to source | array_flow.rb:167:9:167:9 | [post] a [element] | provenance |  |
-| array_flow.rb:167:18:167:29 | call to source | array_flow.rb:167:9:167:44 | call to append [element] | provenance |  |
-| array_flow.rb:167:32:167:43 | call to source | array_flow.rb:167:9:167:9 | [post] a [element] | provenance |  |
-| array_flow.rb:167:32:167:43 | call to source | array_flow.rb:167:9:167:44 | call to append [element] | provenance |  |
-| array_flow.rb:168:10:168:10 | a [element 0] | array_flow.rb:168:10:168:13 | ...[...] | provenance |  |
-| array_flow.rb:168:10:168:10 | a [element] | array_flow.rb:168:10:168:13 | ...[...] | provenance |  |
-| array_flow.rb:169:10:169:10 | a [element] | array_flow.rb:169:10:169:13 | ...[...] | provenance |  |
-| array_flow.rb:170:10:170:10 | b [element 0] | array_flow.rb:170:10:170:13 | ...[...] | provenance |  |
-| array_flow.rb:170:10:170:10 | b [element] | array_flow.rb:170:10:170:13 | ...[...] | provenance |  |
-| array_flow.rb:171:10:171:10 | b [element] | array_flow.rb:171:10:171:13 | ...[...] | provenance |  |
-| array_flow.rb:177:5:177:5 | c [element 1] | array_flow.rb:178:16:178:16 | c [element 1] | provenance |  |
-| array_flow.rb:177:9:177:25 | call to [] [element 1] | array_flow.rb:177:5:177:5 | c [element 1] | provenance |  |
-| array_flow.rb:177:15:177:24 | call to source | array_flow.rb:177:9:177:25 | call to [] [element 1] | provenance |  |
-| array_flow.rb:178:5:178:5 | d [element 2, element 1] | array_flow.rb:179:11:179:11 | d [element 2, element 1] | provenance |  |
-| array_flow.rb:178:5:178:5 | d [element 2, element 1] | array_flow.rb:180:11:180:11 | d [element 2, element 1] | provenance |  |
-| array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | array_flow.rb:178:5:178:5 | d [element 2, element 1] | provenance |  |
-| array_flow.rb:178:16:178:16 | c [element 1] | array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | provenance |  |
-| array_flow.rb:179:11:179:11 | d [element 2, element 1] | array_flow.rb:179:11:179:22 | call to assoc [element 1] | provenance |  |
+| array_flow.rb:166:5:166:5 | a : Array [element 0] | array_flow.rb:167:9:167:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:166:5:166:5 | a : Array [element 0] | array_flow.rb:168:10:168:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:166:9:166:25 | call to [] : Array [element 0] | array_flow.rb:166:5:166:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:166:10:166:21 | call to source | array_flow.rb:166:9:166:25 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:167:5:167:5 | b : Array [element 0] | array_flow.rb:170:10:170:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:167:5:167:5 | b : [collection] [element] | array_flow.rb:170:10:170:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:167:5:167:5 | b : [collection] [element] | array_flow.rb:171:10:171:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:167:9:167:9 | [post] a : [collection] [element] | array_flow.rb:168:10:168:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:167:9:167:9 | [post] a : [collection] [element] | array_flow.rb:169:10:169:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:167:9:167:9 | a : Array [element 0] | array_flow.rb:167:9:167:44 | call to append : Array [element 0] | provenance |  |
+| array_flow.rb:167:9:167:44 | call to append : Array [element 0] | array_flow.rb:167:5:167:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:167:9:167:44 | call to append : [collection] [element] | array_flow.rb:167:5:167:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:167:18:167:29 | call to source | array_flow.rb:167:9:167:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:167:18:167:29 | call to source | array_flow.rb:167:9:167:44 | call to append : [collection] [element] | provenance |  |
+| array_flow.rb:167:32:167:43 | call to source | array_flow.rb:167:9:167:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:167:32:167:43 | call to source | array_flow.rb:167:9:167:44 | call to append : [collection] [element] | provenance |  |
+| array_flow.rb:168:10:168:10 | a : Array [element 0] | array_flow.rb:168:10:168:13 | ...[...] | provenance |  |
+| array_flow.rb:168:10:168:10 | a : [collection] [element] | array_flow.rb:168:10:168:13 | ...[...] | provenance |  |
+| array_flow.rb:169:10:169:10 | a : [collection] [element] | array_flow.rb:169:10:169:13 | ...[...] | provenance |  |
+| array_flow.rb:170:10:170:10 | b : Array [element 0] | array_flow.rb:170:10:170:13 | ...[...] | provenance |  |
+| array_flow.rb:170:10:170:10 | b : [collection] [element] | array_flow.rb:170:10:170:13 | ...[...] | provenance |  |
+| array_flow.rb:171:10:171:10 | b : [collection] [element] | array_flow.rb:171:10:171:13 | ...[...] | provenance |  |
+| array_flow.rb:177:5:177:5 | c : Array [element 1] | array_flow.rb:178:16:178:16 | c : Array [element 1] | provenance |  |
+| array_flow.rb:177:9:177:25 | call to [] : Array [element 1] | array_flow.rb:177:5:177:5 | c : Array [element 1] | provenance |  |
+| array_flow.rb:177:15:177:24 | call to source | array_flow.rb:177:9:177:25 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:178:5:178:5 | d : Array [element 2, element 1] | array_flow.rb:179:11:179:11 | d : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:178:5:178:5 | d : Array [element 2, element 1] | array_flow.rb:180:11:180:11 | d : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:178:9:178:17 | call to [] : Array [element 2, element 1] | array_flow.rb:178:5:178:5 | d : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:178:16:178:16 | c : Array [element 1] | array_flow.rb:178:9:178:17 | call to [] : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:179:11:179:11 | d : Array [element 2, element 1] | array_flow.rb:179:11:179:22 | call to assoc [element 1] | provenance |  |
 | array_flow.rb:179:11:179:22 | call to assoc [element 1] | array_flow.rb:179:11:179:25 | ...[...] | provenance |  |
 | array_flow.rb:179:11:179:25 | ...[...] | array_flow.rb:179:10:179:26 | ( ... ) | provenance |  |
-| array_flow.rb:180:11:180:11 | d [element 2, element 1] | array_flow.rb:180:11:180:22 | call to assoc [element 1] | provenance |  |
+| array_flow.rb:180:11:180:11 | d : Array [element 2, element 1] | array_flow.rb:180:11:180:22 | call to assoc [element 1] | provenance |  |
 | array_flow.rb:180:11:180:22 | call to assoc [element 1] | array_flow.rb:180:11:180:25 | ...[...] | provenance |  |
 | array_flow.rb:180:11:180:25 | ...[...] | array_flow.rb:180:10:180:26 | ( ... ) | provenance |  |
-| array_flow.rb:184:5:184:5 | a [element 1] | array_flow.rb:186:10:186:10 | a [element 1] | provenance |  |
-| array_flow.rb:184:5:184:5 | a [element 1] | array_flow.rb:188:10:188:10 | a [element 1] | provenance |  |
-| array_flow.rb:184:9:184:26 | call to [] [element 1] | array_flow.rb:184:5:184:5 | a [element 1] | provenance |  |
-| array_flow.rb:184:13:184:22 | call to source | array_flow.rb:184:9:184:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:186:10:186:10 | a [element 1] | array_flow.rb:186:10:186:16 | call to at | provenance |  |
-| array_flow.rb:188:10:188:10 | a [element 1] | array_flow.rb:188:10:188:16 | call to at | provenance |  |
-| array_flow.rb:192:5:192:5 | a [element 2] | array_flow.rb:193:9:193:9 | a [element 2] | provenance |  |
-| array_flow.rb:192:9:192:26 | call to [] [element 2] | array_flow.rb:192:5:192:5 | a [element 2] | provenance |  |
-| array_flow.rb:192:16:192:25 | call to source | array_flow.rb:192:9:192:26 | call to [] [element 2] | provenance |  |
+| array_flow.rb:184:5:184:5 | a : Array [element 1] | array_flow.rb:186:10:186:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:184:5:184:5 | a : Array [element 1] | array_flow.rb:188:10:188:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:184:9:184:26 | call to [] : Array [element 1] | array_flow.rb:184:5:184:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:184:13:184:22 | call to source | array_flow.rb:184:9:184:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:186:10:186:10 | a : Array [element 1] | array_flow.rb:186:10:186:16 | call to at | provenance |  |
+| array_flow.rb:188:10:188:10 | a : Array [element 1] | array_flow.rb:188:10:188:16 | call to at | provenance |  |
+| array_flow.rb:192:5:192:5 | a : Array [element 2] | array_flow.rb:193:9:193:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:192:9:192:26 | call to [] : Array [element 2] | array_flow.rb:192:5:192:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:192:16:192:25 | call to source | array_flow.rb:192:9:192:26 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:193:5:193:5 | b | array_flow.rb:196:10:196:10 | b | provenance |  |
-| array_flow.rb:193:9:193:9 | a [element 2] | array_flow.rb:193:9:195:7 | call to bsearch | provenance |  |
-| array_flow.rb:193:9:193:9 | a [element 2] | array_flow.rb:193:23:193:23 | x | provenance |  |
+| array_flow.rb:193:9:193:9 | a : Array [element 2] | array_flow.rb:193:9:195:7 | call to bsearch | provenance |  |
+| array_flow.rb:193:9:193:9 | a : Array [element 2] | array_flow.rb:193:23:193:23 | x | provenance |  |
 | array_flow.rb:193:9:195:7 | call to bsearch | array_flow.rb:193:5:193:5 | b | provenance |  |
 | array_flow.rb:193:23:193:23 | x | array_flow.rb:194:14:194:14 | x | provenance |  |
-| array_flow.rb:200:5:200:5 | a [element 2] | array_flow.rb:201:9:201:9 | a [element 2] | provenance |  |
-| array_flow.rb:200:9:200:26 | call to [] [element 2] | array_flow.rb:200:5:200:5 | a [element 2] | provenance |  |
-| array_flow.rb:200:16:200:25 | call to source | array_flow.rb:200:9:200:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:201:9:201:9 | a [element 2] | array_flow.rb:201:29:201:29 | x | provenance |  |
+| array_flow.rb:200:5:200:5 | a : Array [element 2] | array_flow.rb:201:9:201:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:200:9:200:26 | call to [] : Array [element 2] | array_flow.rb:200:5:200:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:200:16:200:25 | call to source | array_flow.rb:200:9:200:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:201:9:201:9 | a : Array [element 2] | array_flow.rb:201:29:201:29 | x | provenance |  |
 | array_flow.rb:201:29:201:29 | x | array_flow.rb:202:14:202:14 | x | provenance |  |
-| array_flow.rb:208:5:208:5 | a [element 2] | array_flow.rb:209:5:209:5 | a [element 2] | provenance |  |
-| array_flow.rb:208:9:208:26 | call to [] [element 2] | array_flow.rb:208:5:208:5 | a [element 2] | provenance |  |
-| array_flow.rb:208:16:208:25 | call to source | array_flow.rb:208:9:208:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:209:5:209:5 | a [element 2] | array_flow.rb:209:17:209:17 | x | provenance |  |
+| array_flow.rb:208:5:208:5 | a : Array [element 2] | array_flow.rb:209:5:209:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:208:9:208:26 | call to [] : Array [element 2] | array_flow.rb:208:5:208:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:208:16:208:25 | call to source | array_flow.rb:208:9:208:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:209:5:209:5 | a : Array [element 2] | array_flow.rb:209:17:209:17 | x | provenance |  |
 | array_flow.rb:209:17:209:17 | x | array_flow.rb:210:14:210:14 | x | provenance |  |
-| array_flow.rb:215:5:215:5 | a [element 2] | array_flow.rb:216:9:216:9 | a [element 2] | provenance |  |
-| array_flow.rb:215:5:215:5 | a [element 3] | array_flow.rb:216:9:216:9 | a [element 3] | provenance |  |
-| array_flow.rb:215:9:215:42 | call to [] [element 2] | array_flow.rb:215:5:215:5 | a [element 2] | provenance |  |
-| array_flow.rb:215:9:215:42 | call to [] [element 3] | array_flow.rb:215:5:215:5 | a [element 3] | provenance |  |
-| array_flow.rb:215:16:215:27 | call to source | array_flow.rb:215:9:215:42 | call to [] [element 2] | provenance |  |
-| array_flow.rb:215:30:215:41 | call to source | array_flow.rb:215:9:215:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:216:9:216:9 | a [element 2] | array_flow.rb:216:27:216:27 | x | provenance |  |
-| array_flow.rb:216:9:216:9 | a [element 2] | array_flow.rb:216:30:216:30 | y | provenance |  |
-| array_flow.rb:216:9:216:9 | a [element 3] | array_flow.rb:216:27:216:27 | x | provenance |  |
-| array_flow.rb:216:9:216:9 | a [element 3] | array_flow.rb:216:30:216:30 | y | provenance |  |
+| array_flow.rb:215:5:215:5 | a : Array [element 2] | array_flow.rb:216:9:216:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:215:5:215:5 | a : Array [element 3] | array_flow.rb:216:9:216:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:215:9:215:42 | call to [] : Array [element 2] | array_flow.rb:215:5:215:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:215:9:215:42 | call to [] : Array [element 3] | array_flow.rb:215:5:215:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:215:16:215:27 | call to source | array_flow.rb:215:9:215:42 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:215:30:215:41 | call to source | array_flow.rb:215:9:215:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:216:9:216:9 | a : Array [element 2] | array_flow.rb:216:27:216:27 | x | provenance |  |
+| array_flow.rb:216:9:216:9 | a : Array [element 2] | array_flow.rb:216:30:216:30 | y | provenance |  |
+| array_flow.rb:216:9:216:9 | a : Array [element 3] | array_flow.rb:216:27:216:27 | x | provenance |  |
+| array_flow.rb:216:9:216:9 | a : Array [element 3] | array_flow.rb:216:30:216:30 | y | provenance |  |
 | array_flow.rb:216:27:216:27 | x | array_flow.rb:217:14:217:14 | x | provenance |  |
 | array_flow.rb:216:30:216:30 | y | array_flow.rb:218:14:218:14 | y | provenance |  |
-| array_flow.rb:231:5:231:5 | a [element 2] | array_flow.rb:232:9:232:9 | a [element 2] | provenance |  |
-| array_flow.rb:231:9:231:28 | call to [] [element 2] | array_flow.rb:231:5:231:5 | a [element 2] | provenance |  |
-| array_flow.rb:231:16:231:27 | call to source | array_flow.rb:231:9:231:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:232:5:232:5 | b [element] | array_flow.rb:236:10:236:10 | b [element] | provenance |  |
-| array_flow.rb:232:9:232:9 | a [element 2] | array_flow.rb:232:23:232:23 | x | provenance |  |
-| array_flow.rb:232:9:235:7 | call to collect [element] | array_flow.rb:232:5:232:5 | b [element] | provenance |  |
+| array_flow.rb:231:5:231:5 | a : Array [element 2] | array_flow.rb:232:9:232:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:231:9:231:28 | call to [] : Array [element 2] | array_flow.rb:231:5:231:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:231:16:231:27 | call to source | array_flow.rb:231:9:231:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:232:5:232:5 | b : [collection] [element] | array_flow.rb:236:10:236:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:232:9:232:9 | a : Array [element 2] | array_flow.rb:232:23:232:23 | x | provenance |  |
+| array_flow.rb:232:9:235:7 | call to collect : [collection] [element] | array_flow.rb:232:5:232:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:232:23:232:23 | x | array_flow.rb:233:14:233:14 | x | provenance |  |
-| array_flow.rb:234:9:234:19 | call to source | array_flow.rb:232:9:235:7 | call to collect [element] | provenance |  |
-| array_flow.rb:236:10:236:10 | b [element] | array_flow.rb:236:10:236:13 | ...[...] | provenance |  |
-| array_flow.rb:240:5:240:5 | a [element 2] | array_flow.rb:241:9:241:9 | a [element 2] | provenance |  |
-| array_flow.rb:240:9:240:28 | call to [] [element 2] | array_flow.rb:240:5:240:5 | a [element 2] | provenance |  |
-| array_flow.rb:240:16:240:27 | call to source | array_flow.rb:240:9:240:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:241:5:241:5 | b [element] | array_flow.rb:246:10:246:10 | b [element] | provenance |  |
-| array_flow.rb:241:9:241:9 | [post] a [element] | array_flow.rb:245:10:245:10 | a [element] | provenance |  |
-| array_flow.rb:241:9:241:9 | a [element 2] | array_flow.rb:241:24:241:24 | x | provenance |  |
-| array_flow.rb:241:9:244:7 | call to collect! [element] | array_flow.rb:241:5:241:5 | b [element] | provenance |  |
+| array_flow.rb:234:9:234:19 | call to source | array_flow.rb:232:9:235:7 | call to collect : [collection] [element] | provenance |  |
+| array_flow.rb:236:10:236:10 | b : [collection] [element] | array_flow.rb:236:10:236:13 | ...[...] | provenance |  |
+| array_flow.rb:240:5:240:5 | a : Array [element 2] | array_flow.rb:241:9:241:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:240:9:240:28 | call to [] : Array [element 2] | array_flow.rb:240:5:240:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:240:16:240:27 | call to source | array_flow.rb:240:9:240:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:241:5:241:5 | b : [collection] [element] | array_flow.rb:246:10:246:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:241:9:241:9 | [post] a : [collection] [element] | array_flow.rb:245:10:245:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:241:9:241:9 | a : Array [element 2] | array_flow.rb:241:24:241:24 | x | provenance |  |
+| array_flow.rb:241:9:244:7 | call to collect! : [collection] [element] | array_flow.rb:241:5:241:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:241:24:241:24 | x | array_flow.rb:242:14:242:14 | x | provenance |  |
-| array_flow.rb:243:9:243:19 | call to source | array_flow.rb:241:9:241:9 | [post] a [element] | provenance |  |
-| array_flow.rb:243:9:243:19 | call to source | array_flow.rb:241:9:244:7 | call to collect! [element] | provenance |  |
-| array_flow.rb:245:10:245:10 | a [element] | array_flow.rb:245:10:245:13 | ...[...] | provenance |  |
-| array_flow.rb:246:10:246:10 | b [element] | array_flow.rb:246:10:246:13 | ...[...] | provenance |  |
-| array_flow.rb:250:5:250:5 | a [element 2] | array_flow.rb:251:9:251:9 | a [element 2] | provenance |  |
-| array_flow.rb:250:5:250:5 | a [element 2] | array_flow.rb:256:9:256:9 | a [element 2] | provenance |  |
-| array_flow.rb:250:9:250:28 | call to [] [element 2] | array_flow.rb:250:5:250:5 | a [element 2] | provenance |  |
-| array_flow.rb:250:16:250:27 | call to source | array_flow.rb:250:9:250:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:251:5:251:5 | b [element] | array_flow.rb:255:10:255:10 | b [element] | provenance |  |
-| array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
-| array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | provenance |  |
-| array_flow.rb:251:9:254:7 | call to collect_concat [element] | array_flow.rb:251:5:251:5 | b [element] | provenance |  |
+| array_flow.rb:243:9:243:19 | call to source | array_flow.rb:241:9:241:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:243:9:243:19 | call to source | array_flow.rb:241:9:244:7 | call to collect! : [collection] [element] | provenance |  |
+| array_flow.rb:245:10:245:10 | a : [collection] [element] | array_flow.rb:245:10:245:13 | ...[...] | provenance |  |
+| array_flow.rb:246:10:246:10 | b : [collection] [element] | array_flow.rb:246:10:246:13 | ...[...] | provenance |  |
+| array_flow.rb:250:5:250:5 | a : Array [element 2] | array_flow.rb:251:9:251:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:250:5:250:5 | a : Array [element 2] | array_flow.rb:256:9:256:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:250:9:250:28 | call to [] : Array [element 2] | array_flow.rb:250:5:250:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:250:16:250:27 | call to source | array_flow.rb:250:9:250:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:251:5:251:5 | b : [collection] [element] | array_flow.rb:255:10:255:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:251:9:251:9 | a : Array [element 2] | array_flow.rb:251:9:254:7 | call to collect_concat : [collection] [element] | provenance |  |
+| array_flow.rb:251:9:251:9 | a : Array [element 2] | array_flow.rb:251:30:251:30 | x | provenance |  |
+| array_flow.rb:251:9:254:7 | call to collect_concat : [collection] [element] | array_flow.rb:251:5:251:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:251:30:251:30 | x | array_flow.rb:252:14:252:14 | x | provenance |  |
 | array_flow.rb:251:30:251:30 | x | array_flow.rb:253:10:253:10 | x | provenance |  |
-| array_flow.rb:253:9:253:25 | call to [] [element 1] | array_flow.rb:251:9:254:7 | call to collect_concat [element] | provenance |  |
-| array_flow.rb:253:10:253:10 | x | array_flow.rb:253:9:253:25 | call to [] [element 0] | provenance |  |
-| array_flow.rb:253:13:253:24 | call to source | array_flow.rb:253:9:253:25 | call to [] [element 1] | provenance |  |
-| array_flow.rb:255:10:255:10 | b [element] | array_flow.rb:255:10:255:13 | ...[...] | provenance |  |
-| array_flow.rb:256:5:256:5 | b [element] | array_flow.rb:260:10:260:10 | b [element] | provenance |  |
-| array_flow.rb:256:9:256:9 | a [element 2] | array_flow.rb:256:30:256:30 | x | provenance |  |
-| array_flow.rb:256:9:259:7 | call to collect_concat [element] | array_flow.rb:256:5:256:5 | b [element] | provenance |  |
+| array_flow.rb:253:9:253:25 | call to [] : Array [element 1] | array_flow.rb:251:9:254:7 | call to collect_concat : [collection] [element] | provenance |  |
+| array_flow.rb:253:10:253:10 | x | array_flow.rb:253:9:253:25 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:253:13:253:24 | call to source | array_flow.rb:253:9:253:25 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:255:10:255:10 | b : [collection] [element] | array_flow.rb:255:10:255:13 | ...[...] | provenance |  |
+| array_flow.rb:256:5:256:5 | b : [collection] [element] : [collection] | array_flow.rb:260:10:260:10 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:256:9:256:9 | a : Array [element 2] | array_flow.rb:256:30:256:30 | x | provenance |  |
+| array_flow.rb:256:9:259:7 | call to collect_concat : [collection] [element] : [collection] | array_flow.rb:256:5:256:5 | b : [collection] [element] : [collection] | provenance |  |
 | array_flow.rb:256:30:256:30 | x | array_flow.rb:257:14:257:14 | x | provenance |  |
-| array_flow.rb:258:9:258:20 | call to source | array_flow.rb:256:9:259:7 | call to collect_concat [element] | provenance |  |
-| array_flow.rb:260:10:260:10 | b [element] | array_flow.rb:260:10:260:13 | ...[...] | provenance |  |
-| array_flow.rb:264:5:264:5 | a [element 2] | array_flow.rb:265:9:265:9 | a [element 2] | provenance |  |
-| array_flow.rb:264:9:264:26 | call to [] [element 2] | array_flow.rb:264:5:264:5 | a [element 2] | provenance |  |
-| array_flow.rb:264:16:264:25 | call to source | array_flow.rb:264:9:264:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:265:5:265:5 | b [element 2] | array_flow.rb:269:10:269:10 | b [element 2] | provenance |  |
-| array_flow.rb:265:9:265:9 | a [element 2] | array_flow.rb:265:9:267:7 | call to combination [element 2] | provenance |  |
-| array_flow.rb:265:9:265:9 | a [element 2] | array_flow.rb:265:30:265:30 | x [element] | provenance |  |
-| array_flow.rb:265:9:267:7 | call to combination [element 2] | array_flow.rb:265:5:265:5 | b [element 2] | provenance |  |
-| array_flow.rb:265:30:265:30 | x [element] | array_flow.rb:266:14:266:14 | x [element] | provenance |  |
-| array_flow.rb:266:14:266:14 | x [element] | array_flow.rb:266:14:266:17 | ...[...] | provenance |  |
-| array_flow.rb:269:10:269:10 | b [element 2] | array_flow.rb:269:10:269:13 | ...[...] | provenance |  |
-| array_flow.rb:273:5:273:5 | a [element 2] | array_flow.rb:274:9:274:9 | a [element 2] | provenance |  |
-| array_flow.rb:273:9:273:26 | call to [] [element 2] | array_flow.rb:273:5:273:5 | a [element 2] | provenance |  |
-| array_flow.rb:273:16:273:25 | call to source | array_flow.rb:273:9:273:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:274:5:274:5 | b [element] | array_flow.rb:275:10:275:10 | b [element] | provenance |  |
-| array_flow.rb:274:9:274:9 | a [element 2] | array_flow.rb:274:9:274:17 | call to compact [element] | provenance |  |
-| array_flow.rb:274:9:274:17 | call to compact [element] | array_flow.rb:274:5:274:5 | b [element] | provenance |  |
-| array_flow.rb:275:10:275:10 | b [element] | array_flow.rb:275:10:275:13 | ...[...] | provenance |  |
-| array_flow.rb:279:5:279:5 | a [element 2] | array_flow.rb:280:9:280:9 | a [element 2] | provenance |  |
-| array_flow.rb:279:9:279:26 | call to [] [element 2] | array_flow.rb:279:5:279:5 | a [element 2] | provenance |  |
-| array_flow.rb:279:16:279:25 | call to source | array_flow.rb:279:9:279:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:280:5:280:5 | b [element] | array_flow.rb:282:10:282:10 | b [element] | provenance |  |
-| array_flow.rb:280:9:280:9 | [post] a [element] | array_flow.rb:281:10:281:10 | a [element] | provenance |  |
-| array_flow.rb:280:9:280:9 | a [element 2] | array_flow.rb:280:9:280:9 | [post] a [element] | provenance |  |
-| array_flow.rb:280:9:280:9 | a [element 2] | array_flow.rb:280:9:280:18 | call to compact! [element] | provenance |  |
-| array_flow.rb:280:9:280:18 | call to compact! [element] | array_flow.rb:280:5:280:5 | b [element] | provenance |  |
-| array_flow.rb:281:10:281:10 | a [element] | array_flow.rb:281:10:281:13 | ...[...] | provenance |  |
-| array_flow.rb:282:10:282:10 | b [element] | array_flow.rb:282:10:282:13 | ...[...] | provenance |  |
-| array_flow.rb:286:5:286:5 | a [element 2] | array_flow.rb:290:10:290:10 | a [element 2] | provenance |  |
-| array_flow.rb:286:9:286:28 | call to [] [element 2] | array_flow.rb:286:5:286:5 | a [element 2] | provenance |  |
-| array_flow.rb:286:16:286:27 | call to source | array_flow.rb:286:9:286:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:287:5:287:5 | b [element 2] | array_flow.rb:288:14:288:14 | b [element 2] | provenance |  |
-| array_flow.rb:287:9:287:28 | call to [] [element 2] | array_flow.rb:287:5:287:5 | b [element 2] | provenance |  |
-| array_flow.rb:287:16:287:27 | call to source | array_flow.rb:287:9:287:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:288:5:288:5 | [post] a [element] | array_flow.rb:289:10:289:10 | a [element] | provenance |  |
-| array_flow.rb:288:5:288:5 | [post] a [element] | array_flow.rb:290:10:290:10 | a [element] | provenance |  |
-| array_flow.rb:288:14:288:14 | b [element 2] | array_flow.rb:288:5:288:5 | [post] a [element] | provenance |  |
-| array_flow.rb:289:10:289:10 | a [element] | array_flow.rb:289:10:289:13 | ...[...] | provenance |  |
-| array_flow.rb:290:10:290:10 | a [element 2] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
-| array_flow.rb:290:10:290:10 | a [element] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
-| array_flow.rb:294:5:294:5 | a [element 2] | array_flow.rb:295:5:295:5 | a [element 2] | provenance |  |
-| array_flow.rb:294:9:294:26 | call to [] [element 2] | array_flow.rb:294:5:294:5 | a [element 2] | provenance |  |
-| array_flow.rb:294:16:294:25 | call to source | array_flow.rb:294:9:294:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:295:5:295:5 | a [element 2] | array_flow.rb:295:17:295:17 | x | provenance |  |
+| array_flow.rb:258:9:258:20 | call to source | array_flow.rb:256:9:259:7 | call to collect_concat : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:260:10:260:10 | b : [collection] [element] : [collection] | array_flow.rb:260:10:260:13 | ...[...] | provenance |  |
+| array_flow.rb:264:5:264:5 | a : Array [element 2] | array_flow.rb:265:9:265:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:264:9:264:26 | call to [] : Array [element 2] | array_flow.rb:264:5:264:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:264:16:264:25 | call to source | array_flow.rb:264:9:264:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:265:5:265:5 | b : Array [element 2] | array_flow.rb:269:10:269:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:265:9:265:9 | a : Array [element 2] | array_flow.rb:265:9:267:7 | call to combination : Array [element 2] | provenance |  |
+| array_flow.rb:265:9:265:9 | a : Array [element 2] | array_flow.rb:265:30:265:30 | x : [collection] [element] | provenance |  |
+| array_flow.rb:265:9:267:7 | call to combination : Array [element 2] | array_flow.rb:265:5:265:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:265:30:265:30 | x : [collection] [element] | array_flow.rb:266:14:266:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:266:14:266:14 | x : [collection] [element] | array_flow.rb:266:14:266:17 | ...[...] | provenance |  |
+| array_flow.rb:269:10:269:10 | b : Array [element 2] | array_flow.rb:269:10:269:13 | ...[...] | provenance |  |
+| array_flow.rb:273:5:273:5 | a : Array [element 2] | array_flow.rb:274:9:274:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:273:9:273:26 | call to [] : Array [element 2] | array_flow.rb:273:5:273:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:273:16:273:25 | call to source | array_flow.rb:273:9:273:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:274:5:274:5 | b : [collection] [element] | array_flow.rb:275:10:275:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:274:9:274:9 | a : Array [element 2] | array_flow.rb:274:9:274:17 | call to compact : [collection] [element] | provenance |  |
+| array_flow.rb:274:9:274:17 | call to compact : [collection] [element] | array_flow.rb:274:5:274:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:275:10:275:10 | b : [collection] [element] | array_flow.rb:275:10:275:13 | ...[...] | provenance |  |
+| array_flow.rb:279:5:279:5 | a : Array [element 2] | array_flow.rb:280:9:280:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:279:9:279:26 | call to [] : Array [element 2] | array_flow.rb:279:5:279:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:279:16:279:25 | call to source | array_flow.rb:279:9:279:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:280:5:280:5 | b : [collection] [element] | array_flow.rb:282:10:282:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:280:9:280:9 | [post] a : [collection] [element] | array_flow.rb:281:10:281:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:280:9:280:9 | a : Array [element 2] | array_flow.rb:280:9:280:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:280:9:280:9 | a : Array [element 2] | array_flow.rb:280:9:280:18 | call to compact! : [collection] [element] | provenance |  |
+| array_flow.rb:280:9:280:18 | call to compact! : [collection] [element] | array_flow.rb:280:5:280:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:281:10:281:10 | a : [collection] [element] | array_flow.rb:281:10:281:13 | ...[...] | provenance |  |
+| array_flow.rb:282:10:282:10 | b : [collection] [element] | array_flow.rb:282:10:282:13 | ...[...] | provenance |  |
+| array_flow.rb:286:5:286:5 | a : Array [element 2] | array_flow.rb:290:10:290:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:286:9:286:28 | call to [] : Array [element 2] | array_flow.rb:286:5:286:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:286:16:286:27 | call to source | array_flow.rb:286:9:286:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:287:5:287:5 | b : Array [element 2] | array_flow.rb:288:14:288:14 | b : Array [element 2] | provenance |  |
+| array_flow.rb:287:9:287:28 | call to [] : Array [element 2] | array_flow.rb:287:5:287:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:287:16:287:27 | call to source | array_flow.rb:287:9:287:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:288:5:288:5 | [post] a : [collection] [element] | array_flow.rb:289:10:289:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:288:5:288:5 | [post] a : [collection] [element] | array_flow.rb:290:10:290:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:288:14:288:14 | b : Array [element 2] | array_flow.rb:288:5:288:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:289:10:289:10 | a : [collection] [element] | array_flow.rb:289:10:289:13 | ...[...] | provenance |  |
+| array_flow.rb:290:10:290:10 | a : Array [element 2] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
+| array_flow.rb:290:10:290:10 | a : [collection] [element] | array_flow.rb:290:10:290:13 | ...[...] | provenance |  |
+| array_flow.rb:294:5:294:5 | a : Array [element 2] | array_flow.rb:295:5:295:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:294:9:294:26 | call to [] : Array [element 2] | array_flow.rb:294:5:294:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:294:16:294:25 | call to source | array_flow.rb:294:9:294:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:295:5:295:5 | a : Array [element 2] | array_flow.rb:295:17:295:17 | x | provenance |  |
 | array_flow.rb:295:17:295:17 | x | array_flow.rb:296:14:296:14 | x | provenance |  |
-| array_flow.rb:301:5:301:5 | a [element 2] | array_flow.rb:302:5:302:5 | a [element 2] | provenance |  |
-| array_flow.rb:301:9:301:26 | call to [] [element 2] | array_flow.rb:301:5:301:5 | a [element 2] | provenance |  |
-| array_flow.rb:301:16:301:25 | call to source | array_flow.rb:301:9:301:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:302:5:302:5 | a [element 2] | array_flow.rb:302:20:302:20 | x | provenance |  |
+| array_flow.rb:301:5:301:5 | a : Array [element 2] | array_flow.rb:302:5:302:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:301:9:301:26 | call to [] : Array [element 2] | array_flow.rb:301:5:301:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:301:16:301:25 | call to source | array_flow.rb:301:9:301:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:302:5:302:5 | a : Array [element 2] | array_flow.rb:302:20:302:20 | x | provenance |  |
 | array_flow.rb:302:20:302:20 | x | array_flow.rb:303:14:303:14 | x | provenance |  |
-| array_flow.rb:308:5:308:5 | a [element 2] | array_flow.rb:309:9:309:9 | a [element 2] | provenance |  |
-| array_flow.rb:308:9:308:26 | call to [] [element 2] | array_flow.rb:308:5:308:5 | a [element 2] | provenance |  |
-| array_flow.rb:308:16:308:25 | call to source | array_flow.rb:308:9:308:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:309:5:309:5 | b [element 2] | array_flow.rb:312:10:312:10 | b [element 2] | provenance |  |
-| array_flow.rb:309:9:309:9 | a [element 2] | array_flow.rb:309:9:309:21 | call to deconstruct [element 2] | provenance |  |
-| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] | array_flow.rb:309:5:309:5 | b [element 2] | provenance |  |
-| array_flow.rb:312:10:312:10 | b [element 2] | array_flow.rb:312:10:312:13 | ...[...] | provenance |  |
-| array_flow.rb:316:5:316:5 | a [element 2] | array_flow.rb:317:9:317:9 | a [element 2] | provenance |  |
-| array_flow.rb:316:9:316:28 | call to [] [element 2] | array_flow.rb:316:5:316:5 | a [element 2] | provenance |  |
-| array_flow.rb:316:16:316:27 | call to source | array_flow.rb:316:9:316:28 | call to [] [element 2] | provenance |  |
+| array_flow.rb:308:5:308:5 | a : Array [element 2] | array_flow.rb:309:9:309:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:308:9:308:26 | call to [] : Array [element 2] | array_flow.rb:308:5:308:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:308:16:308:25 | call to source | array_flow.rb:308:9:308:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:309:5:309:5 | b : Array [element 2] | array_flow.rb:312:10:312:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:309:9:309:9 | a : Array [element 2] | array_flow.rb:309:9:309:21 | call to deconstruct : Array [element 2] | provenance |  |
+| array_flow.rb:309:9:309:21 | call to deconstruct : Array [element 2] | array_flow.rb:309:5:309:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:312:10:312:10 | b : Array [element 2] | array_flow.rb:312:10:312:13 | ...[...] | provenance |  |
+| array_flow.rb:316:5:316:5 | a : Array [element 2] | array_flow.rb:317:9:317:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:316:9:316:28 | call to [] : Array [element 2] | array_flow.rb:316:5:316:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:316:16:316:27 | call to source | array_flow.rb:316:9:316:28 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:317:5:317:5 | b | array_flow.rb:318:10:318:10 | b | provenance |  |
-| array_flow.rb:317:9:317:9 | a [element 2] | array_flow.rb:317:9:317:36 | call to delete | provenance |  |
+| array_flow.rb:317:9:317:9 | a : Array [element 2] | array_flow.rb:317:9:317:36 | call to delete | provenance |  |
 | array_flow.rb:317:9:317:36 | call to delete | array_flow.rb:317:5:317:5 | b | provenance |  |
 | array_flow.rb:317:23:317:34 | call to source | array_flow.rb:317:9:317:36 | call to delete | provenance |  |
-| array_flow.rb:325:5:325:5 | a [element 2] | array_flow.rb:326:9:326:9 | a [element 2] | provenance |  |
-| array_flow.rb:325:5:325:5 | a [element 3] | array_flow.rb:326:9:326:9 | a [element 3] | provenance |  |
-| array_flow.rb:325:9:325:42 | call to [] [element 2] | array_flow.rb:325:5:325:5 | a [element 2] | provenance |  |
-| array_flow.rb:325:9:325:42 | call to [] [element 3] | array_flow.rb:325:5:325:5 | a [element 3] | provenance |  |
-| array_flow.rb:325:16:325:27 | call to source | array_flow.rb:325:9:325:42 | call to [] [element 2] | provenance |  |
-| array_flow.rb:325:30:325:41 | call to source | array_flow.rb:325:9:325:42 | call to [] [element 3] | provenance |  |
+| array_flow.rb:325:5:325:5 | a : Array [element 2] | array_flow.rb:326:9:326:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:325:5:325:5 | a : Array [element 3] | array_flow.rb:326:9:326:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:325:9:325:42 | call to [] : Array [element 2] | array_flow.rb:325:5:325:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:325:9:325:42 | call to [] : Array [element 3] | array_flow.rb:325:5:325:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:325:16:325:27 | call to source | array_flow.rb:325:9:325:42 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:325:30:325:41 | call to source | array_flow.rb:325:9:325:42 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:326:5:326:5 | b | array_flow.rb:327:10:327:10 | b | provenance |  |
-| array_flow.rb:326:9:326:9 | [post] a [element 2] | array_flow.rb:328:10:328:10 | a [element 2] | provenance |  |
-| array_flow.rb:326:9:326:9 | a [element 2] | array_flow.rb:326:9:326:22 | call to delete_at | provenance |  |
-| array_flow.rb:326:9:326:9 | a [element 3] | array_flow.rb:326:9:326:9 | [post] a [element 2] | provenance |  |
+| array_flow.rb:326:9:326:9 | [post] a : [collection] [element 2] | array_flow.rb:328:10:328:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:326:9:326:9 | a : Array [element 2] | array_flow.rb:326:9:326:22 | call to delete_at | provenance |  |
+| array_flow.rb:326:9:326:9 | a : Array [element 3] | array_flow.rb:326:9:326:9 | [post] a : [collection] [element 2] | provenance |  |
 | array_flow.rb:326:9:326:22 | call to delete_at | array_flow.rb:326:5:326:5 | b | provenance |  |
-| array_flow.rb:328:10:328:10 | a [element 2] | array_flow.rb:328:10:328:13 | ...[...] | provenance |  |
-| array_flow.rb:330:5:330:5 | a [element 2] | array_flow.rb:331:9:331:9 | a [element 2] | provenance |  |
-| array_flow.rb:330:5:330:5 | a [element 3] | array_flow.rb:331:9:331:9 | a [element 3] | provenance |  |
-| array_flow.rb:330:9:330:42 | call to [] [element 2] | array_flow.rb:330:5:330:5 | a [element 2] | provenance |  |
-| array_flow.rb:330:9:330:42 | call to [] [element 3] | array_flow.rb:330:5:330:5 | a [element 3] | provenance |  |
-| array_flow.rb:330:16:330:27 | call to source | array_flow.rb:330:9:330:42 | call to [] [element 2] | provenance |  |
-| array_flow.rb:330:30:330:41 | call to source | array_flow.rb:330:9:330:42 | call to [] [element 3] | provenance |  |
+| array_flow.rb:328:10:328:10 | a : [collection] [element 2] | array_flow.rb:328:10:328:13 | ...[...] | provenance |  |
+| array_flow.rb:330:5:330:5 | a : Array [element 2] | array_flow.rb:331:9:331:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:330:5:330:5 | a : Array [element 3] | array_flow.rb:331:9:331:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:330:9:330:42 | call to [] : Array [element 2] | array_flow.rb:330:5:330:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:330:9:330:42 | call to [] : Array [element 3] | array_flow.rb:330:5:330:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:330:16:330:27 | call to source | array_flow.rb:330:9:330:42 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:330:30:330:41 | call to source | array_flow.rb:330:9:330:42 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:331:5:331:5 | b | array_flow.rb:332:10:332:10 | b | provenance |  |
-| array_flow.rb:331:9:331:9 | [post] a [element] | array_flow.rb:333:10:333:10 | a [element] | provenance |  |
-| array_flow.rb:331:9:331:9 | [post] a [element] | array_flow.rb:334:10:334:10 | a [element] | provenance |  |
-| array_flow.rb:331:9:331:9 | a [element 2] | array_flow.rb:331:9:331:9 | [post] a [element] | provenance |  |
-| array_flow.rb:331:9:331:9 | a [element 2] | array_flow.rb:331:9:331:22 | call to delete_at | provenance |  |
-| array_flow.rb:331:9:331:9 | a [element 3] | array_flow.rb:331:9:331:9 | [post] a [element] | provenance |  |
-| array_flow.rb:331:9:331:9 | a [element 3] | array_flow.rb:331:9:331:22 | call to delete_at | provenance |  |
+| array_flow.rb:331:9:331:9 | [post] a : [collection] [element] | array_flow.rb:333:10:333:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:331:9:331:9 | [post] a : [collection] [element] | array_flow.rb:334:10:334:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:331:9:331:9 | a : Array [element 2] | array_flow.rb:331:9:331:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:331:9:331:9 | a : Array [element 2] | array_flow.rb:331:9:331:22 | call to delete_at | provenance |  |
+| array_flow.rb:331:9:331:9 | a : Array [element 3] | array_flow.rb:331:9:331:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:331:9:331:9 | a : Array [element 3] | array_flow.rb:331:9:331:22 | call to delete_at | provenance |  |
 | array_flow.rb:331:9:331:22 | call to delete_at | array_flow.rb:331:5:331:5 | b | provenance |  |
-| array_flow.rb:333:10:333:10 | a [element] | array_flow.rb:333:10:333:13 | ...[...] | provenance |  |
-| array_flow.rb:334:10:334:10 | a [element] | array_flow.rb:334:10:334:13 | ...[...] | provenance |  |
-| array_flow.rb:338:5:338:5 | a [element 2] | array_flow.rb:339:9:339:9 | a [element 2] | provenance |  |
-| array_flow.rb:338:9:338:26 | call to [] [element 2] | array_flow.rb:338:5:338:5 | a [element 2] | provenance |  |
-| array_flow.rb:338:16:338:25 | call to source | array_flow.rb:338:9:338:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:339:5:339:5 | b [element] | array_flow.rb:342:10:342:10 | b [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | [post] a [element] | array_flow.rb:343:10:343:10 | a [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | [post] a [element] | array_flow.rb:344:10:344:10 | a [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | [post] a [element] | array_flow.rb:345:10:345:10 | a [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | a [element 2] | array_flow.rb:339:9:339:9 | [post] a [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | a [element 2] | array_flow.rb:339:9:341:7 | call to delete_if [element] | provenance |  |
-| array_flow.rb:339:9:339:9 | a [element 2] | array_flow.rb:339:25:339:25 | x | provenance |  |
-| array_flow.rb:339:9:341:7 | call to delete_if [element] | array_flow.rb:339:5:339:5 | b [element] | provenance |  |
+| array_flow.rb:333:10:333:10 | a : [collection] [element] | array_flow.rb:333:10:333:13 | ...[...] | provenance |  |
+| array_flow.rb:334:10:334:10 | a : [collection] [element] | array_flow.rb:334:10:334:13 | ...[...] | provenance |  |
+| array_flow.rb:338:5:338:5 | a : Array [element 2] | array_flow.rb:339:9:339:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:338:9:338:26 | call to [] : Array [element 2] | array_flow.rb:338:5:338:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:338:16:338:25 | call to source | array_flow.rb:338:9:338:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:339:5:339:5 | b : [collection] [element] | array_flow.rb:342:10:342:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | [post] a : [collection] [element] | array_flow.rb:343:10:343:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | [post] a : [collection] [element] | array_flow.rb:344:10:344:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | [post] a : [collection] [element] | array_flow.rb:345:10:345:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | a : Array [element 2] | array_flow.rb:339:9:339:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | a : Array [element 2] | array_flow.rb:339:9:341:7 | call to delete_if : [collection] [element] | provenance |  |
+| array_flow.rb:339:9:339:9 | a : Array [element 2] | array_flow.rb:339:25:339:25 | x | provenance |  |
+| array_flow.rb:339:9:341:7 | call to delete_if : [collection] [element] | array_flow.rb:339:5:339:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:339:25:339:25 | x | array_flow.rb:340:14:340:14 | x | provenance |  |
-| array_flow.rb:342:10:342:10 | b [element] | array_flow.rb:342:10:342:13 | ...[...] | provenance |  |
-| array_flow.rb:343:10:343:10 | a [element] | array_flow.rb:343:10:343:13 | ...[...] | provenance |  |
-| array_flow.rb:344:10:344:10 | a [element] | array_flow.rb:344:10:344:13 | ...[...] | provenance |  |
-| array_flow.rb:345:10:345:10 | a [element] | array_flow.rb:345:10:345:13 | ...[...] | provenance |  |
-| array_flow.rb:349:5:349:5 | a [element 2] | array_flow.rb:350:9:350:9 | a [element 2] | provenance |  |
-| array_flow.rb:349:9:349:26 | call to [] [element 2] | array_flow.rb:349:5:349:5 | a [element 2] | provenance |  |
-| array_flow.rb:349:16:349:25 | call to source | array_flow.rb:349:9:349:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:350:5:350:5 | b [element] | array_flow.rb:351:10:351:10 | b [element] | provenance |  |
-| array_flow.rb:350:9:350:9 | a [element 2] | array_flow.rb:350:9:350:25 | call to difference [element] | provenance |  |
-| array_flow.rb:350:9:350:25 | call to difference [element] | array_flow.rb:350:5:350:5 | b [element] | provenance |  |
-| array_flow.rb:351:10:351:10 | b [element] | array_flow.rb:351:10:351:13 | ...[...] | provenance |  |
-| array_flow.rb:355:5:355:5 | a [element 2] | array_flow.rb:357:10:357:10 | a [element 2] | provenance |  |
-| array_flow.rb:355:5:355:5 | a [element 2] | array_flow.rb:358:10:358:10 | a [element 2] | provenance |  |
-| array_flow.rb:355:5:355:5 | a [element 3, element 1] | array_flow.rb:360:10:360:10 | a [element 3, element 1] | provenance |  |
-| array_flow.rb:355:9:355:47 | call to [] [element 2] | array_flow.rb:355:5:355:5 | a [element 2] | provenance |  |
-| array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | array_flow.rb:355:5:355:5 | a [element 3, element 1] | provenance |  |
-| array_flow.rb:355:16:355:27 | call to source | array_flow.rb:355:9:355:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:355:30:355:46 | call to [] [element 1] | array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | provenance |  |
-| array_flow.rb:355:34:355:45 | call to source | array_flow.rb:355:30:355:46 | call to [] [element 1] | provenance |  |
-| array_flow.rb:357:10:357:10 | a [element 2] | array_flow.rb:357:10:357:17 | call to dig | provenance |  |
-| array_flow.rb:358:10:358:10 | a [element 2] | array_flow.rb:358:10:358:17 | call to dig | provenance |  |
-| array_flow.rb:360:10:360:10 | a [element 3, element 1] | array_flow.rb:360:10:360:19 | call to dig | provenance |  |
-| array_flow.rb:364:5:364:5 | a [element 2] | array_flow.rb:365:9:365:9 | a [element 2] | provenance |  |
-| array_flow.rb:364:9:364:28 | call to [] [element 2] | array_flow.rb:364:5:364:5 | a [element 2] | provenance |  |
-| array_flow.rb:364:16:364:27 | call to source | array_flow.rb:364:9:364:28 | call to [] [element 2] | provenance |  |
+| array_flow.rb:342:10:342:10 | b : [collection] [element] | array_flow.rb:342:10:342:13 | ...[...] | provenance |  |
+| array_flow.rb:343:10:343:10 | a : [collection] [element] | array_flow.rb:343:10:343:13 | ...[...] | provenance |  |
+| array_flow.rb:344:10:344:10 | a : [collection] [element] | array_flow.rb:344:10:344:13 | ...[...] | provenance |  |
+| array_flow.rb:345:10:345:10 | a : [collection] [element] | array_flow.rb:345:10:345:13 | ...[...] | provenance |  |
+| array_flow.rb:349:5:349:5 | a : Array [element 2] | array_flow.rb:350:9:350:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:349:9:349:26 | call to [] : Array [element 2] | array_flow.rb:349:5:349:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:349:16:349:25 | call to source | array_flow.rb:349:9:349:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:350:5:350:5 | b : [collection] [element] | array_flow.rb:351:10:351:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:350:9:350:9 | a : Array [element 2] | array_flow.rb:350:9:350:25 | call to difference : [collection] [element] | provenance |  |
+| array_flow.rb:350:9:350:25 | call to difference : [collection] [element] | array_flow.rb:350:5:350:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:351:10:351:10 | b : [collection] [element] | array_flow.rb:351:10:351:13 | ...[...] | provenance |  |
+| array_flow.rb:355:5:355:5 | a : Array [element 2] | array_flow.rb:357:10:357:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:355:5:355:5 | a : Array [element 2] | array_flow.rb:358:10:358:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:355:5:355:5 | a : Array [element 3, element 1] | array_flow.rb:360:10:360:10 | a : Array [element 3, element 1] | provenance |  |
+| array_flow.rb:355:9:355:47 | call to [] : Array [element 2] | array_flow.rb:355:5:355:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:355:9:355:47 | call to [] : Array [element 3, element 1] | array_flow.rb:355:5:355:5 | a : Array [element 3, element 1] | provenance |  |
+| array_flow.rb:355:16:355:27 | call to source | array_flow.rb:355:9:355:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:355:30:355:46 | call to [] : Array [element 1] | array_flow.rb:355:9:355:47 | call to [] : Array [element 3, element 1] | provenance |  |
+| array_flow.rb:355:34:355:45 | call to source | array_flow.rb:355:30:355:46 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:357:10:357:10 | a : Array [element 2] | array_flow.rb:357:10:357:17 | call to dig | provenance |  |
+| array_flow.rb:358:10:358:10 | a : Array [element 2] | array_flow.rb:358:10:358:17 | call to dig | provenance |  |
+| array_flow.rb:360:10:360:10 | a : Array [element 3, element 1] | array_flow.rb:360:10:360:19 | call to dig | provenance |  |
+| array_flow.rb:364:5:364:5 | a : Array [element 2] | array_flow.rb:365:9:365:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:364:9:364:28 | call to [] : Array [element 2] | array_flow.rb:364:5:364:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:364:16:364:27 | call to source | array_flow.rb:364:9:364:28 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:365:5:365:5 | b | array_flow.rb:368:10:368:10 | b | provenance |  |
-| array_flow.rb:365:9:365:9 | a [element 2] | array_flow.rb:365:9:367:7 | call to detect | provenance |  |
-| array_flow.rb:365:9:365:9 | a [element 2] | array_flow.rb:365:43:365:43 | x | provenance |  |
+| array_flow.rb:365:9:365:9 | a : Array [element 2] | array_flow.rb:365:9:367:7 | call to detect | provenance |  |
+| array_flow.rb:365:9:365:9 | a : Array [element 2] | array_flow.rb:365:43:365:43 | x | provenance |  |
 | array_flow.rb:365:9:367:7 | call to detect | array_flow.rb:365:5:365:5 | b | provenance |  |
 | array_flow.rb:365:23:365:34 | call to source | array_flow.rb:365:9:367:7 | call to detect | provenance |  |
 | array_flow.rb:365:43:365:43 | x | array_flow.rb:366:14:366:14 | x | provenance |  |
-| array_flow.rb:372:5:372:5 | a [element 2] | array_flow.rb:373:9:373:9 | a [element 2] | provenance |  |
-| array_flow.rb:372:5:372:5 | a [element 2] | array_flow.rb:375:9:375:9 | a [element 2] | provenance |  |
-| array_flow.rb:372:5:372:5 | a [element 2] | array_flow.rb:380:9:380:9 | a [element 2] | provenance |  |
-| array_flow.rb:372:5:372:5 | a [element 3] | array_flow.rb:373:9:373:9 | a [element 3] | provenance |  |
-| array_flow.rb:372:5:372:5 | a [element 3] | array_flow.rb:375:9:375:9 | a [element 3] | provenance |  |
-| array_flow.rb:372:9:372:42 | call to [] [element 2] | array_flow.rb:372:5:372:5 | a [element 2] | provenance |  |
-| array_flow.rb:372:9:372:42 | call to [] [element 3] | array_flow.rb:372:5:372:5 | a [element 3] | provenance |  |
-| array_flow.rb:372:16:372:27 | call to source | array_flow.rb:372:9:372:42 | call to [] [element 2] | provenance |  |
-| array_flow.rb:372:30:372:41 | call to source | array_flow.rb:372:9:372:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:373:5:373:5 | b [element] | array_flow.rb:374:10:374:10 | b [element] | provenance |  |
-| array_flow.rb:373:9:373:9 | a [element 2] | array_flow.rb:373:9:373:17 | call to drop [element] | provenance |  |
-| array_flow.rb:373:9:373:9 | a [element 3] | array_flow.rb:373:9:373:17 | call to drop [element] | provenance |  |
-| array_flow.rb:373:9:373:17 | call to drop [element] | array_flow.rb:373:5:373:5 | b [element] | provenance |  |
-| array_flow.rb:374:10:374:10 | b [element] | array_flow.rb:374:10:374:13 | ...[...] | provenance |  |
-| array_flow.rb:375:5:375:5 | b [element 1] | array_flow.rb:377:10:377:10 | b [element 1] | provenance |  |
-| array_flow.rb:375:5:375:5 | b [element 1] | array_flow.rb:378:10:378:10 | b [element 1] | provenance |  |
-| array_flow.rb:375:5:375:5 | b [element 2] | array_flow.rb:378:10:378:10 | b [element 2] | provenance |  |
-| array_flow.rb:375:9:375:9 | a [element 2] | array_flow.rb:375:9:375:17 | call to drop [element 1] | provenance |  |
-| array_flow.rb:375:9:375:9 | a [element 3] | array_flow.rb:375:9:375:17 | call to drop [element 2] | provenance |  |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] | array_flow.rb:375:5:375:5 | b [element 1] | provenance |  |
-| array_flow.rb:375:9:375:17 | call to drop [element 2] | array_flow.rb:375:5:375:5 | b [element 2] | provenance |  |
-| array_flow.rb:377:10:377:10 | b [element 1] | array_flow.rb:377:10:377:13 | ...[...] | provenance |  |
-| array_flow.rb:378:10:378:10 | b [element 1] | array_flow.rb:378:10:378:13 | ...[...] | provenance |  |
-| array_flow.rb:378:10:378:10 | b [element 2] | array_flow.rb:378:10:378:13 | ...[...] | provenance |  |
-| array_flow.rb:379:5:379:5 | [post] a [element] | array_flow.rb:380:9:380:9 | a [element] | provenance |  |
-| array_flow.rb:379:12:379:23 | call to source | array_flow.rb:379:5:379:5 | [post] a [element] | provenance |  |
-| array_flow.rb:380:5:380:5 | b [element 1] | array_flow.rb:381:10:381:10 | b [element 1] | provenance |  |
-| array_flow.rb:380:5:380:5 | b [element] | array_flow.rb:381:10:381:10 | b [element] | provenance |  |
-| array_flow.rb:380:5:380:5 | b [element] | array_flow.rb:382:9:382:9 | b [element] | provenance |  |
-| array_flow.rb:380:9:380:9 | a [element 2] | array_flow.rb:380:9:380:17 | call to drop [element 1] | provenance |  |
-| array_flow.rb:380:9:380:9 | a [element] | array_flow.rb:380:9:380:17 | call to drop [element] | provenance |  |
-| array_flow.rb:380:9:380:17 | call to drop [element 1] | array_flow.rb:380:5:380:5 | b [element 1] | provenance |  |
-| array_flow.rb:380:9:380:17 | call to drop [element] | array_flow.rb:380:5:380:5 | b [element] | provenance |  |
-| array_flow.rb:381:10:381:10 | b [element 1] | array_flow.rb:381:10:381:13 | ...[...] | provenance |  |
-| array_flow.rb:381:10:381:10 | b [element] | array_flow.rb:381:10:381:13 | ...[...] | provenance |  |
-| array_flow.rb:382:5:382:5 | c [element] | array_flow.rb:383:10:383:10 | c [element] | provenance |  |
-| array_flow.rb:382:9:382:9 | b [element] | array_flow.rb:382:9:382:19 | call to drop [element] | provenance |  |
-| array_flow.rb:382:9:382:19 | call to drop [element] | array_flow.rb:382:5:382:5 | c [element] | provenance |  |
-| array_flow.rb:383:10:383:10 | c [element] | array_flow.rb:383:10:383:13 | ...[...] | provenance |  |
-| array_flow.rb:387:5:387:5 | a [element 2] | array_flow.rb:388:9:388:9 | a [element 2] | provenance |  |
-| array_flow.rb:387:5:387:5 | a [element 3] | array_flow.rb:388:9:388:9 | a [element 3] | provenance |  |
-| array_flow.rb:387:9:387:42 | call to [] [element 2] | array_flow.rb:387:5:387:5 | a [element 2] | provenance |  |
-| array_flow.rb:387:9:387:42 | call to [] [element 3] | array_flow.rb:387:5:387:5 | a [element 3] | provenance |  |
-| array_flow.rb:387:16:387:27 | call to source | array_flow.rb:387:9:387:42 | call to [] [element 2] | provenance |  |
-| array_flow.rb:387:30:387:41 | call to source | array_flow.rb:387:9:387:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:388:5:388:5 | b [element] | array_flow.rb:391:10:391:10 | b [element] | provenance |  |
-| array_flow.rb:388:9:388:9 | a [element 2] | array_flow.rb:388:9:390:7 | call to drop_while [element] | provenance |  |
-| array_flow.rb:388:9:388:9 | a [element 2] | array_flow.rb:388:26:388:26 | x | provenance |  |
-| array_flow.rb:388:9:388:9 | a [element 3] | array_flow.rb:388:9:390:7 | call to drop_while [element] | provenance |  |
-| array_flow.rb:388:9:388:9 | a [element 3] | array_flow.rb:388:26:388:26 | x | provenance |  |
-| array_flow.rb:388:9:390:7 | call to drop_while [element] | array_flow.rb:388:5:388:5 | b [element] | provenance |  |
+| array_flow.rb:372:5:372:5 | a : Array [element 2] | array_flow.rb:373:9:373:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:372:5:372:5 | a : Array [element 2] | array_flow.rb:375:9:375:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:372:5:372:5 | a : Array [element 2] | array_flow.rb:380:9:380:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:372:5:372:5 | a : Array [element 3] | array_flow.rb:373:9:373:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:372:5:372:5 | a : Array [element 3] | array_flow.rb:375:9:375:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:372:9:372:42 | call to [] : Array [element 2] | array_flow.rb:372:5:372:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:372:9:372:42 | call to [] : Array [element 3] | array_flow.rb:372:5:372:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:372:16:372:27 | call to source | array_flow.rb:372:9:372:42 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:372:30:372:41 | call to source | array_flow.rb:372:9:372:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:373:5:373:5 | b : [collection] [element] | array_flow.rb:374:10:374:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:373:9:373:9 | a : Array [element 2] | array_flow.rb:373:9:373:17 | call to drop : [collection] [element] | provenance |  |
+| array_flow.rb:373:9:373:9 | a : Array [element 3] | array_flow.rb:373:9:373:17 | call to drop : [collection] [element] | provenance |  |
+| array_flow.rb:373:9:373:17 | call to drop : [collection] [element] | array_flow.rb:373:5:373:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:374:10:374:10 | b : [collection] [element] | array_flow.rb:374:10:374:13 | ...[...] | provenance |  |
+| array_flow.rb:375:5:375:5 | b : [collection] [element 1] | array_flow.rb:377:10:377:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:375:5:375:5 | b : [collection] [element 1] | array_flow.rb:378:10:378:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:375:5:375:5 | b : [collection] [element 2] | array_flow.rb:378:10:378:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:375:9:375:9 | a : Array [element 2] | array_flow.rb:375:9:375:17 | call to drop : [collection] [element 1] | provenance |  |
+| array_flow.rb:375:9:375:9 | a : Array [element 3] | array_flow.rb:375:9:375:17 | call to drop : [collection] [element 2] | provenance |  |
+| array_flow.rb:375:9:375:17 | call to drop : [collection] [element 1] | array_flow.rb:375:5:375:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:375:9:375:17 | call to drop : [collection] [element 2] | array_flow.rb:375:5:375:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:377:10:377:10 | b : [collection] [element 1] | array_flow.rb:377:10:377:13 | ...[...] | provenance |  |
+| array_flow.rb:378:10:378:10 | b : [collection] [element 1] | array_flow.rb:378:10:378:13 | ...[...] | provenance |  |
+| array_flow.rb:378:10:378:10 | b : [collection] [element 2] | array_flow.rb:378:10:378:13 | ...[...] | provenance |  |
+| array_flow.rb:379:5:379:5 | [post] a : [collection] [element] | array_flow.rb:380:9:380:9 | a : [collection] [element] | provenance |  |
+| array_flow.rb:379:12:379:23 | call to source | array_flow.rb:379:5:379:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:380:5:380:5 | b : [collection] [element 1] | array_flow.rb:381:10:381:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:380:5:380:5 | b : [collection] [element] | array_flow.rb:381:10:381:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:380:5:380:5 | b : [collection] [element] | array_flow.rb:382:9:382:9 | b : [collection] [element] | provenance |  |
+| array_flow.rb:380:9:380:9 | a : Array [element 2] | array_flow.rb:380:9:380:17 | call to drop : [collection] [element 1] | provenance |  |
+| array_flow.rb:380:9:380:9 | a : [collection] [element] | array_flow.rb:380:9:380:17 | call to drop : [collection] [element] | provenance |  |
+| array_flow.rb:380:9:380:17 | call to drop : [collection] [element 1] | array_flow.rb:380:5:380:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:380:9:380:17 | call to drop : [collection] [element] | array_flow.rb:380:5:380:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:381:10:381:10 | b : [collection] [element 1] | array_flow.rb:381:10:381:13 | ...[...] | provenance |  |
+| array_flow.rb:381:10:381:10 | b : [collection] [element] | array_flow.rb:381:10:381:13 | ...[...] | provenance |  |
+| array_flow.rb:382:5:382:5 | c : [collection] [element] | array_flow.rb:383:10:383:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:382:9:382:9 | b : [collection] [element] | array_flow.rb:382:9:382:19 | call to drop : [collection] [element] | provenance |  |
+| array_flow.rb:382:9:382:19 | call to drop : [collection] [element] | array_flow.rb:382:5:382:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:383:10:383:10 | c : [collection] [element] | array_flow.rb:383:10:383:13 | ...[...] | provenance |  |
+| array_flow.rb:387:5:387:5 | a : Array [element 2] | array_flow.rb:388:9:388:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:387:5:387:5 | a : Array [element 3] | array_flow.rb:388:9:388:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:387:9:387:42 | call to [] : Array [element 2] | array_flow.rb:387:5:387:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:387:9:387:42 | call to [] : Array [element 3] | array_flow.rb:387:5:387:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:387:16:387:27 | call to source | array_flow.rb:387:9:387:42 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:387:30:387:41 | call to source | array_flow.rb:387:9:387:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:388:5:388:5 | b : [collection] [element] | array_flow.rb:391:10:391:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:388:9:388:9 | a : Array [element 2] | array_flow.rb:388:9:390:7 | call to drop_while : [collection] [element] | provenance |  |
+| array_flow.rb:388:9:388:9 | a : Array [element 2] | array_flow.rb:388:26:388:26 | x | provenance |  |
+| array_flow.rb:388:9:388:9 | a : Array [element 3] | array_flow.rb:388:9:390:7 | call to drop_while : [collection] [element] | provenance |  |
+| array_flow.rb:388:9:388:9 | a : Array [element 3] | array_flow.rb:388:26:388:26 | x | provenance |  |
+| array_flow.rb:388:9:390:7 | call to drop_while : [collection] [element] | array_flow.rb:388:5:388:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:388:26:388:26 | x | array_flow.rb:389:14:389:14 | x | provenance |  |
-| array_flow.rb:391:10:391:10 | b [element] | array_flow.rb:391:10:391:13 | ...[...] | provenance |  |
-| array_flow.rb:395:5:395:5 | a [element 2] | array_flow.rb:396:9:396:9 | a [element 2] | provenance |  |
-| array_flow.rb:395:9:395:26 | call to [] [element 2] | array_flow.rb:395:5:395:5 | a [element 2] | provenance |  |
-| array_flow.rb:395:16:395:25 | call to source | array_flow.rb:395:9:395:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:396:5:396:5 | b [element 2] | array_flow.rb:399:10:399:10 | b [element 2] | provenance |  |
-| array_flow.rb:396:9:396:9 | a [element 2] | array_flow.rb:396:9:398:7 | call to each [element 2] | provenance |  |
-| array_flow.rb:396:9:396:9 | a [element 2] | array_flow.rb:396:20:396:20 | x | provenance |  |
-| array_flow.rb:396:9:398:7 | call to each [element 2] | array_flow.rb:396:5:396:5 | b [element 2] | provenance |  |
+| array_flow.rb:391:10:391:10 | b : [collection] [element] | array_flow.rb:391:10:391:13 | ...[...] | provenance |  |
+| array_flow.rb:395:5:395:5 | a : Array [element 2] | array_flow.rb:396:9:396:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:395:9:395:26 | call to [] : Array [element 2] | array_flow.rb:395:5:395:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:395:16:395:25 | call to source | array_flow.rb:395:9:395:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:396:5:396:5 | b : Array [element 2] | array_flow.rb:399:10:399:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:396:9:396:9 | a : Array [element 2] | array_flow.rb:396:9:398:7 | call to each : Array [element 2] | provenance |  |
+| array_flow.rb:396:9:396:9 | a : Array [element 2] | array_flow.rb:396:20:396:20 | x | provenance |  |
+| array_flow.rb:396:9:398:7 | call to each : Array [element 2] | array_flow.rb:396:5:396:5 | b : Array [element 2] | provenance |  |
 | array_flow.rb:396:20:396:20 | x | array_flow.rb:397:14:397:14 | x | provenance |  |
-| array_flow.rb:399:10:399:10 | b [element 2] | array_flow.rb:399:10:399:13 | ...[...] | provenance |  |
-| array_flow.rb:403:5:403:5 | a [element 2] | array_flow.rb:404:18:404:18 | a [element 2] | provenance |  |
-| array_flow.rb:403:9:403:26 | call to [] [element 2] | array_flow.rb:403:5:403:5 | a [element 2] | provenance |  |
-| array_flow.rb:403:16:403:25 | call to source | array_flow.rb:403:9:403:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:404:5:404:5 | b [element 2] | array_flow.rb:408:10:408:10 | b [element 2] | provenance |  |
-| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:404:5:404:5 | b [element 2] | provenance |  |
-| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:405:14:405:14 | x | provenance |  |
-| array_flow.rb:404:18:404:18 | a [element 2] | array_flow.rb:407:10:407:10 | x | provenance |  |
-| array_flow.rb:408:10:408:10 | b [element 2] | array_flow.rb:408:10:408:13 | ...[...] | provenance |  |
-| array_flow.rb:412:5:412:5 | a [element 2] | array_flow.rb:413:5:413:5 | a [element 2] | provenance |  |
-| array_flow.rb:412:9:412:26 | call to [] [element 2] | array_flow.rb:412:5:412:5 | a [element 2] | provenance |  |
-| array_flow.rb:412:16:412:25 | call to source | array_flow.rb:412:9:412:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:413:5:413:5 | a [element 2] | array_flow.rb:413:24:413:24 | x [element] | provenance |  |
-| array_flow.rb:413:24:413:24 | x [element] | array_flow.rb:414:15:414:15 | x [element] | provenance |  |
-| array_flow.rb:414:15:414:15 | x [element] | array_flow.rb:414:15:414:18 | ...[...] | provenance |  |
+| array_flow.rb:399:10:399:10 | b : Array [element 2] | array_flow.rb:399:10:399:13 | ...[...] | provenance |  |
+| array_flow.rb:403:5:403:5 | a : Array [element 2] | array_flow.rb:404:18:404:18 | a : Array [element 2] | provenance |  |
+| array_flow.rb:403:9:403:26 | call to [] : Array [element 2] | array_flow.rb:403:5:403:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:403:16:403:25 | call to source | array_flow.rb:403:9:403:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:404:5:404:5 | b : Array [element 2] | array_flow.rb:408:10:408:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:404:18:404:18 | a : Array [element 2] | array_flow.rb:404:5:404:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:404:18:404:18 | a : Array [element 2] | array_flow.rb:405:14:405:14 | x | provenance |  |
+| array_flow.rb:404:18:404:18 | a : Array [element 2] | array_flow.rb:407:10:407:10 | x | provenance |  |
+| array_flow.rb:408:10:408:10 | b : Array [element 2] | array_flow.rb:408:10:408:13 | ...[...] | provenance |  |
+| array_flow.rb:412:5:412:5 | a : Array [element 2] | array_flow.rb:413:5:413:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:412:9:412:26 | call to [] : Array [element 2] | array_flow.rb:412:5:412:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:412:16:412:25 | call to source | array_flow.rb:412:9:412:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:413:5:413:5 | a : Array [element 2] | array_flow.rb:413:24:413:24 | x : [collection] [element] | provenance |  |
+| array_flow.rb:413:24:413:24 | x : [collection] [element] | array_flow.rb:414:15:414:15 | x : [collection] [element] | provenance |  |
+| array_flow.rb:414:15:414:15 | x : [collection] [element] | array_flow.rb:414:15:414:18 | ...[...] | provenance |  |
 | array_flow.rb:414:15:414:18 | ...[...] | array_flow.rb:414:14:414:19 | ( ... ) | provenance |  |
-| array_flow.rb:419:5:419:5 | a [element 2] | array_flow.rb:420:9:420:9 | a [element 2] | provenance |  |
-| array_flow.rb:419:9:419:26 | call to [] [element 2] | array_flow.rb:419:5:419:5 | a [element 2] | provenance |  |
-| array_flow.rb:419:16:419:25 | call to source | array_flow.rb:419:9:419:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:420:5:420:5 | b [element 2] | array_flow.rb:423:10:423:10 | b [element 2] | provenance |  |
-| array_flow.rb:420:9:420:9 | a [element 2] | array_flow.rb:420:9:422:7 | call to each_entry [element 2] | provenance |  |
-| array_flow.rb:420:9:420:9 | a [element 2] | array_flow.rb:420:26:420:26 | x | provenance |  |
-| array_flow.rb:420:9:422:7 | call to each_entry [element 2] | array_flow.rb:420:5:420:5 | b [element 2] | provenance |  |
+| array_flow.rb:419:5:419:5 | a : Array [element 2] | array_flow.rb:420:9:420:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:419:9:419:26 | call to [] : Array [element 2] | array_flow.rb:419:5:419:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:419:16:419:25 | call to source | array_flow.rb:419:9:419:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:420:5:420:5 | b : Array [element 2] | array_flow.rb:423:10:423:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:420:9:420:9 | a : Array [element 2] | array_flow.rb:420:9:422:7 | call to each_entry : Array [element 2] | provenance |  |
+| array_flow.rb:420:9:420:9 | a : Array [element 2] | array_flow.rb:420:26:420:26 | x | provenance |  |
+| array_flow.rb:420:9:422:7 | call to each_entry : Array [element 2] | array_flow.rb:420:5:420:5 | b : Array [element 2] | provenance |  |
 | array_flow.rb:420:26:420:26 | x | array_flow.rb:421:14:421:14 | x | provenance |  |
-| array_flow.rb:423:10:423:10 | b [element 2] | array_flow.rb:423:10:423:13 | ...[...] | provenance |  |
-| array_flow.rb:427:5:427:5 | a [element 2] | array_flow.rb:428:9:428:9 | a [element 2] | provenance |  |
-| array_flow.rb:427:9:427:26 | call to [] [element 2] | array_flow.rb:427:5:427:5 | a [element 2] | provenance |  |
-| array_flow.rb:427:16:427:25 | call to source | array_flow.rb:427:9:427:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:428:5:428:5 | b [element 2] | array_flow.rb:431:10:431:10 | b [element 2] | provenance |  |
-| array_flow.rb:428:9:428:9 | a [element 2] | array_flow.rb:428:9:430:7 | call to each_index [element 2] | provenance |  |
-| array_flow.rb:428:9:430:7 | call to each_index [element 2] | array_flow.rb:428:5:428:5 | b [element 2] | provenance |  |
-| array_flow.rb:431:10:431:10 | b [element 2] | array_flow.rb:431:10:431:13 | ...[...] | provenance |  |
-| array_flow.rb:435:5:435:5 | a [element 3] | array_flow.rb:436:5:436:5 | a [element 3] | provenance |  |
-| array_flow.rb:435:9:435:29 | call to [] [element 3] | array_flow.rb:435:5:435:5 | a [element 3] | provenance |  |
-| array_flow.rb:435:19:435:28 | call to source | array_flow.rb:435:9:435:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:436:5:436:5 | a [element 3] | array_flow.rb:436:25:436:25 | x [element] | provenance |  |
-| array_flow.rb:436:25:436:25 | x [element] | array_flow.rb:437:14:437:14 | x [element] | provenance |  |
-| array_flow.rb:437:14:437:14 | x [element] | array_flow.rb:437:14:437:17 | ...[...] | provenance |  |
-| array_flow.rb:442:5:442:5 | a [element 3] | array_flow.rb:443:9:443:9 | a [element 3] | provenance |  |
-| array_flow.rb:442:9:442:29 | call to [] [element 3] | array_flow.rb:442:5:442:5 | a [element 3] | provenance |  |
-| array_flow.rb:442:19:442:28 | call to source | array_flow.rb:442:9:442:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:443:5:443:5 | b [element 3] | array_flow.rb:447:10:447:10 | b [element 3] | provenance |  |
-| array_flow.rb:443:9:443:9 | a [element 3] | array_flow.rb:443:9:446:7 | call to each_with_index [element 3] | provenance |  |
-| array_flow.rb:443:9:443:9 | a [element 3] | array_flow.rb:443:31:443:31 | x | provenance |  |
-| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] | array_flow.rb:443:5:443:5 | b [element 3] | provenance |  |
+| array_flow.rb:423:10:423:10 | b : Array [element 2] | array_flow.rb:423:10:423:13 | ...[...] | provenance |  |
+| array_flow.rb:427:5:427:5 | a : Array [element 2] | array_flow.rb:428:9:428:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:427:9:427:26 | call to [] : Array [element 2] | array_flow.rb:427:5:427:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:427:16:427:25 | call to source | array_flow.rb:427:9:427:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:428:5:428:5 | b : Array [element 2] | array_flow.rb:431:10:431:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:428:9:428:9 | a : Array [element 2] | array_flow.rb:428:9:430:7 | call to each_index : Array [element 2] | provenance |  |
+| array_flow.rb:428:9:430:7 | call to each_index : Array [element 2] | array_flow.rb:428:5:428:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:431:10:431:10 | b : Array [element 2] | array_flow.rb:431:10:431:13 | ...[...] | provenance |  |
+| array_flow.rb:435:5:435:5 | a : Array [element 3] | array_flow.rb:436:5:436:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:435:9:435:29 | call to [] : Array [element 3] | array_flow.rb:435:5:435:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:435:19:435:28 | call to source | array_flow.rb:435:9:435:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:436:5:436:5 | a : Array [element 3] | array_flow.rb:436:25:436:25 | x : [collection] [element] | provenance |  |
+| array_flow.rb:436:25:436:25 | x : [collection] [element] | array_flow.rb:437:14:437:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:437:14:437:14 | x : [collection] [element] | array_flow.rb:437:14:437:17 | ...[...] | provenance |  |
+| array_flow.rb:442:5:442:5 | a : Array [element 3] | array_flow.rb:443:9:443:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:442:9:442:29 | call to [] : Array [element 3] | array_flow.rb:442:5:442:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:442:19:442:28 | call to source | array_flow.rb:442:9:442:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:443:5:443:5 | b : Array [element 3] | array_flow.rb:447:10:447:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:443:9:443:9 | a : Array [element 3] | array_flow.rb:443:9:446:7 | call to each_with_index : Array [element 3] | provenance |  |
+| array_flow.rb:443:9:443:9 | a : Array [element 3] | array_flow.rb:443:31:443:31 | x | provenance |  |
+| array_flow.rb:443:9:446:7 | call to each_with_index : Array [element 3] | array_flow.rb:443:5:443:5 | b : Array [element 3] | provenance |  |
 | array_flow.rb:443:31:443:31 | x | array_flow.rb:444:14:444:14 | x | provenance |  |
-| array_flow.rb:447:10:447:10 | b [element 3] | array_flow.rb:447:10:447:13 | ...[...] | provenance |  |
-| array_flow.rb:451:5:451:5 | a [element 3] | array_flow.rb:452:9:452:9 | a [element 3] | provenance |  |
-| array_flow.rb:451:9:451:31 | call to [] [element 3] | array_flow.rb:451:5:451:5 | a [element 3] | provenance |  |
-| array_flow.rb:451:19:451:30 | call to source | array_flow.rb:451:9:451:31 | call to [] [element 3] | provenance |  |
+| array_flow.rb:447:10:447:10 | b : Array [element 3] | array_flow.rb:447:10:447:13 | ...[...] | provenance |  |
+| array_flow.rb:451:5:451:5 | a : Array [element 3] | array_flow.rb:452:9:452:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:451:9:451:31 | call to [] : Array [element 3] | array_flow.rb:451:5:451:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:451:19:451:30 | call to source | array_flow.rb:451:9:451:31 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:452:5:452:5 | b | array_flow.rb:456:10:456:10 | b | provenance |  |
-| array_flow.rb:452:9:452:9 | a [element 3] | array_flow.rb:452:46:452:46 | x | provenance |  |
+| array_flow.rb:452:9:452:9 | a : Array [element 3] | array_flow.rb:452:46:452:46 | x | provenance |  |
 | array_flow.rb:452:9:455:7 | call to each_with_object | array_flow.rb:452:5:452:5 | b | provenance |  |
 | array_flow.rb:452:28:452:39 | call to source | array_flow.rb:452:9:455:7 | call to each_with_object | provenance |  |
 | array_flow.rb:452:28:452:39 | call to source | array_flow.rb:452:48:452:48 | a | provenance |  |
 | array_flow.rb:452:46:452:46 | x | array_flow.rb:453:14:453:14 | x | provenance |  |
 | array_flow.rb:452:48:452:48 | a | array_flow.rb:454:14:454:14 | a | provenance |  |
-| array_flow.rb:460:5:460:5 | a [element 3] | array_flow.rb:461:9:461:9 | a [element 3] | provenance |  |
-| array_flow.rb:460:9:460:29 | call to [] [element 3] | array_flow.rb:460:5:460:5 | a [element 3] | provenance |  |
-| array_flow.rb:460:19:460:28 | call to source | array_flow.rb:460:9:460:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:461:5:461:5 | b [element 3] | array_flow.rb:462:10:462:10 | b [element 3] | provenance |  |
-| array_flow.rb:461:9:461:9 | a [element 3] | array_flow.rb:461:9:461:17 | call to entries [element 3] | provenance |  |
-| array_flow.rb:461:9:461:17 | call to entries [element 3] | array_flow.rb:461:5:461:5 | b [element 3] | provenance |  |
-| array_flow.rb:462:10:462:10 | b [element 3] | array_flow.rb:462:10:462:13 | ...[...] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 3] | array_flow.rb:467:9:467:9 | a [element 3] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 3] | array_flow.rb:471:9:471:9 | a [element 3] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 3] | array_flow.rb:473:9:473:9 | a [element 3] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 3] | array_flow.rb:477:9:477:9 | a [element 3] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 4] | array_flow.rb:467:9:467:9 | a [element 4] | provenance |  |
-| array_flow.rb:466:5:466:5 | a [element 4] | array_flow.rb:477:9:477:9 | a [element 4] | provenance |  |
-| array_flow.rb:466:9:466:45 | call to [] [element 3] | array_flow.rb:466:5:466:5 | a [element 3] | provenance |  |
-| array_flow.rb:466:9:466:45 | call to [] [element 4] | array_flow.rb:466:5:466:5 | a [element 4] | provenance |  |
-| array_flow.rb:466:19:466:30 | call to source | array_flow.rb:466:9:466:45 | call to [] [element 3] | provenance |  |
-| array_flow.rb:466:33:466:44 | call to source | array_flow.rb:466:9:466:45 | call to [] [element 4] | provenance |  |
+| array_flow.rb:460:5:460:5 | a : Array [element 3] | array_flow.rb:461:9:461:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:460:9:460:29 | call to [] : Array [element 3] | array_flow.rb:460:5:460:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:460:19:460:28 | call to source | array_flow.rb:460:9:460:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:461:5:461:5 | b : Array [element 3] | array_flow.rb:462:10:462:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:461:9:461:9 | a : Array [element 3] | array_flow.rb:461:9:461:17 | call to entries : Array [element 3] | provenance |  |
+| array_flow.rb:461:9:461:17 | call to entries : Array [element 3] | array_flow.rb:461:5:461:5 | b : Array [element 3] | provenance |  |
+| array_flow.rb:462:10:462:10 | b : Array [element 3] | array_flow.rb:462:10:462:13 | ...[...] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 3] | array_flow.rb:467:9:467:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 3] | array_flow.rb:471:9:471:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 3] | array_flow.rb:473:9:473:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 3] | array_flow.rb:477:9:477:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 4] | array_flow.rb:467:9:467:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:466:5:466:5 | a : Array [element 4] | array_flow.rb:477:9:477:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:466:9:466:45 | call to [] : Array [element 3] | array_flow.rb:466:5:466:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:466:9:466:45 | call to [] : Array [element 4] | array_flow.rb:466:5:466:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:466:19:466:30 | call to source | array_flow.rb:466:9:466:45 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:466:33:466:44 | call to source | array_flow.rb:466:9:466:45 | call to [] : Array [element 4] | provenance |  |
 | array_flow.rb:467:5:467:5 | b | array_flow.rb:470:10:470:10 | b | provenance |  |
-| array_flow.rb:467:9:467:9 | a [element 3] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
-| array_flow.rb:467:9:467:9 | a [element 4] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
+| array_flow.rb:467:9:467:9 | a : Array [element 3] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
+| array_flow.rb:467:9:467:9 | a : Array [element 4] | array_flow.rb:467:9:469:7 | call to fetch | provenance |  |
 | array_flow.rb:467:9:469:7 | call to fetch | array_flow.rb:467:5:467:5 | b | provenance |  |
 | array_flow.rb:467:17:467:28 | call to source | array_flow.rb:467:35:467:35 | x | provenance |  |
 | array_flow.rb:467:35:467:35 | x | array_flow.rb:468:14:468:14 | x | provenance |  |
 | array_flow.rb:471:5:471:5 | b | array_flow.rb:472:10:472:10 | b | provenance |  |
-| array_flow.rb:471:9:471:9 | a [element 3] | array_flow.rb:471:9:471:18 | call to fetch | provenance |  |
+| array_flow.rb:471:9:471:9 | a : Array [element 3] | array_flow.rb:471:9:471:18 | call to fetch | provenance |  |
 | array_flow.rb:471:9:471:18 | call to fetch | array_flow.rb:471:5:471:5 | b | provenance |  |
 | array_flow.rb:473:5:473:5 | b | array_flow.rb:474:10:474:10 | b | provenance |  |
-| array_flow.rb:473:9:473:9 | a [element 3] | array_flow.rb:473:9:473:32 | call to fetch | provenance |  |
+| array_flow.rb:473:9:473:9 | a : Array [element 3] | array_flow.rb:473:9:473:32 | call to fetch | provenance |  |
 | array_flow.rb:473:9:473:32 | call to fetch | array_flow.rb:473:5:473:5 | b | provenance |  |
 | array_flow.rb:473:20:473:31 | call to source | array_flow.rb:473:9:473:32 | call to fetch | provenance |  |
 | array_flow.rb:475:5:475:5 | b | array_flow.rb:476:10:476:10 | b | provenance |  |
 | array_flow.rb:475:9:475:34 | call to fetch | array_flow.rb:475:5:475:5 | b | provenance |  |
 | array_flow.rb:475:22:475:33 | call to source | array_flow.rb:475:9:475:34 | call to fetch | provenance |  |
 | array_flow.rb:477:5:477:5 | b | array_flow.rb:478:10:478:10 | b | provenance |  |
-| array_flow.rb:477:9:477:9 | a [element 3] | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
-| array_flow.rb:477:9:477:9 | a [element 4] | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
+| array_flow.rb:477:9:477:9 | a : Array [element 3] | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
+| array_flow.rb:477:9:477:9 | a : Array [element 4] | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
 | array_flow.rb:477:9:477:32 | call to fetch | array_flow.rb:477:5:477:5 | b | provenance |  |
 | array_flow.rb:477:20:477:31 | call to source | array_flow.rb:477:9:477:32 | call to fetch | provenance |  |
-| array_flow.rb:482:5:482:5 | a [element 3] | array_flow.rb:484:10:484:10 | a [element 3] | provenance |  |
-| array_flow.rb:482:9:482:31 | call to [] [element 3] | array_flow.rb:482:5:482:5 | a [element 3] | provenance |  |
-| array_flow.rb:482:19:482:30 | call to source | array_flow.rb:482:9:482:31 | call to [] [element 3] | provenance |  |
-| array_flow.rb:483:5:483:5 | [post] a [element] | array_flow.rb:484:10:484:10 | a [element] | provenance |  |
-| array_flow.rb:483:12:483:23 | call to source | array_flow.rb:483:5:483:5 | [post] a [element] | provenance |  |
-| array_flow.rb:484:10:484:10 | a [element 3] | array_flow.rb:484:10:484:13 | ...[...] | provenance |  |
-| array_flow.rb:484:10:484:10 | a [element] | array_flow.rb:484:10:484:13 | ...[...] | provenance |  |
-| array_flow.rb:485:5:485:5 | [post] a [element] | array_flow.rb:486:10:486:10 | a [element] | provenance |  |
-| array_flow.rb:485:12:485:23 | call to source | array_flow.rb:485:5:485:5 | [post] a [element] | provenance |  |
-| array_flow.rb:486:10:486:10 | a [element] | array_flow.rb:486:10:486:13 | ...[...] | provenance |  |
-| array_flow.rb:487:5:487:5 | [post] a [element] | array_flow.rb:490:10:490:10 | a [element] | provenance |  |
-| array_flow.rb:487:5:487:5 | [post] a [element] | array_flow.rb:494:10:494:10 | a [element] | provenance |  |
-| array_flow.rb:488:9:488:20 | call to source | array_flow.rb:487:5:487:5 | [post] a [element] | provenance |  |
-| array_flow.rb:490:10:490:10 | a [element] | array_flow.rb:490:10:490:13 | ...[...] | provenance |  |
-| array_flow.rb:491:5:491:5 | [post] a [element] | array_flow.rb:494:10:494:10 | a [element] | provenance |  |
-| array_flow.rb:492:9:492:20 | call to source | array_flow.rb:491:5:491:5 | [post] a [element] | provenance |  |
-| array_flow.rb:494:10:494:10 | a [element] | array_flow.rb:494:10:494:13 | ...[...] | provenance |  |
-| array_flow.rb:498:5:498:5 | a [element 3] | array_flow.rb:499:9:499:9 | a [element 3] | provenance |  |
-| array_flow.rb:498:9:498:29 | call to [] [element 3] | array_flow.rb:498:5:498:5 | a [element 3] | provenance |  |
-| array_flow.rb:498:19:498:28 | call to source | array_flow.rb:498:9:498:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:499:5:499:5 | b [element] | array_flow.rb:502:10:502:10 | b [element] | provenance |  |
-| array_flow.rb:499:9:499:9 | a [element 3] | array_flow.rb:499:9:501:7 | call to filter [element] | provenance |  |
-| array_flow.rb:499:9:499:9 | a [element 3] | array_flow.rb:499:22:499:22 | x | provenance |  |
-| array_flow.rb:499:9:501:7 | call to filter [element] | array_flow.rb:499:5:499:5 | b [element] | provenance |  |
+| array_flow.rb:482:5:482:5 | a : Array [element 3] | array_flow.rb:484:10:484:10 | a : Array [element 3] | provenance |  |
+| array_flow.rb:482:9:482:31 | call to [] : Array [element 3] | array_flow.rb:482:5:482:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:482:19:482:30 | call to source | array_flow.rb:482:9:482:31 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:483:5:483:5 | [post] a : [collection] [element] | array_flow.rb:484:10:484:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:483:12:483:23 | call to source | array_flow.rb:483:5:483:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:484:10:484:10 | a : Array [element 3] | array_flow.rb:484:10:484:13 | ...[...] | provenance |  |
+| array_flow.rb:484:10:484:10 | a : [collection] [element] | array_flow.rb:484:10:484:13 | ...[...] | provenance |  |
+| array_flow.rb:485:5:485:5 | [post] a : [collection] [element] | array_flow.rb:486:10:486:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:485:12:485:23 | call to source | array_flow.rb:485:5:485:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:486:10:486:10 | a : [collection] [element] | array_flow.rb:486:10:486:13 | ...[...] | provenance |  |
+| array_flow.rb:487:5:487:5 | [post] a : [collection] [element] | array_flow.rb:490:10:490:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:487:5:487:5 | [post] a : [collection] [element] | array_flow.rb:494:10:494:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:488:9:488:20 | call to source | array_flow.rb:487:5:487:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:490:10:490:10 | a : [collection] [element] | array_flow.rb:490:10:490:13 | ...[...] | provenance |  |
+| array_flow.rb:491:5:491:5 | [post] a : [collection] [element] | array_flow.rb:494:10:494:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:492:9:492:20 | call to source | array_flow.rb:491:5:491:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:494:10:494:10 | a : [collection] [element] | array_flow.rb:494:10:494:13 | ...[...] | provenance |  |
+| array_flow.rb:498:5:498:5 | a : Array [element 3] | array_flow.rb:499:9:499:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:498:9:498:29 | call to [] : Array [element 3] | array_flow.rb:498:5:498:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:498:19:498:28 | call to source | array_flow.rb:498:9:498:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:499:5:499:5 | b : [collection] [element] | array_flow.rb:502:10:502:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:499:9:499:9 | a : Array [element 3] | array_flow.rb:499:9:501:7 | call to filter : [collection] [element] | provenance |  |
+| array_flow.rb:499:9:499:9 | a : Array [element 3] | array_flow.rb:499:22:499:22 | x | provenance |  |
+| array_flow.rb:499:9:501:7 | call to filter : [collection] [element] | array_flow.rb:499:5:499:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:499:22:499:22 | x | array_flow.rb:500:14:500:14 | x | provenance |  |
-| array_flow.rb:502:10:502:10 | b [element] | array_flow.rb:502:10:502:13 | ...[...] | provenance |  |
-| array_flow.rb:506:5:506:5 | a [element 3] | array_flow.rb:507:9:507:9 | a [element 3] | provenance |  |
-| array_flow.rb:506:9:506:29 | call to [] [element 3] | array_flow.rb:506:5:506:5 | a [element 3] | provenance |  |
-| array_flow.rb:506:19:506:28 | call to source | array_flow.rb:506:9:506:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:507:5:507:5 | b [element] | array_flow.rb:511:10:511:10 | b [element] | provenance |  |
-| array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:9:510:7 | call to filter_map [element] | provenance |  |
-| array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | provenance |  |
-| array_flow.rb:507:9:510:7 | call to filter_map [element] | array_flow.rb:507:5:507:5 | b [element] | provenance |  |
+| array_flow.rb:502:10:502:10 | b : [collection] [element] | array_flow.rb:502:10:502:13 | ...[...] | provenance |  |
+| array_flow.rb:506:5:506:5 | a : Array [element 3] | array_flow.rb:507:9:507:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:506:9:506:29 | call to [] : Array [element 3] | array_flow.rb:506:5:506:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:506:19:506:28 | call to source | array_flow.rb:506:9:506:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:507:5:507:5 | b : [collection] [element] | array_flow.rb:511:10:511:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:507:9:507:9 | a : Array [element 3] | array_flow.rb:507:9:510:7 | call to filter_map : [collection] [element] | provenance |  |
+| array_flow.rb:507:9:507:9 | a : Array [element 3] | array_flow.rb:507:26:507:26 | x | provenance |  |
+| array_flow.rb:507:9:510:7 | call to filter_map : [collection] [element] | array_flow.rb:507:5:507:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:507:26:507:26 | x | array_flow.rb:508:14:508:14 | x | provenance |  |
 | array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | provenance |  |
-| array_flow.rb:511:10:511:10 | b [element] | array_flow.rb:511:10:511:13 | ...[...] | provenance |  |
-| array_flow.rb:518:5:518:5 | d [element] | array_flow.rb:521:10:521:10 | d [element] | provenance |  |
-| array_flow.rb:518:9:520:7 | call to filter_map [element] | array_flow.rb:518:5:518:5 | d [element] | provenance |  |
-| array_flow.rb:519:9:519:20 | call to source | array_flow.rb:518:9:520:7 | call to filter_map [element] | provenance |  |
-| array_flow.rb:521:10:521:10 | d [element] | array_flow.rb:521:10:521:13 | ...[...] | provenance |  |
-| array_flow.rb:525:5:525:5 | a [element 3] | array_flow.rb:526:9:526:9 | a [element 3] | provenance |  |
-| array_flow.rb:525:9:525:29 | call to [] [element 3] | array_flow.rb:525:5:525:5 | a [element 3] | provenance |  |
-| array_flow.rb:525:19:525:28 | call to source | array_flow.rb:525:9:525:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:526:5:526:5 | b [element] | array_flow.rb:531:10:531:10 | b [element] | provenance |  |
-| array_flow.rb:526:9:526:9 | [post] a [element] | array_flow.rb:530:10:530:10 | a [element] | provenance |  |
-| array_flow.rb:526:9:526:9 | a [element 3] | array_flow.rb:526:9:526:9 | [post] a [element] | provenance |  |
-| array_flow.rb:526:9:526:9 | a [element 3] | array_flow.rb:526:9:529:7 | call to filter! [element] | provenance |  |
-| array_flow.rb:526:9:526:9 | a [element 3] | array_flow.rb:526:23:526:23 | x | provenance |  |
-| array_flow.rb:526:9:529:7 | call to filter! [element] | array_flow.rb:526:5:526:5 | b [element] | provenance |  |
+| array_flow.rb:511:10:511:10 | b : [collection] [element] | array_flow.rb:511:10:511:13 | ...[...] | provenance |  |
+| array_flow.rb:518:5:518:5 | d : [collection] [element] | array_flow.rb:521:10:521:10 | d : [collection] [element] | provenance |  |
+| array_flow.rb:518:9:520:7 | call to filter_map : [collection] [element] | array_flow.rb:518:5:518:5 | d : [collection] [element] | provenance |  |
+| array_flow.rb:519:9:519:20 | call to source | array_flow.rb:518:9:520:7 | call to filter_map : [collection] [element] | provenance |  |
+| array_flow.rb:521:10:521:10 | d : [collection] [element] | array_flow.rb:521:10:521:13 | ...[...] | provenance |  |
+| array_flow.rb:525:5:525:5 | a : Array [element 3] | array_flow.rb:526:9:526:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:525:9:525:29 | call to [] : Array [element 3] | array_flow.rb:525:5:525:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:525:19:525:28 | call to source | array_flow.rb:525:9:525:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:526:5:526:5 | b : [collection] [element] | array_flow.rb:531:10:531:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:526:9:526:9 | [post] a : [collection] [element] | array_flow.rb:530:10:530:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:526:9:526:9 | a : Array [element 3] | array_flow.rb:526:9:526:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:526:9:526:9 | a : Array [element 3] | array_flow.rb:526:9:529:7 | call to filter! : [collection] [element] | provenance |  |
+| array_flow.rb:526:9:526:9 | a : Array [element 3] | array_flow.rb:526:23:526:23 | x | provenance |  |
+| array_flow.rb:526:9:529:7 | call to filter! : [collection] [element] | array_flow.rb:526:5:526:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:526:23:526:23 | x | array_flow.rb:527:14:527:14 | x | provenance |  |
-| array_flow.rb:530:10:530:10 | a [element] | array_flow.rb:530:10:530:13 | ...[...] | provenance |  |
-| array_flow.rb:531:10:531:10 | b [element] | array_flow.rb:531:10:531:13 | ...[...] | provenance |  |
-| array_flow.rb:535:5:535:5 | a [element 3] | array_flow.rb:536:9:536:9 | a [element 3] | provenance |  |
-| array_flow.rb:535:9:535:31 | call to [] [element 3] | array_flow.rb:535:5:535:5 | a [element 3] | provenance |  |
-| array_flow.rb:535:19:535:30 | call to source | array_flow.rb:535:9:535:31 | call to [] [element 3] | provenance |  |
+| array_flow.rb:530:10:530:10 | a : [collection] [element] | array_flow.rb:530:10:530:13 | ...[...] | provenance |  |
+| array_flow.rb:531:10:531:10 | b : [collection] [element] | array_flow.rb:531:10:531:13 | ...[...] | provenance |  |
+| array_flow.rb:535:5:535:5 | a : Array [element 3] | array_flow.rb:536:9:536:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:535:9:535:31 | call to [] : Array [element 3] | array_flow.rb:535:5:535:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:535:19:535:30 | call to source | array_flow.rb:535:9:535:31 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:536:5:536:5 | b | array_flow.rb:539:10:539:10 | b | provenance |  |
-| array_flow.rb:536:9:536:9 | a [element 3] | array_flow.rb:536:9:538:7 | call to find | provenance |  |
-| array_flow.rb:536:9:536:9 | a [element 3] | array_flow.rb:536:41:536:41 | x | provenance |  |
+| array_flow.rb:536:9:536:9 | a : Array [element 3] | array_flow.rb:536:9:538:7 | call to find | provenance |  |
+| array_flow.rb:536:9:536:9 | a : Array [element 3] | array_flow.rb:536:41:536:41 | x | provenance |  |
 | array_flow.rb:536:9:538:7 | call to find | array_flow.rb:536:5:536:5 | b | provenance |  |
 | array_flow.rb:536:21:536:32 | call to source | array_flow.rb:536:9:538:7 | call to find | provenance |  |
 | array_flow.rb:536:41:536:41 | x | array_flow.rb:537:14:537:14 | x | provenance |  |
-| array_flow.rb:543:5:543:5 | a [element 3] | array_flow.rb:544:9:544:9 | a [element 3] | provenance |  |
-| array_flow.rb:543:9:543:29 | call to [] [element 3] | array_flow.rb:543:5:543:5 | a [element 3] | provenance |  |
-| array_flow.rb:543:19:543:28 | call to source | array_flow.rb:543:9:543:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:544:5:544:5 | b [element] | array_flow.rb:547:10:547:10 | b [element] | provenance |  |
-| array_flow.rb:544:9:544:9 | a [element 3] | array_flow.rb:544:9:546:7 | call to find_all [element] | provenance |  |
-| array_flow.rb:544:9:544:9 | a [element 3] | array_flow.rb:544:24:544:24 | x | provenance |  |
-| array_flow.rb:544:9:546:7 | call to find_all [element] | array_flow.rb:544:5:544:5 | b [element] | provenance |  |
+| array_flow.rb:543:5:543:5 | a : Array [element 3] | array_flow.rb:544:9:544:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:543:9:543:29 | call to [] : Array [element 3] | array_flow.rb:543:5:543:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:543:19:543:28 | call to source | array_flow.rb:543:9:543:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:544:5:544:5 | b : [collection] [element] | array_flow.rb:547:10:547:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:544:9:544:9 | a : Array [element 3] | array_flow.rb:544:9:546:7 | call to find_all : [collection] [element] | provenance |  |
+| array_flow.rb:544:9:544:9 | a : Array [element 3] | array_flow.rb:544:24:544:24 | x | provenance |  |
+| array_flow.rb:544:9:546:7 | call to find_all : [collection] [element] | array_flow.rb:544:5:544:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:544:24:544:24 | x | array_flow.rb:545:14:545:14 | x | provenance |  |
-| array_flow.rb:547:10:547:10 | b [element] | array_flow.rb:547:10:547:13 | ...[...] | provenance |  |
-| array_flow.rb:551:5:551:5 | a [element 3] | array_flow.rb:552:5:552:5 | a [element 3] | provenance |  |
-| array_flow.rb:551:9:551:29 | call to [] [element 3] | array_flow.rb:551:5:551:5 | a [element 3] | provenance |  |
-| array_flow.rb:551:19:551:28 | call to source | array_flow.rb:551:9:551:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:552:5:552:5 | a [element 3] | array_flow.rb:552:22:552:22 | x | provenance |  |
+| array_flow.rb:547:10:547:10 | b : [collection] [element] | array_flow.rb:547:10:547:13 | ...[...] | provenance |  |
+| array_flow.rb:551:5:551:5 | a : Array [element 3] | array_flow.rb:552:5:552:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:551:9:551:29 | call to [] : Array [element 3] | array_flow.rb:551:5:551:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:551:19:551:28 | call to source | array_flow.rb:551:9:551:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:552:5:552:5 | a : Array [element 3] | array_flow.rb:552:22:552:22 | x | provenance |  |
 | array_flow.rb:552:22:552:22 | x | array_flow.rb:553:14:553:14 | x | provenance |  |
-| array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:560:10:560:10 | a [element 0] | provenance |  |
-| array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:561:9:561:9 | a [element 0] | provenance |  |
-| array_flow.rb:558:5:558:5 | a [element 0] | array_flow.rb:564:9:564:9 | a [element 0] | provenance |  |
-| array_flow.rb:558:5:558:5 | a [element 3] | array_flow.rb:564:9:564:9 | a [element 3] | provenance |  |
-| array_flow.rb:558:9:558:42 | call to [] [element 0] | array_flow.rb:558:5:558:5 | a [element 0] | provenance |  |
-| array_flow.rb:558:9:558:42 | call to [] [element 3] | array_flow.rb:558:5:558:5 | a [element 3] | provenance |  |
-| array_flow.rb:558:10:558:21 | call to source | array_flow.rb:558:9:558:42 | call to [] [element 0] | provenance |  |
-| array_flow.rb:558:30:558:41 | call to source | array_flow.rb:558:9:558:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:560:10:560:10 | a [element] | provenance |  |
-| array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:561:9:561:9 | a [element] | provenance |  |
-| array_flow.rb:559:5:559:5 | [post] a [element] | array_flow.rb:564:9:564:9 | a [element] | provenance |  |
-| array_flow.rb:559:12:559:23 | call to source | array_flow.rb:559:5:559:5 | [post] a [element] | provenance |  |
-| array_flow.rb:560:10:560:10 | a [element 0] | array_flow.rb:560:10:560:16 | call to first | provenance |  |
-| array_flow.rb:560:10:560:10 | a [element] | array_flow.rb:560:10:560:16 | call to first | provenance |  |
-| array_flow.rb:561:5:561:5 | b [element 0] | array_flow.rb:562:10:562:10 | b [element 0] | provenance |  |
-| array_flow.rb:561:5:561:5 | b [element] | array_flow.rb:562:10:562:10 | b [element] | provenance |  |
-| array_flow.rb:561:5:561:5 | b [element] | array_flow.rb:563:10:563:10 | b [element] | provenance |  |
-| array_flow.rb:561:9:561:9 | a [element 0] | array_flow.rb:561:9:561:18 | call to first [element 0] | provenance |  |
-| array_flow.rb:561:9:561:9 | a [element] | array_flow.rb:561:9:561:18 | call to first [element] | provenance |  |
-| array_flow.rb:561:9:561:18 | call to first [element 0] | array_flow.rb:561:5:561:5 | b [element 0] | provenance |  |
-| array_flow.rb:561:9:561:18 | call to first [element] | array_flow.rb:561:5:561:5 | b [element] | provenance |  |
-| array_flow.rb:562:10:562:10 | b [element 0] | array_flow.rb:562:10:562:13 | ...[...] | provenance |  |
-| array_flow.rb:562:10:562:10 | b [element] | array_flow.rb:562:10:562:13 | ...[...] | provenance |  |
-| array_flow.rb:563:10:563:10 | b [element] | array_flow.rb:563:10:563:13 | ...[...] | provenance |  |
-| array_flow.rb:564:5:564:5 | c [element 0] | array_flow.rb:565:10:565:10 | c [element 0] | provenance |  |
-| array_flow.rb:564:5:564:5 | c [element 3] | array_flow.rb:566:10:566:10 | c [element 3] | provenance |  |
-| array_flow.rb:564:5:564:5 | c [element] | array_flow.rb:565:10:565:10 | c [element] | provenance |  |
-| array_flow.rb:564:5:564:5 | c [element] | array_flow.rb:566:10:566:10 | c [element] | provenance |  |
-| array_flow.rb:564:9:564:9 | a [element 0] | array_flow.rb:564:9:564:18 | call to first [element 0] | provenance |  |
-| array_flow.rb:564:9:564:9 | a [element 3] | array_flow.rb:564:9:564:18 | call to first [element 3] | provenance |  |
-| array_flow.rb:564:9:564:9 | a [element] | array_flow.rb:564:9:564:18 | call to first [element] | provenance |  |
-| array_flow.rb:564:9:564:18 | call to first [element 0] | array_flow.rb:564:5:564:5 | c [element 0] | provenance |  |
-| array_flow.rb:564:9:564:18 | call to first [element 3] | array_flow.rb:564:5:564:5 | c [element 3] | provenance |  |
-| array_flow.rb:564:9:564:18 | call to first [element] | array_flow.rb:564:5:564:5 | c [element] | provenance |  |
-| array_flow.rb:565:10:565:10 | c [element 0] | array_flow.rb:565:10:565:13 | ...[...] | provenance |  |
-| array_flow.rb:565:10:565:10 | c [element] | array_flow.rb:565:10:565:13 | ...[...] | provenance |  |
-| array_flow.rb:566:10:566:10 | c [element 3] | array_flow.rb:566:10:566:13 | ...[...] | provenance |  |
-| array_flow.rb:566:10:566:10 | c [element] | array_flow.rb:566:10:566:13 | ...[...] | provenance |  |
-| array_flow.rb:570:5:570:5 | a [element 2] | array_flow.rb:571:9:571:9 | a [element 2] | provenance |  |
-| array_flow.rb:570:5:570:5 | a [element 2] | array_flow.rb:576:9:576:9 | a [element 2] | provenance |  |
-| array_flow.rb:570:9:570:28 | call to [] [element 2] | array_flow.rb:570:5:570:5 | a [element 2] | provenance |  |
-| array_flow.rb:570:16:570:27 | call to source | array_flow.rb:570:9:570:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:571:5:571:5 | b [element] | array_flow.rb:575:10:575:10 | b [element] | provenance |  |
-| array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
-| array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | provenance |  |
-| array_flow.rb:571:9:574:7 | call to flat_map [element] | array_flow.rb:571:5:571:5 | b [element] | provenance |  |
+| array_flow.rb:558:5:558:5 | a : Array [element 0] | array_flow.rb:560:10:560:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:558:5:558:5 | a : Array [element 0] | array_flow.rb:561:9:561:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:558:5:558:5 | a : Array [element 0] | array_flow.rb:564:9:564:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:558:5:558:5 | a : Array [element 3] | array_flow.rb:564:9:564:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:558:9:558:42 | call to [] : Array [element 0] | array_flow.rb:558:5:558:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:558:9:558:42 | call to [] : Array [element 3] | array_flow.rb:558:5:558:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:558:10:558:21 | call to source | array_flow.rb:558:9:558:42 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:558:30:558:41 | call to source | array_flow.rb:558:9:558:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:559:5:559:5 | [post] a : [collection] [element] | array_flow.rb:560:10:560:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:559:5:559:5 | [post] a : [collection] [element] | array_flow.rb:561:9:561:9 | a : [collection] [element] | provenance |  |
+| array_flow.rb:559:5:559:5 | [post] a : [collection] [element] | array_flow.rb:564:9:564:9 | a : [collection] [element] | provenance |  |
+| array_flow.rb:559:12:559:23 | call to source | array_flow.rb:559:5:559:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:560:10:560:10 | a : Array [element 0] | array_flow.rb:560:10:560:16 | call to first | provenance |  |
+| array_flow.rb:560:10:560:10 | a : [collection] [element] | array_flow.rb:560:10:560:16 | call to first | provenance |  |
+| array_flow.rb:561:5:561:5 | b : Array [element 0] | array_flow.rb:562:10:562:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:561:5:561:5 | b : [collection] [element] | array_flow.rb:562:10:562:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:561:5:561:5 | b : [collection] [element] | array_flow.rb:563:10:563:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:561:9:561:9 | a : Array [element 0] | array_flow.rb:561:9:561:18 | call to first : Array [element 0] | provenance |  |
+| array_flow.rb:561:9:561:9 | a : [collection] [element] | array_flow.rb:561:9:561:18 | call to first : [collection] [element] | provenance |  |
+| array_flow.rb:561:9:561:18 | call to first : Array [element 0] | array_flow.rb:561:5:561:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:561:9:561:18 | call to first : [collection] [element] | array_flow.rb:561:5:561:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:562:10:562:10 | b : Array [element 0] | array_flow.rb:562:10:562:13 | ...[...] | provenance |  |
+| array_flow.rb:562:10:562:10 | b : [collection] [element] | array_flow.rb:562:10:562:13 | ...[...] | provenance |  |
+| array_flow.rb:563:10:563:10 | b : [collection] [element] | array_flow.rb:563:10:563:13 | ...[...] | provenance |  |
+| array_flow.rb:564:5:564:5 | c : Array [element 0] | array_flow.rb:565:10:565:10 | c : Array [element 0] | provenance |  |
+| array_flow.rb:564:5:564:5 | c : Array [element 3] | array_flow.rb:566:10:566:10 | c : Array [element 3] | provenance |  |
+| array_flow.rb:564:5:564:5 | c : [collection] [element] | array_flow.rb:565:10:565:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:564:5:564:5 | c : [collection] [element] | array_flow.rb:566:10:566:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:564:9:564:9 | a : Array [element 0] | array_flow.rb:564:9:564:18 | call to first : Array [element 0] | provenance |  |
+| array_flow.rb:564:9:564:9 | a : Array [element 3] | array_flow.rb:564:9:564:18 | call to first : Array [element 3] | provenance |  |
+| array_flow.rb:564:9:564:9 | a : [collection] [element] | array_flow.rb:564:9:564:18 | call to first : [collection] [element] | provenance |  |
+| array_flow.rb:564:9:564:18 | call to first : Array [element 0] | array_flow.rb:564:5:564:5 | c : Array [element 0] | provenance |  |
+| array_flow.rb:564:9:564:18 | call to first : Array [element 3] | array_flow.rb:564:5:564:5 | c : Array [element 3] | provenance |  |
+| array_flow.rb:564:9:564:18 | call to first : [collection] [element] | array_flow.rb:564:5:564:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:565:10:565:10 | c : Array [element 0] | array_flow.rb:565:10:565:13 | ...[...] | provenance |  |
+| array_flow.rb:565:10:565:10 | c : [collection] [element] | array_flow.rb:565:10:565:13 | ...[...] | provenance |  |
+| array_flow.rb:566:10:566:10 | c : Array [element 3] | array_flow.rb:566:10:566:13 | ...[...] | provenance |  |
+| array_flow.rb:566:10:566:10 | c : [collection] [element] | array_flow.rb:566:10:566:13 | ...[...] | provenance |  |
+| array_flow.rb:570:5:570:5 | a : Array [element 2] | array_flow.rb:571:9:571:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:570:5:570:5 | a : Array [element 2] | array_flow.rb:576:9:576:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:570:9:570:28 | call to [] : Array [element 2] | array_flow.rb:570:5:570:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:570:16:570:27 | call to source | array_flow.rb:570:9:570:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:571:5:571:5 | b : [collection] [element] | array_flow.rb:575:10:575:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:571:9:571:9 | a : Array [element 2] | array_flow.rb:571:9:574:7 | call to flat_map : [collection] [element] | provenance |  |
+| array_flow.rb:571:9:571:9 | a : Array [element 2] | array_flow.rb:571:24:571:24 | x | provenance |  |
+| array_flow.rb:571:9:574:7 | call to flat_map : [collection] [element] | array_flow.rb:571:5:571:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:571:24:571:24 | x | array_flow.rb:572:14:572:14 | x | provenance |  |
 | array_flow.rb:571:24:571:24 | x | array_flow.rb:573:10:573:10 | x | provenance |  |
-| array_flow.rb:573:9:573:25 | call to [] [element 1] | array_flow.rb:571:9:574:7 | call to flat_map [element] | provenance |  |
-| array_flow.rb:573:10:573:10 | x | array_flow.rb:573:9:573:25 | call to [] [element 0] | provenance |  |
-| array_flow.rb:573:13:573:24 | call to source | array_flow.rb:573:9:573:25 | call to [] [element 1] | provenance |  |
-| array_flow.rb:575:10:575:10 | b [element] | array_flow.rb:575:10:575:13 | ...[...] | provenance |  |
-| array_flow.rb:576:5:576:5 | b [element] | array_flow.rb:580:10:580:10 | b [element] | provenance |  |
-| array_flow.rb:576:9:576:9 | a [element 2] | array_flow.rb:576:24:576:24 | x | provenance |  |
-| array_flow.rb:576:9:579:7 | call to flat_map [element] | array_flow.rb:576:5:576:5 | b [element] | provenance |  |
+| array_flow.rb:573:9:573:25 | call to [] : Array [element 1] | array_flow.rb:571:9:574:7 | call to flat_map : [collection] [element] | provenance |  |
+| array_flow.rb:573:10:573:10 | x | array_flow.rb:573:9:573:25 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:573:13:573:24 | call to source | array_flow.rb:573:9:573:25 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:575:10:575:10 | b : [collection] [element] | array_flow.rb:575:10:575:13 | ...[...] | provenance |  |
+| array_flow.rb:576:5:576:5 | b : [collection] [element] : [collection] | array_flow.rb:580:10:580:10 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:576:9:576:9 | a : Array [element 2] | array_flow.rb:576:24:576:24 | x | provenance |  |
+| array_flow.rb:576:9:579:7 | call to flat_map : [collection] [element] : [collection] | array_flow.rb:576:5:576:5 | b : [collection] [element] : [collection] | provenance |  |
 | array_flow.rb:576:24:576:24 | x | array_flow.rb:577:14:577:14 | x | provenance |  |
-| array_flow.rb:578:9:578:20 | call to source | array_flow.rb:576:9:579:7 | call to flat_map [element] | provenance |  |
-| array_flow.rb:580:10:580:10 | b [element] | array_flow.rb:580:10:580:13 | ...[...] | provenance |  |
-| array_flow.rb:584:5:584:5 | a [element 2, element 1] | array_flow.rb:585:9:585:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | array_flow.rb:584:5:584:5 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:584:16:584:30 | call to [] [element 1] | array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | provenance |  |
-| array_flow.rb:584:20:584:29 | call to source | array_flow.rb:584:16:584:30 | call to [] [element 1] | provenance |  |
-| array_flow.rb:585:5:585:5 | b [element] | array_flow.rb:586:10:586:10 | b [element] | provenance |  |
-| array_flow.rb:585:9:585:9 | a [element 2, element 1] | array_flow.rb:585:9:585:17 | call to flatten [element] | provenance |  |
-| array_flow.rb:585:9:585:17 | call to flatten [element] | array_flow.rb:585:5:585:5 | b [element] | provenance |  |
-| array_flow.rb:586:10:586:10 | b [element] | array_flow.rb:586:10:586:13 | ...[...] | provenance |  |
-| array_flow.rb:590:5:590:5 | a [element 2, element 1] | array_flow.rb:591:10:591:10 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:590:5:590:5 | a [element 2, element 1] | array_flow.rb:592:9:592:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | array_flow.rb:590:5:590:5 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:590:16:590:30 | call to [] [element 1] | array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | provenance |  |
-| array_flow.rb:590:20:590:29 | call to source | array_flow.rb:590:16:590:30 | call to [] [element 1] | provenance |  |
-| array_flow.rb:591:10:591:10 | a [element 2, element 1] | array_flow.rb:591:10:591:13 | ...[...] [element 1] | provenance |  |
+| array_flow.rb:578:9:578:20 | call to source | array_flow.rb:576:9:579:7 | call to flat_map : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:580:10:580:10 | b : [collection] [element] : [collection] | array_flow.rb:580:10:580:13 | ...[...] | provenance |  |
+| array_flow.rb:584:5:584:5 | a : Array [element 2, element 1] | array_flow.rb:585:9:585:9 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:584:9:584:31 | call to [] : Array [element 2, element 1] | array_flow.rb:584:5:584:5 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:584:16:584:30 | call to [] : Array [element 1] | array_flow.rb:584:9:584:31 | call to [] : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:584:20:584:29 | call to source | array_flow.rb:584:16:584:30 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:585:5:585:5 | b : [collection] [element] : [collection] | array_flow.rb:586:10:586:10 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:585:9:585:9 | a : Array [element 2, element 1] | array_flow.rb:585:9:585:17 | call to flatten : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:585:9:585:17 | call to flatten : [collection] [element] : [collection] | array_flow.rb:585:5:585:5 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:586:10:586:10 | b : [collection] [element] : [collection] | array_flow.rb:586:10:586:13 | ...[...] | provenance |  |
+| array_flow.rb:590:5:590:5 | a : Array [element 2, element 1] | array_flow.rb:591:10:591:10 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:590:5:590:5 | a : Array [element 2, element 1] | array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:590:9:590:31 | call to [] : Array [element 2, element 1] | array_flow.rb:590:5:590:5 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:590:16:590:30 | call to [] : Array [element 1] | array_flow.rb:590:9:590:31 | call to [] : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:590:20:590:29 | call to source | array_flow.rb:590:16:590:30 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:591:10:591:10 | a : Array [element 2, element 1] | array_flow.rb:591:10:591:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:591:10:591:13 | ...[...] [element 1] | array_flow.rb:591:10:591:16 | ...[...] | provenance |  |
-| array_flow.rb:592:5:592:5 | b [element, element 1] | array_flow.rb:596:10:596:10 | b [element, element 1] | provenance |  |
-| array_flow.rb:592:5:592:5 | b [element] | array_flow.rb:595:10:595:10 | b [element] | provenance |  |
-| array_flow.rb:592:9:592:9 | [post] a [element, element 1] | array_flow.rb:594:10:594:10 | a [element, element 1] | provenance |  |
-| array_flow.rb:592:9:592:9 | [post] a [element] | array_flow.rb:593:10:593:10 | a [element] | provenance |  |
-| array_flow.rb:592:9:592:9 | a [element 2, element 1] | array_flow.rb:592:9:592:9 | [post] a [element, element 1] | provenance |  |
-| array_flow.rb:592:9:592:9 | a [element 2, element 1] | array_flow.rb:592:9:592:9 | [post] a [element] | provenance |  |
-| array_flow.rb:592:9:592:9 | a [element 2, element 1] | array_flow.rb:592:9:592:18 | call to flatten! [element, element 1] | provenance |  |
-| array_flow.rb:592:9:592:9 | a [element 2, element 1] | array_flow.rb:592:9:592:18 | call to flatten! [element] | provenance |  |
-| array_flow.rb:592:9:592:18 | call to flatten! [element, element 1] | array_flow.rb:592:5:592:5 | b [element, element 1] | provenance |  |
-| array_flow.rb:592:9:592:18 | call to flatten! [element] | array_flow.rb:592:5:592:5 | b [element] | provenance |  |
-| array_flow.rb:593:10:593:10 | a [element] | array_flow.rb:593:10:593:13 | ...[...] | provenance |  |
-| array_flow.rb:594:10:594:10 | a [element, element 1] | array_flow.rb:594:10:594:13 | ...[...] [element 1] | provenance |  |
+| array_flow.rb:592:5:592:5 | b : [collection] [element, element 1] | array_flow.rb:596:10:596:10 | b : [collection] [element, element 1] | provenance |  |
+| array_flow.rb:592:5:592:5 | b : [collection] [element] : [collection] | array_flow.rb:595:10:595:10 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:592:9:592:9 | [post] a : [collection] [element, element 1] | array_flow.rb:594:10:594:10 | a : [collection] [element, element 1] | provenance |  |
+| array_flow.rb:592:9:592:9 | [post] a : [collection] [element] : [collection] | array_flow.rb:593:10:593:10 | a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | array_flow.rb:592:9:592:9 | [post] a : [collection] [element, element 1] | provenance |  |
+| array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | array_flow.rb:592:9:592:9 | [post] a : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element, element 1] | provenance |  |
+| array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element, element 1] | array_flow.rb:592:5:592:5 | b : [collection] [element, element 1] | provenance |  |
+| array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element] : [collection] | array_flow.rb:592:5:592:5 | b : [collection] [element] : [collection] | provenance |  |
+| array_flow.rb:593:10:593:10 | a : [collection] [element] : [collection] | array_flow.rb:593:10:593:13 | ...[...] | provenance |  |
+| array_flow.rb:594:10:594:10 | a : [collection] [element, element 1] | array_flow.rb:594:10:594:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:594:10:594:13 | ...[...] [element 1] | array_flow.rb:594:10:594:16 | ...[...] | provenance |  |
-| array_flow.rb:595:10:595:10 | b [element] | array_flow.rb:595:10:595:13 | ...[...] | provenance |  |
-| array_flow.rb:596:10:596:10 | b [element, element 1] | array_flow.rb:596:10:596:13 | ...[...] [element 1] | provenance |  |
+| array_flow.rb:595:10:595:10 | b : [collection] [element] : [collection] | array_flow.rb:595:10:595:13 | ...[...] | provenance |  |
+| array_flow.rb:596:10:596:10 | b : [collection] [element, element 1] | array_flow.rb:596:10:596:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:596:10:596:13 | ...[...] [element 1] | array_flow.rb:596:10:596:16 | ...[...] | provenance |  |
-| array_flow.rb:600:5:600:5 | a [element 3] | array_flow.rb:601:9:601:9 | a [element 3] | provenance |  |
-| array_flow.rb:600:5:600:5 | a [element 3] | array_flow.rb:603:9:603:9 | a [element 3] | provenance |  |
-| array_flow.rb:600:9:600:31 | call to [] [element 3] | array_flow.rb:600:5:600:5 | a [element 3] | provenance |  |
-| array_flow.rb:600:19:600:30 | call to source | array_flow.rb:600:9:600:31 | call to [] [element 3] | provenance |  |
-| array_flow.rb:601:5:601:5 | b [element] | array_flow.rb:602:10:602:10 | b [element] | provenance |  |
-| array_flow.rb:601:9:601:9 | a [element 3] | array_flow.rb:601:9:601:20 | call to grep [element] | provenance |  |
-| array_flow.rb:601:9:601:20 | call to grep [element] | array_flow.rb:601:5:601:5 | b [element] | provenance |  |
-| array_flow.rb:602:10:602:10 | b [element] | array_flow.rb:602:10:602:13 | ...[...] | provenance |  |
-| array_flow.rb:603:5:603:5 | b [element] | array_flow.rb:607:10:607:10 | b [element] | provenance |  |
-| array_flow.rb:603:9:603:9 | a [element 3] | array_flow.rb:603:26:603:26 | x | provenance |  |
-| array_flow.rb:603:9:606:7 | call to grep [element] | array_flow.rb:603:5:603:5 | b [element] | provenance |  |
+| array_flow.rb:600:5:600:5 | a : Array [element 3] | array_flow.rb:601:9:601:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:600:5:600:5 | a : Array [element 3] | array_flow.rb:603:9:603:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:600:9:600:31 | call to [] : Array [element 3] | array_flow.rb:600:5:600:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:600:19:600:30 | call to source | array_flow.rb:600:9:600:31 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:601:5:601:5 | b : [collection] [element] | array_flow.rb:602:10:602:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:601:9:601:9 | a : Array [element 3] | array_flow.rb:601:9:601:20 | call to grep : [collection] [element] | provenance |  |
+| array_flow.rb:601:9:601:20 | call to grep : [collection] [element] | array_flow.rb:601:5:601:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:602:10:602:10 | b : [collection] [element] | array_flow.rb:602:10:602:13 | ...[...] | provenance |  |
+| array_flow.rb:603:5:603:5 | b : [collection] [element] | array_flow.rb:607:10:607:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:603:9:603:9 | a : Array [element 3] | array_flow.rb:603:26:603:26 | x | provenance |  |
+| array_flow.rb:603:9:606:7 | call to grep : [collection] [element] | array_flow.rb:603:5:603:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:603:26:603:26 | x | array_flow.rb:604:14:604:14 | x | provenance |  |
-| array_flow.rb:605:9:605:20 | call to source | array_flow.rb:603:9:606:7 | call to grep [element] | provenance |  |
-| array_flow.rb:607:10:607:10 | b [element] | array_flow.rb:607:10:607:13 | ...[...] | provenance |  |
-| array_flow.rb:611:5:611:5 | a [element 3] | array_flow.rb:612:9:612:9 | a [element 3] | provenance |  |
-| array_flow.rb:611:5:611:5 | a [element 3] | array_flow.rb:614:9:614:9 | a [element 3] | provenance |  |
-| array_flow.rb:611:9:611:31 | call to [] [element 3] | array_flow.rb:611:5:611:5 | a [element 3] | provenance |  |
-| array_flow.rb:611:19:611:30 | call to source | array_flow.rb:611:9:611:31 | call to [] [element 3] | provenance |  |
-| array_flow.rb:612:5:612:5 | b [element] | array_flow.rb:613:10:613:10 | b [element] | provenance |  |
-| array_flow.rb:612:9:612:9 | a [element 3] | array_flow.rb:612:9:612:21 | call to grep_v [element] | provenance |  |
-| array_flow.rb:612:9:612:21 | call to grep_v [element] | array_flow.rb:612:5:612:5 | b [element] | provenance |  |
-| array_flow.rb:613:10:613:10 | b [element] | array_flow.rb:613:10:613:13 | ...[...] | provenance |  |
-| array_flow.rb:614:5:614:5 | b [element] | array_flow.rb:618:10:618:10 | b [element] | provenance |  |
-| array_flow.rb:614:9:614:9 | a [element 3] | array_flow.rb:614:27:614:27 | x | provenance |  |
-| array_flow.rb:614:9:617:7 | call to grep_v [element] | array_flow.rb:614:5:614:5 | b [element] | provenance |  |
+| array_flow.rb:605:9:605:20 | call to source | array_flow.rb:603:9:606:7 | call to grep : [collection] [element] | provenance |  |
+| array_flow.rb:607:10:607:10 | b : [collection] [element] | array_flow.rb:607:10:607:13 | ...[...] | provenance |  |
+| array_flow.rb:611:5:611:5 | a : Array [element 3] | array_flow.rb:612:9:612:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:611:5:611:5 | a : Array [element 3] | array_flow.rb:614:9:614:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:611:9:611:31 | call to [] : Array [element 3] | array_flow.rb:611:5:611:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:611:19:611:30 | call to source | array_flow.rb:611:9:611:31 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:612:5:612:5 | b : [collection] [element] | array_flow.rb:613:10:613:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:612:9:612:9 | a : Array [element 3] | array_flow.rb:612:9:612:21 | call to grep_v : [collection] [element] | provenance |  |
+| array_flow.rb:612:9:612:21 | call to grep_v : [collection] [element] | array_flow.rb:612:5:612:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:613:10:613:10 | b : [collection] [element] | array_flow.rb:613:10:613:13 | ...[...] | provenance |  |
+| array_flow.rb:614:5:614:5 | b : [collection] [element] | array_flow.rb:618:10:618:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:614:9:614:9 | a : Array [element 3] | array_flow.rb:614:27:614:27 | x | provenance |  |
+| array_flow.rb:614:9:617:7 | call to grep_v : [collection] [element] | array_flow.rb:614:5:614:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:614:27:614:27 | x | array_flow.rb:615:14:615:14 | x | provenance |  |
-| array_flow.rb:616:9:616:20 | call to source | array_flow.rb:614:9:617:7 | call to grep_v [element] | provenance |  |
-| array_flow.rb:618:10:618:10 | b [element] | array_flow.rb:618:10:618:13 | ...[...] | provenance |  |
-| array_flow.rb:622:5:622:5 | a [element 3] | array_flow.rb:623:9:623:9 | a [element 3] | provenance |  |
-| array_flow.rb:622:9:622:31 | call to [] [element 3] | array_flow.rb:622:5:622:5 | a [element 3] | provenance |  |
-| array_flow.rb:622:19:622:30 | call to source | array_flow.rb:622:9:622:31 | call to [] [element 3] | provenance |  |
-| array_flow.rb:623:9:623:9 | a [element 3] | array_flow.rb:623:24:623:24 | x | provenance |  |
+| array_flow.rb:616:9:616:20 | call to source | array_flow.rb:614:9:617:7 | call to grep_v : [collection] [element] | provenance |  |
+| array_flow.rb:618:10:618:10 | b : [collection] [element] | array_flow.rb:618:10:618:13 | ...[...] | provenance |  |
+| array_flow.rb:622:5:622:5 | a : Array [element 3] | array_flow.rb:623:9:623:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:622:9:622:31 | call to [] : Array [element 3] | array_flow.rb:622:5:622:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:622:19:622:30 | call to source | array_flow.rb:622:9:622:31 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:623:9:623:9 | a : Array [element 3] | array_flow.rb:623:24:623:24 | x | provenance |  |
 | array_flow.rb:623:24:623:24 | x | array_flow.rb:624:14:624:14 | x | provenance |  |
-| array_flow.rb:631:5:631:5 | a [element 3] | array_flow.rb:632:5:632:5 | a [element 3] | provenance |  |
-| array_flow.rb:631:9:631:29 | call to [] [element 3] | array_flow.rb:631:5:631:5 | a [element 3] | provenance |  |
-| array_flow.rb:631:19:631:28 | call to source | array_flow.rb:631:9:631:29 | call to [] [element 3] | provenance |  |
-| array_flow.rb:632:5:632:5 | a [element 3] | array_flow.rb:632:17:632:17 | x | provenance |  |
+| array_flow.rb:631:5:631:5 | a : Array [element 3] | array_flow.rb:632:5:632:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:631:9:631:29 | call to [] : Array [element 3] | array_flow.rb:631:5:631:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:631:19:631:28 | call to source | array_flow.rb:631:9:631:29 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:632:5:632:5 | a : Array [element 3] | array_flow.rb:632:17:632:17 | x | provenance |  |
 | array_flow.rb:632:17:632:17 | x | array_flow.rb:633:14:633:14 | x | provenance |  |
-| array_flow.rb:638:5:638:5 | a [element 0] | array_flow.rb:639:9:639:9 | a [element 0] | provenance |  |
-| array_flow.rb:638:5:638:5 | a [element 0] | array_flow.rb:645:9:645:9 | a [element 0] | provenance |  |
-| array_flow.rb:638:5:638:5 | a [element 2] | array_flow.rb:639:9:639:9 | a [element 2] | provenance |  |
-| array_flow.rb:638:5:638:5 | a [element 2] | array_flow.rb:645:9:645:9 | a [element 2] | provenance |  |
-| array_flow.rb:638:9:638:39 | call to [] [element 0] | array_flow.rb:638:5:638:5 | a [element 0] | provenance |  |
-| array_flow.rb:638:9:638:39 | call to [] [element 2] | array_flow.rb:638:5:638:5 | a [element 2] | provenance |  |
-| array_flow.rb:638:10:638:21 | call to source | array_flow.rb:638:9:638:39 | call to [] [element 0] | provenance |  |
-| array_flow.rb:638:27:638:38 | call to source | array_flow.rb:638:9:638:39 | call to [] [element 2] | provenance |  |
+| array_flow.rb:638:5:638:5 | a : Array [element 0] | array_flow.rb:639:9:639:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:638:5:638:5 | a : Array [element 0] | array_flow.rb:645:9:645:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:638:5:638:5 | a : Array [element 2] | array_flow.rb:639:9:639:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:638:5:638:5 | a : Array [element 2] | array_flow.rb:645:9:645:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:638:9:638:39 | call to [] : Array [element 0] | array_flow.rb:638:5:638:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:638:9:638:39 | call to [] : Array [element 2] | array_flow.rb:638:5:638:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:638:10:638:21 | call to source | array_flow.rb:638:9:638:39 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:638:27:638:38 | call to source | array_flow.rb:638:9:638:39 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:639:5:639:5 | b | array_flow.rb:644:10:644:10 | b | provenance |  |
-| array_flow.rb:639:9:639:9 | a [element 0] | array_flow.rb:639:22:639:22 | x | provenance |  |
-| array_flow.rb:639:9:639:9 | a [element 2] | array_flow.rb:639:25:639:25 | y | provenance |  |
+| array_flow.rb:639:9:639:9 | a : Array [element 0] | array_flow.rb:639:22:639:22 | x | provenance |  |
+| array_flow.rb:639:9:639:9 | a : Array [element 2] | array_flow.rb:639:25:639:25 | y | provenance |  |
 | array_flow.rb:639:9:643:7 | call to inject | array_flow.rb:639:5:639:5 | b | provenance |  |
 | array_flow.rb:639:22:639:22 | x | array_flow.rb:640:14:640:14 | x | provenance |  |
 | array_flow.rb:639:25:639:25 | y | array_flow.rb:641:14:641:14 | y | provenance |  |
 | array_flow.rb:642:9:642:19 | call to source | array_flow.rb:639:9:643:7 | call to inject | provenance |  |
 | array_flow.rb:645:5:645:5 | c | array_flow.rb:650:10:650:10 | c | provenance |  |
-| array_flow.rb:645:9:645:9 | a [element 0] | array_flow.rb:645:28:645:28 | y | provenance |  |
-| array_flow.rb:645:9:645:9 | a [element 2] | array_flow.rb:645:28:645:28 | y | provenance |  |
+| array_flow.rb:645:9:645:9 | a : Array [element 0] | array_flow.rb:645:28:645:28 | y | provenance |  |
+| array_flow.rb:645:9:645:9 | a : Array [element 2] | array_flow.rb:645:28:645:28 | y | provenance |  |
 | array_flow.rb:645:9:649:7 | call to inject | array_flow.rb:645:5:645:5 | c | provenance |  |
 | array_flow.rb:645:28:645:28 | y | array_flow.rb:647:14:647:14 | y | provenance |  |
 | array_flow.rb:648:9:648:19 | call to source | array_flow.rb:645:9:649:7 | call to inject | provenance |  |
-| array_flow.rb:655:5:655:5 | a [element 2] | array_flow.rb:656:9:656:9 | a [element 2] | provenance |  |
-| array_flow.rb:655:9:655:28 | call to [] [element 2] | array_flow.rb:655:5:655:5 | a [element 2] | provenance |  |
-| array_flow.rb:655:16:655:27 | call to source | array_flow.rb:655:9:655:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:656:5:656:5 | b [element 1] | array_flow.rb:663:10:663:10 | b [element 1] | provenance |  |
-| array_flow.rb:656:5:656:5 | b [element 2] | array_flow.rb:664:10:664:10 | b [element 2] | provenance |  |
-| array_flow.rb:656:5:656:5 | b [element 4] | array_flow.rb:666:10:666:10 | b [element 4] | provenance |  |
-| array_flow.rb:656:9:656:9 | [post] a [element 1] | array_flow.rb:658:10:658:10 | a [element 1] | provenance |  |
-| array_flow.rb:656:9:656:9 | [post] a [element 2] | array_flow.rb:659:10:659:10 | a [element 2] | provenance |  |
-| array_flow.rb:656:9:656:9 | [post] a [element 4] | array_flow.rb:661:10:661:10 | a [element 4] | provenance |  |
-| array_flow.rb:656:9:656:9 | a [element 2] | array_flow.rb:656:9:656:9 | [post] a [element 4] | provenance |  |
-| array_flow.rb:656:9:656:9 | a [element 2] | array_flow.rb:656:9:656:47 | call to insert [element 4] | provenance |  |
-| array_flow.rb:656:9:656:47 | call to insert [element 1] | array_flow.rb:656:5:656:5 | b [element 1] | provenance |  |
-| array_flow.rb:656:9:656:47 | call to insert [element 2] | array_flow.rb:656:5:656:5 | b [element 2] | provenance |  |
-| array_flow.rb:656:9:656:47 | call to insert [element 4] | array_flow.rb:656:5:656:5 | b [element 4] | provenance |  |
-| array_flow.rb:656:21:656:32 | call to source | array_flow.rb:656:9:656:9 | [post] a [element 1] | provenance |  |
-| array_flow.rb:656:21:656:32 | call to source | array_flow.rb:656:9:656:47 | call to insert [element 1] | provenance |  |
-| array_flow.rb:656:35:656:46 | call to source | array_flow.rb:656:9:656:9 | [post] a [element 2] | provenance |  |
-| array_flow.rb:656:35:656:46 | call to source | array_flow.rb:656:9:656:47 | call to insert [element 2] | provenance |  |
-| array_flow.rb:658:10:658:10 | a [element 1] | array_flow.rb:658:10:658:13 | ...[...] | provenance |  |
-| array_flow.rb:659:10:659:10 | a [element 2] | array_flow.rb:659:10:659:13 | ...[...] | provenance |  |
-| array_flow.rb:661:10:661:10 | a [element 4] | array_flow.rb:661:10:661:13 | ...[...] | provenance |  |
-| array_flow.rb:663:10:663:10 | b [element 1] | array_flow.rb:663:10:663:13 | ...[...] | provenance |  |
-| array_flow.rb:664:10:664:10 | b [element 2] | array_flow.rb:664:10:664:13 | ...[...] | provenance |  |
-| array_flow.rb:666:10:666:10 | b [element 4] | array_flow.rb:666:10:666:13 | ...[...] | provenance |  |
-| array_flow.rb:669:5:669:5 | c [element 2] | array_flow.rb:670:9:670:9 | c [element 2] | provenance |  |
-| array_flow.rb:669:9:669:28 | call to [] [element 2] | array_flow.rb:669:5:669:5 | c [element 2] | provenance |  |
-| array_flow.rb:669:16:669:27 | call to source | array_flow.rb:669:9:669:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:670:5:670:5 | d [element] | array_flow.rb:672:10:672:10 | d [element] | provenance |  |
-| array_flow.rb:670:9:670:9 | [post] c [element] | array_flow.rb:671:10:671:10 | c [element] | provenance |  |
-| array_flow.rb:670:9:670:9 | c [element 2] | array_flow.rb:670:9:670:9 | [post] c [element] | provenance |  |
-| array_flow.rb:670:9:670:9 | c [element 2] | array_flow.rb:670:9:670:47 | call to insert [element] | provenance |  |
-| array_flow.rb:670:9:670:47 | call to insert [element] | array_flow.rb:670:5:670:5 | d [element] | provenance |  |
-| array_flow.rb:670:21:670:32 | call to source | array_flow.rb:670:9:670:9 | [post] c [element] | provenance |  |
-| array_flow.rb:670:21:670:32 | call to source | array_flow.rb:670:9:670:47 | call to insert [element] | provenance |  |
-| array_flow.rb:670:35:670:46 | call to source | array_flow.rb:670:9:670:9 | [post] c [element] | provenance |  |
-| array_flow.rb:670:35:670:46 | call to source | array_flow.rb:670:9:670:47 | call to insert [element] | provenance |  |
-| array_flow.rb:671:10:671:10 | c [element] | array_flow.rb:671:10:671:13 | ...[...] | provenance |  |
-| array_flow.rb:672:10:672:10 | d [element] | array_flow.rb:672:10:672:13 | ...[...] | provenance |  |
-| array_flow.rb:683:5:683:5 | a [element 2] | array_flow.rb:684:9:684:9 | a [element 2] | provenance |  |
-| array_flow.rb:683:9:683:28 | call to [] [element 2] | array_flow.rb:683:5:683:5 | a [element 2] | provenance |  |
-| array_flow.rb:683:16:683:27 | call to source | array_flow.rb:683:9:683:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:684:5:684:5 | b [element] | array_flow.rb:685:10:685:10 | b [element] | provenance |  |
-| array_flow.rb:684:9:684:9 | a [element 2] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
-| array_flow.rb:684:9:684:60 | call to intersection [element] | array_flow.rb:684:5:684:5 | b [element] | provenance |  |
-| array_flow.rb:684:24:684:43 | call to [] [element 2] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
-| array_flow.rb:684:31:684:42 | call to source | array_flow.rb:684:24:684:43 | call to [] [element 2] | provenance |  |
-| array_flow.rb:684:46:684:59 | call to [] [element 0] | array_flow.rb:684:9:684:60 | call to intersection [element] | provenance |  |
-| array_flow.rb:684:47:684:58 | call to source | array_flow.rb:684:46:684:59 | call to [] [element 0] | provenance |  |
-| array_flow.rb:685:10:685:10 | b [element] | array_flow.rb:685:10:685:13 | ...[...] | provenance |  |
-| array_flow.rb:689:5:689:5 | a [element 2] | array_flow.rb:690:9:690:9 | a [element 2] | provenance |  |
-| array_flow.rb:689:9:689:26 | call to [] [element 2] | array_flow.rb:689:5:689:5 | a [element 2] | provenance |  |
-| array_flow.rb:689:16:689:25 | call to source | array_flow.rb:689:9:689:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:690:5:690:5 | b [element] | array_flow.rb:695:10:695:10 | b [element] | provenance |  |
-| array_flow.rb:690:9:690:9 | [post] a [element] | array_flow.rb:694:10:694:10 | a [element] | provenance |  |
-| array_flow.rb:690:9:690:9 | a [element 2] | array_flow.rb:690:9:690:9 | [post] a [element] | provenance |  |
-| array_flow.rb:690:9:690:9 | a [element 2] | array_flow.rb:690:9:693:7 | call to keep_if [element] | provenance |  |
-| array_flow.rb:690:9:690:9 | a [element 2] | array_flow.rb:690:23:690:23 | x | provenance |  |
-| array_flow.rb:690:9:693:7 | call to keep_if [element] | array_flow.rb:690:5:690:5 | b [element] | provenance |  |
+| array_flow.rb:655:5:655:5 | a : Array [element 2] | array_flow.rb:656:9:656:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:655:9:655:28 | call to [] : Array [element 2] | array_flow.rb:655:5:655:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:655:16:655:27 | call to source | array_flow.rb:655:9:655:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 1] | array_flow.rb:663:10:663:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 2] | array_flow.rb:664:10:664:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 4] | array_flow.rb:666:10:666:10 | b : [collection] [element 4] | provenance |  |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 1] | array_flow.rb:658:10:658:10 | a : [collection] [element 1] | provenance |  |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 2] | array_flow.rb:659:10:659:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 4] | array_flow.rb:661:10:661:10 | a : [collection] [element 4] | provenance |  |
+| array_flow.rb:656:9:656:9 | a : Array [element 2] | array_flow.rb:656:9:656:9 | [post] a : [collection] [element 4] | provenance |  |
+| array_flow.rb:656:9:656:9 | a : Array [element 2] | array_flow.rb:656:9:656:47 | call to insert : [collection] [element 4] | provenance |  |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 1] | array_flow.rb:656:5:656:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 2] | array_flow.rb:656:5:656:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 4] | array_flow.rb:656:5:656:5 | b : [collection] [element 4] | provenance |  |
+| array_flow.rb:656:21:656:32 | call to source | array_flow.rb:656:9:656:9 | [post] a : [collection] [element 1] | provenance |  |
+| array_flow.rb:656:21:656:32 | call to source | array_flow.rb:656:9:656:47 | call to insert : [collection] [element 1] | provenance |  |
+| array_flow.rb:656:35:656:46 | call to source | array_flow.rb:656:9:656:9 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:656:35:656:46 | call to source | array_flow.rb:656:9:656:47 | call to insert : [collection] [element 2] | provenance |  |
+| array_flow.rb:658:10:658:10 | a : [collection] [element 1] | array_flow.rb:658:10:658:13 | ...[...] | provenance |  |
+| array_flow.rb:659:10:659:10 | a : [collection] [element 2] | array_flow.rb:659:10:659:13 | ...[...] | provenance |  |
+| array_flow.rb:661:10:661:10 | a : [collection] [element 4] | array_flow.rb:661:10:661:13 | ...[...] | provenance |  |
+| array_flow.rb:663:10:663:10 | b : [collection] [element 1] | array_flow.rb:663:10:663:13 | ...[...] | provenance |  |
+| array_flow.rb:664:10:664:10 | b : [collection] [element 2] | array_flow.rb:664:10:664:13 | ...[...] | provenance |  |
+| array_flow.rb:666:10:666:10 | b : [collection] [element 4] | array_flow.rb:666:10:666:13 | ...[...] | provenance |  |
+| array_flow.rb:669:5:669:5 | c : Array [element 2] | array_flow.rb:670:9:670:9 | c : Array [element 2] | provenance |  |
+| array_flow.rb:669:9:669:28 | call to [] : Array [element 2] | array_flow.rb:669:5:669:5 | c : Array [element 2] | provenance |  |
+| array_flow.rb:669:16:669:27 | call to source | array_flow.rb:669:9:669:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:670:5:670:5 | d : [collection] [element] | array_flow.rb:672:10:672:10 | d : [collection] [element] | provenance |  |
+| array_flow.rb:670:9:670:9 | [post] c : [collection] [element] | array_flow.rb:671:10:671:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:670:9:670:9 | c : Array [element 2] | array_flow.rb:670:9:670:9 | [post] c : [collection] [element] | provenance |  |
+| array_flow.rb:670:9:670:9 | c : Array [element 2] | array_flow.rb:670:9:670:47 | call to insert : [collection] [element] | provenance |  |
+| array_flow.rb:670:9:670:47 | call to insert : [collection] [element] | array_flow.rb:670:5:670:5 | d : [collection] [element] | provenance |  |
+| array_flow.rb:670:21:670:32 | call to source | array_flow.rb:670:9:670:9 | [post] c : [collection] [element] | provenance |  |
+| array_flow.rb:670:21:670:32 | call to source | array_flow.rb:670:9:670:47 | call to insert : [collection] [element] | provenance |  |
+| array_flow.rb:670:35:670:46 | call to source | array_flow.rb:670:9:670:9 | [post] c : [collection] [element] | provenance |  |
+| array_flow.rb:670:35:670:46 | call to source | array_flow.rb:670:9:670:47 | call to insert : [collection] [element] | provenance |  |
+| array_flow.rb:671:10:671:10 | c : [collection] [element] | array_flow.rb:671:10:671:13 | ...[...] | provenance |  |
+| array_flow.rb:672:10:672:10 | d : [collection] [element] | array_flow.rb:672:10:672:13 | ...[...] | provenance |  |
+| array_flow.rb:683:5:683:5 | a : Array [element 2] | array_flow.rb:684:9:684:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:683:9:683:28 | call to [] : Array [element 2] | array_flow.rb:683:5:683:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:683:16:683:27 | call to source | array_flow.rb:683:9:683:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:684:5:684:5 | b : [collection] [element] | array_flow.rb:685:10:685:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:684:9:684:9 | a : Array [element 2] | array_flow.rb:684:9:684:60 | call to intersection : [collection] [element] | provenance |  |
+| array_flow.rb:684:9:684:60 | call to intersection : [collection] [element] | array_flow.rb:684:5:684:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:684:24:684:43 | call to [] : Array [element 2] | array_flow.rb:684:9:684:60 | call to intersection : [collection] [element] | provenance |  |
+| array_flow.rb:684:31:684:42 | call to source | array_flow.rb:684:24:684:43 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:684:46:684:59 | call to [] : Array [element 0] | array_flow.rb:684:9:684:60 | call to intersection : [collection] [element] | provenance |  |
+| array_flow.rb:684:47:684:58 | call to source | array_flow.rb:684:46:684:59 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:685:10:685:10 | b : [collection] [element] | array_flow.rb:685:10:685:13 | ...[...] | provenance |  |
+| array_flow.rb:689:5:689:5 | a : Array [element 2] | array_flow.rb:690:9:690:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:689:9:689:26 | call to [] : Array [element 2] | array_flow.rb:689:5:689:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:689:16:689:25 | call to source | array_flow.rb:689:9:689:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:690:5:690:5 | b : [collection] [element] | array_flow.rb:695:10:695:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:690:9:690:9 | [post] a : [collection] [element] | array_flow.rb:694:10:694:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:690:9:690:9 | a : Array [element 2] | array_flow.rb:690:9:690:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:690:9:690:9 | a : Array [element 2] | array_flow.rb:690:9:693:7 | call to keep_if : [collection] [element] | provenance |  |
+| array_flow.rb:690:9:690:9 | a : Array [element 2] | array_flow.rb:690:23:690:23 | x | provenance |  |
+| array_flow.rb:690:9:693:7 | call to keep_if : [collection] [element] | array_flow.rb:690:5:690:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:690:23:690:23 | x | array_flow.rb:691:14:691:14 | x | provenance |  |
-| array_flow.rb:694:10:694:10 | a [element] | array_flow.rb:694:10:694:13 | ...[...] | provenance |  |
-| array_flow.rb:695:10:695:10 | b [element] | array_flow.rb:695:10:695:13 | ...[...] | provenance |  |
-| array_flow.rb:699:5:699:5 | a [element 2] | array_flow.rb:701:10:701:10 | a [element 2] | provenance |  |
-| array_flow.rb:699:5:699:5 | a [element 2] | array_flow.rb:702:9:702:9 | a [element 2] | provenance |  |
-| array_flow.rb:699:9:699:28 | call to [] [element 2] | array_flow.rb:699:5:699:5 | a [element 2] | provenance |  |
-| array_flow.rb:699:16:699:27 | call to source | array_flow.rb:699:9:699:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:700:5:700:5 | [post] a [element] | array_flow.rb:701:10:701:10 | a [element] | provenance |  |
-| array_flow.rb:700:5:700:5 | [post] a [element] | array_flow.rb:702:9:702:9 | a [element] | provenance |  |
-| array_flow.rb:700:12:700:23 | call to source | array_flow.rb:700:5:700:5 | [post] a [element] | provenance |  |
-| array_flow.rb:701:10:701:10 | a [element 2] | array_flow.rb:701:10:701:15 | call to last | provenance |  |
-| array_flow.rb:701:10:701:10 | a [element] | array_flow.rb:701:10:701:15 | call to last | provenance |  |
-| array_flow.rb:702:5:702:5 | b [element] | array_flow.rb:703:10:703:10 | b [element] | provenance |  |
-| array_flow.rb:702:5:702:5 | b [element] | array_flow.rb:704:10:704:10 | b [element] | provenance |  |
-| array_flow.rb:702:9:702:9 | a [element 2] | array_flow.rb:702:9:702:17 | call to last [element] | provenance |  |
-| array_flow.rb:702:9:702:9 | a [element] | array_flow.rb:702:9:702:17 | call to last [element] | provenance |  |
-| array_flow.rb:702:9:702:17 | call to last [element] | array_flow.rb:702:5:702:5 | b [element] | provenance |  |
-| array_flow.rb:703:10:703:10 | b [element] | array_flow.rb:703:10:703:13 | ...[...] | provenance |  |
-| array_flow.rb:704:10:704:10 | b [element] | array_flow.rb:704:10:704:13 | ...[...] | provenance |  |
-| array_flow.rb:708:5:708:5 | a [element 2] | array_flow.rb:709:9:709:9 | a [element 2] | provenance |  |
-| array_flow.rb:708:9:708:28 | call to [] [element 2] | array_flow.rb:708:5:708:5 | a [element 2] | provenance |  |
-| array_flow.rb:708:16:708:27 | call to source | array_flow.rb:708:9:708:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:709:5:709:5 | b [element] | array_flow.rb:713:10:713:10 | b [element] | provenance |  |
-| array_flow.rb:709:9:709:9 | a [element 2] | array_flow.rb:709:19:709:19 | x | provenance |  |
-| array_flow.rb:709:9:712:7 | call to map [element] | array_flow.rb:709:5:709:5 | b [element] | provenance |  |
+| array_flow.rb:694:10:694:10 | a : [collection] [element] | array_flow.rb:694:10:694:13 | ...[...] | provenance |  |
+| array_flow.rb:695:10:695:10 | b : [collection] [element] | array_flow.rb:695:10:695:13 | ...[...] | provenance |  |
+| array_flow.rb:699:5:699:5 | a : Array [element 2] | array_flow.rb:701:10:701:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:699:5:699:5 | a : Array [element 2] | array_flow.rb:702:9:702:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:699:9:699:28 | call to [] : Array [element 2] | array_flow.rb:699:5:699:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:699:16:699:27 | call to source | array_flow.rb:699:9:699:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:700:5:700:5 | [post] a : [collection] [element] | array_flow.rb:701:10:701:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:700:5:700:5 | [post] a : [collection] [element] | array_flow.rb:702:9:702:9 | a : [collection] [element] | provenance |  |
+| array_flow.rb:700:12:700:23 | call to source | array_flow.rb:700:5:700:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:701:10:701:10 | a : Array [element 2] | array_flow.rb:701:10:701:15 | call to last | provenance |  |
+| array_flow.rb:701:10:701:10 | a : [collection] [element] | array_flow.rb:701:10:701:15 | call to last | provenance |  |
+| array_flow.rb:702:5:702:5 | b : [collection] [element] | array_flow.rb:703:10:703:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:702:5:702:5 | b : [collection] [element] | array_flow.rb:704:10:704:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:702:9:702:9 | a : Array [element 2] | array_flow.rb:702:9:702:17 | call to last : [collection] [element] | provenance |  |
+| array_flow.rb:702:9:702:9 | a : [collection] [element] | array_flow.rb:702:9:702:17 | call to last : [collection] [element] | provenance |  |
+| array_flow.rb:702:9:702:17 | call to last : [collection] [element] | array_flow.rb:702:5:702:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:703:10:703:10 | b : [collection] [element] | array_flow.rb:703:10:703:13 | ...[...] | provenance |  |
+| array_flow.rb:704:10:704:10 | b : [collection] [element] | array_flow.rb:704:10:704:13 | ...[...] | provenance |  |
+| array_flow.rb:708:5:708:5 | a : Array [element 2] | array_flow.rb:709:9:709:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:708:9:708:28 | call to [] : Array [element 2] | array_flow.rb:708:5:708:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:708:16:708:27 | call to source | array_flow.rb:708:9:708:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:709:5:709:5 | b : [collection] [element] | array_flow.rb:713:10:713:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:709:9:709:9 | a : Array [element 2] | array_flow.rb:709:19:709:19 | x | provenance |  |
+| array_flow.rb:709:9:712:7 | call to map : [collection] [element] | array_flow.rb:709:5:709:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:709:19:709:19 | x | array_flow.rb:710:14:710:14 | x | provenance |  |
-| array_flow.rb:711:9:711:19 | call to source | array_flow.rb:709:9:712:7 | call to map [element] | provenance |  |
-| array_flow.rb:713:10:713:10 | b [element] | array_flow.rb:713:10:713:13 | ...[...] | provenance |  |
-| array_flow.rb:717:5:717:5 | a [element 2] | array_flow.rb:718:9:718:9 | a [element 2] | provenance |  |
-| array_flow.rb:717:9:717:28 | call to [] [element 2] | array_flow.rb:717:5:717:5 | a [element 2] | provenance |  |
-| array_flow.rb:717:16:717:27 | call to source | array_flow.rb:717:9:717:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:718:5:718:5 | b [element] | array_flow.rb:722:10:722:10 | b [element] | provenance |  |
-| array_flow.rb:718:9:718:9 | a [element 2] | array_flow.rb:718:20:718:20 | x | provenance |  |
-| array_flow.rb:718:9:721:7 | call to map! [element] | array_flow.rb:718:5:718:5 | b [element] | provenance |  |
+| array_flow.rb:711:9:711:19 | call to source | array_flow.rb:709:9:712:7 | call to map : [collection] [element] | provenance |  |
+| array_flow.rb:713:10:713:10 | b : [collection] [element] | array_flow.rb:713:10:713:13 | ...[...] | provenance |  |
+| array_flow.rb:717:5:717:5 | a : Array [element 2] | array_flow.rb:718:9:718:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:717:9:717:28 | call to [] : Array [element 2] | array_flow.rb:717:5:717:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:717:16:717:27 | call to source | array_flow.rb:717:9:717:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:718:5:718:5 | b : [collection] [element] | array_flow.rb:722:10:722:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:718:9:718:9 | a : Array [element 2] | array_flow.rb:718:20:718:20 | x | provenance |  |
+| array_flow.rb:718:9:721:7 | call to map! : [collection] [element] | array_flow.rb:718:5:718:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:718:20:718:20 | x | array_flow.rb:719:14:719:14 | x | provenance |  |
-| array_flow.rb:720:9:720:19 | call to source | array_flow.rb:718:9:721:7 | call to map! [element] | provenance |  |
-| array_flow.rb:722:10:722:10 | b [element] | array_flow.rb:722:10:722:13 | ...[...] | provenance |  |
-| array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:729:9:729:9 | a [element 2] | provenance |  |
-| array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:733:9:733:9 | a [element 2] | provenance |  |
-| array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:737:9:737:9 | a [element 2] | provenance |  |
-| array_flow.rb:726:5:726:5 | a [element 2] | array_flow.rb:745:9:745:9 | a [element 2] | provenance |  |
-| array_flow.rb:726:9:726:26 | call to [] [element 2] | array_flow.rb:726:5:726:5 | a [element 2] | provenance |  |
-| array_flow.rb:726:16:726:25 | call to source | array_flow.rb:726:9:726:26 | call to [] [element 2] | provenance |  |
+| array_flow.rb:720:9:720:19 | call to source | array_flow.rb:718:9:721:7 | call to map! : [collection] [element] | provenance |  |
+| array_flow.rb:722:10:722:10 | b : [collection] [element] | array_flow.rb:722:10:722:13 | ...[...] | provenance |  |
+| array_flow.rb:726:5:726:5 | a : Array [element 2] | array_flow.rb:729:9:729:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:726:5:726:5 | a : Array [element 2] | array_flow.rb:733:9:733:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:726:5:726:5 | a : Array [element 2] | array_flow.rb:737:9:737:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:726:5:726:5 | a : Array [element 2] | array_flow.rb:745:9:745:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:726:9:726:26 | call to [] : Array [element 2] | array_flow.rb:726:5:726:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:726:16:726:25 | call to source | array_flow.rb:726:9:726:26 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:729:5:729:5 | b | array_flow.rb:730:10:730:10 | b | provenance |  |
-| array_flow.rb:729:9:729:9 | a [element 2] | array_flow.rb:729:9:729:13 | call to max | provenance |  |
+| array_flow.rb:729:9:729:9 | a : Array [element 2] | array_flow.rb:729:9:729:13 | call to max | provenance |  |
 | array_flow.rb:729:9:729:13 | call to max | array_flow.rb:729:5:729:5 | b | provenance |  |
-| array_flow.rb:733:5:733:5 | c [element] | array_flow.rb:734:10:734:10 | c [element] | provenance |  |
-| array_flow.rb:733:9:733:9 | a [element 2] | array_flow.rb:733:9:733:16 | call to max [element] | provenance |  |
-| array_flow.rb:733:9:733:16 | call to max [element] | array_flow.rb:733:5:733:5 | c [element] | provenance |  |
-| array_flow.rb:734:10:734:10 | c [element] | array_flow.rb:734:10:734:13 | ...[...] | provenance |  |
+| array_flow.rb:733:5:733:5 | c : [collection] [element] | array_flow.rb:734:10:734:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:733:9:733:9 | a : Array [element 2] | array_flow.rb:733:9:733:16 | call to max : [collection] [element] | provenance |  |
+| array_flow.rb:733:9:733:16 | call to max : [collection] [element] | array_flow.rb:733:5:733:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:734:10:734:10 | c : [collection] [element] | array_flow.rb:734:10:734:13 | ...[...] | provenance |  |
 | array_flow.rb:737:5:737:5 | d | array_flow.rb:742:10:742:10 | d | provenance |  |
-| array_flow.rb:737:9:737:9 | a [element 2] | array_flow.rb:737:9:741:7 | call to max | provenance |  |
-| array_flow.rb:737:9:737:9 | a [element 2] | array_flow.rb:737:19:737:19 | x | provenance |  |
-| array_flow.rb:737:9:737:9 | a [element 2] | array_flow.rb:737:22:737:22 | y | provenance |  |
+| array_flow.rb:737:9:737:9 | a : Array [element 2] | array_flow.rb:737:9:741:7 | call to max | provenance |  |
+| array_flow.rb:737:9:737:9 | a : Array [element 2] | array_flow.rb:737:19:737:19 | x | provenance |  |
+| array_flow.rb:737:9:737:9 | a : Array [element 2] | array_flow.rb:737:22:737:22 | y | provenance |  |
 | array_flow.rb:737:9:741:7 | call to max | array_flow.rb:737:5:737:5 | d | provenance |  |
 | array_flow.rb:737:19:737:19 | x | array_flow.rb:738:14:738:14 | x | provenance |  |
 | array_flow.rb:737:22:737:22 | y | array_flow.rb:739:14:739:14 | y | provenance |  |
-| array_flow.rb:745:5:745:5 | e [element] | array_flow.rb:750:10:750:10 | e [element] | provenance |  |
-| array_flow.rb:745:9:745:9 | a [element 2] | array_flow.rb:745:9:749:7 | call to max [element] | provenance |  |
-| array_flow.rb:745:9:745:9 | a [element 2] | array_flow.rb:745:22:745:22 | x | provenance |  |
-| array_flow.rb:745:9:745:9 | a [element 2] | array_flow.rb:745:25:745:25 | y | provenance |  |
-| array_flow.rb:745:9:749:7 | call to max [element] | array_flow.rb:745:5:745:5 | e [element] | provenance |  |
+| array_flow.rb:745:5:745:5 | e : [collection] [element] | array_flow.rb:750:10:750:10 | e : [collection] [element] | provenance |  |
+| array_flow.rb:745:9:745:9 | a : Array [element 2] | array_flow.rb:745:9:749:7 | call to max : [collection] [element] | provenance |  |
+| array_flow.rb:745:9:745:9 | a : Array [element 2] | array_flow.rb:745:22:745:22 | x | provenance |  |
+| array_flow.rb:745:9:745:9 | a : Array [element 2] | array_flow.rb:745:25:745:25 | y | provenance |  |
+| array_flow.rb:745:9:749:7 | call to max : [collection] [element] | array_flow.rb:745:5:745:5 | e : [collection] [element] | provenance |  |
 | array_flow.rb:745:22:745:22 | x | array_flow.rb:746:14:746:14 | x | provenance |  |
 | array_flow.rb:745:25:745:25 | y | array_flow.rb:747:14:747:14 | y | provenance |  |
-| array_flow.rb:750:10:750:10 | e [element] | array_flow.rb:750:10:750:13 | ...[...] | provenance |  |
-| array_flow.rb:754:5:754:5 | a [element 2] | array_flow.rb:757:9:757:9 | a [element 2] | provenance |  |
-| array_flow.rb:754:5:754:5 | a [element 2] | array_flow.rb:764:9:764:9 | a [element 2] | provenance |  |
-| array_flow.rb:754:9:754:26 | call to [] [element 2] | array_flow.rb:754:5:754:5 | a [element 2] | provenance |  |
-| array_flow.rb:754:16:754:25 | call to source | array_flow.rb:754:9:754:26 | call to [] [element 2] | provenance |  |
+| array_flow.rb:750:10:750:10 | e : [collection] [element] | array_flow.rb:750:10:750:13 | ...[...] | provenance |  |
+| array_flow.rb:754:5:754:5 | a : Array [element 2] | array_flow.rb:757:9:757:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:754:5:754:5 | a : Array [element 2] | array_flow.rb:764:9:764:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:754:9:754:26 | call to [] : Array [element 2] | array_flow.rb:754:5:754:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:754:16:754:25 | call to source | array_flow.rb:754:9:754:26 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:757:5:757:5 | b | array_flow.rb:761:10:761:10 | b | provenance |  |
-| array_flow.rb:757:9:757:9 | a [element 2] | array_flow.rb:757:9:760:7 | call to max_by | provenance |  |
-| array_flow.rb:757:9:757:9 | a [element 2] | array_flow.rb:757:22:757:22 | x | provenance |  |
+| array_flow.rb:757:9:757:9 | a : Array [element 2] | array_flow.rb:757:9:760:7 | call to max_by | provenance |  |
+| array_flow.rb:757:9:757:9 | a : Array [element 2] | array_flow.rb:757:22:757:22 | x | provenance |  |
 | array_flow.rb:757:9:760:7 | call to max_by | array_flow.rb:757:5:757:5 | b | provenance |  |
 | array_flow.rb:757:22:757:22 | x | array_flow.rb:758:14:758:14 | x | provenance |  |
-| array_flow.rb:764:5:764:5 | c [element] | array_flow.rb:768:10:768:10 | c [element] | provenance |  |
-| array_flow.rb:764:9:764:9 | a [element 2] | array_flow.rb:764:9:767:7 | call to max_by [element] | provenance |  |
-| array_flow.rb:764:9:764:9 | a [element 2] | array_flow.rb:764:25:764:25 | x | provenance |  |
-| array_flow.rb:764:9:767:7 | call to max_by [element] | array_flow.rb:764:5:764:5 | c [element] | provenance |  |
+| array_flow.rb:764:5:764:5 | c : [collection] [element] | array_flow.rb:768:10:768:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:764:9:764:9 | a : Array [element 2] | array_flow.rb:764:9:767:7 | call to max_by : [collection] [element] | provenance |  |
+| array_flow.rb:764:9:764:9 | a : Array [element 2] | array_flow.rb:764:25:764:25 | x | provenance |  |
+| array_flow.rb:764:9:767:7 | call to max_by : [collection] [element] | array_flow.rb:764:5:764:5 | c : [collection] [element] | provenance |  |
 | array_flow.rb:764:25:764:25 | x | array_flow.rb:765:14:765:14 | x | provenance |  |
-| array_flow.rb:768:10:768:10 | c [element] | array_flow.rb:768:10:768:13 | ...[...] | provenance |  |
-| array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:775:9:775:9 | a [element 2] | provenance |  |
-| array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:779:9:779:9 | a [element 2] | provenance |  |
-| array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:783:9:783:9 | a [element 2] | provenance |  |
-| array_flow.rb:772:5:772:5 | a [element 2] | array_flow.rb:791:9:791:9 | a [element 2] | provenance |  |
-| array_flow.rb:772:9:772:26 | call to [] [element 2] | array_flow.rb:772:5:772:5 | a [element 2] | provenance |  |
-| array_flow.rb:772:16:772:25 | call to source | array_flow.rb:772:9:772:26 | call to [] [element 2] | provenance |  |
+| array_flow.rb:768:10:768:10 | c : [collection] [element] | array_flow.rb:768:10:768:13 | ...[...] | provenance |  |
+| array_flow.rb:772:5:772:5 | a : Array [element 2] | array_flow.rb:775:9:775:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:772:5:772:5 | a : Array [element 2] | array_flow.rb:779:9:779:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:772:5:772:5 | a : Array [element 2] | array_flow.rb:783:9:783:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:772:5:772:5 | a : Array [element 2] | array_flow.rb:791:9:791:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:772:9:772:26 | call to [] : Array [element 2] | array_flow.rb:772:5:772:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:772:16:772:25 | call to source | array_flow.rb:772:9:772:26 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:775:5:775:5 | b | array_flow.rb:776:10:776:10 | b | provenance |  |
-| array_flow.rb:775:9:775:9 | a [element 2] | array_flow.rb:775:9:775:13 | call to min | provenance |  |
+| array_flow.rb:775:9:775:9 | a : Array [element 2] | array_flow.rb:775:9:775:13 | call to min | provenance |  |
 | array_flow.rb:775:9:775:13 | call to min | array_flow.rb:775:5:775:5 | b | provenance |  |
-| array_flow.rb:779:5:779:5 | c [element] | array_flow.rb:780:10:780:10 | c [element] | provenance |  |
-| array_flow.rb:779:9:779:9 | a [element 2] | array_flow.rb:779:9:779:16 | call to min [element] | provenance |  |
-| array_flow.rb:779:9:779:16 | call to min [element] | array_flow.rb:779:5:779:5 | c [element] | provenance |  |
-| array_flow.rb:780:10:780:10 | c [element] | array_flow.rb:780:10:780:13 | ...[...] | provenance |  |
+| array_flow.rb:779:5:779:5 | c : [collection] [element] | array_flow.rb:780:10:780:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:779:9:779:9 | a : Array [element 2] | array_flow.rb:779:9:779:16 | call to min : [collection] [element] | provenance |  |
+| array_flow.rb:779:9:779:16 | call to min : [collection] [element] | array_flow.rb:779:5:779:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:780:10:780:10 | c : [collection] [element] | array_flow.rb:780:10:780:13 | ...[...] | provenance |  |
 | array_flow.rb:783:5:783:5 | d | array_flow.rb:788:10:788:10 | d | provenance |  |
-| array_flow.rb:783:9:783:9 | a [element 2] | array_flow.rb:783:9:787:7 | call to min | provenance |  |
-| array_flow.rb:783:9:783:9 | a [element 2] | array_flow.rb:783:19:783:19 | x | provenance |  |
-| array_flow.rb:783:9:783:9 | a [element 2] | array_flow.rb:783:22:783:22 | y | provenance |  |
+| array_flow.rb:783:9:783:9 | a : Array [element 2] | array_flow.rb:783:9:787:7 | call to min | provenance |  |
+| array_flow.rb:783:9:783:9 | a : Array [element 2] | array_flow.rb:783:19:783:19 | x | provenance |  |
+| array_flow.rb:783:9:783:9 | a : Array [element 2] | array_flow.rb:783:22:783:22 | y | provenance |  |
 | array_flow.rb:783:9:787:7 | call to min | array_flow.rb:783:5:783:5 | d | provenance |  |
 | array_flow.rb:783:19:783:19 | x | array_flow.rb:784:14:784:14 | x | provenance |  |
 | array_flow.rb:783:22:783:22 | y | array_flow.rb:785:14:785:14 | y | provenance |  |
-| array_flow.rb:791:5:791:5 | e [element] | array_flow.rb:796:10:796:10 | e [element] | provenance |  |
-| array_flow.rb:791:9:791:9 | a [element 2] | array_flow.rb:791:9:795:7 | call to min [element] | provenance |  |
-| array_flow.rb:791:9:791:9 | a [element 2] | array_flow.rb:791:22:791:22 | x | provenance |  |
-| array_flow.rb:791:9:791:9 | a [element 2] | array_flow.rb:791:25:791:25 | y | provenance |  |
-| array_flow.rb:791:9:795:7 | call to min [element] | array_flow.rb:791:5:791:5 | e [element] | provenance |  |
+| array_flow.rb:791:5:791:5 | e : [collection] [element] | array_flow.rb:796:10:796:10 | e : [collection] [element] | provenance |  |
+| array_flow.rb:791:9:791:9 | a : Array [element 2] | array_flow.rb:791:9:795:7 | call to min : [collection] [element] | provenance |  |
+| array_flow.rb:791:9:791:9 | a : Array [element 2] | array_flow.rb:791:22:791:22 | x | provenance |  |
+| array_flow.rb:791:9:791:9 | a : Array [element 2] | array_flow.rb:791:25:791:25 | y | provenance |  |
+| array_flow.rb:791:9:795:7 | call to min : [collection] [element] | array_flow.rb:791:5:791:5 | e : [collection] [element] | provenance |  |
 | array_flow.rb:791:22:791:22 | x | array_flow.rb:792:14:792:14 | x | provenance |  |
 | array_flow.rb:791:25:791:25 | y | array_flow.rb:793:14:793:14 | y | provenance |  |
-| array_flow.rb:796:10:796:10 | e [element] | array_flow.rb:796:10:796:13 | ...[...] | provenance |  |
-| array_flow.rb:800:5:800:5 | a [element 2] | array_flow.rb:803:9:803:9 | a [element 2] | provenance |  |
-| array_flow.rb:800:5:800:5 | a [element 2] | array_flow.rb:810:9:810:9 | a [element 2] | provenance |  |
-| array_flow.rb:800:9:800:26 | call to [] [element 2] | array_flow.rb:800:5:800:5 | a [element 2] | provenance |  |
-| array_flow.rb:800:16:800:25 | call to source | array_flow.rb:800:9:800:26 | call to [] [element 2] | provenance |  |
+| array_flow.rb:796:10:796:10 | e : [collection] [element] | array_flow.rb:796:10:796:13 | ...[...] | provenance |  |
+| array_flow.rb:800:5:800:5 | a : Array [element 2] | array_flow.rb:803:9:803:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:800:5:800:5 | a : Array [element 2] | array_flow.rb:810:9:810:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:800:9:800:26 | call to [] : Array [element 2] | array_flow.rb:800:5:800:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:800:16:800:25 | call to source | array_flow.rb:800:9:800:26 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:803:5:803:5 | b | array_flow.rb:807:10:807:10 | b | provenance |  |
-| array_flow.rb:803:9:803:9 | a [element 2] | array_flow.rb:803:9:806:7 | call to min_by | provenance |  |
-| array_flow.rb:803:9:803:9 | a [element 2] | array_flow.rb:803:22:803:22 | x | provenance |  |
+| array_flow.rb:803:9:803:9 | a : Array [element 2] | array_flow.rb:803:9:806:7 | call to min_by | provenance |  |
+| array_flow.rb:803:9:803:9 | a : Array [element 2] | array_flow.rb:803:22:803:22 | x | provenance |  |
 | array_flow.rb:803:9:806:7 | call to min_by | array_flow.rb:803:5:803:5 | b | provenance |  |
 | array_flow.rb:803:22:803:22 | x | array_flow.rb:804:14:804:14 | x | provenance |  |
-| array_flow.rb:810:5:810:5 | c [element] | array_flow.rb:814:10:814:10 | c [element] | provenance |  |
-| array_flow.rb:810:9:810:9 | a [element 2] | array_flow.rb:810:9:813:7 | call to min_by [element] | provenance |  |
-| array_flow.rb:810:9:810:9 | a [element 2] | array_flow.rb:810:25:810:25 | x | provenance |  |
-| array_flow.rb:810:9:813:7 | call to min_by [element] | array_flow.rb:810:5:810:5 | c [element] | provenance |  |
+| array_flow.rb:810:5:810:5 | c : [collection] [element] | array_flow.rb:814:10:814:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:810:9:810:9 | a : Array [element 2] | array_flow.rb:810:9:813:7 | call to min_by : [collection] [element] | provenance |  |
+| array_flow.rb:810:9:810:9 | a : Array [element 2] | array_flow.rb:810:25:810:25 | x | provenance |  |
+| array_flow.rb:810:9:813:7 | call to min_by : [collection] [element] | array_flow.rb:810:5:810:5 | c : [collection] [element] | provenance |  |
 | array_flow.rb:810:25:810:25 | x | array_flow.rb:811:14:811:14 | x | provenance |  |
-| array_flow.rb:814:10:814:10 | c [element] | array_flow.rb:814:10:814:13 | ...[...] | provenance |  |
-| array_flow.rb:818:5:818:5 | a [element 2] | array_flow.rb:820:9:820:9 | a [element 2] | provenance |  |
-| array_flow.rb:818:5:818:5 | a [element 2] | array_flow.rb:824:9:824:9 | a [element 2] | provenance |  |
-| array_flow.rb:818:9:818:26 | call to [] [element 2] | array_flow.rb:818:5:818:5 | a [element 2] | provenance |  |
-| array_flow.rb:818:16:818:25 | call to source | array_flow.rb:818:9:818:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:820:5:820:5 | b [element] | array_flow.rb:821:10:821:10 | b [element] | provenance |  |
-| array_flow.rb:820:5:820:5 | b [element] | array_flow.rb:822:10:822:10 | b [element] | provenance |  |
-| array_flow.rb:820:9:820:9 | a [element 2] | array_flow.rb:820:9:820:16 | call to minmax [element] | provenance |  |
-| array_flow.rb:820:9:820:16 | call to minmax [element] | array_flow.rb:820:5:820:5 | b [element] | provenance |  |
-| array_flow.rb:821:10:821:10 | b [element] | array_flow.rb:821:10:821:13 | ...[...] | provenance |  |
-| array_flow.rb:822:10:822:10 | b [element] | array_flow.rb:822:10:822:13 | ...[...] | provenance |  |
-| array_flow.rb:824:5:824:5 | c [element] | array_flow.rb:829:10:829:10 | c [element] | provenance |  |
-| array_flow.rb:824:5:824:5 | c [element] | array_flow.rb:830:10:830:10 | c [element] | provenance |  |
-| array_flow.rb:824:9:824:9 | a [element 2] | array_flow.rb:824:9:828:7 | call to minmax [element] | provenance |  |
-| array_flow.rb:824:9:824:9 | a [element 2] | array_flow.rb:824:22:824:22 | x | provenance |  |
-| array_flow.rb:824:9:824:9 | a [element 2] | array_flow.rb:824:25:824:25 | y | provenance |  |
-| array_flow.rb:824:9:828:7 | call to minmax [element] | array_flow.rb:824:5:824:5 | c [element] | provenance |  |
+| array_flow.rb:814:10:814:10 | c : [collection] [element] | array_flow.rb:814:10:814:13 | ...[...] | provenance |  |
+| array_flow.rb:818:5:818:5 | a : Array [element 2] | array_flow.rb:820:9:820:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:818:5:818:5 | a : Array [element 2] | array_flow.rb:824:9:824:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:818:9:818:26 | call to [] : Array [element 2] | array_flow.rb:818:5:818:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:818:16:818:25 | call to source | array_flow.rb:818:9:818:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:820:5:820:5 | b : [collection] [element] | array_flow.rb:821:10:821:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:820:5:820:5 | b : [collection] [element] | array_flow.rb:822:10:822:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:820:9:820:9 | a : Array [element 2] | array_flow.rb:820:9:820:16 | call to minmax : [collection] [element] | provenance |  |
+| array_flow.rb:820:9:820:16 | call to minmax : [collection] [element] | array_flow.rb:820:5:820:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:821:10:821:10 | b : [collection] [element] | array_flow.rb:821:10:821:13 | ...[...] | provenance |  |
+| array_flow.rb:822:10:822:10 | b : [collection] [element] | array_flow.rb:822:10:822:13 | ...[...] | provenance |  |
+| array_flow.rb:824:5:824:5 | c : [collection] [element] | array_flow.rb:829:10:829:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:824:5:824:5 | c : [collection] [element] | array_flow.rb:830:10:830:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:824:9:824:9 | a : Array [element 2] | array_flow.rb:824:9:828:7 | call to minmax : [collection] [element] | provenance |  |
+| array_flow.rb:824:9:824:9 | a : Array [element 2] | array_flow.rb:824:22:824:22 | x | provenance |  |
+| array_flow.rb:824:9:824:9 | a : Array [element 2] | array_flow.rb:824:25:824:25 | y | provenance |  |
+| array_flow.rb:824:9:828:7 | call to minmax : [collection] [element] | array_flow.rb:824:5:824:5 | c : [collection] [element] | provenance |  |
 | array_flow.rb:824:22:824:22 | x | array_flow.rb:825:14:825:14 | x | provenance |  |
 | array_flow.rb:824:25:824:25 | y | array_flow.rb:826:14:826:14 | y | provenance |  |
-| array_flow.rb:829:10:829:10 | c [element] | array_flow.rb:829:10:829:13 | ...[...] | provenance |  |
-| array_flow.rb:830:10:830:10 | c [element] | array_flow.rb:830:10:830:13 | ...[...] | provenance |  |
-| array_flow.rb:834:5:834:5 | a [element 2] | array_flow.rb:835:9:835:9 | a [element 2] | provenance |  |
-| array_flow.rb:834:9:834:26 | call to [] [element 2] | array_flow.rb:834:5:834:5 | a [element 2] | provenance |  |
-| array_flow.rb:834:16:834:25 | call to source | array_flow.rb:834:9:834:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:835:5:835:5 | b [element] | array_flow.rb:839:10:839:10 | b [element] | provenance |  |
-| array_flow.rb:835:5:835:5 | b [element] | array_flow.rb:840:10:840:10 | b [element] | provenance |  |
-| array_flow.rb:835:9:835:9 | a [element 2] | array_flow.rb:835:9:838:7 | call to minmax_by [element] | provenance |  |
-| array_flow.rb:835:9:835:9 | a [element 2] | array_flow.rb:835:25:835:25 | x | provenance |  |
-| array_flow.rb:835:9:838:7 | call to minmax_by [element] | array_flow.rb:835:5:835:5 | b [element] | provenance |  |
+| array_flow.rb:829:10:829:10 | c : [collection] [element] | array_flow.rb:829:10:829:13 | ...[...] | provenance |  |
+| array_flow.rb:830:10:830:10 | c : [collection] [element] | array_flow.rb:830:10:830:13 | ...[...] | provenance |  |
+| array_flow.rb:834:5:834:5 | a : Array [element 2] | array_flow.rb:835:9:835:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:834:9:834:26 | call to [] : Array [element 2] | array_flow.rb:834:5:834:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:834:16:834:25 | call to source | array_flow.rb:834:9:834:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:835:5:835:5 | b : [collection] [element] | array_flow.rb:839:10:839:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:835:5:835:5 | b : [collection] [element] | array_flow.rb:840:10:840:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:835:9:835:9 | a : Array [element 2] | array_flow.rb:835:9:838:7 | call to minmax_by : [collection] [element] | provenance |  |
+| array_flow.rb:835:9:835:9 | a : Array [element 2] | array_flow.rb:835:25:835:25 | x | provenance |  |
+| array_flow.rb:835:9:838:7 | call to minmax_by : [collection] [element] | array_flow.rb:835:5:835:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:835:25:835:25 | x | array_flow.rb:836:14:836:14 | x | provenance |  |
-| array_flow.rb:839:10:839:10 | b [element] | array_flow.rb:839:10:839:13 | ...[...] | provenance |  |
-| array_flow.rb:840:10:840:10 | b [element] | array_flow.rb:840:10:840:13 | ...[...] | provenance |  |
-| array_flow.rb:844:5:844:5 | a [element 2] | array_flow.rb:845:5:845:5 | a [element 2] | provenance |  |
-| array_flow.rb:844:9:844:26 | call to [] [element 2] | array_flow.rb:844:5:844:5 | a [element 2] | provenance |  |
-| array_flow.rb:844:16:844:25 | call to source | array_flow.rb:844:9:844:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:845:5:845:5 | a [element 2] | array_flow.rb:845:17:845:17 | x | provenance |  |
+| array_flow.rb:839:10:839:10 | b : [collection] [element] | array_flow.rb:839:10:839:13 | ...[...] | provenance |  |
+| array_flow.rb:840:10:840:10 | b : [collection] [element] | array_flow.rb:840:10:840:13 | ...[...] | provenance |  |
+| array_flow.rb:844:5:844:5 | a : Array [element 2] | array_flow.rb:845:5:845:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:844:9:844:26 | call to [] : Array [element 2] | array_flow.rb:844:5:844:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:844:16:844:25 | call to source | array_flow.rb:844:9:844:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:845:5:845:5 | a : Array [element 2] | array_flow.rb:845:17:845:17 | x | provenance |  |
 | array_flow.rb:845:17:845:17 | x | array_flow.rb:846:14:846:14 | x | provenance |  |
-| array_flow.rb:853:5:853:5 | a [element 2] | array_flow.rb:854:5:854:5 | a [element 2] | provenance |  |
-| array_flow.rb:853:9:853:26 | call to [] [element 2] | array_flow.rb:853:5:853:5 | a [element 2] | provenance |  |
-| array_flow.rb:853:16:853:25 | call to source | array_flow.rb:853:9:853:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:854:5:854:5 | a [element 2] | array_flow.rb:854:16:854:16 | x | provenance |  |
+| array_flow.rb:853:5:853:5 | a : Array [element 2] | array_flow.rb:854:5:854:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:853:9:853:26 | call to [] : Array [element 2] | array_flow.rb:853:5:853:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:853:16:853:25 | call to source | array_flow.rb:853:9:853:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:854:5:854:5 | a : Array [element 2] | array_flow.rb:854:16:854:16 | x | provenance |  |
 | array_flow.rb:854:16:854:16 | x | array_flow.rb:855:14:855:14 | x | provenance |  |
-| array_flow.rb:866:5:866:5 | a [element 2] | array_flow.rb:867:9:867:9 | a [element 2] | provenance |  |
-| array_flow.rb:866:9:866:26 | call to [] [element 2] | array_flow.rb:866:5:866:5 | a [element 2] | provenance |  |
-| array_flow.rb:866:16:866:25 | call to source | array_flow.rb:866:9:866:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:867:5:867:5 | b [element, element] | array_flow.rb:871:10:871:10 | b [element, element] | provenance |  |
-| array_flow.rb:867:5:867:5 | b [element, element] | array_flow.rb:872:10:872:10 | b [element, element] | provenance |  |
-| array_flow.rb:867:9:867:9 | a [element 2] | array_flow.rb:867:9:870:7 | call to partition [element, element] | provenance |  |
-| array_flow.rb:867:9:867:9 | a [element 2] | array_flow.rb:867:25:867:25 | x | provenance |  |
-| array_flow.rb:867:9:870:7 | call to partition [element, element] | array_flow.rb:867:5:867:5 | b [element, element] | provenance |  |
+| array_flow.rb:866:5:866:5 | a : Array [element 2] | array_flow.rb:867:9:867:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:866:9:866:26 | call to [] : Array [element 2] | array_flow.rb:866:5:866:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:866:16:866:25 | call to source | array_flow.rb:866:9:866:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:867:5:867:5 | b : [collection] [element, element] | array_flow.rb:871:10:871:10 | b : [collection] [element, element] | provenance |  |
+| array_flow.rb:867:5:867:5 | b : [collection] [element, element] | array_flow.rb:872:10:872:10 | b : [collection] [element, element] | provenance |  |
+| array_flow.rb:867:9:867:9 | a : Array [element 2] | array_flow.rb:867:9:870:7 | call to partition : [collection] [element, element] | provenance |  |
+| array_flow.rb:867:9:867:9 | a : Array [element 2] | array_flow.rb:867:25:867:25 | x | provenance |  |
+| array_flow.rb:867:9:870:7 | call to partition : [collection] [element, element] | array_flow.rb:867:5:867:5 | b : [collection] [element, element] | provenance |  |
 | array_flow.rb:867:25:867:25 | x | array_flow.rb:868:14:868:14 | x | provenance |  |
-| array_flow.rb:871:10:871:10 | b [element, element] | array_flow.rb:871:10:871:13 | ...[...] [element] | provenance |  |
+| array_flow.rb:871:10:871:10 | b : [collection] [element, element] | array_flow.rb:871:10:871:13 | ...[...] [element] | provenance |  |
 | array_flow.rb:871:10:871:13 | ...[...] [element] | array_flow.rb:871:10:871:16 | ...[...] | provenance |  |
-| array_flow.rb:872:10:872:10 | b [element, element] | array_flow.rb:872:10:872:13 | ...[...] [element] | provenance |  |
+| array_flow.rb:872:10:872:10 | b : [collection] [element, element] | array_flow.rb:872:10:872:13 | ...[...] [element] | provenance |  |
 | array_flow.rb:872:10:872:13 | ...[...] [element] | array_flow.rb:872:10:872:16 | ...[...] | provenance |  |
-| array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:878:9:878:9 | a [element 2] | provenance |  |
-| array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:886:9:886:9 | a [element 2] | provenance |  |
-| array_flow.rb:876:5:876:5 | a [element 2] | array_flow.rb:893:9:893:9 | a [element 2] | provenance |  |
-| array_flow.rb:876:9:876:26 | call to [] [element 2] | array_flow.rb:876:5:876:5 | a [element 2] | provenance |  |
-| array_flow.rb:876:16:876:25 | call to source | array_flow.rb:876:9:876:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:878:5:878:5 | b [element 2] | array_flow.rb:884:10:884:10 | b [element 2] | provenance |  |
-| array_flow.rb:878:9:878:9 | a [element 2] | array_flow.rb:878:9:882:7 | call to permutation [element 2] | provenance |  |
-| array_flow.rb:878:9:878:9 | a [element 2] | array_flow.rb:878:27:878:27 | x [element] | provenance |  |
-| array_flow.rb:878:9:882:7 | call to permutation [element 2] | array_flow.rb:878:5:878:5 | b [element 2] | provenance |  |
-| array_flow.rb:878:27:878:27 | x [element] | array_flow.rb:879:14:879:14 | x [element] | provenance |  |
-| array_flow.rb:878:27:878:27 | x [element] | array_flow.rb:880:14:880:14 | x [element] | provenance |  |
-| array_flow.rb:878:27:878:27 | x [element] | array_flow.rb:881:14:881:14 | x [element] | provenance |  |
-| array_flow.rb:879:14:879:14 | x [element] | array_flow.rb:879:14:879:17 | ...[...] | provenance |  |
-| array_flow.rb:880:14:880:14 | x [element] | array_flow.rb:880:14:880:17 | ...[...] | provenance |  |
-| array_flow.rb:881:14:881:14 | x [element] | array_flow.rb:881:14:881:17 | ...[...] | provenance |  |
-| array_flow.rb:884:10:884:10 | b [element 2] | array_flow.rb:884:10:884:13 | ...[...] | provenance |  |
-| array_flow.rb:886:5:886:5 | c [element 2] | array_flow.rb:891:10:891:10 | c [element 2] | provenance |  |
-| array_flow.rb:886:5:886:5 | c [element 2] | array_flow.rb:898:10:898:10 | c [element 2] | provenance |  |
-| array_flow.rb:886:9:886:9 | a [element 2] | array_flow.rb:886:9:889:7 | call to permutation [element 2] | provenance |  |
-| array_flow.rb:886:9:886:9 | a [element 2] | array_flow.rb:886:30:886:30 | x [element] | provenance |  |
-| array_flow.rb:886:9:889:7 | call to permutation [element 2] | array_flow.rb:886:5:886:5 | c [element 2] | provenance |  |
-| array_flow.rb:886:30:886:30 | x [element] | array_flow.rb:887:14:887:14 | x [element] | provenance |  |
-| array_flow.rb:886:30:886:30 | x [element] | array_flow.rb:888:14:888:14 | x [element] | provenance |  |
-| array_flow.rb:887:14:887:14 | x [element] | array_flow.rb:887:14:887:17 | ...[...] | provenance |  |
-| array_flow.rb:888:14:888:14 | x [element] | array_flow.rb:888:14:888:17 | ...[...] | provenance |  |
-| array_flow.rb:891:10:891:10 | c [element 2] | array_flow.rb:891:10:891:13 | ...[...] | provenance |  |
-| array_flow.rb:893:9:893:9 | a [element 2] | array_flow.rb:893:30:893:30 | x [element] | provenance |  |
-| array_flow.rb:893:30:893:30 | x [element] | array_flow.rb:894:14:894:14 | x [element] | provenance |  |
-| array_flow.rb:893:30:893:30 | x [element] | array_flow.rb:895:14:895:14 | x [element] | provenance |  |
-| array_flow.rb:894:14:894:14 | x [element] | array_flow.rb:894:14:894:17 | ...[...] | provenance |  |
-| array_flow.rb:895:14:895:14 | x [element] | array_flow.rb:895:14:895:17 | ...[...] | provenance |  |
-| array_flow.rb:898:10:898:10 | c [element 2] | array_flow.rb:898:10:898:13 | ...[...] | provenance |  |
-| array_flow.rb:905:5:905:5 | a [element 1] | array_flow.rb:906:9:906:9 | a [element 1] | provenance |  |
-| array_flow.rb:905:5:905:5 | a [element 1] | array_flow.rb:909:10:909:10 | a [element 1] | provenance |  |
-| array_flow.rb:905:5:905:5 | a [element 3] | array_flow.rb:906:9:906:9 | a [element 3] | provenance |  |
-| array_flow.rb:905:5:905:5 | a [element 3] | array_flow.rb:911:10:911:10 | a [element 3] | provenance |  |
-| array_flow.rb:905:9:905:42 | call to [] [element 1] | array_flow.rb:905:5:905:5 | a [element 1] | provenance |  |
-| array_flow.rb:905:9:905:42 | call to [] [element 3] | array_flow.rb:905:5:905:5 | a [element 3] | provenance |  |
-| array_flow.rb:905:13:905:24 | call to source | array_flow.rb:905:9:905:42 | call to [] [element 1] | provenance |  |
-| array_flow.rb:905:30:905:41 | call to source | array_flow.rb:905:9:905:42 | call to [] [element 3] | provenance |  |
+| array_flow.rb:876:5:876:5 | a : Array [element 2] | array_flow.rb:878:9:878:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:876:5:876:5 | a : Array [element 2] | array_flow.rb:886:9:886:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:876:5:876:5 | a : Array [element 2] | array_flow.rb:893:9:893:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:876:9:876:26 | call to [] : Array [element 2] | array_flow.rb:876:5:876:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:876:16:876:25 | call to source | array_flow.rb:876:9:876:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:878:5:878:5 | b : Array [element 2] | array_flow.rb:884:10:884:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:878:9:878:9 | a : Array [element 2] | array_flow.rb:878:9:882:7 | call to permutation : Array [element 2] | provenance |  |
+| array_flow.rb:878:9:878:9 | a : Array [element 2] | array_flow.rb:878:27:878:27 | x : [collection] [element] | provenance |  |
+| array_flow.rb:878:9:882:7 | call to permutation : Array [element 2] | array_flow.rb:878:5:878:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:878:27:878:27 | x : [collection] [element] | array_flow.rb:879:14:879:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:878:27:878:27 | x : [collection] [element] | array_flow.rb:880:14:880:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:878:27:878:27 | x : [collection] [element] | array_flow.rb:881:14:881:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:879:14:879:14 | x : [collection] [element] | array_flow.rb:879:14:879:17 | ...[...] | provenance |  |
+| array_flow.rb:880:14:880:14 | x : [collection] [element] | array_flow.rb:880:14:880:17 | ...[...] | provenance |  |
+| array_flow.rb:881:14:881:14 | x : [collection] [element] | array_flow.rb:881:14:881:17 | ...[...] | provenance |  |
+| array_flow.rb:884:10:884:10 | b : Array [element 2] | array_flow.rb:884:10:884:13 | ...[...] | provenance |  |
+| array_flow.rb:886:5:886:5 | c : Array [element 2] | array_flow.rb:891:10:891:10 | c : Array [element 2] | provenance |  |
+| array_flow.rb:886:5:886:5 | c : Array [element 2] | array_flow.rb:898:10:898:10 | c : Array [element 2] | provenance |  |
+| array_flow.rb:886:9:886:9 | a : Array [element 2] | array_flow.rb:886:9:889:7 | call to permutation : Array [element 2] | provenance |  |
+| array_flow.rb:886:9:886:9 | a : Array [element 2] | array_flow.rb:886:30:886:30 | x : [collection] [element] | provenance |  |
+| array_flow.rb:886:9:889:7 | call to permutation : Array [element 2] | array_flow.rb:886:5:886:5 | c : Array [element 2] | provenance |  |
+| array_flow.rb:886:30:886:30 | x : [collection] [element] | array_flow.rb:887:14:887:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:886:30:886:30 | x : [collection] [element] | array_flow.rb:888:14:888:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:887:14:887:14 | x : [collection] [element] | array_flow.rb:887:14:887:17 | ...[...] | provenance |  |
+| array_flow.rb:888:14:888:14 | x : [collection] [element] | array_flow.rb:888:14:888:17 | ...[...] | provenance |  |
+| array_flow.rb:891:10:891:10 | c : Array [element 2] | array_flow.rb:891:10:891:13 | ...[...] | provenance |  |
+| array_flow.rb:893:9:893:9 | a : Array [element 2] | array_flow.rb:893:30:893:30 | x : [collection] [element] | provenance |  |
+| array_flow.rb:893:30:893:30 | x : [collection] [element] | array_flow.rb:894:14:894:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:893:30:893:30 | x : [collection] [element] | array_flow.rb:895:14:895:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:894:14:894:14 | x : [collection] [element] | array_flow.rb:894:14:894:17 | ...[...] | provenance |  |
+| array_flow.rb:895:14:895:14 | x : [collection] [element] | array_flow.rb:895:14:895:17 | ...[...] | provenance |  |
+| array_flow.rb:898:10:898:10 | c : Array [element 2] | array_flow.rb:898:10:898:13 | ...[...] | provenance |  |
+| array_flow.rb:905:5:905:5 | a : Array [element 1] | array_flow.rb:906:9:906:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:905:5:905:5 | a : Array [element 1] | array_flow.rb:909:10:909:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:905:5:905:5 | a : Array [element 3] | array_flow.rb:906:9:906:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:905:5:905:5 | a : Array [element 3] | array_flow.rb:911:10:911:10 | a : Array [element 3] | provenance |  |
+| array_flow.rb:905:9:905:42 | call to [] : Array [element 1] | array_flow.rb:905:5:905:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:905:9:905:42 | call to [] : Array [element 3] | array_flow.rb:905:5:905:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:905:13:905:24 | call to source | array_flow.rb:905:9:905:42 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:905:30:905:41 | call to source | array_flow.rb:905:9:905:42 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:906:5:906:5 | b | array_flow.rb:907:10:907:10 | b | provenance |  |
-| array_flow.rb:906:9:906:9 | a [element 1] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
-| array_flow.rb:906:9:906:9 | a [element 3] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
+| array_flow.rb:906:9:906:9 | a : Array [element 1] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
+| array_flow.rb:906:9:906:9 | a : Array [element 3] | array_flow.rb:906:9:906:13 | call to pop | provenance |  |
 | array_flow.rb:906:9:906:13 | call to pop | array_flow.rb:906:5:906:5 | b | provenance |  |
-| array_flow.rb:909:10:909:10 | a [element 1] | array_flow.rb:909:10:909:13 | ...[...] | provenance |  |
-| array_flow.rb:911:10:911:10 | a [element 3] | array_flow.rb:911:10:911:13 | ...[...] | provenance |  |
-| array_flow.rb:913:5:913:5 | a [element 1] | array_flow.rb:914:9:914:9 | a [element 1] | provenance |  |
-| array_flow.rb:913:5:913:5 | a [element 1] | array_flow.rb:918:10:918:10 | a [element 1] | provenance |  |
-| array_flow.rb:913:5:913:5 | a [element 3] | array_flow.rb:914:9:914:9 | a [element 3] | provenance |  |
-| array_flow.rb:913:5:913:5 | a [element 3] | array_flow.rb:920:10:920:10 | a [element 3] | provenance |  |
-| array_flow.rb:913:9:913:42 | call to [] [element 1] | array_flow.rb:913:5:913:5 | a [element 1] | provenance |  |
-| array_flow.rb:913:9:913:42 | call to [] [element 3] | array_flow.rb:913:5:913:5 | a [element 3] | provenance |  |
-| array_flow.rb:913:13:913:24 | call to source | array_flow.rb:913:9:913:42 | call to [] [element 1] | provenance |  |
-| array_flow.rb:913:30:913:41 | call to source | array_flow.rb:913:9:913:42 | call to [] [element 3] | provenance |  |
-| array_flow.rb:914:5:914:5 | b [element] | array_flow.rb:915:10:915:10 | b [element] | provenance |  |
-| array_flow.rb:914:5:914:5 | b [element] | array_flow.rb:916:10:916:10 | b [element] | provenance |  |
-| array_flow.rb:914:9:914:9 | a [element 1] | array_flow.rb:914:9:914:16 | call to pop [element] | provenance |  |
-| array_flow.rb:914:9:914:9 | a [element 3] | array_flow.rb:914:9:914:16 | call to pop [element] | provenance |  |
-| array_flow.rb:914:9:914:16 | call to pop [element] | array_flow.rb:914:5:914:5 | b [element] | provenance |  |
-| array_flow.rb:915:10:915:10 | b [element] | array_flow.rb:915:10:915:13 | ...[...] | provenance |  |
-| array_flow.rb:916:10:916:10 | b [element] | array_flow.rb:916:10:916:13 | ...[...] | provenance |  |
-| array_flow.rb:918:10:918:10 | a [element 1] | array_flow.rb:918:10:918:13 | ...[...] | provenance |  |
-| array_flow.rb:920:10:920:10 | a [element 3] | array_flow.rb:920:10:920:13 | ...[...] | provenance |  |
-| array_flow.rb:924:5:924:5 | a [element 2] | array_flow.rb:925:5:925:5 | a [element 2] | provenance |  |
-| array_flow.rb:924:9:924:28 | call to [] [element 2] | array_flow.rb:924:5:924:5 | a [element 2] | provenance |  |
-| array_flow.rb:924:16:924:27 | call to source | array_flow.rb:924:9:924:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:925:5:925:5 | [post] a [element 2] | array_flow.rb:928:10:928:10 | a [element 2] | provenance |  |
-| array_flow.rb:925:5:925:5 | [post] a [element 5] | array_flow.rb:931:10:931:10 | a [element 5] | provenance |  |
-| array_flow.rb:925:5:925:5 | a [element 2] | array_flow.rb:925:5:925:5 | [post] a [element 5] | provenance |  |
-| array_flow.rb:925:21:925:32 | call to source | array_flow.rb:925:5:925:5 | [post] a [element 2] | provenance |  |
-| array_flow.rb:928:10:928:10 | a [element 2] | array_flow.rb:928:10:928:13 | ...[...] | provenance |  |
-| array_flow.rb:931:10:931:10 | a [element 5] | array_flow.rb:931:10:931:13 | ...[...] | provenance |  |
-| array_flow.rb:935:5:935:5 | a [element 2] | array_flow.rb:938:9:938:9 | a [element 2] | provenance |  |
-| array_flow.rb:935:9:935:28 | call to [] [element 2] | array_flow.rb:935:5:935:5 | a [element 2] | provenance |  |
-| array_flow.rb:935:16:935:27 | call to source | array_flow.rb:935:9:935:28 | call to [] [element 2] | provenance |  |
-| array_flow.rb:936:5:936:5 | b [element 1] | array_flow.rb:938:19:938:19 | b [element 1] | provenance |  |
-| array_flow.rb:936:9:936:28 | call to [] [element 1] | array_flow.rb:936:5:936:5 | b [element 1] | provenance |  |
-| array_flow.rb:936:13:936:24 | call to source | array_flow.rb:936:9:936:28 | call to [] [element 1] | provenance |  |
-| array_flow.rb:937:5:937:5 | c [element 0] | array_flow.rb:938:22:938:22 | c [element 0] | provenance |  |
-| array_flow.rb:937:9:937:28 | call to [] [element 0] | array_flow.rb:937:5:937:5 | c [element 0] | provenance |  |
-| array_flow.rb:937:10:937:21 | call to source | array_flow.rb:937:9:937:28 | call to [] [element 0] | provenance |  |
-| array_flow.rb:938:5:938:5 | d [element, element] | array_flow.rb:939:10:939:10 | d [element, element] | provenance |  |
-| array_flow.rb:938:5:938:5 | d [element, element] | array_flow.rb:940:10:940:10 | d [element, element] | provenance |  |
-| array_flow.rb:938:9:938:9 | a [element 2] | array_flow.rb:938:9:938:22 | call to product [element, element] | provenance |  |
-| array_flow.rb:938:9:938:22 | call to product [element, element] | array_flow.rb:938:5:938:5 | d [element, element] | provenance |  |
-| array_flow.rb:938:19:938:19 | b [element 1] | array_flow.rb:938:9:938:22 | call to product [element, element] | provenance |  |
-| array_flow.rb:938:22:938:22 | c [element 0] | array_flow.rb:938:9:938:22 | call to product [element, element] | provenance |  |
-| array_flow.rb:939:10:939:10 | d [element, element] | array_flow.rb:939:10:939:13 | ...[...] [element] | provenance |  |
+| array_flow.rb:909:10:909:10 | a : Array [element 1] | array_flow.rb:909:10:909:13 | ...[...] | provenance |  |
+| array_flow.rb:911:10:911:10 | a : Array [element 3] | array_flow.rb:911:10:911:13 | ...[...] | provenance |  |
+| array_flow.rb:913:5:913:5 | a : Array [element 1] | array_flow.rb:914:9:914:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:913:5:913:5 | a : Array [element 1] | array_flow.rb:918:10:918:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:913:5:913:5 | a : Array [element 3] | array_flow.rb:914:9:914:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:913:5:913:5 | a : Array [element 3] | array_flow.rb:920:10:920:10 | a : Array [element 3] | provenance |  |
+| array_flow.rb:913:9:913:42 | call to [] : Array [element 1] | array_flow.rb:913:5:913:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:913:9:913:42 | call to [] : Array [element 3] | array_flow.rb:913:5:913:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:913:13:913:24 | call to source | array_flow.rb:913:9:913:42 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:913:30:913:41 | call to source | array_flow.rb:913:9:913:42 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:914:5:914:5 | b : [collection] [element] | array_flow.rb:915:10:915:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:914:5:914:5 | b : [collection] [element] | array_flow.rb:916:10:916:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:914:9:914:9 | a : Array [element 1] | array_flow.rb:914:9:914:16 | call to pop : [collection] [element] | provenance |  |
+| array_flow.rb:914:9:914:9 | a : Array [element 3] | array_flow.rb:914:9:914:16 | call to pop : [collection] [element] | provenance |  |
+| array_flow.rb:914:9:914:16 | call to pop : [collection] [element] | array_flow.rb:914:5:914:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:915:10:915:10 | b : [collection] [element] | array_flow.rb:915:10:915:13 | ...[...] | provenance |  |
+| array_flow.rb:916:10:916:10 | b : [collection] [element] | array_flow.rb:916:10:916:13 | ...[...] | provenance |  |
+| array_flow.rb:918:10:918:10 | a : Array [element 1] | array_flow.rb:918:10:918:13 | ...[...] | provenance |  |
+| array_flow.rb:920:10:920:10 | a : Array [element 3] | array_flow.rb:920:10:920:13 | ...[...] | provenance |  |
+| array_flow.rb:924:5:924:5 | a : Array [element 2] | array_flow.rb:925:5:925:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:924:9:924:28 | call to [] : Array [element 2] | array_flow.rb:924:5:924:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:924:16:924:27 | call to source | array_flow.rb:924:9:924:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:925:5:925:5 | [post] a : [collection] [element 2] | array_flow.rb:928:10:928:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:925:5:925:5 | [post] a : [collection] [element 5] | array_flow.rb:931:10:931:10 | a : [collection] [element 5] | provenance |  |
+| array_flow.rb:925:5:925:5 | a : Array [element 2] | array_flow.rb:925:5:925:5 | [post] a : [collection] [element 5] | provenance |  |
+| array_flow.rb:925:21:925:32 | call to source | array_flow.rb:925:5:925:5 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:928:10:928:10 | a : [collection] [element 2] | array_flow.rb:928:10:928:13 | ...[...] | provenance |  |
+| array_flow.rb:931:10:931:10 | a : [collection] [element 5] | array_flow.rb:931:10:931:13 | ...[...] | provenance |  |
+| array_flow.rb:935:5:935:5 | a : Array [element 2] | array_flow.rb:938:9:938:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:935:9:935:28 | call to [] : Array [element 2] | array_flow.rb:935:5:935:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:935:16:935:27 | call to source | array_flow.rb:935:9:935:28 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:936:5:936:5 | b : Array [element 1] | array_flow.rb:938:19:938:19 | b : Array [element 1] | provenance |  |
+| array_flow.rb:936:9:936:28 | call to [] : Array [element 1] | array_flow.rb:936:5:936:5 | b : Array [element 1] | provenance |  |
+| array_flow.rb:936:13:936:24 | call to source | array_flow.rb:936:9:936:28 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:937:5:937:5 | c : Array [element 0] | array_flow.rb:938:22:938:22 | c : Array [element 0] | provenance |  |
+| array_flow.rb:937:9:937:28 | call to [] : Array [element 0] | array_flow.rb:937:5:937:5 | c : Array [element 0] | provenance |  |
+| array_flow.rb:937:10:937:21 | call to source | array_flow.rb:937:9:937:28 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:938:5:938:5 | d : [collection] [element, element] | array_flow.rb:939:10:939:10 | d : [collection] [element, element] | provenance |  |
+| array_flow.rb:938:5:938:5 | d : [collection] [element, element] | array_flow.rb:940:10:940:10 | d : [collection] [element, element] | provenance |  |
+| array_flow.rb:938:9:938:9 | a : Array [element 2] | array_flow.rb:938:9:938:22 | call to product : [collection] [element, element] | provenance |  |
+| array_flow.rb:938:9:938:22 | call to product : [collection] [element, element] | array_flow.rb:938:5:938:5 | d : [collection] [element, element] | provenance |  |
+| array_flow.rb:938:19:938:19 | b : Array [element 1] | array_flow.rb:938:9:938:22 | call to product : [collection] [element, element] | provenance |  |
+| array_flow.rb:938:22:938:22 | c : Array [element 0] | array_flow.rb:938:9:938:22 | call to product : [collection] [element, element] | provenance |  |
+| array_flow.rb:939:10:939:10 | d : [collection] [element, element] | array_flow.rb:939:10:939:13 | ...[...] [element] | provenance |  |
 | array_flow.rb:939:10:939:13 | ...[...] [element] | array_flow.rb:939:10:939:16 | ...[...] | provenance |  |
-| array_flow.rb:940:10:940:10 | d [element, element] | array_flow.rb:940:10:940:13 | ...[...] [element] | provenance |  |
+| array_flow.rb:940:10:940:10 | d : [collection] [element, element] | array_flow.rb:940:10:940:13 | ...[...] [element] | provenance |  |
 | array_flow.rb:940:10:940:13 | ...[...] [element] | array_flow.rb:940:10:940:16 | ...[...] | provenance |  |
-| array_flow.rb:944:5:944:5 | a [element 0] | array_flow.rb:945:9:945:9 | a [element 0] | provenance |  |
-| array_flow.rb:944:5:944:5 | a [element 0] | array_flow.rb:946:10:946:10 | a [element 0] | provenance |  |
-| array_flow.rb:944:9:944:25 | call to [] [element 0] | array_flow.rb:944:5:944:5 | a [element 0] | provenance |  |
-| array_flow.rb:944:10:944:21 | call to source | array_flow.rb:944:9:944:25 | call to [] [element 0] | provenance |  |
-| array_flow.rb:945:5:945:5 | b [element 0] | array_flow.rb:948:10:948:10 | b [element 0] | provenance |  |
-| array_flow.rb:945:5:945:5 | b [element] | array_flow.rb:948:10:948:10 | b [element] | provenance |  |
-| array_flow.rb:945:5:945:5 | b [element] | array_flow.rb:949:10:949:10 | b [element] | provenance |  |
-| array_flow.rb:945:9:945:9 | [post] a [element] | array_flow.rb:946:10:946:10 | a [element] | provenance |  |
-| array_flow.rb:945:9:945:9 | [post] a [element] | array_flow.rb:947:10:947:10 | a [element] | provenance |  |
-| array_flow.rb:945:9:945:9 | a [element 0] | array_flow.rb:945:9:945:44 | call to append [element 0] | provenance |  |
-| array_flow.rb:945:9:945:44 | call to append [element 0] | array_flow.rb:945:5:945:5 | b [element 0] | provenance |  |
-| array_flow.rb:945:9:945:44 | call to append [element] | array_flow.rb:945:5:945:5 | b [element] | provenance |  |
-| array_flow.rb:945:18:945:29 | call to source | array_flow.rb:945:9:945:9 | [post] a [element] | provenance |  |
-| array_flow.rb:945:18:945:29 | call to source | array_flow.rb:945:9:945:44 | call to append [element] | provenance |  |
-| array_flow.rb:945:32:945:43 | call to source | array_flow.rb:945:9:945:9 | [post] a [element] | provenance |  |
-| array_flow.rb:945:32:945:43 | call to source | array_flow.rb:945:9:945:44 | call to append [element] | provenance |  |
-| array_flow.rb:946:10:946:10 | a [element 0] | array_flow.rb:946:10:946:13 | ...[...] | provenance |  |
-| array_flow.rb:946:10:946:10 | a [element] | array_flow.rb:946:10:946:13 | ...[...] | provenance |  |
-| array_flow.rb:947:10:947:10 | a [element] | array_flow.rb:947:10:947:13 | ...[...] | provenance |  |
-| array_flow.rb:948:10:948:10 | b [element 0] | array_flow.rb:948:10:948:13 | ...[...] | provenance |  |
-| array_flow.rb:948:10:948:10 | b [element] | array_flow.rb:948:10:948:13 | ...[...] | provenance |  |
-| array_flow.rb:949:10:949:10 | b [element] | array_flow.rb:949:10:949:13 | ...[...] | provenance |  |
-| array_flow.rb:955:5:955:5 | c [element 0] | array_flow.rb:956:16:956:16 | c [element 0] | provenance |  |
-| array_flow.rb:955:9:955:25 | call to [] [element 0] | array_flow.rb:955:5:955:5 | c [element 0] | provenance |  |
-| array_flow.rb:955:10:955:19 | call to source | array_flow.rb:955:9:955:25 | call to [] [element 0] | provenance |  |
-| array_flow.rb:956:5:956:5 | d [element 2, element 0] | array_flow.rb:957:10:957:10 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:956:5:956:5 | d [element 2, element 0] | array_flow.rb:958:10:958:10 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | array_flow.rb:956:5:956:5 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:956:16:956:16 | c [element 0] | array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | provenance |  |
-| array_flow.rb:957:10:957:10 | d [element 2, element 0] | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | provenance |  |
+| array_flow.rb:944:5:944:5 | a : Array [element 0] | array_flow.rb:945:9:945:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:944:5:944:5 | a : Array [element 0] | array_flow.rb:946:10:946:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:944:9:944:25 | call to [] : Array [element 0] | array_flow.rb:944:5:944:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:944:10:944:21 | call to source | array_flow.rb:944:9:944:25 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:945:5:945:5 | b : Array [element 0] | array_flow.rb:948:10:948:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:945:5:945:5 | b : [collection] [element] | array_flow.rb:948:10:948:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:945:5:945:5 | b : [collection] [element] | array_flow.rb:949:10:949:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:945:9:945:9 | [post] a : [collection] [element] | array_flow.rb:946:10:946:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:945:9:945:9 | [post] a : [collection] [element] | array_flow.rb:947:10:947:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:945:9:945:9 | a : Array [element 0] | array_flow.rb:945:9:945:44 | call to append : Array [element 0] | provenance |  |
+| array_flow.rb:945:9:945:44 | call to append : Array [element 0] | array_flow.rb:945:5:945:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:945:9:945:44 | call to append : [collection] [element] | array_flow.rb:945:5:945:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:945:18:945:29 | call to source | array_flow.rb:945:9:945:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:945:18:945:29 | call to source | array_flow.rb:945:9:945:44 | call to append : [collection] [element] | provenance |  |
+| array_flow.rb:945:32:945:43 | call to source | array_flow.rb:945:9:945:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:945:32:945:43 | call to source | array_flow.rb:945:9:945:44 | call to append : [collection] [element] | provenance |  |
+| array_flow.rb:946:10:946:10 | a : Array [element 0] | array_flow.rb:946:10:946:13 | ...[...] | provenance |  |
+| array_flow.rb:946:10:946:10 | a : [collection] [element] | array_flow.rb:946:10:946:13 | ...[...] | provenance |  |
+| array_flow.rb:947:10:947:10 | a : [collection] [element] | array_flow.rb:947:10:947:13 | ...[...] | provenance |  |
+| array_flow.rb:948:10:948:10 | b : Array [element 0] | array_flow.rb:948:10:948:13 | ...[...] | provenance |  |
+| array_flow.rb:948:10:948:10 | b : [collection] [element] | array_flow.rb:948:10:948:13 | ...[...] | provenance |  |
+| array_flow.rb:949:10:949:10 | b : [collection] [element] | array_flow.rb:949:10:949:13 | ...[...] | provenance |  |
+| array_flow.rb:955:5:955:5 | c : Array [element 0] | array_flow.rb:956:16:956:16 | c : Array [element 0] | provenance |  |
+| array_flow.rb:955:9:955:25 | call to [] : Array [element 0] | array_flow.rb:955:5:955:5 | c : Array [element 0] | provenance |  |
+| array_flow.rb:955:10:955:19 | call to source | array_flow.rb:955:9:955:25 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:956:5:956:5 | d : Array [element 2, element 0] | array_flow.rb:957:10:957:10 | d : Array [element 2, element 0] | provenance |  |
+| array_flow.rb:956:5:956:5 | d : Array [element 2, element 0] | array_flow.rb:958:10:958:10 | d : Array [element 2, element 0] | provenance |  |
+| array_flow.rb:956:9:956:17 | call to [] : Array [element 2, element 0] | array_flow.rb:956:5:956:5 | d : Array [element 2, element 0] | provenance |  |
+| array_flow.rb:956:16:956:16 | c : Array [element 0] | array_flow.rb:956:9:956:17 | call to [] : Array [element 2, element 0] | provenance |  |
+| array_flow.rb:957:10:957:10 | d : Array [element 2, element 0] | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | provenance |  |
 | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | array_flow.rb:957:10:957:25 | ...[...] | provenance |  |
-| array_flow.rb:958:10:958:10 | d [element 2, element 0] | array_flow.rb:958:10:958:22 | call to rassoc [element 0] | provenance |  |
+| array_flow.rb:958:10:958:10 | d : Array [element 2, element 0] | array_flow.rb:958:10:958:22 | call to rassoc [element 0] | provenance |  |
 | array_flow.rb:958:10:958:22 | call to rassoc [element 0] | array_flow.rb:958:10:958:25 | ...[...] | provenance |  |
-| array_flow.rb:962:5:962:5 | a [element 0] | array_flow.rb:963:9:963:9 | a [element 0] | provenance |  |
-| array_flow.rb:962:5:962:5 | a [element 0] | array_flow.rb:968:9:968:9 | a [element 0] | provenance |  |
-| array_flow.rb:962:5:962:5 | a [element 2] | array_flow.rb:963:9:963:9 | a [element 2] | provenance |  |
-| array_flow.rb:962:5:962:5 | a [element 2] | array_flow.rb:968:9:968:9 | a [element 2] | provenance |  |
-| array_flow.rb:962:9:962:39 | call to [] [element 0] | array_flow.rb:962:5:962:5 | a [element 0] | provenance |  |
-| array_flow.rb:962:9:962:39 | call to [] [element 2] | array_flow.rb:962:5:962:5 | a [element 2] | provenance |  |
-| array_flow.rb:962:10:962:21 | call to source | array_flow.rb:962:9:962:39 | call to [] [element 0] | provenance |  |
-| array_flow.rb:962:27:962:38 | call to source | array_flow.rb:962:9:962:39 | call to [] [element 2] | provenance |  |
-| array_flow.rb:963:9:963:9 | a [element 0] | array_flow.rb:963:22:963:22 | x | provenance |  |
-| array_flow.rb:963:9:963:9 | a [element 2] | array_flow.rb:963:25:963:25 | y | provenance |  |
+| array_flow.rb:962:5:962:5 | a : Array [element 0] | array_flow.rb:963:9:963:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:962:5:962:5 | a : Array [element 0] | array_flow.rb:968:9:968:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:962:5:962:5 | a : Array [element 2] | array_flow.rb:963:9:963:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:962:5:962:5 | a : Array [element 2] | array_flow.rb:968:9:968:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:962:9:962:39 | call to [] : Array [element 0] | array_flow.rb:962:5:962:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:962:9:962:39 | call to [] : Array [element 2] | array_flow.rb:962:5:962:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:962:10:962:21 | call to source | array_flow.rb:962:9:962:39 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:962:27:962:38 | call to source | array_flow.rb:962:9:962:39 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:963:9:963:9 | a : Array [element 0] | array_flow.rb:963:22:963:22 | x | provenance |  |
+| array_flow.rb:963:9:963:9 | a : Array [element 2] | array_flow.rb:963:25:963:25 | y | provenance |  |
 | array_flow.rb:963:22:963:22 | x | array_flow.rb:964:14:964:14 | x | provenance |  |
 | array_flow.rb:963:25:963:25 | y | array_flow.rb:965:14:965:14 | y | provenance |  |
-| array_flow.rb:968:9:968:9 | a [element 0] | array_flow.rb:968:28:968:28 | y | provenance |  |
-| array_flow.rb:968:9:968:9 | a [element 2] | array_flow.rb:968:28:968:28 | y | provenance |  |
+| array_flow.rb:968:9:968:9 | a : Array [element 0] | array_flow.rb:968:28:968:28 | y | provenance |  |
+| array_flow.rb:968:9:968:9 | a : Array [element 2] | array_flow.rb:968:28:968:28 | y | provenance |  |
 | array_flow.rb:968:28:968:28 | y | array_flow.rb:970:14:970:14 | y | provenance |  |
-| array_flow.rb:976:5:976:5 | a [element 2] | array_flow.rb:977:9:977:9 | a [element 2] | provenance |  |
-| array_flow.rb:976:9:976:26 | call to [] [element 2] | array_flow.rb:976:5:976:5 | a [element 2] | provenance |  |
-| array_flow.rb:976:16:976:25 | call to source | array_flow.rb:976:9:976:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:977:5:977:5 | b [element] | array_flow.rb:981:10:981:10 | b [element] | provenance |  |
-| array_flow.rb:977:9:977:9 | a [element 2] | array_flow.rb:977:9:980:7 | call to reject [element] | provenance |  |
-| array_flow.rb:977:9:977:9 | a [element 2] | array_flow.rb:977:22:977:22 | x | provenance |  |
-| array_flow.rb:977:9:980:7 | call to reject [element] | array_flow.rb:977:5:977:5 | b [element] | provenance |  |
+| array_flow.rb:976:5:976:5 | a : Array [element 2] | array_flow.rb:977:9:977:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:976:9:976:26 | call to [] : Array [element 2] | array_flow.rb:976:5:976:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:976:16:976:25 | call to source | array_flow.rb:976:9:976:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:977:5:977:5 | b : [collection] [element] | array_flow.rb:981:10:981:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:977:9:977:9 | a : Array [element 2] | array_flow.rb:977:9:980:7 | call to reject : [collection] [element] | provenance |  |
+| array_flow.rb:977:9:977:9 | a : Array [element 2] | array_flow.rb:977:22:977:22 | x | provenance |  |
+| array_flow.rb:977:9:980:7 | call to reject : [collection] [element] | array_flow.rb:977:5:977:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:977:22:977:22 | x | array_flow.rb:978:14:978:14 | x | provenance |  |
-| array_flow.rb:981:10:981:10 | b [element] | array_flow.rb:981:10:981:13 | ...[...] | provenance |  |
-| array_flow.rb:985:5:985:5 | a [element 2] | array_flow.rb:986:9:986:9 | a [element 2] | provenance |  |
-| array_flow.rb:985:9:985:26 | call to [] [element 2] | array_flow.rb:985:5:985:5 | a [element 2] | provenance |  |
-| array_flow.rb:985:16:985:25 | call to source | array_flow.rb:985:9:985:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:986:5:986:5 | b [element] | array_flow.rb:991:10:991:10 | b [element] | provenance |  |
-| array_flow.rb:986:9:986:9 | [post] a [element] | array_flow.rb:990:10:990:10 | a [element] | provenance |  |
-| array_flow.rb:986:9:986:9 | a [element 2] | array_flow.rb:986:9:986:9 | [post] a [element] | provenance |  |
-| array_flow.rb:986:9:986:9 | a [element 2] | array_flow.rb:986:9:989:7 | call to reject! [element] | provenance |  |
-| array_flow.rb:986:9:986:9 | a [element 2] | array_flow.rb:986:23:986:23 | x | provenance |  |
-| array_flow.rb:986:9:989:7 | call to reject! [element] | array_flow.rb:986:5:986:5 | b [element] | provenance |  |
+| array_flow.rb:981:10:981:10 | b : [collection] [element] | array_flow.rb:981:10:981:13 | ...[...] | provenance |  |
+| array_flow.rb:985:5:985:5 | a : Array [element 2] | array_flow.rb:986:9:986:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:985:9:985:26 | call to [] : Array [element 2] | array_flow.rb:985:5:985:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:985:16:985:25 | call to source | array_flow.rb:985:9:985:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:986:5:986:5 | b : [collection] [element] | array_flow.rb:991:10:991:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:986:9:986:9 | [post] a : [collection] [element] | array_flow.rb:990:10:990:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:986:9:986:9 | a : Array [element 2] | array_flow.rb:986:9:986:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:986:9:986:9 | a : Array [element 2] | array_flow.rb:986:9:989:7 | call to reject! : [collection] [element] | provenance |  |
+| array_flow.rb:986:9:986:9 | a : Array [element 2] | array_flow.rb:986:23:986:23 | x | provenance |  |
+| array_flow.rb:986:9:989:7 | call to reject! : [collection] [element] | array_flow.rb:986:5:986:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:986:23:986:23 | x | array_flow.rb:987:14:987:14 | x | provenance |  |
-| array_flow.rb:990:10:990:10 | a [element] | array_flow.rb:990:10:990:13 | ...[...] | provenance |  |
-| array_flow.rb:991:10:991:10 | b [element] | array_flow.rb:991:10:991:13 | ...[...] | provenance |  |
-| array_flow.rb:995:5:995:5 | a [element 2] | array_flow.rb:996:9:996:9 | a [element 2] | provenance |  |
-| array_flow.rb:995:9:995:26 | call to [] [element 2] | array_flow.rb:995:5:995:5 | a [element 2] | provenance |  |
-| array_flow.rb:995:16:995:25 | call to source | array_flow.rb:995:9:995:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:996:5:996:5 | b [element 2] | array_flow.rb:1001:10:1001:10 | b [element 2] | provenance |  |
-| array_flow.rb:996:9:996:9 | a [element 2] | array_flow.rb:996:9:999:7 | call to repeated_combination [element 2] | provenance |  |
-| array_flow.rb:996:9:996:9 | a [element 2] | array_flow.rb:996:39:996:39 | x [element] | provenance |  |
-| array_flow.rb:996:9:999:7 | call to repeated_combination [element 2] | array_flow.rb:996:5:996:5 | b [element 2] | provenance |  |
-| array_flow.rb:996:39:996:39 | x [element] | array_flow.rb:997:14:997:14 | x [element] | provenance |  |
-| array_flow.rb:996:39:996:39 | x [element] | array_flow.rb:998:14:998:14 | x [element] | provenance |  |
-| array_flow.rb:997:14:997:14 | x [element] | array_flow.rb:997:14:997:17 | ...[...] | provenance |  |
-| array_flow.rb:998:14:998:14 | x [element] | array_flow.rb:998:14:998:17 | ...[...] | provenance |  |
-| array_flow.rb:1001:10:1001:10 | b [element 2] | array_flow.rb:1001:10:1001:13 | ...[...] | provenance |  |
-| array_flow.rb:1005:5:1005:5 | a [element 2] | array_flow.rb:1006:9:1006:9 | a [element 2] | provenance |  |
-| array_flow.rb:1005:9:1005:26 | call to [] [element 2] | array_flow.rb:1005:5:1005:5 | a [element 2] | provenance |  |
-| array_flow.rb:1005:16:1005:25 | call to source | array_flow.rb:1005:9:1005:26 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1006:5:1006:5 | b [element 2] | array_flow.rb:1011:10:1011:10 | b [element 2] | provenance |  |
-| array_flow.rb:1006:9:1006:9 | a [element 2] | array_flow.rb:1006:9:1009:7 | call to repeated_permutation [element 2] | provenance |  |
-| array_flow.rb:1006:9:1006:9 | a [element 2] | array_flow.rb:1006:39:1006:39 | x [element] | provenance |  |
-| array_flow.rb:1006:9:1009:7 | call to repeated_permutation [element 2] | array_flow.rb:1006:5:1006:5 | b [element 2] | provenance |  |
-| array_flow.rb:1006:39:1006:39 | x [element] | array_flow.rb:1007:14:1007:14 | x [element] | provenance |  |
-| array_flow.rb:1006:39:1006:39 | x [element] | array_flow.rb:1008:14:1008:14 | x [element] | provenance |  |
-| array_flow.rb:1007:14:1007:14 | x [element] | array_flow.rb:1007:14:1007:17 | ...[...] | provenance |  |
-| array_flow.rb:1008:14:1008:14 | x [element] | array_flow.rb:1008:14:1008:17 | ...[...] | provenance |  |
-| array_flow.rb:1011:10:1011:10 | b [element 2] | array_flow.rb:1011:10:1011:13 | ...[...] | provenance |  |
-| array_flow.rb:1017:5:1017:5 | b [element 0] | array_flow.rb:1019:10:1019:10 | b [element 0] | provenance |  |
-| array_flow.rb:1017:9:1017:9 | [post] a [element 0] | array_flow.rb:1018:10:1018:10 | a [element 0] | provenance |  |
-| array_flow.rb:1017:9:1017:33 | call to replace [element 0] | array_flow.rb:1017:5:1017:5 | b [element 0] | provenance |  |
-| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | array_flow.rb:1017:9:1017:9 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | array_flow.rb:1017:9:1017:33 | call to replace [element 0] | provenance |  |
-| array_flow.rb:1017:20:1017:31 | call to source | array_flow.rb:1017:19:1017:32 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1018:10:1018:10 | a [element 0] | array_flow.rb:1018:10:1018:13 | ...[...] | provenance |  |
-| array_flow.rb:1019:10:1019:10 | b [element 0] | array_flow.rb:1019:10:1019:13 | ...[...] | provenance |  |
-| array_flow.rb:1023:5:1023:5 | a [element 2] | array_flow.rb:1024:9:1024:9 | a [element 2] | provenance |  |
-| array_flow.rb:1023:5:1023:5 | a [element 2] | array_flow.rb:1029:10:1029:10 | a [element 2] | provenance |  |
-| array_flow.rb:1023:5:1023:5 | a [element 3] | array_flow.rb:1024:9:1024:9 | a [element 3] | provenance |  |
-| array_flow.rb:1023:5:1023:5 | a [element 3] | array_flow.rb:1030:10:1030:10 | a [element 3] | provenance |  |
-| array_flow.rb:1023:9:1023:44 | call to [] [element 2] | array_flow.rb:1023:5:1023:5 | a [element 2] | provenance |  |
-| array_flow.rb:1023:9:1023:44 | call to [] [element 3] | array_flow.rb:1023:5:1023:5 | a [element 3] | provenance |  |
-| array_flow.rb:1023:16:1023:28 | call to source | array_flow.rb:1023:9:1023:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1023:31:1023:43 | call to source | array_flow.rb:1023:9:1023:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1025:10:1025:10 | b [element] | provenance |  |
-| array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1026:10:1026:10 | b [element] | provenance |  |
-| array_flow.rb:1024:5:1024:5 | b [element] | array_flow.rb:1027:10:1027:10 | b [element] | provenance |  |
-| array_flow.rb:1024:9:1024:9 | a [element 2] | array_flow.rb:1024:9:1024:17 | call to reverse [element] | provenance |  |
-| array_flow.rb:1024:9:1024:9 | a [element 3] | array_flow.rb:1024:9:1024:17 | call to reverse [element] | provenance |  |
-| array_flow.rb:1024:9:1024:17 | call to reverse [element] | array_flow.rb:1024:5:1024:5 | b [element] | provenance |  |
-| array_flow.rb:1025:10:1025:10 | b [element] | array_flow.rb:1025:10:1025:13 | ...[...] | provenance |  |
-| array_flow.rb:1026:10:1026:10 | b [element] | array_flow.rb:1026:10:1026:13 | ...[...] | provenance |  |
-| array_flow.rb:1027:10:1027:10 | b [element] | array_flow.rb:1027:10:1027:13 | ...[...] | provenance |  |
-| array_flow.rb:1029:10:1029:10 | a [element 2] | array_flow.rb:1029:10:1029:13 | ...[...] | provenance |  |
-| array_flow.rb:1030:10:1030:10 | a [element 3] | array_flow.rb:1030:10:1030:13 | ...[...] | provenance |  |
-| array_flow.rb:1034:5:1034:5 | a [element 2] | array_flow.rb:1035:9:1035:9 | a [element 2] | provenance |  |
-| array_flow.rb:1034:5:1034:5 | a [element 2] | array_flow.rb:1040:10:1040:10 | a [element 2] | provenance |  |
-| array_flow.rb:1034:5:1034:5 | a [element 3] | array_flow.rb:1035:9:1035:9 | a [element 3] | provenance |  |
-| array_flow.rb:1034:5:1034:5 | a [element 3] | array_flow.rb:1041:10:1041:10 | a [element 3] | provenance |  |
-| array_flow.rb:1034:9:1034:44 | call to [] [element 2] | array_flow.rb:1034:5:1034:5 | a [element 2] | provenance |  |
-| array_flow.rb:1034:9:1034:44 | call to [] [element 3] | array_flow.rb:1034:5:1034:5 | a [element 3] | provenance |  |
-| array_flow.rb:1034:16:1034:28 | call to source | array_flow.rb:1034:9:1034:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1034:31:1034:43 | call to source | array_flow.rb:1034:9:1034:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1036:10:1036:10 | b [element] | provenance |  |
-| array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1037:10:1037:10 | b [element] | provenance |  |
-| array_flow.rb:1035:5:1035:5 | b [element] | array_flow.rb:1038:10:1038:10 | b [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | [post] a [element] | array_flow.rb:1039:10:1039:10 | a [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | [post] a [element] | array_flow.rb:1040:10:1040:10 | a [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | [post] a [element] | array_flow.rb:1041:10:1041:10 | a [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | a [element 2] | array_flow.rb:1035:9:1035:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | a [element 2] | array_flow.rb:1035:9:1035:18 | call to reverse! [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | a [element 3] | array_flow.rb:1035:9:1035:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1035:9:1035:9 | a [element 3] | array_flow.rb:1035:9:1035:18 | call to reverse! [element] | provenance |  |
-| array_flow.rb:1035:9:1035:18 | call to reverse! [element] | array_flow.rb:1035:5:1035:5 | b [element] | provenance |  |
-| array_flow.rb:1036:10:1036:10 | b [element] | array_flow.rb:1036:10:1036:13 | ...[...] | provenance |  |
-| array_flow.rb:1037:10:1037:10 | b [element] | array_flow.rb:1037:10:1037:13 | ...[...] | provenance |  |
-| array_flow.rb:1038:10:1038:10 | b [element] | array_flow.rb:1038:10:1038:13 | ...[...] | provenance |  |
-| array_flow.rb:1039:10:1039:10 | a [element] | array_flow.rb:1039:10:1039:13 | ...[...] | provenance |  |
-| array_flow.rb:1040:10:1040:10 | a [element 2] | array_flow.rb:1040:10:1040:13 | ...[...] | provenance |  |
-| array_flow.rb:1040:10:1040:10 | a [element] | array_flow.rb:1040:10:1040:13 | ...[...] | provenance |  |
-| array_flow.rb:1041:10:1041:10 | a [element 3] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
-| array_flow.rb:1041:10:1041:10 | a [element] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
-| array_flow.rb:1045:5:1045:5 | a [element 2] | array_flow.rb:1046:9:1046:9 | a [element 2] | provenance |  |
-| array_flow.rb:1045:9:1045:27 | call to [] [element 2] | array_flow.rb:1045:5:1045:5 | a [element 2] | provenance |  |
-| array_flow.rb:1045:16:1045:26 | call to source | array_flow.rb:1045:9:1045:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1046:5:1046:5 | b [element 2] | array_flow.rb:1049:10:1049:10 | b [element 2] | provenance |  |
-| array_flow.rb:1046:9:1046:9 | a [element 2] | array_flow.rb:1046:9:1048:7 | call to reverse_each [element 2] | provenance |  |
-| array_flow.rb:1046:9:1046:9 | a [element 2] | array_flow.rb:1046:28:1046:28 | x | provenance |  |
-| array_flow.rb:1046:9:1048:7 | call to reverse_each [element 2] | array_flow.rb:1046:5:1046:5 | b [element 2] | provenance |  |
+| array_flow.rb:990:10:990:10 | a : [collection] [element] | array_flow.rb:990:10:990:13 | ...[...] | provenance |  |
+| array_flow.rb:991:10:991:10 | b : [collection] [element] | array_flow.rb:991:10:991:13 | ...[...] | provenance |  |
+| array_flow.rb:995:5:995:5 | a : Array [element 2] | array_flow.rb:996:9:996:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:995:9:995:26 | call to [] : Array [element 2] | array_flow.rb:995:5:995:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:995:16:995:25 | call to source | array_flow.rb:995:9:995:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:996:5:996:5 | b : Array [element 2] | array_flow.rb:1001:10:1001:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:996:9:996:9 | a : Array [element 2] | array_flow.rb:996:9:999:7 | call to repeated_combination : Array [element 2] | provenance |  |
+| array_flow.rb:996:9:996:9 | a : Array [element 2] | array_flow.rb:996:39:996:39 | x : [collection] [element] | provenance |  |
+| array_flow.rb:996:9:999:7 | call to repeated_combination : Array [element 2] | array_flow.rb:996:5:996:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:996:39:996:39 | x : [collection] [element] | array_flow.rb:997:14:997:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:996:39:996:39 | x : [collection] [element] | array_flow.rb:998:14:998:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:997:14:997:14 | x : [collection] [element] | array_flow.rb:997:14:997:17 | ...[...] | provenance |  |
+| array_flow.rb:998:14:998:14 | x : [collection] [element] | array_flow.rb:998:14:998:17 | ...[...] | provenance |  |
+| array_flow.rb:1001:10:1001:10 | b : Array [element 2] | array_flow.rb:1001:10:1001:13 | ...[...] | provenance |  |
+| array_flow.rb:1005:5:1005:5 | a : Array [element 2] | array_flow.rb:1006:9:1006:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1005:9:1005:26 | call to [] : Array [element 2] | array_flow.rb:1005:5:1005:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1005:16:1005:25 | call to source | array_flow.rb:1005:9:1005:26 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1006:5:1006:5 | b : Array [element 2] | array_flow.rb:1011:10:1011:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1006:9:1006:9 | a : Array [element 2] | array_flow.rb:1006:9:1009:7 | call to repeated_permutation : Array [element 2] | provenance |  |
+| array_flow.rb:1006:9:1006:9 | a : Array [element 2] | array_flow.rb:1006:39:1006:39 | x : [collection] [element] | provenance |  |
+| array_flow.rb:1006:9:1009:7 | call to repeated_permutation : Array [element 2] | array_flow.rb:1006:5:1006:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1006:39:1006:39 | x : [collection] [element] | array_flow.rb:1007:14:1007:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:1006:39:1006:39 | x : [collection] [element] | array_flow.rb:1008:14:1008:14 | x : [collection] [element] | provenance |  |
+| array_flow.rb:1007:14:1007:14 | x : [collection] [element] | array_flow.rb:1007:14:1007:17 | ...[...] | provenance |  |
+| array_flow.rb:1008:14:1008:14 | x : [collection] [element] | array_flow.rb:1008:14:1008:17 | ...[...] | provenance |  |
+| array_flow.rb:1011:10:1011:10 | b : Array [element 2] | array_flow.rb:1011:10:1011:13 | ...[...] | provenance |  |
+| array_flow.rb:1017:5:1017:5 | b : Array [element 0] | array_flow.rb:1019:10:1019:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:1017:9:1017:9 | [post] a : Array [element 0] | array_flow.rb:1018:10:1018:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1017:9:1017:33 | call to replace : Array [element 0] | array_flow.rb:1017:5:1017:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:1017:19:1017:32 | call to [] : Array [element 0] | array_flow.rb:1017:9:1017:9 | [post] a : Array [element 0] | provenance |  |
+| array_flow.rb:1017:19:1017:32 | call to [] : Array [element 0] | array_flow.rb:1017:9:1017:33 | call to replace : Array [element 0] | provenance |  |
+| array_flow.rb:1017:20:1017:31 | call to source | array_flow.rb:1017:19:1017:32 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1018:10:1018:10 | a : Array [element 0] | array_flow.rb:1018:10:1018:13 | ...[...] | provenance |  |
+| array_flow.rb:1019:10:1019:10 | b : Array [element 0] | array_flow.rb:1019:10:1019:13 | ...[...] | provenance |  |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 2] | array_flow.rb:1024:9:1024:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 2] | array_flow.rb:1029:10:1029:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 3] | array_flow.rb:1024:9:1024:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 3] | array_flow.rb:1030:10:1030:10 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1023:9:1023:44 | call to [] : Array [element 2] | array_flow.rb:1023:5:1023:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1023:9:1023:44 | call to [] : Array [element 3] | array_flow.rb:1023:5:1023:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1023:16:1023:28 | call to source | array_flow.rb:1023:9:1023:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1023:31:1023:43 | call to source | array_flow.rb:1023:9:1023:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1024:5:1024:5 | b : [collection] [element] | array_flow.rb:1025:10:1025:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1024:5:1024:5 | b : [collection] [element] | array_flow.rb:1026:10:1026:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1024:5:1024:5 | b : [collection] [element] | array_flow.rb:1027:10:1027:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1024:9:1024:9 | a : Array [element 2] | array_flow.rb:1024:9:1024:17 | call to reverse : [collection] [element] | provenance |  |
+| array_flow.rb:1024:9:1024:9 | a : Array [element 3] | array_flow.rb:1024:9:1024:17 | call to reverse : [collection] [element] | provenance |  |
+| array_flow.rb:1024:9:1024:17 | call to reverse : [collection] [element] | array_flow.rb:1024:5:1024:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1025:10:1025:10 | b : [collection] [element] | array_flow.rb:1025:10:1025:13 | ...[...] | provenance |  |
+| array_flow.rb:1026:10:1026:10 | b : [collection] [element] | array_flow.rb:1026:10:1026:13 | ...[...] | provenance |  |
+| array_flow.rb:1027:10:1027:10 | b : [collection] [element] | array_flow.rb:1027:10:1027:13 | ...[...] | provenance |  |
+| array_flow.rb:1029:10:1029:10 | a : Array [element 2] | array_flow.rb:1029:10:1029:13 | ...[...] | provenance |  |
+| array_flow.rb:1030:10:1030:10 | a : Array [element 3] | array_flow.rb:1030:10:1030:13 | ...[...] | provenance |  |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 2] | array_flow.rb:1035:9:1035:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 2] | array_flow.rb:1040:10:1040:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 3] | array_flow.rb:1035:9:1035:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 3] | array_flow.rb:1041:10:1041:10 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1034:9:1034:44 | call to [] : Array [element 2] | array_flow.rb:1034:5:1034:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1034:9:1034:44 | call to [] : Array [element 3] | array_flow.rb:1034:5:1034:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1034:16:1034:28 | call to source | array_flow.rb:1034:9:1034:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1034:31:1034:43 | call to source | array_flow.rb:1034:9:1034:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1035:5:1035:5 | b : [collection] [element] | array_flow.rb:1036:10:1036:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1035:5:1035:5 | b : [collection] [element] | array_flow.rb:1037:10:1037:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1035:5:1035:5 | b : [collection] [element] | array_flow.rb:1038:10:1038:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | array_flow.rb:1039:10:1039:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | array_flow.rb:1040:10:1040:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | array_flow.rb:1041:10:1041:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 2] | array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 2] | array_flow.rb:1035:9:1035:18 | call to reverse! : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 3] | array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 3] | array_flow.rb:1035:9:1035:18 | call to reverse! : [collection] [element] | provenance |  |
+| array_flow.rb:1035:9:1035:18 | call to reverse! : [collection] [element] | array_flow.rb:1035:5:1035:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1036:10:1036:10 | b : [collection] [element] | array_flow.rb:1036:10:1036:13 | ...[...] | provenance |  |
+| array_flow.rb:1037:10:1037:10 | b : [collection] [element] | array_flow.rb:1037:10:1037:13 | ...[...] | provenance |  |
+| array_flow.rb:1038:10:1038:10 | b : [collection] [element] | array_flow.rb:1038:10:1038:13 | ...[...] | provenance |  |
+| array_flow.rb:1039:10:1039:10 | a : [collection] [element] | array_flow.rb:1039:10:1039:13 | ...[...] | provenance |  |
+| array_flow.rb:1040:10:1040:10 | a : Array [element 2] | array_flow.rb:1040:10:1040:13 | ...[...] | provenance |  |
+| array_flow.rb:1040:10:1040:10 | a : [collection] [element] | array_flow.rb:1040:10:1040:13 | ...[...] | provenance |  |
+| array_flow.rb:1041:10:1041:10 | a : Array [element 3] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
+| array_flow.rb:1041:10:1041:10 | a : [collection] [element] | array_flow.rb:1041:10:1041:13 | ...[...] | provenance |  |
+| array_flow.rb:1045:5:1045:5 | a : Array [element 2] | array_flow.rb:1046:9:1046:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1045:9:1045:27 | call to [] : Array [element 2] | array_flow.rb:1045:5:1045:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1045:16:1045:26 | call to source | array_flow.rb:1045:9:1045:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1046:5:1046:5 | b : Array [element 2] | array_flow.rb:1049:10:1049:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1046:9:1046:9 | a : Array [element 2] | array_flow.rb:1046:9:1048:7 | call to reverse_each : Array [element 2] | provenance |  |
+| array_flow.rb:1046:9:1046:9 | a : Array [element 2] | array_flow.rb:1046:28:1046:28 | x | provenance |  |
+| array_flow.rb:1046:9:1048:7 | call to reverse_each : Array [element 2] | array_flow.rb:1046:5:1046:5 | b : Array [element 2] | provenance |  |
 | array_flow.rb:1046:28:1046:28 | x | array_flow.rb:1047:14:1047:14 | x | provenance |  |
-| array_flow.rb:1049:10:1049:10 | b [element 2] | array_flow.rb:1049:10:1049:13 | ...[...] | provenance |  |
-| array_flow.rb:1053:5:1053:5 | a [element 2] | array_flow.rb:1054:5:1054:5 | a [element 2] | provenance |  |
-| array_flow.rb:1053:9:1053:27 | call to [] [element 2] | array_flow.rb:1053:5:1053:5 | a [element 2] | provenance |  |
-| array_flow.rb:1053:16:1053:26 | call to source | array_flow.rb:1053:9:1053:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1054:5:1054:5 | a [element 2] | array_flow.rb:1054:18:1054:18 | x | provenance |  |
+| array_flow.rb:1049:10:1049:10 | b : Array [element 2] | array_flow.rb:1049:10:1049:13 | ...[...] | provenance |  |
+| array_flow.rb:1053:5:1053:5 | a : Array [element 2] | array_flow.rb:1054:5:1054:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1053:9:1053:27 | call to [] : Array [element 2] | array_flow.rb:1053:5:1053:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1053:16:1053:26 | call to source | array_flow.rb:1053:9:1053:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1054:5:1054:5 | a : Array [element 2] | array_flow.rb:1054:18:1054:18 | x | provenance |  |
 | array_flow.rb:1054:18:1054:18 | x | array_flow.rb:1055:14:1055:14 | x | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 0] | array_flow.rb:1065:9:1065:9 | a [element 0] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 0] | array_flow.rb:1071:9:1071:9 | a [element 0] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 0] | array_flow.rb:1077:9:1077:9 | a [element 0] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 0] | array_flow.rb:1083:9:1083:9 | a [element 0] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 2] | array_flow.rb:1065:9:1065:9 | a [element 2] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 2] | array_flow.rb:1071:9:1071:9 | a [element 2] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 2] | array_flow.rb:1077:9:1077:9 | a [element 2] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 2] | array_flow.rb:1083:9:1083:9 | a [element 2] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1065:9:1065:9 | a [element 3] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1071:9:1071:9 | a [element 3] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1077:9:1077:9 | a [element 3] | provenance |  |
-| array_flow.rb:1063:5:1063:5 | a [element 3] | array_flow.rb:1083:9:1083:9 | a [element 3] | provenance |  |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 0] | array_flow.rb:1063:5:1063:5 | a [element 0] | provenance |  |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 2] | array_flow.rb:1063:5:1063:5 | a [element 2] | provenance |  |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 3] | array_flow.rb:1063:5:1063:5 | a [element 3] | provenance |  |
-| array_flow.rb:1063:10:1063:22 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1063:28:1063:40 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1063:43:1063:55 | call to source | array_flow.rb:1063:9:1063:56 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element 1] | array_flow.rb:1067:10:1067:10 | b [element 1] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element 2] | array_flow.rb:1068:10:1068:10 | b [element 2] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element] | array_flow.rb:1066:10:1066:10 | b [element] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element] | array_flow.rb:1067:10:1067:10 | b [element] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element] | array_flow.rb:1068:10:1068:10 | b [element] | provenance |  |
-| array_flow.rb:1065:5:1065:5 | b [element] | array_flow.rb:1069:10:1069:10 | b [element] | provenance |  |
-| array_flow.rb:1065:9:1065:9 | a [element 0] | array_flow.rb:1065:9:1065:16 | call to rotate [element] | provenance |  |
-| array_flow.rb:1065:9:1065:9 | a [element 2] | array_flow.rb:1065:9:1065:16 | call to rotate [element 1] | provenance |  |
-| array_flow.rb:1065:9:1065:9 | a [element 3] | array_flow.rb:1065:9:1065:16 | call to rotate [element 2] | provenance |  |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element 1] | array_flow.rb:1065:5:1065:5 | b [element 1] | provenance |  |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element 2] | array_flow.rb:1065:5:1065:5 | b [element 2] | provenance |  |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element] | array_flow.rb:1065:5:1065:5 | b [element] | provenance |  |
-| array_flow.rb:1066:10:1066:10 | b [element] | array_flow.rb:1066:10:1066:13 | ...[...] | provenance |  |
-| array_flow.rb:1067:10:1067:10 | b [element 1] | array_flow.rb:1067:10:1067:13 | ...[...] | provenance |  |
-| array_flow.rb:1067:10:1067:10 | b [element] | array_flow.rb:1067:10:1067:13 | ...[...] | provenance |  |
-| array_flow.rb:1068:10:1068:10 | b [element 2] | array_flow.rb:1068:10:1068:13 | ...[...] | provenance |  |
-| array_flow.rb:1068:10:1068:10 | b [element] | array_flow.rb:1068:10:1068:13 | ...[...] | provenance |  |
-| array_flow.rb:1069:10:1069:10 | b [element] | array_flow.rb:1069:10:1069:13 | ...[...] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element 0] | array_flow.rb:1072:10:1072:10 | b [element 0] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element 1] | array_flow.rb:1073:10:1073:10 | b [element 1] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element] | array_flow.rb:1072:10:1072:10 | b [element] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element] | array_flow.rb:1073:10:1073:10 | b [element] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element] | array_flow.rb:1074:10:1074:10 | b [element] | provenance |  |
-| array_flow.rb:1071:5:1071:5 | b [element] | array_flow.rb:1075:10:1075:10 | b [element] | provenance |  |
-| array_flow.rb:1071:9:1071:9 | a [element 0] | array_flow.rb:1071:9:1071:19 | call to rotate [element] | provenance |  |
-| array_flow.rb:1071:9:1071:9 | a [element 2] | array_flow.rb:1071:9:1071:19 | call to rotate [element 0] | provenance |  |
-| array_flow.rb:1071:9:1071:9 | a [element 3] | array_flow.rb:1071:9:1071:19 | call to rotate [element 1] | provenance |  |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element 0] | array_flow.rb:1071:5:1071:5 | b [element 0] | provenance |  |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element 1] | array_flow.rb:1071:5:1071:5 | b [element 1] | provenance |  |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element] | array_flow.rb:1071:5:1071:5 | b [element] | provenance |  |
-| array_flow.rb:1072:10:1072:10 | b [element 0] | array_flow.rb:1072:10:1072:13 | ...[...] | provenance |  |
-| array_flow.rb:1072:10:1072:10 | b [element] | array_flow.rb:1072:10:1072:13 | ...[...] | provenance |  |
-| array_flow.rb:1073:10:1073:10 | b [element 1] | array_flow.rb:1073:10:1073:13 | ...[...] | provenance |  |
-| array_flow.rb:1073:10:1073:10 | b [element] | array_flow.rb:1073:10:1073:13 | ...[...] | provenance |  |
-| array_flow.rb:1074:10:1074:10 | b [element] | array_flow.rb:1074:10:1074:13 | ...[...] | provenance |  |
-| array_flow.rb:1075:10:1075:10 | b [element] | array_flow.rb:1075:10:1075:13 | ...[...] | provenance |  |
-| array_flow.rb:1077:5:1077:5 | b [element 0] | array_flow.rb:1078:10:1078:10 | b [element 0] | provenance |  |
-| array_flow.rb:1077:5:1077:5 | b [element 2] | array_flow.rb:1080:10:1080:10 | b [element 2] | provenance |  |
-| array_flow.rb:1077:5:1077:5 | b [element 3] | array_flow.rb:1081:10:1081:10 | b [element 3] | provenance |  |
-| array_flow.rb:1077:9:1077:9 | a [element 0] | array_flow.rb:1077:9:1077:19 | call to rotate [element 0] | provenance |  |
-| array_flow.rb:1077:9:1077:9 | a [element 2] | array_flow.rb:1077:9:1077:19 | call to rotate [element 2] | provenance |  |
-| array_flow.rb:1077:9:1077:9 | a [element 3] | array_flow.rb:1077:9:1077:19 | call to rotate [element 3] | provenance |  |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 0] | array_flow.rb:1077:5:1077:5 | b [element 0] | provenance |  |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 2] | array_flow.rb:1077:5:1077:5 | b [element 2] | provenance |  |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 3] | array_flow.rb:1077:5:1077:5 | b [element 3] | provenance |  |
-| array_flow.rb:1078:10:1078:10 | b [element 0] | array_flow.rb:1078:10:1078:13 | ...[...] | provenance |  |
-| array_flow.rb:1080:10:1080:10 | b [element 2] | array_flow.rb:1080:10:1080:13 | ...[...] | provenance |  |
-| array_flow.rb:1081:10:1081:10 | b [element 3] | array_flow.rb:1081:10:1081:13 | ...[...] | provenance |  |
-| array_flow.rb:1083:5:1083:5 | b [element] | array_flow.rb:1084:10:1084:10 | b [element] | provenance |  |
-| array_flow.rb:1083:5:1083:5 | b [element] | array_flow.rb:1085:10:1085:10 | b [element] | provenance |  |
-| array_flow.rb:1083:5:1083:5 | b [element] | array_flow.rb:1086:10:1086:10 | b [element] | provenance |  |
-| array_flow.rb:1083:5:1083:5 | b [element] | array_flow.rb:1087:10:1087:10 | b [element] | provenance |  |
-| array_flow.rb:1083:9:1083:9 | a [element 0] | array_flow.rb:1083:9:1083:19 | call to rotate [element] | provenance |  |
-| array_flow.rb:1083:9:1083:9 | a [element 2] | array_flow.rb:1083:9:1083:19 | call to rotate [element] | provenance |  |
-| array_flow.rb:1083:9:1083:9 | a [element 3] | array_flow.rb:1083:9:1083:19 | call to rotate [element] | provenance |  |
-| array_flow.rb:1083:9:1083:19 | call to rotate [element] | array_flow.rb:1083:5:1083:5 | b [element] | provenance |  |
-| array_flow.rb:1084:10:1084:10 | b [element] | array_flow.rb:1084:10:1084:13 | ...[...] | provenance |  |
-| array_flow.rb:1085:10:1085:10 | b [element] | array_flow.rb:1085:10:1085:13 | ...[...] | provenance |  |
-| array_flow.rb:1086:10:1086:10 | b [element] | array_flow.rb:1086:10:1086:13 | ...[...] | provenance |  |
-| array_flow.rb:1087:10:1087:10 | b [element] | array_flow.rb:1087:10:1087:13 | ...[...] | provenance |  |
-| array_flow.rb:1095:5:1095:5 | a [element 0] | array_flow.rb:1096:9:1096:9 | a [element 0] | provenance |  |
-| array_flow.rb:1095:5:1095:5 | a [element 2] | array_flow.rb:1096:9:1096:9 | a [element 2] | provenance |  |
-| array_flow.rb:1095:5:1095:5 | a [element 3] | array_flow.rb:1096:9:1096:9 | a [element 3] | provenance |  |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 0] | array_flow.rb:1095:5:1095:5 | a [element 0] | provenance |  |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 2] | array_flow.rb:1095:5:1095:5 | a [element 2] | provenance |  |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 3] | array_flow.rb:1095:5:1095:5 | a [element 3] | provenance |  |
-| array_flow.rb:1095:10:1095:22 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1095:28:1095:40 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1095:43:1095:55 | call to source | array_flow.rb:1095:9:1095:56 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element 1] | array_flow.rb:1102:10:1102:10 | b [element 1] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element 2] | array_flow.rb:1103:10:1103:10 | b [element 2] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element] | array_flow.rb:1101:10:1101:10 | b [element] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element] | array_flow.rb:1102:10:1102:10 | b [element] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element] | array_flow.rb:1103:10:1103:10 | b [element] | provenance |  |
-| array_flow.rb:1096:5:1096:5 | b [element] | array_flow.rb:1104:10:1104:10 | b [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element 1] | array_flow.rb:1098:10:1098:10 | a [element 1] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element 2] | array_flow.rb:1099:10:1099:10 | a [element 2] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element] | array_flow.rb:1097:10:1097:10 | a [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element] | array_flow.rb:1098:10:1098:10 | a [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element] | array_flow.rb:1099:10:1099:10 | a [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | [post] a [element] | array_flow.rb:1100:10:1100:10 | a [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 0] | array_flow.rb:1096:9:1096:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 0] | array_flow.rb:1096:9:1096:17 | call to rotate! [element] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 2] | array_flow.rb:1096:9:1096:9 | [post] a [element 1] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 2] | array_flow.rb:1096:9:1096:17 | call to rotate! [element 1] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 3] | array_flow.rb:1096:9:1096:9 | [post] a [element 2] | provenance |  |
-| array_flow.rb:1096:9:1096:9 | a [element 3] | array_flow.rb:1096:9:1096:17 | call to rotate! [element 2] | provenance |  |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element 1] | array_flow.rb:1096:5:1096:5 | b [element 1] | provenance |  |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element 2] | array_flow.rb:1096:5:1096:5 | b [element 2] | provenance |  |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element] | array_flow.rb:1096:5:1096:5 | b [element] | provenance |  |
-| array_flow.rb:1097:10:1097:10 | a [element] | array_flow.rb:1097:10:1097:13 | ...[...] | provenance |  |
-| array_flow.rb:1098:10:1098:10 | a [element 1] | array_flow.rb:1098:10:1098:13 | ...[...] | provenance |  |
-| array_flow.rb:1098:10:1098:10 | a [element] | array_flow.rb:1098:10:1098:13 | ...[...] | provenance |  |
-| array_flow.rb:1099:10:1099:10 | a [element 2] | array_flow.rb:1099:10:1099:13 | ...[...] | provenance |  |
-| array_flow.rb:1099:10:1099:10 | a [element] | array_flow.rb:1099:10:1099:13 | ...[...] | provenance |  |
-| array_flow.rb:1100:10:1100:10 | a [element] | array_flow.rb:1100:10:1100:13 | ...[...] | provenance |  |
-| array_flow.rb:1101:10:1101:10 | b [element] | array_flow.rb:1101:10:1101:13 | ...[...] | provenance |  |
-| array_flow.rb:1102:10:1102:10 | b [element 1] | array_flow.rb:1102:10:1102:13 | ...[...] | provenance |  |
-| array_flow.rb:1102:10:1102:10 | b [element] | array_flow.rb:1102:10:1102:13 | ...[...] | provenance |  |
-| array_flow.rb:1103:10:1103:10 | b [element 2] | array_flow.rb:1103:10:1103:13 | ...[...] | provenance |  |
-| array_flow.rb:1103:10:1103:10 | b [element] | array_flow.rb:1103:10:1103:13 | ...[...] | provenance |  |
-| array_flow.rb:1104:10:1104:10 | b [element] | array_flow.rb:1104:10:1104:13 | ...[...] | provenance |  |
-| array_flow.rb:1106:5:1106:5 | a [element 0] | array_flow.rb:1107:9:1107:9 | a [element 0] | provenance |  |
-| array_flow.rb:1106:5:1106:5 | a [element 2] | array_flow.rb:1107:9:1107:9 | a [element 2] | provenance |  |
-| array_flow.rb:1106:5:1106:5 | a [element 3] | array_flow.rb:1107:9:1107:9 | a [element 3] | provenance |  |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 0] | array_flow.rb:1106:5:1106:5 | a [element 0] | provenance |  |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 2] | array_flow.rb:1106:5:1106:5 | a [element 2] | provenance |  |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 3] | array_flow.rb:1106:5:1106:5 | a [element 3] | provenance |  |
-| array_flow.rb:1106:10:1106:22 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1106:28:1106:40 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1106:43:1106:55 | call to source | array_flow.rb:1106:9:1106:56 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element 0] | array_flow.rb:1112:10:1112:10 | b [element 0] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element 1] | array_flow.rb:1113:10:1113:10 | b [element 1] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element] | array_flow.rb:1112:10:1112:10 | b [element] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element] | array_flow.rb:1113:10:1113:10 | b [element] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element] | array_flow.rb:1114:10:1114:10 | b [element] | provenance |  |
-| array_flow.rb:1107:5:1107:5 | b [element] | array_flow.rb:1115:10:1115:10 | b [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element 0] | array_flow.rb:1108:10:1108:10 | a [element 0] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element 1] | array_flow.rb:1109:10:1109:10 | a [element 1] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element] | array_flow.rb:1108:10:1108:10 | a [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element] | array_flow.rb:1109:10:1109:10 | a [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element] | array_flow.rb:1110:10:1110:10 | a [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | [post] a [element] | array_flow.rb:1111:10:1111:10 | a [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 0] | array_flow.rb:1107:9:1107:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 0] | array_flow.rb:1107:9:1107:20 | call to rotate! [element] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 2] | array_flow.rb:1107:9:1107:9 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 2] | array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 3] | array_flow.rb:1107:9:1107:9 | [post] a [element 1] | provenance |  |
-| array_flow.rb:1107:9:1107:9 | a [element 3] | array_flow.rb:1107:9:1107:20 | call to rotate! [element 1] | provenance |  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] | array_flow.rb:1107:5:1107:5 | b [element 0] | provenance |  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 1] | array_flow.rb:1107:5:1107:5 | b [element 1] | provenance |  |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element] | array_flow.rb:1107:5:1107:5 | b [element] | provenance |  |
-| array_flow.rb:1108:10:1108:10 | a [element 0] | array_flow.rb:1108:10:1108:13 | ...[...] | provenance |  |
-| array_flow.rb:1108:10:1108:10 | a [element] | array_flow.rb:1108:10:1108:13 | ...[...] | provenance |  |
-| array_flow.rb:1109:10:1109:10 | a [element 1] | array_flow.rb:1109:10:1109:13 | ...[...] | provenance |  |
-| array_flow.rb:1109:10:1109:10 | a [element] | array_flow.rb:1109:10:1109:13 | ...[...] | provenance |  |
-| array_flow.rb:1110:10:1110:10 | a [element] | array_flow.rb:1110:10:1110:13 | ...[...] | provenance |  |
-| array_flow.rb:1111:10:1111:10 | a [element] | array_flow.rb:1111:10:1111:13 | ...[...] | provenance |  |
-| array_flow.rb:1112:10:1112:10 | b [element 0] | array_flow.rb:1112:10:1112:13 | ...[...] | provenance |  |
-| array_flow.rb:1112:10:1112:10 | b [element] | array_flow.rb:1112:10:1112:13 | ...[...] | provenance |  |
-| array_flow.rb:1113:10:1113:10 | b [element 1] | array_flow.rb:1113:10:1113:13 | ...[...] | provenance |  |
-| array_flow.rb:1113:10:1113:10 | b [element] | array_flow.rb:1113:10:1113:13 | ...[...] | provenance |  |
-| array_flow.rb:1114:10:1114:10 | b [element] | array_flow.rb:1114:10:1114:13 | ...[...] | provenance |  |
-| array_flow.rb:1115:10:1115:10 | b [element] | array_flow.rb:1115:10:1115:13 | ...[...] | provenance |  |
-| array_flow.rb:1117:5:1117:5 | a [element 0] | array_flow.rb:1118:9:1118:9 | a [element 0] | provenance |  |
-| array_flow.rb:1117:5:1117:5 | a [element 2] | array_flow.rb:1118:9:1118:9 | a [element 2] | provenance |  |
-| array_flow.rb:1117:5:1117:5 | a [element 3] | array_flow.rb:1118:9:1118:9 | a [element 3] | provenance |  |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 0] | array_flow.rb:1117:5:1117:5 | a [element 0] | provenance |  |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 2] | array_flow.rb:1117:5:1117:5 | a [element 2] | provenance |  |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 3] | array_flow.rb:1117:5:1117:5 | a [element 3] | provenance |  |
-| array_flow.rb:1117:10:1117:22 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1117:28:1117:40 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1117:43:1117:55 | call to source | array_flow.rb:1117:9:1117:56 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1118:5:1118:5 | b [element 0] | array_flow.rb:1123:10:1123:10 | b [element 0] | provenance |  |
-| array_flow.rb:1118:5:1118:5 | b [element 2] | array_flow.rb:1125:10:1125:10 | b [element 2] | provenance |  |
-| array_flow.rb:1118:5:1118:5 | b [element 3] | array_flow.rb:1126:10:1126:10 | b [element 3] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 0] | array_flow.rb:1119:10:1119:10 | a [element 0] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 2] | array_flow.rb:1121:10:1121:10 | a [element 2] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 3] | array_flow.rb:1122:10:1122:10 | a [element 3] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 0] | array_flow.rb:1118:9:1118:9 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 0] | array_flow.rb:1118:9:1118:20 | call to rotate! [element 0] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 2] | array_flow.rb:1118:9:1118:9 | [post] a [element 2] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 2] | array_flow.rb:1118:9:1118:20 | call to rotate! [element 2] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 3] | array_flow.rb:1118:9:1118:9 | [post] a [element 3] | provenance |  |
-| array_flow.rb:1118:9:1118:9 | a [element 3] | array_flow.rb:1118:9:1118:20 | call to rotate! [element 3] | provenance |  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 0] | array_flow.rb:1118:5:1118:5 | b [element 0] | provenance |  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 2] | array_flow.rb:1118:5:1118:5 | b [element 2] | provenance |  |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 3] | array_flow.rb:1118:5:1118:5 | b [element 3] | provenance |  |
-| array_flow.rb:1119:10:1119:10 | a [element 0] | array_flow.rb:1119:10:1119:13 | ...[...] | provenance |  |
-| array_flow.rb:1121:10:1121:10 | a [element 2] | array_flow.rb:1121:10:1121:13 | ...[...] | provenance |  |
-| array_flow.rb:1122:10:1122:10 | a [element 3] | array_flow.rb:1122:10:1122:13 | ...[...] | provenance |  |
-| array_flow.rb:1123:10:1123:10 | b [element 0] | array_flow.rb:1123:10:1123:13 | ...[...] | provenance |  |
-| array_flow.rb:1125:10:1125:10 | b [element 2] | array_flow.rb:1125:10:1125:13 | ...[...] | provenance |  |
-| array_flow.rb:1126:10:1126:10 | b [element 3] | array_flow.rb:1126:10:1126:13 | ...[...] | provenance |  |
-| array_flow.rb:1128:5:1128:5 | a [element 0] | array_flow.rb:1129:9:1129:9 | a [element 0] | provenance |  |
-| array_flow.rb:1128:5:1128:5 | a [element 2] | array_flow.rb:1129:9:1129:9 | a [element 2] | provenance |  |
-| array_flow.rb:1128:5:1128:5 | a [element 3] | array_flow.rb:1129:9:1129:9 | a [element 3] | provenance |  |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 0] | array_flow.rb:1128:5:1128:5 | a [element 0] | provenance |  |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 2] | array_flow.rb:1128:5:1128:5 | a [element 2] | provenance |  |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 3] | array_flow.rb:1128:5:1128:5 | a [element 3] | provenance |  |
-| array_flow.rb:1128:10:1128:22 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1128:28:1128:40 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1128:43:1128:55 | call to source | array_flow.rb:1128:9:1128:56 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1134:10:1134:10 | b [element] | provenance |  |
-| array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1135:10:1135:10 | b [element] | provenance |  |
-| array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1136:10:1136:10 | b [element] | provenance |  |
-| array_flow.rb:1129:5:1129:5 | b [element] | array_flow.rb:1137:10:1137:10 | b [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | [post] a [element] | array_flow.rb:1130:10:1130:10 | a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | [post] a [element] | array_flow.rb:1131:10:1131:10 | a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | [post] a [element] | array_flow.rb:1132:10:1132:10 | a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | [post] a [element] | array_flow.rb:1133:10:1133:10 | a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 0] | array_flow.rb:1129:9:1129:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 0] | array_flow.rb:1129:9:1129:20 | call to rotate! [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 2] | array_flow.rb:1129:9:1129:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 2] | array_flow.rb:1129:9:1129:20 | call to rotate! [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 3] | array_flow.rb:1129:9:1129:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1129:9:1129:9 | a [element 3] | array_flow.rb:1129:9:1129:20 | call to rotate! [element] | provenance |  |
-| array_flow.rb:1129:9:1129:20 | call to rotate! [element] | array_flow.rb:1129:5:1129:5 | b [element] | provenance |  |
-| array_flow.rb:1130:10:1130:10 | a [element] | array_flow.rb:1130:10:1130:13 | ...[...] | provenance |  |
-| array_flow.rb:1131:10:1131:10 | a [element] | array_flow.rb:1131:10:1131:13 | ...[...] | provenance |  |
-| array_flow.rb:1132:10:1132:10 | a [element] | array_flow.rb:1132:10:1132:13 | ...[...] | provenance |  |
-| array_flow.rb:1133:10:1133:10 | a [element] | array_flow.rb:1133:10:1133:13 | ...[...] | provenance |  |
-| array_flow.rb:1134:10:1134:10 | b [element] | array_flow.rb:1134:10:1134:13 | ...[...] | provenance |  |
-| array_flow.rb:1135:10:1135:10 | b [element] | array_flow.rb:1135:10:1135:13 | ...[...] | provenance |  |
-| array_flow.rb:1136:10:1136:10 | b [element] | array_flow.rb:1136:10:1136:13 | ...[...] | provenance |  |
-| array_flow.rb:1137:10:1137:10 | b [element] | array_flow.rb:1137:10:1137:13 | ...[...] | provenance |  |
-| array_flow.rb:1141:5:1141:5 | a [element 3] | array_flow.rb:1142:9:1142:9 | a [element 3] | provenance |  |
-| array_flow.rb:1141:9:1141:30 | call to [] [element 3] | array_flow.rb:1141:5:1141:5 | a [element 3] | provenance |  |
-| array_flow.rb:1141:19:1141:29 | call to source | array_flow.rb:1141:9:1141:30 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1142:5:1142:5 | b [element] | array_flow.rb:1145:10:1145:10 | b [element] | provenance |  |
-| array_flow.rb:1142:9:1142:9 | a [element 3] | array_flow.rb:1142:9:1144:7 | call to select [element] | provenance |  |
-| array_flow.rb:1142:9:1142:9 | a [element 3] | array_flow.rb:1142:22:1142:22 | x | provenance |  |
-| array_flow.rb:1142:9:1144:7 | call to select [element] | array_flow.rb:1142:5:1142:5 | b [element] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 0] | array_flow.rb:1065:9:1065:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 0] | array_flow.rb:1071:9:1071:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 0] | array_flow.rb:1077:9:1077:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 0] | array_flow.rb:1083:9:1083:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 2] | array_flow.rb:1065:9:1065:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 2] | array_flow.rb:1071:9:1071:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 2] | array_flow.rb:1077:9:1077:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 2] | array_flow.rb:1083:9:1083:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 3] | array_flow.rb:1065:9:1065:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 3] | array_flow.rb:1071:9:1071:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 3] | array_flow.rb:1077:9:1077:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 3] | array_flow.rb:1083:9:1083:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 0] | array_flow.rb:1063:5:1063:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 2] | array_flow.rb:1063:5:1063:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 3] | array_flow.rb:1063:5:1063:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1063:10:1063:22 | call to source | array_flow.rb:1063:9:1063:56 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1063:28:1063:40 | call to source | array_flow.rb:1063:9:1063:56 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1063:43:1063:55 | call to source | array_flow.rb:1063:9:1063:56 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element 1] | array_flow.rb:1067:10:1067:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element 2] | array_flow.rb:1068:10:1068:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element] | array_flow.rb:1066:10:1066:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element] | array_flow.rb:1067:10:1067:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element] | array_flow.rb:1068:10:1068:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element] | array_flow.rb:1069:10:1069:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 0] | array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element] | provenance |  |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 2] | array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 1] | provenance |  |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 3] | array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 2] | provenance |  |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 1] | array_flow.rb:1065:5:1065:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 2] | array_flow.rb:1065:5:1065:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element] | array_flow.rb:1065:5:1065:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1066:10:1066:10 | b : [collection] [element] | array_flow.rb:1066:10:1066:13 | ...[...] | provenance |  |
+| array_flow.rb:1067:10:1067:10 | b : [collection] [element 1] | array_flow.rb:1067:10:1067:13 | ...[...] | provenance |  |
+| array_flow.rb:1067:10:1067:10 | b : [collection] [element] | array_flow.rb:1067:10:1067:13 | ...[...] | provenance |  |
+| array_flow.rb:1068:10:1068:10 | b : [collection] [element 2] | array_flow.rb:1068:10:1068:13 | ...[...] | provenance |  |
+| array_flow.rb:1068:10:1068:10 | b : [collection] [element] | array_flow.rb:1068:10:1068:13 | ...[...] | provenance |  |
+| array_flow.rb:1069:10:1069:10 | b : [collection] [element] | array_flow.rb:1069:10:1069:13 | ...[...] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element 0] | array_flow.rb:1072:10:1072:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element 1] | array_flow.rb:1073:10:1073:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element] | array_flow.rb:1072:10:1072:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element] | array_flow.rb:1073:10:1073:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element] | array_flow.rb:1074:10:1074:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element] | array_flow.rb:1075:10:1075:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 0] | array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element] | provenance |  |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 2] | array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 0] | provenance |  |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 3] | array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 1] | provenance |  |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 0] | array_flow.rb:1071:5:1071:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 1] | array_flow.rb:1071:5:1071:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element] | array_flow.rb:1071:5:1071:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1072:10:1072:10 | b : [collection] [element 0] | array_flow.rb:1072:10:1072:13 | ...[...] | provenance |  |
+| array_flow.rb:1072:10:1072:10 | b : [collection] [element] | array_flow.rb:1072:10:1072:13 | ...[...] | provenance |  |
+| array_flow.rb:1073:10:1073:10 | b : [collection] [element 1] | array_flow.rb:1073:10:1073:13 | ...[...] | provenance |  |
+| array_flow.rb:1073:10:1073:10 | b : [collection] [element] | array_flow.rb:1073:10:1073:13 | ...[...] | provenance |  |
+| array_flow.rb:1074:10:1074:10 | b : [collection] [element] | array_flow.rb:1074:10:1074:13 | ...[...] | provenance |  |
+| array_flow.rb:1075:10:1075:10 | b : [collection] [element] | array_flow.rb:1075:10:1075:13 | ...[...] | provenance |  |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 0] | array_flow.rb:1078:10:1078:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 2] | array_flow.rb:1080:10:1080:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 3] | array_flow.rb:1081:10:1081:10 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 0] | array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 0] | provenance |  |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 2] | array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 2] | provenance |  |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 3] | array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 3] | provenance |  |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 0] | array_flow.rb:1077:5:1077:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 2] | array_flow.rb:1077:5:1077:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 3] | array_flow.rb:1077:5:1077:5 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1078:10:1078:10 | b : [collection] [element 0] | array_flow.rb:1078:10:1078:13 | ...[...] | provenance |  |
+| array_flow.rb:1080:10:1080:10 | b : [collection] [element 2] | array_flow.rb:1080:10:1080:13 | ...[...] | provenance |  |
+| array_flow.rb:1081:10:1081:10 | b : [collection] [element 3] | array_flow.rb:1081:10:1081:13 | ...[...] | provenance |  |
+| array_flow.rb:1083:5:1083:5 | b : [collection] [element] | array_flow.rb:1084:10:1084:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1083:5:1083:5 | b : [collection] [element] | array_flow.rb:1085:10:1085:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1083:5:1083:5 | b : [collection] [element] | array_flow.rb:1086:10:1086:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1083:5:1083:5 | b : [collection] [element] | array_flow.rb:1087:10:1087:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 0] | array_flow.rb:1083:9:1083:19 | call to rotate : [collection] [element] | provenance |  |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 2] | array_flow.rb:1083:9:1083:19 | call to rotate : [collection] [element] | provenance |  |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 3] | array_flow.rb:1083:9:1083:19 | call to rotate : [collection] [element] | provenance |  |
+| array_flow.rb:1083:9:1083:19 | call to rotate : [collection] [element] | array_flow.rb:1083:5:1083:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1084:10:1084:10 | b : [collection] [element] | array_flow.rb:1084:10:1084:13 | ...[...] | provenance |  |
+| array_flow.rb:1085:10:1085:10 | b : [collection] [element] | array_flow.rb:1085:10:1085:13 | ...[...] | provenance |  |
+| array_flow.rb:1086:10:1086:10 | b : [collection] [element] | array_flow.rb:1086:10:1086:13 | ...[...] | provenance |  |
+| array_flow.rb:1087:10:1087:10 | b : [collection] [element] | array_flow.rb:1087:10:1087:13 | ...[...] | provenance |  |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 0] | array_flow.rb:1096:9:1096:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 2] | array_flow.rb:1096:9:1096:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 3] | array_flow.rb:1096:9:1096:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 0] | array_flow.rb:1095:5:1095:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 2] | array_flow.rb:1095:5:1095:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 3] | array_flow.rb:1095:5:1095:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1095:10:1095:22 | call to source | array_flow.rb:1095:9:1095:56 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1095:28:1095:40 | call to source | array_flow.rb:1095:9:1095:56 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1095:43:1095:55 | call to source | array_flow.rb:1095:9:1095:56 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element 1] | array_flow.rb:1102:10:1102:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element 2] | array_flow.rb:1103:10:1103:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element] | array_flow.rb:1101:10:1101:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element] | array_flow.rb:1102:10:1102:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element] | array_flow.rb:1103:10:1103:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element] | array_flow.rb:1104:10:1104:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 1] | array_flow.rb:1098:10:1098:10 | a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 2] | array_flow.rb:1099:10:1099:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | array_flow.rb:1097:10:1097:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | array_flow.rb:1098:10:1098:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | array_flow.rb:1099:10:1099:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | array_flow.rb:1100:10:1100:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 0] | array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 0] | array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 2] | array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 2] | array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 1] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 3] | array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 3] | array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 2] | provenance |  |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 1] | array_flow.rb:1096:5:1096:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 2] | array_flow.rb:1096:5:1096:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element] | array_flow.rb:1096:5:1096:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1097:10:1097:10 | a : [collection] [element] | array_flow.rb:1097:10:1097:13 | ...[...] | provenance |  |
+| array_flow.rb:1098:10:1098:10 | a : [collection] [element 1] | array_flow.rb:1098:10:1098:13 | ...[...] | provenance |  |
+| array_flow.rb:1098:10:1098:10 | a : [collection] [element] | array_flow.rb:1098:10:1098:13 | ...[...] | provenance |  |
+| array_flow.rb:1099:10:1099:10 | a : [collection] [element 2] | array_flow.rb:1099:10:1099:13 | ...[...] | provenance |  |
+| array_flow.rb:1099:10:1099:10 | a : [collection] [element] | array_flow.rb:1099:10:1099:13 | ...[...] | provenance |  |
+| array_flow.rb:1100:10:1100:10 | a : [collection] [element] | array_flow.rb:1100:10:1100:13 | ...[...] | provenance |  |
+| array_flow.rb:1101:10:1101:10 | b : [collection] [element] | array_flow.rb:1101:10:1101:13 | ...[...] | provenance |  |
+| array_flow.rb:1102:10:1102:10 | b : [collection] [element 1] | array_flow.rb:1102:10:1102:13 | ...[...] | provenance |  |
+| array_flow.rb:1102:10:1102:10 | b : [collection] [element] | array_flow.rb:1102:10:1102:13 | ...[...] | provenance |  |
+| array_flow.rb:1103:10:1103:10 | b : [collection] [element 2] | array_flow.rb:1103:10:1103:13 | ...[...] | provenance |  |
+| array_flow.rb:1103:10:1103:10 | b : [collection] [element] | array_flow.rb:1103:10:1103:13 | ...[...] | provenance |  |
+| array_flow.rb:1104:10:1104:10 | b : [collection] [element] | array_flow.rb:1104:10:1104:13 | ...[...] | provenance |  |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 0] | array_flow.rb:1107:9:1107:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 2] | array_flow.rb:1107:9:1107:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 3] | array_flow.rb:1107:9:1107:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 0] | array_flow.rb:1106:5:1106:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 2] | array_flow.rb:1106:5:1106:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 3] | array_flow.rb:1106:5:1106:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1106:10:1106:22 | call to source | array_flow.rb:1106:9:1106:56 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1106:28:1106:40 | call to source | array_flow.rb:1106:9:1106:56 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1106:43:1106:55 | call to source | array_flow.rb:1106:9:1106:56 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element 0] | array_flow.rb:1112:10:1112:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element 1] | array_flow.rb:1113:10:1113:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element] | array_flow.rb:1112:10:1112:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element] | array_flow.rb:1113:10:1113:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element] | array_flow.rb:1114:10:1114:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element] | array_flow.rb:1115:10:1115:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 0] | array_flow.rb:1108:10:1108:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 1] | array_flow.rb:1109:10:1109:10 | a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | array_flow.rb:1108:10:1108:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | array_flow.rb:1109:10:1109:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | array_flow.rb:1110:10:1110:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | array_flow.rb:1111:10:1111:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 0] | array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 0] | array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 2] | array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 2] | array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 0] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 3] | array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 3] | array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 1] | provenance |  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 0] | array_flow.rb:1107:5:1107:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 1] | array_flow.rb:1107:5:1107:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element] | array_flow.rb:1107:5:1107:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1108:10:1108:10 | a : [collection] [element 0] | array_flow.rb:1108:10:1108:13 | ...[...] | provenance |  |
+| array_flow.rb:1108:10:1108:10 | a : [collection] [element] | array_flow.rb:1108:10:1108:13 | ...[...] | provenance |  |
+| array_flow.rb:1109:10:1109:10 | a : [collection] [element 1] | array_flow.rb:1109:10:1109:13 | ...[...] | provenance |  |
+| array_flow.rb:1109:10:1109:10 | a : [collection] [element] | array_flow.rb:1109:10:1109:13 | ...[...] | provenance |  |
+| array_flow.rb:1110:10:1110:10 | a : [collection] [element] | array_flow.rb:1110:10:1110:13 | ...[...] | provenance |  |
+| array_flow.rb:1111:10:1111:10 | a : [collection] [element] | array_flow.rb:1111:10:1111:13 | ...[...] | provenance |  |
+| array_flow.rb:1112:10:1112:10 | b : [collection] [element 0] | array_flow.rb:1112:10:1112:13 | ...[...] | provenance |  |
+| array_flow.rb:1112:10:1112:10 | b : [collection] [element] | array_flow.rb:1112:10:1112:13 | ...[...] | provenance |  |
+| array_flow.rb:1113:10:1113:10 | b : [collection] [element 1] | array_flow.rb:1113:10:1113:13 | ...[...] | provenance |  |
+| array_flow.rb:1113:10:1113:10 | b : [collection] [element] | array_flow.rb:1113:10:1113:13 | ...[...] | provenance |  |
+| array_flow.rb:1114:10:1114:10 | b : [collection] [element] | array_flow.rb:1114:10:1114:13 | ...[...] | provenance |  |
+| array_flow.rb:1115:10:1115:10 | b : [collection] [element] | array_flow.rb:1115:10:1115:13 | ...[...] | provenance |  |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 0] | array_flow.rb:1118:9:1118:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 2] | array_flow.rb:1118:9:1118:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 3] | array_flow.rb:1118:9:1118:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 0] | array_flow.rb:1117:5:1117:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 2] | array_flow.rb:1117:5:1117:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 3] | array_flow.rb:1117:5:1117:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1117:10:1117:22 | call to source | array_flow.rb:1117:9:1117:56 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1117:28:1117:40 | call to source | array_flow.rb:1117:9:1117:56 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1117:43:1117:55 | call to source | array_flow.rb:1117:9:1117:56 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 0] | array_flow.rb:1123:10:1123:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 2] | array_flow.rb:1125:10:1125:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 3] | array_flow.rb:1126:10:1126:10 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 0] | array_flow.rb:1119:10:1119:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 2] | array_flow.rb:1121:10:1121:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 3] | array_flow.rb:1122:10:1122:10 | a : [collection] [element 3] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 0] | array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 0] | array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 0] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 2] | array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 2] | array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 2] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 3] | array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 3] | provenance |  |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 3] | array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 3] | provenance |  |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 0] | array_flow.rb:1118:5:1118:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 2] | array_flow.rb:1118:5:1118:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 3] | array_flow.rb:1118:5:1118:5 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1119:10:1119:10 | a : [collection] [element 0] | array_flow.rb:1119:10:1119:13 | ...[...] | provenance |  |
+| array_flow.rb:1121:10:1121:10 | a : [collection] [element 2] | array_flow.rb:1121:10:1121:13 | ...[...] | provenance |  |
+| array_flow.rb:1122:10:1122:10 | a : [collection] [element 3] | array_flow.rb:1122:10:1122:13 | ...[...] | provenance |  |
+| array_flow.rb:1123:10:1123:10 | b : [collection] [element 0] | array_flow.rb:1123:10:1123:13 | ...[...] | provenance |  |
+| array_flow.rb:1125:10:1125:10 | b : [collection] [element 2] | array_flow.rb:1125:10:1125:13 | ...[...] | provenance |  |
+| array_flow.rb:1126:10:1126:10 | b : [collection] [element 3] | array_flow.rb:1126:10:1126:13 | ...[...] | provenance |  |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 0] | array_flow.rb:1129:9:1129:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 2] | array_flow.rb:1129:9:1129:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 3] | array_flow.rb:1129:9:1129:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 0] | array_flow.rb:1128:5:1128:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 2] | array_flow.rb:1128:5:1128:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 3] | array_flow.rb:1128:5:1128:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1128:10:1128:22 | call to source | array_flow.rb:1128:9:1128:56 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1128:28:1128:40 | call to source | array_flow.rb:1128:9:1128:56 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1128:43:1128:55 | call to source | array_flow.rb:1128:9:1128:56 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1129:5:1129:5 | b : [collection] [element] | array_flow.rb:1134:10:1134:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1129:5:1129:5 | b : [collection] [element] | array_flow.rb:1135:10:1135:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1129:5:1129:5 | b : [collection] [element] | array_flow.rb:1136:10:1136:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1129:5:1129:5 | b : [collection] [element] | array_flow.rb:1137:10:1137:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | array_flow.rb:1130:10:1130:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | array_flow.rb:1131:10:1131:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | array_flow.rb:1132:10:1132:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | array_flow.rb:1133:10:1133:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 0] | array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 0] | array_flow.rb:1129:9:1129:20 | call to rotate! : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 2] | array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 2] | array_flow.rb:1129:9:1129:20 | call to rotate! : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 3] | array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 3] | array_flow.rb:1129:9:1129:20 | call to rotate! : [collection] [element] | provenance |  |
+| array_flow.rb:1129:9:1129:20 | call to rotate! : [collection] [element] | array_flow.rb:1129:5:1129:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1130:10:1130:10 | a : [collection] [element] | array_flow.rb:1130:10:1130:13 | ...[...] | provenance |  |
+| array_flow.rb:1131:10:1131:10 | a : [collection] [element] | array_flow.rb:1131:10:1131:13 | ...[...] | provenance |  |
+| array_flow.rb:1132:10:1132:10 | a : [collection] [element] | array_flow.rb:1132:10:1132:13 | ...[...] | provenance |  |
+| array_flow.rb:1133:10:1133:10 | a : [collection] [element] | array_flow.rb:1133:10:1133:13 | ...[...] | provenance |  |
+| array_flow.rb:1134:10:1134:10 | b : [collection] [element] | array_flow.rb:1134:10:1134:13 | ...[...] | provenance |  |
+| array_flow.rb:1135:10:1135:10 | b : [collection] [element] | array_flow.rb:1135:10:1135:13 | ...[...] | provenance |  |
+| array_flow.rb:1136:10:1136:10 | b : [collection] [element] | array_flow.rb:1136:10:1136:13 | ...[...] | provenance |  |
+| array_flow.rb:1137:10:1137:10 | b : [collection] [element] | array_flow.rb:1137:10:1137:13 | ...[...] | provenance |  |
+| array_flow.rb:1141:5:1141:5 | a : Array [element 3] | array_flow.rb:1142:9:1142:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1141:9:1141:30 | call to [] : Array [element 3] | array_flow.rb:1141:5:1141:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1141:19:1141:29 | call to source | array_flow.rb:1141:9:1141:30 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1142:5:1142:5 | b : [collection] [element] | array_flow.rb:1145:10:1145:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1142:9:1142:9 | a : Array [element 3] | array_flow.rb:1142:9:1144:7 | call to select : [collection] [element] | provenance |  |
+| array_flow.rb:1142:9:1142:9 | a : Array [element 3] | array_flow.rb:1142:22:1142:22 | x | provenance |  |
+| array_flow.rb:1142:9:1144:7 | call to select : [collection] [element] | array_flow.rb:1142:5:1142:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1142:22:1142:22 | x | array_flow.rb:1143:14:1143:14 | x | provenance |  |
-| array_flow.rb:1145:10:1145:10 | b [element] | array_flow.rb:1145:10:1145:13 | ...[...] | provenance |  |
-| array_flow.rb:1149:5:1149:5 | a [element 2] | array_flow.rb:1150:9:1150:9 | a [element 2] | provenance |  |
-| array_flow.rb:1149:9:1149:27 | call to [] [element 2] | array_flow.rb:1149:5:1149:5 | a [element 2] | provenance |  |
-| array_flow.rb:1149:16:1149:26 | call to source | array_flow.rb:1149:9:1149:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1150:5:1150:5 | b [element] | array_flow.rb:1155:10:1155:10 | b [element] | provenance |  |
-| array_flow.rb:1150:9:1150:9 | [post] a [element] | array_flow.rb:1154:10:1154:10 | a [element] | provenance |  |
-| array_flow.rb:1150:9:1150:9 | a [element 2] | array_flow.rb:1150:9:1150:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1150:9:1150:9 | a [element 2] | array_flow.rb:1150:9:1153:7 | call to select! [element] | provenance |  |
-| array_flow.rb:1150:9:1150:9 | a [element 2] | array_flow.rb:1150:23:1150:23 | x | provenance |  |
-| array_flow.rb:1150:9:1153:7 | call to select! [element] | array_flow.rb:1150:5:1150:5 | b [element] | provenance |  |
+| array_flow.rb:1145:10:1145:10 | b : [collection] [element] | array_flow.rb:1145:10:1145:13 | ...[...] | provenance |  |
+| array_flow.rb:1149:5:1149:5 | a : Array [element 2] | array_flow.rb:1150:9:1150:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1149:9:1149:27 | call to [] : Array [element 2] | array_flow.rb:1149:5:1149:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1149:16:1149:26 | call to source | array_flow.rb:1149:9:1149:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1150:5:1150:5 | b : [collection] [element] | array_flow.rb:1155:10:1155:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1150:9:1150:9 | [post] a : [collection] [element] | array_flow.rb:1154:10:1154:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1150:9:1150:9 | a : Array [element 2] | array_flow.rb:1150:9:1150:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1150:9:1150:9 | a : Array [element 2] | array_flow.rb:1150:9:1153:7 | call to select! : [collection] [element] | provenance |  |
+| array_flow.rb:1150:9:1150:9 | a : Array [element 2] | array_flow.rb:1150:23:1150:23 | x | provenance |  |
+| array_flow.rb:1150:9:1153:7 | call to select! : [collection] [element] | array_flow.rb:1150:5:1150:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1150:23:1150:23 | x | array_flow.rb:1151:14:1151:14 | x | provenance |  |
-| array_flow.rb:1154:10:1154:10 | a [element] | array_flow.rb:1154:10:1154:13 | ...[...] | provenance |  |
-| array_flow.rb:1155:10:1155:10 | b [element] | array_flow.rb:1155:10:1155:13 | ...[...] | provenance |  |
-| array_flow.rb:1159:5:1159:5 | a [element 0] | array_flow.rb:1160:9:1160:9 | a [element 0] | provenance |  |
-| array_flow.rb:1159:5:1159:5 | a [element 2] | array_flow.rb:1160:9:1160:9 | a [element 2] | provenance |  |
-| array_flow.rb:1159:9:1159:41 | call to [] [element 0] | array_flow.rb:1159:5:1159:5 | a [element 0] | provenance |  |
-| array_flow.rb:1159:9:1159:41 | call to [] [element 2] | array_flow.rb:1159:5:1159:5 | a [element 2] | provenance |  |
-| array_flow.rb:1159:10:1159:22 | call to source | array_flow.rb:1159:9:1159:41 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1159:28:1159:40 | call to source | array_flow.rb:1159:9:1159:41 | call to [] [element 2] | provenance |  |
+| array_flow.rb:1154:10:1154:10 | a : [collection] [element] | array_flow.rb:1154:10:1154:13 | ...[...] | provenance |  |
+| array_flow.rb:1155:10:1155:10 | b : [collection] [element] | array_flow.rb:1155:10:1155:13 | ...[...] | provenance |  |
+| array_flow.rb:1159:5:1159:5 | a : Array [element 0] | array_flow.rb:1160:9:1160:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1159:5:1159:5 | a : Array [element 2] | array_flow.rb:1160:9:1160:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1159:9:1159:41 | call to [] : Array [element 0] | array_flow.rb:1159:5:1159:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1159:9:1159:41 | call to [] : Array [element 2] | array_flow.rb:1159:5:1159:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1159:10:1159:22 | call to source | array_flow.rb:1159:9:1159:41 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1159:28:1159:40 | call to source | array_flow.rb:1159:9:1159:41 | call to [] : Array [element 2] | provenance |  |
 | array_flow.rb:1160:5:1160:5 | b | array_flow.rb:1161:10:1161:10 | b | provenance |  |
-| array_flow.rb:1160:9:1160:9 | [post] a [element 1] | array_flow.rb:1163:10:1163:10 | a [element 1] | provenance |  |
-| array_flow.rb:1160:9:1160:9 | a [element 0] | array_flow.rb:1160:9:1160:15 | call to shift | provenance |  |
-| array_flow.rb:1160:9:1160:9 | a [element 2] | array_flow.rb:1160:9:1160:9 | [post] a [element 1] | provenance |  |
+| array_flow.rb:1160:9:1160:9 | [post] a : [collection] [element 1] | array_flow.rb:1163:10:1163:10 | a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1160:9:1160:9 | a : Array [element 0] | array_flow.rb:1160:9:1160:15 | call to shift | provenance |  |
+| array_flow.rb:1160:9:1160:9 | a : Array [element 2] | array_flow.rb:1160:9:1160:9 | [post] a : [collection] [element 1] | provenance |  |
 | array_flow.rb:1160:9:1160:15 | call to shift | array_flow.rb:1160:5:1160:5 | b | provenance |  |
-| array_flow.rb:1163:10:1163:10 | a [element 1] | array_flow.rb:1163:10:1163:13 | ...[...] | provenance |  |
-| array_flow.rb:1166:5:1166:5 | a [element 0] | array_flow.rb:1167:9:1167:9 | a [element 0] | provenance |  |
-| array_flow.rb:1166:5:1166:5 | a [element 2] | array_flow.rb:1167:9:1167:9 | a [element 2] | provenance |  |
-| array_flow.rb:1166:9:1166:41 | call to [] [element 0] | array_flow.rb:1166:5:1166:5 | a [element 0] | provenance |  |
-| array_flow.rb:1166:9:1166:41 | call to [] [element 2] | array_flow.rb:1166:5:1166:5 | a [element 2] | provenance |  |
-| array_flow.rb:1166:10:1166:22 | call to source | array_flow.rb:1166:9:1166:41 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1166:28:1166:40 | call to source | array_flow.rb:1166:9:1166:41 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1167:5:1167:5 | b [element 0] | array_flow.rb:1168:10:1168:10 | b [element 0] | provenance |  |
-| array_flow.rb:1167:9:1167:9 | [post] a [element 0] | array_flow.rb:1170:10:1170:10 | a [element 0] | provenance |  |
-| array_flow.rb:1167:9:1167:9 | a [element 0] | array_flow.rb:1167:9:1167:18 | call to shift [element 0] | provenance |  |
-| array_flow.rb:1167:9:1167:9 | a [element 2] | array_flow.rb:1167:9:1167:9 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1167:9:1167:18 | call to shift [element 0] | array_flow.rb:1167:5:1167:5 | b [element 0] | provenance |  |
-| array_flow.rb:1168:10:1168:10 | b [element 0] | array_flow.rb:1168:10:1168:13 | ...[...] | provenance |  |
-| array_flow.rb:1170:10:1170:10 | a [element 0] | array_flow.rb:1170:10:1170:13 | ...[...] | provenance |  |
-| array_flow.rb:1174:5:1174:5 | a [element 0] | array_flow.rb:1175:9:1175:9 | a [element 0] | provenance |  |
-| array_flow.rb:1174:5:1174:5 | a [element 0] | array_flow.rb:1178:10:1178:10 | a [element 0] | provenance |  |
-| array_flow.rb:1174:5:1174:5 | a [element 2] | array_flow.rb:1175:9:1175:9 | a [element 2] | provenance |  |
-| array_flow.rb:1174:5:1174:5 | a [element 2] | array_flow.rb:1180:10:1180:10 | a [element 2] | provenance |  |
-| array_flow.rb:1174:9:1174:41 | call to [] [element 0] | array_flow.rb:1174:5:1174:5 | a [element 0] | provenance |  |
-| array_flow.rb:1174:9:1174:41 | call to [] [element 2] | array_flow.rb:1174:5:1174:5 | a [element 2] | provenance |  |
-| array_flow.rb:1174:10:1174:22 | call to source | array_flow.rb:1174:9:1174:41 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1174:28:1174:40 | call to source | array_flow.rb:1174:9:1174:41 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1175:5:1175:5 | b [element] | array_flow.rb:1176:10:1176:10 | b [element] | provenance |  |
-| array_flow.rb:1175:5:1175:5 | b [element] | array_flow.rb:1177:10:1177:10 | b [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | [post] a [element] | array_flow.rb:1178:10:1178:10 | a [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | [post] a [element] | array_flow.rb:1179:10:1179:10 | a [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | [post] a [element] | array_flow.rb:1180:10:1180:10 | a [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | a [element 0] | array_flow.rb:1175:9:1175:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | a [element 0] | array_flow.rb:1175:9:1175:18 | call to shift [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | a [element 2] | array_flow.rb:1175:9:1175:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1175:9:1175:9 | a [element 2] | array_flow.rb:1175:9:1175:18 | call to shift [element] | provenance |  |
-| array_flow.rb:1175:9:1175:18 | call to shift [element] | array_flow.rb:1175:5:1175:5 | b [element] | provenance |  |
-| array_flow.rb:1176:10:1176:10 | b [element] | array_flow.rb:1176:10:1176:13 | ...[...] | provenance |  |
-| array_flow.rb:1177:10:1177:10 | b [element] | array_flow.rb:1177:10:1177:13 | ...[...] | provenance |  |
-| array_flow.rb:1178:10:1178:10 | a [element 0] | array_flow.rb:1178:10:1178:13 | ...[...] | provenance |  |
-| array_flow.rb:1178:10:1178:10 | a [element] | array_flow.rb:1178:10:1178:13 | ...[...] | provenance |  |
-| array_flow.rb:1179:10:1179:10 | a [element] | array_flow.rb:1179:10:1179:13 | ...[...] | provenance |  |
-| array_flow.rb:1180:10:1180:10 | a [element 2] | array_flow.rb:1180:10:1180:13 | ...[...] | provenance |  |
-| array_flow.rb:1180:10:1180:10 | a [element] | array_flow.rb:1180:10:1180:13 | ...[...] | provenance |  |
-| array_flow.rb:1184:5:1184:5 | a [element 2] | array_flow.rb:1185:9:1185:9 | a [element 2] | provenance |  |
-| array_flow.rb:1184:5:1184:5 | a [element 2] | array_flow.rb:1188:10:1188:10 | a [element 2] | provenance |  |
-| array_flow.rb:1184:9:1184:27 | call to [] [element 2] | array_flow.rb:1184:5:1184:5 | a [element 2] | provenance |  |
-| array_flow.rb:1184:16:1184:26 | call to source | array_flow.rb:1184:9:1184:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1189:10:1189:10 | b [element] | provenance |  |
-| array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1190:10:1190:10 | b [element] | provenance |  |
-| array_flow.rb:1185:5:1185:5 | b [element] | array_flow.rb:1191:10:1191:10 | b [element] | provenance |  |
-| array_flow.rb:1185:9:1185:9 | a [element 2] | array_flow.rb:1185:9:1185:17 | call to shuffle [element] | provenance |  |
-| array_flow.rb:1185:9:1185:17 | call to shuffle [element] | array_flow.rb:1185:5:1185:5 | b [element] | provenance |  |
-| array_flow.rb:1188:10:1188:10 | a [element 2] | array_flow.rb:1188:10:1188:13 | ...[...] | provenance |  |
-| array_flow.rb:1189:10:1189:10 | b [element] | array_flow.rb:1189:10:1189:13 | ...[...] | provenance |  |
-| array_flow.rb:1190:10:1190:10 | b [element] | array_flow.rb:1190:10:1190:13 | ...[...] | provenance |  |
-| array_flow.rb:1191:10:1191:10 | b [element] | array_flow.rb:1191:10:1191:13 | ...[...] | provenance |  |
-| array_flow.rb:1195:5:1195:5 | a [element 2] | array_flow.rb:1196:9:1196:9 | a [element 2] | provenance |  |
-| array_flow.rb:1195:5:1195:5 | a [element 2] | array_flow.rb:1199:10:1199:10 | a [element 2] | provenance |  |
-| array_flow.rb:1195:9:1195:27 | call to [] [element 2] | array_flow.rb:1195:5:1195:5 | a [element 2] | provenance |  |
-| array_flow.rb:1195:16:1195:26 | call to source | array_flow.rb:1195:9:1195:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1200:10:1200:10 | b [element] | provenance |  |
-| array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1201:10:1201:10 | b [element] | provenance |  |
-| array_flow.rb:1196:5:1196:5 | b [element] | array_flow.rb:1202:10:1202:10 | b [element] | provenance |  |
-| array_flow.rb:1196:9:1196:9 | [post] a [element] | array_flow.rb:1197:10:1197:10 | a [element] | provenance |  |
-| array_flow.rb:1196:9:1196:9 | [post] a [element] | array_flow.rb:1198:10:1198:10 | a [element] | provenance |  |
-| array_flow.rb:1196:9:1196:9 | [post] a [element] | array_flow.rb:1199:10:1199:10 | a [element] | provenance |  |
-| array_flow.rb:1196:9:1196:9 | a [element 2] | array_flow.rb:1196:9:1196:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1196:9:1196:9 | a [element 2] | array_flow.rb:1196:9:1196:18 | call to shuffle! [element] | provenance |  |
-| array_flow.rb:1196:9:1196:18 | call to shuffle! [element] | array_flow.rb:1196:5:1196:5 | b [element] | provenance |  |
-| array_flow.rb:1197:10:1197:10 | a [element] | array_flow.rb:1197:10:1197:13 | ...[...] | provenance |  |
-| array_flow.rb:1198:10:1198:10 | a [element] | array_flow.rb:1198:10:1198:13 | ...[...] | provenance |  |
-| array_flow.rb:1199:10:1199:10 | a [element 2] | array_flow.rb:1199:10:1199:13 | ...[...] | provenance |  |
-| array_flow.rb:1199:10:1199:10 | a [element] | array_flow.rb:1199:10:1199:13 | ...[...] | provenance |  |
-| array_flow.rb:1200:10:1200:10 | b [element] | array_flow.rb:1200:10:1200:13 | ...[...] | provenance |  |
-| array_flow.rb:1201:10:1201:10 | b [element] | array_flow.rb:1201:10:1201:13 | ...[...] | provenance |  |
-| array_flow.rb:1202:10:1202:10 | b [element] | array_flow.rb:1202:10:1202:13 | ...[...] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1211:9:1211:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1214:9:1214:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1221:9:1221:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1226:9:1226:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1230:9:1230:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1235:9:1235:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1240:9:1240:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1244:9:1244:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1248:9:1248:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | array_flow.rb:1253:9:1253:9 | a [element 2] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1208:9:1208:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1211:9:1211:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1214:9:1214:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1221:9:1221:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1226:9:1226:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1240:9:1240:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1244:9:1244:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | array_flow.rb:1253:9:1253:9 | a [element 4] | provenance |  |
-| array_flow.rb:1206:9:1206:47 | call to [] [element 2] | array_flow.rb:1206:5:1206:5 | a [element 2] | provenance |  |
-| array_flow.rb:1206:9:1206:47 | call to [] [element 4] | array_flow.rb:1206:5:1206:5 | a [element 4] | provenance |  |
-| array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1206:9:1206:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1206:9:1206:47 | call to [] [element 4] | provenance |  |
+| array_flow.rb:1163:10:1163:10 | a : [collection] [element 1] | array_flow.rb:1163:10:1163:13 | ...[...] | provenance |  |
+| array_flow.rb:1166:5:1166:5 | a : Array [element 0] | array_flow.rb:1167:9:1167:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1166:5:1166:5 | a : Array [element 2] | array_flow.rb:1167:9:1167:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1166:9:1166:41 | call to [] : Array [element 0] | array_flow.rb:1166:5:1166:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1166:9:1166:41 | call to [] : Array [element 2] | array_flow.rb:1166:5:1166:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1166:10:1166:22 | call to source | array_flow.rb:1166:9:1166:41 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1166:28:1166:40 | call to source | array_flow.rb:1166:9:1166:41 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1167:5:1167:5 | b : Array [element 0] | array_flow.rb:1168:10:1168:10 | b : Array [element 0] | provenance |  |
+| array_flow.rb:1167:9:1167:9 | [post] a : [collection] [element 0] | array_flow.rb:1170:10:1170:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1167:9:1167:9 | a : Array [element 0] | array_flow.rb:1167:9:1167:18 | call to shift : Array [element 0] | provenance |  |
+| array_flow.rb:1167:9:1167:9 | a : Array [element 2] | array_flow.rb:1167:9:1167:9 | [post] a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1167:9:1167:18 | call to shift : Array [element 0] | array_flow.rb:1167:5:1167:5 | b : Array [element 0] | provenance |  |
+| array_flow.rb:1168:10:1168:10 | b : Array [element 0] | array_flow.rb:1168:10:1168:13 | ...[...] | provenance |  |
+| array_flow.rb:1170:10:1170:10 | a : [collection] [element 0] | array_flow.rb:1170:10:1170:13 | ...[...] | provenance |  |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 0] | array_flow.rb:1175:9:1175:9 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 0] | array_flow.rb:1178:10:1178:10 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 2] | array_flow.rb:1175:9:1175:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 2] | array_flow.rb:1180:10:1180:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1174:9:1174:41 | call to [] : Array [element 0] | array_flow.rb:1174:5:1174:5 | a : Array [element 0] | provenance |  |
+| array_flow.rb:1174:9:1174:41 | call to [] : Array [element 2] | array_flow.rb:1174:5:1174:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1174:10:1174:22 | call to source | array_flow.rb:1174:9:1174:41 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1174:28:1174:40 | call to source | array_flow.rb:1174:9:1174:41 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1175:5:1175:5 | b : [collection] [element] | array_flow.rb:1176:10:1176:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1175:5:1175:5 | b : [collection] [element] | array_flow.rb:1177:10:1177:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | array_flow.rb:1178:10:1178:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | array_flow.rb:1179:10:1179:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | array_flow.rb:1180:10:1180:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 0] | array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 0] | array_flow.rb:1175:9:1175:18 | call to shift : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 2] | array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 2] | array_flow.rb:1175:9:1175:18 | call to shift : [collection] [element] | provenance |  |
+| array_flow.rb:1175:9:1175:18 | call to shift : [collection] [element] | array_flow.rb:1175:5:1175:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1176:10:1176:10 | b : [collection] [element] | array_flow.rb:1176:10:1176:13 | ...[...] | provenance |  |
+| array_flow.rb:1177:10:1177:10 | b : [collection] [element] | array_flow.rb:1177:10:1177:13 | ...[...] | provenance |  |
+| array_flow.rb:1178:10:1178:10 | a : Array [element 0] | array_flow.rb:1178:10:1178:13 | ...[...] | provenance |  |
+| array_flow.rb:1178:10:1178:10 | a : [collection] [element] | array_flow.rb:1178:10:1178:13 | ...[...] | provenance |  |
+| array_flow.rb:1179:10:1179:10 | a : [collection] [element] | array_flow.rb:1179:10:1179:13 | ...[...] | provenance |  |
+| array_flow.rb:1180:10:1180:10 | a : Array [element 2] | array_flow.rb:1180:10:1180:13 | ...[...] | provenance |  |
+| array_flow.rb:1180:10:1180:10 | a : [collection] [element] | array_flow.rb:1180:10:1180:13 | ...[...] | provenance |  |
+| array_flow.rb:1184:5:1184:5 | a : Array [element 2] | array_flow.rb:1185:9:1185:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1184:5:1184:5 | a : Array [element 2] | array_flow.rb:1188:10:1188:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1184:9:1184:27 | call to [] : Array [element 2] | array_flow.rb:1184:5:1184:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1184:16:1184:26 | call to source | array_flow.rb:1184:9:1184:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1185:5:1185:5 | b : [collection] [element] | array_flow.rb:1189:10:1189:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1185:5:1185:5 | b : [collection] [element] | array_flow.rb:1190:10:1190:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1185:5:1185:5 | b : [collection] [element] | array_flow.rb:1191:10:1191:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1185:9:1185:9 | a : Array [element 2] | array_flow.rb:1185:9:1185:17 | call to shuffle : [collection] [element] | provenance |  |
+| array_flow.rb:1185:9:1185:17 | call to shuffle : [collection] [element] | array_flow.rb:1185:5:1185:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1188:10:1188:10 | a : Array [element 2] | array_flow.rb:1188:10:1188:13 | ...[...] | provenance |  |
+| array_flow.rb:1189:10:1189:10 | b : [collection] [element] | array_flow.rb:1189:10:1189:13 | ...[...] | provenance |  |
+| array_flow.rb:1190:10:1190:10 | b : [collection] [element] | array_flow.rb:1190:10:1190:13 | ...[...] | provenance |  |
+| array_flow.rb:1191:10:1191:10 | b : [collection] [element] | array_flow.rb:1191:10:1191:13 | ...[...] | provenance |  |
+| array_flow.rb:1195:5:1195:5 | a : Array [element 2] | array_flow.rb:1196:9:1196:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1195:5:1195:5 | a : Array [element 2] | array_flow.rb:1199:10:1199:10 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1195:9:1195:27 | call to [] : Array [element 2] | array_flow.rb:1195:5:1195:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1195:16:1195:26 | call to source | array_flow.rb:1195:9:1195:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1196:5:1196:5 | b : [collection] [element] | array_flow.rb:1200:10:1200:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1196:5:1196:5 | b : [collection] [element] | array_flow.rb:1201:10:1201:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1196:5:1196:5 | b : [collection] [element] | array_flow.rb:1202:10:1202:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:9 | [post] a : [collection] [element] | array_flow.rb:1197:10:1197:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:9 | [post] a : [collection] [element] | array_flow.rb:1198:10:1198:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:9 | [post] a : [collection] [element] | array_flow.rb:1199:10:1199:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:9 | a : Array [element 2] | array_flow.rb:1196:9:1196:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:9 | a : Array [element 2] | array_flow.rb:1196:9:1196:18 | call to shuffle! : [collection] [element] | provenance |  |
+| array_flow.rb:1196:9:1196:18 | call to shuffle! : [collection] [element] | array_flow.rb:1196:5:1196:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1197:10:1197:10 | a : [collection] [element] | array_flow.rb:1197:10:1197:13 | ...[...] | provenance |  |
+| array_flow.rb:1198:10:1198:10 | a : [collection] [element] | array_flow.rb:1198:10:1198:13 | ...[...] | provenance |  |
+| array_flow.rb:1199:10:1199:10 | a : Array [element 2] | array_flow.rb:1199:10:1199:13 | ...[...] | provenance |  |
+| array_flow.rb:1199:10:1199:10 | a : [collection] [element] | array_flow.rb:1199:10:1199:13 | ...[...] | provenance |  |
+| array_flow.rb:1200:10:1200:10 | b : [collection] [element] | array_flow.rb:1200:10:1200:13 | ...[...] | provenance |  |
+| array_flow.rb:1201:10:1201:10 | b : [collection] [element] | array_flow.rb:1201:10:1201:13 | ...[...] | provenance |  |
+| array_flow.rb:1202:10:1202:10 | b : [collection] [element] | array_flow.rb:1202:10:1202:13 | ...[...] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1211:9:1211:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1214:9:1214:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1221:9:1221:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1226:9:1226:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1230:9:1230:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1235:9:1235:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1240:9:1240:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1244:9:1244:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1248:9:1248:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | array_flow.rb:1253:9:1253:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1208:9:1208:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1211:9:1211:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1214:9:1214:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1221:9:1221:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1226:9:1226:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1240:9:1240:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1244:9:1244:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | array_flow.rb:1253:9:1253:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:9:1206:47 | call to [] : Array [element 2] | array_flow.rb:1206:5:1206:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1206:9:1206:47 | call to [] : Array [element 4] | array_flow.rb:1206:5:1206:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1206:16:1206:28 | call to source | array_flow.rb:1206:9:1206:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1206:34:1206:46 | call to source | array_flow.rb:1206:9:1206:47 | call to [] : Array [element 4] | provenance |  |
 | array_flow.rb:1208:5:1208:5 | b | array_flow.rb:1209:10:1209:10 | b | provenance |  |
-| array_flow.rb:1208:9:1208:9 | a [element 4] | array_flow.rb:1208:9:1208:17 | call to slice | provenance |  |
+| array_flow.rb:1208:9:1208:9 | a : Array [element 4] | array_flow.rb:1208:9:1208:17 | call to slice | provenance |  |
 | array_flow.rb:1208:9:1208:17 | call to slice | array_flow.rb:1208:5:1208:5 | b | provenance |  |
 | array_flow.rb:1211:5:1211:5 | b | array_flow.rb:1212:10:1212:10 | b | provenance |  |
-| array_flow.rb:1211:9:1211:9 | a [element 2] | array_flow.rb:1211:9:1211:19 | call to slice | provenance |  |
-| array_flow.rb:1211:9:1211:9 | a [element 4] | array_flow.rb:1211:9:1211:19 | call to slice | provenance |  |
+| array_flow.rb:1211:9:1211:9 | a : Array [element 2] | array_flow.rb:1211:9:1211:19 | call to slice | provenance |  |
+| array_flow.rb:1211:9:1211:9 | a : Array [element 4] | array_flow.rb:1211:9:1211:19 | call to slice | provenance |  |
 | array_flow.rb:1211:9:1211:19 | call to slice | array_flow.rb:1211:5:1211:5 | b | provenance |  |
 | array_flow.rb:1214:5:1214:5 | b | array_flow.rb:1216:10:1216:10 | b | provenance |  |
-| array_flow.rb:1214:9:1214:9 | a [element 2] | array_flow.rb:1214:9:1214:17 | call to slice | provenance |  |
-| array_flow.rb:1214:9:1214:9 | a [element 4] | array_flow.rb:1214:9:1214:17 | call to slice | provenance |  |
+| array_flow.rb:1214:9:1214:9 | a : Array [element 2] | array_flow.rb:1214:9:1214:17 | call to slice | provenance |  |
+| array_flow.rb:1214:9:1214:9 | a : Array [element 4] | array_flow.rb:1214:9:1214:17 | call to slice | provenance |  |
 | array_flow.rb:1214:9:1214:17 | call to slice | array_flow.rb:1214:5:1214:5 | b | provenance |  |
-| array_flow.rb:1221:5:1221:5 | b [element 0] | array_flow.rb:1222:10:1222:10 | b [element 0] | provenance |  |
-| array_flow.rb:1221:5:1221:5 | b [element 2] | array_flow.rb:1224:10:1224:10 | b [element 2] | provenance |  |
-| array_flow.rb:1221:9:1221:9 | a [element 2] | array_flow.rb:1221:9:1221:21 | call to slice [element 0] | provenance |  |
-| array_flow.rb:1221:9:1221:9 | a [element 4] | array_flow.rb:1221:9:1221:21 | call to slice [element 2] | provenance |  |
-| array_flow.rb:1221:9:1221:21 | call to slice [element 0] | array_flow.rb:1221:5:1221:5 | b [element 0] | provenance |  |
-| array_flow.rb:1221:9:1221:21 | call to slice [element 2] | array_flow.rb:1221:5:1221:5 | b [element 2] | provenance |  |
-| array_flow.rb:1222:10:1222:10 | b [element 0] | array_flow.rb:1222:10:1222:13 | ...[...] | provenance |  |
-| array_flow.rb:1224:10:1224:10 | b [element 2] | array_flow.rb:1224:10:1224:13 | ...[...] | provenance |  |
-| array_flow.rb:1226:5:1226:5 | b [element] | array_flow.rb:1227:10:1227:10 | b [element] | provenance |  |
-| array_flow.rb:1226:5:1226:5 | b [element] | array_flow.rb:1228:10:1228:10 | b [element] | provenance |  |
-| array_flow.rb:1226:9:1226:9 | a [element 2] | array_flow.rb:1226:9:1226:21 | call to slice [element] | provenance |  |
-| array_flow.rb:1226:9:1226:9 | a [element 4] | array_flow.rb:1226:9:1226:21 | call to slice [element] | provenance |  |
-| array_flow.rb:1226:9:1226:21 | call to slice [element] | array_flow.rb:1226:5:1226:5 | b [element] | provenance |  |
-| array_flow.rb:1227:10:1227:10 | b [element] | array_flow.rb:1227:10:1227:13 | ...[...] | provenance |  |
-| array_flow.rb:1228:10:1228:10 | b [element] | array_flow.rb:1228:10:1228:13 | ...[...] | provenance |  |
-| array_flow.rb:1230:5:1230:5 | b [element 0] | array_flow.rb:1231:10:1231:10 | b [element 0] | provenance |  |
-| array_flow.rb:1230:9:1230:9 | a [element 2] | array_flow.rb:1230:9:1230:21 | call to slice [element 0] | provenance |  |
-| array_flow.rb:1230:9:1230:21 | call to slice [element 0] | array_flow.rb:1230:5:1230:5 | b [element 0] | provenance |  |
-| array_flow.rb:1231:10:1231:10 | b [element 0] | array_flow.rb:1231:10:1231:13 | ...[...] | provenance |  |
-| array_flow.rb:1235:5:1235:5 | b [element 0] | array_flow.rb:1236:10:1236:10 | b [element 0] | provenance |  |
-| array_flow.rb:1235:9:1235:9 | a [element 2] | array_flow.rb:1235:9:1235:22 | call to slice [element 0] | provenance |  |
-| array_flow.rb:1235:9:1235:22 | call to slice [element 0] | array_flow.rb:1235:5:1235:5 | b [element 0] | provenance |  |
-| array_flow.rb:1236:10:1236:10 | b [element 0] | array_flow.rb:1236:10:1236:13 | ...[...] | provenance |  |
-| array_flow.rb:1240:5:1240:5 | b [element] | array_flow.rb:1241:10:1241:10 | b [element] | provenance |  |
-| array_flow.rb:1240:5:1240:5 | b [element] | array_flow.rb:1242:10:1242:10 | b [element] | provenance |  |
-| array_flow.rb:1240:9:1240:9 | a [element 2] | array_flow.rb:1240:9:1240:21 | call to slice [element] | provenance |  |
-| array_flow.rb:1240:9:1240:9 | a [element 4] | array_flow.rb:1240:9:1240:21 | call to slice [element] | provenance |  |
-| array_flow.rb:1240:9:1240:21 | call to slice [element] | array_flow.rb:1240:5:1240:5 | b [element] | provenance |  |
-| array_flow.rb:1241:10:1241:10 | b [element] | array_flow.rb:1241:10:1241:13 | ...[...] | provenance |  |
-| array_flow.rb:1242:10:1242:10 | b [element] | array_flow.rb:1242:10:1242:13 | ...[...] | provenance |  |
-| array_flow.rb:1244:5:1244:5 | b [element] | array_flow.rb:1245:10:1245:10 | b [element] | provenance |  |
-| array_flow.rb:1244:5:1244:5 | b [element] | array_flow.rb:1246:10:1246:10 | b [element] | provenance |  |
-| array_flow.rb:1244:9:1244:9 | a [element 2] | array_flow.rb:1244:9:1244:24 | call to slice [element] | provenance |  |
-| array_flow.rb:1244:9:1244:9 | a [element 4] | array_flow.rb:1244:9:1244:24 | call to slice [element] | provenance |  |
-| array_flow.rb:1244:9:1244:24 | call to slice [element] | array_flow.rb:1244:5:1244:5 | b [element] | provenance |  |
-| array_flow.rb:1245:10:1245:10 | b [element] | array_flow.rb:1245:10:1245:13 | ...[...] | provenance |  |
-| array_flow.rb:1246:10:1246:10 | b [element] | array_flow.rb:1246:10:1246:13 | ...[...] | provenance |  |
-| array_flow.rb:1248:5:1248:5 | b [element 2] | array_flow.rb:1251:10:1251:10 | b [element 2] | provenance |  |
-| array_flow.rb:1248:9:1248:9 | a [element 2] | array_flow.rb:1248:9:1248:20 | call to slice [element 2] | provenance |  |
-| array_flow.rb:1248:9:1248:20 | call to slice [element 2] | array_flow.rb:1248:5:1248:5 | b [element 2] | provenance |  |
-| array_flow.rb:1251:10:1251:10 | b [element 2] | array_flow.rb:1251:10:1251:13 | ...[...] | provenance |  |
-| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1254:10:1254:10 | b [element] | provenance |  |
-| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1255:10:1255:10 | b [element] | provenance |  |
-| array_flow.rb:1253:5:1253:5 | b [element] | array_flow.rb:1256:10:1256:10 | b [element] | provenance |  |
-| array_flow.rb:1253:9:1253:9 | a [element 2] | array_flow.rb:1253:9:1253:20 | call to slice [element] | provenance |  |
-| array_flow.rb:1253:9:1253:9 | a [element 4] | array_flow.rb:1253:9:1253:20 | call to slice [element] | provenance |  |
-| array_flow.rb:1253:9:1253:20 | call to slice [element] | array_flow.rb:1253:5:1253:5 | b [element] | provenance |  |
-| array_flow.rb:1254:10:1254:10 | b [element] | array_flow.rb:1254:10:1254:13 | ...[...] | provenance |  |
-| array_flow.rb:1255:10:1255:10 | b [element] | array_flow.rb:1255:10:1255:13 | ...[...] | provenance |  |
-| array_flow.rb:1256:10:1256:10 | b [element] | array_flow.rb:1256:10:1256:13 | ...[...] | provenance |  |
-| array_flow.rb:1260:5:1260:5 | a [element 2] | array_flow.rb:1261:9:1261:9 | a [element 2] | provenance |  |
-| array_flow.rb:1260:5:1260:5 | a [element 4] | array_flow.rb:1261:9:1261:9 | a [element 4] | provenance |  |
-| array_flow.rb:1260:9:1260:47 | call to [] [element 2] | array_flow.rb:1260:5:1260:5 | a [element 2] | provenance |  |
-| array_flow.rb:1260:9:1260:47 | call to [] [element 4] | array_flow.rb:1260:5:1260:5 | a [element 4] | provenance |  |
-| array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1260:9:1260:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1260:9:1260:47 | call to [] [element 4] | provenance |  |
+| array_flow.rb:1221:5:1221:5 | b : [collection] [element 0] | array_flow.rb:1222:10:1222:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1221:5:1221:5 | b : [collection] [element 2] | array_flow.rb:1224:10:1224:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1221:9:1221:9 | a : Array [element 2] | array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 0] | provenance |  |
+| array_flow.rb:1221:9:1221:9 | a : Array [element 4] | array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 2] | provenance |  |
+| array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 0] | array_flow.rb:1221:5:1221:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 2] | array_flow.rb:1221:5:1221:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1222:10:1222:10 | b : [collection] [element 0] | array_flow.rb:1222:10:1222:13 | ...[...] | provenance |  |
+| array_flow.rb:1224:10:1224:10 | b : [collection] [element 2] | array_flow.rb:1224:10:1224:13 | ...[...] | provenance |  |
+| array_flow.rb:1226:5:1226:5 | b : [collection] [element] | array_flow.rb:1227:10:1227:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1226:5:1226:5 | b : [collection] [element] | array_flow.rb:1228:10:1228:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1226:9:1226:9 | a : Array [element 2] | array_flow.rb:1226:9:1226:21 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1226:9:1226:9 | a : Array [element 4] | array_flow.rb:1226:9:1226:21 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1226:9:1226:21 | call to slice : [collection] [element] | array_flow.rb:1226:5:1226:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1227:10:1227:10 | b : [collection] [element] | array_flow.rb:1227:10:1227:13 | ...[...] | provenance |  |
+| array_flow.rb:1228:10:1228:10 | b : [collection] [element] | array_flow.rb:1228:10:1228:13 | ...[...] | provenance |  |
+| array_flow.rb:1230:5:1230:5 | b : [collection] [element 0] | array_flow.rb:1231:10:1231:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1230:9:1230:9 | a : Array [element 2] | array_flow.rb:1230:9:1230:21 | call to slice : [collection] [element 0] | provenance |  |
+| array_flow.rb:1230:9:1230:21 | call to slice : [collection] [element 0] | array_flow.rb:1230:5:1230:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1231:10:1231:10 | b : [collection] [element 0] | array_flow.rb:1231:10:1231:13 | ...[...] | provenance |  |
+| array_flow.rb:1235:5:1235:5 | b : [collection] [element 0] | array_flow.rb:1236:10:1236:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1235:9:1235:9 | a : Array [element 2] | array_flow.rb:1235:9:1235:22 | call to slice : [collection] [element 0] | provenance |  |
+| array_flow.rb:1235:9:1235:22 | call to slice : [collection] [element 0] | array_flow.rb:1235:5:1235:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1236:10:1236:10 | b : [collection] [element 0] | array_flow.rb:1236:10:1236:13 | ...[...] | provenance |  |
+| array_flow.rb:1240:5:1240:5 | b : [collection] [element] | array_flow.rb:1241:10:1241:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1240:5:1240:5 | b : [collection] [element] | array_flow.rb:1242:10:1242:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1240:9:1240:9 | a : Array [element 2] | array_flow.rb:1240:9:1240:21 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1240:9:1240:9 | a : Array [element 4] | array_flow.rb:1240:9:1240:21 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1240:9:1240:21 | call to slice : [collection] [element] | array_flow.rb:1240:5:1240:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1241:10:1241:10 | b : [collection] [element] | array_flow.rb:1241:10:1241:13 | ...[...] | provenance |  |
+| array_flow.rb:1242:10:1242:10 | b : [collection] [element] | array_flow.rb:1242:10:1242:13 | ...[...] | provenance |  |
+| array_flow.rb:1244:5:1244:5 | b : [collection] [element] | array_flow.rb:1245:10:1245:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1244:5:1244:5 | b : [collection] [element] | array_flow.rb:1246:10:1246:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1244:9:1244:9 | a : Array [element 2] | array_flow.rb:1244:9:1244:24 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1244:9:1244:9 | a : Array [element 4] | array_flow.rb:1244:9:1244:24 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1244:9:1244:24 | call to slice : [collection] [element] | array_flow.rb:1244:5:1244:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1245:10:1245:10 | b : [collection] [element] | array_flow.rb:1245:10:1245:13 | ...[...] | provenance |  |
+| array_flow.rb:1246:10:1246:10 | b : [collection] [element] | array_flow.rb:1246:10:1246:13 | ...[...] | provenance |  |
+| array_flow.rb:1248:5:1248:5 | b : [collection] [element 2] | array_flow.rb:1251:10:1251:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1248:9:1248:9 | a : Array [element 2] | array_flow.rb:1248:9:1248:20 | call to slice : [collection] [element 2] | provenance |  |
+| array_flow.rb:1248:9:1248:20 | call to slice : [collection] [element 2] | array_flow.rb:1248:5:1248:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1251:10:1251:10 | b : [collection] [element 2] | array_flow.rb:1251:10:1251:13 | ...[...] | provenance |  |
+| array_flow.rb:1253:5:1253:5 | b : [collection] [element] | array_flow.rb:1254:10:1254:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1253:5:1253:5 | b : [collection] [element] | array_flow.rb:1255:10:1255:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1253:5:1253:5 | b : [collection] [element] | array_flow.rb:1256:10:1256:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1253:9:1253:9 | a : Array [element 2] | array_flow.rb:1253:9:1253:20 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1253:9:1253:9 | a : Array [element 4] | array_flow.rb:1253:9:1253:20 | call to slice : [collection] [element] | provenance |  |
+| array_flow.rb:1253:9:1253:20 | call to slice : [collection] [element] | array_flow.rb:1253:5:1253:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1254:10:1254:10 | b : [collection] [element] | array_flow.rb:1254:10:1254:13 | ...[...] | provenance |  |
+| array_flow.rb:1255:10:1255:10 | b : [collection] [element] | array_flow.rb:1255:10:1255:13 | ...[...] | provenance |  |
+| array_flow.rb:1256:10:1256:10 | b : [collection] [element] | array_flow.rb:1256:10:1256:13 | ...[...] | provenance |  |
+| array_flow.rb:1260:5:1260:5 | a : Array [element 2] | array_flow.rb:1261:9:1261:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1260:5:1260:5 | a : Array [element 4] | array_flow.rb:1261:9:1261:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1260:9:1260:47 | call to [] : Array [element 2] | array_flow.rb:1260:5:1260:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1260:9:1260:47 | call to [] : Array [element 4] | array_flow.rb:1260:5:1260:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1260:16:1260:28 | call to source | array_flow.rb:1260:9:1260:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1260:34:1260:46 | call to source | array_flow.rb:1260:9:1260:47 | call to [] : Array [element 4] | provenance |  |
 | array_flow.rb:1261:5:1261:5 | b | array_flow.rb:1262:10:1262:10 | b | provenance |  |
-| array_flow.rb:1261:9:1261:9 | [post] a [element 3] | array_flow.rb:1266:10:1266:10 | a [element 3] | provenance |  |
-| array_flow.rb:1261:9:1261:9 | a [element 2] | array_flow.rb:1261:9:1261:19 | call to slice! | provenance |  |
-| array_flow.rb:1261:9:1261:9 | a [element 4] | array_flow.rb:1261:9:1261:9 | [post] a [element 3] | provenance |  |
+| array_flow.rb:1261:9:1261:9 | [post] a : [collection] [element 3] | array_flow.rb:1266:10:1266:10 | a : [collection] [element 3] | provenance |  |
+| array_flow.rb:1261:9:1261:9 | a : Array [element 2] | array_flow.rb:1261:9:1261:19 | call to slice! | provenance |  |
+| array_flow.rb:1261:9:1261:9 | a : Array [element 4] | array_flow.rb:1261:9:1261:9 | [post] a : [collection] [element 3] | provenance |  |
 | array_flow.rb:1261:9:1261:19 | call to slice! | array_flow.rb:1261:5:1261:5 | b | provenance |  |
-| array_flow.rb:1266:10:1266:10 | a [element 3] | array_flow.rb:1266:10:1266:13 | ...[...] | provenance |  |
-| array_flow.rb:1268:5:1268:5 | a [element 2] | array_flow.rb:1269:9:1269:9 | a [element 2] | provenance |  |
-| array_flow.rb:1268:5:1268:5 | a [element 4] | array_flow.rb:1269:9:1269:9 | a [element 4] | provenance |  |
-| array_flow.rb:1268:9:1268:47 | call to [] [element 2] | array_flow.rb:1268:5:1268:5 | a [element 2] | provenance |  |
-| array_flow.rb:1268:9:1268:47 | call to [] [element 4] | array_flow.rb:1268:5:1268:5 | a [element 4] | provenance |  |
-| array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1268:9:1268:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1268:9:1268:47 | call to [] [element 4] | provenance |  |
+| array_flow.rb:1266:10:1266:10 | a : [collection] [element 3] | array_flow.rb:1266:10:1266:13 | ...[...] | provenance |  |
+| array_flow.rb:1268:5:1268:5 | a : Array [element 2] | array_flow.rb:1269:9:1269:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1268:5:1268:5 | a : Array [element 4] | array_flow.rb:1269:9:1269:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1268:9:1268:47 | call to [] : Array [element 2] | array_flow.rb:1268:5:1268:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1268:9:1268:47 | call to [] : Array [element 4] | array_flow.rb:1268:5:1268:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1268:16:1268:28 | call to source | array_flow.rb:1268:9:1268:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1268:34:1268:46 | call to source | array_flow.rb:1268:9:1268:47 | call to [] : Array [element 4] | provenance |  |
 | array_flow.rb:1269:5:1269:5 | b | array_flow.rb:1275:10:1275:10 | b | provenance |  |
-| array_flow.rb:1269:5:1269:5 | b [element] | array_flow.rb:1277:10:1277:10 | b [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1270:10:1270:10 | a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1271:10:1271:10 | a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1272:10:1272:10 | a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | [post] a [element] | array_flow.rb:1273:10:1273:10 | a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! | provenance |  |
-| array_flow.rb:1269:9:1269:9 | a [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! [element] | provenance |  |
+| array_flow.rb:1269:5:1269:5 | b : [collection] [element] | array_flow.rb:1277:10:1277:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | array_flow.rb:1270:10:1270:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | array_flow.rb:1271:10:1271:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | array_flow.rb:1272:10:1272:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | array_flow.rb:1273:10:1273:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 2] | array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 2] | array_flow.rb:1269:9:1269:19 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 4] | array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! | provenance |  |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 4] | array_flow.rb:1269:9:1269:19 | call to slice! : [collection] [element] | provenance |  |
 | array_flow.rb:1269:9:1269:19 | call to slice! | array_flow.rb:1269:5:1269:5 | b | provenance |  |
-| array_flow.rb:1269:9:1269:19 | call to slice! [element] | array_flow.rb:1269:5:1269:5 | b [element] | provenance |  |
-| array_flow.rb:1270:10:1270:10 | a [element] | array_flow.rb:1270:10:1270:13 | ...[...] | provenance |  |
-| array_flow.rb:1271:10:1271:10 | a [element] | array_flow.rb:1271:10:1271:13 | ...[...] | provenance |  |
-| array_flow.rb:1272:10:1272:10 | a [element] | array_flow.rb:1272:10:1272:13 | ...[...] | provenance |  |
-| array_flow.rb:1273:10:1273:10 | a [element] | array_flow.rb:1273:10:1273:13 | ...[...] | provenance |  |
-| array_flow.rb:1277:10:1277:10 | b [element] | array_flow.rb:1277:10:1277:13 | ...[...] | provenance |  |
-| array_flow.rb:1279:5:1279:5 | a [element 2] | array_flow.rb:1280:9:1280:9 | a [element 2] | provenance |  |
-| array_flow.rb:1279:5:1279:5 | a [element 4] | array_flow.rb:1280:9:1280:9 | a [element 4] | provenance |  |
-| array_flow.rb:1279:9:1279:47 | call to [] [element 2] | array_flow.rb:1279:5:1279:5 | a [element 2] | provenance |  |
-| array_flow.rb:1279:9:1279:47 | call to [] [element 4] | array_flow.rb:1279:5:1279:5 | a [element 4] | provenance |  |
-| array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1279:9:1279:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1279:9:1279:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1280:5:1280:5 | b [element 0] | array_flow.rb:1281:10:1281:10 | b [element 0] | provenance |  |
-| array_flow.rb:1280:5:1280:5 | b [element 2] | array_flow.rb:1283:10:1283:10 | b [element 2] | provenance |  |
-| array_flow.rb:1280:9:1280:9 | a [element 2] | array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | provenance |  |
-| array_flow.rb:1280:9:1280:9 | a [element 4] | array_flow.rb:1280:9:1280:22 | call to slice! [element 2] | provenance |  |
-| array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | array_flow.rb:1280:5:1280:5 | b [element 0] | provenance |  |
-| array_flow.rb:1280:9:1280:22 | call to slice! [element 2] | array_flow.rb:1280:5:1280:5 | b [element 2] | provenance |  |
-| array_flow.rb:1281:10:1281:10 | b [element 0] | array_flow.rb:1281:10:1281:13 | ...[...] | provenance |  |
-| array_flow.rb:1283:10:1283:10 | b [element 2] | array_flow.rb:1283:10:1283:13 | ...[...] | provenance |  |
-| array_flow.rb:1290:5:1290:5 | a [element 2] | array_flow.rb:1291:9:1291:9 | a [element 2] | provenance |  |
-| array_flow.rb:1290:5:1290:5 | a [element 4] | array_flow.rb:1291:9:1291:9 | a [element 4] | provenance |  |
-| array_flow.rb:1290:9:1290:47 | call to [] [element 2] | array_flow.rb:1290:5:1290:5 | a [element 2] | provenance |  |
-| array_flow.rb:1290:9:1290:47 | call to [] [element 4] | array_flow.rb:1290:5:1290:5 | a [element 4] | provenance |  |
-| array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1290:9:1290:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1290:9:1290:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1291:5:1291:5 | b [element 0] | array_flow.rb:1292:10:1292:10 | b [element 0] | provenance |  |
-| array_flow.rb:1291:9:1291:9 | [post] a [element 2] | array_flow.rb:1297:10:1297:10 | a [element 2] | provenance |  |
-| array_flow.rb:1291:9:1291:9 | a [element 2] | array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | provenance |  |
-| array_flow.rb:1291:9:1291:9 | a [element 4] | array_flow.rb:1291:9:1291:9 | [post] a [element 2] | provenance |  |
-| array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | array_flow.rb:1291:5:1291:5 | b [element 0] | provenance |  |
-| array_flow.rb:1292:10:1292:10 | b [element 0] | array_flow.rb:1292:10:1292:13 | ...[...] | provenance |  |
-| array_flow.rb:1297:10:1297:10 | a [element 2] | array_flow.rb:1297:10:1297:13 | ...[...] | provenance |  |
-| array_flow.rb:1301:5:1301:5 | a [element 2] | array_flow.rb:1302:9:1302:9 | a [element 2] | provenance |  |
-| array_flow.rb:1301:5:1301:5 | a [element 4] | array_flow.rb:1302:9:1302:9 | a [element 4] | provenance |  |
-| array_flow.rb:1301:9:1301:47 | call to [] [element 2] | array_flow.rb:1301:5:1301:5 | a [element 2] | provenance |  |
-| array_flow.rb:1301:9:1301:47 | call to [] [element 4] | array_flow.rb:1301:5:1301:5 | a [element 4] | provenance |  |
-| array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1301:9:1301:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1301:9:1301:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1302:5:1302:5 | b [element 0] | array_flow.rb:1303:10:1303:10 | b [element 0] | provenance |  |
-| array_flow.rb:1302:9:1302:9 | [post] a [element 2] | array_flow.rb:1308:10:1308:10 | a [element 2] | provenance |  |
-| array_flow.rb:1302:9:1302:9 | a [element 2] | array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | provenance |  |
-| array_flow.rb:1302:9:1302:9 | a [element 4] | array_flow.rb:1302:9:1302:9 | [post] a [element 2] | provenance |  |
-| array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | array_flow.rb:1302:5:1302:5 | b [element 0] | provenance |  |
-| array_flow.rb:1303:10:1303:10 | b [element 0] | array_flow.rb:1303:10:1303:13 | ...[...] | provenance |  |
-| array_flow.rb:1308:10:1308:10 | a [element 2] | array_flow.rb:1308:10:1308:13 | ...[...] | provenance |  |
-| array_flow.rb:1312:5:1312:5 | a [element 2] | array_flow.rb:1313:9:1313:9 | a [element 2] | provenance |  |
-| array_flow.rb:1312:5:1312:5 | a [element 4] | array_flow.rb:1313:9:1313:9 | a [element 4] | provenance |  |
-| array_flow.rb:1312:9:1312:47 | call to [] [element 2] | array_flow.rb:1312:5:1312:5 | a [element 2] | provenance |  |
-| array_flow.rb:1312:9:1312:47 | call to [] [element 4] | array_flow.rb:1312:5:1312:5 | a [element 4] | provenance |  |
-| array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1312:9:1312:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1312:9:1312:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1314:10:1314:10 | b [element] | provenance |  |
-| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1315:10:1315:10 | b [element] | provenance |  |
-| array_flow.rb:1313:5:1313:5 | b [element] | array_flow.rb:1316:10:1316:10 | b [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1317:10:1317:10 | a [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1318:10:1318:10 | a [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | [post] a [element] | array_flow.rb:1319:10:1319:10 | a [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | a [element 2] | array_flow.rb:1313:9:1313:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | a [element 2] | array_flow.rb:1313:9:1313:22 | call to slice! [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | a [element 4] | array_flow.rb:1313:9:1313:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1313:9:1313:9 | a [element 4] | array_flow.rb:1313:9:1313:22 | call to slice! [element] | provenance |  |
-| array_flow.rb:1313:9:1313:22 | call to slice! [element] | array_flow.rb:1313:5:1313:5 | b [element] | provenance |  |
-| array_flow.rb:1314:10:1314:10 | b [element] | array_flow.rb:1314:10:1314:13 | ...[...] | provenance |  |
-| array_flow.rb:1315:10:1315:10 | b [element] | array_flow.rb:1315:10:1315:13 | ...[...] | provenance |  |
-| array_flow.rb:1316:10:1316:10 | b [element] | array_flow.rb:1316:10:1316:13 | ...[...] | provenance |  |
-| array_flow.rb:1317:10:1317:10 | a [element] | array_flow.rb:1317:10:1317:13 | ...[...] | provenance |  |
-| array_flow.rb:1318:10:1318:10 | a [element] | array_flow.rb:1318:10:1318:13 | ...[...] | provenance |  |
-| array_flow.rb:1319:10:1319:10 | a [element] | array_flow.rb:1319:10:1319:13 | ...[...] | provenance |  |
-| array_flow.rb:1321:5:1321:5 | a [element 2] | array_flow.rb:1322:9:1322:9 | a [element 2] | provenance |  |
-| array_flow.rb:1321:5:1321:5 | a [element 4] | array_flow.rb:1322:9:1322:9 | a [element 4] | provenance |  |
-| array_flow.rb:1321:9:1321:47 | call to [] [element 2] | array_flow.rb:1321:5:1321:5 | a [element 2] | provenance |  |
-| array_flow.rb:1321:9:1321:47 | call to [] [element 4] | array_flow.rb:1321:5:1321:5 | a [element 4] | provenance |  |
-| array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1321:9:1321:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1321:9:1321:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1323:10:1323:10 | b [element] | provenance |  |
-| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1324:10:1324:10 | b [element] | provenance |  |
-| array_flow.rb:1322:5:1322:5 | b [element] | array_flow.rb:1325:10:1325:10 | b [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1326:10:1326:10 | a [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1327:10:1327:10 | a [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | [post] a [element] | array_flow.rb:1328:10:1328:10 | a [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | a [element 2] | array_flow.rb:1322:9:1322:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | a [element 2] | array_flow.rb:1322:9:1322:22 | call to slice! [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | a [element 4] | array_flow.rb:1322:9:1322:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1322:9:1322:9 | a [element 4] | array_flow.rb:1322:9:1322:22 | call to slice! [element] | provenance |  |
-| array_flow.rb:1322:9:1322:22 | call to slice! [element] | array_flow.rb:1322:5:1322:5 | b [element] | provenance |  |
-| array_flow.rb:1323:10:1323:10 | b [element] | array_flow.rb:1323:10:1323:13 | ...[...] | provenance |  |
-| array_flow.rb:1324:10:1324:10 | b [element] | array_flow.rb:1324:10:1324:13 | ...[...] | provenance |  |
-| array_flow.rb:1325:10:1325:10 | b [element] | array_flow.rb:1325:10:1325:13 | ...[...] | provenance |  |
-| array_flow.rb:1326:10:1326:10 | a [element] | array_flow.rb:1326:10:1326:13 | ...[...] | provenance |  |
-| array_flow.rb:1327:10:1327:10 | a [element] | array_flow.rb:1327:10:1327:13 | ...[...] | provenance |  |
-| array_flow.rb:1328:10:1328:10 | a [element] | array_flow.rb:1328:10:1328:13 | ...[...] | provenance |  |
-| array_flow.rb:1330:5:1330:5 | a [element 2] | array_flow.rb:1331:9:1331:9 | a [element 2] | provenance |  |
-| array_flow.rb:1330:5:1330:5 | a [element 4] | array_flow.rb:1331:9:1331:9 | a [element 4] | provenance |  |
-| array_flow.rb:1330:9:1330:47 | call to [] [element 2] | array_flow.rb:1330:5:1330:5 | a [element 2] | provenance |  |
-| array_flow.rb:1330:9:1330:47 | call to [] [element 4] | array_flow.rb:1330:5:1330:5 | a [element 4] | provenance |  |
-| array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1330:9:1330:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1330:9:1330:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1332:10:1332:10 | b [element] | provenance |  |
-| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1333:10:1333:10 | b [element] | provenance |  |
-| array_flow.rb:1331:5:1331:5 | b [element] | array_flow.rb:1334:10:1334:10 | b [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1335:10:1335:10 | a [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1336:10:1336:10 | a [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | [post] a [element] | array_flow.rb:1337:10:1337:10 | a [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | a [element 2] | array_flow.rb:1331:9:1331:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | a [element 2] | array_flow.rb:1331:9:1331:25 | call to slice! [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | a [element 4] | array_flow.rb:1331:9:1331:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1331:9:1331:9 | a [element 4] | array_flow.rb:1331:9:1331:25 | call to slice! [element] | provenance |  |
-| array_flow.rb:1331:9:1331:25 | call to slice! [element] | array_flow.rb:1331:5:1331:5 | b [element] | provenance |  |
-| array_flow.rb:1332:10:1332:10 | b [element] | array_flow.rb:1332:10:1332:13 | ...[...] | provenance |  |
-| array_flow.rb:1333:10:1333:10 | b [element] | array_flow.rb:1333:10:1333:13 | ...[...] | provenance |  |
-| array_flow.rb:1334:10:1334:10 | b [element] | array_flow.rb:1334:10:1334:13 | ...[...] | provenance |  |
-| array_flow.rb:1335:10:1335:10 | a [element] | array_flow.rb:1335:10:1335:13 | ...[...] | provenance |  |
-| array_flow.rb:1336:10:1336:10 | a [element] | array_flow.rb:1336:10:1336:13 | ...[...] | provenance |  |
-| array_flow.rb:1337:10:1337:10 | a [element] | array_flow.rb:1337:10:1337:13 | ...[...] | provenance |  |
-| array_flow.rb:1339:5:1339:5 | a [element 2] | array_flow.rb:1340:9:1340:9 | a [element 2] | provenance |  |
-| array_flow.rb:1339:5:1339:5 | a [element 4] | array_flow.rb:1340:9:1340:9 | a [element 4] | provenance |  |
-| array_flow.rb:1339:9:1339:47 | call to [] [element 2] | array_flow.rb:1339:5:1339:5 | a [element 2] | provenance |  |
-| array_flow.rb:1339:9:1339:47 | call to [] [element 4] | array_flow.rb:1339:5:1339:5 | a [element 4] | provenance |  |
-| array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1339:9:1339:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1339:9:1339:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1340:5:1340:5 | b [element 2] | array_flow.rb:1343:10:1343:10 | b [element 2] | provenance |  |
-| array_flow.rb:1340:9:1340:9 | [post] a [element 1] | array_flow.rb:1345:10:1345:10 | a [element 1] | provenance |  |
-| array_flow.rb:1340:9:1340:9 | a [element 2] | array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | provenance |  |
-| array_flow.rb:1340:9:1340:9 | a [element 4] | array_flow.rb:1340:9:1340:9 | [post] a [element 1] | provenance |  |
-| array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | array_flow.rb:1340:5:1340:5 | b [element 2] | provenance |  |
-| array_flow.rb:1343:10:1343:10 | b [element 2] | array_flow.rb:1343:10:1343:13 | ...[...] | provenance |  |
-| array_flow.rb:1345:10:1345:10 | a [element 1] | array_flow.rb:1345:10:1345:13 | ...[...] | provenance |  |
-| array_flow.rb:1348:5:1348:5 | a [element 2] | array_flow.rb:1349:9:1349:9 | a [element 2] | provenance |  |
-| array_flow.rb:1348:5:1348:5 | a [element 4] | array_flow.rb:1349:9:1349:9 | a [element 4] | provenance |  |
-| array_flow.rb:1348:9:1348:47 | call to [] [element 2] | array_flow.rb:1348:5:1348:5 | a [element 2] | provenance |  |
-| array_flow.rb:1348:9:1348:47 | call to [] [element 4] | array_flow.rb:1348:5:1348:5 | a [element 4] | provenance |  |
-| array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1348:9:1348:47 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1348:9:1348:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1350:10:1350:10 | b [element] | provenance |  |
-| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1351:10:1351:10 | b [element] | provenance |  |
-| array_flow.rb:1349:5:1349:5 | b [element] | array_flow.rb:1352:10:1352:10 | b [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1353:10:1353:10 | a [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1354:10:1354:10 | a [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | [post] a [element] | array_flow.rb:1355:10:1355:10 | a [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | a [element 2] | array_flow.rb:1349:9:1349:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | a [element 2] | array_flow.rb:1349:9:1349:21 | call to slice! [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | a [element 4] | array_flow.rb:1349:9:1349:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1349:9:1349:9 | a [element 4] | array_flow.rb:1349:9:1349:21 | call to slice! [element] | provenance |  |
-| array_flow.rb:1349:9:1349:21 | call to slice! [element] | array_flow.rb:1349:5:1349:5 | b [element] | provenance |  |
-| array_flow.rb:1350:10:1350:10 | b [element] | array_flow.rb:1350:10:1350:13 | ...[...] | provenance |  |
-| array_flow.rb:1351:10:1351:10 | b [element] | array_flow.rb:1351:10:1351:13 | ...[...] | provenance |  |
-| array_flow.rb:1352:10:1352:10 | b [element] | array_flow.rb:1352:10:1352:13 | ...[...] | provenance |  |
-| array_flow.rb:1353:10:1353:10 | a [element] | array_flow.rb:1353:10:1353:13 | ...[...] | provenance |  |
-| array_flow.rb:1354:10:1354:10 | a [element] | array_flow.rb:1354:10:1354:13 | ...[...] | provenance |  |
-| array_flow.rb:1355:10:1355:10 | a [element] | array_flow.rb:1355:10:1355:13 | ...[...] | provenance |  |
-| array_flow.rb:1359:5:1359:5 | a [element 2] | array_flow.rb:1360:9:1360:9 | a [element 2] | provenance |  |
-| array_flow.rb:1359:9:1359:27 | call to [] [element 2] | array_flow.rb:1359:5:1359:5 | a [element 2] | provenance |  |
-| array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1359:9:1359:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1360:9:1360:9 | a [element 2] | array_flow.rb:1360:27:1360:27 | x | provenance |  |
+| array_flow.rb:1269:9:1269:19 | call to slice! : [collection] [element] | array_flow.rb:1269:5:1269:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1270:10:1270:10 | a : [collection] [element] | array_flow.rb:1270:10:1270:13 | ...[...] | provenance |  |
+| array_flow.rb:1271:10:1271:10 | a : [collection] [element] | array_flow.rb:1271:10:1271:13 | ...[...] | provenance |  |
+| array_flow.rb:1272:10:1272:10 | a : [collection] [element] | array_flow.rb:1272:10:1272:13 | ...[...] | provenance |  |
+| array_flow.rb:1273:10:1273:10 | a : [collection] [element] | array_flow.rb:1273:10:1273:13 | ...[...] | provenance |  |
+| array_flow.rb:1277:10:1277:10 | b : [collection] [element] | array_flow.rb:1277:10:1277:13 | ...[...] | provenance |  |
+| array_flow.rb:1279:5:1279:5 | a : Array [element 2] | array_flow.rb:1280:9:1280:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1279:5:1279:5 | a : Array [element 4] | array_flow.rb:1280:9:1280:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1279:9:1279:47 | call to [] : Array [element 2] | array_flow.rb:1279:5:1279:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1279:9:1279:47 | call to [] : Array [element 4] | array_flow.rb:1279:5:1279:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1279:16:1279:28 | call to source | array_flow.rb:1279:9:1279:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1279:34:1279:46 | call to source | array_flow.rb:1279:9:1279:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1280:5:1280:5 | b : [collection] [element 0] | array_flow.rb:1281:10:1281:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1280:5:1280:5 | b : [collection] [element 2] | array_flow.rb:1283:10:1283:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1280:9:1280:9 | a : Array [element 2] | array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 0] | provenance |  |
+| array_flow.rb:1280:9:1280:9 | a : Array [element 4] | array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 2] | provenance |  |
+| array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 0] | array_flow.rb:1280:5:1280:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 2] | array_flow.rb:1280:5:1280:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1281:10:1281:10 | b : [collection] [element 0] | array_flow.rb:1281:10:1281:13 | ...[...] | provenance |  |
+| array_flow.rb:1283:10:1283:10 | b : [collection] [element 2] | array_flow.rb:1283:10:1283:13 | ...[...] | provenance |  |
+| array_flow.rb:1290:5:1290:5 | a : Array [element 2] | array_flow.rb:1291:9:1291:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1290:5:1290:5 | a : Array [element 4] | array_flow.rb:1291:9:1291:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1290:9:1290:47 | call to [] : Array [element 2] | array_flow.rb:1290:5:1290:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1290:9:1290:47 | call to [] : Array [element 4] | array_flow.rb:1290:5:1290:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1290:16:1290:28 | call to source | array_flow.rb:1290:9:1290:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1290:34:1290:46 | call to source | array_flow.rb:1290:9:1290:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1291:5:1291:5 | b : [collection] [element 0] | array_flow.rb:1292:10:1292:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1291:9:1291:9 | [post] a : [collection] [element 2] | array_flow.rb:1297:10:1297:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1291:9:1291:9 | a : Array [element 2] | array_flow.rb:1291:9:1291:22 | call to slice! : [collection] [element 0] | provenance |  |
+| array_flow.rb:1291:9:1291:9 | a : Array [element 4] | array_flow.rb:1291:9:1291:9 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1291:9:1291:22 | call to slice! : [collection] [element 0] | array_flow.rb:1291:5:1291:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1292:10:1292:10 | b : [collection] [element 0] | array_flow.rb:1292:10:1292:13 | ...[...] | provenance |  |
+| array_flow.rb:1297:10:1297:10 | a : [collection] [element 2] | array_flow.rb:1297:10:1297:13 | ...[...] | provenance |  |
+| array_flow.rb:1301:5:1301:5 | a : Array [element 2] | array_flow.rb:1302:9:1302:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1301:5:1301:5 | a : Array [element 4] | array_flow.rb:1302:9:1302:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1301:9:1301:47 | call to [] : Array [element 2] | array_flow.rb:1301:5:1301:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1301:9:1301:47 | call to [] : Array [element 4] | array_flow.rb:1301:5:1301:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1301:16:1301:28 | call to source | array_flow.rb:1301:9:1301:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1301:34:1301:46 | call to source | array_flow.rb:1301:9:1301:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1302:5:1302:5 | b : [collection] [element 0] | array_flow.rb:1303:10:1303:10 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1302:9:1302:9 | [post] a : [collection] [element 2] | array_flow.rb:1308:10:1308:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1302:9:1302:9 | a : Array [element 2] | array_flow.rb:1302:9:1302:23 | call to slice! : [collection] [element 0] | provenance |  |
+| array_flow.rb:1302:9:1302:9 | a : Array [element 4] | array_flow.rb:1302:9:1302:9 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1302:9:1302:23 | call to slice! : [collection] [element 0] | array_flow.rb:1302:5:1302:5 | b : [collection] [element 0] | provenance |  |
+| array_flow.rb:1303:10:1303:10 | b : [collection] [element 0] | array_flow.rb:1303:10:1303:13 | ...[...] | provenance |  |
+| array_flow.rb:1308:10:1308:10 | a : [collection] [element 2] | array_flow.rb:1308:10:1308:13 | ...[...] | provenance |  |
+| array_flow.rb:1312:5:1312:5 | a : Array [element 2] | array_flow.rb:1313:9:1313:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1312:5:1312:5 | a : Array [element 4] | array_flow.rb:1313:9:1313:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1312:9:1312:47 | call to [] : Array [element 2] | array_flow.rb:1312:5:1312:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1312:9:1312:47 | call to [] : Array [element 4] | array_flow.rb:1312:5:1312:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1312:16:1312:28 | call to source | array_flow.rb:1312:9:1312:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1312:34:1312:46 | call to source | array_flow.rb:1312:9:1312:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1313:5:1313:5 | b : [collection] [element] | array_flow.rb:1314:10:1314:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1313:5:1313:5 | b : [collection] [element] | array_flow.rb:1315:10:1315:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1313:5:1313:5 | b : [collection] [element] | array_flow.rb:1316:10:1316:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | array_flow.rb:1317:10:1317:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | array_flow.rb:1318:10:1318:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | array_flow.rb:1319:10:1319:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 2] | array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 2] | array_flow.rb:1313:9:1313:22 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 4] | array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 4] | array_flow.rb:1313:9:1313:22 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1313:9:1313:22 | call to slice! : [collection] [element] | array_flow.rb:1313:5:1313:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1314:10:1314:10 | b : [collection] [element] | array_flow.rb:1314:10:1314:13 | ...[...] | provenance |  |
+| array_flow.rb:1315:10:1315:10 | b : [collection] [element] | array_flow.rb:1315:10:1315:13 | ...[...] | provenance |  |
+| array_flow.rb:1316:10:1316:10 | b : [collection] [element] | array_flow.rb:1316:10:1316:13 | ...[...] | provenance |  |
+| array_flow.rb:1317:10:1317:10 | a : [collection] [element] | array_flow.rb:1317:10:1317:13 | ...[...] | provenance |  |
+| array_flow.rb:1318:10:1318:10 | a : [collection] [element] | array_flow.rb:1318:10:1318:13 | ...[...] | provenance |  |
+| array_flow.rb:1319:10:1319:10 | a : [collection] [element] | array_flow.rb:1319:10:1319:13 | ...[...] | provenance |  |
+| array_flow.rb:1321:5:1321:5 | a : Array [element 2] | array_flow.rb:1322:9:1322:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1321:5:1321:5 | a : Array [element 4] | array_flow.rb:1322:9:1322:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1321:9:1321:47 | call to [] : Array [element 2] | array_flow.rb:1321:5:1321:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1321:9:1321:47 | call to [] : Array [element 4] | array_flow.rb:1321:5:1321:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1321:16:1321:28 | call to source | array_flow.rb:1321:9:1321:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1321:34:1321:46 | call to source | array_flow.rb:1321:9:1321:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1322:5:1322:5 | b : [collection] [element] | array_flow.rb:1323:10:1323:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1322:5:1322:5 | b : [collection] [element] | array_flow.rb:1324:10:1324:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1322:5:1322:5 | b : [collection] [element] | array_flow.rb:1325:10:1325:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | array_flow.rb:1326:10:1326:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | array_flow.rb:1327:10:1327:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | array_flow.rb:1328:10:1328:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 2] | array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 2] | array_flow.rb:1322:9:1322:22 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 4] | array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 4] | array_flow.rb:1322:9:1322:22 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1322:9:1322:22 | call to slice! : [collection] [element] | array_flow.rb:1322:5:1322:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1323:10:1323:10 | b : [collection] [element] | array_flow.rb:1323:10:1323:13 | ...[...] | provenance |  |
+| array_flow.rb:1324:10:1324:10 | b : [collection] [element] | array_flow.rb:1324:10:1324:13 | ...[...] | provenance |  |
+| array_flow.rb:1325:10:1325:10 | b : [collection] [element] | array_flow.rb:1325:10:1325:13 | ...[...] | provenance |  |
+| array_flow.rb:1326:10:1326:10 | a : [collection] [element] | array_flow.rb:1326:10:1326:13 | ...[...] | provenance |  |
+| array_flow.rb:1327:10:1327:10 | a : [collection] [element] | array_flow.rb:1327:10:1327:13 | ...[...] | provenance |  |
+| array_flow.rb:1328:10:1328:10 | a : [collection] [element] | array_flow.rb:1328:10:1328:13 | ...[...] | provenance |  |
+| array_flow.rb:1330:5:1330:5 | a : Array [element 2] | array_flow.rb:1331:9:1331:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1330:5:1330:5 | a : Array [element 4] | array_flow.rb:1331:9:1331:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1330:9:1330:47 | call to [] : Array [element 2] | array_flow.rb:1330:5:1330:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1330:9:1330:47 | call to [] : Array [element 4] | array_flow.rb:1330:5:1330:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1330:16:1330:28 | call to source | array_flow.rb:1330:9:1330:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1330:34:1330:46 | call to source | array_flow.rb:1330:9:1330:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1331:5:1331:5 | b : [collection] [element] | array_flow.rb:1332:10:1332:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1331:5:1331:5 | b : [collection] [element] | array_flow.rb:1333:10:1333:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1331:5:1331:5 | b : [collection] [element] | array_flow.rb:1334:10:1334:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | array_flow.rb:1335:10:1335:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | array_flow.rb:1336:10:1336:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | array_flow.rb:1337:10:1337:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 2] | array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 2] | array_flow.rb:1331:9:1331:25 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 4] | array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 4] | array_flow.rb:1331:9:1331:25 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1331:9:1331:25 | call to slice! : [collection] [element] | array_flow.rb:1331:5:1331:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1332:10:1332:10 | b : [collection] [element] | array_flow.rb:1332:10:1332:13 | ...[...] | provenance |  |
+| array_flow.rb:1333:10:1333:10 | b : [collection] [element] | array_flow.rb:1333:10:1333:13 | ...[...] | provenance |  |
+| array_flow.rb:1334:10:1334:10 | b : [collection] [element] | array_flow.rb:1334:10:1334:13 | ...[...] | provenance |  |
+| array_flow.rb:1335:10:1335:10 | a : [collection] [element] | array_flow.rb:1335:10:1335:13 | ...[...] | provenance |  |
+| array_flow.rb:1336:10:1336:10 | a : [collection] [element] | array_flow.rb:1336:10:1336:13 | ...[...] | provenance |  |
+| array_flow.rb:1337:10:1337:10 | a : [collection] [element] | array_flow.rb:1337:10:1337:13 | ...[...] | provenance |  |
+| array_flow.rb:1339:5:1339:5 | a : Array [element 2] | array_flow.rb:1340:9:1340:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1339:5:1339:5 | a : Array [element 4] | array_flow.rb:1340:9:1340:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1339:9:1339:47 | call to [] : Array [element 2] | array_flow.rb:1339:5:1339:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1339:9:1339:47 | call to [] : Array [element 4] | array_flow.rb:1339:5:1339:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1339:16:1339:28 | call to source | array_flow.rb:1339:9:1339:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1339:34:1339:46 | call to source | array_flow.rb:1339:9:1339:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1340:5:1340:5 | b : [collection] [element 2] | array_flow.rb:1343:10:1343:10 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1340:9:1340:9 | [post] a : [collection] [element 1] | array_flow.rb:1345:10:1345:10 | a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1340:9:1340:9 | a : Array [element 2] | array_flow.rb:1340:9:1340:21 | call to slice! : [collection] [element 2] | provenance |  |
+| array_flow.rb:1340:9:1340:9 | a : Array [element 4] | array_flow.rb:1340:9:1340:9 | [post] a : [collection] [element 1] | provenance |  |
+| array_flow.rb:1340:9:1340:21 | call to slice! : [collection] [element 2] | array_flow.rb:1340:5:1340:5 | b : [collection] [element 2] | provenance |  |
+| array_flow.rb:1343:10:1343:10 | b : [collection] [element 2] | array_flow.rb:1343:10:1343:13 | ...[...] | provenance |  |
+| array_flow.rb:1345:10:1345:10 | a : [collection] [element 1] | array_flow.rb:1345:10:1345:13 | ...[...] | provenance |  |
+| array_flow.rb:1348:5:1348:5 | a : Array [element 2] | array_flow.rb:1349:9:1349:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1348:5:1348:5 | a : Array [element 4] | array_flow.rb:1349:9:1349:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1348:9:1348:47 | call to [] : Array [element 2] | array_flow.rb:1348:5:1348:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1348:9:1348:47 | call to [] : Array [element 4] | array_flow.rb:1348:5:1348:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1348:16:1348:28 | call to source | array_flow.rb:1348:9:1348:47 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1348:34:1348:46 | call to source | array_flow.rb:1348:9:1348:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1349:5:1349:5 | b : [collection] [element] | array_flow.rb:1350:10:1350:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1349:5:1349:5 | b : [collection] [element] | array_flow.rb:1351:10:1351:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1349:5:1349:5 | b : [collection] [element] | array_flow.rb:1352:10:1352:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | array_flow.rb:1353:10:1353:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | array_flow.rb:1354:10:1354:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | array_flow.rb:1355:10:1355:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 2] | array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 2] | array_flow.rb:1349:9:1349:21 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 4] | array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 4] | array_flow.rb:1349:9:1349:21 | call to slice! : [collection] [element] | provenance |  |
+| array_flow.rb:1349:9:1349:21 | call to slice! : [collection] [element] | array_flow.rb:1349:5:1349:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1350:10:1350:10 | b : [collection] [element] | array_flow.rb:1350:10:1350:13 | ...[...] | provenance |  |
+| array_flow.rb:1351:10:1351:10 | b : [collection] [element] | array_flow.rb:1351:10:1351:13 | ...[...] | provenance |  |
+| array_flow.rb:1352:10:1352:10 | b : [collection] [element] | array_flow.rb:1352:10:1352:13 | ...[...] | provenance |  |
+| array_flow.rb:1353:10:1353:10 | a : [collection] [element] | array_flow.rb:1353:10:1353:13 | ...[...] | provenance |  |
+| array_flow.rb:1354:10:1354:10 | a : [collection] [element] | array_flow.rb:1354:10:1354:13 | ...[...] | provenance |  |
+| array_flow.rb:1355:10:1355:10 | a : [collection] [element] | array_flow.rb:1355:10:1355:13 | ...[...] | provenance |  |
+| array_flow.rb:1359:5:1359:5 | a : Array [element 2] | array_flow.rb:1360:9:1360:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1359:9:1359:27 | call to [] : Array [element 2] | array_flow.rb:1359:5:1359:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1359:16:1359:26 | call to source | array_flow.rb:1359:9:1359:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1360:9:1360:9 | a : Array [element 2] | array_flow.rb:1360:27:1360:27 | x | provenance |  |
 | array_flow.rb:1360:27:1360:27 | x | array_flow.rb:1361:14:1361:14 | x | provenance |  |
-| array_flow.rb:1367:5:1367:5 | a [element 2] | array_flow.rb:1368:9:1368:9 | a [element 2] | provenance |  |
-| array_flow.rb:1367:9:1367:27 | call to [] [element 2] | array_flow.rb:1367:5:1367:5 | a [element 2] | provenance |  |
-| array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1367:9:1367:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1368:9:1368:9 | a [element 2] | array_flow.rb:1368:28:1368:28 | x | provenance |  |
+| array_flow.rb:1367:5:1367:5 | a : Array [element 2] | array_flow.rb:1368:9:1368:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1367:9:1367:27 | call to [] : Array [element 2] | array_flow.rb:1367:5:1367:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1367:16:1367:26 | call to source | array_flow.rb:1367:9:1367:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1368:9:1368:9 | a : Array [element 2] | array_flow.rb:1368:28:1368:28 | x | provenance |  |
 | array_flow.rb:1368:28:1368:28 | x | array_flow.rb:1369:14:1369:14 | x | provenance |  |
-| array_flow.rb:1375:5:1375:5 | a [element 2] | array_flow.rb:1376:9:1376:9 | a [element 2] | provenance |  |
-| array_flow.rb:1375:9:1375:27 | call to [] [element 2] | array_flow.rb:1375:5:1375:5 | a [element 2] | provenance |  |
-| array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1375:9:1375:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:26:1376:26 | x | provenance |  |
-| array_flow.rb:1376:9:1376:9 | a [element 2] | array_flow.rb:1376:29:1376:29 | y | provenance |  |
+| array_flow.rb:1375:5:1375:5 | a : Array [element 2] | array_flow.rb:1376:9:1376:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1375:9:1375:27 | call to [] : Array [element 2] | array_flow.rb:1375:5:1375:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1375:16:1375:26 | call to source | array_flow.rb:1375:9:1375:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1376:9:1376:9 | a : Array [element 2] | array_flow.rb:1376:26:1376:26 | x | provenance |  |
+| array_flow.rb:1376:9:1376:9 | a : Array [element 2] | array_flow.rb:1376:29:1376:29 | y | provenance |  |
 | array_flow.rb:1376:26:1376:26 | x | array_flow.rb:1377:14:1377:14 | x | provenance |  |
 | array_flow.rb:1376:29:1376:29 | y | array_flow.rb:1378:14:1378:14 | y | provenance |  |
-| array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1384:9:1384:9 | a [element 2] | provenance |  |
-| array_flow.rb:1383:5:1383:5 | a [element 2] | array_flow.rb:1387:9:1387:9 | a [element 2] | provenance |  |
-| array_flow.rb:1383:9:1383:27 | call to [] [element 2] | array_flow.rb:1383:5:1383:5 | a [element 2] | provenance |  |
-| array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1383:9:1383:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1385:10:1385:10 | b [element] | provenance |  |
-| array_flow.rb:1384:5:1384:5 | b [element] | array_flow.rb:1386:10:1386:10 | b [element] | provenance |  |
-| array_flow.rb:1384:9:1384:9 | a [element 2] | array_flow.rb:1384:9:1384:14 | call to sort [element] | provenance |  |
-| array_flow.rb:1384:9:1384:14 | call to sort [element] | array_flow.rb:1384:5:1384:5 | b [element] | provenance |  |
-| array_flow.rb:1385:10:1385:10 | b [element] | array_flow.rb:1385:10:1385:13 | ...[...] | provenance |  |
-| array_flow.rb:1386:10:1386:10 | b [element] | array_flow.rb:1386:10:1386:13 | ...[...] | provenance |  |
-| array_flow.rb:1387:5:1387:5 | c [element] | array_flow.rb:1392:10:1392:10 | c [element] | provenance |  |
-| array_flow.rb:1387:5:1387:5 | c [element] | array_flow.rb:1393:10:1393:10 | c [element] | provenance |  |
-| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:9:1391:7 | call to sort [element] | provenance |  |
-| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:20:1387:20 | x | provenance |  |
-| array_flow.rb:1387:9:1387:9 | a [element 2] | array_flow.rb:1387:23:1387:23 | y | provenance |  |
-| array_flow.rb:1387:9:1391:7 | call to sort [element] | array_flow.rb:1387:5:1387:5 | c [element] | provenance |  |
+| array_flow.rb:1383:5:1383:5 | a : Array [element 2] | array_flow.rb:1384:9:1384:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1383:5:1383:5 | a : Array [element 2] | array_flow.rb:1387:9:1387:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1383:9:1383:27 | call to [] : Array [element 2] | array_flow.rb:1383:5:1383:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1383:16:1383:26 | call to source | array_flow.rb:1383:9:1383:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1384:5:1384:5 | b : [collection] [element] | array_flow.rb:1385:10:1385:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1384:5:1384:5 | b : [collection] [element] | array_flow.rb:1386:10:1386:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1384:9:1384:9 | a : Array [element 2] | array_flow.rb:1384:9:1384:14 | call to sort : [collection] [element] | provenance |  |
+| array_flow.rb:1384:9:1384:14 | call to sort : [collection] [element] | array_flow.rb:1384:5:1384:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1385:10:1385:10 | b : [collection] [element] | array_flow.rb:1385:10:1385:13 | ...[...] | provenance |  |
+| array_flow.rb:1386:10:1386:10 | b : [collection] [element] | array_flow.rb:1386:10:1386:13 | ...[...] | provenance |  |
+| array_flow.rb:1387:5:1387:5 | c : [collection] [element] | array_flow.rb:1392:10:1392:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1387:5:1387:5 | c : [collection] [element] | array_flow.rb:1393:10:1393:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1387:9:1387:9 | a : Array [element 2] | array_flow.rb:1387:9:1391:7 | call to sort : [collection] [element] | provenance |  |
+| array_flow.rb:1387:9:1387:9 | a : Array [element 2] | array_flow.rb:1387:20:1387:20 | x | provenance |  |
+| array_flow.rb:1387:9:1387:9 | a : Array [element 2] | array_flow.rb:1387:23:1387:23 | y | provenance |  |
+| array_flow.rb:1387:9:1391:7 | call to sort : [collection] [element] | array_flow.rb:1387:5:1387:5 | c : [collection] [element] | provenance |  |
 | array_flow.rb:1387:20:1387:20 | x | array_flow.rb:1388:14:1388:14 | x | provenance |  |
 | array_flow.rb:1387:23:1387:23 | y | array_flow.rb:1389:14:1389:14 | y | provenance |  |
-| array_flow.rb:1392:10:1392:10 | c [element] | array_flow.rb:1392:10:1392:13 | ...[...] | provenance |  |
-| array_flow.rb:1393:10:1393:10 | c [element] | array_flow.rb:1393:10:1393:13 | ...[...] | provenance |  |
-| array_flow.rb:1397:5:1397:5 | a [element 2] | array_flow.rb:1398:9:1398:9 | a [element 2] | provenance |  |
-| array_flow.rb:1397:9:1397:27 | call to [] [element 2] | array_flow.rb:1397:5:1397:5 | a [element 2] | provenance |  |
-| array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1397:9:1397:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1399:10:1399:10 | b [element] | provenance |  |
-| array_flow.rb:1398:5:1398:5 | b [element] | array_flow.rb:1400:10:1400:10 | b [element] | provenance |  |
-| array_flow.rb:1398:9:1398:9 | [post] a [element] | array_flow.rb:1401:10:1401:10 | a [element] | provenance |  |
-| array_flow.rb:1398:9:1398:9 | [post] a [element] | array_flow.rb:1402:10:1402:10 | a [element] | provenance |  |
-| array_flow.rb:1398:9:1398:9 | a [element 2] | array_flow.rb:1398:9:1398:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1398:9:1398:9 | a [element 2] | array_flow.rb:1398:9:1398:15 | call to sort! [element] | provenance |  |
-| array_flow.rb:1398:9:1398:15 | call to sort! [element] | array_flow.rb:1398:5:1398:5 | b [element] | provenance |  |
-| array_flow.rb:1399:10:1399:10 | b [element] | array_flow.rb:1399:10:1399:13 | ...[...] | provenance |  |
-| array_flow.rb:1400:10:1400:10 | b [element] | array_flow.rb:1400:10:1400:13 | ...[...] | provenance |  |
-| array_flow.rb:1401:10:1401:10 | a [element] | array_flow.rb:1401:10:1401:13 | ...[...] | provenance |  |
-| array_flow.rb:1402:10:1402:10 | a [element] | array_flow.rb:1402:10:1402:13 | ...[...] | provenance |  |
-| array_flow.rb:1404:5:1404:5 | a [element 2] | array_flow.rb:1405:9:1405:9 | a [element 2] | provenance |  |
-| array_flow.rb:1404:9:1404:27 | call to [] [element 2] | array_flow.rb:1404:5:1404:5 | a [element 2] | provenance |  |
-| array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1404:9:1404:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1410:10:1410:10 | b [element] | provenance |  |
-| array_flow.rb:1405:5:1405:5 | b [element] | array_flow.rb:1411:10:1411:10 | b [element] | provenance |  |
-| array_flow.rb:1405:9:1405:9 | [post] a [element] | array_flow.rb:1412:10:1412:10 | a [element] | provenance |  |
-| array_flow.rb:1405:9:1405:9 | [post] a [element] | array_flow.rb:1413:10:1413:10 | a [element] | provenance |  |
-| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:9:1405:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:9:1409:7 | call to sort! [element] | provenance |  |
-| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:21:1405:21 | x | provenance |  |
-| array_flow.rb:1405:9:1405:9 | a [element 2] | array_flow.rb:1405:24:1405:24 | y | provenance |  |
-| array_flow.rb:1405:9:1409:7 | call to sort! [element] | array_flow.rb:1405:5:1405:5 | b [element] | provenance |  |
+| array_flow.rb:1392:10:1392:10 | c : [collection] [element] | array_flow.rb:1392:10:1392:13 | ...[...] | provenance |  |
+| array_flow.rb:1393:10:1393:10 | c : [collection] [element] | array_flow.rb:1393:10:1393:13 | ...[...] | provenance |  |
+| array_flow.rb:1397:5:1397:5 | a : Array [element 2] | array_flow.rb:1398:9:1398:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1397:9:1397:27 | call to [] : Array [element 2] | array_flow.rb:1397:5:1397:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1397:16:1397:26 | call to source | array_flow.rb:1397:9:1397:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1398:5:1398:5 | b : [collection] [element] | array_flow.rb:1399:10:1399:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1398:5:1398:5 | b : [collection] [element] | array_flow.rb:1400:10:1400:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1398:9:1398:9 | [post] a : [collection] [element] | array_flow.rb:1401:10:1401:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1398:9:1398:9 | [post] a : [collection] [element] | array_flow.rb:1402:10:1402:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1398:9:1398:9 | a : Array [element 2] | array_flow.rb:1398:9:1398:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1398:9:1398:9 | a : Array [element 2] | array_flow.rb:1398:9:1398:15 | call to sort! : [collection] [element] | provenance |  |
+| array_flow.rb:1398:9:1398:15 | call to sort! : [collection] [element] | array_flow.rb:1398:5:1398:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1399:10:1399:10 | b : [collection] [element] | array_flow.rb:1399:10:1399:13 | ...[...] | provenance |  |
+| array_flow.rb:1400:10:1400:10 | b : [collection] [element] | array_flow.rb:1400:10:1400:13 | ...[...] | provenance |  |
+| array_flow.rb:1401:10:1401:10 | a : [collection] [element] | array_flow.rb:1401:10:1401:13 | ...[...] | provenance |  |
+| array_flow.rb:1402:10:1402:10 | a : [collection] [element] | array_flow.rb:1402:10:1402:13 | ...[...] | provenance |  |
+| array_flow.rb:1404:5:1404:5 | a : Array [element 2] | array_flow.rb:1405:9:1405:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1404:9:1404:27 | call to [] : Array [element 2] | array_flow.rb:1404:5:1404:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1404:16:1404:26 | call to source | array_flow.rb:1404:9:1404:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1405:5:1405:5 | b : [collection] [element] | array_flow.rb:1410:10:1410:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1405:5:1405:5 | b : [collection] [element] | array_flow.rb:1411:10:1411:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1405:9:1405:9 | [post] a : [collection] [element] | array_flow.rb:1412:10:1412:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1405:9:1405:9 | [post] a : [collection] [element] | array_flow.rb:1413:10:1413:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1405:9:1405:9 | a : Array [element 2] | array_flow.rb:1405:9:1405:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1405:9:1405:9 | a : Array [element 2] | array_flow.rb:1405:9:1409:7 | call to sort! : [collection] [element] | provenance |  |
+| array_flow.rb:1405:9:1405:9 | a : Array [element 2] | array_flow.rb:1405:21:1405:21 | x | provenance |  |
+| array_flow.rb:1405:9:1405:9 | a : Array [element 2] | array_flow.rb:1405:24:1405:24 | y | provenance |  |
+| array_flow.rb:1405:9:1409:7 | call to sort! : [collection] [element] | array_flow.rb:1405:5:1405:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1405:21:1405:21 | x | array_flow.rb:1406:14:1406:14 | x | provenance |  |
 | array_flow.rb:1405:24:1405:24 | y | array_flow.rb:1407:14:1407:14 | y | provenance |  |
-| array_flow.rb:1410:10:1410:10 | b [element] | array_flow.rb:1410:10:1410:13 | ...[...] | provenance |  |
-| array_flow.rb:1411:10:1411:10 | b [element] | array_flow.rb:1411:10:1411:13 | ...[...] | provenance |  |
-| array_flow.rb:1412:10:1412:10 | a [element] | array_flow.rb:1412:10:1412:13 | ...[...] | provenance |  |
-| array_flow.rb:1413:10:1413:10 | a [element] | array_flow.rb:1413:10:1413:13 | ...[...] | provenance |  |
-| array_flow.rb:1417:5:1417:5 | a [element 2] | array_flow.rb:1418:9:1418:9 | a [element 2] | provenance |  |
-| array_flow.rb:1417:9:1417:27 | call to [] [element 2] | array_flow.rb:1417:5:1417:5 | a [element 2] | provenance |  |
-| array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1417:9:1417:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1422:10:1422:10 | b [element] | provenance |  |
-| array_flow.rb:1418:5:1418:5 | b [element] | array_flow.rb:1423:10:1423:10 | b [element] | provenance |  |
-| array_flow.rb:1418:9:1418:9 | a [element 2] | array_flow.rb:1418:9:1421:7 | call to sort_by [element] | provenance |  |
-| array_flow.rb:1418:9:1418:9 | a [element 2] | array_flow.rb:1418:23:1418:23 | x | provenance |  |
-| array_flow.rb:1418:9:1421:7 | call to sort_by [element] | array_flow.rb:1418:5:1418:5 | b [element] | provenance |  |
+| array_flow.rb:1410:10:1410:10 | b : [collection] [element] | array_flow.rb:1410:10:1410:13 | ...[...] | provenance |  |
+| array_flow.rb:1411:10:1411:10 | b : [collection] [element] | array_flow.rb:1411:10:1411:13 | ...[...] | provenance |  |
+| array_flow.rb:1412:10:1412:10 | a : [collection] [element] | array_flow.rb:1412:10:1412:13 | ...[...] | provenance |  |
+| array_flow.rb:1413:10:1413:10 | a : [collection] [element] | array_flow.rb:1413:10:1413:13 | ...[...] | provenance |  |
+| array_flow.rb:1417:5:1417:5 | a : Array [element 2] | array_flow.rb:1418:9:1418:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1417:9:1417:27 | call to [] : Array [element 2] | array_flow.rb:1417:5:1417:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1417:16:1417:26 | call to source | array_flow.rb:1417:9:1417:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1418:5:1418:5 | b : [collection] [element] | array_flow.rb:1422:10:1422:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1418:5:1418:5 | b : [collection] [element] | array_flow.rb:1423:10:1423:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1418:9:1418:9 | a : Array [element 2] | array_flow.rb:1418:9:1421:7 | call to sort_by : [collection] [element] | provenance |  |
+| array_flow.rb:1418:9:1418:9 | a : Array [element 2] | array_flow.rb:1418:23:1418:23 | x | provenance |  |
+| array_flow.rb:1418:9:1421:7 | call to sort_by : [collection] [element] | array_flow.rb:1418:5:1418:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1418:23:1418:23 | x | array_flow.rb:1419:14:1419:14 | x | provenance |  |
-| array_flow.rb:1422:10:1422:10 | b [element] | array_flow.rb:1422:10:1422:13 | ...[...] | provenance |  |
-| array_flow.rb:1423:10:1423:10 | b [element] | array_flow.rb:1423:10:1423:13 | ...[...] | provenance |  |
-| array_flow.rb:1427:5:1427:5 | a [element 2] | array_flow.rb:1428:9:1428:9 | a [element 2] | provenance |  |
-| array_flow.rb:1427:9:1427:27 | call to [] [element 2] | array_flow.rb:1427:5:1427:5 | a [element 2] | provenance |  |
-| array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1427:9:1427:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1434:10:1434:10 | b [element] | provenance |  |
-| array_flow.rb:1428:5:1428:5 | b [element] | array_flow.rb:1435:10:1435:10 | b [element] | provenance |  |
-| array_flow.rb:1428:9:1428:9 | [post] a [element] | array_flow.rb:1432:10:1432:10 | a [element] | provenance |  |
-| array_flow.rb:1428:9:1428:9 | [post] a [element] | array_flow.rb:1433:10:1433:10 | a [element] | provenance |  |
-| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:9:1428:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:9:1431:7 | call to sort_by! [element] | provenance |  |
-| array_flow.rb:1428:9:1428:9 | a [element 2] | array_flow.rb:1428:24:1428:24 | x | provenance |  |
-| array_flow.rb:1428:9:1431:7 | call to sort_by! [element] | array_flow.rb:1428:5:1428:5 | b [element] | provenance |  |
+| array_flow.rb:1422:10:1422:10 | b : [collection] [element] | array_flow.rb:1422:10:1422:13 | ...[...] | provenance |  |
+| array_flow.rb:1423:10:1423:10 | b : [collection] [element] | array_flow.rb:1423:10:1423:13 | ...[...] | provenance |  |
+| array_flow.rb:1427:5:1427:5 | a : Array [element 2] | array_flow.rb:1428:9:1428:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1427:9:1427:27 | call to [] : Array [element 2] | array_flow.rb:1427:5:1427:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1427:16:1427:26 | call to source | array_flow.rb:1427:9:1427:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1428:5:1428:5 | b : [collection] [element] | array_flow.rb:1434:10:1434:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1428:5:1428:5 | b : [collection] [element] | array_flow.rb:1435:10:1435:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1428:9:1428:9 | [post] a : [collection] [element] | array_flow.rb:1432:10:1432:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1428:9:1428:9 | [post] a : [collection] [element] | array_flow.rb:1433:10:1433:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1428:9:1428:9 | a : Array [element 2] | array_flow.rb:1428:9:1428:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1428:9:1428:9 | a : Array [element 2] | array_flow.rb:1428:9:1431:7 | call to sort_by! : [collection] [element] | provenance |  |
+| array_flow.rb:1428:9:1428:9 | a : Array [element 2] | array_flow.rb:1428:24:1428:24 | x | provenance |  |
+| array_flow.rb:1428:9:1431:7 | call to sort_by! : [collection] [element] | array_flow.rb:1428:5:1428:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1428:24:1428:24 | x | array_flow.rb:1429:14:1429:14 | x | provenance |  |
-| array_flow.rb:1432:10:1432:10 | a [element] | array_flow.rb:1432:10:1432:13 | ...[...] | provenance |  |
-| array_flow.rb:1433:10:1433:10 | a [element] | array_flow.rb:1433:10:1433:13 | ...[...] | provenance |  |
-| array_flow.rb:1434:10:1434:10 | b [element] | array_flow.rb:1434:10:1434:13 | ...[...] | provenance |  |
-| array_flow.rb:1435:10:1435:10 | b [element] | array_flow.rb:1435:10:1435:13 | ...[...] | provenance |  |
-| array_flow.rb:1439:5:1439:5 | a [element 2] | array_flow.rb:1440:9:1440:9 | a [element 2] | provenance |  |
-| array_flow.rb:1439:9:1439:27 | call to [] [element 2] | array_flow.rb:1439:5:1439:5 | a [element 2] | provenance |  |
-| array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1439:9:1439:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1440:9:1440:9 | a [element 2] | array_flow.rb:1440:19:1440:19 | x | provenance |  |
+| array_flow.rb:1432:10:1432:10 | a : [collection] [element] | array_flow.rb:1432:10:1432:13 | ...[...] | provenance |  |
+| array_flow.rb:1433:10:1433:10 | a : [collection] [element] | array_flow.rb:1433:10:1433:13 | ...[...] | provenance |  |
+| array_flow.rb:1434:10:1434:10 | b : [collection] [element] | array_flow.rb:1434:10:1434:13 | ...[...] | provenance |  |
+| array_flow.rb:1435:10:1435:10 | b : [collection] [element] | array_flow.rb:1435:10:1435:13 | ...[...] | provenance |  |
+| array_flow.rb:1439:5:1439:5 | a : Array [element 2] | array_flow.rb:1440:9:1440:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1439:9:1439:27 | call to [] : Array [element 2] | array_flow.rb:1439:5:1439:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1439:16:1439:26 | call to source | array_flow.rb:1439:9:1439:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1440:9:1440:9 | a : Array [element 2] | array_flow.rb:1440:19:1440:19 | x | provenance |  |
 | array_flow.rb:1440:19:1440:19 | x | array_flow.rb:1441:14:1441:14 | x | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1448:9:1448:9 | a [element 2] | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1453:9:1453:9 | a [element 2] | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1459:9:1459:9 | a [element 2] | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 2] | array_flow.rb:1466:9:1466:9 | a [element 2] | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1448:9:1448:9 | a [element 3] | provenance |  |
-| array_flow.rb:1447:5:1447:5 | a [element 3] | array_flow.rb:1459:9:1459:9 | a [element 3] | provenance |  |
-| array_flow.rb:1447:9:1447:44 | call to [] [element 2] | array_flow.rb:1447:5:1447:5 | a [element 2] | provenance |  |
-| array_flow.rb:1447:9:1447:44 | call to [] [element 3] | array_flow.rb:1447:5:1447:5 | a [element 3] | provenance |  |
-| array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1447:9:1447:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1447:9:1447:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1448:5:1448:5 | b [element 2] | array_flow.rb:1451:10:1451:10 | b [element 2] | provenance |  |
-| array_flow.rb:1448:5:1448:5 | b [element 3] | array_flow.rb:1452:10:1452:10 | b [element 3] | provenance |  |
-| array_flow.rb:1448:9:1448:9 | a [element 2] | array_flow.rb:1448:9:1448:17 | call to take [element 2] | provenance |  |
-| array_flow.rb:1448:9:1448:9 | a [element 3] | array_flow.rb:1448:9:1448:17 | call to take [element 3] | provenance |  |
-| array_flow.rb:1448:9:1448:17 | call to take [element 2] | array_flow.rb:1448:5:1448:5 | b [element 2] | provenance |  |
-| array_flow.rb:1448:9:1448:17 | call to take [element 3] | array_flow.rb:1448:5:1448:5 | b [element 3] | provenance |  |
-| array_flow.rb:1451:10:1451:10 | b [element 2] | array_flow.rb:1451:10:1451:13 | ...[...] | provenance |  |
-| array_flow.rb:1452:10:1452:10 | b [element 3] | array_flow.rb:1452:10:1452:13 | ...[...] | provenance |  |
-| array_flow.rb:1453:5:1453:5 | b [element 2] | array_flow.rb:1456:10:1456:10 | b [element 2] | provenance |  |
-| array_flow.rb:1453:5:1453:5 | b [element 2] | array_flow.rb:1458:10:1458:10 | b [element 2] | provenance |  |
-| array_flow.rb:1453:9:1453:9 | a [element 2] | array_flow.rb:1453:9:1453:17 | call to take [element 2] | provenance |  |
-| array_flow.rb:1453:9:1453:17 | call to take [element 2] | array_flow.rb:1453:5:1453:5 | b [element 2] | provenance |  |
-| array_flow.rb:1456:10:1456:10 | b [element 2] | array_flow.rb:1456:10:1456:13 | ...[...] | provenance |  |
-| array_flow.rb:1458:10:1458:10 | b [element 2] | array_flow.rb:1458:10:1458:13 | ...[...] | provenance |  |
-| array_flow.rb:1459:5:1459:5 | b [element 2] | array_flow.rb:1462:10:1462:10 | b [element 2] | provenance |  |
-| array_flow.rb:1459:5:1459:5 | b [element 2] | array_flow.rb:1464:10:1464:10 | b [element 2] | provenance |  |
-| array_flow.rb:1459:5:1459:5 | b [element 3] | array_flow.rb:1463:10:1463:10 | b [element 3] | provenance |  |
-| array_flow.rb:1459:5:1459:5 | b [element 3] | array_flow.rb:1464:10:1464:10 | b [element 3] | provenance |  |
-| array_flow.rb:1459:9:1459:9 | a [element 2] | array_flow.rb:1459:9:1459:19 | call to take [element 2] | provenance |  |
-| array_flow.rb:1459:9:1459:9 | a [element 3] | array_flow.rb:1459:9:1459:19 | call to take [element 3] | provenance |  |
-| array_flow.rb:1459:9:1459:19 | call to take [element 2] | array_flow.rb:1459:5:1459:5 | b [element 2] | provenance |  |
-| array_flow.rb:1459:9:1459:19 | call to take [element 3] | array_flow.rb:1459:5:1459:5 | b [element 3] | provenance |  |
-| array_flow.rb:1462:10:1462:10 | b [element 2] | array_flow.rb:1462:10:1462:13 | ...[...] | provenance |  |
-| array_flow.rb:1463:10:1463:10 | b [element 3] | array_flow.rb:1463:10:1463:13 | ...[...] | provenance |  |
-| array_flow.rb:1464:10:1464:10 | b [element 2] | array_flow.rb:1464:10:1464:13 | ...[...] | provenance |  |
-| array_flow.rb:1464:10:1464:10 | b [element 3] | array_flow.rb:1464:10:1464:13 | ...[...] | provenance |  |
-| array_flow.rb:1465:5:1465:5 | [post] a [element] | array_flow.rb:1466:9:1466:9 | a [element] | provenance |  |
-| array_flow.rb:1465:12:1465:24 | call to source | array_flow.rb:1465:5:1465:5 | [post] a [element] | provenance |  |
-| array_flow.rb:1466:5:1466:5 | b [element 2] | array_flow.rb:1467:10:1467:10 | b [element 2] | provenance |  |
-| array_flow.rb:1466:5:1466:5 | b [element] | array_flow.rb:1467:10:1467:10 | b [element] | provenance |  |
-| array_flow.rb:1466:9:1466:9 | a [element 2] | array_flow.rb:1466:9:1466:17 | call to take [element 2] | provenance |  |
-| array_flow.rb:1466:9:1466:9 | a [element] | array_flow.rb:1466:9:1466:17 | call to take [element] | provenance |  |
-| array_flow.rb:1466:9:1466:17 | call to take [element 2] | array_flow.rb:1466:5:1466:5 | b [element 2] | provenance |  |
-| array_flow.rb:1466:9:1466:17 | call to take [element] | array_flow.rb:1466:5:1466:5 | b [element] | provenance |  |
-| array_flow.rb:1467:10:1467:10 | b [element 2] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
-| array_flow.rb:1467:10:1467:10 | b [element] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
-| array_flow.rb:1471:5:1471:5 | a [element 2] | array_flow.rb:1472:9:1472:9 | a [element 2] | provenance |  |
-| array_flow.rb:1471:9:1471:27 | call to [] [element 2] | array_flow.rb:1471:5:1471:5 | a [element 2] | provenance |  |
-| array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1471:9:1471:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1472:5:1472:5 | b [element 2] | array_flow.rb:1478:10:1478:10 | b [element 2] | provenance |  |
-| array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | provenance |  |
-| array_flow.rb:1472:9:1472:9 | a [element 2] | array_flow.rb:1472:26:1472:26 | x | provenance |  |
-| array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | array_flow.rb:1472:5:1472:5 | b [element 2] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 2] | array_flow.rb:1448:9:1448:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 2] | array_flow.rb:1453:9:1453:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 2] | array_flow.rb:1459:9:1459:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 2] | array_flow.rb:1466:9:1466:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 3] | array_flow.rb:1448:9:1448:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 3] | array_flow.rb:1459:9:1459:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1447:9:1447:44 | call to [] : Array [element 2] | array_flow.rb:1447:5:1447:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1447:9:1447:44 | call to [] : Array [element 3] | array_flow.rb:1447:5:1447:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1447:16:1447:28 | call to source | array_flow.rb:1447:9:1447:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1447:31:1447:43 | call to source | array_flow.rb:1447:9:1447:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1448:5:1448:5 | b : Array [element 2] | array_flow.rb:1451:10:1451:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1448:5:1448:5 | b : Array [element 3] | array_flow.rb:1452:10:1452:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1448:9:1448:9 | a : Array [element 2] | array_flow.rb:1448:9:1448:17 | call to take : Array [element 2] | provenance |  |
+| array_flow.rb:1448:9:1448:9 | a : Array [element 3] | array_flow.rb:1448:9:1448:17 | call to take : Array [element 3] | provenance |  |
+| array_flow.rb:1448:9:1448:17 | call to take : Array [element 2] | array_flow.rb:1448:5:1448:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1448:9:1448:17 | call to take : Array [element 3] | array_flow.rb:1448:5:1448:5 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1451:10:1451:10 | b : Array [element 2] | array_flow.rb:1451:10:1451:13 | ...[...] | provenance |  |
+| array_flow.rb:1452:10:1452:10 | b : Array [element 3] | array_flow.rb:1452:10:1452:13 | ...[...] | provenance |  |
+| array_flow.rb:1453:5:1453:5 | b : Array [element 2] | array_flow.rb:1456:10:1456:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1453:5:1453:5 | b : Array [element 2] | array_flow.rb:1458:10:1458:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1453:9:1453:9 | a : Array [element 2] | array_flow.rb:1453:9:1453:17 | call to take : Array [element 2] | provenance |  |
+| array_flow.rb:1453:9:1453:17 | call to take : Array [element 2] | array_flow.rb:1453:5:1453:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1456:10:1456:10 | b : Array [element 2] | array_flow.rb:1456:10:1456:13 | ...[...] | provenance |  |
+| array_flow.rb:1458:10:1458:10 | b : Array [element 2] | array_flow.rb:1458:10:1458:13 | ...[...] | provenance |  |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 2] | array_flow.rb:1462:10:1462:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 2] | array_flow.rb:1464:10:1464:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 3] | array_flow.rb:1463:10:1463:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 3] | array_flow.rb:1464:10:1464:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1459:9:1459:9 | a : Array [element 2] | array_flow.rb:1459:9:1459:19 | call to take : Array [element 2] | provenance |  |
+| array_flow.rb:1459:9:1459:9 | a : Array [element 3] | array_flow.rb:1459:9:1459:19 | call to take : Array [element 3] | provenance |  |
+| array_flow.rb:1459:9:1459:19 | call to take : Array [element 2] | array_flow.rb:1459:5:1459:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1459:9:1459:19 | call to take : Array [element 3] | array_flow.rb:1459:5:1459:5 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1462:10:1462:10 | b : Array [element 2] | array_flow.rb:1462:10:1462:13 | ...[...] | provenance |  |
+| array_flow.rb:1463:10:1463:10 | b : Array [element 3] | array_flow.rb:1463:10:1463:13 | ...[...] | provenance |  |
+| array_flow.rb:1464:10:1464:10 | b : Array [element 2] | array_flow.rb:1464:10:1464:13 | ...[...] | provenance |  |
+| array_flow.rb:1464:10:1464:10 | b : Array [element 3] | array_flow.rb:1464:10:1464:13 | ...[...] | provenance |  |
+| array_flow.rb:1465:5:1465:5 | [post] a : [collection] [element] | array_flow.rb:1466:9:1466:9 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1465:12:1465:24 | call to source | array_flow.rb:1465:5:1465:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1466:5:1466:5 | b : Array [element 2] | array_flow.rb:1467:10:1467:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1466:5:1466:5 | b : [collection] [element] | array_flow.rb:1467:10:1467:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1466:9:1466:9 | a : Array [element 2] | array_flow.rb:1466:9:1466:17 | call to take : Array [element 2] | provenance |  |
+| array_flow.rb:1466:9:1466:9 | a : [collection] [element] | array_flow.rb:1466:9:1466:17 | call to take : [collection] [element] | provenance |  |
+| array_flow.rb:1466:9:1466:17 | call to take : Array [element 2] | array_flow.rb:1466:5:1466:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1466:9:1466:17 | call to take : [collection] [element] | array_flow.rb:1466:5:1466:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1467:10:1467:10 | b : Array [element 2] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
+| array_flow.rb:1467:10:1467:10 | b : [collection] [element] | array_flow.rb:1467:10:1467:13 | ...[...] | provenance |  |
+| array_flow.rb:1471:5:1471:5 | a : Array [element 2] | array_flow.rb:1472:9:1472:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1471:9:1471:27 | call to [] : Array [element 2] | array_flow.rb:1471:5:1471:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1471:16:1471:26 | call to source | array_flow.rb:1471:9:1471:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1472:5:1472:5 | b : Array [element 2] | array_flow.rb:1478:10:1478:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1472:9:1472:9 | a : Array [element 2] | array_flow.rb:1472:9:1475:7 | call to take_while : Array [element 2] | provenance |  |
+| array_flow.rb:1472:9:1472:9 | a : Array [element 2] | array_flow.rb:1472:26:1472:26 | x | provenance |  |
+| array_flow.rb:1472:9:1475:7 | call to take_while : Array [element 2] | array_flow.rb:1472:5:1472:5 | b : Array [element 2] | provenance |  |
 | array_flow.rb:1472:26:1472:26 | x | array_flow.rb:1473:14:1473:14 | x | provenance |  |
-| array_flow.rb:1478:10:1478:10 | b [element 2] | array_flow.rb:1478:10:1478:13 | ...[...] | provenance |  |
-| array_flow.rb:1484:5:1484:5 | a [element 3] | array_flow.rb:1485:9:1485:9 | a [element 3] | provenance |  |
-| array_flow.rb:1484:9:1484:30 | call to [] [element 3] | array_flow.rb:1484:5:1484:5 | a [element 3] | provenance |  |
-| array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1484:9:1484:30 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1485:5:1485:5 | b [element 3] | array_flow.rb:1486:10:1486:10 | b [element 3] | provenance |  |
-| array_flow.rb:1485:9:1485:9 | a [element 3] | array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | provenance |  |
-| array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | array_flow.rb:1485:5:1485:5 | b [element 3] | provenance |  |
-| array_flow.rb:1486:10:1486:10 | b [element 3] | array_flow.rb:1486:10:1486:13 | ...[...] | provenance |  |
-| array_flow.rb:1490:5:1490:5 | a [element 2] | array_flow.rb:1491:9:1491:9 | a [element 2] | provenance |  |
-| array_flow.rb:1490:9:1490:27 | call to [] [element 2] | array_flow.rb:1490:5:1490:5 | a [element 2] | provenance |  |
-| array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1490:9:1490:27 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1491:5:1491:5 | b [element 2] | array_flow.rb:1494:10:1494:10 | b [element 2] | provenance |  |
-| array_flow.rb:1491:9:1491:9 | a [element 2] | array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | provenance |  |
-| array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | array_flow.rb:1491:5:1491:5 | b [element 2] | provenance |  |
-| array_flow.rb:1494:10:1494:10 | b [element 2] | array_flow.rb:1494:10:1494:13 | ...[...] | provenance |  |
-| array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | provenance |  |
-| array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | provenance |  |
-| array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | provenance |  |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | provenance |  |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | provenance |  |
-| array_flow.rb:1507:10:1507:27 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | provenance |  |
-| array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1507:10:1507:27 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1507:30:1507:47 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | provenance |  |
-| array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1507:30:1507:47 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1507:50:1507:67 | call to [] [element 1] | array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | provenance |  |
-| array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1507:50:1507:67 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | provenance |  |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | provenance |  |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | provenance |  |
-| array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] | provenance |  |
-| array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] | provenance |  |
-| array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] | provenance |  |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] | array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | provenance |  |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] | array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | provenance |  |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] | array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | provenance |  |
-| array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1478:10:1478:10 | b : Array [element 2] | array_flow.rb:1478:10:1478:13 | ...[...] | provenance |  |
+| array_flow.rb:1484:5:1484:5 | a : Array [element 3] | array_flow.rb:1485:9:1485:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1484:9:1484:30 | call to [] : Array [element 3] | array_flow.rb:1484:5:1484:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1484:19:1484:29 | call to source | array_flow.rb:1484:9:1484:30 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1485:5:1485:5 | b : Array [element 3] | array_flow.rb:1486:10:1486:10 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1485:9:1485:9 | a : Array [element 3] | array_flow.rb:1485:9:1485:14 | call to to_a : Array [element 3] | provenance |  |
+| array_flow.rb:1485:9:1485:14 | call to to_a : Array [element 3] | array_flow.rb:1485:5:1485:5 | b : Array [element 3] | provenance |  |
+| array_flow.rb:1486:10:1486:10 | b : Array [element 3] | array_flow.rb:1486:10:1486:13 | ...[...] | provenance |  |
+| array_flow.rb:1490:5:1490:5 | a : Array [element 2] | array_flow.rb:1491:9:1491:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1490:9:1490:27 | call to [] : Array [element 2] | array_flow.rb:1490:5:1490:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1490:16:1490:26 | call to source | array_flow.rb:1490:9:1490:27 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1491:5:1491:5 | b : Array [element 2] | array_flow.rb:1494:10:1494:10 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1491:9:1491:9 | a : Array [element 2] | array_flow.rb:1491:9:1491:16 | call to to_ary : Array [element 2] | provenance |  |
+| array_flow.rb:1491:9:1491:16 | call to to_ary : Array [element 2] | array_flow.rb:1491:5:1491:5 | b : Array [element 2] | provenance |  |
+| array_flow.rb:1494:10:1494:10 | b : Array [element 2] | array_flow.rb:1494:10:1494:13 | ...[...] | provenance |  |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 0, element 1] | array_flow.rb:1508:9:1508:9 | a : Array [element 0, element 1] | provenance |  |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 1, element 1] | array_flow.rb:1508:9:1508:9 | a : Array [element 1, element 1] | provenance |  |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 2, element 1] | array_flow.rb:1508:9:1508:9 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 0, element 1] | array_flow.rb:1507:5:1507:5 | a : Array [element 0, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 1, element 1] | array_flow.rb:1507:5:1507:5 | a : Array [element 1, element 1] | provenance |  |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 2, element 1] | array_flow.rb:1507:5:1507:5 | a : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:10:1507:27 | call to [] : Array [element 1] | array_flow.rb:1507:9:1507:68 | call to [] : Array [element 0, element 1] | provenance |  |
+| array_flow.rb:1507:14:1507:26 | call to source | array_flow.rb:1507:10:1507:27 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1507:30:1507:47 | call to [] : Array [element 1] | array_flow.rb:1507:9:1507:68 | call to [] : Array [element 1, element 1] | provenance |  |
+| array_flow.rb:1507:34:1507:46 | call to source | array_flow.rb:1507:30:1507:47 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1507:50:1507:67 | call to [] : Array [element 1] | array_flow.rb:1507:9:1507:68 | call to [] : Array [element 2, element 1] | provenance |  |
+| array_flow.rb:1507:54:1507:66 | call to source | array_flow.rb:1507:50:1507:67 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 0] | array_flow.rb:1512:10:1512:10 | b : [collection] [element 1, element 0] | provenance |  |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 1] | array_flow.rb:1513:10:1513:10 | b : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 2] | array_flow.rb:1514:10:1514:10 | b : [collection] [element 1, element 2] | provenance |  |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 0, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 0] | provenance |  |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 1, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 2, element 1] | array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 2] | provenance |  |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 0] | array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 0] | provenance |  |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 1] | array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 2] | array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 2] | provenance |  |
+| array_flow.rb:1512:10:1512:10 | b : [collection] [element 1, element 0] | array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | provenance |  |
 | array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | array_flow.rb:1512:10:1512:16 | ...[...] | provenance |  |
-| array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | provenance |  |
+| array_flow.rb:1513:10:1513:10 | b : [collection] [element 1, element 1] | array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | array_flow.rb:1513:10:1513:16 | ...[...] | provenance |  |
-| array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | provenance |  |
+| array_flow.rb:1514:10:1514:10 | b : [collection] [element 1, element 2] | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | provenance |  |
 | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | array_flow.rb:1514:10:1514:16 | ...[...] | provenance |  |
-| array_flow.rb:1518:5:1518:5 | a [element 2] | array_flow.rb:1521:9:1521:9 | a [element 2] | provenance |  |
-| array_flow.rb:1518:9:1518:29 | call to [] [element 2] | array_flow.rb:1518:5:1518:5 | a [element 2] | provenance |  |
-| array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1518:9:1518:29 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1519:5:1519:5 | b [element 1] | array_flow.rb:1521:17:1521:17 | b [element 1] | provenance |  |
-| array_flow.rb:1519:9:1519:26 | call to [] [element 1] | array_flow.rb:1519:5:1519:5 | b [element 1] | provenance |  |
-| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:9:1519:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1520:5:1520:5 | c [element 1] | array_flow.rb:1521:20:1521:20 | c [element 1] | provenance |  |
-| array_flow.rb:1520:9:1520:26 | call to [] [element 1] | array_flow.rb:1520:5:1520:5 | c [element 1] | provenance |  |
-| array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1520:9:1520:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1522:10:1522:10 | d [element] | provenance |  |
-| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1523:10:1523:10 | d [element] | provenance |  |
-| array_flow.rb:1521:5:1521:5 | d [element] | array_flow.rb:1524:10:1524:10 | d [element] | provenance |  |
-| array_flow.rb:1521:9:1521:9 | a [element 2] | array_flow.rb:1521:9:1521:21 | call to union [element] | provenance |  |
-| array_flow.rb:1521:9:1521:21 | call to union [element] | array_flow.rb:1521:5:1521:5 | d [element] | provenance |  |
-| array_flow.rb:1521:17:1521:17 | b [element 1] | array_flow.rb:1521:9:1521:21 | call to union [element] | provenance |  |
-| array_flow.rb:1521:20:1521:20 | c [element 1] | array_flow.rb:1521:9:1521:21 | call to union [element] | provenance |  |
-| array_flow.rb:1522:10:1522:10 | d [element] | array_flow.rb:1522:10:1522:13 | ...[...] | provenance |  |
-| array_flow.rb:1523:10:1523:10 | d [element] | array_flow.rb:1523:10:1523:13 | ...[...] | provenance |  |
-| array_flow.rb:1524:10:1524:10 | d [element] | array_flow.rb:1524:10:1524:13 | ...[...] | provenance |  |
-| array_flow.rb:1528:5:1528:5 | a [element 3] | array_flow.rb:1530:9:1530:9 | a [element 3] | provenance |  |
-| array_flow.rb:1528:5:1528:5 | a [element 3] | array_flow.rb:1534:9:1534:9 | a [element 3] | provenance |  |
-| array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1530:9:1530:9 | a [element 4] | provenance |  |
-| array_flow.rb:1528:5:1528:5 | a [element 4] | array_flow.rb:1534:9:1534:9 | a [element 4] | provenance |  |
-| array_flow.rb:1528:9:1528:47 | call to [] [element 3] | array_flow.rb:1528:5:1528:5 | a [element 3] | provenance |  |
-| array_flow.rb:1528:9:1528:47 | call to [] [element 4] | array_flow.rb:1528:5:1528:5 | a [element 4] | provenance |  |
-| array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1528:9:1528:47 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1528:9:1528:47 | call to [] [element 4] | provenance |  |
-| array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1531:10:1531:10 | b [element] | provenance |  |
-| array_flow.rb:1530:5:1530:5 | b [element] | array_flow.rb:1532:10:1532:10 | b [element] | provenance |  |
-| array_flow.rb:1530:9:1530:9 | a [element 3] | array_flow.rb:1530:9:1530:14 | call to uniq [element] | provenance |  |
-| array_flow.rb:1530:9:1530:9 | a [element 4] | array_flow.rb:1530:9:1530:14 | call to uniq [element] | provenance |  |
-| array_flow.rb:1530:9:1530:14 | call to uniq [element] | array_flow.rb:1530:5:1530:5 | b [element] | provenance |  |
-| array_flow.rb:1531:10:1531:10 | b [element] | array_flow.rb:1531:10:1531:13 | ...[...] | provenance |  |
-| array_flow.rb:1532:10:1532:10 | b [element] | array_flow.rb:1532:10:1532:13 | ...[...] | provenance |  |
-| array_flow.rb:1534:5:1534:5 | c [element] | array_flow.rb:1538:10:1538:10 | c [element] | provenance |  |
-| array_flow.rb:1534:9:1534:9 | a [element 3] | array_flow.rb:1534:9:1537:7 | call to uniq [element] | provenance |  |
-| array_flow.rb:1534:9:1534:9 | a [element 3] | array_flow.rb:1534:20:1534:20 | x | provenance |  |
-| array_flow.rb:1534:9:1534:9 | a [element 4] | array_flow.rb:1534:9:1537:7 | call to uniq [element] | provenance |  |
-| array_flow.rb:1534:9:1534:9 | a [element 4] | array_flow.rb:1534:20:1534:20 | x | provenance |  |
-| array_flow.rb:1534:9:1537:7 | call to uniq [element] | array_flow.rb:1534:5:1534:5 | c [element] | provenance |  |
+| array_flow.rb:1518:5:1518:5 | a : Array [element 2] | array_flow.rb:1521:9:1521:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1518:9:1518:29 | call to [] : Array [element 2] | array_flow.rb:1518:5:1518:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1518:16:1518:28 | call to source | array_flow.rb:1518:9:1518:29 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1519:5:1519:5 | b : Array [element 1] | array_flow.rb:1521:17:1521:17 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1519:9:1519:26 | call to [] : Array [element 1] | array_flow.rb:1519:5:1519:5 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1519:13:1519:25 | call to source | array_flow.rb:1519:9:1519:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1520:5:1520:5 | c : Array [element 1] | array_flow.rb:1521:20:1521:20 | c : Array [element 1] | provenance |  |
+| array_flow.rb:1520:9:1520:26 | call to [] : Array [element 1] | array_flow.rb:1520:5:1520:5 | c : Array [element 1] | provenance |  |
+| array_flow.rb:1520:13:1520:25 | call to source | array_flow.rb:1520:9:1520:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1521:5:1521:5 | d : [collection] [element] | array_flow.rb:1522:10:1522:10 | d : [collection] [element] | provenance |  |
+| array_flow.rb:1521:5:1521:5 | d : [collection] [element] | array_flow.rb:1523:10:1523:10 | d : [collection] [element] | provenance |  |
+| array_flow.rb:1521:5:1521:5 | d : [collection] [element] | array_flow.rb:1524:10:1524:10 | d : [collection] [element] | provenance |  |
+| array_flow.rb:1521:9:1521:9 | a : Array [element 2] | array_flow.rb:1521:9:1521:21 | call to union : [collection] [element] | provenance |  |
+| array_flow.rb:1521:9:1521:21 | call to union : [collection] [element] | array_flow.rb:1521:5:1521:5 | d : [collection] [element] | provenance |  |
+| array_flow.rb:1521:17:1521:17 | b : Array [element 1] | array_flow.rb:1521:9:1521:21 | call to union : [collection] [element] | provenance |  |
+| array_flow.rb:1521:20:1521:20 | c : Array [element 1] | array_flow.rb:1521:9:1521:21 | call to union : [collection] [element] | provenance |  |
+| array_flow.rb:1522:10:1522:10 | d : [collection] [element] | array_flow.rb:1522:10:1522:13 | ...[...] | provenance |  |
+| array_flow.rb:1523:10:1523:10 | d : [collection] [element] | array_flow.rb:1523:10:1523:13 | ...[...] | provenance |  |
+| array_flow.rb:1524:10:1524:10 | d : [collection] [element] | array_flow.rb:1524:10:1524:13 | ...[...] | provenance |  |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 3] | array_flow.rb:1530:9:1530:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 3] | array_flow.rb:1534:9:1534:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 4] | array_flow.rb:1530:9:1530:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 4] | array_flow.rb:1534:9:1534:9 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1528:9:1528:47 | call to [] : Array [element 3] | array_flow.rb:1528:5:1528:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1528:9:1528:47 | call to [] : Array [element 4] | array_flow.rb:1528:5:1528:5 | a : Array [element 4] | provenance |  |
+| array_flow.rb:1528:19:1528:31 | call to source | array_flow.rb:1528:9:1528:47 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1528:34:1528:46 | call to source | array_flow.rb:1528:9:1528:47 | call to [] : Array [element 4] | provenance |  |
+| array_flow.rb:1530:5:1530:5 | b : [collection] [element] | array_flow.rb:1531:10:1531:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1530:5:1530:5 | b : [collection] [element] | array_flow.rb:1532:10:1532:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1530:9:1530:9 | a : Array [element 3] | array_flow.rb:1530:9:1530:14 | call to uniq : [collection] [element] | provenance |  |
+| array_flow.rb:1530:9:1530:9 | a : Array [element 4] | array_flow.rb:1530:9:1530:14 | call to uniq : [collection] [element] | provenance |  |
+| array_flow.rb:1530:9:1530:14 | call to uniq : [collection] [element] | array_flow.rb:1530:5:1530:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1531:10:1531:10 | b : [collection] [element] | array_flow.rb:1531:10:1531:13 | ...[...] | provenance |  |
+| array_flow.rb:1532:10:1532:10 | b : [collection] [element] | array_flow.rb:1532:10:1532:13 | ...[...] | provenance |  |
+| array_flow.rb:1534:5:1534:5 | c : [collection] [element] | array_flow.rb:1538:10:1538:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 3] | array_flow.rb:1534:9:1537:7 | call to uniq : [collection] [element] | provenance |  |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 3] | array_flow.rb:1534:20:1534:20 | x | provenance |  |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 4] | array_flow.rb:1534:9:1537:7 | call to uniq : [collection] [element] | provenance |  |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 4] | array_flow.rb:1534:20:1534:20 | x | provenance |  |
+| array_flow.rb:1534:9:1537:7 | call to uniq : [collection] [element] | array_flow.rb:1534:5:1534:5 | c : [collection] [element] | provenance |  |
 | array_flow.rb:1534:20:1534:20 | x | array_flow.rb:1535:14:1535:14 | x | provenance |  |
-| array_flow.rb:1538:10:1538:10 | c [element] | array_flow.rb:1538:10:1538:13 | ...[...] | provenance |  |
-| array_flow.rb:1542:5:1542:5 | a [element 2] | array_flow.rb:1543:9:1543:9 | a [element 2] | provenance |  |
-| array_flow.rb:1542:5:1542:5 | a [element 3] | array_flow.rb:1543:9:1543:9 | a [element 3] | provenance |  |
-| array_flow.rb:1542:9:1542:44 | call to [] [element 2] | array_flow.rb:1542:5:1542:5 | a [element 2] | provenance |  |
-| array_flow.rb:1542:9:1542:44 | call to [] [element 3] | array_flow.rb:1542:5:1542:5 | a [element 3] | provenance |  |
-| array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1542:9:1542:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1542:9:1542:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1544:10:1544:10 | b [element] | provenance |  |
-| array_flow.rb:1543:5:1543:5 | b [element] | array_flow.rb:1545:10:1545:10 | b [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | [post] a [element] | array_flow.rb:1546:10:1546:10 | a [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | [post] a [element] | array_flow.rb:1547:10:1547:10 | a [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | a [element 2] | array_flow.rb:1543:9:1543:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | a [element 2] | array_flow.rb:1543:9:1543:15 | call to uniq! [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | a [element 3] | array_flow.rb:1543:9:1543:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1543:9:1543:9 | a [element 3] | array_flow.rb:1543:9:1543:15 | call to uniq! [element] | provenance |  |
-| array_flow.rb:1543:9:1543:15 | call to uniq! [element] | array_flow.rb:1543:5:1543:5 | b [element] | provenance |  |
-| array_flow.rb:1544:10:1544:10 | b [element] | array_flow.rb:1544:10:1544:13 | ...[...] | provenance |  |
-| array_flow.rb:1545:10:1545:10 | b [element] | array_flow.rb:1545:10:1545:13 | ...[...] | provenance |  |
-| array_flow.rb:1546:10:1546:10 | a [element] | array_flow.rb:1546:10:1546:13 | ...[...] | provenance |  |
-| array_flow.rb:1547:10:1547:10 | a [element] | array_flow.rb:1547:10:1547:13 | ...[...] | provenance |  |
-| array_flow.rb:1549:5:1549:5 | a [element 2] | array_flow.rb:1550:9:1550:9 | a [element 2] | provenance |  |
-| array_flow.rb:1549:5:1549:5 | a [element 3] | array_flow.rb:1550:9:1550:9 | a [element 3] | provenance |  |
-| array_flow.rb:1549:9:1549:44 | call to [] [element 2] | array_flow.rb:1549:5:1549:5 | a [element 2] | provenance |  |
-| array_flow.rb:1549:9:1549:44 | call to [] [element 3] | array_flow.rb:1549:5:1549:5 | a [element 3] | provenance |  |
-| array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1549:9:1549:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1549:9:1549:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1554:10:1554:10 | b [element] | provenance |  |
-| array_flow.rb:1550:5:1550:5 | b [element] | array_flow.rb:1555:10:1555:10 | b [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | [post] a [element] | array_flow.rb:1556:10:1556:10 | a [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | [post] a [element] | array_flow.rb:1557:10:1557:10 | a [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:9:1550:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:9:1553:7 | call to uniq! [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 2] | array_flow.rb:1550:21:1550:21 | x | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:9:1550:9 | [post] a [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:9:1553:7 | call to uniq! [element] | provenance |  |
-| array_flow.rb:1550:9:1550:9 | a [element 3] | array_flow.rb:1550:21:1550:21 | x | provenance |  |
-| array_flow.rb:1550:9:1553:7 | call to uniq! [element] | array_flow.rb:1550:5:1550:5 | b [element] | provenance |  |
+| array_flow.rb:1538:10:1538:10 | c : [collection] [element] | array_flow.rb:1538:10:1538:13 | ...[...] | provenance |  |
+| array_flow.rb:1542:5:1542:5 | a : Array [element 2] | array_flow.rb:1543:9:1543:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1542:5:1542:5 | a : Array [element 3] | array_flow.rb:1543:9:1543:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1542:9:1542:44 | call to [] : Array [element 2] | array_flow.rb:1542:5:1542:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1542:9:1542:44 | call to [] : Array [element 3] | array_flow.rb:1542:5:1542:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1542:16:1542:28 | call to source | array_flow.rb:1542:9:1542:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1542:31:1542:43 | call to source | array_flow.rb:1542:9:1542:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1543:5:1543:5 | b : [collection] [element] | array_flow.rb:1544:10:1544:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1543:5:1543:5 | b : [collection] [element] | array_flow.rb:1545:10:1545:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | [post] a : [collection] [element] | array_flow.rb:1546:10:1546:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | [post] a : [collection] [element] | array_flow.rb:1547:10:1547:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 2] | array_flow.rb:1543:9:1543:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 2] | array_flow.rb:1543:9:1543:15 | call to uniq! : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 3] | array_flow.rb:1543:9:1543:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 3] | array_flow.rb:1543:9:1543:15 | call to uniq! : [collection] [element] | provenance |  |
+| array_flow.rb:1543:9:1543:15 | call to uniq! : [collection] [element] | array_flow.rb:1543:5:1543:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1544:10:1544:10 | b : [collection] [element] | array_flow.rb:1544:10:1544:13 | ...[...] | provenance |  |
+| array_flow.rb:1545:10:1545:10 | b : [collection] [element] | array_flow.rb:1545:10:1545:13 | ...[...] | provenance |  |
+| array_flow.rb:1546:10:1546:10 | a : [collection] [element] | array_flow.rb:1546:10:1546:13 | ...[...] | provenance |  |
+| array_flow.rb:1547:10:1547:10 | a : [collection] [element] | array_flow.rb:1547:10:1547:13 | ...[...] | provenance |  |
+| array_flow.rb:1549:5:1549:5 | a : Array [element 2] | array_flow.rb:1550:9:1550:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1549:5:1549:5 | a : Array [element 3] | array_flow.rb:1550:9:1550:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1549:9:1549:44 | call to [] : Array [element 2] | array_flow.rb:1549:5:1549:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1549:9:1549:44 | call to [] : Array [element 3] | array_flow.rb:1549:5:1549:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1549:16:1549:28 | call to source | array_flow.rb:1549:9:1549:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1549:31:1549:43 | call to source | array_flow.rb:1549:9:1549:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1550:5:1550:5 | b : [collection] [element] | array_flow.rb:1554:10:1554:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1550:5:1550:5 | b : [collection] [element] | array_flow.rb:1555:10:1555:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | [post] a : [collection] [element] | array_flow.rb:1556:10:1556:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | [post] a : [collection] [element] | array_flow.rb:1557:10:1557:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 2] | array_flow.rb:1550:9:1550:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 2] | array_flow.rb:1550:9:1553:7 | call to uniq! : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 2] | array_flow.rb:1550:21:1550:21 | x | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 3] | array_flow.rb:1550:9:1550:9 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 3] | array_flow.rb:1550:9:1553:7 | call to uniq! : [collection] [element] | provenance |  |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 3] | array_flow.rb:1550:21:1550:21 | x | provenance |  |
+| array_flow.rb:1550:9:1553:7 | call to uniq! : [collection] [element] | array_flow.rb:1550:5:1550:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1550:21:1550:21 | x | array_flow.rb:1551:14:1551:14 | x | provenance |  |
-| array_flow.rb:1554:10:1554:10 | b [element] | array_flow.rb:1554:10:1554:13 | ...[...] | provenance |  |
-| array_flow.rb:1555:10:1555:10 | b [element] | array_flow.rb:1555:10:1555:13 | ...[...] | provenance |  |
-| array_flow.rb:1556:10:1556:10 | a [element] | array_flow.rb:1556:10:1556:13 | ...[...] | provenance |  |
-| array_flow.rb:1557:10:1557:10 | a [element] | array_flow.rb:1557:10:1557:13 | ...[...] | provenance |  |
-| array_flow.rb:1561:5:1561:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | a [element 2] | provenance |  |
-| array_flow.rb:1561:9:1561:29 | call to [] [element 2] | array_flow.rb:1561:5:1561:5 | a [element 2] | provenance |  |
-| array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1561:9:1561:29 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1562:5:1562:5 | [post] a [element 2] | array_flow.rb:1565:10:1565:10 | a [element 2] | provenance |  |
-| array_flow.rb:1562:5:1562:5 | [post] a [element 5] | array_flow.rb:1568:10:1568:10 | a [element 5] | provenance |  |
-| array_flow.rb:1562:5:1562:5 | a [element 2] | array_flow.rb:1562:5:1562:5 | [post] a [element 5] | provenance |  |
-| array_flow.rb:1562:21:1562:33 | call to source | array_flow.rb:1562:5:1562:5 | [post] a [element 2] | provenance |  |
-| array_flow.rb:1565:10:1565:10 | a [element 2] | array_flow.rb:1565:10:1565:13 | ...[...] | provenance |  |
-| array_flow.rb:1568:10:1568:10 | a [element 5] | array_flow.rb:1568:10:1568:13 | ...[...] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1574:9:1574:9 | a [element 1] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1580:9:1580:9 | a [element 1] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1584:9:1584:9 | a [element 1] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 1] | array_flow.rb:1588:9:1588:9 | a [element 1] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1580:9:1580:9 | a [element 3] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1584:9:1584:9 | a [element 3] | provenance |  |
-| array_flow.rb:1572:5:1572:5 | a [element 3] | array_flow.rb:1588:9:1588:9 | a [element 3] | provenance |  |
-| array_flow.rb:1572:9:1572:44 | call to [] [element 1] | array_flow.rb:1572:5:1572:5 | a [element 1] | provenance |  |
-| array_flow.rb:1572:9:1572:44 | call to [] [element 3] | array_flow.rb:1572:5:1572:5 | a [element 3] | provenance |  |
-| array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1572:9:1572:44 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1572:9:1572:44 | call to [] [element 3] | provenance |  |
-| array_flow.rb:1574:5:1574:5 | b [element 1] | array_flow.rb:1576:10:1576:10 | b [element 1] | provenance |  |
-| array_flow.rb:1574:5:1574:5 | b [element 3] | array_flow.rb:1578:10:1578:10 | b [element 3] | provenance |  |
-| array_flow.rb:1574:9:1574:9 | a [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | provenance |  |
-| array_flow.rb:1574:9:1574:9 | a [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at [element 3] | provenance |  |
-| array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | array_flow.rb:1574:5:1574:5 | b [element 1] | provenance |  |
-| array_flow.rb:1574:9:1574:31 | call to values_at [element 3] | array_flow.rb:1574:5:1574:5 | b [element 3] | provenance |  |
-| array_flow.rb:1576:10:1576:10 | b [element 1] | array_flow.rb:1576:10:1576:13 | ...[...] | provenance |  |
-| array_flow.rb:1578:10:1578:10 | b [element 3] | array_flow.rb:1578:10:1578:13 | ...[...] | provenance |  |
-| array_flow.rb:1580:5:1580:5 | b [element] | array_flow.rb:1581:10:1581:10 | b [element] | provenance |  |
-| array_flow.rb:1580:5:1580:5 | b [element] | array_flow.rb:1582:10:1582:10 | b [element] | provenance |  |
-| array_flow.rb:1580:9:1580:9 | a [element 1] | array_flow.rb:1580:9:1580:25 | call to values_at [element] | provenance |  |
-| array_flow.rb:1580:9:1580:9 | a [element 3] | array_flow.rb:1580:9:1580:25 | call to values_at [element] | provenance |  |
-| array_flow.rb:1580:9:1580:25 | call to values_at [element] | array_flow.rb:1580:5:1580:5 | b [element] | provenance |  |
-| array_flow.rb:1581:10:1581:10 | b [element] | array_flow.rb:1581:10:1581:13 | ...[...] | provenance |  |
-| array_flow.rb:1582:10:1582:10 | b [element] | array_flow.rb:1582:10:1582:13 | ...[...] | provenance |  |
-| array_flow.rb:1584:5:1584:5 | b [element] | array_flow.rb:1585:10:1585:10 | b [element] | provenance |  |
-| array_flow.rb:1584:5:1584:5 | b [element] | array_flow.rb:1586:10:1586:10 | b [element] | provenance |  |
-| array_flow.rb:1584:9:1584:9 | a [element 1] | array_flow.rb:1584:9:1584:26 | call to values_at [element] | provenance |  |
-| array_flow.rb:1584:9:1584:9 | a [element 3] | array_flow.rb:1584:9:1584:26 | call to values_at [element] | provenance |  |
-| array_flow.rb:1584:9:1584:26 | call to values_at [element] | array_flow.rb:1584:5:1584:5 | b [element] | provenance |  |
-| array_flow.rb:1585:10:1585:10 | b [element] | array_flow.rb:1585:10:1585:13 | ...[...] | provenance |  |
-| array_flow.rb:1586:10:1586:10 | b [element] | array_flow.rb:1586:10:1586:13 | ...[...] | provenance |  |
-| array_flow.rb:1588:5:1588:5 | b [element 1] | array_flow.rb:1590:10:1590:10 | b [element 1] | provenance |  |
-| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1589:10:1589:10 | b [element] | provenance |  |
-| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1590:10:1590:10 | b [element] | provenance |  |
-| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1591:10:1591:10 | b [element] | provenance |  |
-| array_flow.rb:1588:5:1588:5 | b [element] | array_flow.rb:1592:10:1592:10 | b [element] | provenance |  |
-| array_flow.rb:1588:9:1588:9 | a [element 1] | array_flow.rb:1588:9:1588:28 | call to values_at [element] | provenance |  |
-| array_flow.rb:1588:9:1588:9 | a [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at [element 1] | provenance |  |
-| array_flow.rb:1588:9:1588:9 | a [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at [element] | provenance |  |
-| array_flow.rb:1588:9:1588:28 | call to values_at [element 1] | array_flow.rb:1588:5:1588:5 | b [element 1] | provenance |  |
-| array_flow.rb:1588:9:1588:28 | call to values_at [element] | array_flow.rb:1588:5:1588:5 | b [element] | provenance |  |
-| array_flow.rb:1589:10:1589:10 | b [element] | array_flow.rb:1589:10:1589:13 | ...[...] | provenance |  |
-| array_flow.rb:1590:10:1590:10 | b [element 1] | array_flow.rb:1590:10:1590:13 | ...[...] | provenance |  |
-| array_flow.rb:1590:10:1590:10 | b [element] | array_flow.rb:1590:10:1590:13 | ...[...] | provenance |  |
-| array_flow.rb:1591:10:1591:10 | b [element] | array_flow.rb:1591:10:1591:13 | ...[...] | provenance |  |
-| array_flow.rb:1592:10:1592:10 | b [element] | array_flow.rb:1592:10:1592:13 | ...[...] | provenance |  |
-| array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1599:9:1599:9 | a [element 2] | provenance |  |
-| array_flow.rb:1596:5:1596:5 | a [element 2] | array_flow.rb:1604:5:1604:5 | a [element 2] | provenance |  |
-| array_flow.rb:1596:9:1596:29 | call to [] [element 2] | array_flow.rb:1596:5:1596:5 | a [element 2] | provenance |  |
-| array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1596:9:1596:29 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1599:15:1599:15 | b [element 1] | provenance |  |
-| array_flow.rb:1597:5:1597:5 | b [element 1] | array_flow.rb:1604:11:1604:11 | b [element 1] | provenance |  |
-| array_flow.rb:1597:9:1597:29 | call to [] [element 1] | array_flow.rb:1597:5:1597:5 | b [element 1] | provenance |  |
-| array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1597:9:1597:29 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1599:18:1599:18 | c [element 0] | provenance |  |
-| array_flow.rb:1598:5:1598:5 | c [element 0] | array_flow.rb:1604:14:1604:14 | c [element 0] | provenance |  |
-| array_flow.rb:1598:9:1598:29 | call to [] [element 0] | array_flow.rb:1598:5:1598:5 | c [element 0] | provenance |  |
-| array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1598:9:1598:29 | call to [] [element 0] | provenance |  |
-| array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | provenance |  |
-| array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | provenance |  |
-| array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:1599:9:1599:9 | a [element 2] | array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] | provenance |  |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] | array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | provenance |  |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] | array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | provenance |  |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] | array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | provenance |  |
-| array_flow.rb:1599:15:1599:15 | b [element 1] | array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] | provenance |  |
-| array_flow.rb:1599:18:1599:18 | c [element 0] | array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] | provenance |  |
-| array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | provenance |  |
+| array_flow.rb:1554:10:1554:10 | b : [collection] [element] | array_flow.rb:1554:10:1554:13 | ...[...] | provenance |  |
+| array_flow.rb:1555:10:1555:10 | b : [collection] [element] | array_flow.rb:1555:10:1555:13 | ...[...] | provenance |  |
+| array_flow.rb:1556:10:1556:10 | a : [collection] [element] | array_flow.rb:1556:10:1556:13 | ...[...] | provenance |  |
+| array_flow.rb:1557:10:1557:10 | a : [collection] [element] | array_flow.rb:1557:10:1557:13 | ...[...] | provenance |  |
+| array_flow.rb:1561:5:1561:5 | a : Array [element 2] | array_flow.rb:1562:5:1562:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1561:9:1561:29 | call to [] : Array [element 2] | array_flow.rb:1561:5:1561:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1561:16:1561:28 | call to source | array_flow.rb:1561:9:1561:29 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 2] | array_flow.rb:1565:10:1565:10 | a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 5] | array_flow.rb:1568:10:1568:10 | a : [collection] [element 5] | provenance |  |
+| array_flow.rb:1562:5:1562:5 | a : Array [element 2] | array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 5] | provenance |  |
+| array_flow.rb:1562:21:1562:33 | call to source | array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 2] | provenance |  |
+| array_flow.rb:1565:10:1565:10 | a : [collection] [element 2] | array_flow.rb:1565:10:1565:13 | ...[...] | provenance |  |
+| array_flow.rb:1568:10:1568:10 | a : [collection] [element 5] | array_flow.rb:1568:10:1568:13 | ...[...] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 1] | array_flow.rb:1574:9:1574:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 1] | array_flow.rb:1580:9:1580:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 1] | array_flow.rb:1584:9:1584:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 1] | array_flow.rb:1588:9:1588:9 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 3] | array_flow.rb:1580:9:1580:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 3] | array_flow.rb:1584:9:1584:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 3] | array_flow.rb:1588:9:1588:9 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1572:9:1572:44 | call to [] : Array [element 1] | array_flow.rb:1572:5:1572:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1572:9:1572:44 | call to [] : Array [element 3] | array_flow.rb:1572:5:1572:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1572:13:1572:25 | call to source | array_flow.rb:1572:9:1572:44 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1572:31:1572:43 | call to source | array_flow.rb:1572:9:1572:44 | call to [] : Array [element 3] | provenance |  |
+| array_flow.rb:1574:5:1574:5 | b : [collection] [element 1] | array_flow.rb:1576:10:1576:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1574:5:1574:5 | b : [collection] [element 3] | array_flow.rb:1578:10:1578:10 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1574:9:1574:9 | a : Array [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 1] | provenance |  |
+| array_flow.rb:1574:9:1574:9 | a : Array [element 1] | array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 3] | provenance |  |
+| array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 1] | array_flow.rb:1574:5:1574:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 3] | array_flow.rb:1574:5:1574:5 | b : [collection] [element 3] | provenance |  |
+| array_flow.rb:1576:10:1576:10 | b : [collection] [element 1] | array_flow.rb:1576:10:1576:13 | ...[...] | provenance |  |
+| array_flow.rb:1578:10:1578:10 | b : [collection] [element 3] | array_flow.rb:1578:10:1578:13 | ...[...] | provenance |  |
+| array_flow.rb:1580:5:1580:5 | b : [collection] [element] | array_flow.rb:1581:10:1581:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1580:5:1580:5 | b : [collection] [element] | array_flow.rb:1582:10:1582:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1580:9:1580:9 | a : Array [element 1] | array_flow.rb:1580:9:1580:25 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1580:9:1580:9 | a : Array [element 3] | array_flow.rb:1580:9:1580:25 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1580:9:1580:25 | call to values_at : [collection] [element] | array_flow.rb:1580:5:1580:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1581:10:1581:10 | b : [collection] [element] | array_flow.rb:1581:10:1581:13 | ...[...] | provenance |  |
+| array_flow.rb:1582:10:1582:10 | b : [collection] [element] | array_flow.rb:1582:10:1582:13 | ...[...] | provenance |  |
+| array_flow.rb:1584:5:1584:5 | b : [collection] [element] | array_flow.rb:1585:10:1585:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1584:5:1584:5 | b : [collection] [element] | array_flow.rb:1586:10:1586:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1584:9:1584:9 | a : Array [element 1] | array_flow.rb:1584:9:1584:26 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1584:9:1584:9 | a : Array [element 3] | array_flow.rb:1584:9:1584:26 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1584:9:1584:26 | call to values_at : [collection] [element] | array_flow.rb:1584:5:1584:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1585:10:1585:10 | b : [collection] [element] | array_flow.rb:1585:10:1585:13 | ...[...] | provenance |  |
+| array_flow.rb:1586:10:1586:10 | b : [collection] [element] | array_flow.rb:1586:10:1586:13 | ...[...] | provenance |  |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element 1] | array_flow.rb:1590:10:1590:10 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element] | array_flow.rb:1589:10:1589:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element] | array_flow.rb:1590:10:1590:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element] | array_flow.rb:1591:10:1591:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element] | array_flow.rb:1592:10:1592:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1588:9:1588:9 | a : Array [element 1] | array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1588:9:1588:9 | a : Array [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element 1] | provenance |  |
+| array_flow.rb:1588:9:1588:9 | a : Array [element 3] | array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element] | provenance |  |
+| array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element 1] | array_flow.rb:1588:5:1588:5 | b : [collection] [element 1] | provenance |  |
+| array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element] | array_flow.rb:1588:5:1588:5 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1589:10:1589:10 | b : [collection] [element] | array_flow.rb:1589:10:1589:13 | ...[...] | provenance |  |
+| array_flow.rb:1590:10:1590:10 | b : [collection] [element 1] | array_flow.rb:1590:10:1590:13 | ...[...] | provenance |  |
+| array_flow.rb:1590:10:1590:10 | b : [collection] [element] | array_flow.rb:1590:10:1590:13 | ...[...] | provenance |  |
+| array_flow.rb:1591:10:1591:10 | b : [collection] [element] | array_flow.rb:1591:10:1591:13 | ...[...] | provenance |  |
+| array_flow.rb:1592:10:1592:10 | b : [collection] [element] | array_flow.rb:1592:10:1592:13 | ...[...] | provenance |  |
+| array_flow.rb:1596:5:1596:5 | a : Array [element 2] | array_flow.rb:1599:9:1599:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1596:5:1596:5 | a : Array [element 2] | array_flow.rb:1604:5:1604:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1596:9:1596:29 | call to [] : Array [element 2] | array_flow.rb:1596:5:1596:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1596:16:1596:28 | call to source | array_flow.rb:1596:9:1596:29 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1597:5:1597:5 | b : Array [element 1] | array_flow.rb:1599:15:1599:15 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1597:5:1597:5 | b : Array [element 1] | array_flow.rb:1604:11:1604:11 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1597:9:1597:29 | call to [] : Array [element 1] | array_flow.rb:1597:5:1597:5 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1597:13:1597:25 | call to source | array_flow.rb:1597:9:1597:29 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1598:5:1598:5 | c : Array [element 0] | array_flow.rb:1599:18:1599:18 | c : Array [element 0] | provenance |  |
+| array_flow.rb:1598:5:1598:5 | c : Array [element 0] | array_flow.rb:1604:14:1604:14 | c : Array [element 0] | provenance |  |
+| array_flow.rb:1598:9:1598:29 | call to [] : Array [element 0] | array_flow.rb:1598:5:1598:5 | c : Array [element 0] | provenance |  |
+| array_flow.rb:1598:10:1598:22 | call to source | array_flow.rb:1598:9:1598:29 | call to [] : Array [element 0] | provenance |  |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 0, element 2] | array_flow.rb:1601:10:1601:10 | d : [collection] [element 0, element 2] | provenance |  |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 1, element 1] | array_flow.rb:1602:10:1602:10 | d : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 2, element 0] | array_flow.rb:1603:10:1603:10 | d : [collection] [element 2, element 0] | provenance |  |
+| array_flow.rb:1599:9:1599:9 | a : Array [element 2] | array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 2, element 0] | provenance |  |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 0, element 2] | array_flow.rb:1599:5:1599:5 | d : [collection] [element 0, element 2] | provenance |  |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 1, element 1] | array_flow.rb:1599:5:1599:5 | d : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 2, element 0] | array_flow.rb:1599:5:1599:5 | d : [collection] [element 2, element 0] | provenance |  |
+| array_flow.rb:1599:15:1599:15 | b : Array [element 1] | array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 1, element 1] | provenance |  |
+| array_flow.rb:1599:18:1599:18 | c : Array [element 0] | array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 0, element 2] | provenance |  |
+| array_flow.rb:1601:10:1601:10 | d : [collection] [element 0, element 2] | array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | provenance |  |
 | array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | array_flow.rb:1601:10:1601:16 | ...[...] | provenance |  |
-| array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | provenance |  |
+| array_flow.rb:1602:10:1602:10 | d : [collection] [element 1, element 1] | array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | provenance |  |
 | array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | array_flow.rb:1602:10:1602:16 | ...[...] | provenance |  |
-| array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1603:10:1603:10 | d : [collection] [element 2, element 0] | array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | provenance |  |
 | array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | array_flow.rb:1603:10:1603:16 | ...[...] | provenance |  |
-| array_flow.rb:1604:5:1604:5 | a [element 2] | array_flow.rb:1604:21:1604:21 | x [element 0] | provenance |  |
-| array_flow.rb:1604:11:1604:11 | b [element 1] | array_flow.rb:1604:21:1604:21 | x [element 1] | provenance |  |
-| array_flow.rb:1604:14:1604:14 | c [element 0] | array_flow.rb:1604:21:1604:21 | x [element 2] | provenance |  |
-| array_flow.rb:1604:21:1604:21 | x [element 0] | array_flow.rb:1605:14:1605:14 | x [element 0] | provenance |  |
-| array_flow.rb:1604:21:1604:21 | x [element 1] | array_flow.rb:1606:14:1606:14 | x [element 1] | provenance |  |
-| array_flow.rb:1604:21:1604:21 | x [element 2] | array_flow.rb:1607:14:1607:14 | x [element 2] | provenance |  |
-| array_flow.rb:1605:14:1605:14 | x [element 0] | array_flow.rb:1605:14:1605:17 | ...[...] | provenance |  |
-| array_flow.rb:1606:14:1606:14 | x [element 1] | array_flow.rb:1606:14:1606:17 | ...[...] | provenance |  |
-| array_flow.rb:1607:14:1607:14 | x [element 2] | array_flow.rb:1607:14:1607:17 | ...[...] | provenance |  |
-| array_flow.rb:1612:5:1612:5 | a [element 2] | array_flow.rb:1614:9:1614:9 | a [element 2] | provenance |  |
-| array_flow.rb:1612:9:1612:29 | call to [] [element 2] | array_flow.rb:1612:5:1612:5 | a [element 2] | provenance |  |
-| array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1612:9:1612:29 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1613:5:1613:5 | b [element 1] | array_flow.rb:1614:13:1614:13 | b [element 1] | provenance |  |
-| array_flow.rb:1613:9:1613:26 | call to [] [element 1] | array_flow.rb:1613:5:1613:5 | b [element 1] | provenance |  |
-| array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1613:9:1613:26 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1615:10:1615:10 | c [element] | provenance |  |
-| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1616:10:1616:10 | c [element] | provenance |  |
-| array_flow.rb:1614:5:1614:5 | c [element] | array_flow.rb:1617:10:1617:10 | c [element] | provenance |  |
-| array_flow.rb:1614:9:1614:9 | a [element 2] | array_flow.rb:1614:9:1614:13 | ... \| ... [element] | provenance |  |
-| array_flow.rb:1614:9:1614:13 | ... \| ... [element] | array_flow.rb:1614:5:1614:5 | c [element] | provenance |  |
-| array_flow.rb:1614:13:1614:13 | b [element 1] | array_flow.rb:1614:9:1614:13 | ... \| ... [element] | provenance |  |
-| array_flow.rb:1615:10:1615:10 | c [element] | array_flow.rb:1615:10:1615:13 | ...[...] | provenance |  |
-| array_flow.rb:1616:10:1616:10 | c [element] | array_flow.rb:1616:10:1616:13 | ...[...] | provenance |  |
-| array_flow.rb:1617:10:1617:10 | c [element] | array_flow.rb:1617:10:1617:13 | ...[...] | provenance |  |
-| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1623:10:1623:10 | a [element, element 0] | provenance |  |
-| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1626:10:1626:10 | a [element, element 0] | provenance |  |
-| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | array_flow.rb:1627:10:1627:10 | a [element, element 0] | provenance |  |
-| array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] | array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | provenance |  |
-| array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] | provenance |  |
-| array_flow.rb:1623:10:1623:10 | a [element, element 0] | array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1604:5:1604:5 | a : Array [element 2] | array_flow.rb:1604:21:1604:21 | x : [collection] [element 0] | provenance |  |
+| array_flow.rb:1604:11:1604:11 | b : Array [element 1] | array_flow.rb:1604:21:1604:21 | x : [collection] [element 1] | provenance |  |
+| array_flow.rb:1604:14:1604:14 | c : Array [element 0] | array_flow.rb:1604:21:1604:21 | x : [collection] [element 2] | provenance |  |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 0] | array_flow.rb:1605:14:1605:14 | x : [collection] [element 0] | provenance |  |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 1] | array_flow.rb:1606:14:1606:14 | x : [collection] [element 1] | provenance |  |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 2] | array_flow.rb:1607:14:1607:14 | x : [collection] [element 2] | provenance |  |
+| array_flow.rb:1605:14:1605:14 | x : [collection] [element 0] | array_flow.rb:1605:14:1605:17 | ...[...] | provenance |  |
+| array_flow.rb:1606:14:1606:14 | x : [collection] [element 1] | array_flow.rb:1606:14:1606:17 | ...[...] | provenance |  |
+| array_flow.rb:1607:14:1607:14 | x : [collection] [element 2] | array_flow.rb:1607:14:1607:17 | ...[...] | provenance |  |
+| array_flow.rb:1612:5:1612:5 | a : Array [element 2] | array_flow.rb:1614:9:1614:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1612:9:1612:29 | call to [] : Array [element 2] | array_flow.rb:1612:5:1612:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1612:16:1612:28 | call to source | array_flow.rb:1612:9:1612:29 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1613:5:1613:5 | b : Array [element 1] | array_flow.rb:1614:13:1614:13 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1613:9:1613:26 | call to [] : Array [element 1] | array_flow.rb:1613:5:1613:5 | b : Array [element 1] | provenance |  |
+| array_flow.rb:1613:13:1613:25 | call to source | array_flow.rb:1613:9:1613:26 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1614:5:1614:5 | c : [collection] [element] | array_flow.rb:1615:10:1615:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1614:5:1614:5 | c : [collection] [element] | array_flow.rb:1616:10:1616:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1614:5:1614:5 | c : [collection] [element] | array_flow.rb:1617:10:1617:10 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1614:9:1614:9 | a : Array [element 2] | array_flow.rb:1614:9:1614:13 | ... \| ... : [collection] [element] | provenance |  |
+| array_flow.rb:1614:9:1614:13 | ... \| ... : [collection] [element] | array_flow.rb:1614:5:1614:5 | c : [collection] [element] | provenance |  |
+| array_flow.rb:1614:13:1614:13 | b : Array [element 1] | array_flow.rb:1614:9:1614:13 | ... \| ... : [collection] [element] | provenance |  |
+| array_flow.rb:1615:10:1615:10 | c : [collection] [element] | array_flow.rb:1615:10:1615:13 | ...[...] | provenance |  |
+| array_flow.rb:1616:10:1616:10 | c : [collection] [element] | array_flow.rb:1616:10:1616:13 | ...[...] | provenance |  |
+| array_flow.rb:1617:10:1617:10 | c : [collection] [element] | array_flow.rb:1617:10:1617:13 | ...[...] | provenance |  |
+| array_flow.rb:1622:5:1622:5 | [post] a : [collection] [element, element 0] | array_flow.rb:1623:10:1623:10 | a : [collection] [element, element 0] | provenance |  |
+| array_flow.rb:1622:5:1622:5 | [post] a : [collection] [element, element 0] | array_flow.rb:1626:10:1626:10 | a : [collection] [element, element 0] | provenance |  |
+| array_flow.rb:1622:5:1622:5 | [post] a : [collection] [element, element 0] | array_flow.rb:1627:10:1627:10 | a : [collection] [element, element 0] | provenance |  |
+| array_flow.rb:1622:5:1622:8 | [post] ...[...] : [collection] [element 0] | array_flow.rb:1622:5:1622:5 | [post] a : [collection] [element, element 0] | provenance |  |
+| array_flow.rb:1622:15:1622:27 | call to source | array_flow.rb:1622:5:1622:8 | [post] ...[...] : [collection] [element 0] | provenance |  |
+| array_flow.rb:1623:10:1623:10 | a : [collection] [element, element 0] | array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | provenance |  |
 | array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | array_flow.rb:1623:10:1623:16 | ...[...] | provenance |  |
-| array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] | array_flow.rb:1626:10:1626:10 | a [element 1, element 0] | provenance |  |
-| array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] | array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] | provenance |  |
-| array_flow.rb:1625:15:1625:27 | call to source | array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] | provenance |  |
-| array_flow.rb:1626:10:1626:10 | a [element 1, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | provenance |  |
-| array_flow.rb:1626:10:1626:10 | a [element, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1625:5:1625:5 | [post] a : [collection] [element 1, element 0] | array_flow.rb:1626:10:1626:10 | a : [collection] [element 1, element 0] | provenance |  |
+| array_flow.rb:1625:5:1625:8 | [post] ...[...] : [collection] [element 0] | array_flow.rb:1625:5:1625:5 | [post] a : [collection] [element 1, element 0] | provenance |  |
+| array_flow.rb:1625:15:1625:27 | call to source | array_flow.rb:1625:5:1625:8 | [post] ...[...] : [collection] [element 0] | provenance |  |
+| array_flow.rb:1626:10:1626:10 | a : [collection] [element 1, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1626:10:1626:10 | a : [collection] [element, element 0] | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | provenance |  |
 | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | array_flow.rb:1626:10:1626:16 | ...[...] | provenance |  |
-| array_flow.rb:1627:10:1627:10 | a [element, element 0] | array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | provenance |  |
+| array_flow.rb:1627:10:1627:10 | a : [collection] [element, element 0] | array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | provenance |  |
 | array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | array_flow.rb:1627:10:1627:16 | ...[...] | provenance |  |
-| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | array_flow.rb:1641:10:1641:10 | a [element 0] | provenance |  |
-| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | array_flow.rb:1643:10:1643:10 | a [element 0] | provenance |  |
-| array_flow.rb:1632:12:1632:24 | call to source | array_flow.rb:1632:5:1632:5 | [post] a [element 0] | provenance |  |
-| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] | provenance |  |
-| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] | provenance |  |
-| array_flow.rb:1634:5:1634:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] | provenance |  |
-| array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1634:5:1634:5 | [post] a [element] | provenance |  |
-| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] | provenance |  |
-| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] | provenance |  |
-| array_flow.rb:1636:5:1636:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] | provenance |  |
-| array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1636:5:1636:5 | [post] a [element] | provenance |  |
-| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1639:10:1639:10 | a [element] | provenance |  |
-| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1641:10:1641:10 | a [element] | provenance |  |
-| array_flow.rb:1638:5:1638:5 | [post] a [element] | array_flow.rb:1643:10:1643:10 | a [element] | provenance |  |
-| array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1638:5:1638:5 | [post] a [element] | provenance |  |
-| array_flow.rb:1639:10:1639:10 | a [element] | array_flow.rb:1639:10:1639:13 | ...[...] | provenance |  |
-| array_flow.rb:1641:10:1641:10 | a [element 0] | array_flow.rb:1641:10:1641:17 | ...[...] | provenance |  |
-| array_flow.rb:1641:10:1641:10 | a [element] | array_flow.rb:1641:10:1641:17 | ...[...] | provenance |  |
-| array_flow.rb:1643:10:1643:10 | a [element 0] | array_flow.rb:1643:10:1643:15 | ...[...] | provenance |  |
-| array_flow.rb:1643:10:1643:10 | a [element] | array_flow.rb:1643:10:1643:15 | ...[...] | provenance |  |
-| array_flow.rb:1647:5:1647:5 | a [element 1] | array_flow.rb:1649:10:1649:10 | a [element 1] | provenance |  |
-| array_flow.rb:1647:5:1647:5 | a [element 1] | array_flow.rb:1651:10:1651:10 | a [element 1] | provenance |  |
-| array_flow.rb:1647:9:1647:32 | ...[...] [element 1] | array_flow.rb:1647:5:1647:5 | a [element 1] | provenance |  |
-| array_flow.rb:1647:18:1647:28 | call to source | array_flow.rb:1647:9:1647:32 | ...[...] [element 1] | provenance |  |
-| array_flow.rb:1649:10:1649:10 | a [element 1] | array_flow.rb:1649:10:1649:13 | ...[...] | provenance |  |
-| array_flow.rb:1651:10:1651:10 | a [element 1] | array_flow.rb:1651:10:1651:13 | ...[...] | provenance |  |
-| array_flow.rb:1668:9:1668:10 | a2 [element 1] | array_flow.rb:1670:14:1670:15 | a2 [element 1] | provenance |  |
-| array_flow.rb:1668:9:1668:10 | a2 [element 1] | array_flow.rb:1672:14:1672:15 | a2 [element 1] | provenance |  |
-| array_flow.rb:1668:14:1668:41 | ...[...] [element 1] | array_flow.rb:1668:9:1668:10 | a2 [element 1] | provenance |  |
-| array_flow.rb:1668:25:1668:37 | call to source | array_flow.rb:1668:14:1668:41 | ...[...] [element 1] | provenance |  |
-| array_flow.rb:1670:14:1670:15 | a2 [element 1] | array_flow.rb:1670:14:1670:18 | ...[...] | provenance |  |
-| array_flow.rb:1672:14:1672:15 | a2 [element 1] | array_flow.rb:1672:14:1672:18 | ...[...] | provenance |  |
-| array_flow.rb:1677:5:1677:5 | a [element 2] | array_flow.rb:1678:9:1678:9 | a [element 2] | provenance |  |
-| array_flow.rb:1677:9:1677:29 | call to [] [element 2] | array_flow.rb:1677:5:1677:5 | a [element 2] | provenance |  |
-| array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:9:1677:29 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1678:5:1678:5 | b [element] | array_flow.rb:1681:10:1681:10 | b [element] | provenance |  |
-| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:9:1680:7 | call to map [element] | provenance |  |
-| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:19:1678:19 | x | provenance |  |
-| array_flow.rb:1678:9:1680:7 | call to map [element] | array_flow.rb:1678:5:1678:5 | b [element] | provenance |  |
+| array_flow.rb:1632:5:1632:5 | [post] a : [collection] [element 0] | array_flow.rb:1641:10:1641:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1632:5:1632:5 | [post] a : [collection] [element 0] | array_flow.rb:1643:10:1643:10 | a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1632:12:1632:24 | call to source | array_flow.rb:1632:5:1632:5 | [post] a : [collection] [element 0] | provenance |  |
+| array_flow.rb:1634:5:1634:5 | [post] a : [collection] [element] | array_flow.rb:1639:10:1639:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1634:5:1634:5 | [post] a : [collection] [element] | array_flow.rb:1641:10:1641:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1634:5:1634:5 | [post] a : [collection] [element] | array_flow.rb:1643:10:1643:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1634:16:1634:28 | call to source | array_flow.rb:1634:5:1634:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1636:5:1636:5 | [post] a : [collection] [element] | array_flow.rb:1639:10:1639:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1636:5:1636:5 | [post] a : [collection] [element] | array_flow.rb:1641:10:1641:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1636:5:1636:5 | [post] a : [collection] [element] | array_flow.rb:1643:10:1643:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1636:14:1636:26 | call to source | array_flow.rb:1636:5:1636:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1638:5:1638:5 | [post] a : [collection] [element] | array_flow.rb:1639:10:1639:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1638:5:1638:5 | [post] a : [collection] [element] | array_flow.rb:1641:10:1641:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1638:5:1638:5 | [post] a : [collection] [element] | array_flow.rb:1643:10:1643:10 | a : [collection] [element] | provenance |  |
+| array_flow.rb:1638:16:1638:28 | call to source | array_flow.rb:1638:5:1638:5 | [post] a : [collection] [element] | provenance |  |
+| array_flow.rb:1639:10:1639:10 | a : [collection] [element] | array_flow.rb:1639:10:1639:13 | ...[...] | provenance |  |
+| array_flow.rb:1641:10:1641:10 | a : [collection] [element 0] | array_flow.rb:1641:10:1641:17 | ...[...] | provenance |  |
+| array_flow.rb:1641:10:1641:10 | a : [collection] [element] | array_flow.rb:1641:10:1641:17 | ...[...] | provenance |  |
+| array_flow.rb:1643:10:1643:10 | a : [collection] [element 0] | array_flow.rb:1643:10:1643:15 | ...[...] | provenance |  |
+| array_flow.rb:1643:10:1643:10 | a : [collection] [element] | array_flow.rb:1643:10:1643:15 | ...[...] | provenance |  |
+| array_flow.rb:1647:5:1647:5 | a : Array [element 1] | array_flow.rb:1649:10:1649:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1647:5:1647:5 | a : Array [element 1] | array_flow.rb:1651:10:1651:10 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1647:9:1647:32 | ...[...] : Array [element 1] | array_flow.rb:1647:5:1647:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1647:18:1647:28 | call to source | array_flow.rb:1647:9:1647:32 | ...[...] : Array [element 1] | provenance |  |
+| array_flow.rb:1649:10:1649:10 | a : Array [element 1] | array_flow.rb:1649:10:1649:13 | ...[...] | provenance |  |
+| array_flow.rb:1651:10:1651:10 | a : Array [element 1] | array_flow.rb:1651:10:1651:13 | ...[...] | provenance |  |
+| array_flow.rb:1668:9:1668:10 | a2 : Array [element 1] | array_flow.rb:1670:14:1670:15 | a2 : Array [element 1] | provenance |  |
+| array_flow.rb:1668:9:1668:10 | a2 : Array [element 1] | array_flow.rb:1672:14:1672:15 | a2 : Array [element 1] | provenance |  |
+| array_flow.rb:1668:14:1668:41 | ...[...] : Array [element 1] | array_flow.rb:1668:9:1668:10 | a2 : Array [element 1] | provenance |  |
+| array_flow.rb:1668:25:1668:37 | call to source | array_flow.rb:1668:14:1668:41 | ...[...] : Array [element 1] | provenance |  |
+| array_flow.rb:1670:14:1670:15 | a2 : Array [element 1] | array_flow.rb:1670:14:1670:18 | ...[...] | provenance |  |
+| array_flow.rb:1672:14:1672:15 | a2 : Array [element 1] | array_flow.rb:1672:14:1672:18 | ...[...] | provenance |  |
+| array_flow.rb:1677:5:1677:5 | a : Array [element 2] | array_flow.rb:1678:9:1678:9 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1677:9:1677:29 | call to [] : Array [element 2] | array_flow.rb:1677:5:1677:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1677:16:1677:28 | call to source | array_flow.rb:1677:9:1677:29 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1678:5:1678:5 | b : [collection] [element] | array_flow.rb:1681:10:1681:10 | b : [collection] [element] | provenance |  |
+| array_flow.rb:1678:9:1678:9 | a : Array [element 2] | array_flow.rb:1678:9:1680:7 | call to map : [collection] [element] | provenance |  |
+| array_flow.rb:1678:9:1678:9 | a : Array [element 2] | array_flow.rb:1678:19:1678:19 | x | provenance |  |
+| array_flow.rb:1678:9:1680:7 | call to map : [collection] [element] | array_flow.rb:1678:5:1678:5 | b : [collection] [element] | provenance |  |
 | array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | provenance |  |
-| array_flow.rb:1681:10:1681:10 | b [element] | array_flow.rb:1681:10:1681:13 | ...[...] | provenance |  |
-| array_flow.rb:1685:5:1685:5 | a [element 2] | array_flow.rb:1686:18:1686:18 | a [element 2] | provenance |  |
-| array_flow.rb:1685:5:1685:5 | a [element 3] | array_flow.rb:1686:18:1686:18 | a [element 3] | provenance |  |
-| array_flow.rb:1685:9:1685:44 | call to [] [element 2] | array_flow.rb:1685:5:1685:5 | a [element 2] | provenance |  |
-| array_flow.rb:1685:9:1685:44 | call to [] [element 3] | array_flow.rb:1685:5:1685:5 | a [element 3] | provenance |  |
-| array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1685:9:1685:44 | call to [] [element 2] | provenance |  |
-| array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1685:9:1685:44 | call to [] [element 3] | provenance |  |
+| array_flow.rb:1681:10:1681:10 | b : [collection] [element] | array_flow.rb:1681:10:1681:13 | ...[...] | provenance |  |
+| array_flow.rb:1685:5:1685:5 | a : Array [element 2] | array_flow.rb:1686:18:1686:18 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1685:5:1685:5 | a : Array [element 3] | array_flow.rb:1686:18:1686:18 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1685:9:1685:44 | call to [] : Array [element 2] | array_flow.rb:1685:5:1685:5 | a : Array [element 2] | provenance |  |
+| array_flow.rb:1685:9:1685:44 | call to [] : Array [element 3] | array_flow.rb:1685:5:1685:5 | a : Array [element 3] | provenance |  |
+| array_flow.rb:1685:16:1685:28 | call to source | array_flow.rb:1685:9:1685:44 | call to [] : Array [element 2] | provenance |  |
+| array_flow.rb:1685:31:1685:43 | call to source | array_flow.rb:1685:9:1685:44 | call to [] : Array [element 3] | provenance |  |
 | array_flow.rb:1686:11:1686:11 | z | array_flow.rb:1689:10:1689:10 | z | provenance |  |
 | array_flow.rb:1686:14:1686:14 | w | array_flow.rb:1690:10:1690:10 | w | provenance |  |
-| array_flow.rb:1686:18:1686:18 | a [element 2] | array_flow.rb:1686:11:1686:11 | z | provenance |  |
-| array_flow.rb:1686:18:1686:18 | a [element 3] | array_flow.rb:1686:14:1686:14 | w | provenance |  |
-| array_flow.rb:1693:10:1693:14 | *args [element 1] | array_flow.rb:1694:17:1694:20 | args [element 1] | provenance |  |
-| array_flow.rb:1694:16:1694:20 | * ... [element 1] | array_flow.rb:1694:5:1694:21 | call to [] [element 1] | provenance |  |
-| array_flow.rb:1694:17:1694:20 | args [element 1] | array_flow.rb:1694:16:1694:20 | * ... [element 1] | provenance |  |
+| array_flow.rb:1686:18:1686:18 | a : Array [element 2] | array_flow.rb:1686:11:1686:11 | z | provenance |  |
+| array_flow.rb:1686:18:1686:18 | a : Array [element 3] | array_flow.rb:1686:14:1686:14 | w | provenance |  |
+| array_flow.rb:1693:10:1693:14 | *args : Array [element 1] | array_flow.rb:1694:17:1694:20 | args : Array [element 1] | provenance |  |
+| array_flow.rb:1694:16:1694:20 | * ... : Array [element 1] | array_flow.rb:1694:5:1694:21 | call to [] : Array [element 1] | provenance |  |
+| array_flow.rb:1694:17:1694:20 | args : Array [element 1] | array_flow.rb:1694:16:1694:20 | * ... : Array [element 1] | provenance |  |
 | array_flow.rb:1697:13:1697:13 | y | array_flow.rb:1699:10:1699:10 | y | provenance |  |
-| array_flow.rb:1704:5:1704:5 | a [element 1] | array_flow.rb:1705:11:1705:11 | a [element 1] | provenance |  |
-| array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | array_flow.rb:1704:5:1704:5 | a [element 1] | provenance |  |
-| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args [element 1] | provenance |  |
-| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | provenance |  |
-| array_flow.rb:1705:10:1705:11 | * ... [element 1] | array_flow.rb:1697:13:1697:13 | y | provenance |  |
-| array_flow.rb:1705:11:1705:11 | a [element 1] | array_flow.rb:1705:10:1705:11 | * ... [element 1] | provenance |  |
+| array_flow.rb:1704:5:1704:5 | a : Array [element 1] | array_flow.rb:1705:11:1705:11 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1704:9:1704:31 | call to m141 : Array [element 1] | array_flow.rb:1704:5:1704:5 | a : Array [element 1] | provenance |  |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args : Array [element 1] | provenance |  |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1704:9:1704:31 | call to m141 : Array [element 1] | provenance |  |
+| array_flow.rb:1705:10:1705:11 | * ... : Array [element 1] | array_flow.rb:1697:13:1697:13 | y | provenance |  |
+| array_flow.rb:1705:11:1705:11 | a : Array [element 1] | array_flow.rb:1705:10:1705:11 | * ... : Array [element 1] | provenance |  |
 nodes
-| array_flow.rb:2:5:2:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:2:9:2:20 | * ... [element 0] | semmle.label | * ... [element 0] |
+| array_flow.rb:2:5:2:5 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
+| array_flow.rb:2:9:2:20 | * ... : [collection] [element 0] | semmle.label | * ... : [collection] [element 0] |
 | array_flow.rb:2:10:2:20 | call to source | semmle.label | call to source |
-| array_flow.rb:3:10:3:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:3:10:3:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
 | array_flow.rb:3:10:3:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:5:10:5:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:5:10:5:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
 | array_flow.rb:5:10:5:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:9:5:9:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:9:9:9:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:9:5:9:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:9:9:9:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:9:13:9:21 | call to source | semmle.label | call to source |
-| array_flow.rb:11:10:11:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:11:10:11:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:11:10:11:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:13:10:13:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:13:10:13:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:13:10:13:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:17:5:17:5 | a [element] | semmle.label | a [element] |
-| array_flow.rb:17:9:17:33 | call to new [element] | semmle.label | call to new [element] |
+| array_flow.rb:17:5:17:5 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:17:9:17:33 | call to new : [collection] [element] | semmle.label | call to new : [collection] [element] |
 | array_flow.rb:17:22:17:32 | call to source | semmle.label | call to source |
-| array_flow.rb:18:10:18:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:18:10:18:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:18:10:18:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:19:10:19:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:19:10:19:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:19:10:19:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:21:5:21:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:21:9:21:20 | call to new [element] | semmle.label | call to new [element] |
-| array_flow.rb:21:19:21:19 | a [element] | semmle.label | a [element] |
-| array_flow.rb:22:10:22:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:21:5:21:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:21:9:21:20 | call to new : [collection] [element] | semmle.label | call to new : [collection] [element] |
+| array_flow.rb:21:19:21:19 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:22:10:22:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:22:10:22:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:23:10:23:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:23:10:23:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:23:10:23:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:25:5:25:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:25:9:27:7 | call to new [element] | semmle.label | call to new [element] |
+| array_flow.rb:25:5:25:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:25:9:27:7 | call to new : [collection] [element] | semmle.label | call to new : [collection] [element] |
 | array_flow.rb:26:9:26:19 | call to source | semmle.label | call to source |
-| array_flow.rb:28:10:28:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:28:10:28:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:28:10:28:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:29:10:29:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:29:10:29:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:29:10:29:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:33:5:33:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:33:9:33:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:33:5:33:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:33:9:33:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:33:10:33:18 | call to source | semmle.label | call to source |
-| array_flow.rb:34:5:34:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:34:9:34:28 | call to try_convert [element 0] | semmle.label | call to try_convert [element 0] |
-| array_flow.rb:34:27:34:27 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:35:10:35:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:34:5:34:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:34:9:34:28 | call to try_convert : Array [element 0] | semmle.label | call to try_convert : Array [element 0] |
+| array_flow.rb:34:27:34:27 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:35:10:35:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
 | array_flow.rb:35:10:35:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:40:5:40:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:40:9:40:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:40:5:40:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:40:9:40:24 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:40:10:40:20 | call to source | semmle.label | call to source |
-| array_flow.rb:41:5:41:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:41:9:41:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:41:5:41:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:41:9:41:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:41:16:41:26 | call to source | semmle.label | call to source |
-| array_flow.rb:42:5:42:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:42:9:42:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:42:9:42:13 | ... & ... [element] | semmle.label | ... & ... [element] |
-| array_flow.rb:42:13:42:13 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:43:10:43:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:42:5:42:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:42:9:42:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:42:9:42:13 | ... & ... : [collection] [element] | semmle.label | ... & ... : [collection] [element] |
+| array_flow.rb:42:13:42:13 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:43:10:43:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:43:10:43:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:44:10:44:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:44:10:44:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:44:10:44:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:48:5:48:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:48:9:48:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:48:5:48:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:48:9:48:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:48:10:48:18 | call to source | semmle.label | call to source |
-| array_flow.rb:49:5:49:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:49:9:49:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:49:9:49:13 | ... * ... [element] | semmle.label | ... * ... [element] |
-| array_flow.rb:50:10:50:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:49:5:49:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:49:9:49:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:49:9:49:13 | ... * ... : [collection] [element] | semmle.label | ... * ... : [collection] [element] |
+| array_flow.rb:50:10:50:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:50:10:50:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:51:10:51:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:51:10:51:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:51:10:51:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:55:5:55:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:55:9:55:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:55:5:55:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:55:9:55:24 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:55:10:55:20 | call to source | semmle.label | call to source |
-| array_flow.rb:56:5:56:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:56:9:56:24 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:56:5:56:5 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:56:9:56:24 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:56:13:56:23 | call to source | semmle.label | call to source |
-| array_flow.rb:57:5:57:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:57:5:57:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:57:9:57:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:57:9:57:13 | ... + ... [element 0] | semmle.label | ... + ... [element 0] |
-| array_flow.rb:57:9:57:13 | ... + ... [element] | semmle.label | ... + ... [element] |
-| array_flow.rb:57:13:57:13 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:58:10:58:10 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:58:10:58:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:57:5:57:5 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:57:5:57:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:57:9:57:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:57:9:57:13 | ... + ... : Array [element 0] | semmle.label | ... + ... : Array [element 0] |
+| array_flow.rb:57:9:57:13 | ... + ... : [collection] [element] | semmle.label | ... + ... : [collection] [element] |
+| array_flow.rb:57:13:57:13 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:58:10:58:10 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:58:10:58:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:58:10:58:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:59:10:59:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:59:10:59:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:59:10:59:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:63:5:63:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:63:9:63:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:63:5:63:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:63:9:63:24 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:63:10:63:20 | call to source | semmle.label | call to source |
-| array_flow.rb:65:5:65:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:65:9:65:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:65:9:65:13 | ... - ... [element] | semmle.label | ... - ... [element] |
-| array_flow.rb:66:10:66:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:65:5:65:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:65:9:65:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:65:9:65:13 | ... - ... : [collection] [element] | semmle.label | ... - ... : [collection] [element] |
+| array_flow.rb:66:10:66:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:66:10:66:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:67:10:67:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:67:10:67:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:67:10:67:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:71:5:71:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:71:9:71:24 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:71:5:71:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:71:9:71:24 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:71:10:71:20 | call to source | semmle.label | call to source |
-| array_flow.rb:72:5:72:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:72:5:72:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:72:9:72:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:72:9:72:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:72:9:72:24 | ... << ... [element 0] | semmle.label | ... << ... [element 0] |
-| array_flow.rb:72:9:72:24 | ... << ... [element] | semmle.label | ... << ... [element] |
+| array_flow.rb:72:5:72:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:72:5:72:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:72:9:72:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:72:9:72:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:72:9:72:24 | ... << ... : Array [element 0] | semmle.label | ... << ... : Array [element 0] |
+| array_flow.rb:72:9:72:24 | ... << ... : [collection] [element] | semmle.label | ... << ... : [collection] [element] |
 | array_flow.rb:72:14:72:24 | call to source | semmle.label | call to source |
-| array_flow.rb:73:10:73:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:73:10:73:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:73:10:73:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:73:10:73:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:73:10:73:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:74:10:74:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:74:10:74:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:74:10:74:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:75:10:75:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:75:10:75:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:75:10:75:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:75:10:75:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:75:10:75:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:76:10:76:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:76:10:76:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:76:10:76:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:80:5:80:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:80:9:80:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:80:5:80:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:80:9:80:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:80:13:80:21 | call to source | semmle.label | call to source |
 | array_flow.rb:81:8:81:8 | c | semmle.label | c |
-| array_flow.rb:81:15:81:15 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:81:15:81:15 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:83:10:83:10 | c | semmle.label | c |
-| array_flow.rb:88:5:88:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:88:9:88:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:88:5:88:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:88:9:88:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:88:13:88:22 | call to source | semmle.label | call to source |
-| array_flow.rb:89:5:89:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:89:9:89:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:89:9:89:15 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
-| array_flow.rb:91:10:91:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:89:5:89:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:89:9:89:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:89:9:89:15 | ...[...] : [collection] [element 1] | semmle.label | ...[...] : [collection] [element 1] |
+| array_flow.rb:91:10:91:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:91:10:91:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:92:10:92:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:92:10:92:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:92:10:92:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:96:5:96:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:96:9:96:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:96:5:96:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:96:9:96:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:96:13:96:22 | call to source | semmle.label | call to source |
-| array_flow.rb:97:5:97:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:97:9:97:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:97:9:97:15 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
-| array_flow.rb:99:10:99:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:97:5:97:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:97:9:97:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:97:9:97:15 | ...[...] : [collection] [element 1] | semmle.label | ...[...] : [collection] [element 1] |
+| array_flow.rb:99:10:99:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:99:10:99:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:101:10:101:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:101:10:101:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:101:10:101:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:103:5:103:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:103:9:103:39 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:103:5:103:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:103:9:103:39 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:103:13:103:24 | call to source | semmle.label | call to source |
-| array_flow.rb:104:5:104:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:104:9:104:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:104:9:104:16 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
-| array_flow.rb:106:10:106:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:104:5:104:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:104:9:104:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:104:9:104:16 | ...[...] : [collection] [element 1] | semmle.label | ...[...] : [collection] [element 1] |
+| array_flow.rb:106:10:106:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:106:10:106:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:109:5:109:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:109:5:109:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:109:9:109:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| array_flow.rb:109:9:109:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:109:5:109:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:109:5:109:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:109:9:109:42 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| array_flow.rb:109:9:109:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:109:13:109:24 | call to source | semmle.label | call to source |
 | array_flow.rb:109:30:109:41 | call to source | semmle.label | call to source |
-| array_flow.rb:110:5:110:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:110:9:110:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:110:9:110:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:110:9:110:18 | ...[...] [element] | semmle.label | ...[...] [element] |
-| array_flow.rb:111:10:111:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:110:5:110:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:110:9:110:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:110:9:110:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:110:9:110:18 | ...[...] : [collection] [element] | semmle.label | ...[...] : [collection] [element] |
+| array_flow.rb:111:10:111:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:111:10:111:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:112:10:112:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:112:10:112:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:112:10:112:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:114:5:114:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:114:9:114:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:114:9:114:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:114:9:114:19 | ...[...] [element] | semmle.label | ...[...] [element] |
-| array_flow.rb:115:10:115:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:114:5:114:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:114:9:114:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:114:9:114:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:114:9:114:19 | ...[...] : [collection] [element] | semmle.label | ...[...] : [collection] [element] |
+| array_flow.rb:115:10:115:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:115:10:115:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:116:10:116:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:116:10:116:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:116:10:116:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:121:5:121:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:121:5:121:5 | [post] a : [collection] [element] : [collection] | semmle.label | [post] a : [collection] [element] : [collection] |
 | array_flow.rb:121:15:121:24 | call to source | semmle.label | call to source |
-| array_flow.rb:122:10:122:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:122:10:122:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:122:10:122:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:123:10:123:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:123:10:123:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:123:10:123:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:124:10:124:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:124:10:124:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:124:10:124:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:129:5:129:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:129:15:129:32 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:129:5:129:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:129:15:129:32 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:129:19:129:28 | call to source | semmle.label | call to source |
-| array_flow.rb:130:10:130:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:130:10:130:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:130:10:130:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:131:10:131:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:131:10:131:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:131:10:131:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:132:10:132:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:132:10:132:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:132:10:132:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:137:5:137:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:137:5:137:5 | [post] a : [collection] [element] : [collection] | semmle.label | [post] a : [collection] [element] : [collection] |
 | array_flow.rb:137:15:137:24 | call to source | semmle.label | call to source |
-| array_flow.rb:138:10:138:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:138:10:138:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:138:10:138:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:139:10:139:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:139:10:139:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:139:10:139:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:140:10:140:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:140:10:140:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:140:10:140:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:145:5:145:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:145:15:145:32 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:145:5:145:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:145:15:145:32 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:145:19:145:28 | call to source | semmle.label | call to source |
-| array_flow.rb:146:10:146:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:146:10:146:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:146:10:146:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:147:10:147:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:147:10:147:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:147:10:147:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:148:10:148:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:148:10:148:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:148:10:148:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:152:5:152:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:152:9:152:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:152:5:152:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:152:9:152:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:152:16:152:25 | call to source | semmle.label | call to source |
-| array_flow.rb:153:5:153:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:153:5:153:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:153:16:153:16 | x | semmle.label | x |
 | array_flow.rb:154:14:154:14 | x | semmle.label | x |
-| array_flow.rb:159:5:159:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:159:9:159:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:159:5:159:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:159:9:159:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:159:16:159:25 | call to source | semmle.label | call to source |
-| array_flow.rb:160:5:160:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:160:5:160:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:160:16:160:16 | x | semmle.label | x |
 | array_flow.rb:161:14:161:14 | x | semmle.label | x |
-| array_flow.rb:166:5:166:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:166:9:166:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:166:5:166:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:166:9:166:25 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:166:10:166:21 | call to source | semmle.label | call to source |
-| array_flow.rb:167:5:167:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:167:5:167:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:167:9:167:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:167:9:167:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:167:9:167:44 | call to append [element 0] | semmle.label | call to append [element 0] |
-| array_flow.rb:167:9:167:44 | call to append [element] | semmle.label | call to append [element] |
+| array_flow.rb:167:5:167:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:167:5:167:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:167:9:167:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:167:9:167:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:167:9:167:44 | call to append : Array [element 0] | semmle.label | call to append : Array [element 0] |
+| array_flow.rb:167:9:167:44 | call to append : [collection] [element] | semmle.label | call to append : [collection] [element] |
 | array_flow.rb:167:18:167:29 | call to source | semmle.label | call to source |
 | array_flow.rb:167:32:167:43 | call to source | semmle.label | call to source |
-| array_flow.rb:168:10:168:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:168:10:168:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:168:10:168:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:168:10:168:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:168:10:168:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:169:10:169:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:169:10:169:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:169:10:169:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:170:10:170:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:170:10:170:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:170:10:170:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:170:10:170:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:170:10:170:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:171:10:171:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:171:10:171:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:171:10:171:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:177:5:177:5 | c [element 1] | semmle.label | c [element 1] |
-| array_flow.rb:177:9:177:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:177:5:177:5 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| array_flow.rb:177:9:177:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:177:15:177:24 | call to source | semmle.label | call to source |
-| array_flow.rb:178:5:178:5 | d [element 2, element 1] | semmle.label | d [element 2, element 1] |
-| array_flow.rb:178:9:178:17 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
-| array_flow.rb:178:16:178:16 | c [element 1] | semmle.label | c [element 1] |
+| array_flow.rb:178:5:178:5 | d : Array [element 2, element 1] | semmle.label | d : Array [element 2, element 1] |
+| array_flow.rb:178:9:178:17 | call to [] : Array [element 2, element 1] | semmle.label | call to [] : Array [element 2, element 1] |
+| array_flow.rb:178:16:178:16 | c : Array [element 1] | semmle.label | c : Array [element 1] |
 | array_flow.rb:179:10:179:26 | ( ... ) | semmle.label | ( ... ) |
-| array_flow.rb:179:11:179:11 | d [element 2, element 1] | semmle.label | d [element 2, element 1] |
+| array_flow.rb:179:11:179:11 | d : Array [element 2, element 1] | semmle.label | d : Array [element 2, element 1] |
 | array_flow.rb:179:11:179:22 | call to assoc [element 1] | semmle.label | call to assoc [element 1] |
 | array_flow.rb:179:11:179:25 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:180:10:180:26 | ( ... ) | semmle.label | ( ... ) |
-| array_flow.rb:180:11:180:11 | d [element 2, element 1] | semmle.label | d [element 2, element 1] |
+| array_flow.rb:180:11:180:11 | d : Array [element 2, element 1] | semmle.label | d : Array [element 2, element 1] |
 | array_flow.rb:180:11:180:22 | call to assoc [element 1] | semmle.label | call to assoc [element 1] |
 | array_flow.rb:180:11:180:25 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:184:5:184:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:184:9:184:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:184:5:184:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:184:9:184:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:184:13:184:22 | call to source | semmle.label | call to source |
-| array_flow.rb:186:10:186:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:186:10:186:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:186:10:186:16 | call to at | semmle.label | call to at |
-| array_flow.rb:188:10:188:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:188:10:188:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:188:10:188:16 | call to at | semmle.label | call to at |
-| array_flow.rb:192:5:192:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:192:9:192:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:192:5:192:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:192:9:192:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:192:16:192:25 | call to source | semmle.label | call to source |
 | array_flow.rb:193:5:193:5 | b | semmle.label | b |
-| array_flow.rb:193:9:193:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:193:9:193:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:193:9:195:7 | call to bsearch | semmle.label | call to bsearch |
 | array_flow.rb:193:23:193:23 | x | semmle.label | x |
 | array_flow.rb:194:14:194:14 | x | semmle.label | x |
 | array_flow.rb:196:10:196:10 | b | semmle.label | b |
-| array_flow.rb:200:5:200:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:200:9:200:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:200:5:200:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:200:9:200:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:200:16:200:25 | call to source | semmle.label | call to source |
-| array_flow.rb:201:9:201:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:201:9:201:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:201:29:201:29 | x | semmle.label | x |
 | array_flow.rb:202:14:202:14 | x | semmle.label | x |
-| array_flow.rb:208:5:208:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:208:9:208:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:208:5:208:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:208:9:208:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:208:16:208:25 | call to source | semmle.label | call to source |
-| array_flow.rb:209:5:209:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:209:5:209:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:209:17:209:17 | x | semmle.label | x |
 | array_flow.rb:210:14:210:14 | x | semmle.label | x |
-| array_flow.rb:215:5:215:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:215:5:215:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:215:9:215:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:215:9:215:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:215:5:215:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:215:5:215:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:215:9:215:42 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:215:9:215:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:215:16:215:27 | call to source | semmle.label | call to source |
 | array_flow.rb:215:30:215:41 | call to source | semmle.label | call to source |
-| array_flow.rb:216:9:216:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:216:9:216:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:216:9:216:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:216:9:216:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:216:27:216:27 | x | semmle.label | x |
 | array_flow.rb:216:30:216:30 | y | semmle.label | y |
 | array_flow.rb:217:14:217:14 | x | semmle.label | x |
 | array_flow.rb:218:14:218:14 | y | semmle.label | y |
-| array_flow.rb:231:5:231:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:231:9:231:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:231:5:231:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:231:9:231:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:231:16:231:27 | call to source | semmle.label | call to source |
-| array_flow.rb:232:5:232:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:232:9:232:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:232:9:235:7 | call to collect [element] | semmle.label | call to collect [element] |
+| array_flow.rb:232:5:232:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:232:9:232:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:232:9:235:7 | call to collect : [collection] [element] | semmle.label | call to collect : [collection] [element] |
 | array_flow.rb:232:23:232:23 | x | semmle.label | x |
 | array_flow.rb:233:14:233:14 | x | semmle.label | x |
 | array_flow.rb:234:9:234:19 | call to source | semmle.label | call to source |
-| array_flow.rb:236:10:236:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:236:10:236:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:236:10:236:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:240:5:240:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:240:9:240:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:240:5:240:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:240:9:240:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:240:16:240:27 | call to source | semmle.label | call to source |
-| array_flow.rb:241:5:241:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:241:9:241:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:241:9:241:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:241:9:244:7 | call to collect! [element] | semmle.label | call to collect! [element] |
+| array_flow.rb:241:5:241:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:241:9:241:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:241:9:241:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:241:9:244:7 | call to collect! : [collection] [element] | semmle.label | call to collect! : [collection] [element] |
 | array_flow.rb:241:24:241:24 | x | semmle.label | x |
 | array_flow.rb:242:14:242:14 | x | semmle.label | x |
 | array_flow.rb:243:9:243:19 | call to source | semmle.label | call to source |
-| array_flow.rb:245:10:245:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:245:10:245:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:245:10:245:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:246:10:246:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:246:10:246:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:246:10:246:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:250:5:250:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:250:9:250:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:250:5:250:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:250:9:250:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:250:16:250:27 | call to source | semmle.label | call to source |
-| array_flow.rb:251:5:251:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:251:9:251:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:251:9:254:7 | call to collect_concat [element] | semmle.label | call to collect_concat [element] |
+| array_flow.rb:251:5:251:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:251:9:251:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:251:9:254:7 | call to collect_concat : [collection] [element] | semmle.label | call to collect_concat : [collection] [element] |
 | array_flow.rb:251:30:251:30 | x | semmle.label | x |
 | array_flow.rb:252:14:252:14 | x | semmle.label | x |
-| array_flow.rb:253:9:253:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:253:9:253:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:253:9:253:25 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:253:9:253:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:253:10:253:10 | x | semmle.label | x |
 | array_flow.rb:253:13:253:24 | call to source | semmle.label | call to source |
-| array_flow.rb:255:10:255:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:255:10:255:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:255:10:255:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:256:5:256:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:256:9:256:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:256:9:259:7 | call to collect_concat [element] | semmle.label | call to collect_concat [element] |
+| array_flow.rb:256:5:256:5 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| array_flow.rb:256:9:256:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:256:9:259:7 | call to collect_concat : [collection] [element] : [collection] | semmle.label | call to collect_concat : [collection] [element] : [collection] |
 | array_flow.rb:256:30:256:30 | x | semmle.label | x |
 | array_flow.rb:257:14:257:14 | x | semmle.label | x |
 | array_flow.rb:258:9:258:20 | call to source | semmle.label | call to source |
-| array_flow.rb:260:10:260:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:260:10:260:10 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
 | array_flow.rb:260:10:260:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:264:5:264:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:264:9:264:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:264:5:264:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:264:9:264:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:264:16:264:25 | call to source | semmle.label | call to source |
-| array_flow.rb:265:5:265:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:265:9:265:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:265:9:267:7 | call to combination [element 2] | semmle.label | call to combination [element 2] |
-| array_flow.rb:265:30:265:30 | x [element] | semmle.label | x [element] |
-| array_flow.rb:266:14:266:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:265:5:265:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:265:9:265:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:265:9:267:7 | call to combination : Array [element 2] | semmle.label | call to combination : Array [element 2] |
+| array_flow.rb:265:30:265:30 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:266:14:266:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:266:14:266:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:269:10:269:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:269:10:269:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:269:10:269:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:273:5:273:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:273:9:273:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:273:5:273:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:273:9:273:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:273:16:273:25 | call to source | semmle.label | call to source |
-| array_flow.rb:274:5:274:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:274:9:274:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:274:9:274:17 | call to compact [element] | semmle.label | call to compact [element] |
-| array_flow.rb:275:10:275:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:274:5:274:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:274:9:274:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:274:9:274:17 | call to compact : [collection] [element] | semmle.label | call to compact : [collection] [element] |
+| array_flow.rb:275:10:275:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:275:10:275:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:279:5:279:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:279:9:279:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:279:5:279:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:279:9:279:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:279:16:279:25 | call to source | semmle.label | call to source |
-| array_flow.rb:280:5:280:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:280:9:280:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:280:9:280:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:280:9:280:18 | call to compact! [element] | semmle.label | call to compact! [element] |
-| array_flow.rb:281:10:281:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:280:5:280:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:280:9:280:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:280:9:280:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:280:9:280:18 | call to compact! : [collection] [element] | semmle.label | call to compact! : [collection] [element] |
+| array_flow.rb:281:10:281:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:281:10:281:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:282:10:282:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:282:10:282:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:282:10:282:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:286:5:286:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:286:9:286:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:286:5:286:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:286:9:286:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:286:16:286:27 | call to source | semmle.label | call to source |
-| array_flow.rb:287:5:287:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:287:9:287:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:287:5:287:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:287:9:287:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:287:16:287:27 | call to source | semmle.label | call to source |
-| array_flow.rb:288:5:288:5 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:288:14:288:14 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:289:10:289:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:288:5:288:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:288:14:288:14 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:289:10:289:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:289:10:289:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:290:10:290:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:290:10:290:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:290:10:290:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:290:10:290:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:290:10:290:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:294:5:294:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:294:9:294:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:294:5:294:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:294:9:294:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:294:16:294:25 | call to source | semmle.label | call to source |
-| array_flow.rb:295:5:295:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:295:5:295:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:295:17:295:17 | x | semmle.label | x |
 | array_flow.rb:296:14:296:14 | x | semmle.label | x |
-| array_flow.rb:301:5:301:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:301:9:301:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:301:5:301:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:301:9:301:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:301:16:301:25 | call to source | semmle.label | call to source |
-| array_flow.rb:302:5:302:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:302:5:302:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:302:20:302:20 | x | semmle.label | x |
 | array_flow.rb:303:14:303:14 | x | semmle.label | x |
-| array_flow.rb:308:5:308:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:308:9:308:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:308:5:308:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:308:9:308:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:308:16:308:25 | call to source | semmle.label | call to source |
-| array_flow.rb:309:5:309:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:309:9:309:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:309:9:309:21 | call to deconstruct [element 2] | semmle.label | call to deconstruct [element 2] |
-| array_flow.rb:312:10:312:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:309:5:309:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:309:9:309:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:309:9:309:21 | call to deconstruct : Array [element 2] | semmle.label | call to deconstruct : Array [element 2] |
+| array_flow.rb:312:10:312:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:312:10:312:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:316:5:316:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:316:9:316:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:316:5:316:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:316:9:316:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:316:16:316:27 | call to source | semmle.label | call to source |
 | array_flow.rb:317:5:317:5 | b | semmle.label | b |
-| array_flow.rb:317:9:317:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:317:9:317:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:317:9:317:36 | call to delete | semmle.label | call to delete |
 | array_flow.rb:317:23:317:34 | call to source | semmle.label | call to source |
 | array_flow.rb:318:10:318:10 | b | semmle.label | b |
-| array_flow.rb:325:5:325:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:325:5:325:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:325:9:325:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:325:9:325:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:325:5:325:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:325:5:325:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:325:9:325:42 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:325:9:325:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:325:16:325:27 | call to source | semmle.label | call to source |
 | array_flow.rb:325:30:325:41 | call to source | semmle.label | call to source |
 | array_flow.rb:326:5:326:5 | b | semmle.label | b |
-| array_flow.rb:326:9:326:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:326:9:326:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:326:9:326:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:326:9:326:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:326:9:326:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:326:9:326:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:326:9:326:22 | call to delete_at | semmle.label | call to delete_at |
 | array_flow.rb:327:10:327:10 | b | semmle.label | b |
-| array_flow.rb:328:10:328:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:328:10:328:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:328:10:328:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:330:5:330:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:330:5:330:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:330:9:330:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:330:9:330:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:330:5:330:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:330:5:330:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:330:9:330:42 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:330:9:330:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:330:16:330:27 | call to source | semmle.label | call to source |
 | array_flow.rb:330:30:330:41 | call to source | semmle.label | call to source |
 | array_flow.rb:331:5:331:5 | b | semmle.label | b |
-| array_flow.rb:331:9:331:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:331:9:331:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:331:9:331:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:331:9:331:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:331:9:331:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:331:9:331:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:331:9:331:22 | call to delete_at | semmle.label | call to delete_at |
 | array_flow.rb:332:10:332:10 | b | semmle.label | b |
-| array_flow.rb:333:10:333:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:333:10:333:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:333:10:333:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:334:10:334:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:334:10:334:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:334:10:334:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:338:5:338:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:338:9:338:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:338:5:338:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:338:9:338:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:338:16:338:25 | call to source | semmle.label | call to source |
-| array_flow.rb:339:5:339:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:339:9:339:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:339:9:339:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:339:9:341:7 | call to delete_if [element] | semmle.label | call to delete_if [element] |
+| array_flow.rb:339:5:339:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:339:9:339:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:339:9:339:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:339:9:341:7 | call to delete_if : [collection] [element] | semmle.label | call to delete_if : [collection] [element] |
 | array_flow.rb:339:25:339:25 | x | semmle.label | x |
 | array_flow.rb:340:14:340:14 | x | semmle.label | x |
-| array_flow.rb:342:10:342:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:342:10:342:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:342:10:342:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:343:10:343:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:343:10:343:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:343:10:343:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:344:10:344:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:344:10:344:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:344:10:344:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:345:10:345:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:345:10:345:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:349:5:349:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:349:9:349:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:349:5:349:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:349:9:349:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:349:16:349:25 | call to source | semmle.label | call to source |
-| array_flow.rb:350:5:350:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:350:9:350:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:350:9:350:25 | call to difference [element] | semmle.label | call to difference [element] |
-| array_flow.rb:351:10:351:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:350:5:350:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:350:9:350:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:350:9:350:25 | call to difference : [collection] [element] | semmle.label | call to difference : [collection] [element] |
+| array_flow.rb:351:10:351:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:351:10:351:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:355:5:355:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:355:5:355:5 | a [element 3, element 1] | semmle.label | a [element 3, element 1] |
-| array_flow.rb:355:9:355:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:355:9:355:47 | call to [] [element 3, element 1] | semmle.label | call to [] [element 3, element 1] |
+| array_flow.rb:355:5:355:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:355:5:355:5 | a : Array [element 3, element 1] | semmle.label | a : Array [element 3, element 1] |
+| array_flow.rb:355:9:355:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:355:9:355:47 | call to [] : Array [element 3, element 1] | semmle.label | call to [] : Array [element 3, element 1] |
 | array_flow.rb:355:16:355:27 | call to source | semmle.label | call to source |
-| array_flow.rb:355:30:355:46 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:355:30:355:46 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:355:34:355:45 | call to source | semmle.label | call to source |
-| array_flow.rb:357:10:357:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:357:10:357:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:357:10:357:17 | call to dig | semmle.label | call to dig |
-| array_flow.rb:358:10:358:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:358:10:358:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:358:10:358:17 | call to dig | semmle.label | call to dig |
-| array_flow.rb:360:10:360:10 | a [element 3, element 1] | semmle.label | a [element 3, element 1] |
+| array_flow.rb:360:10:360:10 | a : Array [element 3, element 1] | semmle.label | a : Array [element 3, element 1] |
 | array_flow.rb:360:10:360:19 | call to dig | semmle.label | call to dig |
-| array_flow.rb:364:5:364:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:364:9:364:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:364:5:364:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:364:9:364:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:364:16:364:27 | call to source | semmle.label | call to source |
 | array_flow.rb:365:5:365:5 | b | semmle.label | b |
-| array_flow.rb:365:9:365:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:365:9:365:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:365:9:367:7 | call to detect | semmle.label | call to detect |
 | array_flow.rb:365:23:365:34 | call to source | semmle.label | call to source |
 | array_flow.rb:365:43:365:43 | x | semmle.label | x |
 | array_flow.rb:366:14:366:14 | x | semmle.label | x |
 | array_flow.rb:368:10:368:10 | b | semmle.label | b |
-| array_flow.rb:372:5:372:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:372:5:372:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:372:9:372:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:372:9:372:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:372:5:372:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:372:5:372:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:372:9:372:42 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:372:9:372:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:372:16:372:27 | call to source | semmle.label | call to source |
 | array_flow.rb:372:30:372:41 | call to source | semmle.label | call to source |
-| array_flow.rb:373:5:373:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:373:9:373:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:373:9:373:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:373:9:373:17 | call to drop [element] | semmle.label | call to drop [element] |
-| array_flow.rb:374:10:374:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:373:5:373:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:373:9:373:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:373:9:373:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:373:9:373:17 | call to drop : [collection] [element] | semmle.label | call to drop : [collection] [element] |
+| array_flow.rb:374:10:374:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:374:10:374:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:375:5:375:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:375:5:375:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:375:9:375:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:375:9:375:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:375:9:375:17 | call to drop [element 1] | semmle.label | call to drop [element 1] |
-| array_flow.rb:375:9:375:17 | call to drop [element 2] | semmle.label | call to drop [element 2] |
-| array_flow.rb:377:10:377:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:375:5:375:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:375:5:375:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:375:9:375:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:375:9:375:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:375:9:375:17 | call to drop : [collection] [element 1] | semmle.label | call to drop : [collection] [element 1] |
+| array_flow.rb:375:9:375:17 | call to drop : [collection] [element 2] | semmle.label | call to drop : [collection] [element 2] |
+| array_flow.rb:377:10:377:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:377:10:377:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:378:10:378:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:378:10:378:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:378:10:378:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:378:10:378:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:378:10:378:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:379:5:379:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:379:5:379:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:379:12:379:23 | call to source | semmle.label | call to source |
-| array_flow.rb:380:5:380:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:380:5:380:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:380:9:380:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:380:9:380:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:380:9:380:17 | call to drop [element 1] | semmle.label | call to drop [element 1] |
-| array_flow.rb:380:9:380:17 | call to drop [element] | semmle.label | call to drop [element] |
-| array_flow.rb:381:10:381:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:381:10:381:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:380:5:380:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:380:5:380:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:380:9:380:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:380:9:380:9 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:380:9:380:17 | call to drop : [collection] [element 1] | semmle.label | call to drop : [collection] [element 1] |
+| array_flow.rb:380:9:380:17 | call to drop : [collection] [element] | semmle.label | call to drop : [collection] [element] |
+| array_flow.rb:381:10:381:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:381:10:381:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:381:10:381:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:382:5:382:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:382:9:382:9 | b [element] | semmle.label | b [element] |
-| array_flow.rb:382:9:382:19 | call to drop [element] | semmle.label | call to drop [element] |
-| array_flow.rb:383:10:383:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:382:5:382:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:382:9:382:9 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:382:9:382:19 | call to drop : [collection] [element] | semmle.label | call to drop : [collection] [element] |
+| array_flow.rb:383:10:383:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:383:10:383:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:387:5:387:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:387:5:387:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:387:9:387:42 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:387:9:387:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:387:5:387:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:387:5:387:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:387:9:387:42 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:387:9:387:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:387:16:387:27 | call to source | semmle.label | call to source |
 | array_flow.rb:387:30:387:41 | call to source | semmle.label | call to source |
-| array_flow.rb:388:5:388:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:388:9:388:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:388:9:388:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:388:9:390:7 | call to drop_while [element] | semmle.label | call to drop_while [element] |
+| array_flow.rb:388:5:388:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:388:9:388:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:388:9:388:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:388:9:390:7 | call to drop_while : [collection] [element] | semmle.label | call to drop_while : [collection] [element] |
 | array_flow.rb:388:26:388:26 | x | semmle.label | x |
 | array_flow.rb:389:14:389:14 | x | semmle.label | x |
-| array_flow.rb:391:10:391:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:391:10:391:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:391:10:391:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:395:5:395:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:395:9:395:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:395:5:395:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:395:9:395:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:395:16:395:25 | call to source | semmle.label | call to source |
-| array_flow.rb:396:5:396:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:396:9:396:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:396:9:398:7 | call to each [element 2] | semmle.label | call to each [element 2] |
+| array_flow.rb:396:5:396:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:396:9:396:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:396:9:398:7 | call to each : Array [element 2] | semmle.label | call to each : Array [element 2] |
 | array_flow.rb:396:20:396:20 | x | semmle.label | x |
 | array_flow.rb:397:14:397:14 | x | semmle.label | x |
-| array_flow.rb:399:10:399:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:399:10:399:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:399:10:399:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:403:5:403:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:403:9:403:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:403:5:403:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:403:9:403:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:403:16:403:25 | call to source | semmle.label | call to source |
-| array_flow.rb:404:5:404:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:404:18:404:18 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:404:5:404:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:404:18:404:18 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:405:14:405:14 | x | semmle.label | x |
 | array_flow.rb:407:10:407:10 | x | semmle.label | x |
-| array_flow.rb:408:10:408:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:408:10:408:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:408:10:408:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:412:5:412:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:412:9:412:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:412:5:412:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:412:9:412:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:412:16:412:25 | call to source | semmle.label | call to source |
-| array_flow.rb:413:5:413:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:413:24:413:24 | x [element] | semmle.label | x [element] |
+| array_flow.rb:413:5:413:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:413:24:413:24 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:414:14:414:19 | ( ... ) | semmle.label | ( ... ) |
-| array_flow.rb:414:15:414:15 | x [element] | semmle.label | x [element] |
+| array_flow.rb:414:15:414:15 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:414:15:414:18 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:419:5:419:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:419:9:419:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:419:5:419:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:419:9:419:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:419:16:419:25 | call to source | semmle.label | call to source |
-| array_flow.rb:420:5:420:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:420:9:420:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:420:9:422:7 | call to each_entry [element 2] | semmle.label | call to each_entry [element 2] |
+| array_flow.rb:420:5:420:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:420:9:420:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:420:9:422:7 | call to each_entry : Array [element 2] | semmle.label | call to each_entry : Array [element 2] |
 | array_flow.rb:420:26:420:26 | x | semmle.label | x |
 | array_flow.rb:421:14:421:14 | x | semmle.label | x |
-| array_flow.rb:423:10:423:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:423:10:423:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:423:10:423:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:427:5:427:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:427:9:427:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:427:5:427:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:427:9:427:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:427:16:427:25 | call to source | semmle.label | call to source |
-| array_flow.rb:428:5:428:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:428:9:428:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:428:9:430:7 | call to each_index [element 2] | semmle.label | call to each_index [element 2] |
-| array_flow.rb:431:10:431:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:428:5:428:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:428:9:428:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:428:9:430:7 | call to each_index : Array [element 2] | semmle.label | call to each_index : Array [element 2] |
+| array_flow.rb:431:10:431:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:431:10:431:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:435:5:435:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:435:9:435:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:435:5:435:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:435:9:435:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:435:19:435:28 | call to source | semmle.label | call to source |
-| array_flow.rb:436:5:436:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:436:25:436:25 | x [element] | semmle.label | x [element] |
-| array_flow.rb:437:14:437:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:436:5:436:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:436:25:436:25 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:437:14:437:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:437:14:437:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:442:5:442:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:442:9:442:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:442:5:442:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:442:9:442:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:442:19:442:28 | call to source | semmle.label | call to source |
-| array_flow.rb:443:5:443:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:443:9:443:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:443:9:446:7 | call to each_with_index [element 3] | semmle.label | call to each_with_index [element 3] |
+| array_flow.rb:443:5:443:5 | b : Array [element 3] | semmle.label | b : Array [element 3] |
+| array_flow.rb:443:9:443:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:443:9:446:7 | call to each_with_index : Array [element 3] | semmle.label | call to each_with_index : Array [element 3] |
 | array_flow.rb:443:31:443:31 | x | semmle.label | x |
 | array_flow.rb:444:14:444:14 | x | semmle.label | x |
-| array_flow.rb:447:10:447:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:447:10:447:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:447:10:447:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:451:5:451:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:451:9:451:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:451:5:451:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:451:9:451:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:451:19:451:30 | call to source | semmle.label | call to source |
 | array_flow.rb:452:5:452:5 | b | semmle.label | b |
-| array_flow.rb:452:9:452:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:452:9:452:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:452:9:455:7 | call to each_with_object | semmle.label | call to each_with_object |
 | array_flow.rb:452:28:452:39 | call to source | semmle.label | call to source |
 | array_flow.rb:452:46:452:46 | x | semmle.label | x |
@@ -2981,34 +2981,34 @@ nodes
 | array_flow.rb:453:14:453:14 | x | semmle.label | x |
 | array_flow.rb:454:14:454:14 | a | semmle.label | a |
 | array_flow.rb:456:10:456:10 | b | semmle.label | b |
-| array_flow.rb:460:5:460:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:460:9:460:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:460:5:460:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:460:9:460:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:460:19:460:28 | call to source | semmle.label | call to source |
-| array_flow.rb:461:5:461:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:461:9:461:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:461:9:461:17 | call to entries [element 3] | semmle.label | call to entries [element 3] |
-| array_flow.rb:462:10:462:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:461:5:461:5 | b : Array [element 3] | semmle.label | b : Array [element 3] |
+| array_flow.rb:461:9:461:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:461:9:461:17 | call to entries : Array [element 3] | semmle.label | call to entries : Array [element 3] |
+| array_flow.rb:462:10:462:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:462:10:462:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:466:5:466:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:466:5:466:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:466:9:466:45 | call to [] [element 3] | semmle.label | call to [] [element 3] |
-| array_flow.rb:466:9:466:45 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:466:5:466:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:466:5:466:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:466:9:466:45 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
+| array_flow.rb:466:9:466:45 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:466:19:466:30 | call to source | semmle.label | call to source |
 | array_flow.rb:466:33:466:44 | call to source | semmle.label | call to source |
 | array_flow.rb:467:5:467:5 | b | semmle.label | b |
-| array_flow.rb:467:9:467:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:467:9:467:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:467:9:467:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:467:9:467:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:467:9:469:7 | call to fetch | semmle.label | call to fetch |
 | array_flow.rb:467:17:467:28 | call to source | semmle.label | call to source |
 | array_flow.rb:467:35:467:35 | x | semmle.label | x |
 | array_flow.rb:468:14:468:14 | x | semmle.label | x |
 | array_flow.rb:470:10:470:10 | b | semmle.label | b |
 | array_flow.rb:471:5:471:5 | b | semmle.label | b |
-| array_flow.rb:471:9:471:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:471:9:471:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:471:9:471:18 | call to fetch | semmle.label | call to fetch |
 | array_flow.rb:472:10:472:10 | b | semmle.label | b |
 | array_flow.rb:473:5:473:5 | b | semmle.label | b |
-| array_flow.rb:473:9:473:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:473:9:473:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:473:9:473:32 | call to fetch | semmle.label | call to fetch |
 | array_flow.rb:473:20:473:31 | call to source | semmle.label | call to source |
 | array_flow.rb:474:10:474:10 | b | semmle.label | b |
@@ -3017,241 +3017,241 @@ nodes
 | array_flow.rb:475:22:475:33 | call to source | semmle.label | call to source |
 | array_flow.rb:476:10:476:10 | b | semmle.label | b |
 | array_flow.rb:477:5:477:5 | b | semmle.label | b |
-| array_flow.rb:477:9:477:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:477:9:477:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:477:9:477:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:477:9:477:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:477:9:477:32 | call to fetch | semmle.label | call to fetch |
 | array_flow.rb:477:20:477:31 | call to source | semmle.label | call to source |
 | array_flow.rb:478:10:478:10 | b | semmle.label | b |
-| array_flow.rb:482:5:482:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:482:9:482:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:482:5:482:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:482:9:482:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:482:19:482:30 | call to source | semmle.label | call to source |
-| array_flow.rb:483:5:483:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:483:5:483:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:483:12:483:23 | call to source | semmle.label | call to source |
-| array_flow.rb:484:10:484:10 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:484:10:484:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:484:10:484:10 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:484:10:484:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:484:10:484:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:485:5:485:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:485:5:485:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:485:12:485:23 | call to source | semmle.label | call to source |
-| array_flow.rb:486:10:486:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:486:10:486:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:486:10:486:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:487:5:487:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:487:5:487:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:488:9:488:20 | call to source | semmle.label | call to source |
-| array_flow.rb:490:10:490:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:490:10:490:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:490:10:490:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:491:5:491:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:491:5:491:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:492:9:492:20 | call to source | semmle.label | call to source |
-| array_flow.rb:494:10:494:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:494:10:494:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:494:10:494:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:498:5:498:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:498:9:498:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:498:5:498:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:498:9:498:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:498:19:498:28 | call to source | semmle.label | call to source |
-| array_flow.rb:499:5:499:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:499:9:499:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:499:9:501:7 | call to filter [element] | semmle.label | call to filter [element] |
+| array_flow.rb:499:5:499:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:499:9:499:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:499:9:501:7 | call to filter : [collection] [element] | semmle.label | call to filter : [collection] [element] |
 | array_flow.rb:499:22:499:22 | x | semmle.label | x |
 | array_flow.rb:500:14:500:14 | x | semmle.label | x |
-| array_flow.rb:502:10:502:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:502:10:502:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:502:10:502:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:506:5:506:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:506:9:506:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:506:5:506:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:506:9:506:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:506:19:506:28 | call to source | semmle.label | call to source |
-| array_flow.rb:507:5:507:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:507:9:507:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:507:9:510:7 | call to filter_map [element] | semmle.label | call to filter_map [element] |
+| array_flow.rb:507:5:507:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:507:9:507:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:507:9:510:7 | call to filter_map : [collection] [element] | semmle.label | call to filter_map : [collection] [element] |
 | array_flow.rb:507:26:507:26 | x | semmle.label | x |
 | array_flow.rb:508:14:508:14 | x | semmle.label | x |
 | array_flow.rb:509:9:509:9 | x | semmle.label | x |
-| array_flow.rb:511:10:511:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:511:10:511:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:511:10:511:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:518:5:518:5 | d [element] | semmle.label | d [element] |
-| array_flow.rb:518:9:520:7 | call to filter_map [element] | semmle.label | call to filter_map [element] |
+| array_flow.rb:518:5:518:5 | d : [collection] [element] | semmle.label | d : [collection] [element] |
+| array_flow.rb:518:9:520:7 | call to filter_map : [collection] [element] | semmle.label | call to filter_map : [collection] [element] |
 | array_flow.rb:519:9:519:20 | call to source | semmle.label | call to source |
-| array_flow.rb:521:10:521:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:521:10:521:10 | d : [collection] [element] | semmle.label | d : [collection] [element] |
 | array_flow.rb:521:10:521:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:525:5:525:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:525:9:525:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:525:5:525:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:525:9:525:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:525:19:525:28 | call to source | semmle.label | call to source |
-| array_flow.rb:526:5:526:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:526:9:526:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:526:9:526:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:526:9:529:7 | call to filter! [element] | semmle.label | call to filter! [element] |
+| array_flow.rb:526:5:526:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:526:9:526:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:526:9:526:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:526:9:529:7 | call to filter! : [collection] [element] | semmle.label | call to filter! : [collection] [element] |
 | array_flow.rb:526:23:526:23 | x | semmle.label | x |
 | array_flow.rb:527:14:527:14 | x | semmle.label | x |
-| array_flow.rb:530:10:530:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:530:10:530:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:530:10:530:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:531:10:531:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:531:10:531:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:531:10:531:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:535:5:535:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:535:9:535:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:535:5:535:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:535:9:535:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:535:19:535:30 | call to source | semmle.label | call to source |
 | array_flow.rb:536:5:536:5 | b | semmle.label | b |
-| array_flow.rb:536:9:536:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:536:9:536:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:536:9:538:7 | call to find | semmle.label | call to find |
 | array_flow.rb:536:21:536:32 | call to source | semmle.label | call to source |
 | array_flow.rb:536:41:536:41 | x | semmle.label | x |
 | array_flow.rb:537:14:537:14 | x | semmle.label | x |
 | array_flow.rb:539:10:539:10 | b | semmle.label | b |
-| array_flow.rb:543:5:543:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:543:9:543:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:543:5:543:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:543:9:543:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:543:19:543:28 | call to source | semmle.label | call to source |
-| array_flow.rb:544:5:544:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:544:9:544:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:544:9:546:7 | call to find_all [element] | semmle.label | call to find_all [element] |
+| array_flow.rb:544:5:544:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:544:9:544:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:544:9:546:7 | call to find_all : [collection] [element] | semmle.label | call to find_all : [collection] [element] |
 | array_flow.rb:544:24:544:24 | x | semmle.label | x |
 | array_flow.rb:545:14:545:14 | x | semmle.label | x |
-| array_flow.rb:547:10:547:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:547:10:547:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:547:10:547:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:551:5:551:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:551:9:551:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:551:5:551:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:551:9:551:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:551:19:551:28 | call to source | semmle.label | call to source |
-| array_flow.rb:552:5:552:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:552:5:552:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:552:22:552:22 | x | semmle.label | x |
 | array_flow.rb:553:14:553:14 | x | semmle.label | x |
-| array_flow.rb:558:5:558:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:558:5:558:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:558:9:558:42 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:558:9:558:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:558:5:558:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:558:5:558:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:558:9:558:42 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:558:9:558:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:558:10:558:21 | call to source | semmle.label | call to source |
 | array_flow.rb:558:30:558:41 | call to source | semmle.label | call to source |
-| array_flow.rb:559:5:559:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:559:5:559:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:559:12:559:23 | call to source | semmle.label | call to source |
-| array_flow.rb:560:10:560:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:560:10:560:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:560:10:560:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:560:10:560:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:560:10:560:16 | call to first | semmle.label | call to first |
-| array_flow.rb:561:5:561:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:561:5:561:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:561:9:561:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:561:9:561:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:561:9:561:18 | call to first [element 0] | semmle.label | call to first [element 0] |
-| array_flow.rb:561:9:561:18 | call to first [element] | semmle.label | call to first [element] |
-| array_flow.rb:562:10:562:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:562:10:562:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:561:5:561:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:561:5:561:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:561:9:561:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:561:9:561:9 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:561:9:561:18 | call to first : Array [element 0] | semmle.label | call to first : Array [element 0] |
+| array_flow.rb:561:9:561:18 | call to first : [collection] [element] | semmle.label | call to first : [collection] [element] |
+| array_flow.rb:562:10:562:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:562:10:562:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:562:10:562:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:563:10:563:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:563:10:563:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:563:10:563:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:564:5:564:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:564:5:564:5 | c [element 3] | semmle.label | c [element 3] |
-| array_flow.rb:564:5:564:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:564:9:564:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:564:9:564:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:564:9:564:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:564:9:564:18 | call to first [element 0] | semmle.label | call to first [element 0] |
-| array_flow.rb:564:9:564:18 | call to first [element 3] | semmle.label | call to first [element 3] |
-| array_flow.rb:564:9:564:18 | call to first [element] | semmle.label | call to first [element] |
-| array_flow.rb:565:10:565:10 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:565:10:565:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:564:5:564:5 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:564:5:564:5 | c : Array [element 3] | semmle.label | c : Array [element 3] |
+| array_flow.rb:564:5:564:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:564:9:564:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:564:9:564:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:564:9:564:9 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:564:9:564:18 | call to first : Array [element 0] | semmle.label | call to first : Array [element 0] |
+| array_flow.rb:564:9:564:18 | call to first : Array [element 3] | semmle.label | call to first : Array [element 3] |
+| array_flow.rb:564:9:564:18 | call to first : [collection] [element] | semmle.label | call to first : [collection] [element] |
+| array_flow.rb:565:10:565:10 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:565:10:565:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:565:10:565:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:566:10:566:10 | c [element 3] | semmle.label | c [element 3] |
-| array_flow.rb:566:10:566:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:566:10:566:10 | c : Array [element 3] | semmle.label | c : Array [element 3] |
+| array_flow.rb:566:10:566:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:566:10:566:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:570:5:570:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:570:9:570:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:570:5:570:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:570:9:570:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:570:16:570:27 | call to source | semmle.label | call to source |
-| array_flow.rb:571:5:571:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:571:9:571:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:571:9:574:7 | call to flat_map [element] | semmle.label | call to flat_map [element] |
+| array_flow.rb:571:5:571:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:571:9:571:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:571:9:574:7 | call to flat_map : [collection] [element] | semmle.label | call to flat_map : [collection] [element] |
 | array_flow.rb:571:24:571:24 | x | semmle.label | x |
 | array_flow.rb:572:14:572:14 | x | semmle.label | x |
-| array_flow.rb:573:9:573:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:573:9:573:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:573:9:573:25 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:573:9:573:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:573:10:573:10 | x | semmle.label | x |
 | array_flow.rb:573:13:573:24 | call to source | semmle.label | call to source |
-| array_flow.rb:575:10:575:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:575:10:575:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:575:10:575:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:576:5:576:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:576:9:576:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:576:9:579:7 | call to flat_map [element] | semmle.label | call to flat_map [element] |
+| array_flow.rb:576:5:576:5 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| array_flow.rb:576:9:576:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:576:9:579:7 | call to flat_map : [collection] [element] : [collection] | semmle.label | call to flat_map : [collection] [element] : [collection] |
 | array_flow.rb:576:24:576:24 | x | semmle.label | x |
 | array_flow.rb:577:14:577:14 | x | semmle.label | x |
 | array_flow.rb:578:9:578:20 | call to source | semmle.label | call to source |
-| array_flow.rb:580:10:580:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:580:10:580:10 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
 | array_flow.rb:580:10:580:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:584:5:584:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:584:9:584:31 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
-| array_flow.rb:584:16:584:30 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:584:5:584:5 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:584:9:584:31 | call to [] : Array [element 2, element 1] | semmle.label | call to [] : Array [element 2, element 1] |
+| array_flow.rb:584:16:584:30 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:584:20:584:29 | call to source | semmle.label | call to source |
-| array_flow.rb:585:5:585:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:585:9:585:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:585:9:585:17 | call to flatten [element] | semmle.label | call to flatten [element] |
-| array_flow.rb:586:10:586:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:585:5:585:5 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| array_flow.rb:585:9:585:9 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:585:9:585:17 | call to flatten : [collection] [element] : [collection] | semmle.label | call to flatten : [collection] [element] : [collection] |
+| array_flow.rb:586:10:586:10 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
 | array_flow.rb:586:10:586:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:590:5:590:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:590:9:590:31 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
-| array_flow.rb:590:16:590:30 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:590:5:590:5 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:590:9:590:31 | call to [] : Array [element 2, element 1] | semmle.label | call to [] : Array [element 2, element 1] |
+| array_flow.rb:590:16:590:30 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:590:20:590:29 | call to source | semmle.label | call to source |
-| array_flow.rb:591:10:591:10 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
+| array_flow.rb:591:10:591:10 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
 | array_flow.rb:591:10:591:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:591:10:591:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:592:5:592:5 | b [element, element 1] | semmle.label | b [element, element 1] |
-| array_flow.rb:592:5:592:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:592:9:592:9 | [post] a [element, element 1] | semmle.label | [post] a [element, element 1] |
-| array_flow.rb:592:9:592:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:592:9:592:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:592:9:592:18 | call to flatten! [element, element 1] | semmle.label | call to flatten! [element, element 1] |
-| array_flow.rb:592:9:592:18 | call to flatten! [element] | semmle.label | call to flatten! [element] |
-| array_flow.rb:593:10:593:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:592:5:592:5 | b : [collection] [element, element 1] | semmle.label | b : [collection] [element, element 1] |
+| array_flow.rb:592:5:592:5 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| array_flow.rb:592:9:592:9 | [post] a : [collection] [element, element 1] | semmle.label | [post] a : [collection] [element, element 1] |
+| array_flow.rb:592:9:592:9 | [post] a : [collection] [element] : [collection] | semmle.label | [post] a : [collection] [element] : [collection] |
+| array_flow.rb:592:9:592:9 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element, element 1] | semmle.label | call to flatten! : [collection] [element, element 1] |
+| array_flow.rb:592:9:592:18 | call to flatten! : [collection] [element] : [collection] | semmle.label | call to flatten! : [collection] [element] : [collection] |
+| array_flow.rb:593:10:593:10 | a : [collection] [element] : [collection] | semmle.label | a : [collection] [element] : [collection] |
 | array_flow.rb:593:10:593:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:594:10:594:10 | a [element, element 1] | semmle.label | a [element, element 1] |
+| array_flow.rb:594:10:594:10 | a : [collection] [element, element 1] | semmle.label | a : [collection] [element, element 1] |
 | array_flow.rb:594:10:594:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:594:10:594:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:595:10:595:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:595:10:595:10 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
 | array_flow.rb:595:10:595:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:596:10:596:10 | b [element, element 1] | semmle.label | b [element, element 1] |
+| array_flow.rb:596:10:596:10 | b : [collection] [element, element 1] | semmle.label | b : [collection] [element, element 1] |
 | array_flow.rb:596:10:596:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:596:10:596:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:600:5:600:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:600:9:600:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:600:5:600:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:600:9:600:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:600:19:600:30 | call to source | semmle.label | call to source |
-| array_flow.rb:601:5:601:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:601:9:601:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:601:9:601:20 | call to grep [element] | semmle.label | call to grep [element] |
-| array_flow.rb:602:10:602:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:601:5:601:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:601:9:601:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:601:9:601:20 | call to grep : [collection] [element] | semmle.label | call to grep : [collection] [element] |
+| array_flow.rb:602:10:602:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:602:10:602:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:603:5:603:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:603:9:603:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:603:9:606:7 | call to grep [element] | semmle.label | call to grep [element] |
+| array_flow.rb:603:5:603:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:603:9:603:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:603:9:606:7 | call to grep : [collection] [element] | semmle.label | call to grep : [collection] [element] |
 | array_flow.rb:603:26:603:26 | x | semmle.label | x |
 | array_flow.rb:604:14:604:14 | x | semmle.label | x |
 | array_flow.rb:605:9:605:20 | call to source | semmle.label | call to source |
-| array_flow.rb:607:10:607:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:607:10:607:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:607:10:607:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:611:5:611:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:611:9:611:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:611:5:611:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:611:9:611:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:611:19:611:30 | call to source | semmle.label | call to source |
-| array_flow.rb:612:5:612:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:612:9:612:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:612:9:612:21 | call to grep_v [element] | semmle.label | call to grep_v [element] |
-| array_flow.rb:613:10:613:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:612:5:612:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:612:9:612:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:612:9:612:21 | call to grep_v : [collection] [element] | semmle.label | call to grep_v : [collection] [element] |
+| array_flow.rb:613:10:613:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:613:10:613:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:614:5:614:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:614:9:614:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:614:9:617:7 | call to grep_v [element] | semmle.label | call to grep_v [element] |
+| array_flow.rb:614:5:614:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:614:9:614:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:614:9:617:7 | call to grep_v : [collection] [element] | semmle.label | call to grep_v : [collection] [element] |
 | array_flow.rb:614:27:614:27 | x | semmle.label | x |
 | array_flow.rb:615:14:615:14 | x | semmle.label | x |
 | array_flow.rb:616:9:616:20 | call to source | semmle.label | call to source |
-| array_flow.rb:618:10:618:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:618:10:618:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:618:10:618:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:622:5:622:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:622:9:622:31 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:622:5:622:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:622:9:622:31 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:622:19:622:30 | call to source | semmle.label | call to source |
-| array_flow.rb:623:9:623:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:623:9:623:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:623:24:623:24 | x | semmle.label | x |
 | array_flow.rb:624:14:624:14 | x | semmle.label | x |
-| array_flow.rb:631:5:631:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:631:9:631:29 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:631:5:631:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:631:9:631:29 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:631:19:631:28 | call to source | semmle.label | call to source |
-| array_flow.rb:632:5:632:5 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:632:5:632:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:632:17:632:17 | x | semmle.label | x |
 | array_flow.rb:633:14:633:14 | x | semmle.label | x |
-| array_flow.rb:638:5:638:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:638:5:638:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:638:9:638:39 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:638:9:638:39 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:638:5:638:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:638:5:638:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:638:9:638:39 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:638:9:638:39 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:638:10:638:21 | call to source | semmle.label | call to source |
 | array_flow.rb:638:27:638:38 | call to source | semmle.label | call to source |
 | array_flow.rb:639:5:639:5 | b | semmle.label | b |
-| array_flow.rb:639:9:639:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:639:9:639:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:639:9:639:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:639:9:639:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:639:9:643:7 | call to inject | semmle.label | call to inject |
 | array_flow.rb:639:22:639:22 | x | semmle.label | x |
 | array_flow.rb:639:25:639:25 | y | semmle.label | y |
@@ -3260,1622 +3260,1622 @@ nodes
 | array_flow.rb:642:9:642:19 | call to source | semmle.label | call to source |
 | array_flow.rb:644:10:644:10 | b | semmle.label | b |
 | array_flow.rb:645:5:645:5 | c | semmle.label | c |
-| array_flow.rb:645:9:645:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:645:9:645:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:645:9:645:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:645:9:645:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:645:9:649:7 | call to inject | semmle.label | call to inject |
 | array_flow.rb:645:28:645:28 | y | semmle.label | y |
 | array_flow.rb:647:14:647:14 | y | semmle.label | y |
 | array_flow.rb:648:9:648:19 | call to source | semmle.label | call to source |
 | array_flow.rb:650:10:650:10 | c | semmle.label | c |
-| array_flow.rb:655:5:655:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:655:9:655:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:655:5:655:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:655:9:655:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:655:16:655:27 | call to source | semmle.label | call to source |
-| array_flow.rb:656:5:656:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:656:5:656:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:656:5:656:5 | b [element 4] | semmle.label | b [element 4] |
-| array_flow.rb:656:9:656:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:656:9:656:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:656:9:656:9 | [post] a [element 4] | semmle.label | [post] a [element 4] |
-| array_flow.rb:656:9:656:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:656:9:656:47 | call to insert [element 1] | semmle.label | call to insert [element 1] |
-| array_flow.rb:656:9:656:47 | call to insert [element 2] | semmle.label | call to insert [element 2] |
-| array_flow.rb:656:9:656:47 | call to insert [element 4] | semmle.label | call to insert [element 4] |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:656:5:656:5 | b : [collection] [element 4] | semmle.label | b : [collection] [element 4] |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 1] | semmle.label | [post] a : [collection] [element 1] |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:656:9:656:9 | [post] a : [collection] [element 4] | semmle.label | [post] a : [collection] [element 4] |
+| array_flow.rb:656:9:656:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 1] | semmle.label | call to insert : [collection] [element 1] |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 2] | semmle.label | call to insert : [collection] [element 2] |
+| array_flow.rb:656:9:656:47 | call to insert : [collection] [element 4] | semmle.label | call to insert : [collection] [element 4] |
 | array_flow.rb:656:21:656:32 | call to source | semmle.label | call to source |
 | array_flow.rb:656:35:656:46 | call to source | semmle.label | call to source |
-| array_flow.rb:658:10:658:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:658:10:658:10 | a : [collection] [element 1] | semmle.label | a : [collection] [element 1] |
 | array_flow.rb:658:10:658:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:659:10:659:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:659:10:659:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:659:10:659:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:661:10:661:10 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:661:10:661:10 | a : [collection] [element 4] | semmle.label | a : [collection] [element 4] |
 | array_flow.rb:661:10:661:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:663:10:663:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:663:10:663:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:663:10:663:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:664:10:664:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:664:10:664:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:664:10:664:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:666:10:666:10 | b [element 4] | semmle.label | b [element 4] |
+| array_flow.rb:666:10:666:10 | b : [collection] [element 4] | semmle.label | b : [collection] [element 4] |
 | array_flow.rb:666:10:666:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:669:5:669:5 | c [element 2] | semmle.label | c [element 2] |
-| array_flow.rb:669:9:669:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:669:5:669:5 | c : Array [element 2] | semmle.label | c : Array [element 2] |
+| array_flow.rb:669:9:669:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:669:16:669:27 | call to source | semmle.label | call to source |
-| array_flow.rb:670:5:670:5 | d [element] | semmle.label | d [element] |
-| array_flow.rb:670:9:670:9 | [post] c [element] | semmle.label | [post] c [element] |
-| array_flow.rb:670:9:670:9 | c [element 2] | semmle.label | c [element 2] |
-| array_flow.rb:670:9:670:47 | call to insert [element] | semmle.label | call to insert [element] |
+| array_flow.rb:670:5:670:5 | d : [collection] [element] | semmle.label | d : [collection] [element] |
+| array_flow.rb:670:9:670:9 | [post] c : [collection] [element] | semmle.label | [post] c : [collection] [element] |
+| array_flow.rb:670:9:670:9 | c : Array [element 2] | semmle.label | c : Array [element 2] |
+| array_flow.rb:670:9:670:47 | call to insert : [collection] [element] | semmle.label | call to insert : [collection] [element] |
 | array_flow.rb:670:21:670:32 | call to source | semmle.label | call to source |
 | array_flow.rb:670:35:670:46 | call to source | semmle.label | call to source |
-| array_flow.rb:671:10:671:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:671:10:671:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:671:10:671:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:672:10:672:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:672:10:672:10 | d : [collection] [element] | semmle.label | d : [collection] [element] |
 | array_flow.rb:672:10:672:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:683:5:683:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:683:9:683:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:683:5:683:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:683:9:683:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:683:16:683:27 | call to source | semmle.label | call to source |
-| array_flow.rb:684:5:684:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:684:9:684:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:684:9:684:60 | call to intersection [element] | semmle.label | call to intersection [element] |
-| array_flow.rb:684:24:684:43 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:684:5:684:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:684:9:684:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:684:9:684:60 | call to intersection : [collection] [element] | semmle.label | call to intersection : [collection] [element] |
+| array_flow.rb:684:24:684:43 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:684:31:684:42 | call to source | semmle.label | call to source |
-| array_flow.rb:684:46:684:59 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:684:46:684:59 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:684:47:684:58 | call to source | semmle.label | call to source |
-| array_flow.rb:685:10:685:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:685:10:685:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:685:10:685:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:689:5:689:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:689:9:689:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:689:5:689:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:689:9:689:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:689:16:689:25 | call to source | semmle.label | call to source |
-| array_flow.rb:690:5:690:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:690:9:690:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:690:9:690:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:690:9:693:7 | call to keep_if [element] | semmle.label | call to keep_if [element] |
+| array_flow.rb:690:5:690:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:690:9:690:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:690:9:690:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:690:9:693:7 | call to keep_if : [collection] [element] | semmle.label | call to keep_if : [collection] [element] |
 | array_flow.rb:690:23:690:23 | x | semmle.label | x |
 | array_flow.rb:691:14:691:14 | x | semmle.label | x |
-| array_flow.rb:694:10:694:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:694:10:694:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:694:10:694:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:695:10:695:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:695:10:695:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:695:10:695:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:699:5:699:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:699:9:699:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:699:5:699:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:699:9:699:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:699:16:699:27 | call to source | semmle.label | call to source |
-| array_flow.rb:700:5:700:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:700:5:700:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:700:12:700:23 | call to source | semmle.label | call to source |
-| array_flow.rb:701:10:701:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:701:10:701:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:701:10:701:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:701:10:701:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:701:10:701:15 | call to last | semmle.label | call to last |
-| array_flow.rb:702:5:702:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:702:9:702:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:702:9:702:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:702:9:702:17 | call to last [element] | semmle.label | call to last [element] |
-| array_flow.rb:703:10:703:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:702:5:702:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:702:9:702:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:702:9:702:9 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:702:9:702:17 | call to last : [collection] [element] | semmle.label | call to last : [collection] [element] |
+| array_flow.rb:703:10:703:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:703:10:703:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:704:10:704:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:704:10:704:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:704:10:704:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:708:5:708:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:708:9:708:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:708:5:708:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:708:9:708:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:708:16:708:27 | call to source | semmle.label | call to source |
-| array_flow.rb:709:5:709:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:709:9:709:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:709:9:712:7 | call to map [element] | semmle.label | call to map [element] |
+| array_flow.rb:709:5:709:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:709:9:709:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:709:9:712:7 | call to map : [collection] [element] | semmle.label | call to map : [collection] [element] |
 | array_flow.rb:709:19:709:19 | x | semmle.label | x |
 | array_flow.rb:710:14:710:14 | x | semmle.label | x |
 | array_flow.rb:711:9:711:19 | call to source | semmle.label | call to source |
-| array_flow.rb:713:10:713:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:713:10:713:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:713:10:713:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:717:5:717:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:717:9:717:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:717:5:717:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:717:9:717:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:717:16:717:27 | call to source | semmle.label | call to source |
-| array_flow.rb:718:5:718:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:718:9:718:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:718:9:721:7 | call to map! [element] | semmle.label | call to map! [element] |
+| array_flow.rb:718:5:718:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:718:9:718:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:718:9:721:7 | call to map! : [collection] [element] | semmle.label | call to map! : [collection] [element] |
 | array_flow.rb:718:20:718:20 | x | semmle.label | x |
 | array_flow.rb:719:14:719:14 | x | semmle.label | x |
 | array_flow.rb:720:9:720:19 | call to source | semmle.label | call to source |
-| array_flow.rb:722:10:722:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:722:10:722:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:722:10:722:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:726:5:726:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:726:9:726:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:726:5:726:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:726:9:726:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:726:16:726:25 | call to source | semmle.label | call to source |
 | array_flow.rb:729:5:729:5 | b | semmle.label | b |
-| array_flow.rb:729:9:729:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:729:9:729:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:729:9:729:13 | call to max | semmle.label | call to max |
 | array_flow.rb:730:10:730:10 | b | semmle.label | b |
-| array_flow.rb:733:5:733:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:733:9:733:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:733:9:733:16 | call to max [element] | semmle.label | call to max [element] |
-| array_flow.rb:734:10:734:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:733:5:733:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:733:9:733:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:733:9:733:16 | call to max : [collection] [element] | semmle.label | call to max : [collection] [element] |
+| array_flow.rb:734:10:734:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:734:10:734:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:737:5:737:5 | d | semmle.label | d |
-| array_flow.rb:737:9:737:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:737:9:737:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:737:9:741:7 | call to max | semmle.label | call to max |
 | array_flow.rb:737:19:737:19 | x | semmle.label | x |
 | array_flow.rb:737:22:737:22 | y | semmle.label | y |
 | array_flow.rb:738:14:738:14 | x | semmle.label | x |
 | array_flow.rb:739:14:739:14 | y | semmle.label | y |
 | array_flow.rb:742:10:742:10 | d | semmle.label | d |
-| array_flow.rb:745:5:745:5 | e [element] | semmle.label | e [element] |
-| array_flow.rb:745:9:745:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:745:9:749:7 | call to max [element] | semmle.label | call to max [element] |
+| array_flow.rb:745:5:745:5 | e : [collection] [element] | semmle.label | e : [collection] [element] |
+| array_flow.rb:745:9:745:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:745:9:749:7 | call to max : [collection] [element] | semmle.label | call to max : [collection] [element] |
 | array_flow.rb:745:22:745:22 | x | semmle.label | x |
 | array_flow.rb:745:25:745:25 | y | semmle.label | y |
 | array_flow.rb:746:14:746:14 | x | semmle.label | x |
 | array_flow.rb:747:14:747:14 | y | semmle.label | y |
-| array_flow.rb:750:10:750:10 | e [element] | semmle.label | e [element] |
+| array_flow.rb:750:10:750:10 | e : [collection] [element] | semmle.label | e : [collection] [element] |
 | array_flow.rb:750:10:750:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:754:5:754:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:754:9:754:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:754:5:754:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:754:9:754:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:754:16:754:25 | call to source | semmle.label | call to source |
 | array_flow.rb:757:5:757:5 | b | semmle.label | b |
-| array_flow.rb:757:9:757:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:757:9:757:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:757:9:760:7 | call to max_by | semmle.label | call to max_by |
 | array_flow.rb:757:22:757:22 | x | semmle.label | x |
 | array_flow.rb:758:14:758:14 | x | semmle.label | x |
 | array_flow.rb:761:10:761:10 | b | semmle.label | b |
-| array_flow.rb:764:5:764:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:764:9:764:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:764:9:767:7 | call to max_by [element] | semmle.label | call to max_by [element] |
+| array_flow.rb:764:5:764:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:764:9:764:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:764:9:767:7 | call to max_by : [collection] [element] | semmle.label | call to max_by : [collection] [element] |
 | array_flow.rb:764:25:764:25 | x | semmle.label | x |
 | array_flow.rb:765:14:765:14 | x | semmle.label | x |
-| array_flow.rb:768:10:768:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:768:10:768:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:768:10:768:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:772:5:772:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:772:9:772:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:772:5:772:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:772:9:772:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:772:16:772:25 | call to source | semmle.label | call to source |
 | array_flow.rb:775:5:775:5 | b | semmle.label | b |
-| array_flow.rb:775:9:775:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:775:9:775:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:775:9:775:13 | call to min | semmle.label | call to min |
 | array_flow.rb:776:10:776:10 | b | semmle.label | b |
-| array_flow.rb:779:5:779:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:779:9:779:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:779:9:779:16 | call to min [element] | semmle.label | call to min [element] |
-| array_flow.rb:780:10:780:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:779:5:779:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:779:9:779:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:779:9:779:16 | call to min : [collection] [element] | semmle.label | call to min : [collection] [element] |
+| array_flow.rb:780:10:780:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:780:10:780:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:783:5:783:5 | d | semmle.label | d |
-| array_flow.rb:783:9:783:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:783:9:783:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:783:9:787:7 | call to min | semmle.label | call to min |
 | array_flow.rb:783:19:783:19 | x | semmle.label | x |
 | array_flow.rb:783:22:783:22 | y | semmle.label | y |
 | array_flow.rb:784:14:784:14 | x | semmle.label | x |
 | array_flow.rb:785:14:785:14 | y | semmle.label | y |
 | array_flow.rb:788:10:788:10 | d | semmle.label | d |
-| array_flow.rb:791:5:791:5 | e [element] | semmle.label | e [element] |
-| array_flow.rb:791:9:791:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:791:9:795:7 | call to min [element] | semmle.label | call to min [element] |
+| array_flow.rb:791:5:791:5 | e : [collection] [element] | semmle.label | e : [collection] [element] |
+| array_flow.rb:791:9:791:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:791:9:795:7 | call to min : [collection] [element] | semmle.label | call to min : [collection] [element] |
 | array_flow.rb:791:22:791:22 | x | semmle.label | x |
 | array_flow.rb:791:25:791:25 | y | semmle.label | y |
 | array_flow.rb:792:14:792:14 | x | semmle.label | x |
 | array_flow.rb:793:14:793:14 | y | semmle.label | y |
-| array_flow.rb:796:10:796:10 | e [element] | semmle.label | e [element] |
+| array_flow.rb:796:10:796:10 | e : [collection] [element] | semmle.label | e : [collection] [element] |
 | array_flow.rb:796:10:796:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:800:5:800:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:800:9:800:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:800:5:800:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:800:9:800:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:800:16:800:25 | call to source | semmle.label | call to source |
 | array_flow.rb:803:5:803:5 | b | semmle.label | b |
-| array_flow.rb:803:9:803:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:803:9:803:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:803:9:806:7 | call to min_by | semmle.label | call to min_by |
 | array_flow.rb:803:22:803:22 | x | semmle.label | x |
 | array_flow.rb:804:14:804:14 | x | semmle.label | x |
 | array_flow.rb:807:10:807:10 | b | semmle.label | b |
-| array_flow.rb:810:5:810:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:810:9:810:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:810:9:813:7 | call to min_by [element] | semmle.label | call to min_by [element] |
+| array_flow.rb:810:5:810:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:810:9:810:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:810:9:813:7 | call to min_by : [collection] [element] | semmle.label | call to min_by : [collection] [element] |
 | array_flow.rb:810:25:810:25 | x | semmle.label | x |
 | array_flow.rb:811:14:811:14 | x | semmle.label | x |
-| array_flow.rb:814:10:814:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:814:10:814:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:814:10:814:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:818:5:818:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:818:9:818:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:818:5:818:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:818:9:818:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:818:16:818:25 | call to source | semmle.label | call to source |
-| array_flow.rb:820:5:820:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:820:9:820:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:820:9:820:16 | call to minmax [element] | semmle.label | call to minmax [element] |
-| array_flow.rb:821:10:821:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:820:5:820:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:820:9:820:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:820:9:820:16 | call to minmax : [collection] [element] | semmle.label | call to minmax : [collection] [element] |
+| array_flow.rb:821:10:821:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:821:10:821:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:822:10:822:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:822:10:822:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:822:10:822:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:824:5:824:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:824:9:824:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:824:9:828:7 | call to minmax [element] | semmle.label | call to minmax [element] |
+| array_flow.rb:824:5:824:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:824:9:824:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:824:9:828:7 | call to minmax : [collection] [element] | semmle.label | call to minmax : [collection] [element] |
 | array_flow.rb:824:22:824:22 | x | semmle.label | x |
 | array_flow.rb:824:25:824:25 | y | semmle.label | y |
 | array_flow.rb:825:14:825:14 | x | semmle.label | x |
 | array_flow.rb:826:14:826:14 | y | semmle.label | y |
-| array_flow.rb:829:10:829:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:829:10:829:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:829:10:829:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:830:10:830:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:830:10:830:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:830:10:830:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:834:5:834:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:834:9:834:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:834:5:834:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:834:9:834:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:834:16:834:25 | call to source | semmle.label | call to source |
-| array_flow.rb:835:5:835:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:835:9:835:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:835:9:838:7 | call to minmax_by [element] | semmle.label | call to minmax_by [element] |
+| array_flow.rb:835:5:835:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:835:9:835:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:835:9:838:7 | call to minmax_by : [collection] [element] | semmle.label | call to minmax_by : [collection] [element] |
 | array_flow.rb:835:25:835:25 | x | semmle.label | x |
 | array_flow.rb:836:14:836:14 | x | semmle.label | x |
-| array_flow.rb:839:10:839:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:839:10:839:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:839:10:839:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:840:10:840:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:840:10:840:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:840:10:840:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:844:5:844:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:844:9:844:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:844:5:844:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:844:9:844:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:844:16:844:25 | call to source | semmle.label | call to source |
-| array_flow.rb:845:5:845:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:845:5:845:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:845:17:845:17 | x | semmle.label | x |
 | array_flow.rb:846:14:846:14 | x | semmle.label | x |
-| array_flow.rb:853:5:853:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:853:9:853:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:853:5:853:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:853:9:853:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:853:16:853:25 | call to source | semmle.label | call to source |
-| array_flow.rb:854:5:854:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:854:5:854:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:854:16:854:16 | x | semmle.label | x |
 | array_flow.rb:855:14:855:14 | x | semmle.label | x |
-| array_flow.rb:866:5:866:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:866:9:866:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:866:5:866:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:866:9:866:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:866:16:866:25 | call to source | semmle.label | call to source |
-| array_flow.rb:867:5:867:5 | b [element, element] | semmle.label | b [element, element] |
-| array_flow.rb:867:9:867:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:867:9:870:7 | call to partition [element, element] | semmle.label | call to partition [element, element] |
+| array_flow.rb:867:5:867:5 | b : [collection] [element, element] | semmle.label | b : [collection] [element, element] |
+| array_flow.rb:867:9:867:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:867:9:870:7 | call to partition : [collection] [element, element] | semmle.label | call to partition : [collection] [element, element] |
 | array_flow.rb:867:25:867:25 | x | semmle.label | x |
 | array_flow.rb:868:14:868:14 | x | semmle.label | x |
-| array_flow.rb:871:10:871:10 | b [element, element] | semmle.label | b [element, element] |
+| array_flow.rb:871:10:871:10 | b : [collection] [element, element] | semmle.label | b : [collection] [element, element] |
 | array_flow.rb:871:10:871:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:871:10:871:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:872:10:872:10 | b [element, element] | semmle.label | b [element, element] |
+| array_flow.rb:872:10:872:10 | b : [collection] [element, element] | semmle.label | b : [collection] [element, element] |
 | array_flow.rb:872:10:872:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:872:10:872:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:876:5:876:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:876:9:876:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:876:5:876:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:876:9:876:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:876:16:876:25 | call to source | semmle.label | call to source |
-| array_flow.rb:878:5:878:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:878:9:878:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:878:9:882:7 | call to permutation [element 2] | semmle.label | call to permutation [element 2] |
-| array_flow.rb:878:27:878:27 | x [element] | semmle.label | x [element] |
-| array_flow.rb:879:14:879:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:878:5:878:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:878:9:878:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:878:9:882:7 | call to permutation : Array [element 2] | semmle.label | call to permutation : Array [element 2] |
+| array_flow.rb:878:27:878:27 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:879:14:879:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:879:14:879:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:880:14:880:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:880:14:880:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:880:14:880:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:881:14:881:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:881:14:881:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:881:14:881:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:884:10:884:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:884:10:884:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:884:10:884:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:886:5:886:5 | c [element 2] | semmle.label | c [element 2] |
-| array_flow.rb:886:9:886:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:886:9:889:7 | call to permutation [element 2] | semmle.label | call to permutation [element 2] |
-| array_flow.rb:886:30:886:30 | x [element] | semmle.label | x [element] |
-| array_flow.rb:887:14:887:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:886:5:886:5 | c : Array [element 2] | semmle.label | c : Array [element 2] |
+| array_flow.rb:886:9:886:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:886:9:889:7 | call to permutation : Array [element 2] | semmle.label | call to permutation : Array [element 2] |
+| array_flow.rb:886:30:886:30 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:887:14:887:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:887:14:887:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:888:14:888:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:888:14:888:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:888:14:888:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:891:10:891:10 | c [element 2] | semmle.label | c [element 2] |
+| array_flow.rb:891:10:891:10 | c : Array [element 2] | semmle.label | c : Array [element 2] |
 | array_flow.rb:891:10:891:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:893:9:893:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:893:30:893:30 | x [element] | semmle.label | x [element] |
-| array_flow.rb:894:14:894:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:893:9:893:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:893:30:893:30 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:894:14:894:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:894:14:894:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:895:14:895:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:895:14:895:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:895:14:895:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:898:10:898:10 | c [element 2] | semmle.label | c [element 2] |
+| array_flow.rb:898:10:898:10 | c : Array [element 2] | semmle.label | c : Array [element 2] |
 | array_flow.rb:898:10:898:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:905:5:905:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:905:5:905:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:905:9:905:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| array_flow.rb:905:9:905:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:905:5:905:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:905:5:905:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:905:9:905:42 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| array_flow.rb:905:9:905:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:905:13:905:24 | call to source | semmle.label | call to source |
 | array_flow.rb:905:30:905:41 | call to source | semmle.label | call to source |
 | array_flow.rb:906:5:906:5 | b | semmle.label | b |
-| array_flow.rb:906:9:906:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:906:9:906:9 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:906:9:906:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:906:9:906:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:906:9:906:13 | call to pop | semmle.label | call to pop |
 | array_flow.rb:907:10:907:10 | b | semmle.label | b |
-| array_flow.rb:909:10:909:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:909:10:909:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:909:10:909:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:911:10:911:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:911:10:911:10 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:911:10:911:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:913:5:913:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:913:5:913:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:913:9:913:42 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| array_flow.rb:913:9:913:42 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:913:5:913:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:913:5:913:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:913:9:913:42 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| array_flow.rb:913:9:913:42 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:913:13:913:24 | call to source | semmle.label | call to source |
 | array_flow.rb:913:30:913:41 | call to source | semmle.label | call to source |
-| array_flow.rb:914:5:914:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:914:9:914:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:914:9:914:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:914:9:914:16 | call to pop [element] | semmle.label | call to pop [element] |
-| array_flow.rb:915:10:915:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:914:5:914:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:914:9:914:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:914:9:914:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:914:9:914:16 | call to pop : [collection] [element] | semmle.label | call to pop : [collection] [element] |
+| array_flow.rb:915:10:915:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:915:10:915:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:916:10:916:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:916:10:916:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:916:10:916:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:918:10:918:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:918:10:918:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:918:10:918:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:920:10:920:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:920:10:920:10 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:920:10:920:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:924:5:924:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:924:9:924:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:924:5:924:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:924:9:924:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:924:16:924:27 | call to source | semmle.label | call to source |
-| array_flow.rb:925:5:925:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:925:5:925:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
-| array_flow.rb:925:5:925:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:925:5:925:5 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:925:5:925:5 | [post] a : [collection] [element 5] | semmle.label | [post] a : [collection] [element 5] |
+| array_flow.rb:925:5:925:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:925:21:925:32 | call to source | semmle.label | call to source |
-| array_flow.rb:928:10:928:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:928:10:928:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:928:10:928:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:931:10:931:10 | a [element 5] | semmle.label | a [element 5] |
+| array_flow.rb:931:10:931:10 | a : [collection] [element 5] | semmle.label | a : [collection] [element 5] |
 | array_flow.rb:931:10:931:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:935:5:935:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:935:9:935:28 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:935:5:935:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:935:9:935:28 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:935:16:935:27 | call to source | semmle.label | call to source |
-| array_flow.rb:936:5:936:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:936:9:936:28 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:936:5:936:5 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:936:9:936:28 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:936:13:936:24 | call to source | semmle.label | call to source |
-| array_flow.rb:937:5:937:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:937:9:937:28 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:937:5:937:5 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:937:9:937:28 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:937:10:937:21 | call to source | semmle.label | call to source |
-| array_flow.rb:938:5:938:5 | d [element, element] | semmle.label | d [element, element] |
-| array_flow.rb:938:9:938:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:938:9:938:22 | call to product [element, element] | semmle.label | call to product [element, element] |
-| array_flow.rb:938:19:938:19 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:938:22:938:22 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:939:10:939:10 | d [element, element] | semmle.label | d [element, element] |
+| array_flow.rb:938:5:938:5 | d : [collection] [element, element] | semmle.label | d : [collection] [element, element] |
+| array_flow.rb:938:9:938:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:938:9:938:22 | call to product : [collection] [element, element] | semmle.label | call to product : [collection] [element, element] |
+| array_flow.rb:938:19:938:19 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:938:22:938:22 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:939:10:939:10 | d : [collection] [element, element] | semmle.label | d : [collection] [element, element] |
 | array_flow.rb:939:10:939:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:939:10:939:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:940:10:940:10 | d [element, element] | semmle.label | d [element, element] |
+| array_flow.rb:940:10:940:10 | d : [collection] [element, element] | semmle.label | d : [collection] [element, element] |
 | array_flow.rb:940:10:940:13 | ...[...] [element] | semmle.label | ...[...] [element] |
 | array_flow.rb:940:10:940:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:944:5:944:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:944:9:944:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:944:5:944:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:944:9:944:25 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:944:10:944:21 | call to source | semmle.label | call to source |
-| array_flow.rb:945:5:945:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:945:5:945:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:945:9:945:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:945:9:945:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:945:9:945:44 | call to append [element 0] | semmle.label | call to append [element 0] |
-| array_flow.rb:945:9:945:44 | call to append [element] | semmle.label | call to append [element] |
+| array_flow.rb:945:5:945:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:945:5:945:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:945:9:945:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:945:9:945:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:945:9:945:44 | call to append : Array [element 0] | semmle.label | call to append : Array [element 0] |
+| array_flow.rb:945:9:945:44 | call to append : [collection] [element] | semmle.label | call to append : [collection] [element] |
 | array_flow.rb:945:18:945:29 | call to source | semmle.label | call to source |
 | array_flow.rb:945:32:945:43 | call to source | semmle.label | call to source |
-| array_flow.rb:946:10:946:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:946:10:946:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:946:10:946:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:946:10:946:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:946:10:946:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:947:10:947:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:947:10:947:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:947:10:947:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:948:10:948:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:948:10:948:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:948:10:948:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:948:10:948:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:948:10:948:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:949:10:949:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:949:10:949:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:949:10:949:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:955:5:955:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:955:9:955:25 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:955:5:955:5 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:955:9:955:25 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:955:10:955:19 | call to source | semmle.label | call to source |
-| array_flow.rb:956:5:956:5 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
-| array_flow.rb:956:9:956:17 | call to [] [element 2, element 0] | semmle.label | call to [] [element 2, element 0] |
-| array_flow.rb:956:16:956:16 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:957:10:957:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:956:5:956:5 | d : Array [element 2, element 0] | semmle.label | d : Array [element 2, element 0] |
+| array_flow.rb:956:9:956:17 | call to [] : Array [element 2, element 0] | semmle.label | call to [] : Array [element 2, element 0] |
+| array_flow.rb:956:16:956:16 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:957:10:957:10 | d : Array [element 2, element 0] | semmle.label | d : Array [element 2, element 0] |
 | array_flow.rb:957:10:957:22 | call to rassoc [element 0] | semmle.label | call to rassoc [element 0] |
 | array_flow.rb:957:10:957:25 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:958:10:958:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:958:10:958:10 | d : Array [element 2, element 0] | semmle.label | d : Array [element 2, element 0] |
 | array_flow.rb:958:10:958:22 | call to rassoc [element 0] | semmle.label | call to rassoc [element 0] |
 | array_flow.rb:958:10:958:25 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:962:5:962:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:962:5:962:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:962:9:962:39 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:962:9:962:39 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:962:5:962:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:962:5:962:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:962:9:962:39 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:962:9:962:39 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:962:10:962:21 | call to source | semmle.label | call to source |
 | array_flow.rb:962:27:962:38 | call to source | semmle.label | call to source |
-| array_flow.rb:963:9:963:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:963:9:963:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:963:9:963:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:963:9:963:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:963:22:963:22 | x | semmle.label | x |
 | array_flow.rb:963:25:963:25 | y | semmle.label | y |
 | array_flow.rb:964:14:964:14 | x | semmle.label | x |
 | array_flow.rb:965:14:965:14 | y | semmle.label | y |
-| array_flow.rb:968:9:968:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:968:9:968:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:968:9:968:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:968:9:968:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:968:28:968:28 | y | semmle.label | y |
 | array_flow.rb:970:14:970:14 | y | semmle.label | y |
-| array_flow.rb:976:5:976:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:976:9:976:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:976:5:976:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:976:9:976:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:976:16:976:25 | call to source | semmle.label | call to source |
-| array_flow.rb:977:5:977:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:977:9:977:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:977:9:980:7 | call to reject [element] | semmle.label | call to reject [element] |
+| array_flow.rb:977:5:977:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:977:9:977:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:977:9:980:7 | call to reject : [collection] [element] | semmle.label | call to reject : [collection] [element] |
 | array_flow.rb:977:22:977:22 | x | semmle.label | x |
 | array_flow.rb:978:14:978:14 | x | semmle.label | x |
-| array_flow.rb:981:10:981:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:981:10:981:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:981:10:981:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:985:5:985:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:985:9:985:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:985:5:985:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:985:9:985:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:985:16:985:25 | call to source | semmle.label | call to source |
-| array_flow.rb:986:5:986:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:986:9:986:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:986:9:986:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:986:9:989:7 | call to reject! [element] | semmle.label | call to reject! [element] |
+| array_flow.rb:986:5:986:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:986:9:986:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:986:9:986:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:986:9:989:7 | call to reject! : [collection] [element] | semmle.label | call to reject! : [collection] [element] |
 | array_flow.rb:986:23:986:23 | x | semmle.label | x |
 | array_flow.rb:987:14:987:14 | x | semmle.label | x |
-| array_flow.rb:990:10:990:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:990:10:990:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:990:10:990:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:991:10:991:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:991:10:991:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:991:10:991:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:995:5:995:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:995:9:995:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:995:5:995:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:995:9:995:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:995:16:995:25 | call to source | semmle.label | call to source |
-| array_flow.rb:996:5:996:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:996:9:996:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:996:9:999:7 | call to repeated_combination [element 2] | semmle.label | call to repeated_combination [element 2] |
-| array_flow.rb:996:39:996:39 | x [element] | semmle.label | x [element] |
-| array_flow.rb:997:14:997:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:996:5:996:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:996:9:996:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:996:9:999:7 | call to repeated_combination : Array [element 2] | semmle.label | call to repeated_combination : Array [element 2] |
+| array_flow.rb:996:39:996:39 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:997:14:997:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:997:14:997:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:998:14:998:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:998:14:998:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:998:14:998:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1001:10:1001:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1001:10:1001:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1001:10:1001:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1005:5:1005:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1005:9:1005:26 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1005:5:1005:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1005:9:1005:26 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1005:16:1005:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1006:5:1006:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1006:9:1006:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1006:9:1009:7 | call to repeated_permutation [element 2] | semmle.label | call to repeated_permutation [element 2] |
-| array_flow.rb:1006:39:1006:39 | x [element] | semmle.label | x [element] |
-| array_flow.rb:1007:14:1007:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:1006:5:1006:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1006:9:1006:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1006:9:1009:7 | call to repeated_permutation : Array [element 2] | semmle.label | call to repeated_permutation : Array [element 2] |
+| array_flow.rb:1006:39:1006:39 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| array_flow.rb:1007:14:1007:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:1007:14:1007:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1008:14:1008:14 | x [element] | semmle.label | x [element] |
+| array_flow.rb:1008:14:1008:14 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | array_flow.rb:1008:14:1008:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1011:10:1011:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1011:10:1011:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1011:10:1011:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1017:5:1017:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1017:9:1017:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
-| array_flow.rb:1017:9:1017:33 | call to replace [element 0] | semmle.label | call to replace [element 0] |
-| array_flow.rb:1017:19:1017:32 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1017:5:1017:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:1017:9:1017:9 | [post] a : Array [element 0] | semmle.label | [post] a : Array [element 0] |
+| array_flow.rb:1017:9:1017:33 | call to replace : Array [element 0] | semmle.label | call to replace : Array [element 0] |
+| array_flow.rb:1017:19:1017:32 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:1017:20:1017:31 | call to source | semmle.label | call to source |
-| array_flow.rb:1018:10:1018:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:1018:10:1018:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
 | array_flow.rb:1018:10:1018:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1019:10:1019:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1019:10:1019:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
 | array_flow.rb:1019:10:1019:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1023:5:1023:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1023:5:1023:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1023:9:1023:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1023:9:1023:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1023:5:1023:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1023:9:1023:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1023:9:1023:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1023:16:1023:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1023:31:1023:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1024:5:1024:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1024:9:1024:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1024:9:1024:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1024:9:1024:17 | call to reverse [element] | semmle.label | call to reverse [element] |
-| array_flow.rb:1025:10:1025:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1024:5:1024:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1024:9:1024:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1024:9:1024:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1024:9:1024:17 | call to reverse : [collection] [element] | semmle.label | call to reverse : [collection] [element] |
+| array_flow.rb:1025:10:1025:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1025:10:1025:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1026:10:1026:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1026:10:1026:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1026:10:1026:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1027:10:1027:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1027:10:1027:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1027:10:1027:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1029:10:1029:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1029:10:1029:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1029:10:1029:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1030:10:1030:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1030:10:1030:10 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:1030:10:1030:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1034:5:1034:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1034:5:1034:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1034:9:1034:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1034:9:1034:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1034:5:1034:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1034:9:1034:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1034:9:1034:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1034:16:1034:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1034:31:1034:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1035:5:1035:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1035:9:1035:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1035:9:1035:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1035:9:1035:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1035:9:1035:18 | call to reverse! [element] | semmle.label | call to reverse! [element] |
-| array_flow.rb:1036:10:1036:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1035:5:1035:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1035:9:1035:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1035:9:1035:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1035:9:1035:18 | call to reverse! : [collection] [element] | semmle.label | call to reverse! : [collection] [element] |
+| array_flow.rb:1036:10:1036:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1036:10:1036:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1037:10:1037:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1037:10:1037:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1037:10:1037:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1038:10:1038:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1038:10:1038:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1038:10:1038:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1039:10:1039:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1039:10:1039:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1039:10:1039:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1040:10:1040:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1040:10:1040:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1040:10:1040:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1040:10:1040:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1040:10:1040:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1041:10:1041:10 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1041:10:1041:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1041:10:1041:10 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1041:10:1041:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1041:10:1041:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1045:5:1045:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1045:9:1045:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1045:5:1045:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1045:9:1045:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1045:16:1045:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1046:5:1046:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1046:9:1046:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1046:9:1048:7 | call to reverse_each [element 2] | semmle.label | call to reverse_each [element 2] |
+| array_flow.rb:1046:5:1046:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1046:9:1046:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1046:9:1048:7 | call to reverse_each : Array [element 2] | semmle.label | call to reverse_each : Array [element 2] |
 | array_flow.rb:1046:28:1046:28 | x | semmle.label | x |
 | array_flow.rb:1047:14:1047:14 | x | semmle.label | x |
-| array_flow.rb:1049:10:1049:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1049:10:1049:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1049:10:1049:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1053:5:1053:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1053:9:1053:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1053:5:1053:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1053:9:1053:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1053:16:1053:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1054:5:1054:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1054:5:1054:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1054:18:1054:18 | x | semmle.label | x |
 | array_flow.rb:1055:14:1055:14 | x | semmle.label | x |
-| array_flow.rb:1063:5:1063:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1063:5:1063:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1063:5:1063:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1063:9:1063:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1063:5:1063:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1063:9:1063:56 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1063:10:1063:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1063:28:1063:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1063:43:1063:55 | call to source | semmle.label | call to source |
-| array_flow.rb:1065:5:1065:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1065:5:1065:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1065:5:1065:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1065:9:1065:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1065:9:1065:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1065:9:1065:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element 1] | semmle.label | call to rotate [element 1] |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element 2] | semmle.label | call to rotate [element 2] |
-| array_flow.rb:1065:9:1065:16 | call to rotate [element] | semmle.label | call to rotate [element] |
-| array_flow.rb:1066:10:1066:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1065:5:1065:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1065:9:1065:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 1] | semmle.label | call to rotate : [collection] [element 1] |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element 2] | semmle.label | call to rotate : [collection] [element 2] |
+| array_flow.rb:1065:9:1065:16 | call to rotate : [collection] [element] | semmle.label | call to rotate : [collection] [element] |
+| array_flow.rb:1066:10:1066:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1066:10:1066:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1067:10:1067:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1067:10:1067:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1067:10:1067:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1067:10:1067:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1067:10:1067:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1068:10:1068:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1068:10:1068:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1068:10:1068:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1068:10:1068:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1068:10:1068:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1069:10:1069:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1069:10:1069:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1069:10:1069:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1071:5:1071:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1071:5:1071:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1071:5:1071:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1071:9:1071:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1071:9:1071:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1071:9:1071:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element 0] | semmle.label | call to rotate [element 0] |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element 1] | semmle.label | call to rotate [element 1] |
-| array_flow.rb:1071:9:1071:19 | call to rotate [element] | semmle.label | call to rotate [element] |
-| array_flow.rb:1072:10:1072:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1072:10:1072:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1071:5:1071:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1071:9:1071:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 0] | semmle.label | call to rotate : [collection] [element 0] |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element 1] | semmle.label | call to rotate : [collection] [element 1] |
+| array_flow.rb:1071:9:1071:19 | call to rotate : [collection] [element] | semmle.label | call to rotate : [collection] [element] |
+| array_flow.rb:1072:10:1072:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1072:10:1072:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1072:10:1072:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1073:10:1073:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1073:10:1073:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1073:10:1073:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1073:10:1073:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1073:10:1073:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1074:10:1074:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1074:10:1074:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1074:10:1074:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1075:10:1075:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1075:10:1075:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1075:10:1075:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1077:5:1077:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1077:5:1077:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1077:5:1077:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1077:9:1077:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1077:9:1077:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1077:9:1077:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 0] | semmle.label | call to rotate [element 0] |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 2] | semmle.label | call to rotate [element 2] |
-| array_flow.rb:1077:9:1077:19 | call to rotate [element 3] | semmle.label | call to rotate [element 3] |
-| array_flow.rb:1078:10:1078:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1077:5:1077:5 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1077:9:1077:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 0] | semmle.label | call to rotate : [collection] [element 0] |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 2] | semmle.label | call to rotate : [collection] [element 2] |
+| array_flow.rb:1077:9:1077:19 | call to rotate : [collection] [element 3] | semmle.label | call to rotate : [collection] [element 3] |
+| array_flow.rb:1078:10:1078:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1078:10:1078:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1080:10:1080:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1080:10:1080:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1080:10:1080:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1081:10:1081:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1081:10:1081:10 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
 | array_flow.rb:1081:10:1081:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1083:5:1083:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1083:9:1083:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1083:9:1083:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1083:9:1083:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1083:9:1083:19 | call to rotate [element] | semmle.label | call to rotate [element] |
-| array_flow.rb:1084:10:1084:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1083:5:1083:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1083:9:1083:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1083:9:1083:19 | call to rotate : [collection] [element] | semmle.label | call to rotate : [collection] [element] |
+| array_flow.rb:1084:10:1084:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1084:10:1084:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1085:10:1085:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1085:10:1085:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1085:10:1085:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1086:10:1086:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1086:10:1086:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1086:10:1086:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1087:10:1087:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1087:10:1087:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1087:10:1087:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1095:5:1095:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1095:5:1095:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1095:5:1095:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1095:9:1095:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1095:5:1095:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1095:9:1095:56 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1095:10:1095:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1095:28:1095:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1095:43:1095:55 | call to source | semmle.label | call to source |
-| array_flow.rb:1096:5:1096:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1096:5:1096:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1096:5:1096:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1096:9:1096:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:1096:9:1096:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1096:9:1096:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1096:9:1096:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1096:9:1096:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1096:9:1096:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element 1] | semmle.label | call to rotate! [element 1] |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element 2] | semmle.label | call to rotate! [element 2] |
-| array_flow.rb:1096:9:1096:17 | call to rotate! [element] | semmle.label | call to rotate! [element] |
-| array_flow.rb:1097:10:1097:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1096:5:1096:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 1] | semmle.label | [post] a : [collection] [element 1] |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:1096:9:1096:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1096:9:1096:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 1] | semmle.label | call to rotate! : [collection] [element 1] |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element 2] | semmle.label | call to rotate! : [collection] [element 2] |
+| array_flow.rb:1096:9:1096:17 | call to rotate! : [collection] [element] | semmle.label | call to rotate! : [collection] [element] |
+| array_flow.rb:1097:10:1097:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1097:10:1097:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1098:10:1098:10 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1098:10:1098:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1098:10:1098:10 | a : [collection] [element 1] | semmle.label | a : [collection] [element 1] |
+| array_flow.rb:1098:10:1098:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1098:10:1098:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1099:10:1099:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1099:10:1099:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1099:10:1099:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
+| array_flow.rb:1099:10:1099:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1099:10:1099:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1100:10:1100:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1100:10:1100:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1100:10:1100:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1101:10:1101:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1101:10:1101:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1101:10:1101:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1102:10:1102:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1102:10:1102:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1102:10:1102:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1102:10:1102:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1102:10:1102:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1103:10:1103:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1103:10:1103:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1103:10:1103:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1103:10:1103:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1103:10:1103:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1104:10:1104:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1104:10:1104:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1104:10:1104:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1106:5:1106:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1106:5:1106:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1106:5:1106:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1106:9:1106:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1106:5:1106:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1106:9:1106:56 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1106:10:1106:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1106:28:1106:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1106:43:1106:55 | call to source | semmle.label | call to source |
-| array_flow.rb:1107:5:1107:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1107:5:1107:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1107:5:1107:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1107:9:1107:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
-| array_flow.rb:1107:9:1107:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:1107:9:1107:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1107:9:1107:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1107:9:1107:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1107:9:1107:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 0] | semmle.label | call to rotate! [element 0] |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element 1] | semmle.label | call to rotate! [element 1] |
-| array_flow.rb:1107:9:1107:20 | call to rotate! [element] | semmle.label | call to rotate! [element] |
-| array_flow.rb:1108:10:1108:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1108:10:1108:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1107:5:1107:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 0] | semmle.label | [post] a : [collection] [element 0] |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element 1] | semmle.label | [post] a : [collection] [element 1] |
+| array_flow.rb:1107:9:1107:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1107:9:1107:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 0] | semmle.label | call to rotate! : [collection] [element 0] |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element 1] | semmle.label | call to rotate! : [collection] [element 1] |
+| array_flow.rb:1107:9:1107:20 | call to rotate! : [collection] [element] | semmle.label | call to rotate! : [collection] [element] |
+| array_flow.rb:1108:10:1108:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
+| array_flow.rb:1108:10:1108:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1108:10:1108:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1109:10:1109:10 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1109:10:1109:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1109:10:1109:10 | a : [collection] [element 1] | semmle.label | a : [collection] [element 1] |
+| array_flow.rb:1109:10:1109:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1109:10:1109:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1110:10:1110:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1110:10:1110:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1110:10:1110:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1111:10:1111:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1111:10:1111:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1111:10:1111:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1112:10:1112:10 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1112:10:1112:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1112:10:1112:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1112:10:1112:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1112:10:1112:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1113:10:1113:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1113:10:1113:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1113:10:1113:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1113:10:1113:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1113:10:1113:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1114:10:1114:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1114:10:1114:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1114:10:1114:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1115:10:1115:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1115:10:1115:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1115:10:1115:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1117:5:1117:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1117:5:1117:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1117:5:1117:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1117:9:1117:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1117:5:1117:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1117:9:1117:56 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1117:10:1117:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1117:28:1117:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1117:43:1117:55 | call to source | semmle.label | call to source |
-| array_flow.rb:1118:5:1118:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1118:5:1118:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1118:5:1118:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1118:9:1118:9 | [post] a [element 3] | semmle.label | [post] a [element 3] |
-| array_flow.rb:1118:9:1118:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1118:9:1118:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1118:9:1118:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 0] | semmle.label | call to rotate! [element 0] |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 2] | semmle.label | call to rotate! [element 2] |
-| array_flow.rb:1118:9:1118:20 | call to rotate! [element 3] | semmle.label | call to rotate! [element 3] |
-| array_flow.rb:1119:10:1119:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1118:5:1118:5 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 0] | semmle.label | [post] a : [collection] [element 0] |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:1118:9:1118:9 | [post] a : [collection] [element 3] | semmle.label | [post] a : [collection] [element 3] |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1118:9:1118:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 0] | semmle.label | call to rotate! : [collection] [element 0] |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 2] | semmle.label | call to rotate! : [collection] [element 2] |
+| array_flow.rb:1118:9:1118:20 | call to rotate! : [collection] [element 3] | semmle.label | call to rotate! : [collection] [element 3] |
+| array_flow.rb:1119:10:1119:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
 | array_flow.rb:1119:10:1119:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1121:10:1121:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1121:10:1121:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:1121:10:1121:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1122:10:1122:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1122:10:1122:10 | a : [collection] [element 3] | semmle.label | a : [collection] [element 3] |
 | array_flow.rb:1122:10:1122:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1123:10:1123:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1123:10:1123:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1123:10:1123:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1125:10:1125:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1125:10:1125:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1125:10:1125:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1126:10:1126:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1126:10:1126:10 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
 | array_flow.rb:1126:10:1126:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1128:5:1128:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1128:5:1128:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1128:5:1128:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1128:9:1128:56 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1128:5:1128:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1128:9:1128:56 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1128:10:1128:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1128:28:1128:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1128:43:1128:55 | call to source | semmle.label | call to source |
-| array_flow.rb:1129:5:1129:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1129:9:1129:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1129:9:1129:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1129:9:1129:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1129:9:1129:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1129:9:1129:20 | call to rotate! [element] | semmle.label | call to rotate! [element] |
-| array_flow.rb:1130:10:1130:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1129:5:1129:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1129:9:1129:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1129:9:1129:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1129:9:1129:20 | call to rotate! : [collection] [element] | semmle.label | call to rotate! : [collection] [element] |
+| array_flow.rb:1130:10:1130:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1130:10:1130:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1131:10:1131:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1131:10:1131:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1131:10:1131:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1132:10:1132:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1132:10:1132:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1132:10:1132:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1133:10:1133:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1133:10:1133:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1133:10:1133:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1134:10:1134:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1134:10:1134:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1134:10:1134:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1135:10:1135:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1135:10:1135:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1135:10:1135:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1136:10:1136:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1136:10:1136:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1136:10:1136:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1137:10:1137:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1137:10:1137:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1137:10:1137:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1141:5:1141:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1141:9:1141:30 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1141:5:1141:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1141:9:1141:30 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1141:19:1141:29 | call to source | semmle.label | call to source |
-| array_flow.rb:1142:5:1142:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1142:9:1142:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1142:9:1144:7 | call to select [element] | semmle.label | call to select [element] |
+| array_flow.rb:1142:5:1142:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1142:9:1142:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1142:9:1144:7 | call to select : [collection] [element] | semmle.label | call to select : [collection] [element] |
 | array_flow.rb:1142:22:1142:22 | x | semmle.label | x |
 | array_flow.rb:1143:14:1143:14 | x | semmle.label | x |
-| array_flow.rb:1145:10:1145:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1145:10:1145:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1145:10:1145:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1149:5:1149:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1149:9:1149:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1149:5:1149:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1149:9:1149:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1149:16:1149:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1150:5:1150:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1150:9:1150:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1150:9:1150:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1150:9:1153:7 | call to select! [element] | semmle.label | call to select! [element] |
+| array_flow.rb:1150:5:1150:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1150:9:1150:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1150:9:1150:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1150:9:1153:7 | call to select! : [collection] [element] | semmle.label | call to select! : [collection] [element] |
 | array_flow.rb:1150:23:1150:23 | x | semmle.label | x |
 | array_flow.rb:1151:14:1151:14 | x | semmle.label | x |
-| array_flow.rb:1154:10:1154:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1154:10:1154:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1154:10:1154:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1155:10:1155:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1155:10:1155:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1155:10:1155:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1159:5:1159:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1159:5:1159:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1159:9:1159:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1159:9:1159:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1159:5:1159:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1159:5:1159:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1159:9:1159:41 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1159:9:1159:41 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1159:10:1159:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1159:28:1159:40 | call to source | semmle.label | call to source |
 | array_flow.rb:1160:5:1160:5 | b | semmle.label | b |
-| array_flow.rb:1160:9:1160:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:1160:9:1160:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1160:9:1160:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1160:9:1160:9 | [post] a : [collection] [element 1] | semmle.label | [post] a : [collection] [element 1] |
+| array_flow.rb:1160:9:1160:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1160:9:1160:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1160:9:1160:15 | call to shift | semmle.label | call to shift |
 | array_flow.rb:1161:10:1161:10 | b | semmle.label | b |
-| array_flow.rb:1163:10:1163:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1163:10:1163:10 | a : [collection] [element 1] | semmle.label | a : [collection] [element 1] |
 | array_flow.rb:1163:10:1163:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1166:5:1166:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1166:5:1166:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1166:9:1166:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1166:9:1166:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1166:5:1166:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1166:5:1166:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1166:9:1166:41 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1166:9:1166:41 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1166:10:1166:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1166:28:1166:40 | call to source | semmle.label | call to source |
-| array_flow.rb:1167:5:1167:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1167:9:1167:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
-| array_flow.rb:1167:9:1167:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1167:9:1167:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1167:9:1167:18 | call to shift [element 0] | semmle.label | call to shift [element 0] |
-| array_flow.rb:1168:10:1168:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1167:5:1167:5 | b : Array [element 0] | semmle.label | b : Array [element 0] |
+| array_flow.rb:1167:9:1167:9 | [post] a : [collection] [element 0] | semmle.label | [post] a : [collection] [element 0] |
+| array_flow.rb:1167:9:1167:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1167:9:1167:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1167:9:1167:18 | call to shift : Array [element 0] | semmle.label | call to shift : Array [element 0] |
+| array_flow.rb:1168:10:1168:10 | b : Array [element 0] | semmle.label | b : Array [element 0] |
 | array_flow.rb:1168:10:1168:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1170:10:1170:10 | a [element 0] | semmle.label | a [element 0] |
+| array_flow.rb:1170:10:1170:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
 | array_flow.rb:1170:10:1170:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1174:5:1174:5 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1174:5:1174:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1174:9:1174:41 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| array_flow.rb:1174:9:1174:41 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1174:5:1174:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1174:9:1174:41 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| array_flow.rb:1174:9:1174:41 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1174:10:1174:22 | call to source | semmle.label | call to source |
 | array_flow.rb:1174:28:1174:40 | call to source | semmle.label | call to source |
-| array_flow.rb:1175:5:1175:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1175:9:1175:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1175:9:1175:9 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1175:9:1175:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1175:9:1175:18 | call to shift [element] | semmle.label | call to shift [element] |
-| array_flow.rb:1176:10:1176:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1175:5:1175:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1175:9:1175:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1175:9:1175:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1175:9:1175:18 | call to shift : [collection] [element] | semmle.label | call to shift : [collection] [element] |
+| array_flow.rb:1176:10:1176:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1176:10:1176:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1177:10:1177:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1177:10:1177:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1177:10:1177:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1178:10:1178:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1178:10:1178:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1178:10:1178:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| array_flow.rb:1178:10:1178:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1178:10:1178:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1179:10:1179:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1179:10:1179:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1179:10:1179:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1180:10:1180:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1180:10:1180:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1180:10:1180:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1180:10:1180:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1180:10:1180:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1184:5:1184:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1184:9:1184:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1184:5:1184:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1184:9:1184:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1184:16:1184:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1185:5:1185:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1185:9:1185:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1185:9:1185:17 | call to shuffle [element] | semmle.label | call to shuffle [element] |
-| array_flow.rb:1188:10:1188:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1185:5:1185:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1185:9:1185:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1185:9:1185:17 | call to shuffle : [collection] [element] | semmle.label | call to shuffle : [collection] [element] |
+| array_flow.rb:1188:10:1188:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1188:10:1188:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1189:10:1189:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1189:10:1189:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1189:10:1189:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1190:10:1190:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1190:10:1190:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1190:10:1190:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1191:10:1191:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1191:10:1191:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1191:10:1191:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1195:5:1195:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1195:9:1195:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1195:5:1195:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1195:9:1195:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1195:16:1195:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1196:5:1196:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1196:9:1196:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1196:9:1196:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1196:9:1196:18 | call to shuffle! [element] | semmle.label | call to shuffle! [element] |
-| array_flow.rb:1197:10:1197:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1196:5:1196:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1196:9:1196:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1196:9:1196:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1196:9:1196:18 | call to shuffle! : [collection] [element] | semmle.label | call to shuffle! : [collection] [element] |
+| array_flow.rb:1197:10:1197:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1197:10:1197:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1198:10:1198:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1198:10:1198:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1198:10:1198:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1199:10:1199:10 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1199:10:1199:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1199:10:1199:10 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1199:10:1199:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1199:10:1199:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1200:10:1200:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1200:10:1200:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1200:10:1200:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1201:10:1201:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1201:10:1201:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1201:10:1201:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1202:10:1202:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1202:10:1202:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1202:10:1202:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1206:5:1206:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1206:5:1206:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1206:9:1206:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1206:9:1206:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1206:5:1206:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1206:9:1206:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1206:9:1206:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1206:16:1206:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1206:34:1206:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1208:5:1208:5 | b | semmle.label | b |
-| array_flow.rb:1208:9:1208:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1208:9:1208:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:1208:9:1208:17 | call to slice | semmle.label | call to slice |
 | array_flow.rb:1209:10:1209:10 | b | semmle.label | b |
 | array_flow.rb:1211:5:1211:5 | b | semmle.label | b |
-| array_flow.rb:1211:9:1211:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1211:9:1211:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1211:9:1211:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1211:9:1211:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:1211:9:1211:19 | call to slice | semmle.label | call to slice |
 | array_flow.rb:1212:10:1212:10 | b | semmle.label | b |
 | array_flow.rb:1214:5:1214:5 | b | semmle.label | b |
-| array_flow.rb:1214:9:1214:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1214:9:1214:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1214:9:1214:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1214:9:1214:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:1214:9:1214:17 | call to slice | semmle.label | call to slice |
 | array_flow.rb:1216:10:1216:10 | b | semmle.label | b |
-| array_flow.rb:1221:5:1221:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1221:5:1221:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1221:9:1221:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1221:9:1221:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1221:9:1221:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1221:9:1221:21 | call to slice [element 2] | semmle.label | call to slice [element 2] |
-| array_flow.rb:1222:10:1222:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1221:5:1221:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1221:5:1221:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1221:9:1221:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1221:9:1221:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 0] | semmle.label | call to slice : [collection] [element 0] |
+| array_flow.rb:1221:9:1221:21 | call to slice : [collection] [element 2] | semmle.label | call to slice : [collection] [element 2] |
+| array_flow.rb:1222:10:1222:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1222:10:1222:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1224:10:1224:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1224:10:1224:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1224:10:1224:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1226:5:1226:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1226:9:1226:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1226:9:1226:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1226:9:1226:21 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1227:10:1227:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1226:5:1226:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1226:9:1226:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1226:9:1226:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1226:9:1226:21 | call to slice : [collection] [element] | semmle.label | call to slice : [collection] [element] |
+| array_flow.rb:1227:10:1227:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1227:10:1227:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1228:10:1228:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1228:10:1228:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1228:10:1228:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1230:5:1230:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1230:9:1230:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1230:9:1230:21 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1231:10:1231:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1230:5:1230:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1230:9:1230:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1230:9:1230:21 | call to slice : [collection] [element 0] | semmle.label | call to slice : [collection] [element 0] |
+| array_flow.rb:1231:10:1231:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1231:10:1231:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1235:5:1235:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1235:9:1235:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1235:9:1235:22 | call to slice [element 0] | semmle.label | call to slice [element 0] |
-| array_flow.rb:1236:10:1236:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1235:5:1235:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1235:9:1235:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1235:9:1235:22 | call to slice : [collection] [element 0] | semmle.label | call to slice : [collection] [element 0] |
+| array_flow.rb:1236:10:1236:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1236:10:1236:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1240:5:1240:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1240:9:1240:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1240:9:1240:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1240:9:1240:21 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1241:10:1241:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1240:5:1240:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1240:9:1240:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1240:9:1240:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1240:9:1240:21 | call to slice : [collection] [element] | semmle.label | call to slice : [collection] [element] |
+| array_flow.rb:1241:10:1241:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1241:10:1241:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1242:10:1242:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1242:10:1242:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1242:10:1242:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1244:5:1244:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1244:9:1244:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1244:9:1244:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1244:9:1244:24 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1245:10:1245:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1244:5:1244:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1244:9:1244:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1244:9:1244:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1244:9:1244:24 | call to slice : [collection] [element] | semmle.label | call to slice : [collection] [element] |
+| array_flow.rb:1245:10:1245:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1245:10:1245:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1246:10:1246:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1246:10:1246:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1246:10:1246:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1248:5:1248:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1248:9:1248:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1248:9:1248:20 | call to slice [element 2] | semmle.label | call to slice [element 2] |
-| array_flow.rb:1251:10:1251:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1248:5:1248:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1248:9:1248:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1248:9:1248:20 | call to slice : [collection] [element 2] | semmle.label | call to slice : [collection] [element 2] |
+| array_flow.rb:1251:10:1251:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1251:10:1251:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1253:5:1253:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1253:9:1253:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1253:9:1253:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1253:9:1253:20 | call to slice [element] | semmle.label | call to slice [element] |
-| array_flow.rb:1254:10:1254:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1253:5:1253:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1253:9:1253:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1253:9:1253:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1253:9:1253:20 | call to slice : [collection] [element] | semmle.label | call to slice : [collection] [element] |
+| array_flow.rb:1254:10:1254:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1254:10:1254:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1255:10:1255:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1255:10:1255:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1255:10:1255:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1256:10:1256:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1256:10:1256:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1256:10:1256:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1260:5:1260:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1260:5:1260:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1260:9:1260:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1260:9:1260:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1260:5:1260:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1260:5:1260:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1260:9:1260:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1260:9:1260:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1260:16:1260:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1260:34:1260:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1261:5:1261:5 | b | semmle.label | b |
-| array_flow.rb:1261:9:1261:9 | [post] a [element 3] | semmle.label | [post] a [element 3] |
-| array_flow.rb:1261:9:1261:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1261:9:1261:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1261:9:1261:9 | [post] a : [collection] [element 3] | semmle.label | [post] a : [collection] [element 3] |
+| array_flow.rb:1261:9:1261:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1261:9:1261:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:1261:9:1261:19 | call to slice! | semmle.label | call to slice! |
 | array_flow.rb:1262:10:1262:10 | b | semmle.label | b |
-| array_flow.rb:1266:10:1266:10 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1266:10:1266:10 | a : [collection] [element 3] | semmle.label | a : [collection] [element 3] |
 | array_flow.rb:1266:10:1266:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1268:5:1268:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1268:5:1268:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1268:9:1268:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1268:9:1268:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1268:5:1268:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1268:5:1268:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1268:9:1268:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1268:9:1268:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1268:16:1268:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1268:34:1268:46 | call to source | semmle.label | call to source |
 | array_flow.rb:1269:5:1269:5 | b | semmle.label | b |
-| array_flow.rb:1269:5:1269:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1269:9:1269:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1269:9:1269:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1269:9:1269:9 | a [element 4] | semmle.label | a [element 4] |
+| array_flow.rb:1269:5:1269:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1269:9:1269:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1269:9:1269:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
 | array_flow.rb:1269:9:1269:19 | call to slice! | semmle.label | call to slice! |
-| array_flow.rb:1269:9:1269:19 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1270:10:1270:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1269:9:1269:19 | call to slice! : [collection] [element] | semmle.label | call to slice! : [collection] [element] |
+| array_flow.rb:1270:10:1270:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1270:10:1270:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1271:10:1271:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1271:10:1271:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1271:10:1271:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1272:10:1272:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1272:10:1272:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1272:10:1272:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1273:10:1273:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1273:10:1273:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1273:10:1273:13 | ...[...] | semmle.label | ...[...] |
 | array_flow.rb:1275:10:1275:10 | b | semmle.label | b |
-| array_flow.rb:1277:10:1277:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1277:10:1277:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1277:10:1277:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1279:5:1279:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1279:5:1279:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1279:9:1279:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1279:9:1279:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1279:5:1279:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1279:5:1279:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1279:9:1279:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1279:9:1279:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1279:16:1279:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1279:34:1279:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1280:5:1280:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1280:5:1280:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1280:9:1280:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1280:9:1280:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1280:9:1280:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1280:9:1280:22 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
-| array_flow.rb:1281:10:1281:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1280:5:1280:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1280:5:1280:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1280:9:1280:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1280:9:1280:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 0] | semmle.label | call to slice! : [collection] [element 0] |
+| array_flow.rb:1280:9:1280:22 | call to slice! : [collection] [element 2] | semmle.label | call to slice! : [collection] [element 2] |
+| array_flow.rb:1281:10:1281:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1281:10:1281:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1283:10:1283:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1283:10:1283:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1283:10:1283:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1290:5:1290:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1290:5:1290:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1290:9:1290:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1290:9:1290:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1290:5:1290:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1290:5:1290:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1290:9:1290:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1290:9:1290:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1290:16:1290:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1290:34:1290:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1291:5:1291:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1291:9:1291:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1291:9:1291:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1291:9:1291:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1291:9:1291:22 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1292:10:1292:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1291:5:1291:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1291:9:1291:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:1291:9:1291:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1291:9:1291:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1291:9:1291:22 | call to slice! : [collection] [element 0] | semmle.label | call to slice! : [collection] [element 0] |
+| array_flow.rb:1292:10:1292:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1292:10:1292:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1297:10:1297:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1297:10:1297:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:1297:10:1297:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1301:5:1301:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1301:5:1301:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1301:9:1301:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1301:9:1301:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1301:5:1301:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1301:5:1301:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1301:9:1301:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1301:9:1301:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1301:16:1301:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1301:34:1301:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1302:5:1302:5 | b [element 0] | semmle.label | b [element 0] |
-| array_flow.rb:1302:9:1302:9 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1302:9:1302:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1302:9:1302:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1302:9:1302:23 | call to slice! [element 0] | semmle.label | call to slice! [element 0] |
-| array_flow.rb:1303:10:1303:10 | b [element 0] | semmle.label | b [element 0] |
+| array_flow.rb:1302:5:1302:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| array_flow.rb:1302:9:1302:9 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:1302:9:1302:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1302:9:1302:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1302:9:1302:23 | call to slice! : [collection] [element 0] | semmle.label | call to slice! : [collection] [element 0] |
+| array_flow.rb:1303:10:1303:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | array_flow.rb:1303:10:1303:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1308:10:1308:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1308:10:1308:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:1308:10:1308:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1312:5:1312:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1312:5:1312:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1312:9:1312:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1312:9:1312:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1312:5:1312:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1312:5:1312:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1312:9:1312:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1312:9:1312:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1312:16:1312:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1312:34:1312:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1313:5:1313:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1313:9:1313:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1313:9:1313:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1313:9:1313:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1313:9:1313:22 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1314:10:1314:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1313:5:1313:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1313:9:1313:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1313:9:1313:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1313:9:1313:22 | call to slice! : [collection] [element] | semmle.label | call to slice! : [collection] [element] |
+| array_flow.rb:1314:10:1314:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1314:10:1314:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1315:10:1315:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1315:10:1315:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1315:10:1315:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1316:10:1316:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1316:10:1316:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1316:10:1316:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1317:10:1317:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1317:10:1317:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1317:10:1317:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1318:10:1318:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1318:10:1318:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1318:10:1318:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1319:10:1319:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1319:10:1319:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1319:10:1319:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1321:5:1321:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1321:5:1321:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1321:9:1321:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1321:9:1321:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1321:5:1321:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1321:5:1321:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1321:9:1321:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1321:9:1321:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1321:16:1321:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1321:34:1321:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1322:5:1322:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1322:9:1322:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1322:9:1322:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1322:9:1322:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1322:9:1322:22 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1323:10:1323:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1322:5:1322:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1322:9:1322:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1322:9:1322:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1322:9:1322:22 | call to slice! : [collection] [element] | semmle.label | call to slice! : [collection] [element] |
+| array_flow.rb:1323:10:1323:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1323:10:1323:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1324:10:1324:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1324:10:1324:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1324:10:1324:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1325:10:1325:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1325:10:1325:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1325:10:1325:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1326:10:1326:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1326:10:1326:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1326:10:1326:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1327:10:1327:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1327:10:1327:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1327:10:1327:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1328:10:1328:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1328:10:1328:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1328:10:1328:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1330:5:1330:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1330:5:1330:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1330:9:1330:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1330:9:1330:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1330:5:1330:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1330:5:1330:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1330:9:1330:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1330:9:1330:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1330:16:1330:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1330:34:1330:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1331:5:1331:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1331:9:1331:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1331:9:1331:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1331:9:1331:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1331:9:1331:25 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1332:10:1332:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1331:5:1331:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1331:9:1331:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1331:9:1331:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1331:9:1331:25 | call to slice! : [collection] [element] | semmle.label | call to slice! : [collection] [element] |
+| array_flow.rb:1332:10:1332:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1332:10:1332:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1333:10:1333:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1333:10:1333:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1333:10:1333:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1334:10:1334:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1334:10:1334:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1334:10:1334:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1335:10:1335:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1335:10:1335:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1335:10:1335:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1336:10:1336:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1336:10:1336:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1336:10:1336:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1337:10:1337:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1337:10:1337:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1337:10:1337:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1339:5:1339:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1339:5:1339:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1339:9:1339:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1339:9:1339:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1339:5:1339:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1339:5:1339:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1339:9:1339:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1339:9:1339:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1339:16:1339:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1339:34:1339:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1340:5:1340:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1340:9:1340:9 | [post] a [element 1] | semmle.label | [post] a [element 1] |
-| array_flow.rb:1340:9:1340:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1340:9:1340:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1340:9:1340:21 | call to slice! [element 2] | semmle.label | call to slice! [element 2] |
-| array_flow.rb:1343:10:1343:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1340:5:1340:5 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
+| array_flow.rb:1340:9:1340:9 | [post] a : [collection] [element 1] | semmle.label | [post] a : [collection] [element 1] |
+| array_flow.rb:1340:9:1340:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1340:9:1340:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1340:9:1340:21 | call to slice! : [collection] [element 2] | semmle.label | call to slice! : [collection] [element 2] |
+| array_flow.rb:1343:10:1343:10 | b : [collection] [element 2] | semmle.label | b : [collection] [element 2] |
 | array_flow.rb:1343:10:1343:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1345:10:1345:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1345:10:1345:10 | a : [collection] [element 1] | semmle.label | a : [collection] [element 1] |
 | array_flow.rb:1345:10:1345:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1348:5:1348:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1348:5:1348:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1348:9:1348:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1348:9:1348:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1348:5:1348:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1348:5:1348:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1348:9:1348:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1348:9:1348:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1348:16:1348:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1348:34:1348:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1349:5:1349:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1349:9:1349:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1349:9:1349:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1349:9:1349:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1349:9:1349:21 | call to slice! [element] | semmle.label | call to slice! [element] |
-| array_flow.rb:1350:10:1350:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1349:5:1349:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1349:9:1349:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1349:9:1349:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1349:9:1349:21 | call to slice! : [collection] [element] | semmle.label | call to slice! : [collection] [element] |
+| array_flow.rb:1350:10:1350:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1350:10:1350:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1351:10:1351:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1351:10:1351:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1351:10:1351:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1352:10:1352:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1352:10:1352:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1352:10:1352:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1353:10:1353:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1353:10:1353:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1353:10:1353:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1354:10:1354:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1354:10:1354:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1354:10:1354:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1355:10:1355:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1355:10:1355:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1355:10:1355:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1359:5:1359:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1359:9:1359:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1359:5:1359:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1359:9:1359:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1359:16:1359:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1360:9:1360:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1360:9:1360:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1360:27:1360:27 | x | semmle.label | x |
 | array_flow.rb:1361:14:1361:14 | x | semmle.label | x |
-| array_flow.rb:1367:5:1367:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1367:9:1367:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1367:5:1367:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1367:9:1367:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1367:16:1367:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1368:9:1368:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1368:9:1368:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1368:28:1368:28 | x | semmle.label | x |
 | array_flow.rb:1369:14:1369:14 | x | semmle.label | x |
-| array_flow.rb:1375:5:1375:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1375:9:1375:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1375:5:1375:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1375:9:1375:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1375:16:1375:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1376:9:1376:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1376:9:1376:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1376:26:1376:26 | x | semmle.label | x |
 | array_flow.rb:1376:29:1376:29 | y | semmle.label | y |
 | array_flow.rb:1377:14:1377:14 | x | semmle.label | x |
 | array_flow.rb:1378:14:1378:14 | y | semmle.label | y |
-| array_flow.rb:1383:5:1383:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1383:9:1383:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1383:5:1383:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1383:9:1383:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1383:16:1383:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1384:5:1384:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1384:9:1384:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1384:9:1384:14 | call to sort [element] | semmle.label | call to sort [element] |
-| array_flow.rb:1385:10:1385:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1384:5:1384:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1384:9:1384:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1384:9:1384:14 | call to sort : [collection] [element] | semmle.label | call to sort : [collection] [element] |
+| array_flow.rb:1385:10:1385:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1385:10:1385:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1386:10:1386:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1386:10:1386:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1386:10:1386:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1387:5:1387:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1387:9:1387:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1387:9:1391:7 | call to sort [element] | semmle.label | call to sort [element] |
+| array_flow.rb:1387:5:1387:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:1387:9:1387:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1387:9:1391:7 | call to sort : [collection] [element] | semmle.label | call to sort : [collection] [element] |
 | array_flow.rb:1387:20:1387:20 | x | semmle.label | x |
 | array_flow.rb:1387:23:1387:23 | y | semmle.label | y |
 | array_flow.rb:1388:14:1388:14 | x | semmle.label | x |
 | array_flow.rb:1389:14:1389:14 | y | semmle.label | y |
-| array_flow.rb:1392:10:1392:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1392:10:1392:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1392:10:1392:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1393:10:1393:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1393:10:1393:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1393:10:1393:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1397:5:1397:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1397:9:1397:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1397:5:1397:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1397:9:1397:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1397:16:1397:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1398:5:1398:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1398:9:1398:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1398:9:1398:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1398:9:1398:15 | call to sort! [element] | semmle.label | call to sort! [element] |
-| array_flow.rb:1399:10:1399:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1398:5:1398:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1398:9:1398:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1398:9:1398:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1398:9:1398:15 | call to sort! : [collection] [element] | semmle.label | call to sort! : [collection] [element] |
+| array_flow.rb:1399:10:1399:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1399:10:1399:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1400:10:1400:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1400:10:1400:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1400:10:1400:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1401:10:1401:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1401:10:1401:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1401:10:1401:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1402:10:1402:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1402:10:1402:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1402:10:1402:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1404:5:1404:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1404:9:1404:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1404:5:1404:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1404:9:1404:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1404:16:1404:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1405:5:1405:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1405:9:1405:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1405:9:1405:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1405:9:1409:7 | call to sort! [element] | semmle.label | call to sort! [element] |
+| array_flow.rb:1405:5:1405:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1405:9:1405:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1405:9:1405:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1405:9:1409:7 | call to sort! : [collection] [element] | semmle.label | call to sort! : [collection] [element] |
 | array_flow.rb:1405:21:1405:21 | x | semmle.label | x |
 | array_flow.rb:1405:24:1405:24 | y | semmle.label | y |
 | array_flow.rb:1406:14:1406:14 | x | semmle.label | x |
 | array_flow.rb:1407:14:1407:14 | y | semmle.label | y |
-| array_flow.rb:1410:10:1410:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1410:10:1410:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1410:10:1410:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1411:10:1411:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1411:10:1411:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1411:10:1411:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1412:10:1412:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1412:10:1412:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1412:10:1412:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1413:10:1413:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1413:10:1413:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1413:10:1413:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1417:5:1417:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1417:9:1417:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1417:5:1417:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1417:9:1417:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1417:16:1417:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1418:5:1418:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1418:9:1418:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1418:9:1421:7 | call to sort_by [element] | semmle.label | call to sort_by [element] |
+| array_flow.rb:1418:5:1418:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1418:9:1418:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1418:9:1421:7 | call to sort_by : [collection] [element] | semmle.label | call to sort_by : [collection] [element] |
 | array_flow.rb:1418:23:1418:23 | x | semmle.label | x |
 | array_flow.rb:1419:14:1419:14 | x | semmle.label | x |
-| array_flow.rb:1422:10:1422:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1422:10:1422:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1422:10:1422:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1423:10:1423:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1423:10:1423:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1423:10:1423:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1427:5:1427:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1427:9:1427:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1427:5:1427:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1427:9:1427:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1427:16:1427:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1428:5:1428:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1428:9:1428:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1428:9:1428:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1428:9:1431:7 | call to sort_by! [element] | semmle.label | call to sort_by! [element] |
+| array_flow.rb:1428:5:1428:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1428:9:1428:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1428:9:1428:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1428:9:1431:7 | call to sort_by! : [collection] [element] | semmle.label | call to sort_by! : [collection] [element] |
 | array_flow.rb:1428:24:1428:24 | x | semmle.label | x |
 | array_flow.rb:1429:14:1429:14 | x | semmle.label | x |
-| array_flow.rb:1432:10:1432:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1432:10:1432:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1432:10:1432:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1433:10:1433:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1433:10:1433:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1433:10:1433:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1434:10:1434:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1434:10:1434:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1434:10:1434:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1435:10:1435:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1435:10:1435:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1435:10:1435:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1439:5:1439:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1439:9:1439:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1439:5:1439:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1439:9:1439:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1439:16:1439:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1440:9:1440:9 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1440:9:1440:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1440:19:1440:19 | x | semmle.label | x |
 | array_flow.rb:1441:14:1441:14 | x | semmle.label | x |
-| array_flow.rb:1447:5:1447:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1447:5:1447:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1447:9:1447:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1447:9:1447:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1447:5:1447:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1447:9:1447:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1447:9:1447:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1447:16:1447:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1447:31:1447:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1448:5:1448:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1448:5:1448:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1448:9:1448:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1448:9:1448:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1448:9:1448:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1448:9:1448:17 | call to take [element 3] | semmle.label | call to take [element 3] |
-| array_flow.rb:1451:10:1451:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1448:5:1448:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1448:5:1448:5 | b : Array [element 3] | semmle.label | b : Array [element 3] |
+| array_flow.rb:1448:9:1448:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1448:9:1448:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1448:9:1448:17 | call to take : Array [element 2] | semmle.label | call to take : Array [element 2] |
+| array_flow.rb:1448:9:1448:17 | call to take : Array [element 3] | semmle.label | call to take : Array [element 3] |
+| array_flow.rb:1451:10:1451:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1451:10:1451:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1452:10:1452:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1452:10:1452:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:1452:10:1452:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1453:5:1453:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1453:9:1453:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1453:9:1453:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1456:10:1456:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1453:5:1453:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1453:9:1453:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1453:9:1453:17 | call to take : Array [element 2] | semmle.label | call to take : Array [element 2] |
+| array_flow.rb:1456:10:1456:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1456:10:1456:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1458:10:1458:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1458:10:1458:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1458:10:1458:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1459:5:1459:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1459:5:1459:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1459:9:1459:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1459:9:1459:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1459:9:1459:19 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1459:9:1459:19 | call to take [element 3] | semmle.label | call to take [element 3] |
-| array_flow.rb:1462:10:1462:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1459:5:1459:5 | b : Array [element 3] | semmle.label | b : Array [element 3] |
+| array_flow.rb:1459:9:1459:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1459:9:1459:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1459:9:1459:19 | call to take : Array [element 2] | semmle.label | call to take : Array [element 2] |
+| array_flow.rb:1459:9:1459:19 | call to take : Array [element 3] | semmle.label | call to take : Array [element 3] |
+| array_flow.rb:1462:10:1462:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1462:10:1462:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1463:10:1463:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1463:10:1463:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:1463:10:1463:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1464:10:1464:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1464:10:1464:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1464:10:1464:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1464:10:1464:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:1464:10:1464:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1465:5:1465:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1465:5:1465:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:1465:12:1465:24 | call to source | semmle.label | call to source |
-| array_flow.rb:1466:5:1466:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1466:5:1466:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1466:9:1466:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1466:9:1466:9 | a [element] | semmle.label | a [element] |
-| array_flow.rb:1466:9:1466:17 | call to take [element 2] | semmle.label | call to take [element 2] |
-| array_flow.rb:1466:9:1466:17 | call to take [element] | semmle.label | call to take [element] |
-| array_flow.rb:1467:10:1467:10 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1467:10:1467:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1466:5:1466:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1466:5:1466:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1466:9:1466:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1466:9:1466:9 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| array_flow.rb:1466:9:1466:17 | call to take : Array [element 2] | semmle.label | call to take : Array [element 2] |
+| array_flow.rb:1466:9:1466:17 | call to take : [collection] [element] | semmle.label | call to take : [collection] [element] |
+| array_flow.rb:1467:10:1467:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1467:10:1467:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1467:10:1467:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1471:5:1471:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1471:9:1471:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1471:5:1471:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1471:9:1471:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1471:16:1471:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1472:5:1472:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1472:9:1472:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1472:9:1475:7 | call to take_while [element 2] | semmle.label | call to take_while [element 2] |
+| array_flow.rb:1472:5:1472:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1472:9:1472:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1472:9:1475:7 | call to take_while : Array [element 2] | semmle.label | call to take_while : Array [element 2] |
 | array_flow.rb:1472:26:1472:26 | x | semmle.label | x |
 | array_flow.rb:1473:14:1473:14 | x | semmle.label | x |
-| array_flow.rb:1478:10:1478:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1478:10:1478:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1478:10:1478:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1484:5:1484:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1484:9:1484:30 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1484:5:1484:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1484:9:1484:30 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1484:19:1484:29 | call to source | semmle.label | call to source |
-| array_flow.rb:1485:5:1485:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1485:9:1485:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1485:9:1485:14 | call to to_a [element 3] | semmle.label | call to to_a [element 3] |
-| array_flow.rb:1486:10:1486:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1485:5:1485:5 | b : Array [element 3] | semmle.label | b : Array [element 3] |
+| array_flow.rb:1485:9:1485:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1485:9:1485:14 | call to to_a : Array [element 3] | semmle.label | call to to_a : Array [element 3] |
+| array_flow.rb:1486:10:1486:10 | b : Array [element 3] | semmle.label | b : Array [element 3] |
 | array_flow.rb:1486:10:1486:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1490:5:1490:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1490:9:1490:27 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1490:5:1490:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1490:9:1490:27 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1490:16:1490:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1491:5:1491:5 | b [element 2] | semmle.label | b [element 2] |
-| array_flow.rb:1491:9:1491:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1491:9:1491:16 | call to to_ary [element 2] | semmle.label | call to to_ary [element 2] |
-| array_flow.rb:1494:10:1494:10 | b [element 2] | semmle.label | b [element 2] |
+| array_flow.rb:1491:5:1491:5 | b : Array [element 2] | semmle.label | b : Array [element 2] |
+| array_flow.rb:1491:9:1491:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1491:9:1491:16 | call to to_ary : Array [element 2] | semmle.label | call to to_ary : Array [element 2] |
+| array_flow.rb:1494:10:1494:10 | b : Array [element 2] | semmle.label | b : Array [element 2] |
 | array_flow.rb:1494:10:1494:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1507:5:1507:5 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
-| array_flow.rb:1507:5:1507:5 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
-| array_flow.rb:1507:5:1507:5 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 0, element 1] | semmle.label | call to [] [element 0, element 1] |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 1, element 1] | semmle.label | call to [] [element 1, element 1] |
-| array_flow.rb:1507:9:1507:68 | call to [] [element 2, element 1] | semmle.label | call to [] [element 2, element 1] |
-| array_flow.rb:1507:10:1507:27 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 0, element 1] | semmle.label | a : Array [element 0, element 1] |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 1, element 1] | semmle.label | a : Array [element 1, element 1] |
+| array_flow.rb:1507:5:1507:5 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 0, element 1] | semmle.label | call to [] : Array [element 0, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 1, element 1] | semmle.label | call to [] : Array [element 1, element 1] |
+| array_flow.rb:1507:9:1507:68 | call to [] : Array [element 2, element 1] | semmle.label | call to [] : Array [element 2, element 1] |
+| array_flow.rb:1507:10:1507:27 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1507:14:1507:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1507:30:1507:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1507:30:1507:47 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1507:34:1507:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1507:50:1507:67 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1507:50:1507:67 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1507:54:1507:66 | call to source | semmle.label | call to source |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
-| array_flow.rb:1508:5:1508:5 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
-| array_flow.rb:1508:9:1508:9 | a [element 0, element 1] | semmle.label | a [element 0, element 1] |
-| array_flow.rb:1508:9:1508:9 | a [element 1, element 1] | semmle.label | a [element 1, element 1] |
-| array_flow.rb:1508:9:1508:9 | a [element 2, element 1] | semmle.label | a [element 2, element 1] |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 0] | semmle.label | call to transpose [element 1, element 0] |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 1] | semmle.label | call to transpose [element 1, element 1] |
-| array_flow.rb:1508:9:1508:19 | call to transpose [element 1, element 2] | semmle.label | call to transpose [element 1, element 2] |
-| array_flow.rb:1512:10:1512:10 | b [element 1, element 0] | semmle.label | b [element 1, element 0] |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 0] | semmle.label | b : [collection] [element 1, element 0] |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 1] | semmle.label | b : [collection] [element 1, element 1] |
+| array_flow.rb:1508:5:1508:5 | b : [collection] [element 1, element 2] | semmle.label | b : [collection] [element 1, element 2] |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 0, element 1] | semmle.label | a : Array [element 0, element 1] |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 1, element 1] | semmle.label | a : Array [element 1, element 1] |
+| array_flow.rb:1508:9:1508:9 | a : Array [element 2, element 1] | semmle.label | a : Array [element 2, element 1] |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 0] | semmle.label | call to transpose : [collection] [element 1, element 0] |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 1] | semmle.label | call to transpose : [collection] [element 1, element 1] |
+| array_flow.rb:1508:9:1508:19 | call to transpose : [collection] [element 1, element 2] | semmle.label | call to transpose : [collection] [element 1, element 2] |
+| array_flow.rb:1512:10:1512:10 | b : [collection] [element 1, element 0] | semmle.label | b : [collection] [element 1, element 0] |
 | array_flow.rb:1512:10:1512:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1512:10:1512:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1513:10:1513:10 | b [element 1, element 1] | semmle.label | b [element 1, element 1] |
+| array_flow.rb:1513:10:1513:10 | b : [collection] [element 1, element 1] | semmle.label | b : [collection] [element 1, element 1] |
 | array_flow.rb:1513:10:1513:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:1513:10:1513:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1514:10:1514:10 | b [element 1, element 2] | semmle.label | b [element 1, element 2] |
+| array_flow.rb:1514:10:1514:10 | b : [collection] [element 1, element 2] | semmle.label | b : [collection] [element 1, element 2] |
 | array_flow.rb:1514:10:1514:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
 | array_flow.rb:1514:10:1514:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1518:5:1518:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1518:9:1518:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1518:5:1518:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1518:9:1518:29 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1518:16:1518:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1519:5:1519:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1519:9:1519:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1519:5:1519:5 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1519:9:1519:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1519:13:1519:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1520:5:1520:5 | c [element 1] | semmle.label | c [element 1] |
-| array_flow.rb:1520:9:1520:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1520:5:1520:5 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| array_flow.rb:1520:9:1520:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1520:13:1520:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1521:5:1521:5 | d [element] | semmle.label | d [element] |
-| array_flow.rb:1521:9:1521:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1521:9:1521:21 | call to union [element] | semmle.label | call to union [element] |
-| array_flow.rb:1521:17:1521:17 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1521:20:1521:20 | c [element 1] | semmle.label | c [element 1] |
-| array_flow.rb:1522:10:1522:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:1521:5:1521:5 | d : [collection] [element] | semmle.label | d : [collection] [element] |
+| array_flow.rb:1521:9:1521:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1521:9:1521:21 | call to union : [collection] [element] | semmle.label | call to union : [collection] [element] |
+| array_flow.rb:1521:17:1521:17 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1521:20:1521:20 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| array_flow.rb:1522:10:1522:10 | d : [collection] [element] | semmle.label | d : [collection] [element] |
 | array_flow.rb:1522:10:1522:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1523:10:1523:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:1523:10:1523:10 | d : [collection] [element] | semmle.label | d : [collection] [element] |
 | array_flow.rb:1523:10:1523:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1524:10:1524:10 | d [element] | semmle.label | d [element] |
+| array_flow.rb:1524:10:1524:10 | d : [collection] [element] | semmle.label | d : [collection] [element] |
 | array_flow.rb:1524:10:1524:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1528:5:1528:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1528:5:1528:5 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1528:9:1528:47 | call to [] [element 3] | semmle.label | call to [] [element 3] |
-| array_flow.rb:1528:9:1528:47 | call to [] [element 4] | semmle.label | call to [] [element 4] |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1528:5:1528:5 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1528:9:1528:47 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
+| array_flow.rb:1528:9:1528:47 | call to [] : Array [element 4] | semmle.label | call to [] : Array [element 4] |
 | array_flow.rb:1528:19:1528:31 | call to source | semmle.label | call to source |
 | array_flow.rb:1528:34:1528:46 | call to source | semmle.label | call to source |
-| array_flow.rb:1530:5:1530:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1530:9:1530:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1530:9:1530:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1530:9:1530:14 | call to uniq [element] | semmle.label | call to uniq [element] |
-| array_flow.rb:1531:10:1531:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1530:5:1530:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1530:9:1530:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1530:9:1530:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1530:9:1530:14 | call to uniq : [collection] [element] | semmle.label | call to uniq : [collection] [element] |
+| array_flow.rb:1531:10:1531:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1531:10:1531:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1532:10:1532:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1532:10:1532:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1532:10:1532:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1534:5:1534:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1534:9:1534:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1534:9:1534:9 | a [element 4] | semmle.label | a [element 4] |
-| array_flow.rb:1534:9:1537:7 | call to uniq [element] | semmle.label | call to uniq [element] |
+| array_flow.rb:1534:5:1534:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1534:9:1534:9 | a : Array [element 4] | semmle.label | a : Array [element 4] |
+| array_flow.rb:1534:9:1537:7 | call to uniq : [collection] [element] | semmle.label | call to uniq : [collection] [element] |
 | array_flow.rb:1534:20:1534:20 | x | semmle.label | x |
 | array_flow.rb:1535:14:1535:14 | x | semmle.label | x |
-| array_flow.rb:1538:10:1538:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1538:10:1538:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1538:10:1538:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1542:5:1542:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1542:5:1542:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1542:9:1542:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1542:9:1542:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1542:5:1542:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1542:5:1542:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1542:9:1542:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1542:9:1542:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1542:16:1542:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1542:31:1542:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1543:5:1543:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1543:9:1543:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1543:9:1543:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1543:9:1543:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1543:9:1543:15 | call to uniq! [element] | semmle.label | call to uniq! [element] |
-| array_flow.rb:1544:10:1544:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1543:5:1543:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1543:9:1543:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1543:9:1543:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1543:9:1543:15 | call to uniq! : [collection] [element] | semmle.label | call to uniq! : [collection] [element] |
+| array_flow.rb:1544:10:1544:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1544:10:1544:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1545:10:1545:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1545:10:1545:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1545:10:1545:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1546:10:1546:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1546:10:1546:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1546:10:1546:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1547:10:1547:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1547:10:1547:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1547:10:1547:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1549:5:1549:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1549:5:1549:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1549:9:1549:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1549:9:1549:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1549:5:1549:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1549:5:1549:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1549:9:1549:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1549:9:1549:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1549:16:1549:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1549:31:1549:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1550:5:1550:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1550:9:1550:9 | [post] a [element] | semmle.label | [post] a [element] |
-| array_flow.rb:1550:9:1550:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1550:9:1550:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1550:9:1553:7 | call to uniq! [element] | semmle.label | call to uniq! [element] |
+| array_flow.rb:1550:5:1550:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1550:9:1550:9 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1550:9:1550:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1550:9:1553:7 | call to uniq! : [collection] [element] | semmle.label | call to uniq! : [collection] [element] |
 | array_flow.rb:1550:21:1550:21 | x | semmle.label | x |
 | array_flow.rb:1551:14:1551:14 | x | semmle.label | x |
-| array_flow.rb:1554:10:1554:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1554:10:1554:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1554:10:1554:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1555:10:1555:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1555:10:1555:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1555:10:1555:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1556:10:1556:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1556:10:1556:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1556:10:1556:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1557:10:1557:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1557:10:1557:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1557:10:1557:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1561:5:1561:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1561:9:1561:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1561:5:1561:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1561:9:1561:29 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1561:16:1561:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1562:5:1562:5 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| array_flow.rb:1562:5:1562:5 | [post] a [element 5] | semmle.label | [post] a [element 5] |
-| array_flow.rb:1562:5:1562:5 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 2] | semmle.label | [post] a : [collection] [element 2] |
+| array_flow.rb:1562:5:1562:5 | [post] a : [collection] [element 5] | semmle.label | [post] a : [collection] [element 5] |
+| array_flow.rb:1562:5:1562:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | array_flow.rb:1562:21:1562:33 | call to source | semmle.label | call to source |
-| array_flow.rb:1565:10:1565:10 | a [element 2] | semmle.label | a [element 2] |
+| array_flow.rb:1565:10:1565:10 | a : [collection] [element 2] | semmle.label | a : [collection] [element 2] |
 | array_flow.rb:1565:10:1565:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1568:10:1568:10 | a [element 5] | semmle.label | a [element 5] |
+| array_flow.rb:1568:10:1568:10 | a : [collection] [element 5] | semmle.label | a : [collection] [element 5] |
 | array_flow.rb:1568:10:1568:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1572:5:1572:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1572:5:1572:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1572:9:1572:44 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| array_flow.rb:1572:9:1572:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1572:5:1572:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1572:9:1572:44 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| array_flow.rb:1572:9:1572:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1572:13:1572:25 | call to source | semmle.label | call to source |
 | array_flow.rb:1572:31:1572:43 | call to source | semmle.label | call to source |
-| array_flow.rb:1574:5:1574:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1574:5:1574:5 | b [element 3] | semmle.label | b [element 3] |
-| array_flow.rb:1574:9:1574:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1574:9:1574:31 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
-| array_flow.rb:1574:9:1574:31 | call to values_at [element 3] | semmle.label | call to values_at [element 3] |
-| array_flow.rb:1576:10:1576:10 | b [element 1] | semmle.label | b [element 1] |
+| array_flow.rb:1574:5:1574:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1574:5:1574:5 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
+| array_flow.rb:1574:9:1574:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 1] | semmle.label | call to values_at : [collection] [element 1] |
+| array_flow.rb:1574:9:1574:31 | call to values_at : [collection] [element 3] | semmle.label | call to values_at : [collection] [element 3] |
+| array_flow.rb:1576:10:1576:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | array_flow.rb:1576:10:1576:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1578:10:1578:10 | b [element 3] | semmle.label | b [element 3] |
+| array_flow.rb:1578:10:1578:10 | b : [collection] [element 3] | semmle.label | b : [collection] [element 3] |
 | array_flow.rb:1578:10:1578:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1580:5:1580:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1580:9:1580:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1580:9:1580:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1580:9:1580:25 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1581:10:1581:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1580:5:1580:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1580:9:1580:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1580:9:1580:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1580:9:1580:25 | call to values_at : [collection] [element] | semmle.label | call to values_at : [collection] [element] |
+| array_flow.rb:1581:10:1581:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1581:10:1581:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1582:10:1582:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1582:10:1582:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1582:10:1582:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1584:5:1584:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1584:9:1584:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1584:9:1584:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1584:9:1584:26 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1585:10:1585:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1584:5:1584:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1584:9:1584:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1584:9:1584:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1584:9:1584:26 | call to values_at : [collection] [element] | semmle.label | call to values_at : [collection] [element] |
+| array_flow.rb:1585:10:1585:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1585:10:1585:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1586:10:1586:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1586:10:1586:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1586:10:1586:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1588:5:1588:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1588:5:1588:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1588:9:1588:9 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1588:9:1588:9 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1588:9:1588:28 | call to values_at [element 1] | semmle.label | call to values_at [element 1] |
-| array_flow.rb:1588:9:1588:28 | call to values_at [element] | semmle.label | call to values_at [element] |
-| array_flow.rb:1589:10:1589:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1588:5:1588:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1588:9:1588:9 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1588:9:1588:9 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element 1] | semmle.label | call to values_at : [collection] [element 1] |
+| array_flow.rb:1588:9:1588:28 | call to values_at : [collection] [element] | semmle.label | call to values_at : [collection] [element] |
+| array_flow.rb:1589:10:1589:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1589:10:1589:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1590:10:1590:10 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1590:10:1590:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1590:10:1590:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| array_flow.rb:1590:10:1590:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1590:10:1590:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1591:10:1591:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1591:10:1591:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1591:10:1591:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1592:10:1592:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1592:10:1592:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1592:10:1592:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1596:5:1596:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1596:9:1596:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1596:5:1596:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1596:9:1596:29 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1596:16:1596:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1597:5:1597:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1597:9:1597:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1597:5:1597:5 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1597:9:1597:29 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1597:13:1597:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1598:5:1598:5 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1598:9:1598:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| array_flow.rb:1598:5:1598:5 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:1598:9:1598:29 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | array_flow.rb:1598:10:1598:22 | call to source | semmle.label | call to source |
-| array_flow.rb:1599:5:1599:5 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
-| array_flow.rb:1599:5:1599:5 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
-| array_flow.rb:1599:5:1599:5 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
-| array_flow.rb:1599:9:1599:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 0, element 2] | semmle.label | call to zip [element 0, element 2] |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 1, element 1] | semmle.label | call to zip [element 1, element 1] |
-| array_flow.rb:1599:9:1599:19 | call to zip [element 2, element 0] | semmle.label | call to zip [element 2, element 0] |
-| array_flow.rb:1599:15:1599:15 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1599:18:1599:18 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1601:10:1601:10 | d [element 0, element 2] | semmle.label | d [element 0, element 2] |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 0, element 2] | semmle.label | d : [collection] [element 0, element 2] |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 1, element 1] | semmle.label | d : [collection] [element 1, element 1] |
+| array_flow.rb:1599:5:1599:5 | d : [collection] [element 2, element 0] | semmle.label | d : [collection] [element 2, element 0] |
+| array_flow.rb:1599:9:1599:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 0, element 2] | semmle.label | call to zip : [collection] [element 0, element 2] |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 1, element 1] | semmle.label | call to zip : [collection] [element 1, element 1] |
+| array_flow.rb:1599:9:1599:19 | call to zip : [collection] [element 2, element 0] | semmle.label | call to zip : [collection] [element 2, element 0] |
+| array_flow.rb:1599:15:1599:15 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1599:18:1599:18 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:1601:10:1601:10 | d : [collection] [element 0, element 2] | semmle.label | d : [collection] [element 0, element 2] |
 | array_flow.rb:1601:10:1601:13 | ...[...] [element 2] | semmle.label | ...[...] [element 2] |
 | array_flow.rb:1601:10:1601:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1602:10:1602:10 | d [element 1, element 1] | semmle.label | d [element 1, element 1] |
+| array_flow.rb:1602:10:1602:10 | d : [collection] [element 1, element 1] | semmle.label | d : [collection] [element 1, element 1] |
 | array_flow.rb:1602:10:1602:13 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | array_flow.rb:1602:10:1602:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1603:10:1603:10 | d [element 2, element 0] | semmle.label | d [element 2, element 0] |
+| array_flow.rb:1603:10:1603:10 | d : [collection] [element 2, element 0] | semmle.label | d : [collection] [element 2, element 0] |
 | array_flow.rb:1603:10:1603:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1603:10:1603:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1604:5:1604:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1604:11:1604:11 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1604:14:1604:14 | c [element 0] | semmle.label | c [element 0] |
-| array_flow.rb:1604:21:1604:21 | x [element 0] | semmle.label | x [element 0] |
-| array_flow.rb:1604:21:1604:21 | x [element 1] | semmle.label | x [element 1] |
-| array_flow.rb:1604:21:1604:21 | x [element 2] | semmle.label | x [element 2] |
-| array_flow.rb:1605:14:1605:14 | x [element 0] | semmle.label | x [element 0] |
+| array_flow.rb:1604:5:1604:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1604:11:1604:11 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1604:14:1604:14 | c : Array [element 0] | semmle.label | c : Array [element 0] |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
+| array_flow.rb:1604:21:1604:21 | x : [collection] [element 2] | semmle.label | x : [collection] [element 2] |
+| array_flow.rb:1605:14:1605:14 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | array_flow.rb:1605:14:1605:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1606:14:1606:14 | x [element 1] | semmle.label | x [element 1] |
+| array_flow.rb:1606:14:1606:14 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
 | array_flow.rb:1606:14:1606:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1607:14:1607:14 | x [element 2] | semmle.label | x [element 2] |
+| array_flow.rb:1607:14:1607:14 | x : [collection] [element 2] | semmle.label | x : [collection] [element 2] |
 | array_flow.rb:1607:14:1607:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1612:5:1612:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1612:9:1612:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1612:5:1612:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1612:9:1612:29 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1612:16:1612:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1613:5:1613:5 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1613:9:1613:26 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| array_flow.rb:1613:5:1613:5 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1613:9:1613:26 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | array_flow.rb:1613:13:1613:25 | call to source | semmle.label | call to source |
-| array_flow.rb:1614:5:1614:5 | c [element] | semmle.label | c [element] |
-| array_flow.rb:1614:9:1614:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1614:9:1614:13 | ... \| ... [element] | semmle.label | ... \| ... [element] |
-| array_flow.rb:1614:13:1614:13 | b [element 1] | semmle.label | b [element 1] |
-| array_flow.rb:1615:10:1615:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1614:5:1614:5 | c : [collection] [element] | semmle.label | c : [collection] [element] |
+| array_flow.rb:1614:9:1614:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1614:9:1614:13 | ... \| ... : [collection] [element] | semmle.label | ... \| ... : [collection] [element] |
+| array_flow.rb:1614:13:1614:13 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| array_flow.rb:1615:10:1615:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1615:10:1615:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1616:10:1616:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1616:10:1616:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1616:10:1616:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1617:10:1617:10 | c [element] | semmle.label | c [element] |
+| array_flow.rb:1617:10:1617:10 | c : [collection] [element] | semmle.label | c : [collection] [element] |
 | array_flow.rb:1617:10:1617:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1622:5:1622:5 | [post] a [element, element 0] | semmle.label | [post] a [element, element 0] |
-| array_flow.rb:1622:5:1622:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
+| array_flow.rb:1622:5:1622:5 | [post] a : [collection] [element, element 0] | semmle.label | [post] a : [collection] [element, element 0] |
+| array_flow.rb:1622:5:1622:8 | [post] ...[...] : [collection] [element 0] | semmle.label | [post] ...[...] : [collection] [element 0] |
 | array_flow.rb:1622:15:1622:27 | call to source | semmle.label | call to source |
-| array_flow.rb:1623:10:1623:10 | a [element, element 0] | semmle.label | a [element, element 0] |
+| array_flow.rb:1623:10:1623:10 | a : [collection] [element, element 0] | semmle.label | a : [collection] [element, element 0] |
 | array_flow.rb:1623:10:1623:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1623:10:1623:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1625:5:1625:5 | [post] a [element 1, element 0] | semmle.label | [post] a [element 1, element 0] |
-| array_flow.rb:1625:5:1625:8 | [post] ...[...] [element 0] | semmle.label | [post] ...[...] [element 0] |
+| array_flow.rb:1625:5:1625:5 | [post] a : [collection] [element 1, element 0] | semmle.label | [post] a : [collection] [element 1, element 0] |
+| array_flow.rb:1625:5:1625:8 | [post] ...[...] : [collection] [element 0] | semmle.label | [post] ...[...] : [collection] [element 0] |
 | array_flow.rb:1625:15:1625:27 | call to source | semmle.label | call to source |
-| array_flow.rb:1626:10:1626:10 | a [element 1, element 0] | semmle.label | a [element 1, element 0] |
-| array_flow.rb:1626:10:1626:10 | a [element, element 0] | semmle.label | a [element, element 0] |
+| array_flow.rb:1626:10:1626:10 | a : [collection] [element 1, element 0] | semmle.label | a : [collection] [element 1, element 0] |
+| array_flow.rb:1626:10:1626:10 | a : [collection] [element, element 0] | semmle.label | a : [collection] [element, element 0] |
 | array_flow.rb:1626:10:1626:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1626:10:1626:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1627:10:1627:10 | a [element, element 0] | semmle.label | a [element, element 0] |
+| array_flow.rb:1627:10:1627:10 | a : [collection] [element, element 0] | semmle.label | a : [collection] [element, element 0] |
 | array_flow.rb:1627:10:1627:13 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | array_flow.rb:1627:10:1627:16 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1632:5:1632:5 | [post] a [element 0] | semmle.label | [post] a [element 0] |
+| array_flow.rb:1632:5:1632:5 | [post] a : [collection] [element 0] | semmle.label | [post] a : [collection] [element 0] |
 | array_flow.rb:1632:12:1632:24 | call to source | semmle.label | call to source |
-| array_flow.rb:1634:5:1634:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1634:5:1634:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:1634:16:1634:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1636:5:1636:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1636:5:1636:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:1636:14:1636:26 | call to source | semmle.label | call to source |
-| array_flow.rb:1638:5:1638:5 | [post] a [element] | semmle.label | [post] a [element] |
+| array_flow.rb:1638:5:1638:5 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | array_flow.rb:1638:16:1638:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1639:10:1639:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1639:10:1639:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1639:10:1639:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1641:10:1641:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1641:10:1641:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1641:10:1641:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
+| array_flow.rb:1641:10:1641:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1641:10:1641:17 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1643:10:1643:10 | a [element 0] | semmle.label | a [element 0] |
-| array_flow.rb:1643:10:1643:10 | a [element] | semmle.label | a [element] |
+| array_flow.rb:1643:10:1643:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
+| array_flow.rb:1643:10:1643:10 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | array_flow.rb:1643:10:1643:15 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1647:5:1647:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1647:9:1647:32 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
+| array_flow.rb:1647:5:1647:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1647:9:1647:32 | ...[...] : Array [element 1] | semmle.label | ...[...] : Array [element 1] |
 | array_flow.rb:1647:18:1647:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1649:10:1649:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1649:10:1649:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:1649:10:1649:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1651:10:1651:10 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1651:10:1651:10 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | array_flow.rb:1651:10:1651:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1668:9:1668:10 | a2 [element 1] | semmle.label | a2 [element 1] |
-| array_flow.rb:1668:14:1668:41 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
+| array_flow.rb:1668:9:1668:10 | a2 : Array [element 1] | semmle.label | a2 : Array [element 1] |
+| array_flow.rb:1668:14:1668:41 | ...[...] : Array [element 1] | semmle.label | ...[...] : Array [element 1] |
 | array_flow.rb:1668:25:1668:37 | call to source | semmle.label | call to source |
-| array_flow.rb:1670:14:1670:15 | a2 [element 1] | semmle.label | a2 [element 1] |
+| array_flow.rb:1670:14:1670:15 | a2 : Array [element 1] | semmle.label | a2 : Array [element 1] |
 | array_flow.rb:1670:14:1670:18 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1672:14:1672:15 | a2 [element 1] | semmle.label | a2 [element 1] |
+| array_flow.rb:1672:14:1672:15 | a2 : Array [element 1] | semmle.label | a2 : Array [element 1] |
 | array_flow.rb:1672:14:1672:18 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1677:5:1677:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1677:9:1677:29 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| array_flow.rb:1677:5:1677:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1677:9:1677:29 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | array_flow.rb:1677:16:1677:28 | call to source | semmle.label | call to source |
-| array_flow.rb:1678:5:1678:5 | b [element] | semmle.label | b [element] |
-| array_flow.rb:1678:9:1678:9 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1678:9:1680:7 | call to map [element] | semmle.label | call to map [element] |
+| array_flow.rb:1678:5:1678:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| array_flow.rb:1678:9:1678:9 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1678:9:1680:7 | call to map : [collection] [element] | semmle.label | call to map : [collection] [element] |
 | array_flow.rb:1678:19:1678:19 | x | semmle.label | x |
 | array_flow.rb:1679:9:1679:9 | x | semmle.label | x |
-| array_flow.rb:1681:10:1681:10 | b [element] | semmle.label | b [element] |
+| array_flow.rb:1681:10:1681:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | array_flow.rb:1681:10:1681:13 | ...[...] | semmle.label | ...[...] |
-| array_flow.rb:1685:5:1685:5 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1685:5:1685:5 | a [element 3] | semmle.label | a [element 3] |
-| array_flow.rb:1685:9:1685:44 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| array_flow.rb:1685:9:1685:44 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| array_flow.rb:1685:5:1685:5 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1685:5:1685:5 | a : Array [element 3] | semmle.label | a : Array [element 3] |
+| array_flow.rb:1685:9:1685:44 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| array_flow.rb:1685:9:1685:44 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | array_flow.rb:1685:16:1685:28 | call to source | semmle.label | call to source |
 | array_flow.rb:1685:31:1685:43 | call to source | semmle.label | call to source |
 | array_flow.rb:1686:11:1686:11 | z | semmle.label | z |
 | array_flow.rb:1686:14:1686:14 | w | semmle.label | w |
-| array_flow.rb:1686:18:1686:18 | a [element 2] | semmle.label | a [element 2] |
-| array_flow.rb:1686:18:1686:18 | a [element 3] | semmle.label | a [element 3] |
+| array_flow.rb:1686:18:1686:18 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| array_flow.rb:1686:18:1686:18 | a : Array [element 3] | semmle.label | a : Array [element 3] |
 | array_flow.rb:1689:10:1689:10 | z | semmle.label | z |
 | array_flow.rb:1690:10:1690:10 | w | semmle.label | w |
-| array_flow.rb:1693:10:1693:14 | *args [element 1] | semmle.label | *args [element 1] |
-| array_flow.rb:1694:5:1694:21 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| array_flow.rb:1694:16:1694:20 | * ... [element 1] | semmle.label | * ... [element 1] |
-| array_flow.rb:1694:17:1694:20 | args [element 1] | semmle.label | args [element 1] |
+| array_flow.rb:1693:10:1693:14 | *args : Array [element 1] | semmle.label | *args : Array [element 1] |
+| array_flow.rb:1694:5:1694:21 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| array_flow.rb:1694:16:1694:20 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| array_flow.rb:1694:17:1694:20 | args : Array [element 1] | semmle.label | args : Array [element 1] |
 | array_flow.rb:1697:13:1697:13 | y | semmle.label | y |
 | array_flow.rb:1699:10:1699:10 | y | semmle.label | y |
-| array_flow.rb:1704:5:1704:5 | a [element 1] | semmle.label | a [element 1] |
-| array_flow.rb:1704:9:1704:31 | call to m141 [element 1] | semmle.label | call to m141 [element 1] |
+| array_flow.rb:1704:5:1704:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| array_flow.rb:1704:9:1704:31 | call to m141 : Array [element 1] | semmle.label | call to m141 : Array [element 1] |
 | array_flow.rb:1704:17:1704:27 | call to source | semmle.label | call to source |
-| array_flow.rb:1705:10:1705:11 | * ... [element 1] | semmle.label | * ... [element 1] |
-| array_flow.rb:1705:11:1705:11 | a [element 1] | semmle.label | a [element 1] |
+| array_flow.rb:1705:10:1705:11 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| array_flow.rb:1705:11:1705:11 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 subpaths
-| array_flow.rb:251:9:251:9 | a [element 2] | array_flow.rb:251:30:251:30 | x | array_flow.rb:253:9:253:25 | call to [] [element 0] | array_flow.rb:251:9:254:7 | call to collect_concat [element] |
-| array_flow.rb:507:9:507:9 | a [element 3] | array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | array_flow.rb:507:9:510:7 | call to filter_map [element] |
-| array_flow.rb:571:9:571:9 | a [element 2] | array_flow.rb:571:24:571:24 | x | array_flow.rb:573:9:573:25 | call to [] [element 0] | array_flow.rb:571:9:574:7 | call to flat_map [element] |
-| array_flow.rb:1678:9:1678:9 | a [element 2] | array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | array_flow.rb:1678:9:1680:7 | call to map [element] |
-| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args [element 1] | array_flow.rb:1694:5:1694:21 | call to [] [element 1] | array_flow.rb:1704:9:1704:31 | call to m141 [element 1] |
+| array_flow.rb:251:9:251:9 | a : Array [element 2] | array_flow.rb:251:30:251:30 | x | array_flow.rb:253:9:253:25 | call to [] : Array [element 0] | array_flow.rb:251:9:254:7 | call to collect_concat : [collection] [element] |
+| array_flow.rb:507:9:507:9 | a : Array [element 3] | array_flow.rb:507:26:507:26 | x | array_flow.rb:509:9:509:9 | x | array_flow.rb:507:9:510:7 | call to filter_map : [collection] [element] |
+| array_flow.rb:571:9:571:9 | a : Array [element 2] | array_flow.rb:571:24:571:24 | x | array_flow.rb:573:9:573:25 | call to [] : Array [element 0] | array_flow.rb:571:9:574:7 | call to flat_map : [collection] [element] |
+| array_flow.rb:1678:9:1678:9 | a : Array [element 2] | array_flow.rb:1678:19:1678:19 | x | array_flow.rb:1679:9:1679:9 | x | array_flow.rb:1678:9:1680:7 | call to map : [collection] [element] |
+| array_flow.rb:1704:17:1704:27 | call to source | array_flow.rb:1693:10:1693:14 | *args : Array [element 1] | array_flow.rb:1694:5:1694:21 | call to [] : Array [element 1] | array_flow.rb:1704:9:1704:31 | call to m141 : Array [element 1] |
 testFailures
 arrayLiteral
 | array_flow.rb:9:9:9:25 | call to [] |

--- a/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
+++ b/ruby/ql/test/library-tests/dataflow/call-sensitivity/call-sensitivity.expected
@@ -28,9 +28,9 @@ edges
 | call_sensitivity.rb:66:20:66:20 | x | call_sensitivity.rb:67:24:67:24 | x | provenance |  |
 | call_sensitivity.rb:67:24:67:24 | x | call_sensitivity.rb:62:18:62:18 | y | provenance |  |
 | call_sensitivity.rb:70:30:70:30 | x | call_sensitivity.rb:71:10:71:10 | x | provenance |  |
-| call_sensitivity.rb:74:18:74:18 | y | call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | provenance |  |
-| call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | call_sensitivity.rb:76:17:76:17 | y | provenance |  |
-| call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | call_sensitivity.rb:76:17:76:17 | y | provenance | heuristic-callback |
+| call_sensitivity.rb:74:18:74:18 | y | call_sensitivity.rb:75:20:77:7 | do ... end : [lambda] [captured y] | provenance |  |
+| call_sensitivity.rb:75:20:77:7 | do ... end : [lambda] [captured y] | call_sensitivity.rb:76:17:76:17 | y | provenance |  |
+| call_sensitivity.rb:75:20:77:7 | do ... end : [lambda] [captured y] | call_sensitivity.rb:76:17:76:17 | y | provenance | heuristic-callback |
 | call_sensitivity.rb:76:17:76:17 | y | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
 | call_sensitivity.rb:80:15:80:15 | x | call_sensitivity.rb:81:18:81:18 | x | provenance |  |
 | call_sensitivity.rb:81:18:81:18 | x | call_sensitivity.rb:50:15:50:15 | x | provenance |  |
@@ -121,7 +121,7 @@ nodes
 | call_sensitivity.rb:70:30:70:30 | x | semmle.label | x |
 | call_sensitivity.rb:71:10:71:10 | x | semmle.label | x |
 | call_sensitivity.rb:74:18:74:18 | y | semmle.label | y |
-| call_sensitivity.rb:75:20:77:7 | do ... end [captured y] | semmle.label | do ... end [captured y] |
+| call_sensitivity.rb:75:20:77:7 | do ... end : [lambda] [captured y] | semmle.label | do ... end : [lambda] [captured y] |
 | call_sensitivity.rb:76:17:76:17 | y | semmle.label | y |
 | call_sensitivity.rb:80:15:80:15 | x | semmle.label | x |
 | call_sensitivity.rb:81:18:81:18 | x | semmle.label | x |

--- a/ruby/ql/test/library-tests/dataflow/erb/erb.expected
+++ b/ruby/ql/test/library-tests/dataflow/erb/erb.expected
@@ -2,110 +2,110 @@ models
 edges
 | main.rb:3:9:3:9 | x | main.rb:4:26:4:26 | x | provenance |  |
 | main.rb:3:13:3:21 | call to source | main.rb:3:9:3:9 | x | provenance |  |
-| main.rb:4:9:4:12 | view [@x] | main.rb:5:16:5:19 | view [@x] | provenance |  |
-| main.rb:4:16:4:27 | call to new [@x] | main.rb:4:9:4:12 | view [@x] | provenance |  |
-| main.rb:4:26:4:26 | x | main.rb:4:16:4:27 | call to new [@x] | provenance |  |
-| main.rb:4:26:4:26 | x | view1.rb:5:20:5:20 | x | provenance |  |
-| main.rb:5:16:5:19 | view [@x] | view1.html.erb:2:5:8:1 | self in view1.html.erb [@x] | provenance |  |
-| main.rb:10:16:10:19 | [post] view [@x] | main.rb:11:9:11:12 | view [@x] | provenance |  |
-| main.rb:11:9:11:12 | view [@x] | view2.rb:2:5:4:7 | self in foo [@x] | provenance |  |
+| main.rb:4:9:4:12 | view : View1 [@x] | main.rb:5:16:5:19 | view : View1 [@x] | provenance |  |
+| main.rb:4:16:4:27 | call to new : View1 [@x] | main.rb:4:9:4:12 | view : View1 [@x] | provenance |  |
+| main.rb:4:26:4:26 | x | main.rb:4:16:4:27 | call to new : View1 [@x] | provenance |  |
+| main.rb:4:26:4:26 | x | view1.rb:2:20:2:20 | x | provenance |  |
+| main.rb:5:16:5:19 | view : View1 [@x] | view1.html.erb:2:5:8:1 | self in view1.html.erb : View1 [@x] | provenance |  |
+| main.rb:10:16:10:19 | [post] view : View2 [@x] | main.rb:11:9:11:12 | view : View2 [@x] | provenance |  |
+| main.rb:11:9:11:12 | view : View2 [@x] | view2.rb:2:5:4:7 | self in foo : View2 [@x] | provenance |  |
 | main.rb:15:9:15:9 | x | main.rb:16:26:16:26 | x | provenance |  |
 | main.rb:15:13:15:21 | call to source | main.rb:15:9:15:9 | x | provenance |  |
-| main.rb:16:9:16:12 | view [@x] | main.rb:17:16:17:19 | view [@x] | provenance |  |
-| main.rb:16:16:16:27 | call to new [@x] | main.rb:16:9:16:12 | view [@x] | provenance |  |
-| main.rb:16:26:16:26 | x | main.rb:16:16:16:27 | call to new [@x] | provenance |  |
+| main.rb:16:9:16:12 | view : View3 [@x] | main.rb:17:16:17:19 | view : View3 [@x] | provenance |  |
+| main.rb:16:16:16:27 | call to new : View3 [@x] | main.rb:16:9:16:12 | view : View3 [@x] | provenance |  |
+| main.rb:16:26:16:26 | x | main.rb:16:16:16:27 | call to new : View3 [@x] | provenance |  |
 | main.rb:16:26:16:26 | x | view3.rb:2:20:2:20 | x | provenance |  |
-| main.rb:17:16:17:19 | view [@x] | view3.html.erb:3:1:4:1 | self in view3.html.erb [@x] | provenance |  |
-| view1.html.erb:2:5:2:9 | self [@x] | view1.rb:9:5:11:7 | self in foo [@x] | provenance |  |
-| view1.html.erb:2:5:8:1 | self in view1.html.erb [@x] | view1.html.erb:2:5:2:9 | self [@x] | provenance |  |
-| view1.html.erb:2:5:8:1 | self in view1.html.erb [@x] | view1.html.erb:7:1:7:5 | self [@x] | provenance |  |
-| view1.html.erb:6:1:6:14 | [post] self [@x] | view1.html.erb:7:1:7:5 | self [@x] | provenance |  |
-| view1.html.erb:6:5:6:13 | call to source | view1.html.erb:6:1:6:14 | [post] self [@x] | provenance |  |
-| view1.html.erb:6:5:6:13 | call to source | view1.rb:13:13:13:13 | x | provenance |  |
-| view1.html.erb:7:1:7:5 | self [@x] | view1.rb:9:5:11:7 | self in foo [@x] | provenance |  |
-| view1.html.erb:7:1:7:5 | self [@x] | view1.rb:9:5:11:7 | self in foo [@x] | provenance |  |
-| view1.rb:5:20:5:20 | x | view1.rb:6:14:6:14 | x | provenance |  |
-| view1.rb:6:14:6:14 | x | view1.rb:6:9:6:10 | [post] self [@x] | provenance |  |
-| view1.rb:9:5:11:7 | self in foo [@x] | view1.rb:10:14:10:15 | self [@x] | provenance |  |
-| view1.rb:10:14:10:15 | self [@x] | view1.rb:10:14:10:15 | @x | provenance |  |
-| view1.rb:13:13:13:13 | x | view1.rb:14:14:14:14 | x | provenance |  |
-| view1.rb:14:9:14:10 | [post] self [@x] | view1.rb:13:5:15:7 | self in set [Return] [@x] | provenance |  |
-| view1.rb:14:14:14:14 | x | view1.rb:14:9:14:10 | [post] self [@x] | provenance |  |
-| view2.html.erb:3:1:3:14 | [post] self [@x] | view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | provenance |  |
-| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | main.rb:10:16:10:19 | [post] view [@x] | provenance |  |
-| view2.html.erb:3:5:3:13 | call to source | view2.html.erb:3:1:3:14 | [post] self [@x] | provenance |  |
+| main.rb:17:16:17:19 | view : View3 [@x] | view3.html.erb:3:1:4:1 | self in view3.html.erb : View3 [@x] | provenance |  |
+| view1.html.erb:2:5:2:9 | self : View1 [@x] | view1.rb:6:5:8:7 | self in foo : View1 [@x] | provenance |  |
+| view1.html.erb:2:5:8:1 | self in view1.html.erb : View1 [@x] | view1.html.erb:2:5:2:9 | self : View1 [@x] | provenance |  |
+| view1.html.erb:2:5:8:1 | self in view1.html.erb : View1 [@x] | view1.html.erb:7:1:7:5 | self : View1 [@x] | provenance |  |
+| view1.html.erb:6:1:6:14 | [post] self : View1 [@x] | view1.html.erb:7:1:7:5 | self : View1 [@x] | provenance |  |
+| view1.html.erb:6:5:6:13 | call to source | view1.html.erb:6:1:6:14 | [post] self : View1 [@x] | provenance |  |
+| view1.html.erb:6:5:6:13 | call to source | view1.rb:10:13:10:13 | x | provenance |  |
+| view1.html.erb:7:1:7:5 | self : View1 [@x] | view1.rb:6:5:8:7 | self in foo : View1 [@x] | provenance |  |
+| view1.html.erb:7:1:7:5 | self : View1 [@x] | view1.rb:6:5:8:7 | self in foo : View1 [@x] | provenance |  |
+| view1.rb:2:20:2:20 | x | view1.rb:3:14:3:14 | x | provenance |  |
+| view1.rb:3:14:3:14 | x | view1.rb:3:9:3:10 | [post] self [@x] | provenance |  |
+| view1.rb:6:5:8:7 | self in foo : View1 [@x] | view1.rb:7:14:7:15 | self : View1 [@x] | provenance |  |
+| view1.rb:7:14:7:15 | self : View1 [@x] | view1.rb:7:14:7:15 | @x | provenance |  |
+| view1.rb:10:13:10:13 | x | view1.rb:11:14:11:14 | x | provenance |  |
+| view1.rb:11:9:11:10 | [post] self [@x] | view1.rb:10:5:12:7 | self in set [Return] : View1 [@x] | provenance |  |
+| view1.rb:11:14:11:14 | x | view1.rb:11:9:11:10 | [post] self [@x] | provenance |  |
+| view2.html.erb:3:1:3:14 | [post] self : View2 [@x] | view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] : View2 [@x] | provenance |  |
+| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] : View2 [@x] | main.rb:10:16:10:19 | [post] view : View2 [@x] | provenance |  |
+| view2.html.erb:3:5:3:13 | call to source | view2.html.erb:3:1:3:14 | [post] self : View2 [@x] | provenance |  |
 | view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | provenance |  |
-| view2.rb:2:5:4:7 | self in foo [@x] | view2.rb:3:14:3:15 | self [@x] | provenance |  |
-| view2.rb:3:14:3:15 | self [@x] | view2.rb:3:14:3:15 | @x | provenance |  |
+| view2.rb:2:5:4:7 | self in foo : View2 [@x] | view2.rb:3:14:3:15 | self : View2 [@x] | provenance |  |
+| view2.rb:3:14:3:15 | self : View2 [@x] | view2.rb:3:14:3:15 | @x | provenance |  |
 | view2.rb:6:13:6:13 | x | view2.rb:7:14:7:14 | x | provenance |  |
-| view2.rb:7:9:7:10 | [post] self [@x] | view2.rb:6:5:8:7 | self in set [Return] [@x] | provenance |  |
+| view2.rb:7:9:7:10 | [post] self [@x] | view2.rb:6:5:8:7 | self in set [Return] : View2 [@x] | provenance |  |
 | view2.rb:7:14:7:14 | x | view2.rb:7:9:7:10 | [post] self [@x] | provenance |  |
-| view3.html.erb:3:1:4:1 | self in view3.html.erb [@x] | view3.html.erb:3:6:3:8 | self [@x] | provenance |  |
-| view3.html.erb:3:6:3:8 | self [@x] | view3.html.erb:3:6:3:8 | call to get | provenance |  |
-| view3.html.erb:3:6:3:8 | self [@x] | view3.rb:6:5:8:7 | self in get [@x] | provenance |  |
+| view3.html.erb:3:1:4:1 | self in view3.html.erb : View3 [@x] | view3.html.erb:3:6:3:8 | self : View3 [@x] | provenance |  |
+| view3.html.erb:3:6:3:8 | self : View3 [@x] | view3.html.erb:3:6:3:8 | call to get | provenance |  |
+| view3.html.erb:3:6:3:8 | self : View3 [@x] | view3.rb:6:5:8:7 | self in get : View3 [@x] | provenance |  |
 | view3.rb:2:20:2:20 | x | view3.rb:3:14:3:14 | x | provenance |  |
 | view3.rb:3:14:3:14 | x | view3.rb:3:9:3:10 | [post] self [@x] | provenance |  |
-| view3.rb:6:5:8:7 | self in get [@x] | view3.rb:7:9:7:10 | self [@x] | provenance |  |
-| view3.rb:7:9:7:10 | self [@x] | view3.rb:7:9:7:10 | @x | provenance |  |
+| view3.rb:6:5:8:7 | self in get : View3 [@x] | view3.rb:7:9:7:10 | self : View3 [@x] | provenance |  |
+| view3.rb:7:9:7:10 | self : View3 [@x] | view3.rb:7:9:7:10 | @x | provenance |  |
 nodes
 | main.rb:3:9:3:9 | x | semmle.label | x |
 | main.rb:3:13:3:21 | call to source | semmle.label | call to source |
-| main.rb:4:9:4:12 | view [@x] | semmle.label | view [@x] |
-| main.rb:4:16:4:27 | call to new [@x] | semmle.label | call to new [@x] |
+| main.rb:4:9:4:12 | view : View1 [@x] | semmle.label | view : View1 [@x] |
+| main.rb:4:16:4:27 | call to new : View1 [@x] | semmle.label | call to new : View1 [@x] |
 | main.rb:4:26:4:26 | x | semmle.label | x |
-| main.rb:5:16:5:19 | view [@x] | semmle.label | view [@x] |
-| main.rb:10:16:10:19 | [post] view [@x] | semmle.label | [post] view [@x] |
-| main.rb:11:9:11:12 | view [@x] | semmle.label | view [@x] |
+| main.rb:5:16:5:19 | view : View1 [@x] | semmle.label | view : View1 [@x] |
+| main.rb:10:16:10:19 | [post] view : View2 [@x] | semmle.label | [post] view : View2 [@x] |
+| main.rb:11:9:11:12 | view : View2 [@x] | semmle.label | view : View2 [@x] |
 | main.rb:15:9:15:9 | x | semmle.label | x |
 | main.rb:15:13:15:21 | call to source | semmle.label | call to source |
-| main.rb:16:9:16:12 | view [@x] | semmle.label | view [@x] |
-| main.rb:16:16:16:27 | call to new [@x] | semmle.label | call to new [@x] |
+| main.rb:16:9:16:12 | view : View3 [@x] | semmle.label | view : View3 [@x] |
+| main.rb:16:16:16:27 | call to new : View3 [@x] | semmle.label | call to new : View3 [@x] |
 | main.rb:16:26:16:26 | x | semmle.label | x |
-| main.rb:17:16:17:19 | view [@x] | semmle.label | view [@x] |
-| view1.html.erb:2:5:2:9 | self [@x] | semmle.label | self [@x] |
-| view1.html.erb:2:5:8:1 | self in view1.html.erb [@x] | semmle.label | self in view1.html.erb [@x] |
-| view1.html.erb:6:1:6:14 | [post] self [@x] | semmle.label | [post] self [@x] |
+| main.rb:17:16:17:19 | view : View3 [@x] | semmle.label | view : View3 [@x] |
+| view1.html.erb:2:5:2:9 | self : View1 [@x] | semmle.label | self : View1 [@x] |
+| view1.html.erb:2:5:8:1 | self in view1.html.erb : View1 [@x] | semmle.label | self in view1.html.erb : View1 [@x] |
+| view1.html.erb:6:1:6:14 | [post] self : View1 [@x] | semmle.label | [post] self : View1 [@x] |
 | view1.html.erb:6:5:6:13 | call to source | semmle.label | call to source |
-| view1.html.erb:7:1:7:5 | self [@x] | semmle.label | self [@x] |
-| view1.html.erb:7:1:7:5 | self [@x] | semmle.label | self [@x] |
-| view1.rb:5:20:5:20 | x | semmle.label | x |
-| view1.rb:6:9:6:10 | [post] self [@x] | semmle.label | [post] self [@x] |
-| view1.rb:6:14:6:14 | x | semmle.label | x |
-| view1.rb:9:5:11:7 | self in foo [@x] | semmle.label | self in foo [@x] |
-| view1.rb:10:14:10:15 | @x | semmle.label | @x |
-| view1.rb:10:14:10:15 | self [@x] | semmle.label | self [@x] |
-| view1.rb:13:5:15:7 | self in set [Return] [@x] | semmle.label | self in set [Return] [@x] |
-| view1.rb:13:13:13:13 | x | semmle.label | x |
-| view1.rb:14:9:14:10 | [post] self [@x] | semmle.label | [post] self [@x] |
-| view1.rb:14:14:14:14 | x | semmle.label | x |
-| view2.html.erb:3:1:3:14 | [post] self [@x] | semmle.label | [post] self [@x] |
-| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] [@x] | semmle.label | self in view2.html.erb [Return] [@x] |
+| view1.html.erb:7:1:7:5 | self : View1 [@x] | semmle.label | self : View1 [@x] |
+| view1.html.erb:7:1:7:5 | self : View1 [@x] | semmle.label | self : View1 [@x] |
+| view1.rb:2:20:2:20 | x | semmle.label | x |
+| view1.rb:3:9:3:10 | [post] self [@x] | semmle.label | [post] self [@x] |
+| view1.rb:3:14:3:14 | x | semmle.label | x |
+| view1.rb:6:5:8:7 | self in foo : View1 [@x] | semmle.label | self in foo : View1 [@x] |
+| view1.rb:7:14:7:15 | @x | semmle.label | @x |
+| view1.rb:7:14:7:15 | self : View1 [@x] | semmle.label | self : View1 [@x] |
+| view1.rb:10:5:12:7 | self in set [Return] : View1 [@x] | semmle.label | self in set [Return] : View1 [@x] |
+| view1.rb:10:13:10:13 | x | semmle.label | x |
+| view1.rb:11:9:11:10 | [post] self [@x] | semmle.label | [post] self [@x] |
+| view1.rb:11:14:11:14 | x | semmle.label | x |
+| view2.html.erb:3:1:3:14 | [post] self : View2 [@x] | semmle.label | [post] self : View2 [@x] |
+| view2.html.erb:3:1:4:1 | self in view2.html.erb [Return] : View2 [@x] | semmle.label | self in view2.html.erb [Return] : View2 [@x] |
 | view2.html.erb:3:5:3:13 | call to source | semmle.label | call to source |
-| view2.rb:2:5:4:7 | self in foo [@x] | semmle.label | self in foo [@x] |
+| view2.rb:2:5:4:7 | self in foo : View2 [@x] | semmle.label | self in foo : View2 [@x] |
 | view2.rb:3:14:3:15 | @x | semmle.label | @x |
-| view2.rb:3:14:3:15 | self [@x] | semmle.label | self [@x] |
-| view2.rb:6:5:8:7 | self in set [Return] [@x] | semmle.label | self in set [Return] [@x] |
+| view2.rb:3:14:3:15 | self : View2 [@x] | semmle.label | self : View2 [@x] |
+| view2.rb:6:5:8:7 | self in set [Return] : View2 [@x] | semmle.label | self in set [Return] : View2 [@x] |
 | view2.rb:6:13:6:13 | x | semmle.label | x |
 | view2.rb:7:9:7:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | view2.rb:7:14:7:14 | x | semmle.label | x |
-| view3.html.erb:3:1:4:1 | self in view3.html.erb [@x] | semmle.label | self in view3.html.erb [@x] |
+| view3.html.erb:3:1:4:1 | self in view3.html.erb : View3 [@x] | semmle.label | self in view3.html.erb : View3 [@x] |
 | view3.html.erb:3:6:3:8 | call to get | semmle.label | call to get |
-| view3.html.erb:3:6:3:8 | self [@x] | semmle.label | self [@x] |
+| view3.html.erb:3:6:3:8 | self : View3 [@x] | semmle.label | self : View3 [@x] |
 | view3.rb:2:20:2:20 | x | semmle.label | x |
 | view3.rb:3:9:3:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | view3.rb:3:14:3:14 | x | semmle.label | x |
-| view3.rb:6:5:8:7 | self in get [@x] | semmle.label | self in get [@x] |
+| view3.rb:6:5:8:7 | self in get : View3 [@x] | semmle.label | self in get : View3 [@x] |
 | view3.rb:7:9:7:10 | @x | semmle.label | @x |
-| view3.rb:7:9:7:10 | self [@x] | semmle.label | self [@x] |
+| view3.rb:7:9:7:10 | self : View3 [@x] | semmle.label | self : View3 [@x] |
 subpaths
-| main.rb:4:26:4:26 | x | view1.rb:5:20:5:20 | x | view1.rb:6:9:6:10 | [post] self [@x] | main.rb:4:16:4:27 | call to new [@x] |
-| main.rb:16:26:16:26 | x | view3.rb:2:20:2:20 | x | view3.rb:3:9:3:10 | [post] self [@x] | main.rb:16:16:16:27 | call to new [@x] |
-| view1.html.erb:6:5:6:13 | call to source | view1.rb:13:13:13:13 | x | view1.rb:13:5:15:7 | self in set [Return] [@x] | view1.html.erb:6:1:6:14 | [post] self [@x] |
-| view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | view2.rb:6:5:8:7 | self in set [Return] [@x] | view2.html.erb:3:1:3:14 | [post] self [@x] |
-| view3.html.erb:3:6:3:8 | self [@x] | view3.rb:6:5:8:7 | self in get [@x] | view3.rb:7:9:7:10 | @x | view3.html.erb:3:6:3:8 | call to get |
+| main.rb:4:26:4:26 | x | view1.rb:2:20:2:20 | x | view1.rb:3:9:3:10 | [post] self [@x] | main.rb:4:16:4:27 | call to new : View1 [@x] |
+| main.rb:16:26:16:26 | x | view3.rb:2:20:2:20 | x | view3.rb:3:9:3:10 | [post] self [@x] | main.rb:16:16:16:27 | call to new : View3 [@x] |
+| view1.html.erb:6:5:6:13 | call to source | view1.rb:10:13:10:13 | x | view1.rb:10:5:12:7 | self in set [Return] : View1 [@x] | view1.html.erb:6:1:6:14 | [post] self : View1 [@x] |
+| view2.html.erb:3:5:3:13 | call to source | view2.rb:6:13:6:13 | x | view2.rb:6:5:8:7 | self in set [Return] : View2 [@x] | view2.html.erb:3:1:3:14 | [post] self : View2 [@x] |
+| view3.html.erb:3:6:3:8 | self : View3 [@x] | view3.rb:6:5:8:7 | self in get : View3 [@x] | view3.rb:7:9:7:10 | @x | view3.html.erb:3:6:3:8 | call to get |
 testFailures
 #select
-| view1.rb:10:14:10:15 | @x | main.rb:3:13:3:21 | call to source | view1.rb:10:14:10:15 | @x | $@ | main.rb:3:13:3:21 | call to source | call to source |
-| view1.rb:10:14:10:15 | @x | view1.html.erb:6:5:6:13 | call to source | view1.rb:10:14:10:15 | @x | $@ | view1.html.erb:6:5:6:13 | call to source | call to source |
+| view1.rb:7:14:7:15 | @x | main.rb:3:13:3:21 | call to source | view1.rb:7:14:7:15 | @x | $@ | main.rb:3:13:3:21 | call to source | call to source |
+| view1.rb:7:14:7:15 | @x | view1.html.erb:6:5:6:13 | call to source | view1.rb:7:14:7:15 | @x | $@ | view1.html.erb:6:5:6:13 | call to source | call to source |
 | view2.rb:3:14:3:15 | @x | view2.html.erb:3:5:3:13 | call to source | view2.rb:3:14:3:15 | @x | $@ | view2.html.erb:3:5:3:13 | call to source | call to source |
 | view3.html.erb:3:6:3:8 | call to get | main.rb:15:13:15:21 | call to source | view3.html.erb:3:6:3:8 | call to get | $@ | main.rb:15:13:15:21 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/erb/main.rb
+++ b/ruby/ql/test/library-tests/dataflow/erb/main.rb
@@ -23,3 +23,6 @@ class App
         render(view)
     end
 end
+
+class ViewComponent::Base
+end

--- a/ruby/ql/test/library-tests/dataflow/erb/view1.rb
+++ b/ruby/ql/test/library-tests/dataflow/erb/view1.rb
@@ -1,6 +1,3 @@
-class ViewComponent::Base
-end
-
 class View1 < ViewComponent::Base
     def initialize(x)
         @x = x

--- a/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
+++ b/ruby/ql/test/library-tests/dataflow/flow-summaries/semantics.expected
@@ -140,14 +140,14 @@ edges
 | semantics.rb:108:5:108:5 | b | semantics.rb:110:27:110:27 | b | provenance |  |
 | semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b | provenance |  |
 | semantics.rb:108:9:108:18 | call to source | semantics.rb:108:5:108:5 | b | provenance |  |
-| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
-| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
-| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [element :foo] | provenance |  |
-| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 [element :foo] | provenance |  |
-| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
-| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
-| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [element :bar] | provenance |  |
-| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 [element :bar] | provenance |  |
+| semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
+| semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | semantics.rb:109:10:109:34 | ...[...] | provenance |  |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | provenance |  |
+| semantics.rb:109:19:109:19 | a | semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | provenance |  |
+| semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
+| semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | semantics.rb:110:10:110:34 | ...[...] | provenance |  |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | provenance |  |
+| semantics.rb:110:27:110:27 | b | semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:116:14:116:14 | a | provenance |  |
 | semantics.rb:114:5:114:5 | a | semantics.rb:119:17:119:17 | a | provenance |  |
@@ -158,26 +158,26 @@ edges
 | semantics.rb:115:5:115:5 | b | semantics.rb:121:17:121:17 | b | provenance |  |
 | semantics.rb:115:9:115:18 | call to source | semantics.rb:115:5:115:5 | b | provenance |  |
 | semantics.rb:115:9:115:18 | call to source | semantics.rb:115:5:115:5 | b | provenance |  |
-| semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:117:16:117:16 | h [element :a] | provenance |  |
-| semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:117:16:117:16 | h [element :a] | provenance |  |
-| semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:121:22:121:22 | h [element :a] | provenance |  |
-| semantics.rb:116:5:116:5 | h [element :a] | semantics.rb:121:22:121:22 | h [element :a] | provenance |  |
-| semantics.rb:116:9:116:22 | call to [] [element :a] | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
-| semantics.rb:116:9:116:22 | call to [] [element :a] | semantics.rb:116:5:116:5 | h [element :a] | provenance |  |
-| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] [element :a] | provenance |  |
-| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] [element :a] | provenance |  |
-| semantics.rb:117:14:117:16 | ** ... [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
-| semantics.rb:117:14:117:16 | ** ... [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
-| semantics.rb:117:16:117:16 | h [element :a] | semantics.rb:117:14:117:16 | ** ... [element :a] | provenance |  |
-| semantics.rb:117:16:117:16 | h [element :a] | semantics.rb:117:14:117:16 | ** ... [element :a] | provenance |  |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semantics.rb:117:16:117:16 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semantics.rb:117:16:117:16 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semantics.rb:121:22:121:22 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semantics.rb:121:22:121:22 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | semantics.rb:116:5:116:5 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | semantics.rb:116:5:116:5 | h : Hash [element :a] | provenance |  |
+| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | provenance |  |
+| semantics.rb:116:14:116:14 | a | semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | provenance |  |
+| semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
+| semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | semantics.rb:117:10:117:17 | call to s16 | provenance |  |
+| semantics.rb:117:16:117:16 | h : Hash [element :a] | semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | provenance |  |
+| semantics.rb:117:16:117:16 | h : Hash [element :a] | semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | provenance |  |
 | semantics.rb:119:17:119:17 | a | semantics.rb:119:10:119:18 | call to s16 | provenance |  |
 | semantics.rb:119:17:119:17 | a | semantics.rb:119:10:119:18 | call to s16 | provenance |  |
 | semantics.rb:121:17:121:17 | b | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
 | semantics.rb:121:17:121:17 | b | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
-| semantics.rb:121:20:121:22 | ** ... [element :a] | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
-| semantics.rb:121:20:121:22 | ** ... [element :a] | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
-| semantics.rb:121:22:121:22 | h [element :a] | semantics.rb:121:20:121:22 | ** ... [element :a] | provenance |  |
-| semantics.rb:121:22:121:22 | h [element :a] | semantics.rb:121:20:121:22 | ** ... [element :a] | provenance |  |
+| semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
+| semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | semantics.rb:121:10:121:23 | call to s16 | provenance |  |
+| semantics.rb:121:22:121:22 | h : Hash [element :a] | semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | provenance |  |
+| semantics.rb:121:22:121:22 | h : Hash [element :a] | semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | provenance |  |
 | semantics.rb:125:5:125:5 | a | semantics.rb:127:14:127:14 | a | provenance |  |
 | semantics.rb:125:5:125:5 | a | semantics.rb:128:14:128:14 | a | provenance |  |
 | semantics.rb:125:5:125:5 | a | semantics.rb:128:14:128:14 | a | provenance |  |
@@ -190,14 +190,14 @@ edges
 | semantics.rb:126:9:126:18 | call to source | semantics.rb:126:5:126:5 | b | provenance |  |
 | semantics.rb:127:14:127:14 | a | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
 | semantics.rb:127:17:127:17 | b | semantics.rb:127:10:127:18 | call to s17 | provenance |  |
-| semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
-| semantics.rb:128:10:128:18 | call to s17 [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
-| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [element 0] | provenance |  |
-| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 [element 0] | provenance |  |
-| semantics.rb:129:10:129:18 | call to s17 [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
-| semantics.rb:129:10:129:18 | call to s17 [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
-| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [element 1] | provenance |  |
-| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 [element 1] | provenance |  |
+| semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
+| semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | semantics.rb:128:10:128:21 | ...[...] | provenance |  |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | provenance |  |
+| semantics.rb:128:14:128:14 | a | semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | provenance |  |
+| semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
+| semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | semantics.rb:129:10:129:21 | ...[...] | provenance |  |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | provenance |  |
+| semantics.rb:129:17:129:17 | b | semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:135:12:135:12 | a | provenance |  |
 | semantics.rb:133:5:133:5 | a | semantics.rb:137:14:137:14 | a | provenance |  |
@@ -208,400 +208,400 @@ edges
 | semantics.rb:134:5:134:5 | b | semantics.rb:135:15:135:15 | b | provenance |  |
 | semantics.rb:134:9:134:18 | call to source | semantics.rb:134:5:134:5 | b | provenance |  |
 | semantics.rb:134:9:134:18 | call to source | semantics.rb:134:5:134:5 | b | provenance |  |
-| semantics.rb:135:5:135:7 | arr [element 0] | semantics.rb:136:15:136:17 | arr [element 0] | provenance |  |
-| semantics.rb:135:5:135:7 | arr [element 0] | semantics.rb:136:15:136:17 | arr [element 0] | provenance |  |
-| semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] | provenance |  |
-| semantics.rb:135:5:135:7 | arr [element 1] | semantics.rb:136:15:136:17 | arr [element 1] | provenance |  |
-| semantics.rb:135:11:135:16 | call to [] [element 0] | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
-| semantics.rb:135:11:135:16 | call to [] [element 0] | semantics.rb:135:5:135:7 | arr [element 0] | provenance |  |
-| semantics.rb:135:11:135:16 | call to [] [element 1] | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
-| semantics.rb:135:11:135:16 | call to [] [element 1] | semantics.rb:135:5:135:7 | arr [element 1] | provenance |  |
-| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] [element 0] | provenance |  |
-| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] [element 0] | provenance |  |
-| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] [element 1] | provenance |  |
-| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] [element 1] | provenance |  |
-| semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
-| semantics.rb:136:14:136:17 | * ... [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
-| semantics.rb:136:14:136:17 | * ... [element 1] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
-| semantics.rb:136:14:136:17 | * ... [element 1] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
-| semantics.rb:136:15:136:17 | arr [element 0] | semantics.rb:136:14:136:17 | * ... [element 0] | provenance |  |
-| semantics.rb:136:15:136:17 | arr [element 0] | semantics.rb:136:14:136:17 | * ... [element 0] | provenance |  |
-| semantics.rb:136:15:136:17 | arr [element 1] | semantics.rb:136:14:136:17 | * ... [element 1] | provenance |  |
-| semantics.rb:136:15:136:17 | arr [element 1] | semantics.rb:136:14:136:17 | * ... [element 1] | provenance |  |
+| semantics.rb:135:5:135:7 | arr : Array [element 0] | semantics.rb:136:15:136:17 | arr : Array [element 0] | provenance |  |
+| semantics.rb:135:5:135:7 | arr : Array [element 0] | semantics.rb:136:15:136:17 | arr : Array [element 0] | provenance |  |
+| semantics.rb:135:5:135:7 | arr : Array [element 1] | semantics.rb:136:15:136:17 | arr : Array [element 1] | provenance |  |
+| semantics.rb:135:5:135:7 | arr : Array [element 1] | semantics.rb:136:15:136:17 | arr : Array [element 1] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 0] | semantics.rb:135:5:135:7 | arr : Array [element 0] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 0] | semantics.rb:135:5:135:7 | arr : Array [element 0] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 1] | semantics.rb:135:5:135:7 | arr : Array [element 1] | provenance |  |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 1] | semantics.rb:135:5:135:7 | arr : Array [element 1] | provenance |  |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] : Array [element 0] | provenance |  |
+| semantics.rb:135:12:135:12 | a | semantics.rb:135:11:135:16 | call to [] : Array [element 0] | provenance |  |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] : Array [element 1] | provenance |  |
+| semantics.rb:135:15:135:15 | b | semantics.rb:135:11:135:16 | call to [] : Array [element 1] | provenance |  |
+| semantics.rb:136:14:136:17 | * ... : Array [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
+| semantics.rb:136:14:136:17 | * ... : Array [element 0] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
+| semantics.rb:136:14:136:17 | * ... : Array [element 1] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
+| semantics.rb:136:14:136:17 | * ... : Array [element 1] | semantics.rb:136:10:136:18 | call to s18 | provenance |  |
+| semantics.rb:136:15:136:17 | arr : Array [element 0] | semantics.rb:136:14:136:17 | * ... : Array [element 0] | provenance |  |
+| semantics.rb:136:15:136:17 | arr : Array [element 0] | semantics.rb:136:14:136:17 | * ... : Array [element 0] | provenance |  |
+| semantics.rb:136:15:136:17 | arr : Array [element 1] | semantics.rb:136:14:136:17 | * ... : Array [element 1] | provenance |  |
+| semantics.rb:136:15:136:17 | arr : Array [element 1] | semantics.rb:136:14:136:17 | * ... : Array [element 1] | provenance |  |
 | semantics.rb:137:14:137:14 | a | semantics.rb:137:10:137:15 | call to s18 | provenance |  |
 | semantics.rb:137:14:137:14 | a | semantics.rb:137:10:137:15 | call to s18 | provenance |  |
-| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h [element] | provenance |  |
-| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h [element] | provenance |  |
+| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:142:5:142:5 | b | semantics.rb:146:5:146:5 | [post] h : [collection] [element] | provenance |  |
 | semantics.rb:142:9:142:18 | call to source | semantics.rb:142:5:142:5 | b | provenance |  |
 | semantics.rb:142:9:142:18 | call to source | semantics.rb:142:5:142:5 | b | provenance |  |
-| semantics.rb:146:5:146:5 | [post] h [element] | semantics.rb:148:14:148:14 | h [element] | provenance |  |
-| semantics.rb:146:5:146:5 | [post] h [element] | semantics.rb:148:14:148:14 | h [element] | provenance |  |
-| semantics.rb:148:14:148:14 | h [element] | semantics.rb:148:10:148:15 | call to s19 | provenance |  |
-| semantics.rb:148:14:148:14 | h [element] | semantics.rb:148:10:148:15 | call to s19 | provenance |  |
+| semantics.rb:146:5:146:5 | [post] h : [collection] [element] | semantics.rb:148:14:148:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:146:5:146:5 | [post] h : [collection] [element] | semantics.rb:148:14:148:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:148:14:148:14 | h : [collection] [element] | semantics.rb:148:10:148:15 | call to s19 | provenance |  |
+| semantics.rb:148:14:148:14 | h : [collection] [element] | semantics.rb:148:10:148:15 | call to s19 | provenance |  |
 | semantics.rb:152:5:152:5 | a | semantics.rb:153:13:153:13 | a | provenance |  |
 | semantics.rb:152:5:152:5 | a | semantics.rb:153:13:153:13 | a | provenance |  |
 | semantics.rb:152:9:152:18 | call to source | semantics.rb:152:5:152:5 | a | provenance |  |
 | semantics.rb:152:9:152:18 | call to source | semantics.rb:152:5:152:5 | a | provenance |  |
-| semantics.rb:153:5:153:5 | x [element] | semantics.rb:154:10:154:10 | x [element] | provenance |  |
-| semantics.rb:153:5:153:5 | x [element] | semantics.rb:154:10:154:10 | x [element] | provenance |  |
-| semantics.rb:153:5:153:5 | x [element] | semantics.rb:155:10:155:10 | x [element] | provenance |  |
-| semantics.rb:153:5:153:5 | x [element] | semantics.rb:155:10:155:10 | x [element] | provenance |  |
-| semantics.rb:153:9:153:14 | call to s20 [element] | semantics.rb:153:5:153:5 | x [element] | provenance |  |
-| semantics.rb:153:9:153:14 | call to s20 [element] | semantics.rb:153:5:153:5 | x [element] | provenance |  |
-| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 [element] | provenance |  |
-| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 [element] | provenance |  |
-| semantics.rb:154:10:154:10 | x [element] | semantics.rb:154:10:154:13 | ...[...] | provenance |  |
-| semantics.rb:154:10:154:10 | x [element] | semantics.rb:154:10:154:13 | ...[...] | provenance |  |
-| semantics.rb:155:10:155:10 | x [element] | semantics.rb:155:10:155:13 | ...[...] | provenance |  |
-| semantics.rb:155:10:155:10 | x [element] | semantics.rb:155:10:155:13 | ...[...] | provenance |  |
-| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h [element 0] | provenance |  |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semantics.rb:154:10:154:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semantics.rb:154:10:154:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semantics.rb:155:10:155:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semantics.rb:155:10:155:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | semantics.rb:153:5:153:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | semantics.rb:153:5:153:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | provenance |  |
+| semantics.rb:153:13:153:13 | a | semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | provenance |  |
+| semantics.rb:154:10:154:10 | x : [collection] [element] | semantics.rb:154:10:154:13 | ...[...] | provenance |  |
+| semantics.rb:154:10:154:10 | x : [collection] [element] | semantics.rb:154:10:154:13 | ...[...] | provenance |  |
+| semantics.rb:155:10:155:10 | x : [collection] [element] | semantics.rb:155:10:155:13 | ...[...] | provenance |  |
+| semantics.rb:155:10:155:10 | x : [collection] [element] | semantics.rb:155:10:155:13 | ...[...] | provenance |  |
+| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:159:5:159:5 | a | semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | provenance |  |
 | semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | a | provenance |  |
 | semantics.rb:159:9:159:18 | call to source | semantics.rb:159:5:159:5 | a | provenance |  |
-| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h [element] | provenance |  |
-| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h [element] | provenance |  |
+| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:160:5:160:5 | b | semantics.rb:164:5:164:5 | [post] h : [collection] [element] | provenance |  |
 | semantics.rb:160:9:160:18 | call to source | semantics.rb:160:5:160:5 | b | provenance |  |
 | semantics.rb:160:9:160:18 | call to source | semantics.rb:160:5:160:5 | b | provenance |  |
-| semantics.rb:163:5:163:5 | [post] h [element 0] | semantics.rb:166:14:166:14 | h [element 0] | provenance |  |
-| semantics.rb:163:5:163:5 | [post] h [element 0] | semantics.rb:166:14:166:14 | h [element 0] | provenance |  |
-| semantics.rb:164:5:164:5 | [post] h [element] | semantics.rb:166:14:166:14 | h [element] | provenance |  |
-| semantics.rb:164:5:164:5 | [post] h [element] | semantics.rb:166:14:166:14 | h [element] | provenance |  |
-| semantics.rb:166:14:166:14 | h [element 0] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
-| semantics.rb:166:14:166:14 | h [element 0] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
-| semantics.rb:166:14:166:14 | h [element] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
-| semantics.rb:166:14:166:14 | h [element] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
+| semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | semantics.rb:166:14:166:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | semantics.rb:166:14:166:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:164:5:164:5 | [post] h : [collection] [element] | semantics.rb:166:14:166:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:164:5:164:5 | [post] h : [collection] [element] | semantics.rb:166:14:166:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:166:14:166:14 | h : [collection] [element 0] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
+| semantics.rb:166:14:166:14 | h : [collection] [element 0] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
+| semantics.rb:166:14:166:14 | h : [collection] [element] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
+| semantics.rb:166:14:166:14 | h : [collection] [element] | semantics.rb:166:10:166:15 | call to s21 | provenance |  |
 | semantics.rb:170:5:170:5 | a | semantics.rb:171:13:171:13 | a | provenance |  |
 | semantics.rb:170:5:170:5 | a | semantics.rb:171:13:171:13 | a | provenance |  |
 | semantics.rb:170:9:170:18 | call to source | semantics.rb:170:5:170:5 | a | provenance |  |
 | semantics.rb:170:9:170:18 | call to source | semantics.rb:170:5:170:5 | a | provenance |  |
-| semantics.rb:171:5:171:5 | x [element] | semantics.rb:172:10:172:10 | x [element] | provenance |  |
-| semantics.rb:171:5:171:5 | x [element] | semantics.rb:172:10:172:10 | x [element] | provenance |  |
-| semantics.rb:171:5:171:5 | x [element] | semantics.rb:173:10:173:10 | x [element] | provenance |  |
-| semantics.rb:171:5:171:5 | x [element] | semantics.rb:173:10:173:10 | x [element] | provenance |  |
-| semantics.rb:171:9:171:14 | call to s22 [element] | semantics.rb:171:5:171:5 | x [element] | provenance |  |
-| semantics.rb:171:9:171:14 | call to s22 [element] | semantics.rb:171:5:171:5 | x [element] | provenance |  |
-| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 [element] | provenance |  |
-| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 [element] | provenance |  |
-| semantics.rb:172:10:172:10 | x [element] | semantics.rb:172:10:172:13 | ...[...] | provenance |  |
-| semantics.rb:172:10:172:10 | x [element] | semantics.rb:172:10:172:13 | ...[...] | provenance |  |
-| semantics.rb:173:10:173:10 | x [element] | semantics.rb:173:10:173:13 | ...[...] | provenance |  |
-| semantics.rb:173:10:173:10 | x [element] | semantics.rb:173:10:173:13 | ...[...] | provenance |  |
-| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h [element 0] | provenance |  |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semantics.rb:172:10:172:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semantics.rb:172:10:172:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semantics.rb:173:10:173:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semantics.rb:173:10:173:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | semantics.rb:171:5:171:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | semantics.rb:171:5:171:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | provenance |  |
+| semantics.rb:171:13:171:13 | a | semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | provenance |  |
+| semantics.rb:172:10:172:10 | x : [collection] [element] | semantics.rb:172:10:172:13 | ...[...] | provenance |  |
+| semantics.rb:172:10:172:10 | x : [collection] [element] | semantics.rb:172:10:172:13 | ...[...] | provenance |  |
+| semantics.rb:173:10:173:10 | x : [collection] [element] | semantics.rb:173:10:173:13 | ...[...] | provenance |  |
+| semantics.rb:173:10:173:10 | x : [collection] [element] | semantics.rb:173:10:173:13 | ...[...] | provenance |  |
+| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:177:5:177:5 | a | semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | provenance |  |
 | semantics.rb:177:9:177:18 | call to source | semantics.rb:177:5:177:5 | a | provenance |  |
 | semantics.rb:177:9:177:18 | call to source | semantics.rb:177:5:177:5 | a | provenance |  |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:5:181:5 | h [element 0] | provenance |  |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semantics.rb:181:5:181:5 | h [element 0] | provenance |  |
-| semantics.rb:181:5:181:5 | [post] h [element 0] | semantics.rb:182:14:182:14 | h [element 0] | provenance |  |
-| semantics.rb:181:5:181:5 | [post] h [element 0] | semantics.rb:182:14:182:14 | h [element 0] | provenance |  |
-| semantics.rb:181:5:181:5 | h [element 0] | semantics.rb:181:5:181:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:181:5:181:5 | h [element 0] | semantics.rb:181:5:181:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:182:14:182:14 | h [element 0] | semantics.rb:182:10:182:15 | call to s23 | provenance |  |
-| semantics.rb:182:14:182:14 | h [element 0] | semantics.rb:182:10:182:15 | call to s23 | provenance |  |
+| semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | semantics.rb:181:5:181:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | semantics.rb:181:5:181:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | semantics.rb:182:14:182:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | semantics.rb:182:14:182:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:181:5:181:5 | h : [collection] [element 0] | semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:181:5:181:5 | h : [collection] [element 0] | semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:182:14:182:14 | h : [collection] [element 0] | semantics.rb:182:10:182:15 | call to s23 | provenance |  |
+| semantics.rb:182:14:182:14 | h : [collection] [element 0] | semantics.rb:182:10:182:15 | call to s23 | provenance |  |
 | semantics.rb:186:5:186:5 | a | semantics.rb:187:13:187:13 | a | provenance |  |
 | semantics.rb:186:5:186:5 | a | semantics.rb:187:13:187:13 | a | provenance |  |
 | semantics.rb:186:9:186:18 | call to source | semantics.rb:186:5:186:5 | a | provenance |  |
 | semantics.rb:186:9:186:18 | call to source | semantics.rb:186:5:186:5 | a | provenance |  |
-| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:188:10:188:10 | x [element 0] | provenance |  |
-| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:188:10:188:10 | x [element 0] | provenance |  |
-| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:190:10:190:10 | x [element 0] | provenance |  |
-| semantics.rb:187:5:187:5 | x [element 0] | semantics.rb:190:10:190:10 | x [element 0] | provenance |  |
-| semantics.rb:187:9:187:14 | call to s24 [element 0] | semantics.rb:187:5:187:5 | x [element 0] | provenance |  |
-| semantics.rb:187:9:187:14 | call to s24 [element 0] | semantics.rb:187:5:187:5 | x [element 0] | provenance |  |
-| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 [element 0] | provenance |  |
-| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 [element 0] | provenance |  |
-| semantics.rb:188:10:188:10 | x [element 0] | semantics.rb:188:10:188:13 | ...[...] | provenance |  |
-| semantics.rb:188:10:188:10 | x [element 0] | semantics.rb:188:10:188:13 | ...[...] | provenance |  |
-| semantics.rb:190:10:190:10 | x [element 0] | semantics.rb:190:10:190:13 | ...[...] | provenance |  |
-| semantics.rb:190:10:190:10 | x [element 0] | semantics.rb:190:10:190:13 | ...[...] | provenance |  |
-| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h [element 0] | provenance |  |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semantics.rb:188:10:188:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semantics.rb:188:10:188:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semantics.rb:190:10:190:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semantics.rb:190:10:190:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | semantics.rb:187:5:187:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | semantics.rb:187:5:187:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | provenance |  |
+| semantics.rb:187:13:187:13 | a | semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | provenance |  |
+| semantics.rb:188:10:188:10 | x : [collection] [element 0] | semantics.rb:188:10:188:13 | ...[...] | provenance |  |
+| semantics.rb:188:10:188:10 | x : [collection] [element 0] | semantics.rb:188:10:188:13 | ...[...] | provenance |  |
+| semantics.rb:190:10:190:10 | x : [collection] [element 0] | semantics.rb:190:10:190:13 | ...[...] | provenance |  |
+| semantics.rb:190:10:190:10 | x : [collection] [element 0] | semantics.rb:190:10:190:13 | ...[...] | provenance |  |
+| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:194:5:194:5 | a | semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | provenance |  |
 | semantics.rb:194:9:194:18 | call to source | semantics.rb:194:5:194:5 | a | provenance |  |
 | semantics.rb:194:9:194:18 | call to source | semantics.rb:194:5:194:5 | a | provenance |  |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:5:198:5 | h [element 0] | provenance |  |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semantics.rb:198:5:198:5 | h [element 0] | provenance |  |
-| semantics.rb:198:5:198:5 | [post] h [element 0] | semantics.rb:199:14:199:14 | h [element 0] | provenance |  |
-| semantics.rb:198:5:198:5 | [post] h [element 0] | semantics.rb:199:14:199:14 | h [element 0] | provenance |  |
-| semantics.rb:198:5:198:5 | h [element 0] | semantics.rb:198:5:198:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:198:5:198:5 | h [element 0] | semantics.rb:198:5:198:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:199:14:199:14 | h [element 0] | semantics.rb:199:10:199:15 | call to s25 | provenance |  |
-| semantics.rb:199:14:199:14 | h [element 0] | semantics.rb:199:10:199:15 | call to s25 | provenance |  |
+| semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | semantics.rb:198:5:198:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | semantics.rb:198:5:198:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | semantics.rb:199:14:199:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | semantics.rb:199:14:199:14 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:198:5:198:5 | h : [collection] [element 0] | semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:198:5:198:5 | h : [collection] [element 0] | semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:199:14:199:14 | h : [collection] [element 0] | semantics.rb:199:10:199:15 | call to s25 | provenance |  |
+| semantics.rb:199:14:199:14 | h : [collection] [element 0] | semantics.rb:199:10:199:15 | call to s25 | provenance |  |
 | semantics.rb:203:5:203:5 | a | semantics.rb:204:13:204:13 | a | provenance |  |
 | semantics.rb:203:5:203:5 | a | semantics.rb:204:13:204:13 | a | provenance |  |
 | semantics.rb:203:9:203:18 | call to source | semantics.rb:203:5:203:5 | a | provenance |  |
 | semantics.rb:203:9:203:18 | call to source | semantics.rb:203:5:203:5 | a | provenance |  |
-| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:205:10:205:10 | x [element 0] | provenance |  |
-| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:205:10:205:10 | x [element 0] | provenance |  |
-| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:207:10:207:10 | x [element 0] | provenance |  |
-| semantics.rb:204:5:204:5 | x [element 0] | semantics.rb:207:10:207:10 | x [element 0] | provenance |  |
-| semantics.rb:204:9:204:14 | call to s26 [element 0] | semantics.rb:204:5:204:5 | x [element 0] | provenance |  |
-| semantics.rb:204:9:204:14 | call to s26 [element 0] | semantics.rb:204:5:204:5 | x [element 0] | provenance |  |
-| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 [element 0] | provenance |  |
-| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 [element 0] | provenance |  |
-| semantics.rb:205:10:205:10 | x [element 0] | semantics.rb:205:10:205:13 | ...[...] | provenance |  |
-| semantics.rb:205:10:205:10 | x [element 0] | semantics.rb:205:10:205:13 | ...[...] | provenance |  |
-| semantics.rb:207:10:207:10 | x [element 0] | semantics.rb:207:10:207:13 | ...[...] | provenance |  |
-| semantics.rb:207:10:207:10 | x [element 0] | semantics.rb:207:10:207:13 | ...[...] | provenance |  |
-| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h [element 1] | provenance |  |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semantics.rb:205:10:205:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semantics.rb:205:10:205:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semantics.rb:207:10:207:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semantics.rb:207:10:207:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | semantics.rb:204:5:204:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | semantics.rb:204:5:204:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | provenance |  |
+| semantics.rb:204:13:204:13 | a | semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | provenance |  |
+| semantics.rb:205:10:205:10 | x : [collection] [element 0] | semantics.rb:205:10:205:13 | ...[...] | provenance |  |
+| semantics.rb:205:10:205:10 | x : [collection] [element 0] | semantics.rb:205:10:205:13 | ...[...] | provenance |  |
+| semantics.rb:207:10:207:10 | x : [collection] [element 0] | semantics.rb:207:10:207:13 | ...[...] | provenance |  |
+| semantics.rb:207:10:207:10 | x : [collection] [element 0] | semantics.rb:207:10:207:13 | ...[...] | provenance |  |
+| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:212:5:212:5 | b | semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | provenance |  |
 | semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | b | provenance |  |
 | semantics.rb:212:9:212:18 | call to source | semantics.rb:212:5:212:5 | b | provenance |  |
-| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h [element 2] | provenance |  |
-| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h [element 2] | provenance |  |
+| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | provenance |  |
+| semantics.rb:213:5:213:5 | c | semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | provenance |  |
 | semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | c | provenance |  |
 | semantics.rb:213:9:213:18 | call to source | semantics.rb:213:5:213:5 | c | provenance |  |
-| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h [element] | provenance |  |
-| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h [element] | provenance |  |
+| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:214:5:214:5 | d | semantics.rb:220:5:220:5 | [post] h : [collection] [element] | provenance |  |
 | semantics.rb:214:9:214:18 | call to source | semantics.rb:214:5:214:5 | d | provenance |  |
 | semantics.rb:214:9:214:18 | call to source | semantics.rb:214:5:214:5 | d | provenance |  |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:219:5:219:5 | h [element 1] | provenance |  |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semantics.rb:219:5:219:5 | h [element 1] | provenance |  |
-| semantics.rb:219:5:219:5 | [post] h [element 1] | semantics.rb:222:14:222:14 | h [element 1] | provenance |  |
-| semantics.rb:219:5:219:5 | [post] h [element 1] | semantics.rb:222:14:222:14 | h [element 1] | provenance |  |
-| semantics.rb:219:5:219:5 | [post] h [element 2] | semantics.rb:222:14:222:14 | h [element 2] | provenance |  |
-| semantics.rb:219:5:219:5 | [post] h [element 2] | semantics.rb:222:14:222:14 | h [element 2] | provenance |  |
-| semantics.rb:219:5:219:5 | h [element 1] | semantics.rb:219:5:219:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:219:5:219:5 | h [element 1] | semantics.rb:219:5:219:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:220:5:220:5 | [post] h [element] | semantics.rb:222:14:222:14 | h [element] | provenance |  |
-| semantics.rb:220:5:220:5 | [post] h [element] | semantics.rb:222:14:222:14 | h [element] | provenance |  |
-| semantics.rb:222:14:222:14 | h [element 1] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
-| semantics.rb:222:14:222:14 | h [element 1] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
-| semantics.rb:222:14:222:14 | h [element 2] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
-| semantics.rb:222:14:222:14 | h [element 2] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
-| semantics.rb:222:14:222:14 | h [element] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
-| semantics.rb:222:14:222:14 | h [element] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | semantics.rb:219:5:219:5 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | semantics.rb:219:5:219:5 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | semantics.rb:222:14:222:14 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | semantics.rb:222:14:222:14 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | semantics.rb:222:14:222:14 | h : [collection] [element 2] | provenance |  |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | semantics.rb:222:14:222:14 | h : [collection] [element 2] | provenance |  |
+| semantics.rb:219:5:219:5 | h : [collection] [element 1] | semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:219:5:219:5 | h : [collection] [element 1] | semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:220:5:220:5 | [post] h : [collection] [element] | semantics.rb:222:14:222:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:220:5:220:5 | [post] h : [collection] [element] | semantics.rb:222:14:222:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element 1] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element 1] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element 2] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element 2] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
+| semantics.rb:222:14:222:14 | h : [collection] [element] | semantics.rb:222:10:222:15 | call to s27 | provenance |  |
 | semantics.rb:226:5:226:5 | a | semantics.rb:227:13:227:13 | a | provenance |  |
 | semantics.rb:226:5:226:5 | a | semantics.rb:227:13:227:13 | a | provenance |  |
 | semantics.rb:226:9:226:18 | call to source | semantics.rb:226:5:226:5 | a | provenance |  |
 | semantics.rb:226:9:226:18 | call to source | semantics.rb:226:5:226:5 | a | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:228:10:228:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:228:10:228:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:229:10:229:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:229:10:229:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:230:10:230:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:230:10:230:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:231:10:231:10 | x [element] | provenance |  |
-| semantics.rb:227:5:227:5 | x [element] | semantics.rb:231:10:231:10 | x [element] | provenance |  |
-| semantics.rb:227:9:227:14 | call to s28 [element] | semantics.rb:227:5:227:5 | x [element] | provenance |  |
-| semantics.rb:227:9:227:14 | call to s28 [element] | semantics.rb:227:5:227:5 | x [element] | provenance |  |
-| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 [element] | provenance |  |
-| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 [element] | provenance |  |
-| semantics.rb:228:10:228:10 | x [element] | semantics.rb:228:10:228:13 | ...[...] | provenance |  |
-| semantics.rb:228:10:228:10 | x [element] | semantics.rb:228:10:228:13 | ...[...] | provenance |  |
-| semantics.rb:229:10:229:10 | x [element] | semantics.rb:229:10:229:13 | ...[...] | provenance |  |
-| semantics.rb:229:10:229:10 | x [element] | semantics.rb:229:10:229:13 | ...[...] | provenance |  |
-| semantics.rb:230:10:230:10 | x [element] | semantics.rb:230:10:230:13 | ...[...] | provenance |  |
-| semantics.rb:230:10:230:10 | x [element] | semantics.rb:230:10:230:13 | ...[...] | provenance |  |
-| semantics.rb:231:10:231:10 | x [element] | semantics.rb:231:10:231:13 | ...[...] | provenance |  |
-| semantics.rb:231:10:231:10 | x [element] | semantics.rb:231:10:231:13 | ...[...] | provenance |  |
-| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h [element 1] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:228:10:228:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:228:10:228:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:229:10:229:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:229:10:229:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:230:10:230:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:230:10:230:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:231:10:231:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semantics.rb:231:10:231:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | semantics.rb:227:5:227:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | semantics.rb:227:5:227:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | provenance |  |
+| semantics.rb:227:13:227:13 | a | semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | provenance |  |
+| semantics.rb:228:10:228:10 | x : [collection] [element] | semantics.rb:228:10:228:13 | ...[...] | provenance |  |
+| semantics.rb:228:10:228:10 | x : [collection] [element] | semantics.rb:228:10:228:13 | ...[...] | provenance |  |
+| semantics.rb:229:10:229:10 | x : [collection] [element] | semantics.rb:229:10:229:13 | ...[...] | provenance |  |
+| semantics.rb:229:10:229:10 | x : [collection] [element] | semantics.rb:229:10:229:13 | ...[...] | provenance |  |
+| semantics.rb:230:10:230:10 | x : [collection] [element] | semantics.rb:230:10:230:13 | ...[...] | provenance |  |
+| semantics.rb:230:10:230:10 | x : [collection] [element] | semantics.rb:230:10:230:13 | ...[...] | provenance |  |
+| semantics.rb:231:10:231:10 | x : [collection] [element] | semantics.rb:231:10:231:13 | ...[...] | provenance |  |
+| semantics.rb:231:10:231:10 | x : [collection] [element] | semantics.rb:231:10:231:13 | ...[...] | provenance |  |
+| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:236:5:236:5 | b | semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | provenance |  |
 | semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | b | provenance |  |
 | semantics.rb:236:9:236:18 | call to source | semantics.rb:236:5:236:5 | b | provenance |  |
-| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h [element 2] | provenance |  |
-| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h [element 2] | provenance |  |
+| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | provenance |  |
+| semantics.rb:237:5:237:5 | c | semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | provenance |  |
 | semantics.rb:237:9:237:18 | call to source | semantics.rb:237:5:237:5 | c | provenance |  |
 | semantics.rb:237:9:237:18 | call to source | semantics.rb:237:5:237:5 | c | provenance |  |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:242:5:242:5 | h [element 1] | provenance |  |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semantics.rb:242:5:242:5 | h [element 1] | provenance |  |
-| semantics.rb:242:5:242:5 | [post] h [element 1] | semantics.rb:245:14:245:14 | h [element 1] | provenance |  |
-| semantics.rb:242:5:242:5 | [post] h [element 1] | semantics.rb:245:14:245:14 | h [element 1] | provenance |  |
-| semantics.rb:242:5:242:5 | [post] h [element 2] | semantics.rb:245:14:245:14 | h [element 2] | provenance |  |
-| semantics.rb:242:5:242:5 | [post] h [element 2] | semantics.rb:245:14:245:14 | h [element 2] | provenance |  |
-| semantics.rb:242:5:242:5 | h [element 1] | semantics.rb:242:5:242:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:242:5:242:5 | h [element 1] | semantics.rb:242:5:242:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:245:14:245:14 | h [element 1] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
-| semantics.rb:245:14:245:14 | h [element 1] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
-| semantics.rb:245:14:245:14 | h [element 2] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
-| semantics.rb:245:14:245:14 | h [element 2] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
+| semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | semantics.rb:242:5:242:5 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | semantics.rb:242:5:242:5 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | semantics.rb:245:14:245:14 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | semantics.rb:245:14:245:14 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | semantics.rb:245:14:245:14 | h : [collection] [element 2] | provenance |  |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | semantics.rb:245:14:245:14 | h : [collection] [element 2] | provenance |  |
+| semantics.rb:242:5:242:5 | h : [collection] [element 1] | semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:242:5:242:5 | h : [collection] [element 1] | semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:245:14:245:14 | h : [collection] [element 1] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
+| semantics.rb:245:14:245:14 | h : [collection] [element 1] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
+| semantics.rb:245:14:245:14 | h : [collection] [element 2] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
+| semantics.rb:245:14:245:14 | h : [collection] [element 2] | semantics.rb:245:10:245:15 | call to s29 | provenance |  |
 | semantics.rb:249:5:249:5 | a | semantics.rb:250:13:250:13 | a | provenance |  |
 | semantics.rb:249:5:249:5 | a | semantics.rb:250:13:250:13 | a | provenance |  |
 | semantics.rb:249:9:249:18 | call to source | semantics.rb:249:5:249:5 | a | provenance |  |
 | semantics.rb:249:9:249:18 | call to source | semantics.rb:249:5:249:5 | a | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:251:10:251:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:251:10:251:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:252:10:252:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:252:10:252:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:253:10:253:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:253:10:253:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:254:10:254:10 | x [element] | provenance |  |
-| semantics.rb:250:5:250:5 | x [element] | semantics.rb:254:10:254:10 | x [element] | provenance |  |
-| semantics.rb:250:9:250:14 | call to s30 [element] | semantics.rb:250:5:250:5 | x [element] | provenance |  |
-| semantics.rb:250:9:250:14 | call to s30 [element] | semantics.rb:250:5:250:5 | x [element] | provenance |  |
-| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 [element] | provenance |  |
-| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 [element] | provenance |  |
-| semantics.rb:251:10:251:10 | x [element] | semantics.rb:251:10:251:13 | ...[...] | provenance |  |
-| semantics.rb:251:10:251:10 | x [element] | semantics.rb:251:10:251:13 | ...[...] | provenance |  |
-| semantics.rb:252:10:252:10 | x [element] | semantics.rb:252:10:252:13 | ...[...] | provenance |  |
-| semantics.rb:252:10:252:10 | x [element] | semantics.rb:252:10:252:13 | ...[...] | provenance |  |
-| semantics.rb:253:10:253:10 | x [element] | semantics.rb:253:10:253:13 | ...[...] | provenance |  |
-| semantics.rb:253:10:253:10 | x [element] | semantics.rb:253:10:253:13 | ...[...] | provenance |  |
-| semantics.rb:254:10:254:10 | x [element] | semantics.rb:254:10:254:13 | ...[...] | provenance |  |
-| semantics.rb:254:10:254:10 | x [element] | semantics.rb:254:10:254:13 | ...[...] | provenance |  |
-| semantics.rb:258:5:258:5 | [post] h [element :foo] | semantics.rb:259:5:259:5 | h [element :foo] | provenance |  |
-| semantics.rb:258:5:258:5 | [post] h [element :foo] | semantics.rb:259:5:259:5 | h [element :foo] | provenance |  |
-| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:260:5:260:5 | h [element :foo] | provenance |  |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semantics.rb:260:5:260:5 | h [element :foo] | provenance |  |
-| semantics.rb:259:5:259:5 | h [element :foo] | semantics.rb:259:5:259:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:259:5:259:5 | h [element :foo] | semantics.rb:259:5:259:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:260:5:260:5 | [post] h [element :foo] | semantics.rb:263:14:263:14 | h [element :foo] | provenance |  |
-| semantics.rb:260:5:260:5 | [post] h [element :foo] | semantics.rb:263:14:263:14 | h [element :foo] | provenance |  |
-| semantics.rb:260:5:260:5 | h [element :foo] | semantics.rb:260:5:260:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:260:5:260:5 | h [element :foo] | semantics.rb:260:5:260:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:261:5:261:5 | [post] h [element] | semantics.rb:263:14:263:14 | h [element] | provenance |  |
-| semantics.rb:261:5:261:5 | [post] h [element] | semantics.rb:263:14:263:14 | h [element] | provenance |  |
-| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h [element] | provenance |  |
-| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h [element] | provenance |  |
-| semantics.rb:263:14:263:14 | h [element :foo] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
-| semantics.rb:263:14:263:14 | h [element :foo] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
-| semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
-| semantics.rb:263:14:263:14 | h [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
-| semantics.rb:267:5:267:5 | [post] h [element :foo] | semantics.rb:268:5:268:5 | h [element :foo] | provenance |  |
-| semantics.rb:267:5:267:5 | [post] h [element :foo] | semantics.rb:268:5:268:5 | h [element :foo] | provenance |  |
-| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:268:5:268:5 | [post] h [element :foo] | semantics.rb:269:5:269:5 | h [element :foo] | provenance |  |
-| semantics.rb:268:5:268:5 | [post] h [element :foo] | semantics.rb:269:5:269:5 | h [element :foo] | provenance |  |
-| semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] | provenance |  |
-| semantics.rb:268:5:268:5 | [post] h [element foo] | semantics.rb:269:5:269:5 | h [element foo] | provenance |  |
-| semantics.rb:268:5:268:5 | h [element :foo] | semantics.rb:268:5:268:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:268:5:268:5 | h [element :foo] | semantics.rb:268:5:268:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:269:5:269:5 | [post] h [element :foo] | semantics.rb:270:5:270:5 | h [element :foo] | provenance |  |
-| semantics.rb:269:5:269:5 | [post] h [element :foo] | semantics.rb:270:5:270:5 | h [element :foo] | provenance |  |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] | provenance |  |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semantics.rb:270:5:270:5 | h [element foo] | provenance |  |
-| semantics.rb:269:5:269:5 | h [element :foo] | semantics.rb:269:5:269:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:269:5:269:5 | h [element :foo] | semantics.rb:269:5:269:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:269:5:269:5 | h [element foo] | semantics.rb:269:5:269:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:270:5:270:5 | [post] h [element :foo] | semantics.rb:273:14:273:14 | h [element :foo] | provenance |  |
-| semantics.rb:270:5:270:5 | [post] h [element :foo] | semantics.rb:273:14:273:14 | h [element :foo] | provenance |  |
-| semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] | provenance |  |
-| semantics.rb:270:5:270:5 | [post] h [element foo] | semantics.rb:273:14:273:14 | h [element foo] | provenance |  |
-| semantics.rb:270:5:270:5 | h [element :foo] | semantics.rb:270:5:270:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:270:5:270:5 | h [element :foo] | semantics.rb:270:5:270:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:270:5:270:5 | h [element foo] | semantics.rb:270:5:270:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] | provenance |  |
-| semantics.rb:271:5:271:5 | [post] h [element] | semantics.rb:273:14:273:14 | h [element] | provenance |  |
-| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] | provenance |  |
-| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h [element] | provenance |  |
-| semantics.rb:273:14:273:14 | h [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:273:14:273:14 | h [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:273:14:273:14 | h [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:273:14:273:14 | h [element] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:273:14:273:14 | h [element] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
-| semantics.rb:281:5:281:5 | [post] h [element] | semantics.rb:282:5:282:5 | h [element] | provenance |  |
-| semantics.rb:281:5:281:5 | [post] h [element] | semantics.rb:282:5:282:5 | h [element] | provenance |  |
-| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h [element] | provenance |  |
-| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h [element] | provenance |  |
-| semantics.rb:282:5:282:5 | [post] h [element nil] | semantics.rb:283:5:283:5 | h [element nil] | provenance |  |
-| semantics.rb:282:5:282:5 | [post] h [element nil] | semantics.rb:283:5:283:5 | h [element nil] | provenance |  |
-| semantics.rb:282:5:282:5 | [post] h [element] | semantics.rb:283:5:283:5 | h [element] | provenance |  |
-| semantics.rb:282:5:282:5 | [post] h [element] | semantics.rb:283:5:283:5 | h [element] | provenance |  |
-| semantics.rb:282:5:282:5 | h [element] | semantics.rb:282:5:282:5 | [post] h [element] | provenance |  |
-| semantics.rb:282:5:282:5 | h [element] | semantics.rb:282:5:282:5 | [post] h [element] | provenance |  |
-| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:284:5:284:5 | h [element nil] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semantics.rb:284:5:284:5 | h [element nil] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:284:5:284:5 | h [element true] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semantics.rb:284:5:284:5 | h [element true] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:284:5:284:5 | h [element] | provenance |  |
-| semantics.rb:283:5:283:5 | [post] h [element] | semantics.rb:284:5:284:5 | h [element] | provenance |  |
-| semantics.rb:283:5:283:5 | h [element nil] | semantics.rb:283:5:283:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:283:5:283:5 | h [element nil] | semantics.rb:283:5:283:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:283:5:283:5 | h [element] | semantics.rb:283:5:283:5 | [post] h [element] | provenance |  |
-| semantics.rb:283:5:283:5 | h [element] | semantics.rb:283:5:283:5 | [post] h [element] | provenance |  |
-| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h [element true] | provenance |  |
-| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h [element true] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element false] | semantics.rb:286:14:286:14 | h [element false] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element false] | semantics.rb:286:14:286:14 | h [element false] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element nil] | semantics.rb:286:14:286:14 | h [element nil] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element nil] | semantics.rb:286:14:286:14 | h [element nil] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element true] | semantics.rb:286:14:286:14 | h [element true] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element true] | semantics.rb:286:14:286:14 | h [element true] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element] | semantics.rb:286:14:286:14 | h [element] | provenance |  |
-| semantics.rb:284:5:284:5 | [post] h [element] | semantics.rb:286:14:286:14 | h [element] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element nil] | semantics.rb:284:5:284:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element nil] | semantics.rb:284:5:284:5 | [post] h [element nil] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element true] | semantics.rb:284:5:284:5 | [post] h [element true] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element true] | semantics.rb:284:5:284:5 | [post] h [element true] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element] | semantics.rb:284:5:284:5 | [post] h [element] | provenance |  |
-| semantics.rb:284:5:284:5 | h [element] | semantics.rb:284:5:284:5 | [post] h [element] | provenance |  |
-| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h [element false] | provenance |  |
-| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h [element false] | provenance |  |
-| semantics.rb:286:14:286:14 | h [element false] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element false] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element nil] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element nil] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element true] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element true] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:286:14:286:14 | h [element] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
-| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:291:10:291:10 | x [element :foo] | provenance |  |
-| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:291:10:291:10 | x [element :foo] | provenance |  |
-| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:293:10:293:10 | x [element :foo] | provenance |  |
-| semantics.rb:290:5:290:5 | x [element :foo] | semantics.rb:293:10:293:10 | x [element :foo] | provenance |  |
-| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semantics.rb:290:5:290:5 | x [element :foo] | provenance |  |
-| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semantics.rb:290:5:290:5 | x [element :foo] | provenance |  |
-| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 [element :foo] | provenance |  |
-| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 [element :foo] | provenance |  |
-| semantics.rb:291:10:291:10 | x [element :foo] | semantics.rb:291:10:291:16 | ...[...] | provenance |  |
-| semantics.rb:291:10:291:10 | x [element :foo] | semantics.rb:291:10:291:16 | ...[...] | provenance |  |
-| semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
-| semantics.rb:293:10:293:10 | x [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:298:10:298:10 | x [element foo] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:299:10:299:10 | x [element foo] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:301:10:301:10 | x [element foo] | provenance |  |
-| semantics.rb:297:5:297:5 | x [element foo] | semantics.rb:301:10:301:10 | x [element foo] | provenance |  |
-| semantics.rb:297:9:297:24 | call to s36 [element foo] | semantics.rb:297:5:297:5 | x [element foo] | provenance |  |
-| semantics.rb:297:9:297:24 | call to s36 [element foo] | semantics.rb:297:5:297:5 | x [element foo] | provenance |  |
-| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] | provenance |  |
-| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 [element foo] | provenance |  |
-| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
-| semantics.rb:298:10:298:10 | x [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
-| semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
-| semantics.rb:299:10:299:10 | x [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
-| semantics.rb:301:10:301:10 | x [element foo] | semantics.rb:301:10:301:13 | ...[...] | provenance |  |
-| semantics.rb:301:10:301:10 | x [element foo] | semantics.rb:301:10:301:13 | ...[...] | provenance |  |
-| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:307:10:307:10 | x [element true] | provenance |  |
-| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:307:10:307:10 | x [element true] | provenance |  |
-| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:309:10:309:10 | x [element true] | provenance |  |
-| semantics.rb:305:5:305:5 | x [element true] | semantics.rb:309:10:309:10 | x [element true] | provenance |  |
-| semantics.rb:305:9:305:24 | call to s37 [element true] | semantics.rb:305:5:305:5 | x [element true] | provenance |  |
-| semantics.rb:305:9:305:24 | call to s37 [element true] | semantics.rb:305:5:305:5 | x [element true] | provenance |  |
-| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 [element true] | provenance |  |
-| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 [element true] | provenance |  |
-| semantics.rb:307:10:307:10 | x [element true] | semantics.rb:307:10:307:16 | ...[...] | provenance |  |
-| semantics.rb:307:10:307:10 | x [element true] | semantics.rb:307:10:307:16 | ...[...] | provenance |  |
-| semantics.rb:309:10:309:10 | x [element true] | semantics.rb:309:10:309:13 | ...[...] | provenance |  |
-| semantics.rb:309:10:309:10 | x [element true] | semantics.rb:309:10:309:13 | ...[...] | provenance |  |
-| semantics.rb:313:5:313:5 | [post] h [element foo] | semantics.rb:316:14:316:14 | h [element foo] | provenance |  |
-| semantics.rb:313:5:313:5 | [post] h [element foo] | semantics.rb:316:14:316:14 | h [element foo] | provenance |  |
-| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h [element foo] | provenance |  |
-| semantics.rb:316:14:316:14 | h [element foo] | semantics.rb:316:10:316:15 | call to s38 | provenance |  |
-| semantics.rb:316:14:316:14 | h [element foo] | semantics.rb:316:10:316:15 | call to s38 | provenance |  |
-| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] | provenance |  |
-| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:322:10:322:10 | x [element :foo] | provenance |  |
-| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:323:10:323:10 | x [element :foo] | provenance |  |
-| semantics.rb:320:5:320:5 | x [element :foo] | semantics.rb:323:10:323:10 | x [element :foo] | provenance |  |
-| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semantics.rb:320:5:320:5 | x [element :foo] | provenance |  |
-| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semantics.rb:320:5:320:5 | x [element :foo] | provenance |  |
-| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 [element :foo] | provenance |  |
-| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 [element :foo] | provenance |  |
-| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:16 | ...[...] | provenance |  |
-| semantics.rb:322:10:322:10 | x [element :foo] | semantics.rb:322:10:322:16 | ...[...] | provenance |  |
-| semantics.rb:323:10:323:10 | x [element :foo] | semantics.rb:323:10:323:13 | ...[...] | provenance |  |
-| semantics.rb:323:10:323:10 | x [element :foo] | semantics.rb:323:10:323:13 | ...[...] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:251:10:251:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:251:10:251:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:252:10:252:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:252:10:252:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:253:10:253:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:253:10:253:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:254:10:254:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semantics.rb:254:10:254:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | semantics.rb:250:5:250:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | semantics.rb:250:5:250:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | provenance |  |
+| semantics.rb:250:13:250:13 | a | semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | provenance |  |
+| semantics.rb:251:10:251:10 | x : [collection] [element] | semantics.rb:251:10:251:13 | ...[...] | provenance |  |
+| semantics.rb:251:10:251:10 | x : [collection] [element] | semantics.rb:251:10:251:13 | ...[...] | provenance |  |
+| semantics.rb:252:10:252:10 | x : [collection] [element] | semantics.rb:252:10:252:13 | ...[...] | provenance |  |
+| semantics.rb:252:10:252:10 | x : [collection] [element] | semantics.rb:252:10:252:13 | ...[...] | provenance |  |
+| semantics.rb:253:10:253:10 | x : [collection] [element] | semantics.rb:253:10:253:13 | ...[...] | provenance |  |
+| semantics.rb:253:10:253:10 | x : [collection] [element] | semantics.rb:253:10:253:13 | ...[...] | provenance |  |
+| semantics.rb:254:10:254:10 | x : [collection] [element] | semantics.rb:254:10:254:13 | ...[...] | provenance |  |
+| semantics.rb:254:10:254:10 | x : [collection] [element] | semantics.rb:254:10:254:13 | ...[...] | provenance |  |
+| semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | semantics.rb:259:5:259:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | semantics.rb:259:5:259:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:258:15:258:25 | call to source | semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | semantics.rb:260:5:260:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | semantics.rb:260:5:260:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:259:5:259:5 | h : [collection] [element :foo] | semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:259:5:259:5 | h : [collection] [element :foo] | semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | semantics.rb:263:14:263:14 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | semantics.rb:263:14:263:14 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:260:5:260:5 | h : [collection] [element :foo] | semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:260:5:260:5 | h : [collection] [element :foo] | semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:261:5:261:5 | [post] h : [collection] [element] | semantics.rb:263:14:263:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:261:5:261:5 | [post] h : [collection] [element] | semantics.rb:263:14:263:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:261:12:261:22 | call to source | semantics.rb:261:5:261:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:263:14:263:14 | h : [collection] [element :foo] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
+| semantics.rb:263:14:263:14 | h : [collection] [element :foo] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
+| semantics.rb:263:14:263:14 | h : [collection] [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
+| semantics.rb:263:14:263:14 | h : [collection] [element] | semantics.rb:263:10:263:15 | call to s31 | provenance |  |
+| semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | semantics.rb:268:5:268:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | semantics.rb:268:5:268:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:267:15:267:25 | call to source | semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | semantics.rb:269:5:269:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | semantics.rb:269:5:269:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | semantics.rb:269:5:269:5 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | semantics.rb:269:5:269:5 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:268:5:268:5 | h : [collection] [element :foo] | semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:268:5:268:5 | h : [collection] [element :foo] | semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:268:16:268:26 | call to source | semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | semantics.rb:270:5:270:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | semantics.rb:270:5:270:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | semantics.rb:270:5:270:5 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | semantics.rb:270:5:270:5 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h : [collection] [element :foo] | semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h : [collection] [element :foo] | semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h : [collection] [element foo] | semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:269:5:269:5 | h : [collection] [element foo] | semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | semantics.rb:273:14:273:14 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | semantics.rb:273:14:273:14 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | semantics.rb:273:14:273:14 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | semantics.rb:273:14:273:14 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h : [collection] [element :foo] | semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h : [collection] [element :foo] | semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h : [collection] [element foo] | semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:270:5:270:5 | h : [collection] [element foo] | semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:271:5:271:5 | [post] h : [collection] [element] | semantics.rb:273:14:273:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:271:5:271:5 | [post] h : [collection] [element] | semantics.rb:273:14:273:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:271:12:271:22 | call to source | semantics.rb:271:5:271:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element :foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element foo] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:273:14:273:14 | h : [collection] [element] | semantics.rb:273:10:273:15 | call to s32 | provenance |  |
+| semantics.rb:281:5:281:5 | [post] h : [collection] [element] | semantics.rb:282:5:282:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:281:5:281:5 | [post] h : [collection] [element] | semantics.rb:282:5:282:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:281:12:281:22 | call to source | semantics.rb:281:5:281:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | semantics.rb:283:5:283:5 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | semantics.rb:283:5:283:5 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element] | semantics.rb:283:5:283:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element] | semantics.rb:283:5:283:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:282:5:282:5 | h : [collection] [element] | semantics.rb:282:5:282:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:282:5:282:5 | h : [collection] [element] | semantics.rb:282:5:282:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:282:14:282:24 | call to source | semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | semantics.rb:284:5:284:5 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | semantics.rb:284:5:284:5 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | semantics.rb:284:5:284:5 | h : [collection] [element true] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | semantics.rb:284:5:284:5 | h : [collection] [element true] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element] | semantics.rb:284:5:284:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element] | semantics.rb:284:5:284:5 | h : [collection] [element] | provenance |  |
+| semantics.rb:283:5:283:5 | h : [collection] [element nil] | semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:283:5:283:5 | h : [collection] [element nil] | semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:283:5:283:5 | h : [collection] [element] | semantics.rb:283:5:283:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:283:5:283:5 | h : [collection] [element] | semantics.rb:283:5:283:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | provenance |  |
+| semantics.rb:283:15:283:25 | call to source | semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | semantics.rb:286:14:286:14 | h : [collection] [element false] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | semantics.rb:286:14:286:14 | h : [collection] [element false] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | semantics.rb:286:14:286:14 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | semantics.rb:286:14:286:14 | h : [collection] [element nil] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | semantics.rb:286:14:286:14 | h : [collection] [element true] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | semantics.rb:286:14:286:14 | h : [collection] [element true] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element] | semantics.rb:286:14:286:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element] | semantics.rb:286:14:286:14 | h : [collection] [element] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element nil] | semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element nil] | semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element true] | semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element true] | semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element] | semantics.rb:284:5:284:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:284:5:284:5 | h : [collection] [element] | semantics.rb:284:5:284:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | provenance |  |
+| semantics.rb:284:16:284:26 | call to source | semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element false] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element false] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element nil] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element nil] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element true] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element true] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:286:14:286:14 | h : [collection] [element] | semantics.rb:286:10:286:15 | call to s33 | provenance |  |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semantics.rb:291:10:291:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semantics.rb:291:10:291:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semantics.rb:293:10:293:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semantics.rb:293:10:293:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | semantics.rb:290:5:290:5 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | semantics.rb:290:5:290:5 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | provenance |  |
+| semantics.rb:290:13:290:23 | call to source | semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | provenance |  |
+| semantics.rb:291:10:291:10 | x : [collection] [element :foo] | semantics.rb:291:10:291:16 | ...[...] | provenance |  |
+| semantics.rb:291:10:291:10 | x : [collection] [element :foo] | semantics.rb:291:10:291:16 | ...[...] | provenance |  |
+| semantics.rb:293:10:293:10 | x : [collection] [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
+| semantics.rb:293:10:293:10 | x : [collection] [element :foo] | semantics.rb:293:10:293:13 | ...[...] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:298:10:298:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:298:10:298:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:299:10:299:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:299:10:299:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:301:10:301:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semantics.rb:301:10:301:10 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | semantics.rb:297:5:297:5 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | semantics.rb:297:5:297:5 | x : [collection] [element foo] | provenance |  |
+| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | provenance |  |
+| semantics.rb:297:13:297:23 | call to source | semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | provenance |  |
+| semantics.rb:298:10:298:10 | x : [collection] [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
+| semantics.rb:298:10:298:10 | x : [collection] [element foo] | semantics.rb:298:10:298:16 | ...[...] | provenance |  |
+| semantics.rb:299:10:299:10 | x : [collection] [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
+| semantics.rb:299:10:299:10 | x : [collection] [element foo] | semantics.rb:299:10:299:17 | ...[...] | provenance |  |
+| semantics.rb:301:10:301:10 | x : [collection] [element foo] | semantics.rb:301:10:301:13 | ...[...] | provenance |  |
+| semantics.rb:301:10:301:10 | x : [collection] [element foo] | semantics.rb:301:10:301:13 | ...[...] | provenance |  |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semantics.rb:307:10:307:10 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semantics.rb:307:10:307:10 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semantics.rb:309:10:309:10 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semantics.rb:309:10:309:10 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | semantics.rb:305:5:305:5 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | semantics.rb:305:5:305:5 | x : [collection] [element true] | provenance |  |
+| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | provenance |  |
+| semantics.rb:305:13:305:23 | call to source | semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | provenance |  |
+| semantics.rb:307:10:307:10 | x : [collection] [element true] | semantics.rb:307:10:307:16 | ...[...] | provenance |  |
+| semantics.rb:307:10:307:10 | x : [collection] [element true] | semantics.rb:307:10:307:16 | ...[...] | provenance |  |
+| semantics.rb:309:10:309:10 | x : [collection] [element true] | semantics.rb:309:10:309:13 | ...[...] | provenance |  |
+| semantics.rb:309:10:309:10 | x : [collection] [element true] | semantics.rb:309:10:309:13 | ...[...] | provenance |  |
+| semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | semantics.rb:316:14:316:14 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | semantics.rb:316:14:316:14 | h : [collection] [element foo] | provenance |  |
+| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:313:16:313:26 | call to source | semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | provenance |  |
+| semantics.rb:316:14:316:14 | h : [collection] [element foo] | semantics.rb:316:10:316:15 | call to s38 | provenance |  |
+| semantics.rb:316:14:316:14 | h : [collection] [element foo] | semantics.rb:316:10:316:15 | call to s38 | provenance |  |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semantics.rb:322:10:322:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semantics.rb:322:10:322:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semantics.rb:323:10:323:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semantics.rb:323:10:323:10 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | semantics.rb:320:5:320:5 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | semantics.rb:320:5:320:5 | x : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | provenance |  |
+| semantics.rb:320:13:320:23 | call to source | semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | provenance |  |
+| semantics.rb:322:10:322:10 | x : [collection] [element :foo] | semantics.rb:322:10:322:16 | ...[...] | provenance |  |
+| semantics.rb:322:10:322:10 | x : [collection] [element :foo] | semantics.rb:322:10:322:16 | ...[...] | provenance |  |
+| semantics.rb:323:10:323:10 | x : [collection] [element :foo] | semantics.rb:323:10:323:13 | ...[...] | provenance |  |
+| semantics.rb:323:10:323:10 | x : [collection] [element :foo] | semantics.rb:323:10:323:13 | ...[...] | provenance |  |
 | semantics.rb:328:5:328:5 | [post] x [@foo] | semantics.rb:330:14:330:14 | x [@foo] | provenance |  |
 | semantics.rb:328:5:328:5 | [post] x [@foo] | semantics.rb:330:14:330:14 | x [@foo] | provenance |  |
 | semantics.rb:328:13:328:23 | call to source | semantics.rb:328:5:328:5 | [post] x [@foo] | provenance |  |
@@ -616,500 +616,500 @@ edges
 | semantics.rb:334:13:334:23 | call to source | semantics.rb:334:9:334:24 | call to s41 [@foo] | provenance |  |
 | semantics.rb:335:10:335:10 | x [@foo] | semantics.rb:335:10:335:14 | call to foo | provenance |  |
 | semantics.rb:335:10:335:10 | x [@foo] | semantics.rb:335:10:335:14 | call to foo | provenance |  |
-| semantics.rb:340:5:340:5 | [post] h [element 0] | semantics.rb:343:13:343:13 | h [element 0] | provenance |  |
-| semantics.rb:340:5:340:5 | [post] h [element 0] | semantics.rb:343:13:343:13 | h [element 0] | provenance |  |
-| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:341:5:341:5 | [post] h [element] | semantics.rb:343:13:343:13 | h [element] | provenance |  |
-| semantics.rb:341:5:341:5 | [post] h [element] | semantics.rb:343:13:343:13 | h [element] | provenance |  |
-| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h [element] | provenance |  |
-| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:345:10:345:10 | x [element 0] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:345:10:345:10 | x [element 0] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:347:10:347:10 | x [element 0] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element 0] | semantics.rb:347:10:347:10 | x [element 0] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:345:10:345:10 | x [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:345:10:345:10 | x [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:346:10:346:10 | x [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:346:10:346:10 | x [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:347:10:347:10 | x [element] | provenance |  |
-| semantics.rb:343:5:343:5 | x [element] | semantics.rb:347:10:347:10 | x [element] | provenance |  |
-| semantics.rb:343:9:343:14 | call to s42 [element 0] | semantics.rb:343:5:343:5 | x [element 0] | provenance |  |
-| semantics.rb:343:9:343:14 | call to s42 [element 0] | semantics.rb:343:5:343:5 | x [element 0] | provenance |  |
-| semantics.rb:343:9:343:14 | call to s42 [element] | semantics.rb:343:5:343:5 | x [element] | provenance |  |
-| semantics.rb:343:9:343:14 | call to s42 [element] | semantics.rb:343:5:343:5 | x [element] | provenance |  |
-| semantics.rb:343:13:343:13 | h [element 0] | semantics.rb:343:9:343:14 | call to s42 [element 0] | provenance |  |
-| semantics.rb:343:13:343:13 | h [element 0] | semantics.rb:343:9:343:14 | call to s42 [element 0] | provenance |  |
-| semantics.rb:343:13:343:13 | h [element] | semantics.rb:343:9:343:14 | call to s42 [element] | provenance |  |
-| semantics.rb:343:13:343:13 | h [element] | semantics.rb:343:9:343:14 | call to s42 [element] | provenance |  |
-| semantics.rb:345:10:345:10 | x [element 0] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
-| semantics.rb:345:10:345:10 | x [element 0] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
-| semantics.rb:345:10:345:10 | x [element] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
-| semantics.rb:345:10:345:10 | x [element] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
-| semantics.rb:346:10:346:10 | x [element] | semantics.rb:346:10:346:13 | ...[...] | provenance |  |
-| semantics.rb:346:10:346:10 | x [element] | semantics.rb:346:10:346:13 | ...[...] | provenance |  |
-| semantics.rb:347:10:347:10 | x [element 0] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
-| semantics.rb:347:10:347:10 | x [element 0] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
-| semantics.rb:347:10:347:10 | x [element] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
-| semantics.rb:347:10:347:10 | x [element] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
-| semantics.rb:351:5:351:5 | [post] h [element 0] | semantics.rb:354:13:354:13 | h [element 0] | provenance |  |
-| semantics.rb:351:5:351:5 | [post] h [element 0] | semantics.rb:354:13:354:13 | h [element 0] | provenance |  |
-| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:356:10:356:10 | x [element 0] | provenance |  |
-| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:356:10:356:10 | x [element 0] | provenance |  |
-| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:358:10:358:10 | x [element 0] | provenance |  |
-| semantics.rb:354:5:354:5 | x [element 0] | semantics.rb:358:10:358:10 | x [element 0] | provenance |  |
-| semantics.rb:354:9:354:14 | call to s43 [element 0] | semantics.rb:354:5:354:5 | x [element 0] | provenance |  |
-| semantics.rb:354:9:354:14 | call to s43 [element 0] | semantics.rb:354:5:354:5 | x [element 0] | provenance |  |
-| semantics.rb:354:13:354:13 | h [element 0] | semantics.rb:354:9:354:14 | call to s43 [element 0] | provenance |  |
-| semantics.rb:354:13:354:13 | h [element 0] | semantics.rb:354:9:354:14 | call to s43 [element 0] | provenance |  |
-| semantics.rb:356:10:356:10 | x [element 0] | semantics.rb:356:10:356:13 | ...[...] | provenance |  |
-| semantics.rb:356:10:356:10 | x [element 0] | semantics.rb:356:10:356:13 | ...[...] | provenance |  |
-| semantics.rb:358:10:358:10 | x [element 0] | semantics.rb:358:10:358:13 | ...[...] | provenance |  |
-| semantics.rb:358:10:358:10 | x [element 0] | semantics.rb:358:10:358:13 | ...[...] | provenance |  |
-| semantics.rb:363:5:363:5 | [post] h [element 1] | semantics.rb:366:9:366:9 | h [element 1] | provenance |  |
-| semantics.rb:363:5:363:5 | [post] h [element 1] | semantics.rb:366:9:366:9 | h [element 1] | provenance |  |
-| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:369:10:369:10 | h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:370:10:370:10 | h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semantics.rb:370:10:370:10 | h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | h [element 1] | semantics.rb:366:9:366:9 | [post] h [element 1] | provenance |  |
-| semantics.rb:366:9:366:9 | h [element 1] | semantics.rb:366:9:366:9 | [post] h [element 1] | provenance |  |
-| semantics.rb:369:10:369:10 | h [element 1] | semantics.rb:369:10:369:13 | ...[...] | provenance |  |
-| semantics.rb:369:10:369:10 | h [element 1] | semantics.rb:369:10:369:13 | ...[...] | provenance |  |
-| semantics.rb:370:10:370:10 | h [element 1] | semantics.rb:370:10:370:13 | ...[...] | provenance |  |
-| semantics.rb:370:10:370:10 | h [element 1] | semantics.rb:370:10:370:13 | ...[...] | provenance |  |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:375:5:375:5 | h [element 0] | provenance |  |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semantics.rb:375:5:375:5 | h [element 0] | provenance |  |
-| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:378:10:378:10 | h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:378:10:378:10 | h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:380:10:380:10 | h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semantics.rb:380:10:380:10 | h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:379:10:379:10 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:380:10:380:10 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:380:10:380:10 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:382:9:382:9 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semantics.rb:382:9:382:9 | h [element 1] | provenance |  |
-| semantics.rb:375:5:375:5 | h [element 0] | semantics.rb:375:5:375:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:375:5:375:5 | h [element 0] | semantics.rb:375:5:375:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:378:10:378:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:379:10:379:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:380:10:380:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:380:10:380:10 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:382:9:382:9 | h [element] | provenance |  |
-| semantics.rb:376:5:376:5 | [post] h [element] | semantics.rb:382:9:382:9 | h [element] | provenance |  |
-| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h [element] | provenance |  |
-| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h [element] | provenance |  |
-| semantics.rb:378:10:378:10 | h [element 0] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
-| semantics.rb:378:10:378:10 | h [element 0] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
-| semantics.rb:378:10:378:10 | h [element] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
-| semantics.rb:378:10:378:10 | h [element] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
-| semantics.rb:379:10:379:10 | h [element 1] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
-| semantics.rb:379:10:379:10 | h [element 1] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
-| semantics.rb:379:10:379:10 | h [element] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
-| semantics.rb:379:10:379:10 | h [element] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element 0] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element 0] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element 1] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element 1] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:380:10:380:10 | h [element] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:385:10:385:10 | h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:386:10:386:10 | h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semantics.rb:386:10:386:10 | h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:384:10:384:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:385:10:385:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:386:10:386:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | [post] h [element] | semantics.rb:386:10:386:10 | h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | h [element 1] | semantics.rb:382:9:382:9 | [post] h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | h [element 1] | semantics.rb:382:9:382:9 | [post] h [element 1] | provenance |  |
-| semantics.rb:382:9:382:9 | h [element] | semantics.rb:382:9:382:9 | [post] h [element] | provenance |  |
-| semantics.rb:382:9:382:9 | h [element] | semantics.rb:382:9:382:9 | [post] h [element] | provenance |  |
-| semantics.rb:384:10:384:10 | h [element] | semantics.rb:384:10:384:13 | ...[...] | provenance |  |
-| semantics.rb:384:10:384:10 | h [element] | semantics.rb:384:10:384:13 | ...[...] | provenance |  |
-| semantics.rb:385:10:385:10 | h [element 1] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
-| semantics.rb:385:10:385:10 | h [element 1] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
-| semantics.rb:385:10:385:10 | h [element] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
-| semantics.rb:385:10:385:10 | h [element] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
-| semantics.rb:386:10:386:10 | h [element 1] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
-| semantics.rb:386:10:386:10 | h [element 1] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
-| semantics.rb:386:10:386:10 | h [element] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
-| semantics.rb:386:10:386:10 | h [element] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:391:5:391:5 | h [element 0] | provenance |  |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semantics.rb:391:5:391:5 | h [element 0] | provenance |  |
-| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:394:10:394:10 | h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:394:10:394:10 | h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:396:10:396:10 | h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semantics.rb:396:10:396:10 | h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:395:10:395:10 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:396:10:396:10 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:396:10:396:10 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:398:13:398:13 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semantics.rb:398:13:398:13 | h [element 1] | provenance |  |
-| semantics.rb:391:5:391:5 | h [element 0] | semantics.rb:391:5:391:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:391:5:391:5 | h [element 0] | semantics.rb:391:5:391:5 | [post] h [element 0] | provenance |  |
-| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h [element 1] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:394:10:394:10 | h [element] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:395:10:395:10 | h [element] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:396:10:396:10 | h [element] | provenance |  |
-| semantics.rb:392:5:392:5 | [post] h [element] | semantics.rb:396:10:396:10 | h [element] | provenance |  |
-| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h [element] | provenance |  |
-| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h [element] | provenance |  |
-| semantics.rb:394:10:394:10 | h [element 0] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
-| semantics.rb:394:10:394:10 | h [element 0] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
-| semantics.rb:394:10:394:10 | h [element] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
-| semantics.rb:394:10:394:10 | h [element] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
-| semantics.rb:395:10:395:10 | h [element 1] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
-| semantics.rb:395:10:395:10 | h [element 1] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
-| semantics.rb:395:10:395:10 | h [element] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
-| semantics.rb:395:10:395:10 | h [element] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element 0] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element 0] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element 1] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element 1] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:396:10:396:10 | h [element] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
-| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] | provenance |  |
-| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:401:10:401:10 | x [element 1] | provenance |  |
-| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:402:10:402:10 | x [element 1] | provenance |  |
-| semantics.rb:398:5:398:5 | x [element 1] | semantics.rb:402:10:402:10 | x [element 1] | provenance |  |
-| semantics.rb:398:9:398:14 | call to s46 [element 1] | semantics.rb:398:5:398:5 | x [element 1] | provenance |  |
-| semantics.rb:398:9:398:14 | call to s46 [element 1] | semantics.rb:398:5:398:5 | x [element 1] | provenance |  |
-| semantics.rb:398:13:398:13 | h [element 1] | semantics.rb:398:9:398:14 | call to s46 [element 1] | provenance |  |
-| semantics.rb:398:13:398:13 | h [element 1] | semantics.rb:398:9:398:14 | call to s46 [element 1] | provenance |  |
-| semantics.rb:401:10:401:10 | x [element 1] | semantics.rb:401:10:401:13 | ...[...] | provenance |  |
-| semantics.rb:401:10:401:10 | x [element 1] | semantics.rb:401:10:401:13 | ...[...] | provenance |  |
-| semantics.rb:402:10:402:10 | x [element 1] | semantics.rb:402:10:402:13 | ...[...] | provenance |  |
-| semantics.rb:402:10:402:10 | x [element 1] | semantics.rb:402:10:402:13 | ...[...] | provenance |  |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:407:5:407:5 | h [element :foo] | provenance |  |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semantics.rb:407:5:407:5 | h [element :foo] | provenance |  |
-| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:411:10:411:10 | h [element :bar] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:411:10:411:10 | h [element :bar] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:413:13:413:13 | h [element :bar] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semantics.rb:413:13:413:13 | h [element :bar] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :foo] | semantics.rb:410:10:410:10 | h [element :foo] | provenance |  |
-| semantics.rb:407:5:407:5 | [post] h [element :foo] | semantics.rb:410:10:410:10 | h [element :foo] | provenance |  |
-| semantics.rb:407:5:407:5 | h [element :foo] | semantics.rb:407:5:407:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:407:5:407:5 | h [element :foo] | semantics.rb:407:5:407:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] | provenance |  |
-| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:410:10:410:10 | h [element] | provenance |  |
-| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:411:10:411:10 | h [element] | provenance |  |
-| semantics.rb:408:5:408:5 | [post] h [element] | semantics.rb:411:10:411:10 | h [element] | provenance |  |
-| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h [element] | provenance |  |
-| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h [element] | provenance |  |
-| semantics.rb:410:10:410:10 | h [element :foo] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
-| semantics.rb:410:10:410:10 | h [element :foo] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
-| semantics.rb:410:10:410:10 | h [element] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
-| semantics.rb:410:10:410:10 | h [element] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
-| semantics.rb:411:10:411:10 | h [element :bar] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
-| semantics.rb:411:10:411:10 | h [element :bar] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
-| semantics.rb:411:10:411:10 | h [element] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
-| semantics.rb:411:10:411:10 | h [element] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
-| semantics.rb:413:5:413:5 | x [element :bar] | semantics.rb:416:10:416:10 | x [element :bar] | provenance |  |
-| semantics.rb:413:5:413:5 | x [element :bar] | semantics.rb:416:10:416:10 | x [element :bar] | provenance |  |
-| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semantics.rb:413:5:413:5 | x [element :bar] | provenance |  |
-| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semantics.rb:413:5:413:5 | x [element :bar] | provenance |  |
-| semantics.rb:413:13:413:13 | h [element :bar] | semantics.rb:413:9:413:14 | call to s47 [element :bar] | provenance |  |
-| semantics.rb:413:13:413:13 | h [element :bar] | semantics.rb:413:9:413:14 | call to s47 [element :bar] | provenance |  |
-| semantics.rb:416:10:416:10 | x [element :bar] | semantics.rb:416:10:416:16 | ...[...] | provenance |  |
-| semantics.rb:416:10:416:10 | x [element :bar] | semantics.rb:416:10:416:16 | ...[...] | provenance |  |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:421:5:421:5 | h [element :foo] | provenance |  |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semantics.rb:421:5:421:5 | h [element :foo] | provenance |  |
-| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:425:10:425:10 | h [element :bar] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:425:10:425:10 | h [element :bar] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:427:13:427:13 | h [element :bar] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semantics.rb:427:13:427:13 | h [element :bar] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :foo] | semantics.rb:424:10:424:10 | h [element :foo] | provenance |  |
-| semantics.rb:421:5:421:5 | [post] h [element :foo] | semantics.rb:424:10:424:10 | h [element :foo] | provenance |  |
-| semantics.rb:421:5:421:5 | h [element :foo] | semantics.rb:421:5:421:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:421:5:421:5 | h [element :foo] | semantics.rb:421:5:421:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] | provenance |  |
-| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:424:10:424:10 | h [element] | provenance |  |
-| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:425:10:425:10 | h [element] | provenance |  |
-| semantics.rb:422:5:422:5 | [post] h [element] | semantics.rb:425:10:425:10 | h [element] | provenance |  |
-| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h [element] | provenance |  |
-| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h [element] | provenance |  |
-| semantics.rb:424:10:424:10 | h [element :foo] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
-| semantics.rb:424:10:424:10 | h [element :foo] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
-| semantics.rb:424:10:424:10 | h [element] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
-| semantics.rb:424:10:424:10 | h [element] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
-| semantics.rb:425:10:425:10 | h [element :bar] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
-| semantics.rb:425:10:425:10 | h [element :bar] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
-| semantics.rb:425:10:425:10 | h [element] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
-| semantics.rb:425:10:425:10 | h [element] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
-| semantics.rb:427:5:427:5 | x [element :bar] | semantics.rb:430:10:430:10 | x [element :bar] | provenance |  |
-| semantics.rb:427:5:427:5 | x [element :bar] | semantics.rb:430:10:430:10 | x [element :bar] | provenance |  |
-| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semantics.rb:427:5:427:5 | x [element :bar] | provenance |  |
-| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semantics.rb:427:5:427:5 | x [element :bar] | provenance |  |
-| semantics.rb:427:13:427:13 | h [element :bar] | semantics.rb:427:9:427:14 | call to s48 [element :bar] | provenance |  |
-| semantics.rb:427:13:427:13 | h [element :bar] | semantics.rb:427:9:427:14 | call to s48 [element :bar] | provenance |  |
-| semantics.rb:430:10:430:10 | x [element :bar] | semantics.rb:430:10:430:16 | ...[...] | provenance |  |
-| semantics.rb:430:10:430:10 | x [element :bar] | semantics.rb:430:10:430:16 | ...[...] | provenance |  |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:435:5:435:5 | h [element :foo] | provenance |  |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semantics.rb:435:5:435:5 | h [element :foo] | provenance |  |
-| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:439:10:439:10 | h [element :bar] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:439:10:439:10 | h [element :bar] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:441:13:441:13 | h [element :bar] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semantics.rb:441:13:441:13 | h [element :bar] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :foo] | semantics.rb:438:10:438:10 | h [element :foo] | provenance |  |
-| semantics.rb:435:5:435:5 | [post] h [element :foo] | semantics.rb:438:10:438:10 | h [element :foo] | provenance |  |
-| semantics.rb:435:5:435:5 | h [element :foo] | semantics.rb:435:5:435:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:435:5:435:5 | h [element :foo] | semantics.rb:435:5:435:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:438:10:438:10 | h [element] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:439:10:439:10 | h [element] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:439:10:439:10 | h [element] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:441:13:441:13 | h [element] | provenance |  |
-| semantics.rb:436:5:436:5 | [post] h [element] | semantics.rb:441:13:441:13 | h [element] | provenance |  |
-| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h [element] | provenance |  |
-| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h [element] | provenance |  |
-| semantics.rb:438:10:438:10 | h [element :foo] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
-| semantics.rb:438:10:438:10 | h [element :foo] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
-| semantics.rb:438:10:438:10 | h [element] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
-| semantics.rb:438:10:438:10 | h [element] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
-| semantics.rb:439:10:439:10 | h [element :bar] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
-| semantics.rb:439:10:439:10 | h [element :bar] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
-| semantics.rb:439:10:439:10 | h [element] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
-| semantics.rb:439:10:439:10 | h [element] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element :bar] | semantics.rb:444:10:444:10 | x [element :bar] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element :bar] | semantics.rb:444:10:444:10 | x [element :bar] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element] | semantics.rb:443:10:443:10 | x [element] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element] | semantics.rb:443:10:443:10 | x [element] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element] | semantics.rb:444:10:444:10 | x [element] | provenance |  |
-| semantics.rb:441:5:441:5 | x [element] | semantics.rb:444:10:444:10 | x [element] | provenance |  |
-| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semantics.rb:441:5:441:5 | x [element :bar] | provenance |  |
-| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semantics.rb:441:5:441:5 | x [element :bar] | provenance |  |
-| semantics.rb:441:9:441:14 | call to s49 [element] | semantics.rb:441:5:441:5 | x [element] | provenance |  |
-| semantics.rb:441:9:441:14 | call to s49 [element] | semantics.rb:441:5:441:5 | x [element] | provenance |  |
-| semantics.rb:441:13:441:13 | h [element :bar] | semantics.rb:441:9:441:14 | call to s49 [element :bar] | provenance |  |
-| semantics.rb:441:13:441:13 | h [element :bar] | semantics.rb:441:9:441:14 | call to s49 [element :bar] | provenance |  |
-| semantics.rb:441:13:441:13 | h [element] | semantics.rb:441:9:441:14 | call to s49 [element] | provenance |  |
-| semantics.rb:441:13:441:13 | h [element] | semantics.rb:441:9:441:14 | call to s49 [element] | provenance |  |
-| semantics.rb:443:10:443:10 | x [element] | semantics.rb:443:10:443:16 | ...[...] | provenance |  |
-| semantics.rb:443:10:443:10 | x [element] | semantics.rb:443:10:443:16 | ...[...] | provenance |  |
-| semantics.rb:444:10:444:10 | x [element :bar] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
-| semantics.rb:444:10:444:10 | x [element :bar] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
-| semantics.rb:444:10:444:10 | x [element] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
-| semantics.rb:444:10:444:10 | x [element] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:449:5:449:5 | h [element :foo] | provenance |  |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semantics.rb:449:5:449:5 | h [element :foo] | provenance |  |
-| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:453:10:453:10 | h [element :bar] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:453:10:453:10 | h [element :bar] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:455:9:455:9 | h [element :bar] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semantics.rb:455:9:455:9 | h [element :bar] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :foo] | semantics.rb:452:10:452:10 | h [element :foo] | provenance |  |
-| semantics.rb:449:5:449:5 | [post] h [element :foo] | semantics.rb:452:10:452:10 | h [element :foo] | provenance |  |
-| semantics.rb:449:5:449:5 | h [element :foo] | semantics.rb:449:5:449:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:449:5:449:5 | h [element :foo] | semantics.rb:449:5:449:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] | provenance |  |
-| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:452:10:452:10 | h [element] | provenance |  |
-| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:453:10:453:10 | h [element] | provenance |  |
-| semantics.rb:450:5:450:5 | [post] h [element] | semantics.rb:453:10:453:10 | h [element] | provenance |  |
-| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h [element] | provenance |  |
-| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h [element] | provenance |  |
-| semantics.rb:452:10:452:10 | h [element :foo] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
-| semantics.rb:452:10:452:10 | h [element :foo] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
-| semantics.rb:452:10:452:10 | h [element] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
-| semantics.rb:452:10:452:10 | h [element] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
-| semantics.rb:453:10:453:10 | h [element :bar] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
-| semantics.rb:453:10:453:10 | h [element :bar] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
-| semantics.rb:453:10:453:10 | h [element] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
-| semantics.rb:453:10:453:10 | h [element] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
-| semantics.rb:455:9:455:9 | [post] h [element :bar] | semantics.rb:458:10:458:10 | h [element :bar] | provenance |  |
-| semantics.rb:455:9:455:9 | [post] h [element :bar] | semantics.rb:458:10:458:10 | h [element :bar] | provenance |  |
-| semantics.rb:455:9:455:9 | h [element :bar] | semantics.rb:455:9:455:9 | [post] h [element :bar] | provenance |  |
-| semantics.rb:455:9:455:9 | h [element :bar] | semantics.rb:455:9:455:9 | [post] h [element :bar] | provenance |  |
-| semantics.rb:458:10:458:10 | h [element :bar] | semantics.rb:458:10:458:16 | ...[...] | provenance |  |
-| semantics.rb:458:10:458:10 | h [element :bar] | semantics.rb:458:10:458:16 | ...[...] | provenance |  |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:463:5:463:5 | h [element :foo] | provenance |  |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semantics.rb:463:5:463:5 | h [element :foo] | provenance |  |
-| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:467:10:467:10 | h [element :bar] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:467:10:467:10 | h [element :bar] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:469:9:469:9 | h [element :bar] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semantics.rb:469:9:469:9 | h [element :bar] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :foo] | semantics.rb:466:10:466:10 | h [element :foo] | provenance |  |
-| semantics.rb:463:5:463:5 | [post] h [element :foo] | semantics.rb:466:10:466:10 | h [element :foo] | provenance |  |
-| semantics.rb:463:5:463:5 | h [element :foo] | semantics.rb:463:5:463:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:463:5:463:5 | h [element :foo] | semantics.rb:463:5:463:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:466:10:466:10 | h [element] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:467:10:467:10 | h [element] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:467:10:467:10 | h [element] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:469:9:469:9 | h [element] | provenance |  |
-| semantics.rb:464:5:464:5 | [post] h [element] | semantics.rb:469:9:469:9 | h [element] | provenance |  |
-| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h [element] | provenance |  |
-| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h [element] | provenance |  |
-| semantics.rb:466:10:466:10 | h [element :foo] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
-| semantics.rb:466:10:466:10 | h [element :foo] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
-| semantics.rb:466:10:466:10 | h [element] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
-| semantics.rb:466:10:466:10 | h [element] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
-| semantics.rb:467:10:467:10 | h [element :bar] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
-| semantics.rb:467:10:467:10 | h [element :bar] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
-| semantics.rb:467:10:467:10 | h [element] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
-| semantics.rb:467:10:467:10 | h [element] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element :bar] | semantics.rb:472:10:472:10 | h [element :bar] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element :bar] | semantics.rb:472:10:472:10 | h [element :bar] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:471:10:471:10 | h [element] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:472:10:472:10 | h [element] | provenance |  |
-| semantics.rb:469:9:469:9 | [post] h [element] | semantics.rb:472:10:472:10 | h [element] | provenance |  |
-| semantics.rb:469:9:469:9 | h [element :bar] | semantics.rb:469:9:469:9 | [post] h [element :bar] | provenance |  |
-| semantics.rb:469:9:469:9 | h [element :bar] | semantics.rb:469:9:469:9 | [post] h [element :bar] | provenance |  |
-| semantics.rb:469:9:469:9 | h [element] | semantics.rb:469:9:469:9 | [post] h [element] | provenance |  |
-| semantics.rb:469:9:469:9 | h [element] | semantics.rb:469:9:469:9 | [post] h [element] | provenance |  |
-| semantics.rb:471:10:471:10 | h [element] | semantics.rb:471:10:471:16 | ...[...] | provenance |  |
-| semantics.rb:471:10:471:10 | h [element] | semantics.rb:471:10:471:16 | ...[...] | provenance |  |
-| semantics.rb:472:10:472:10 | h [element :bar] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
-| semantics.rb:472:10:472:10 | h [element :bar] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
-| semantics.rb:472:10:472:10 | h [element] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
-| semantics.rb:472:10:472:10 | h [element] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:477:5:477:5 | h [element :foo] | provenance |  |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semantics.rb:477:5:477:5 | h [element :foo] | provenance |  |
-| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:481:10:481:10 | h [element :bar] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:481:10:481:10 | h [element :bar] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:483:5:483:5 | h [element :bar] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semantics.rb:483:5:483:5 | h [element :bar] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :foo] | semantics.rb:480:10:480:10 | h [element :foo] | provenance |  |
-| semantics.rb:477:5:477:5 | [post] h [element :foo] | semantics.rb:480:10:480:10 | h [element :foo] | provenance |  |
-| semantics.rb:477:5:477:5 | h [element :foo] | semantics.rb:477:5:477:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:477:5:477:5 | h [element :foo] | semantics.rb:477:5:477:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] | provenance |  |
-| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:480:10:480:10 | h [element] | provenance |  |
-| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:481:10:481:10 | h [element] | provenance |  |
-| semantics.rb:478:5:478:5 | [post] h [element] | semantics.rb:481:10:481:10 | h [element] | provenance |  |
-| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h [element] | provenance |  |
-| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h [element] | provenance |  |
-| semantics.rb:480:10:480:10 | h [element :foo] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
-| semantics.rb:480:10:480:10 | h [element :foo] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
-| semantics.rb:480:10:480:10 | h [element] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
-| semantics.rb:480:10:480:10 | h [element] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
-| semantics.rb:481:10:481:10 | h [element :bar] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
-| semantics.rb:481:10:481:10 | h [element :bar] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
-| semantics.rb:481:10:481:10 | h [element] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
-| semantics.rb:481:10:481:10 | h [element] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
-| semantics.rb:483:5:483:5 | [post] h [element :bar] | semantics.rb:486:10:486:10 | h [element :bar] | provenance |  |
-| semantics.rb:483:5:483:5 | [post] h [element :bar] | semantics.rb:486:10:486:10 | h [element :bar] | provenance |  |
-| semantics.rb:483:5:483:5 | h [element :bar] | semantics.rb:483:5:483:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:483:5:483:5 | h [element :bar] | semantics.rb:483:5:483:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:486:10:486:10 | h [element :bar] | semantics.rb:486:10:486:16 | ...[...] | provenance |  |
-| semantics.rb:486:10:486:10 | h [element :bar] | semantics.rb:486:10:486:16 | ...[...] | provenance |  |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:491:5:491:5 | h [element :foo] | provenance |  |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semantics.rb:491:5:491:5 | h [element :foo] | provenance |  |
-| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:495:10:495:10 | h [element :bar] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:495:10:495:10 | h [element :bar] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:497:9:497:9 | h [element :bar] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semantics.rb:497:9:497:9 | h [element :bar] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :foo] | semantics.rb:494:10:494:10 | h [element :foo] | provenance |  |
-| semantics.rb:491:5:491:5 | [post] h [element :foo] | semantics.rb:494:10:494:10 | h [element :foo] | provenance |  |
-| semantics.rb:491:5:491:5 | h [element :foo] | semantics.rb:491:5:491:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:491:5:491:5 | h [element :foo] | semantics.rb:491:5:491:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] | provenance |  |
-| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:494:10:494:10 | h [element] | provenance |  |
-| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:495:10:495:10 | h [element] | provenance |  |
-| semantics.rb:492:5:492:5 | [post] h [element] | semantics.rb:495:10:495:10 | h [element] | provenance |  |
-| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h [element] | provenance |  |
-| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h [element] | provenance |  |
-| semantics.rb:494:10:494:10 | h [element :foo] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
-| semantics.rb:494:10:494:10 | h [element :foo] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
-| semantics.rb:494:10:494:10 | h [element] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
-| semantics.rb:494:10:494:10 | h [element] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
-| semantics.rb:495:10:495:10 | h [element :bar] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
-| semantics.rb:495:10:495:10 | h [element :bar] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
-| semantics.rb:495:10:495:10 | h [element] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
-| semantics.rb:495:10:495:10 | h [element] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
-| semantics.rb:497:5:497:5 | x [element :bar] | semantics.rb:500:10:500:10 | x [element :bar] | provenance |  |
-| semantics.rb:497:5:497:5 | x [element :bar] | semantics.rb:500:10:500:10 | x [element :bar] | provenance |  |
-| semantics.rb:497:9:497:9 | h [element :bar] | semantics.rb:497:9:497:15 | call to s53 [element :bar] | provenance |  |
-| semantics.rb:497:9:497:9 | h [element :bar] | semantics.rb:497:9:497:15 | call to s53 [element :bar] | provenance |  |
-| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semantics.rb:497:5:497:5 | x [element :bar] | provenance |  |
-| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semantics.rb:497:5:497:5 | x [element :bar] | provenance |  |
-| semantics.rb:500:10:500:10 | x [element :bar] | semantics.rb:500:10:500:16 | ...[...] | provenance |  |
-| semantics.rb:500:10:500:10 | x [element :bar] | semantics.rb:500:10:500:16 | ...[...] | provenance |  |
+| semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | semantics.rb:343:13:343:13 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | semantics.rb:343:13:343:13 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:340:12:340:22 | call to source | semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:341:5:341:5 | [post] h : [collection] [element] | semantics.rb:343:13:343:13 | h : [collection] [element] | provenance |  |
+| semantics.rb:341:5:341:5 | [post] h : [collection] [element] | semantics.rb:343:13:343:13 | h : [collection] [element] | provenance |  |
+| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:341:12:341:22 | call to source | semantics.rb:341:5:341:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semantics.rb:345:10:345:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semantics.rb:345:10:345:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semantics.rb:347:10:347:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semantics.rb:347:10:347:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:345:10:345:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:345:10:345:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:346:10:346:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:346:10:346:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:347:10:347:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semantics.rb:347:10:347:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | semantics.rb:343:5:343:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | semantics.rb:343:5:343:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | semantics.rb:343:5:343:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | semantics.rb:343:5:343:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:343:13:343:13 | h : [collection] [element 0] | semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | provenance |  |
+| semantics.rb:343:13:343:13 | h : [collection] [element 0] | semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | provenance |  |
+| semantics.rb:343:13:343:13 | h : [collection] [element] | semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | provenance |  |
+| semantics.rb:343:13:343:13 | h : [collection] [element] | semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | provenance |  |
+| semantics.rb:345:10:345:10 | x : [collection] [element 0] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
+| semantics.rb:345:10:345:10 | x : [collection] [element 0] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
+| semantics.rb:345:10:345:10 | x : [collection] [element] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
+| semantics.rb:345:10:345:10 | x : [collection] [element] | semantics.rb:345:10:345:13 | ...[...] | provenance |  |
+| semantics.rb:346:10:346:10 | x : [collection] [element] | semantics.rb:346:10:346:13 | ...[...] | provenance |  |
+| semantics.rb:346:10:346:10 | x : [collection] [element] | semantics.rb:346:10:346:13 | ...[...] | provenance |  |
+| semantics.rb:347:10:347:10 | x : [collection] [element 0] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
+| semantics.rb:347:10:347:10 | x : [collection] [element 0] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
+| semantics.rb:347:10:347:10 | x : [collection] [element] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
+| semantics.rb:347:10:347:10 | x : [collection] [element] | semantics.rb:347:10:347:13 | ...[...] | provenance |  |
+| semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | semantics.rb:354:13:354:13 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | semantics.rb:354:13:354:13 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:351:12:351:22 | call to source | semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semantics.rb:356:10:356:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semantics.rb:356:10:356:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semantics.rb:358:10:358:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semantics.rb:358:10:358:10 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | semantics.rb:354:5:354:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | semantics.rb:354:5:354:5 | x : [collection] [element 0] | provenance |  |
+| semantics.rb:354:13:354:13 | h : [collection] [element 0] | semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | provenance |  |
+| semantics.rb:354:13:354:13 | h : [collection] [element 0] | semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | provenance |  |
+| semantics.rb:356:10:356:10 | x : [collection] [element 0] | semantics.rb:356:10:356:13 | ...[...] | provenance |  |
+| semantics.rb:356:10:356:10 | x : [collection] [element 0] | semantics.rb:356:10:356:13 | ...[...] | provenance |  |
+| semantics.rb:358:10:358:10 | x : [collection] [element 0] | semantics.rb:358:10:358:13 | ...[...] | provenance |  |
+| semantics.rb:358:10:358:10 | x : [collection] [element 0] | semantics.rb:358:10:358:13 | ...[...] | provenance |  |
+| semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | semantics.rb:366:9:366:9 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | semantics.rb:366:9:366:9 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:363:12:363:22 | call to source | semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semantics.rb:369:10:369:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semantics.rb:369:10:369:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semantics.rb:370:10:370:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semantics.rb:370:10:370:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | h : [collection] [element 1] | semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:366:9:366:9 | h : [collection] [element 1] | semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:369:10:369:10 | h : [collection] [element 1] | semantics.rb:369:10:369:13 | ...[...] | provenance |  |
+| semantics.rb:369:10:369:10 | h : [collection] [element 1] | semantics.rb:369:10:369:13 | ...[...] | provenance |  |
+| semantics.rb:370:10:370:10 | h : [collection] [element 1] | semantics.rb:370:10:370:13 | ...[...] | provenance |  |
+| semantics.rb:370:10:370:10 | h : [collection] [element 1] | semantics.rb:370:10:370:13 | ...[...] | provenance |  |
+| semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | semantics.rb:375:5:375:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | semantics.rb:375:5:375:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:374:12:374:22 | call to source | semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semantics.rb:378:10:378:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semantics.rb:378:10:378:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semantics.rb:380:10:380:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semantics.rb:380:10:380:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:379:10:379:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:379:10:379:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:380:10:380:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:380:10:380:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:382:9:382:9 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semantics.rb:382:9:382:9 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:5:375:5 | h : [collection] [element 0] | semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:5:375:5 | h : [collection] [element 0] | semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:375:12:375:22 | call to source | semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:378:10:378:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:378:10:378:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:379:10:379:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:379:10:379:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:380:10:380:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:380:10:380:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:382:9:382:9 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semantics.rb:382:9:382:9 | h : [collection] [element] | provenance |  |
+| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:376:12:376:22 | call to source | semantics.rb:376:5:376:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:378:10:378:10 | h : [collection] [element 0] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
+| semantics.rb:378:10:378:10 | h : [collection] [element 0] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
+| semantics.rb:378:10:378:10 | h : [collection] [element] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
+| semantics.rb:378:10:378:10 | h : [collection] [element] | semantics.rb:378:10:378:13 | ...[...] | provenance |  |
+| semantics.rb:379:10:379:10 | h : [collection] [element 1] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
+| semantics.rb:379:10:379:10 | h : [collection] [element 1] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
+| semantics.rb:379:10:379:10 | h : [collection] [element] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
+| semantics.rb:379:10:379:10 | h : [collection] [element] | semantics.rb:379:10:379:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element 0] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element 0] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element 1] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element 1] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:380:10:380:10 | h : [collection] [element] | semantics.rb:380:10:380:13 | ...[...] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semantics.rb:385:10:385:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semantics.rb:385:10:385:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semantics.rb:386:10:386:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semantics.rb:386:10:386:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:384:10:384:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:384:10:384:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:385:10:385:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:385:10:385:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:386:10:386:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semantics.rb:386:10:386:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | h : [collection] [element 1] | semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | h : [collection] [element 1] | semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:382:9:382:9 | h : [collection] [element] | semantics.rb:382:9:382:9 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:382:9:382:9 | h : [collection] [element] | semantics.rb:382:9:382:9 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:384:10:384:10 | h : [collection] [element] | semantics.rb:384:10:384:13 | ...[...] | provenance |  |
+| semantics.rb:384:10:384:10 | h : [collection] [element] | semantics.rb:384:10:384:13 | ...[...] | provenance |  |
+| semantics.rb:385:10:385:10 | h : [collection] [element 1] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
+| semantics.rb:385:10:385:10 | h : [collection] [element 1] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
+| semantics.rb:385:10:385:10 | h : [collection] [element] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
+| semantics.rb:385:10:385:10 | h : [collection] [element] | semantics.rb:385:10:385:13 | ...[...] | provenance |  |
+| semantics.rb:386:10:386:10 | h : [collection] [element 1] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
+| semantics.rb:386:10:386:10 | h : [collection] [element 1] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
+| semantics.rb:386:10:386:10 | h : [collection] [element] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
+| semantics.rb:386:10:386:10 | h : [collection] [element] | semantics.rb:386:10:386:13 | ...[...] | provenance |  |
+| semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | semantics.rb:391:5:391:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | semantics.rb:391:5:391:5 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:390:12:390:22 | call to source | semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semantics.rb:394:10:394:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semantics.rb:394:10:394:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semantics.rb:396:10:396:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semantics.rb:396:10:396:10 | h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:395:10:395:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:395:10:395:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:396:10:396:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:396:10:396:10 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:398:13:398:13 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semantics.rb:398:13:398:13 | h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:5:391:5 | h : [collection] [element 0] | semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:5:391:5 | h : [collection] [element 0] | semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | provenance |  |
+| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:391:12:391:22 | call to source | semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:394:10:394:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:394:10:394:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:395:10:395:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:395:10:395:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:396:10:396:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semantics.rb:396:10:396:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:392:12:392:22 | call to source | semantics.rb:392:5:392:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:394:10:394:10 | h : [collection] [element 0] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
+| semantics.rb:394:10:394:10 | h : [collection] [element 0] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
+| semantics.rb:394:10:394:10 | h : [collection] [element] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
+| semantics.rb:394:10:394:10 | h : [collection] [element] | semantics.rb:394:10:394:13 | ...[...] | provenance |  |
+| semantics.rb:395:10:395:10 | h : [collection] [element 1] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
+| semantics.rb:395:10:395:10 | h : [collection] [element 1] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
+| semantics.rb:395:10:395:10 | h : [collection] [element] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
+| semantics.rb:395:10:395:10 | h : [collection] [element] | semantics.rb:395:10:395:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element 0] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element 0] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element 1] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element 1] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:396:10:396:10 | h : [collection] [element] | semantics.rb:396:10:396:13 | ...[...] | provenance |  |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semantics.rb:401:10:401:10 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semantics.rb:401:10:401:10 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semantics.rb:402:10:402:10 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semantics.rb:402:10:402:10 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | semantics.rb:398:5:398:5 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | semantics.rb:398:5:398:5 | x : [collection] [element 1] | provenance |  |
+| semantics.rb:398:13:398:13 | h : [collection] [element 1] | semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | provenance |  |
+| semantics.rb:398:13:398:13 | h : [collection] [element 1] | semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | provenance |  |
+| semantics.rb:401:10:401:10 | x : [collection] [element 1] | semantics.rb:401:10:401:13 | ...[...] | provenance |  |
+| semantics.rb:401:10:401:10 | x : [collection] [element 1] | semantics.rb:401:10:401:13 | ...[...] | provenance |  |
+| semantics.rb:402:10:402:10 | x : [collection] [element 1] | semantics.rb:402:10:402:13 | ...[...] | provenance |  |
+| semantics.rb:402:10:402:10 | x : [collection] [element 1] | semantics.rb:402:10:402:13 | ...[...] | provenance |  |
+| semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | semantics.rb:407:5:407:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | semantics.rb:407:5:407:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:406:15:406:25 | call to source | semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semantics.rb:411:10:411:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semantics.rb:411:10:411:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semantics.rb:413:13:413:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semantics.rb:413:13:413:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | semantics.rb:410:10:410:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | semantics.rb:410:10:410:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:407:5:407:5 | h : [collection] [element :foo] | semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:407:5:407:5 | h : [collection] [element :foo] | semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:407:15:407:25 | call to source | semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semantics.rb:410:10:410:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semantics.rb:410:10:410:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semantics.rb:411:10:411:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semantics.rb:411:10:411:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:408:12:408:22 | call to source | semantics.rb:408:5:408:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:410:10:410:10 | h : [collection] [element :foo] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
+| semantics.rb:410:10:410:10 | h : [collection] [element :foo] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
+| semantics.rb:410:10:410:10 | h : [collection] [element] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
+| semantics.rb:410:10:410:10 | h : [collection] [element] | semantics.rb:410:10:410:16 | ...[...] | provenance |  |
+| semantics.rb:411:10:411:10 | h : [collection] [element :bar] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
+| semantics.rb:411:10:411:10 | h : [collection] [element :bar] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
+| semantics.rb:411:10:411:10 | h : [collection] [element] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
+| semantics.rb:411:10:411:10 | h : [collection] [element] | semantics.rb:411:10:411:16 | ...[...] | provenance |  |
+| semantics.rb:413:5:413:5 | x : [collection] [element :bar] | semantics.rb:416:10:416:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:413:5:413:5 | x : [collection] [element :bar] | semantics.rb:416:10:416:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | semantics.rb:413:5:413:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | semantics.rb:413:5:413:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:413:13:413:13 | h : [collection] [element :bar] | semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | provenance |  |
+| semantics.rb:413:13:413:13 | h : [collection] [element :bar] | semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | provenance |  |
+| semantics.rb:416:10:416:10 | x : [collection] [element :bar] | semantics.rb:416:10:416:16 | ...[...] | provenance |  |
+| semantics.rb:416:10:416:10 | x : [collection] [element :bar] | semantics.rb:416:10:416:16 | ...[...] | provenance |  |
+| semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | semantics.rb:421:5:421:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | semantics.rb:421:5:421:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:420:15:420:25 | call to source | semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semantics.rb:425:10:425:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semantics.rb:425:10:425:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semantics.rb:427:13:427:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semantics.rb:427:13:427:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | semantics.rb:424:10:424:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | semantics.rb:424:10:424:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:421:5:421:5 | h : [collection] [element :foo] | semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:421:5:421:5 | h : [collection] [element :foo] | semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:421:15:421:25 | call to source | semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semantics.rb:424:10:424:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semantics.rb:424:10:424:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semantics.rb:425:10:425:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semantics.rb:425:10:425:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:422:12:422:22 | call to source | semantics.rb:422:5:422:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:424:10:424:10 | h : [collection] [element :foo] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
+| semantics.rb:424:10:424:10 | h : [collection] [element :foo] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
+| semantics.rb:424:10:424:10 | h : [collection] [element] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
+| semantics.rb:424:10:424:10 | h : [collection] [element] | semantics.rb:424:10:424:16 | ...[...] | provenance |  |
+| semantics.rb:425:10:425:10 | h : [collection] [element :bar] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
+| semantics.rb:425:10:425:10 | h : [collection] [element :bar] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
+| semantics.rb:425:10:425:10 | h : [collection] [element] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
+| semantics.rb:425:10:425:10 | h : [collection] [element] | semantics.rb:425:10:425:16 | ...[...] | provenance |  |
+| semantics.rb:427:5:427:5 | x : [collection] [element :bar] | semantics.rb:430:10:430:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:427:5:427:5 | x : [collection] [element :bar] | semantics.rb:430:10:430:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | semantics.rb:427:5:427:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | semantics.rb:427:5:427:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:427:13:427:13 | h : [collection] [element :bar] | semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | provenance |  |
+| semantics.rb:427:13:427:13 | h : [collection] [element :bar] | semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | provenance |  |
+| semantics.rb:430:10:430:10 | x : [collection] [element :bar] | semantics.rb:430:10:430:16 | ...[...] | provenance |  |
+| semantics.rb:430:10:430:10 | x : [collection] [element :bar] | semantics.rb:430:10:430:16 | ...[...] | provenance |  |
+| semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | semantics.rb:435:5:435:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | semantics.rb:435:5:435:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:434:15:434:25 | call to source | semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semantics.rb:439:10:439:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semantics.rb:439:10:439:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semantics.rb:441:13:441:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semantics.rb:441:13:441:13 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | semantics.rb:438:10:438:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | semantics.rb:438:10:438:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:435:5:435:5 | h : [collection] [element :foo] | semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:435:5:435:5 | h : [collection] [element :foo] | semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:435:15:435:25 | call to source | semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:438:10:438:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:438:10:438:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:439:10:439:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:439:10:439:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:441:13:441:13 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semantics.rb:441:13:441:13 | h : [collection] [element] | provenance |  |
+| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:436:12:436:22 | call to source | semantics.rb:436:5:436:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:438:10:438:10 | h : [collection] [element :foo] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
+| semantics.rb:438:10:438:10 | h : [collection] [element :foo] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
+| semantics.rb:438:10:438:10 | h : [collection] [element] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
+| semantics.rb:438:10:438:10 | h : [collection] [element] | semantics.rb:438:10:438:16 | ...[...] | provenance |  |
+| semantics.rb:439:10:439:10 | h : [collection] [element :bar] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
+| semantics.rb:439:10:439:10 | h : [collection] [element :bar] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
+| semantics.rb:439:10:439:10 | h : [collection] [element] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
+| semantics.rb:439:10:439:10 | h : [collection] [element] | semantics.rb:439:10:439:16 | ...[...] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element :bar] | semantics.rb:444:10:444:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element :bar] | semantics.rb:444:10:444:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semantics.rb:443:10:443:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semantics.rb:443:10:443:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semantics.rb:444:10:444:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semantics.rb:444:10:444:10 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | semantics.rb:441:5:441:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | semantics.rb:441:5:441:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | semantics.rb:441:5:441:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | semantics.rb:441:5:441:5 | x : [collection] [element] | provenance |  |
+| semantics.rb:441:13:441:13 | h : [collection] [element :bar] | semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:13:441:13 | h : [collection] [element :bar] | semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | provenance |  |
+| semantics.rb:441:13:441:13 | h : [collection] [element] | semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | provenance |  |
+| semantics.rb:441:13:441:13 | h : [collection] [element] | semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | provenance |  |
+| semantics.rb:443:10:443:10 | x : [collection] [element] | semantics.rb:443:10:443:16 | ...[...] | provenance |  |
+| semantics.rb:443:10:443:10 | x : [collection] [element] | semantics.rb:443:10:443:16 | ...[...] | provenance |  |
+| semantics.rb:444:10:444:10 | x : [collection] [element :bar] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
+| semantics.rb:444:10:444:10 | x : [collection] [element :bar] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
+| semantics.rb:444:10:444:10 | x : [collection] [element] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
+| semantics.rb:444:10:444:10 | x : [collection] [element] | semantics.rb:444:10:444:16 | ...[...] | provenance |  |
+| semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | semantics.rb:449:5:449:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | semantics.rb:449:5:449:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:448:15:448:25 | call to source | semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semantics.rb:453:10:453:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semantics.rb:453:10:453:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semantics.rb:455:9:455:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semantics.rb:455:9:455:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | semantics.rb:452:10:452:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | semantics.rb:452:10:452:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:449:5:449:5 | h : [collection] [element :foo] | semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:449:5:449:5 | h : [collection] [element :foo] | semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:449:15:449:25 | call to source | semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semantics.rb:452:10:452:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semantics.rb:452:10:452:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semantics.rb:453:10:453:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semantics.rb:453:10:453:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:450:12:450:22 | call to source | semantics.rb:450:5:450:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:452:10:452:10 | h : [collection] [element :foo] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
+| semantics.rb:452:10:452:10 | h : [collection] [element :foo] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
+| semantics.rb:452:10:452:10 | h : [collection] [element] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
+| semantics.rb:452:10:452:10 | h : [collection] [element] | semantics.rb:452:10:452:16 | ...[...] | provenance |  |
+| semantics.rb:453:10:453:10 | h : [collection] [element :bar] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
+| semantics.rb:453:10:453:10 | h : [collection] [element :bar] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
+| semantics.rb:453:10:453:10 | h : [collection] [element] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
+| semantics.rb:453:10:453:10 | h : [collection] [element] | semantics.rb:453:10:453:16 | ...[...] | provenance |  |
+| semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | semantics.rb:458:10:458:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | semantics.rb:458:10:458:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:455:9:455:9 | h : [collection] [element :bar] | semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:455:9:455:9 | h : [collection] [element :bar] | semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:458:10:458:10 | h : [collection] [element :bar] | semantics.rb:458:10:458:16 | ...[...] | provenance |  |
+| semantics.rb:458:10:458:10 | h : [collection] [element :bar] | semantics.rb:458:10:458:16 | ...[...] | provenance |  |
+| semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | semantics.rb:463:5:463:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | semantics.rb:463:5:463:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:462:15:462:25 | call to source | semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semantics.rb:467:10:467:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semantics.rb:467:10:467:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semantics.rb:469:9:469:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semantics.rb:469:9:469:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | semantics.rb:466:10:466:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | semantics.rb:466:10:466:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:463:5:463:5 | h : [collection] [element :foo] | semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:463:5:463:5 | h : [collection] [element :foo] | semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:463:15:463:25 | call to source | semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:466:10:466:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:466:10:466:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:467:10:467:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:467:10:467:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:469:9:469:9 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semantics.rb:469:9:469:9 | h : [collection] [element] | provenance |  |
+| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:464:12:464:22 | call to source | semantics.rb:464:5:464:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:466:10:466:10 | h : [collection] [element :foo] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
+| semantics.rb:466:10:466:10 | h : [collection] [element :foo] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
+| semantics.rb:466:10:466:10 | h : [collection] [element] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
+| semantics.rb:466:10:466:10 | h : [collection] [element] | semantics.rb:466:10:466:16 | ...[...] | provenance |  |
+| semantics.rb:467:10:467:10 | h : [collection] [element :bar] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
+| semantics.rb:467:10:467:10 | h : [collection] [element :bar] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
+| semantics.rb:467:10:467:10 | h : [collection] [element] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
+| semantics.rb:467:10:467:10 | h : [collection] [element] | semantics.rb:467:10:467:16 | ...[...] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | semantics.rb:472:10:472:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | semantics.rb:472:10:472:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semantics.rb:471:10:471:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semantics.rb:471:10:471:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semantics.rb:472:10:472:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semantics.rb:472:10:472:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:469:9:469:9 | h : [collection] [element :bar] | semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:469:9:469:9 | h : [collection] [element :bar] | semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:469:9:469:9 | h : [collection] [element] | semantics.rb:469:9:469:9 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:469:9:469:9 | h : [collection] [element] | semantics.rb:469:9:469:9 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:471:10:471:10 | h : [collection] [element] | semantics.rb:471:10:471:16 | ...[...] | provenance |  |
+| semantics.rb:471:10:471:10 | h : [collection] [element] | semantics.rb:471:10:471:16 | ...[...] | provenance |  |
+| semantics.rb:472:10:472:10 | h : [collection] [element :bar] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
+| semantics.rb:472:10:472:10 | h : [collection] [element :bar] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
+| semantics.rb:472:10:472:10 | h : [collection] [element] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
+| semantics.rb:472:10:472:10 | h : [collection] [element] | semantics.rb:472:10:472:16 | ...[...] | provenance |  |
+| semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | semantics.rb:477:5:477:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | semantics.rb:477:5:477:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:476:15:476:25 | call to source | semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semantics.rb:481:10:481:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semantics.rb:481:10:481:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semantics.rb:483:5:483:5 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semantics.rb:483:5:483:5 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | semantics.rb:480:10:480:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | semantics.rb:480:10:480:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:477:5:477:5 | h : [collection] [element :foo] | semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:477:5:477:5 | h : [collection] [element :foo] | semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:477:15:477:25 | call to source | semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semantics.rb:480:10:480:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semantics.rb:480:10:480:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semantics.rb:481:10:481:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semantics.rb:481:10:481:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:478:12:478:22 | call to source | semantics.rb:478:5:478:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:480:10:480:10 | h : [collection] [element :foo] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
+| semantics.rb:480:10:480:10 | h : [collection] [element :foo] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
+| semantics.rb:480:10:480:10 | h : [collection] [element] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
+| semantics.rb:480:10:480:10 | h : [collection] [element] | semantics.rb:480:10:480:16 | ...[...] | provenance |  |
+| semantics.rb:481:10:481:10 | h : [collection] [element :bar] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
+| semantics.rb:481:10:481:10 | h : [collection] [element :bar] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
+| semantics.rb:481:10:481:10 | h : [collection] [element] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
+| semantics.rb:481:10:481:10 | h : [collection] [element] | semantics.rb:481:10:481:16 | ...[...] | provenance |  |
+| semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | semantics.rb:486:10:486:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | semantics.rb:486:10:486:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:483:5:483:5 | h : [collection] [element :bar] | semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:483:5:483:5 | h : [collection] [element :bar] | semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:486:10:486:10 | h : [collection] [element :bar] | semantics.rb:486:10:486:16 | ...[...] | provenance |  |
+| semantics.rb:486:10:486:10 | h : [collection] [element :bar] | semantics.rb:486:10:486:16 | ...[...] | provenance |  |
+| semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | semantics.rb:491:5:491:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | semantics.rb:491:5:491:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:490:15:490:25 | call to source | semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semantics.rb:495:10:495:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semantics.rb:495:10:495:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semantics.rb:497:9:497:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semantics.rb:497:9:497:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | semantics.rb:494:10:494:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | semantics.rb:494:10:494:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:491:5:491:5 | h : [collection] [element :foo] | semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:491:5:491:5 | h : [collection] [element :foo] | semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:491:15:491:25 | call to source | semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semantics.rb:494:10:494:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semantics.rb:494:10:494:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semantics.rb:495:10:495:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semantics.rb:495:10:495:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:492:12:492:22 | call to source | semantics.rb:492:5:492:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:494:10:494:10 | h : [collection] [element :foo] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
+| semantics.rb:494:10:494:10 | h : [collection] [element :foo] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
+| semantics.rb:494:10:494:10 | h : [collection] [element] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
+| semantics.rb:494:10:494:10 | h : [collection] [element] | semantics.rb:494:10:494:16 | ...[...] | provenance |  |
+| semantics.rb:495:10:495:10 | h : [collection] [element :bar] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
+| semantics.rb:495:10:495:10 | h : [collection] [element :bar] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
+| semantics.rb:495:10:495:10 | h : [collection] [element] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
+| semantics.rb:495:10:495:10 | h : [collection] [element] | semantics.rb:495:10:495:16 | ...[...] | provenance |  |
+| semantics.rb:497:5:497:5 | x : [collection] [element :bar] | semantics.rb:500:10:500:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:497:5:497:5 | x : [collection] [element :bar] | semantics.rb:500:10:500:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:497:9:497:9 | h : [collection] [element :bar] | semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | provenance |  |
+| semantics.rb:497:9:497:9 | h : [collection] [element :bar] | semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | provenance |  |
+| semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | semantics.rb:497:5:497:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | semantics.rb:497:5:497:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:500:10:500:10 | x : [collection] [element :bar] | semantics.rb:500:10:500:16 | ...[...] | provenance |  |
+| semantics.rb:500:10:500:10 | x : [collection] [element :bar] | semantics.rb:500:10:500:16 | ...[...] | provenance |  |
 | semantics.rb:502:10:502:20 | call to source | semantics.rb:502:10:502:26 | call to s53 | provenance |  |
 | semantics.rb:502:10:502:20 | call to source | semantics.rb:502:10:502:26 | call to s53 | provenance |  |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:507:5:507:5 | h [element :foo] | provenance |  |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semantics.rb:507:5:507:5 | h [element :foo] | provenance |  |
-| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:511:10:511:10 | h [element :bar] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:511:10:511:10 | h [element :bar] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:513:9:513:9 | h [element :bar] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semantics.rb:513:9:513:9 | h [element :bar] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :foo] | semantics.rb:510:10:510:10 | h [element :foo] | provenance |  |
-| semantics.rb:507:5:507:5 | [post] h [element :foo] | semantics.rb:510:10:510:10 | h [element :foo] | provenance |  |
-| semantics.rb:507:5:507:5 | h [element :foo] | semantics.rb:507:5:507:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:507:5:507:5 | h [element :foo] | semantics.rb:507:5:507:5 | [post] h [element :foo] | provenance |  |
-| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h [element :bar] | provenance |  |
-| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] | provenance |  |
-| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:510:10:510:10 | h [element] | provenance |  |
-| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:511:10:511:10 | h [element] | provenance |  |
-| semantics.rb:508:5:508:5 | [post] h [element] | semantics.rb:511:10:511:10 | h [element] | provenance |  |
-| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h [element] | provenance |  |
-| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h [element] | provenance |  |
-| semantics.rb:510:10:510:10 | h [element :foo] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
-| semantics.rb:510:10:510:10 | h [element :foo] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
-| semantics.rb:510:10:510:10 | h [element] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
-| semantics.rb:510:10:510:10 | h [element] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
-| semantics.rb:511:10:511:10 | h [element :bar] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
-| semantics.rb:511:10:511:10 | h [element :bar] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
-| semantics.rb:511:10:511:10 | h [element] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
-| semantics.rb:511:10:511:10 | h [element] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
-| semantics.rb:513:5:513:5 | x [element :bar] | semantics.rb:516:10:516:10 | x [element :bar] | provenance |  |
-| semantics.rb:513:5:513:5 | x [element :bar] | semantics.rb:516:10:516:10 | x [element :bar] | provenance |  |
-| semantics.rb:513:9:513:9 | h [element :bar] | semantics.rb:513:9:513:15 | call to s54 [element :bar] | provenance |  |
-| semantics.rb:513:9:513:9 | h [element :bar] | semantics.rb:513:9:513:15 | call to s54 [element :bar] | provenance |  |
-| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semantics.rb:513:5:513:5 | x [element :bar] | provenance |  |
-| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semantics.rb:513:5:513:5 | x [element :bar] | provenance |  |
-| semantics.rb:516:10:516:10 | x [element :bar] | semantics.rb:516:10:516:16 | ...[...] | provenance |  |
-| semantics.rb:516:10:516:10 | x [element :bar] | semantics.rb:516:10:516:16 | ...[...] | provenance |  |
+| semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | semantics.rb:507:5:507:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | semantics.rb:507:5:507:5 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:506:15:506:25 | call to source | semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semantics.rb:511:10:511:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semantics.rb:511:10:511:10 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semantics.rb:513:9:513:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semantics.rb:513:9:513:9 | h : [collection] [element :bar] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | semantics.rb:510:10:510:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | semantics.rb:510:10:510:10 | h : [collection] [element :foo] | provenance |  |
+| semantics.rb:507:5:507:5 | h : [collection] [element :foo] | semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:507:5:507:5 | h : [collection] [element :foo] | semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | provenance |  |
+| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:507:15:507:25 | call to source | semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | provenance |  |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semantics.rb:510:10:510:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semantics.rb:510:10:510:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semantics.rb:511:10:511:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semantics.rb:511:10:511:10 | h : [collection] [element] | provenance |  |
+| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:508:12:508:22 | call to source | semantics.rb:508:5:508:5 | [post] h : [collection] [element] | provenance |  |
+| semantics.rb:510:10:510:10 | h : [collection] [element :foo] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
+| semantics.rb:510:10:510:10 | h : [collection] [element :foo] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
+| semantics.rb:510:10:510:10 | h : [collection] [element] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
+| semantics.rb:510:10:510:10 | h : [collection] [element] | semantics.rb:510:10:510:16 | ...[...] | provenance |  |
+| semantics.rb:511:10:511:10 | h : [collection] [element :bar] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
+| semantics.rb:511:10:511:10 | h : [collection] [element :bar] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
+| semantics.rb:511:10:511:10 | h : [collection] [element] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
+| semantics.rb:511:10:511:10 | h : [collection] [element] | semantics.rb:511:10:511:16 | ...[...] | provenance |  |
+| semantics.rb:513:5:513:5 | x : [collection] [element :bar] | semantics.rb:516:10:516:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:513:5:513:5 | x : [collection] [element :bar] | semantics.rb:516:10:516:10 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:513:9:513:9 | h : [collection] [element :bar] | semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | provenance |  |
+| semantics.rb:513:9:513:9 | h : [collection] [element :bar] | semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | provenance |  |
+| semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | semantics.rb:513:5:513:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | semantics.rb:513:5:513:5 | x : [collection] [element :bar] | provenance |  |
+| semantics.rb:516:10:516:10 | x : [collection] [element :bar] | semantics.rb:516:10:516:16 | ...[...] | provenance |  |
+| semantics.rb:516:10:516:10 | x : [collection] [element :bar] | semantics.rb:516:10:516:16 | ...[...] | provenance |  |
 nodes
 | semantics.rb:2:5:2:5 | a | semmle.label | a |
 | semantics.rb:2:5:2:5 | a | semmle.label | a |
@@ -1283,14 +1283,14 @@ nodes
 | semantics.rb:108:5:108:5 | b | semmle.label | b |
 | semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
 | semantics.rb:108:9:108:18 | call to source | semmle.label | call to source |
-| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semmle.label | call to s15 [element :foo] |
-| semantics.rb:109:10:109:28 | call to s15 [element :foo] | semmle.label | call to s15 [element :foo] |
+| semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | semmle.label | call to s15 : Hash [element :foo] |
+| semantics.rb:109:10:109:28 | call to s15 : Hash [element :foo] | semmle.label | call to s15 : Hash [element :foo] |
 | semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:109:10:109:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:109:19:109:19 | a | semmle.label | a |
 | semantics.rb:109:19:109:19 | a | semmle.label | a |
-| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semmle.label | call to s15 [element :bar] |
-| semantics.rb:110:10:110:28 | call to s15 [element :bar] | semmle.label | call to s15 [element :bar] |
+| semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | semmle.label | call to s15 : Hash [element :bar] |
+| semantics.rb:110:10:110:28 | call to s15 : Hash [element :bar] | semmle.label | call to s15 : Hash [element :bar] |
 | semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:110:10:110:34 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:110:27:110:27 | b | semmle.label | b |
@@ -1303,18 +1303,18 @@ nodes
 | semantics.rb:115:5:115:5 | b | semmle.label | b |
 | semantics.rb:115:9:115:18 | call to source | semmle.label | call to source |
 | semantics.rb:115:9:115:18 | call to source | semmle.label | call to source |
-| semantics.rb:116:5:116:5 | h [element :a] | semmle.label | h [element :a] |
-| semantics.rb:116:5:116:5 | h [element :a] | semmle.label | h [element :a] |
-| semantics.rb:116:9:116:22 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| semantics.rb:116:9:116:22 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| semantics.rb:116:5:116:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| semantics.rb:116:9:116:22 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | semantics.rb:116:14:116:14 | a | semmle.label | a |
 | semantics.rb:116:14:116:14 | a | semmle.label | a |
 | semantics.rb:117:10:117:17 | call to s16 | semmle.label | call to s16 |
 | semantics.rb:117:10:117:17 | call to s16 | semmle.label | call to s16 |
-| semantics.rb:117:14:117:16 | ** ... [element :a] | semmle.label | ** ... [element :a] |
-| semantics.rb:117:14:117:16 | ** ... [element :a] | semmle.label | ** ... [element :a] |
-| semantics.rb:117:16:117:16 | h [element :a] | semmle.label | h [element :a] |
-| semantics.rb:117:16:117:16 | h [element :a] | semmle.label | h [element :a] |
+| semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | semmle.label | ** ... : Hash [element :a] |
+| semantics.rb:117:14:117:16 | ** ... : Hash [element :a] | semmle.label | ** ... : Hash [element :a] |
+| semantics.rb:117:16:117:16 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| semantics.rb:117:16:117:16 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
 | semantics.rb:119:10:119:18 | call to s16 | semmle.label | call to s16 |
 | semantics.rb:119:10:119:18 | call to s16 | semmle.label | call to s16 |
 | semantics.rb:119:17:119:17 | a | semmle.label | a |
@@ -1323,10 +1323,10 @@ nodes
 | semantics.rb:121:10:121:23 | call to s16 | semmle.label | call to s16 |
 | semantics.rb:121:17:121:17 | b | semmle.label | b |
 | semantics.rb:121:17:121:17 | b | semmle.label | b |
-| semantics.rb:121:20:121:22 | ** ... [element :a] | semmle.label | ** ... [element :a] |
-| semantics.rb:121:20:121:22 | ** ... [element :a] | semmle.label | ** ... [element :a] |
-| semantics.rb:121:22:121:22 | h [element :a] | semmle.label | h [element :a] |
-| semantics.rb:121:22:121:22 | h [element :a] | semmle.label | h [element :a] |
+| semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | semmle.label | ** ... : Hash [element :a] |
+| semantics.rb:121:20:121:22 | ** ... : Hash [element :a] | semmle.label | ** ... : Hash [element :a] |
+| semantics.rb:121:22:121:22 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| semantics.rb:121:22:121:22 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
 | semantics.rb:125:5:125:5 | a | semmle.label | a |
 | semantics.rb:125:5:125:5 | a | semmle.label | a |
 | semantics.rb:125:9:125:18 | call to source | semmle.label | call to source |
@@ -1338,14 +1338,14 @@ nodes
 | semantics.rb:127:10:127:18 | call to s17 | semmle.label | call to s17 |
 | semantics.rb:127:14:127:14 | a | semmle.label | a |
 | semantics.rb:127:17:127:17 | b | semmle.label | b |
-| semantics.rb:128:10:128:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
-| semantics.rb:128:10:128:18 | call to s17 [element 0] | semmle.label | call to s17 [element 0] |
+| semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | semmle.label | call to s17 : Array [element 0] |
+| semantics.rb:128:10:128:18 | call to s17 : Array [element 0] | semmle.label | call to s17 : Array [element 0] |
 | semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:128:10:128:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:128:14:128:14 | a | semmle.label | a |
 | semantics.rb:128:14:128:14 | a | semmle.label | a |
-| semantics.rb:129:10:129:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
-| semantics.rb:129:10:129:18 | call to s17 [element 1] | semmle.label | call to s17 [element 1] |
+| semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | semmle.label | call to s17 : Array [element 1] |
+| semantics.rb:129:10:129:18 | call to s17 : Array [element 1] | semmle.label | call to s17 : Array [element 1] |
 | semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:129:10:129:21 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:129:17:129:17 | b | semmle.label | b |
@@ -1358,28 +1358,28 @@ nodes
 | semantics.rb:134:5:134:5 | b | semmle.label | b |
 | semantics.rb:134:9:134:18 | call to source | semmle.label | call to source |
 | semantics.rb:134:9:134:18 | call to source | semmle.label | call to source |
-| semantics.rb:135:5:135:7 | arr [element 0] | semmle.label | arr [element 0] |
-| semantics.rb:135:5:135:7 | arr [element 0] | semmle.label | arr [element 0] |
-| semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
-| semantics.rb:135:5:135:7 | arr [element 1] | semmle.label | arr [element 1] |
-| semantics.rb:135:11:135:16 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| semantics.rb:135:11:135:16 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| semantics.rb:135:11:135:16 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| semantics.rb:135:11:135:16 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| semantics.rb:135:5:135:7 | arr : Array [element 0] | semmle.label | arr : Array [element 0] |
+| semantics.rb:135:5:135:7 | arr : Array [element 0] | semmle.label | arr : Array [element 0] |
+| semantics.rb:135:5:135:7 | arr : Array [element 1] | semmle.label | arr : Array [element 1] |
+| semantics.rb:135:5:135:7 | arr : Array [element 1] | semmle.label | arr : Array [element 1] |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| semantics.rb:135:11:135:16 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | semantics.rb:135:12:135:12 | a | semmle.label | a |
 | semantics.rb:135:12:135:12 | a | semmle.label | a |
 | semantics.rb:135:15:135:15 | b | semmle.label | b |
 | semantics.rb:135:15:135:15 | b | semmle.label | b |
 | semantics.rb:136:10:136:18 | call to s18 | semmle.label | call to s18 |
 | semantics.rb:136:10:136:18 | call to s18 | semmle.label | call to s18 |
-| semantics.rb:136:14:136:17 | * ... [element 0] | semmle.label | * ... [element 0] |
-| semantics.rb:136:14:136:17 | * ... [element 0] | semmle.label | * ... [element 0] |
-| semantics.rb:136:14:136:17 | * ... [element 1] | semmle.label | * ... [element 1] |
-| semantics.rb:136:14:136:17 | * ... [element 1] | semmle.label | * ... [element 1] |
-| semantics.rb:136:15:136:17 | arr [element 0] | semmle.label | arr [element 0] |
-| semantics.rb:136:15:136:17 | arr [element 0] | semmle.label | arr [element 0] |
-| semantics.rb:136:15:136:17 | arr [element 1] | semmle.label | arr [element 1] |
-| semantics.rb:136:15:136:17 | arr [element 1] | semmle.label | arr [element 1] |
+| semantics.rb:136:14:136:17 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| semantics.rb:136:14:136:17 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| semantics.rb:136:14:136:17 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| semantics.rb:136:14:136:17 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| semantics.rb:136:15:136:17 | arr : Array [element 0] | semmle.label | arr : Array [element 0] |
+| semantics.rb:136:15:136:17 | arr : Array [element 0] | semmle.label | arr : Array [element 0] |
+| semantics.rb:136:15:136:17 | arr : Array [element 1] | semmle.label | arr : Array [element 1] |
+| semantics.rb:136:15:136:17 | arr : Array [element 1] | semmle.label | arr : Array [element 1] |
 | semantics.rb:137:10:137:15 | call to s18 | semmle.label | call to s18 |
 | semantics.rb:137:10:137:15 | call to s18 | semmle.label | call to s18 |
 | semantics.rb:137:14:137:14 | a | semmle.label | a |
@@ -1388,28 +1388,28 @@ nodes
 | semantics.rb:142:5:142:5 | b | semmle.label | b |
 | semantics.rb:142:9:142:18 | call to source | semmle.label | call to source |
 | semantics.rb:142:9:142:18 | call to source | semmle.label | call to source |
-| semantics.rb:146:5:146:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:146:5:146:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:146:5:146:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:146:5:146:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:148:10:148:15 | call to s19 | semmle.label | call to s19 |
 | semantics.rb:148:10:148:15 | call to s19 | semmle.label | call to s19 |
-| semantics.rb:148:14:148:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:148:14:148:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:148:14:148:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:148:14:148:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:152:5:152:5 | a | semmle.label | a |
 | semantics.rb:152:5:152:5 | a | semmle.label | a |
 | semantics.rb:152:9:152:18 | call to source | semmle.label | call to source |
 | semantics.rb:152:9:152:18 | call to source | semmle.label | call to source |
-| semantics.rb:153:5:153:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:153:5:153:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:153:9:153:14 | call to s20 [element] | semmle.label | call to s20 [element] |
-| semantics.rb:153:9:153:14 | call to s20 [element] | semmle.label | call to s20 [element] |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:153:5:153:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | semmle.label | call to s20 : [collection] [element] |
+| semantics.rb:153:9:153:14 | call to s20 : [collection] [element] | semmle.label | call to s20 : [collection] [element] |
 | semantics.rb:153:13:153:13 | a | semmle.label | a |
 | semantics.rb:153:13:153:13 | a | semmle.label | a |
-| semantics.rb:154:10:154:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:154:10:154:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:154:10:154:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:154:10:154:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:154:10:154:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:155:10:155:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:155:10:155:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:155:10:155:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:155:10:155:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:155:10:155:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:155:10:155:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:159:5:159:5 | a | semmle.label | a |
@@ -1420,96 +1420,96 @@ nodes
 | semantics.rb:160:5:160:5 | b | semmle.label | b |
 | semantics.rb:160:9:160:18 | call to source | semmle.label | call to source |
 | semantics.rb:160:9:160:18 | call to source | semmle.label | call to source |
-| semantics.rb:163:5:163:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:163:5:163:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:164:5:164:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:164:5:164:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:163:5:163:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:164:5:164:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:164:5:164:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:166:10:166:15 | call to s21 | semmle.label | call to s21 |
 | semantics.rb:166:10:166:15 | call to s21 | semmle.label | call to s21 |
-| semantics.rb:166:14:166:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:166:14:166:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:166:14:166:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:166:14:166:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:166:14:166:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:166:14:166:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:166:14:166:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:166:14:166:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:170:5:170:5 | a | semmle.label | a |
 | semantics.rb:170:5:170:5 | a | semmle.label | a |
 | semantics.rb:170:9:170:18 | call to source | semmle.label | call to source |
 | semantics.rb:170:9:170:18 | call to source | semmle.label | call to source |
-| semantics.rb:171:5:171:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:171:5:171:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:171:9:171:14 | call to s22 [element] | semmle.label | call to s22 [element] |
-| semantics.rb:171:9:171:14 | call to s22 [element] | semmle.label | call to s22 [element] |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:171:5:171:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | semmle.label | call to s22 : [collection] [element] |
+| semantics.rb:171:9:171:14 | call to s22 : [collection] [element] | semmle.label | call to s22 : [collection] [element] |
 | semantics.rb:171:13:171:13 | a | semmle.label | a |
 | semantics.rb:171:13:171:13 | a | semmle.label | a |
-| semantics.rb:172:10:172:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:172:10:172:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:172:10:172:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:172:10:172:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:172:10:172:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:173:10:173:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:173:10:173:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:173:10:173:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:173:10:173:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:173:10:173:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:173:10:173:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:177:5:177:5 | a | semmle.label | a |
 | semantics.rb:177:5:177:5 | a | semmle.label | a |
 | semantics.rb:177:9:177:18 | call to source | semmle.label | call to source |
 | semantics.rb:177:9:177:18 | call to source | semmle.label | call to source |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:180:5:180:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:181:5:181:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:181:5:181:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:181:5:181:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:181:5:181:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:180:5:180:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:181:5:181:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:181:5:181:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:181:5:181:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:182:10:182:15 | call to s23 | semmle.label | call to s23 |
 | semantics.rb:182:10:182:15 | call to s23 | semmle.label | call to s23 |
-| semantics.rb:182:14:182:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:182:14:182:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:182:14:182:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:182:14:182:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:186:5:186:5 | a | semmle.label | a |
 | semantics.rb:186:5:186:5 | a | semmle.label | a |
 | semantics.rb:186:9:186:18 | call to source | semmle.label | call to source |
 | semantics.rb:186:9:186:18 | call to source | semmle.label | call to source |
-| semantics.rb:187:5:187:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:187:5:187:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:187:9:187:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
-| semantics.rb:187:9:187:14 | call to s24 [element 0] | semmle.label | call to s24 [element 0] |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:187:5:187:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | semmle.label | call to s24 : [collection] [element 0] |
+| semantics.rb:187:9:187:14 | call to s24 : [collection] [element 0] | semmle.label | call to s24 : [collection] [element 0] |
 | semantics.rb:187:13:187:13 | a | semmle.label | a |
 | semantics.rb:187:13:187:13 | a | semmle.label | a |
-| semantics.rb:188:10:188:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:188:10:188:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:188:10:188:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:188:10:188:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:190:10:190:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:190:10:190:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:190:10:190:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:190:10:190:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:190:10:190:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:190:10:190:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:194:5:194:5 | a | semmle.label | a |
 | semantics.rb:194:5:194:5 | a | semmle.label | a |
 | semantics.rb:194:9:194:18 | call to source | semmle.label | call to source |
 | semantics.rb:194:9:194:18 | call to source | semmle.label | call to source |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:197:5:197:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:198:5:198:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:198:5:198:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:198:5:198:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:198:5:198:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:197:5:197:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:198:5:198:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:198:5:198:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:198:5:198:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:199:10:199:15 | call to s25 | semmle.label | call to s25 |
 | semantics.rb:199:10:199:15 | call to s25 | semmle.label | call to s25 |
-| semantics.rb:199:14:199:14 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:199:14:199:14 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:199:14:199:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:199:14:199:14 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:203:5:203:5 | a | semmle.label | a |
 | semantics.rb:203:5:203:5 | a | semmle.label | a |
 | semantics.rb:203:9:203:18 | call to source | semmle.label | call to source |
 | semantics.rb:203:9:203:18 | call to source | semmle.label | call to source |
-| semantics.rb:204:5:204:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:204:5:204:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:204:9:204:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
-| semantics.rb:204:9:204:14 | call to s26 [element 0] | semmle.label | call to s26 [element 0] |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:204:5:204:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | semmle.label | call to s26 : [collection] [element 0] |
+| semantics.rb:204:9:204:14 | call to s26 : [collection] [element 0] | semmle.label | call to s26 : [collection] [element 0] |
 | semantics.rb:204:13:204:13 | a | semmle.label | a |
 | semantics.rb:204:13:204:13 | a | semmle.label | a |
-| semantics.rb:205:10:205:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:205:10:205:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:205:10:205:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:205:10:205:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:205:10:205:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:205:10:205:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:207:10:207:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:207:10:207:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:207:10:207:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:207:10:207:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:207:10:207:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:207:10:207:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:212:5:212:5 | b | semmle.label | b |
@@ -1524,48 +1524,48 @@ nodes
 | semantics.rb:214:5:214:5 | d | semmle.label | d |
 | semantics.rb:214:9:214:18 | call to source | semmle.label | call to source |
 | semantics.rb:214:9:214:18 | call to source | semmle.label | call to source |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:218:5:218:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:219:5:219:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:219:5:219:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:219:5:219:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:219:5:219:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:219:5:219:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:219:5:219:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:220:5:220:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:220:5:220:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:218:5:218:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | semmle.label | [post] h : [collection] [element 2] |
+| semantics.rb:219:5:219:5 | [post] h : [collection] [element 2] | semmle.label | [post] h : [collection] [element 2] |
+| semantics.rb:219:5:219:5 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:219:5:219:5 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:220:5:220:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:220:5:220:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:222:10:222:15 | call to s27 | semmle.label | call to s27 |
 | semantics.rb:222:10:222:15 | call to s27 | semmle.label | call to s27 |
-| semantics.rb:222:14:222:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:222:14:222:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:222:14:222:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:222:14:222:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:222:14:222:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:222:14:222:14 | h [element] | semmle.label | h [element] |
+| semantics.rb:222:14:222:14 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:222:14:222:14 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:222:14:222:14 | h : [collection] [element 2] | semmle.label | h : [collection] [element 2] |
+| semantics.rb:222:14:222:14 | h : [collection] [element 2] | semmle.label | h : [collection] [element 2] |
+| semantics.rb:222:14:222:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:222:14:222:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:226:5:226:5 | a | semmle.label | a |
 | semantics.rb:226:5:226:5 | a | semmle.label | a |
 | semantics.rb:226:9:226:18 | call to source | semmle.label | call to source |
 | semantics.rb:226:9:226:18 | call to source | semmle.label | call to source |
-| semantics.rb:227:5:227:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:227:5:227:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:227:9:227:14 | call to s28 [element] | semmle.label | call to s28 [element] |
-| semantics.rb:227:9:227:14 | call to s28 [element] | semmle.label | call to s28 [element] |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:227:5:227:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | semmle.label | call to s28 : [collection] [element] |
+| semantics.rb:227:9:227:14 | call to s28 : [collection] [element] | semmle.label | call to s28 : [collection] [element] |
 | semantics.rb:227:13:227:13 | a | semmle.label | a |
 | semantics.rb:227:13:227:13 | a | semmle.label | a |
-| semantics.rb:228:10:228:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:228:10:228:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:228:10:228:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:228:10:228:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:228:10:228:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:228:10:228:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:229:10:229:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:229:10:229:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:229:10:229:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:229:10:229:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:229:10:229:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:229:10:229:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:230:10:230:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:230:10:230:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:230:10:230:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:230:10:230:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:230:10:230:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:231:10:231:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:231:10:231:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:231:10:231:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:231:10:231:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:231:10:231:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:231:10:231:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:236:5:236:5 | b | semmle.label | b |
@@ -1576,224 +1576,224 @@ nodes
 | semantics.rb:237:5:237:5 | c | semmle.label | c |
 | semantics.rb:237:9:237:18 | call to source | semmle.label | call to source |
 | semantics.rb:237:9:237:18 | call to source | semmle.label | call to source |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:241:5:241:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:242:5:242:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:242:5:242:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:242:5:242:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:242:5:242:5 | [post] h [element 2] | semmle.label | [post] h [element 2] |
-| semantics.rb:242:5:242:5 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:242:5:242:5 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:241:5:241:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | semmle.label | [post] h : [collection] [element 2] |
+| semantics.rb:242:5:242:5 | [post] h : [collection] [element 2] | semmle.label | [post] h : [collection] [element 2] |
+| semantics.rb:242:5:242:5 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:242:5:242:5 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
 | semantics.rb:245:10:245:15 | call to s29 | semmle.label | call to s29 |
 | semantics.rb:245:10:245:15 | call to s29 | semmle.label | call to s29 |
-| semantics.rb:245:14:245:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:245:14:245:14 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:245:14:245:14 | h [element 2] | semmle.label | h [element 2] |
-| semantics.rb:245:14:245:14 | h [element 2] | semmle.label | h [element 2] |
+| semantics.rb:245:14:245:14 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:245:14:245:14 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:245:14:245:14 | h : [collection] [element 2] | semmle.label | h : [collection] [element 2] |
+| semantics.rb:245:14:245:14 | h : [collection] [element 2] | semmle.label | h : [collection] [element 2] |
 | semantics.rb:249:5:249:5 | a | semmle.label | a |
 | semantics.rb:249:5:249:5 | a | semmle.label | a |
 | semantics.rb:249:9:249:18 | call to source | semmle.label | call to source |
 | semantics.rb:249:9:249:18 | call to source | semmle.label | call to source |
-| semantics.rb:250:5:250:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:250:5:250:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:250:9:250:14 | call to s30 [element] | semmle.label | call to s30 [element] |
-| semantics.rb:250:9:250:14 | call to s30 [element] | semmle.label | call to s30 [element] |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:250:5:250:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | semmle.label | call to s30 : [collection] [element] |
+| semantics.rb:250:9:250:14 | call to s30 : [collection] [element] | semmle.label | call to s30 : [collection] [element] |
 | semantics.rb:250:13:250:13 | a | semmle.label | a |
 | semantics.rb:250:13:250:13 | a | semmle.label | a |
-| semantics.rb:251:10:251:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:251:10:251:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:251:10:251:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:251:10:251:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:251:10:251:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:251:10:251:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:252:10:252:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:252:10:252:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:252:10:252:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:252:10:252:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:252:10:252:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:252:10:252:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:253:10:253:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:253:10:253:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:253:10:253:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:253:10:253:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:253:10:253:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:253:10:253:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:254:10:254:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:254:10:254:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:254:10:254:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:254:10:254:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:254:10:254:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:254:10:254:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:258:5:258:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:258:5:258:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:258:5:258:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:258:15:258:25 | call to source | semmle.label | call to source |
 | semantics.rb:258:15:258:25 | call to source | semmle.label | call to source |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:259:5:259:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:259:5:259:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:259:5:259:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:260:5:260:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:260:5:260:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:260:5:260:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:260:5:260:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:261:5:261:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:261:5:261:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:259:5:259:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:259:5:259:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:259:5:259:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:260:5:260:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:260:5:260:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:260:5:260:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:261:5:261:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:261:5:261:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:261:12:261:22 | call to source | semmle.label | call to source |
 | semantics.rb:261:12:261:22 | call to source | semmle.label | call to source |
 | semantics.rb:263:10:263:15 | call to s31 | semmle.label | call to s31 |
 | semantics.rb:263:10:263:15 | call to s31 | semmle.label | call to s31 |
-| semantics.rb:263:14:263:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:263:14:263:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:263:14:263:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:267:5:267:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:267:5:267:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:263:14:263:14 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:263:14:263:14 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:263:14:263:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:263:14:263:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:267:5:267:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:267:15:267:25 | call to source | semmle.label | call to source |
 | semantics.rb:267:15:267:25 | call to source | semmle.label | call to source |
-| semantics.rb:268:5:268:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:268:5:268:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:268:5:268:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:268:5:268:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:268:5:268:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:268:5:268:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:268:5:268:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:268:5:268:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
 | semantics.rb:268:16:268:26 | call to source | semmle.label | call to source |
-| semantics.rb:269:5:269:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:269:5:269:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:269:5:269:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:269:5:269:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:269:5:269:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:269:5:269:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:270:5:270:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:270:5:270:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:270:5:270:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:270:5:270:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:270:5:270:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:270:5:270:5 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:271:5:271:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:271:5:271:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:269:5:269:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:269:5:269:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:269:5:269:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:269:5:269:5 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:269:5:269:5 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:270:5:270:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:270:5:270:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:270:5:270:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:270:5:270:5 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:270:5:270:5 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:271:5:271:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:271:5:271:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:271:12:271:22 | call to source | semmle.label | call to source |
 | semantics.rb:271:12:271:22 | call to source | semmle.label | call to source |
 | semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
 | semantics.rb:273:10:273:15 | call to s32 | semmle.label | call to s32 |
-| semantics.rb:273:14:273:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:273:14:273:14 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:273:14:273:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:273:14:273:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:273:14:273:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:281:5:281:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:281:5:281:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:273:14:273:14 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:273:14:273:14 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:273:14:273:14 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:273:14:273:14 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:273:14:273:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:273:14:273:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:281:5:281:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:281:5:281:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:281:12:281:22 | call to source | semmle.label | call to source |
 | semantics.rb:281:12:281:22 | call to source | semmle.label | call to source |
-| semantics.rb:282:5:282:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:282:5:282:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:282:5:282:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:282:5:282:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:282:5:282:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:282:5:282:5 | h [element] | semmle.label | h [element] |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:282:5:282:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:282:5:282:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:282:5:282:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:282:14:282:24 | call to source | semmle.label | call to source |
 | semantics.rb:282:14:282:24 | call to source | semmle.label | call to source |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:283:5:283:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semmle.label | [post] h [element true] |
-| semantics.rb:283:5:283:5 | [post] h [element true] | semmle.label | [post] h [element true] |
-| semantics.rb:283:5:283:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:283:5:283:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:283:5:283:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:283:5:283:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:283:5:283:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:283:5:283:5 | h [element] | semmle.label | h [element] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | semmle.label | [post] h : [collection] [element true] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element true] | semmle.label | [post] h : [collection] [element true] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:283:5:283:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:283:5:283:5 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:283:5:283:5 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:283:5:283:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:283:5:283:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:283:15:283:25 | call to source | semmle.label | call to source |
 | semantics.rb:283:15:283:25 | call to source | semmle.label | call to source |
-| semantics.rb:284:5:284:5 | [post] h [element false] | semmle.label | [post] h [element false] |
-| semantics.rb:284:5:284:5 | [post] h [element false] | semmle.label | [post] h [element false] |
-| semantics.rb:284:5:284:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:284:5:284:5 | [post] h [element nil] | semmle.label | [post] h [element nil] |
-| semantics.rb:284:5:284:5 | [post] h [element true] | semmle.label | [post] h [element true] |
-| semantics.rb:284:5:284:5 | [post] h [element true] | semmle.label | [post] h [element true] |
-| semantics.rb:284:5:284:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:284:5:284:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:284:5:284:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:284:5:284:5 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:284:5:284:5 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:284:5:284:5 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:284:5:284:5 | h [element] | semmle.label | h [element] |
-| semantics.rb:284:5:284:5 | h [element] | semmle.label | h [element] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | semmle.label | [post] h : [collection] [element false] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element false] | semmle.label | [post] h : [collection] [element false] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element nil] | semmle.label | [post] h : [collection] [element nil] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | semmle.label | [post] h : [collection] [element true] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element true] | semmle.label | [post] h : [collection] [element true] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:284:5:284:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:284:5:284:5 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:284:5:284:5 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:284:5:284:5 | h : [collection] [element true] | semmle.label | h : [collection] [element true] |
+| semantics.rb:284:5:284:5 | h : [collection] [element true] | semmle.label | h : [collection] [element true] |
+| semantics.rb:284:5:284:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:284:5:284:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:284:16:284:26 | call to source | semmle.label | call to source |
 | semantics.rb:284:16:284:26 | call to source | semmle.label | call to source |
 | semantics.rb:286:10:286:15 | call to s33 | semmle.label | call to s33 |
 | semantics.rb:286:10:286:15 | call to s33 | semmle.label | call to s33 |
-| semantics.rb:286:14:286:14 | h [element false] | semmle.label | h [element false] |
-| semantics.rb:286:14:286:14 | h [element false] | semmle.label | h [element false] |
-| semantics.rb:286:14:286:14 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:286:14:286:14 | h [element nil] | semmle.label | h [element nil] |
-| semantics.rb:286:14:286:14 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:286:14:286:14 | h [element true] | semmle.label | h [element true] |
-| semantics.rb:286:14:286:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:286:14:286:14 | h [element] | semmle.label | h [element] |
-| semantics.rb:290:5:290:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:290:5:290:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
-| semantics.rb:290:9:290:24 | call to s35 [element :foo] | semmle.label | call to s35 [element :foo] |
+| semantics.rb:286:14:286:14 | h : [collection] [element false] | semmle.label | h : [collection] [element false] |
+| semantics.rb:286:14:286:14 | h : [collection] [element false] | semmle.label | h : [collection] [element false] |
+| semantics.rb:286:14:286:14 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:286:14:286:14 | h : [collection] [element nil] | semmle.label | h : [collection] [element nil] |
+| semantics.rb:286:14:286:14 | h : [collection] [element true] | semmle.label | h : [collection] [element true] |
+| semantics.rb:286:14:286:14 | h : [collection] [element true] | semmle.label | h : [collection] [element true] |
+| semantics.rb:286:14:286:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:286:14:286:14 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:290:5:290:5 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | semmle.label | call to s35 : [collection] [element :foo] |
+| semantics.rb:290:9:290:24 | call to s35 : [collection] [element :foo] | semmle.label | call to s35 : [collection] [element :foo] |
 | semantics.rb:290:13:290:23 | call to source | semmle.label | call to source |
 | semantics.rb:290:13:290:23 | call to source | semmle.label | call to source |
-| semantics.rb:291:10:291:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:291:10:291:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:291:10:291:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:291:10:291:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
 | semantics.rb:291:10:291:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:291:10:291:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:293:10:293:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:293:10:293:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:293:10:293:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:293:10:293:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
 | semantics.rb:293:10:293:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:293:10:293:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:297:5:297:5 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:297:5:297:5 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:297:9:297:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
-| semantics.rb:297:9:297:24 | call to s36 [element foo] | semmle.label | call to s36 [element foo] |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
+| semantics.rb:297:5:297:5 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | semmle.label | call to s36 : [collection] [element foo] |
+| semantics.rb:297:9:297:24 | call to s36 : [collection] [element foo] | semmle.label | call to s36 : [collection] [element foo] |
 | semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
 | semantics.rb:297:13:297:23 | call to source | semmle.label | call to source |
-| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:298:10:298:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:298:10:298:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
+| semantics.rb:298:10:298:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
 | semantics.rb:298:10:298:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:298:10:298:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:299:10:299:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:299:10:299:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
+| semantics.rb:299:10:299:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
 | semantics.rb:299:10:299:17 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:299:10:299:17 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:301:10:301:10 | x [element foo] | semmle.label | x [element foo] |
-| semantics.rb:301:10:301:10 | x [element foo] | semmle.label | x [element foo] |
+| semantics.rb:301:10:301:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
+| semantics.rb:301:10:301:10 | x : [collection] [element foo] | semmle.label | x : [collection] [element foo] |
 | semantics.rb:301:10:301:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:301:10:301:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:305:5:305:5 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:305:5:305:5 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:305:9:305:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
-| semantics.rb:305:9:305:24 | call to s37 [element true] | semmle.label | call to s37 [element true] |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
+| semantics.rb:305:5:305:5 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
+| semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | semmle.label | call to s37 : [collection] [element true] |
+| semantics.rb:305:9:305:24 | call to s37 : [collection] [element true] | semmle.label | call to s37 : [collection] [element true] |
 | semantics.rb:305:13:305:23 | call to source | semmle.label | call to source |
 | semantics.rb:305:13:305:23 | call to source | semmle.label | call to source |
-| semantics.rb:307:10:307:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:307:10:307:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:307:10:307:10 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
+| semantics.rb:307:10:307:10 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
 | semantics.rb:307:10:307:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:307:10:307:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:309:10:309:10 | x [element true] | semmle.label | x [element true] |
-| semantics.rb:309:10:309:10 | x [element true] | semmle.label | x [element true] |
+| semantics.rb:309:10:309:10 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
+| semantics.rb:309:10:309:10 | x : [collection] [element true] | semmle.label | x : [collection] [element true] |
 | semantics.rb:309:10:309:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:309:10:309:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:313:5:313:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
-| semantics.rb:313:5:313:5 | [post] h [element foo] | semmle.label | [post] h [element foo] |
+| semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
+| semantics.rb:313:5:313:5 | [post] h : [collection] [element foo] | semmle.label | [post] h : [collection] [element foo] |
 | semantics.rb:313:16:313:26 | call to source | semmle.label | call to source |
 | semantics.rb:313:16:313:26 | call to source | semmle.label | call to source |
 | semantics.rb:316:10:316:15 | call to s38 | semmle.label | call to s38 |
 | semantics.rb:316:10:316:15 | call to s38 | semmle.label | call to s38 |
-| semantics.rb:316:14:316:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:316:14:316:14 | h [element foo] | semmle.label | h [element foo] |
-| semantics.rb:320:5:320:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:320:5:320:5 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
-| semantics.rb:320:9:320:24 | call to s39 [element :foo] | semmle.label | call to s39 [element :foo] |
+| semantics.rb:316:14:316:14 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:316:14:316:14 | h : [collection] [element foo] | semmle.label | h : [collection] [element foo] |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:320:5:320:5 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | semmle.label | call to s39 : [collection] [element :foo] |
+| semantics.rb:320:9:320:24 | call to s39 : [collection] [element :foo] | semmle.label | call to s39 : [collection] [element :foo] |
 | semantics.rb:320:13:320:23 | call to source | semmle.label | call to source |
 | semantics.rb:320:13:320:23 | call to source | semmle.label | call to source |
-| semantics.rb:322:10:322:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:322:10:322:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:322:10:322:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:322:10:322:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
 | semantics.rb:322:10:322:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:322:10:322:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:323:10:323:10 | x [element :foo] | semmle.label | x [element :foo] |
-| semantics.rb:323:10:323:10 | x [element :foo] | semmle.label | x [element :foo] |
+| semantics.rb:323:10:323:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
+| semantics.rb:323:10:323:10 | x : [collection] [element :foo] | semmle.label | x : [collection] [element :foo] |
 | semantics.rb:323:10:323:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:323:10:323:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:328:5:328:5 | [post] x [@foo] | semmle.label | [post] x [@foo] |
@@ -1814,508 +1814,508 @@ nodes
 | semantics.rb:335:10:335:10 | x [@foo] | semmle.label | x [@foo] |
 | semantics.rb:335:10:335:14 | call to foo | semmle.label | call to foo |
 | semantics.rb:335:10:335:14 | call to foo | semmle.label | call to foo |
-| semantics.rb:340:5:340:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:340:5:340:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:340:5:340:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
 | semantics.rb:340:12:340:22 | call to source | semmle.label | call to source |
 | semantics.rb:340:12:340:22 | call to source | semmle.label | call to source |
-| semantics.rb:341:5:341:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:341:5:341:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:341:5:341:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:341:5:341:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:341:12:341:22 | call to source | semmle.label | call to source |
 | semantics.rb:341:12:341:22 | call to source | semmle.label | call to source |
-| semantics.rb:343:5:343:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:343:5:343:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:343:5:343:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:343:5:343:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:343:9:343:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
-| semantics.rb:343:9:343:14 | call to s42 [element 0] | semmle.label | call to s42 [element 0] |
-| semantics.rb:343:9:343:14 | call to s42 [element] | semmle.label | call to s42 [element] |
-| semantics.rb:343:9:343:14 | call to s42 [element] | semmle.label | call to s42 [element] |
-| semantics.rb:343:13:343:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:343:13:343:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:343:13:343:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:343:13:343:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:345:10:345:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:345:10:345:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:345:10:345:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:345:10:345:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:343:5:343:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:343:5:343:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | semmle.label | call to s42 : [collection] [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element 0] | semmle.label | call to s42 : [collection] [element 0] |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | semmle.label | call to s42 : [collection] [element] |
+| semantics.rb:343:9:343:14 | call to s42 : [collection] [element] | semmle.label | call to s42 : [collection] [element] |
+| semantics.rb:343:13:343:13 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:343:13:343:13 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:343:13:343:13 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:343:13:343:13 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:345:10:345:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:345:10:345:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:345:10:345:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:345:10:345:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:345:10:345:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:346:10:346:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:346:10:346:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:346:10:346:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:346:10:346:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:346:10:346:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:346:10:346:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:347:10:347:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:347:10:347:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:347:10:347:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:347:10:347:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:347:10:347:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:347:10:347:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:347:10:347:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:347:10:347:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:347:10:347:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:347:10:347:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:351:5:351:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:351:5:351:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:351:5:351:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
 | semantics.rb:351:12:351:22 | call to source | semmle.label | call to source |
 | semantics.rb:351:12:351:22 | call to source | semmle.label | call to source |
-| semantics.rb:354:5:354:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:354:5:354:5 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:354:9:354:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
-| semantics.rb:354:9:354:14 | call to s43 [element 0] | semmle.label | call to s43 [element 0] |
-| semantics.rb:354:13:354:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:354:13:354:13 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:356:10:356:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:356:10:356:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:354:5:354:5 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | semmle.label | call to s43 : [collection] [element 0] |
+| semantics.rb:354:9:354:14 | call to s43 : [collection] [element 0] | semmle.label | call to s43 : [collection] [element 0] |
+| semantics.rb:354:13:354:13 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:354:13:354:13 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:356:10:356:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:356:10:356:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:356:10:356:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:356:10:356:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:358:10:358:10 | x [element 0] | semmle.label | x [element 0] |
-| semantics.rb:358:10:358:10 | x [element 0] | semmle.label | x [element 0] |
+| semantics.rb:358:10:358:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
+| semantics.rb:358:10:358:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | semantics.rb:358:10:358:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:358:10:358:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:363:5:363:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:363:5:363:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
+| semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:363:5:363:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
 | semantics.rb:363:12:363:22 | call to source | semmle.label | call to source |
 | semantics.rb:363:12:363:22 | call to source | semmle.label | call to source |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:366:9:366:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:366:9:366:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:366:9:366:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:369:10:369:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:369:10:369:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:366:9:366:9 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:366:9:366:9 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:366:9:366:9 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:369:10:369:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:369:10:369:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
 | semantics.rb:369:10:369:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:369:10:369:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:370:10:370:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:370:10:370:10 | h [element 1] | semmle.label | h [element 1] |
+| semantics.rb:370:10:370:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:370:10:370:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
 | semantics.rb:370:10:370:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:370:10:370:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:374:5:374:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:374:5:374:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
 | semantics.rb:374:12:374:22 | call to source | semmle.label | call to source |
 | semantics.rb:374:12:374:22 | call to source | semmle.label | call to source |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:375:5:375:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:375:5:375:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:375:5:375:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:375:5:375:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:375:5:375:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:375:5:375:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:375:5:375:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:375:12:375:22 | call to source | semmle.label | call to source |
 | semantics.rb:375:12:375:22 | call to source | semmle.label | call to source |
-| semantics.rb:376:5:376:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:376:5:376:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:376:5:376:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:376:12:376:22 | call to source | semmle.label | call to source |
 | semantics.rb:376:12:376:22 | call to source | semmle.label | call to source |
-| semantics.rb:378:10:378:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:378:10:378:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:378:10:378:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:378:10:378:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:378:10:378:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:378:10:378:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:378:10:378:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:378:10:378:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:378:10:378:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:378:10:378:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:379:10:379:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:379:10:379:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:379:10:379:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:379:10:379:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:379:10:379:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:379:10:379:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:379:10:379:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:379:10:379:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:379:10:379:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:379:10:379:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:380:10:380:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:380:10:380:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:380:10:380:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:380:10:380:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:380:10:380:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:380:10:380:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:380:10:380:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:380:10:380:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:380:10:380:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:380:10:380:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:380:10:380:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:380:10:380:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:380:10:380:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:380:10:380:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:382:9:382:9 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:382:9:382:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:382:9:382:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:382:9:382:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:382:9:382:9 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:382:9:382:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:382:9:382:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:384:10:384:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:384:10:384:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:382:9:382:9 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:382:9:382:9 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:382:9:382:9 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:382:9:382:9 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:382:9:382:9 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:384:10:384:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:384:10:384:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:384:10:384:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:384:10:384:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:385:10:385:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:385:10:385:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:385:10:385:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:385:10:385:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:385:10:385:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:385:10:385:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:385:10:385:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:385:10:385:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:385:10:385:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:385:10:385:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:386:10:386:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:386:10:386:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:386:10:386:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:386:10:386:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:386:10:386:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:386:10:386:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:386:10:386:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:386:10:386:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:386:10:386:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:386:10:386:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:390:5:390:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
+| semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:390:5:390:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
 | semantics.rb:390:12:390:22 | call to source | semmle.label | call to source |
 | semantics.rb:390:12:390:22 | call to source | semmle.label | call to source |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:391:5:391:5 | [post] h [element 0] | semmle.label | [post] h [element 0] |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:391:5:391:5 | [post] h [element 1] | semmle.label | [post] h [element 1] |
-| semantics.rb:391:5:391:5 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:391:5:391:5 | h [element 0] | semmle.label | h [element 0] |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 0] | semmle.label | [post] h : [collection] [element 0] |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:391:5:391:5 | [post] h : [collection] [element 1] | semmle.label | [post] h : [collection] [element 1] |
+| semantics.rb:391:5:391:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:391:5:391:5 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
 | semantics.rb:391:12:391:22 | call to source | semmle.label | call to source |
 | semantics.rb:391:12:391:22 | call to source | semmle.label | call to source |
-| semantics.rb:392:5:392:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:392:5:392:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:392:5:392:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:392:12:392:22 | call to source | semmle.label | call to source |
 | semantics.rb:392:12:392:22 | call to source | semmle.label | call to source |
-| semantics.rb:394:10:394:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:394:10:394:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:394:10:394:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:394:10:394:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:394:10:394:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:394:10:394:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:394:10:394:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:394:10:394:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:394:10:394:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:394:10:394:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:395:10:395:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:395:10:395:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:395:10:395:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:395:10:395:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:395:10:395:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:395:10:395:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:395:10:395:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:395:10:395:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:395:10:395:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:396:10:396:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:396:10:396:10 | h [element 0] | semmle.label | h [element 0] |
-| semantics.rb:396:10:396:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:396:10:396:10 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:396:10:396:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:396:10:396:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:396:10:396:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:396:10:396:10 | h : [collection] [element 0] | semmle.label | h : [collection] [element 0] |
+| semantics.rb:396:10:396:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:396:10:396:10 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:396:10:396:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:396:10:396:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:396:10:396:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:396:10:396:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:398:5:398:5 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:398:5:398:5 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:398:9:398:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
-| semantics.rb:398:9:398:14 | call to s46 [element 1] | semmle.label | call to s46 [element 1] |
-| semantics.rb:398:13:398:13 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:398:13:398:13 | h [element 1] | semmle.label | h [element 1] |
-| semantics.rb:401:10:401:10 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:401:10:401:10 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
+| semantics.rb:398:5:398:5 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | semmle.label | call to s46 : [collection] [element 1] |
+| semantics.rb:398:9:398:14 | call to s46 : [collection] [element 1] | semmle.label | call to s46 : [collection] [element 1] |
+| semantics.rb:398:13:398:13 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:398:13:398:13 | h : [collection] [element 1] | semmle.label | h : [collection] [element 1] |
+| semantics.rb:401:10:401:10 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
+| semantics.rb:401:10:401:10 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
 | semantics.rb:401:10:401:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:401:10:401:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:402:10:402:10 | x [element 1] | semmle.label | x [element 1] |
-| semantics.rb:402:10:402:10 | x [element 1] | semmle.label | x [element 1] |
+| semantics.rb:402:10:402:10 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
+| semantics.rb:402:10:402:10 | x : [collection] [element 1] | semmle.label | x : [collection] [element 1] |
 | semantics.rb:402:10:402:13 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:402:10:402:13 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:406:5:406:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:406:5:406:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:406:15:406:25 | call to source | semmle.label | call to source |
 | semantics.rb:406:15:406:25 | call to source | semmle.label | call to source |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:407:5:407:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:407:5:407:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:407:5:407:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:407:5:407:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:407:5:407:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:407:5:407:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:407:5:407:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:407:5:407:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:407:15:407:25 | call to source | semmle.label | call to source |
 | semantics.rb:407:15:407:25 | call to source | semmle.label | call to source |
-| semantics.rb:408:5:408:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:408:5:408:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:408:5:408:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:408:12:408:22 | call to source | semmle.label | call to source |
 | semantics.rb:408:12:408:22 | call to source | semmle.label | call to source |
-| semantics.rb:410:10:410:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:410:10:410:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:410:10:410:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:410:10:410:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:410:10:410:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:410:10:410:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:410:10:410:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:410:10:410:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:410:10:410:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:411:10:411:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:411:10:411:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:411:10:411:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:411:10:411:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:411:10:411:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:411:10:411:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:411:10:411:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:411:10:411:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:411:10:411:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:411:10:411:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:413:5:413:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:413:5:413:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
-| semantics.rb:413:9:413:14 | call to s47 [element :bar] | semmle.label | call to s47 [element :bar] |
-| semantics.rb:413:13:413:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:413:13:413:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:416:10:416:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:416:10:416:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:413:5:413:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:413:5:413:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | semmle.label | call to s47 : [collection] [element :bar] |
+| semantics.rb:413:9:413:14 | call to s47 : [collection] [element :bar] | semmle.label | call to s47 : [collection] [element :bar] |
+| semantics.rb:413:13:413:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:413:13:413:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:416:10:416:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:416:10:416:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
 | semantics.rb:416:10:416:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:416:10:416:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:420:5:420:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:420:5:420:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:420:15:420:25 | call to source | semmle.label | call to source |
 | semantics.rb:420:15:420:25 | call to source | semmle.label | call to source |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:421:5:421:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:421:5:421:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:421:5:421:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:421:5:421:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:421:5:421:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:421:5:421:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:421:5:421:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:421:5:421:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:421:15:421:25 | call to source | semmle.label | call to source |
 | semantics.rb:421:15:421:25 | call to source | semmle.label | call to source |
-| semantics.rb:422:5:422:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:422:5:422:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:422:5:422:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:422:12:422:22 | call to source | semmle.label | call to source |
 | semantics.rb:422:12:422:22 | call to source | semmle.label | call to source |
-| semantics.rb:424:10:424:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:424:10:424:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:424:10:424:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:424:10:424:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:424:10:424:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:424:10:424:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:424:10:424:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:424:10:424:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:424:10:424:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:425:10:425:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:425:10:425:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:425:10:425:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:425:10:425:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:425:10:425:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:425:10:425:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:425:10:425:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:425:10:425:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:425:10:425:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:425:10:425:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:427:5:427:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:427:5:427:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
-| semantics.rb:427:9:427:14 | call to s48 [element :bar] | semmle.label | call to s48 [element :bar] |
-| semantics.rb:427:13:427:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:427:13:427:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:430:10:430:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:430:10:430:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:427:5:427:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:427:5:427:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | semmle.label | call to s48 : [collection] [element :bar] |
+| semantics.rb:427:9:427:14 | call to s48 : [collection] [element :bar] | semmle.label | call to s48 : [collection] [element :bar] |
+| semantics.rb:427:13:427:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:427:13:427:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:430:10:430:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:430:10:430:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
 | semantics.rb:430:10:430:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:430:10:430:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:434:5:434:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:434:5:434:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:434:15:434:25 | call to source | semmle.label | call to source |
 | semantics.rb:434:15:434:25 | call to source | semmle.label | call to source |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:435:5:435:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:435:5:435:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:435:5:435:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:435:5:435:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:435:5:435:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:435:5:435:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:435:5:435:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:435:5:435:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:435:15:435:25 | call to source | semmle.label | call to source |
 | semantics.rb:435:15:435:25 | call to source | semmle.label | call to source |
-| semantics.rb:436:5:436:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:436:5:436:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:436:5:436:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:436:12:436:22 | call to source | semmle.label | call to source |
 | semantics.rb:436:12:436:22 | call to source | semmle.label | call to source |
-| semantics.rb:438:10:438:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:438:10:438:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:438:10:438:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:438:10:438:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:438:10:438:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:438:10:438:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:438:10:438:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:438:10:438:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:438:10:438:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:439:10:439:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:439:10:439:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:439:10:439:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:439:10:439:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:439:10:439:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:439:10:439:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:439:10:439:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:439:10:439:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:439:10:439:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:439:10:439:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:441:5:441:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:441:5:441:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:441:5:441:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:441:5:441:5 | x [element] | semmle.label | x [element] |
-| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
-| semantics.rb:441:9:441:14 | call to s49 [element :bar] | semmle.label | call to s49 [element :bar] |
-| semantics.rb:441:9:441:14 | call to s49 [element] | semmle.label | call to s49 [element] |
-| semantics.rb:441:9:441:14 | call to s49 [element] | semmle.label | call to s49 [element] |
-| semantics.rb:441:13:441:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:441:13:441:13 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:441:13:441:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:441:13:441:13 | h [element] | semmle.label | h [element] |
-| semantics.rb:443:10:443:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:443:10:443:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:441:5:441:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:441:5:441:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:441:5:441:5 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | semmle.label | call to s49 : [collection] [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element :bar] | semmle.label | call to s49 : [collection] [element :bar] |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | semmle.label | call to s49 : [collection] [element] |
+| semantics.rb:441:9:441:14 | call to s49 : [collection] [element] | semmle.label | call to s49 : [collection] [element] |
+| semantics.rb:441:13:441:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:441:13:441:13 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:441:13:441:13 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:441:13:441:13 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:443:10:443:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:443:10:443:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:443:10:443:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:443:10:443:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:444:10:444:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:444:10:444:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:444:10:444:10 | x [element] | semmle.label | x [element] |
-| semantics.rb:444:10:444:10 | x [element] | semmle.label | x [element] |
+| semantics.rb:444:10:444:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:444:10:444:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:444:10:444:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| semantics.rb:444:10:444:10 | x : [collection] [element] | semmle.label | x : [collection] [element] |
 | semantics.rb:444:10:444:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:444:10:444:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:448:5:448:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:448:5:448:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:448:15:448:25 | call to source | semmle.label | call to source |
 | semantics.rb:448:15:448:25 | call to source | semmle.label | call to source |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:449:5:449:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:449:5:449:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:449:5:449:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:449:5:449:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:449:5:449:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:449:5:449:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:449:5:449:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:449:5:449:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:449:15:449:25 | call to source | semmle.label | call to source |
 | semantics.rb:449:15:449:25 | call to source | semmle.label | call to source |
-| semantics.rb:450:5:450:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:450:5:450:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:450:5:450:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:450:12:450:22 | call to source | semmle.label | call to source |
 | semantics.rb:450:12:450:22 | call to source | semmle.label | call to source |
-| semantics.rb:452:10:452:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:452:10:452:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:452:10:452:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:452:10:452:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:452:10:452:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:452:10:452:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:452:10:452:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:452:10:452:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:452:10:452:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:452:10:452:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:453:10:453:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:453:10:453:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:453:10:453:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:453:10:453:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:453:10:453:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:453:10:453:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:453:10:453:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:453:10:453:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:453:10:453:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:453:10:453:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:455:9:455:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:455:9:455:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:455:9:455:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:455:9:455:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:458:10:458:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:458:10:458:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:455:9:455:9 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:455:9:455:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:455:9:455:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:458:10:458:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:458:10:458:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
 | semantics.rb:458:10:458:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:458:10:458:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:462:5:462:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:462:5:462:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:462:15:462:25 | call to source | semmle.label | call to source |
 | semantics.rb:462:15:462:25 | call to source | semmle.label | call to source |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:463:5:463:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:463:5:463:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:463:5:463:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:463:5:463:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:463:5:463:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:463:5:463:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:463:5:463:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:463:5:463:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:463:15:463:25 | call to source | semmle.label | call to source |
 | semantics.rb:463:15:463:25 | call to source | semmle.label | call to source |
-| semantics.rb:464:5:464:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:464:5:464:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:464:5:464:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:464:12:464:22 | call to source | semmle.label | call to source |
 | semantics.rb:464:12:464:22 | call to source | semmle.label | call to source |
-| semantics.rb:466:10:466:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:466:10:466:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:466:10:466:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:466:10:466:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:466:10:466:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:466:10:466:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:466:10:466:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:466:10:466:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:466:10:466:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:466:10:466:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:467:10:467:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:467:10:467:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:467:10:467:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:467:10:467:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:467:10:467:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:467:10:467:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:467:10:467:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:467:10:467:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:467:10:467:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:467:10:467:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:469:9:469:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:469:9:469:9 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:469:9:469:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:469:9:469:9 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:469:9:469:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:469:9:469:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:469:9:469:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:469:9:469:9 | h [element] | semmle.label | h [element] |
-| semantics.rb:471:10:471:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:471:10:471:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:469:9:469:9 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:469:9:469:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:469:9:469:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:469:9:469:9 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:469:9:469:9 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:471:10:471:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:471:10:471:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:471:10:471:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:471:10:471:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:472:10:472:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:472:10:472:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:472:10:472:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:472:10:472:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:472:10:472:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:472:10:472:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:472:10:472:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:472:10:472:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:472:10:472:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:472:10:472:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:476:5:476:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:476:5:476:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:476:15:476:25 | call to source | semmle.label | call to source |
 | semantics.rb:476:15:476:25 | call to source | semmle.label | call to source |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:477:5:477:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:477:5:477:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:477:5:477:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:477:5:477:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:477:5:477:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:477:5:477:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:477:5:477:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:477:5:477:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:477:15:477:25 | call to source | semmle.label | call to source |
 | semantics.rb:477:15:477:25 | call to source | semmle.label | call to source |
-| semantics.rb:478:5:478:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:478:5:478:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:478:5:478:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:478:12:478:22 | call to source | semmle.label | call to source |
 | semantics.rb:478:12:478:22 | call to source | semmle.label | call to source |
-| semantics.rb:480:10:480:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:480:10:480:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:480:10:480:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:480:10:480:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:480:10:480:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:480:10:480:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:480:10:480:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:480:10:480:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:480:10:480:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:480:10:480:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:481:10:481:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:481:10:481:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:481:10:481:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:481:10:481:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:481:10:481:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:481:10:481:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:481:10:481:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:481:10:481:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:481:10:481:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:481:10:481:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:483:5:483:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:483:5:483:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:483:5:483:5 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:483:5:483:5 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:486:10:486:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:486:10:486:10 | h [element :bar] | semmle.label | h [element :bar] |
+| semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:483:5:483:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:483:5:483:5 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:483:5:483:5 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:486:10:486:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:486:10:486:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
 | semantics.rb:486:10:486:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:486:10:486:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:490:5:490:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:490:5:490:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:490:15:490:25 | call to source | semmle.label | call to source |
 | semantics.rb:490:15:490:25 | call to source | semmle.label | call to source |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:491:5:491:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:491:5:491:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:491:5:491:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:491:5:491:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:491:5:491:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:491:5:491:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:491:5:491:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:491:5:491:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:491:15:491:25 | call to source | semmle.label | call to source |
 | semantics.rb:491:15:491:25 | call to source | semmle.label | call to source |
-| semantics.rb:492:5:492:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:492:5:492:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:492:5:492:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:492:12:492:22 | call to source | semmle.label | call to source |
 | semantics.rb:492:12:492:22 | call to source | semmle.label | call to source |
-| semantics.rb:494:10:494:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:494:10:494:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:494:10:494:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:494:10:494:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:494:10:494:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:494:10:494:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:494:10:494:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:494:10:494:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:494:10:494:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:495:10:495:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:495:10:495:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:495:10:495:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:495:10:495:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:495:10:495:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:495:10:495:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:495:10:495:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:495:10:495:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:495:10:495:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:495:10:495:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:497:5:497:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:497:5:497:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:497:9:497:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:497:9:497:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
-| semantics.rb:497:9:497:15 | call to s53 [element :bar] | semmle.label | call to s53 [element :bar] |
-| semantics.rb:500:10:500:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:500:10:500:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:497:5:497:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:497:5:497:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:497:9:497:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:497:9:497:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | semmle.label | call to s53 : [collection] [element :bar] |
+| semantics.rb:497:9:497:15 | call to s53 : [collection] [element :bar] | semmle.label | call to s53 : [collection] [element :bar] |
+| semantics.rb:500:10:500:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:500:10:500:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
 | semantics.rb:500:10:500:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:500:10:500:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:502:10:502:20 | call to source | semmle.label | call to source |
 | semantics.rb:502:10:502:20 | call to source | semmle.label | call to source |
 | semantics.rb:502:10:502:26 | call to s53 | semmle.label | call to s53 |
 | semantics.rb:502:10:502:26 | call to s53 | semmle.label | call to s53 |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:506:5:506:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
+| semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:506:5:506:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
 | semantics.rb:506:15:506:25 | call to source | semmle.label | call to source |
 | semantics.rb:506:15:506:25 | call to source | semmle.label | call to source |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:507:5:507:5 | [post] h [element :bar] | semmle.label | [post] h [element :bar] |
-| semantics.rb:507:5:507:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:507:5:507:5 | [post] h [element :foo] | semmle.label | [post] h [element :foo] |
-| semantics.rb:507:5:507:5 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:507:5:507:5 | h [element :foo] | semmle.label | h [element :foo] |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :bar] | semmle.label | [post] h : [collection] [element :bar] |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:507:5:507:5 | [post] h : [collection] [element :foo] | semmle.label | [post] h : [collection] [element :foo] |
+| semantics.rb:507:5:507:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:507:5:507:5 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
 | semantics.rb:507:15:507:25 | call to source | semmle.label | call to source |
 | semantics.rb:507:15:507:25 | call to source | semmle.label | call to source |
-| semantics.rb:508:5:508:5 | [post] h [element] | semmle.label | [post] h [element] |
-| semantics.rb:508:5:508:5 | [post] h [element] | semmle.label | [post] h [element] |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
+| semantics.rb:508:5:508:5 | [post] h : [collection] [element] | semmle.label | [post] h : [collection] [element] |
 | semantics.rb:508:12:508:22 | call to source | semmle.label | call to source |
 | semantics.rb:508:12:508:22 | call to source | semmle.label | call to source |
-| semantics.rb:510:10:510:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:510:10:510:10 | h [element :foo] | semmle.label | h [element :foo] |
-| semantics.rb:510:10:510:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:510:10:510:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:510:10:510:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:510:10:510:10 | h : [collection] [element :foo] | semmle.label | h : [collection] [element :foo] |
+| semantics.rb:510:10:510:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:510:10:510:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:510:10:510:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:511:10:511:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:511:10:511:10 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:511:10:511:10 | h [element] | semmle.label | h [element] |
-| semantics.rb:511:10:511:10 | h [element] | semmle.label | h [element] |
+| semantics.rb:511:10:511:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:511:10:511:10 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:511:10:511:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| semantics.rb:511:10:511:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | semantics.rb:511:10:511:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:511:10:511:16 | ...[...] | semmle.label | ...[...] |
-| semantics.rb:513:5:513:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:513:5:513:5 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:513:9:513:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:513:9:513:9 | h [element :bar] | semmle.label | h [element :bar] |
-| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
-| semantics.rb:513:9:513:15 | call to s54 [element :bar] | semmle.label | call to s54 [element :bar] |
-| semantics.rb:516:10:516:10 | x [element :bar] | semmle.label | x [element :bar] |
-| semantics.rb:516:10:516:10 | x [element :bar] | semmle.label | x [element :bar] |
+| semantics.rb:513:5:513:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:513:5:513:5 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:513:9:513:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:513:9:513:9 | h : [collection] [element :bar] | semmle.label | h : [collection] [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | semmle.label | call to s54 : [collection] [element :bar] |
+| semantics.rb:513:9:513:15 | call to s54 : [collection] [element :bar] | semmle.label | call to s54 : [collection] [element :bar] |
+| semantics.rb:516:10:516:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
+| semantics.rb:516:10:516:10 | x : [collection] [element :bar] | semmle.label | x : [collection] [element :bar] |
 | semantics.rb:516:10:516:16 | ...[...] | semmle.label | ...[...] |
 | semantics.rb:516:10:516:16 | ...[...] | semmle.label | ...[...] |
 subpaths

--- a/ruby/ql/test/library-tests/dataflow/global/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/global/Flow.expected
@@ -5,254 +5,263 @@ edges
 | blocks.rb:18:11:18:11 | x | blocks.rb:24:18:24:18 | x | provenance |  |
 | blocks.rb:24:3:24:11 | call to source | blocks.rb:17:10:17:10 | x | provenance |  |
 | blocks.rb:24:18:24:18 | x | blocks.rb:25:8:25:8 | x | provenance |  |
-| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:11:5:11:6 | fn [captured x] | provenance |  |
-| captured_variables.rb:11:5:11:6 | fn [captured x] | captured_variables.rb:10:20:10:20 | x | provenance |  |
+| captured_variables.rb:9:24:9:24 | x | captured_variables.rb:11:5:11:6 | fn : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:11:5:11:6 | fn : [lambda] [captured x] | captured_variables.rb:10:20:10:20 | x | provenance |  |
 | captured_variables.rb:13:20:13:29 | call to taint | captured_variables.rb:9:24:9:24 | x | provenance |  |
-| captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | provenance |  |
-| captured_variables.rb:20:1:20:35 | ( ... ) [captured x] | captured_variables.rb:17:14:17:14 | x | provenance |  |
-| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] | captured_variables.rb:20:1:20:35 | ( ... ) [captured x] | provenance |  |
+| captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:20:1:20:35 | ( ... ) : [lambda] [captured x] | captured_variables.rb:17:14:17:14 | x | provenance |  |
+| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 : [lambda] [captured x] | captured_variables.rb:20:1:20:35 | ( ... ) : [lambda] [captured x] | provenance |  |
 | captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x | provenance |  |
-| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] | provenance |  |
-| captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | provenance |  |
-| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] | captured_variables.rb:24:14:24:14 | x | provenance | heuristic-callback |
+| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 : [lambda] [captured x] | captured_variables.rb:24:14:24:14 | x | provenance | heuristic-callback |
 | captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x | provenance |  |
-| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] | provenance |  |
-| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:33:29:33:30 | fn [captured x] | provenance |  |
-| captured_variables.rb:33:29:33:30 | fn [captured x] | captured_variables.rb:31:14:31:14 | x | provenance | heuristic-callback |
+| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:29:33:29:33 | x | captured_variables.rb:33:29:33:30 | fn : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:33:29:33:30 | fn : [lambda] [captured x] | captured_variables.rb:31:14:31:14 | x | provenance | heuristic-callback |
 | captured_variables.rb:35:29:35:38 | call to taint | captured_variables.rb:29:33:29:33 | x | provenance |  |
-| captured_variables.rb:37:13:37:14 | fn [captured x] | captured_variables.rb:38:5:38:6 | fn [captured x] | provenance |  |
-| captured_variables.rb:38:5:38:6 | fn [captured x] | captured_variables.rb:42:14:42:14 | x | provenance |  |
-| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:44:13:44:14 | fn [captured x] | provenance |  |
-| captured_variables.rb:44:13:44:14 | fn [captured x] | captured_variables.rb:37:13:37:14 | fn [captured x] | provenance |  |
+| captured_variables.rb:37:13:37:14 | fn : [lambda] [captured x] | captured_variables.rb:38:5:38:6 | fn : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:38:5:38:6 | fn : [lambda] [captured x] | captured_variables.rb:42:14:42:14 | x | provenance |  |
+| captured_variables.rb:40:31:40:31 | x | captured_variables.rb:44:13:44:14 | fn : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:44:13:44:14 | fn : [lambda] [captured x] | captured_variables.rb:37:13:37:14 | fn : [lambda] [captured x] | provenance |  |
 | captured_variables.rb:46:27:46:36 | call to taint | captured_variables.rb:40:31:40:31 | x | provenance |  |
-| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:49:16:52:3 | do ... end [captured x] | provenance |  |
+| captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:49:16:52:3 | do ... end : [lambda] [captured x] | provenance |  |
 | captured_variables.rb:48:5:48:12 | call to taint | captured_variables.rb:54:6:54:6 | x | provenance |  |
-| captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | captured_variables.rb:54:6:54:6 | x | provenance |  |
-| captured_variables.rb:49:16:52:3 | do ... end [captured x] | captured_variables.rb:50:10:50:10 | x | provenance |  |
-| captured_variables.rb:49:16:52:3 | do ... end [captured x] | captured_variables.rb:50:10:50:10 | x | provenance | heuristic-callback |
-| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | provenance |  |
-| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | provenance | heuristic-callback |
+| captured_variables.rb:49:16:52:3 | [post] do ... end : [lambda] [captured x] | captured_variables.rb:54:6:54:6 | x | provenance |  |
+| captured_variables.rb:49:16:52:3 | do ... end : [lambda] [captured x] | captured_variables.rb:50:10:50:10 | x | provenance |  |
+| captured_variables.rb:49:16:52:3 | do ... end : [lambda] [captured x] | captured_variables.rb:50:10:50:10 | x | provenance | heuristic-callback |
+| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:51:9:51:16 | call to taint | captured_variables.rb:49:16:52:3 | [post] do ... end : [lambda] [captured x] | provenance | heuristic-callback |
 | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:58:18:58:18 | x | provenance |  |
-| captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | provenance |  |
+| captured_variables.rb:58:9:58:14 | [post] self [@field] | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | provenance |  |
 | captured_variables.rb:58:18:58:18 | x | captured_variables.rb:58:9:58:14 | [post] self [@field] | provenance |  |
-| captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:16:61:21 | self [@field] | provenance |  |
+| captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:16:61:21 | self : Foo [@field] | provenance |  |
+| captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:16:61:21 | self : Foo [@field] | provenance |  |
 | captured_variables.rb:61:16:61:21 | @field | captured_variables.rb:61:9:61:21 | return | provenance |  |
-| captured_variables.rb:61:16:61:21 | self [@field] | captured_variables.rb:61:16:61:21 | @field | provenance |  |
-| captured_variables.rb:66:1:66:3 | [post] foo [@field] | captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | provenance |  |
-| captured_variables.rb:66:1:66:3 | [post] foo [@field] | captured_variables.rb:72:6:72:8 | foo [@field] | provenance |  |
+| captured_variables.rb:61:16:61:21 | @field | captured_variables.rb:61:9:61:21 | return | provenance |  |
+| captured_variables.rb:61:16:61:21 | self : Foo [@field] | captured_variables.rb:61:16:61:21 | @field | provenance |  |
+| captured_variables.rb:61:16:61:21 | self : Foo [@field] | captured_variables.rb:61:16:61:21 | @field | provenance |  |
+| captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] | captured_variables.rb:67:16:70:3 | do ... end : [lambda] [captured foo, @field] | provenance |  |
+| captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] | captured_variables.rb:72:6:72:8 | foo : Foo [@field] | provenance |  |
 | captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
-| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:66:1:66:3 | [post] foo [@field] | provenance |  |
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] | provenance |  |
 | captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | captured_variables.rb:72:6:72:8 | foo [@field] | provenance |  |
-| captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | captured_variables.rb:68:10:68:12 | foo [@field] | provenance |  |
-| captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | captured_variables.rb:68:10:68:12 | foo [@field] | provenance | heuristic-callback |
-| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
+| captured_variables.rb:67:16:70:3 | [post] do ... end : [lambda] [captured foo, @field] | captured_variables.rb:72:6:72:8 | foo [@field] | provenance |  |
+| captured_variables.rb:67:16:70:3 | do ... end : [lambda] [captured foo, @field] | captured_variables.rb:68:10:68:12 | foo [@field] | provenance |  |
+| captured_variables.rb:67:16:70:3 | do ... end : [lambda] [captured foo, @field] | captured_variables.rb:68:10:68:12 | foo [@field] | provenance | heuristic-callback |
+| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
 | captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:68:10:68:22 | call to get_field | provenance |  |
-| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| captured_variables.rb:69:5:69:7 | [post] foo [@field] | captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | provenance |  |
-| captured_variables.rb:69:5:69:7 | [post] foo [@field] | captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | provenance | heuristic-callback |
+| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] | captured_variables.rb:67:16:70:3 | [post] do ... end : [lambda] [captured foo, @field] | provenance |  |
+| captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] | captured_variables.rb:67:16:70:3 | [post] do ... end : [lambda] [captured foo, @field] | provenance | heuristic-callback |
 | captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
-| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:69:5:69:7 | [post] foo [@field] | provenance |  |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] | provenance |  |
 | captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | captured_variables.rb:72:6:72:18 | call to get_field | provenance |  |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
 | captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:72:6:72:18 | call to get_field | provenance |  |
-| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | captured_variables.rb:83:6:83:8 | foo [@field] | provenance |  |
-| captured_variables.rb:79:9:79:11 | [post] foo [@field] | captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | provenance |  |
-| captured_variables.rb:79:9:79:11 | [post] foo [@field] | captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | provenance | heuristic-callback |
+| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| captured_variables.rb:78:20:80:7 | [post] do ... end : [lambda] [captured foo, @field] | captured_variables.rb:83:6:83:8 | foo [@field] | provenance |  |
+| captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] | captured_variables.rb:78:20:80:7 | [post] do ... end : [lambda] [captured foo, @field] | provenance |  |
+| captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] | captured_variables.rb:78:20:80:7 | [post] do ... end : [lambda] [captured foo, @field] | provenance | heuristic-callback |
 | captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
-| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:79:9:79:11 | [post] foo [@field] | provenance |  |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] | provenance |  |
 | captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
+| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
 | captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:83:6:83:18 | call to get_field | provenance |  |
-| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:90:1:90:2 | fn [captured y] | provenance |  |
+| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:90:1:90:2 | fn : [lambda] [captured y] | provenance |  |
 | captured_variables.rb:85:5:85:12 | call to taint | captured_variables.rb:91:6:91:6 | y | provenance |  |
-| captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:90:1:90:2 | [post] fn [captured y] | provenance |  |
-| captured_variables.rb:90:1:90:2 | [post] fn [captured y] | captured_variables.rb:91:6:91:6 | y | provenance |  |
-| captured_variables.rb:90:1:90:2 | fn [captured y] | captured_variables.rb:87:10:87:10 | y | provenance |  |
-| captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | provenance |  |
-| captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] | captured_variables.rb:95:14:95:14 | x | provenance |  |
+| captured_variables.rb:88:9:88:16 | call to taint | captured_variables.rb:90:1:90:2 | [post] fn : [lambda] [captured y] | provenance |  |
+| captured_variables.rb:90:1:90:2 | [post] fn : [lambda] [captured y] | captured_variables.rb:91:6:91:6 | y | provenance |  |
+| captured_variables.rb:90:1:90:2 | fn : [lambda] [captured y] | captured_variables.rb:87:10:87:10 | y | provenance |  |
+| captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:98:1:98:21 | call to capture_arg : [lambda] [captured x] | captured_variables.rb:95:14:95:14 | x | provenance |  |
 | captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | provenance |  |
-| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] | provenance |  |
+| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:98:1:98:21 | call to capture_arg : [lambda] [captured x] | provenance |  |
 | captured_variables.rb:100:21:100:21 | x | captured_variables.rb:101:11:101:11 | x | provenance |  |
 | captured_variables.rb:101:11:101:11 | x | captured_variables.rb:104:31:104:31 | x | provenance |  |
 | captured_variables.rb:104:17:104:24 | call to taint | captured_variables.rb:100:21:100:21 | x | provenance |  |
 | captured_variables.rb:104:31:104:31 | x | captured_variables.rb:105:10:105:10 | x | provenance |  |
-| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:117:5:117:10 | middle [captured x] | provenance |  |
+| captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:117:5:117:10 | middle : [lambda] [captured x] | provenance |  |
 | captured_variables.rb:109:9:109:17 | call to taint | captured_variables.rb:118:10:118:10 | x | provenance |  |
-| captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:115:9:115:13 | [post] inner [captured x] | provenance |  |
-| captured_variables.rb:115:9:115:13 | [post] inner [captured x] | captured_variables.rb:117:5:117:10 | [post] middle [captured x] | provenance |  |
-| captured_variables.rb:115:9:115:13 | inner [captured x] | captured_variables.rb:112:18:112:18 | x | provenance |  |
-| captured_variables.rb:117:5:117:10 | [post] middle [captured x] | captured_variables.rb:118:10:118:10 | x | provenance |  |
-| captured_variables.rb:117:5:117:10 | middle [captured x] | captured_variables.rb:115:9:115:13 | inner [captured x] | provenance |  |
-| captured_variables.rb:147:5:147:6 | [post] self [@x] | captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] | provenance |  |
+| captured_variables.rb:113:17:113:25 | call to taint | captured_variables.rb:115:9:115:13 | [post] inner : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:115:9:115:13 | [post] inner : [lambda] [captured x] | captured_variables.rb:117:5:117:10 | [post] middle : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:115:9:115:13 | inner : [lambda] [captured x] | captured_variables.rb:112:18:112:18 | x | provenance |  |
+| captured_variables.rb:117:5:117:10 | [post] middle : [lambda] [captured x] | captured_variables.rb:118:10:118:10 | x | provenance |  |
+| captured_variables.rb:117:5:117:10 | middle : [lambda] [captured x] | captured_variables.rb:115:9:115:13 | inner : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:147:5:147:6 | [post] self [@x] | captured_variables.rb:153:14:155:7 | do ... end : [lambda] [captured self, @x] | provenance |  |
 | captured_variables.rb:147:10:147:18 | call to taint | captured_variables.rb:147:5:147:6 | [post] self [@x] | provenance |  |
-| captured_variables.rb:149:5:151:7 | &block [captured self, @x] | captured_variables.rb:154:14:154:15 | self [@x] | provenance |  |
-| captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] | captured_variables.rb:149:5:151:7 | &block [captured self, @x] | provenance |  |
+| captured_variables.rb:149:5:151:7 | &block : [lambda] [captured self, @x] | captured_variables.rb:154:14:154:15 | self [@x] | provenance |  |
+| captured_variables.rb:153:14:155:7 | do ... end : [lambda] [captured self, @x] | captured_variables.rb:149:5:151:7 | &block : [lambda] [captured self, @x] | provenance |  |
 | captured_variables.rb:154:14:154:15 | self [@x] | captured_variables.rb:154:14:154:15 | @x | provenance |  |
-| captured_variables.rb:160:9:160:10 | [post] self [@x] | captured_variables.rb:174:1:174:24 | call to new [@x] | provenance |  |
+| captured_variables.rb:160:9:160:10 | [post] self [@x] | captured_variables.rb:174:1:174:24 | call to new : CaptureInstanceSelf1 [@x] | provenance |  |
 | captured_variables.rb:160:14:160:22 | call to taint | captured_variables.rb:160:9:160:10 | [post] self [@x] | provenance |  |
-| captured_variables.rb:163:5:165:7 | &block [captured self, @x] | captured_variables.rb:169:18:169:19 | self [@x] | provenance |  |
-| captured_variables.rb:167:5:171:7 | self in baz [@x] | captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | provenance |  |
-| captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | captured_variables.rb:163:5:165:7 | &block [captured self, @x] | provenance |  |
-| captured_variables.rb:169:18:169:19 | self [@x] | captured_variables.rb:169:18:169:19 | @x | provenance |  |
-| captured_variables.rb:174:1:174:24 | call to new [@x] | captured_variables.rb:167:5:171:7 | self in baz [@x] | provenance |  |
-| captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | captured_variables.rb:193:1:193:1 | [post] c [@x] | provenance |  |
-| captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | provenance |  |
+| captured_variables.rb:163:5:165:7 | &block : [lambda] [captured self, @x] | captured_variables.rb:169:18:169:19 | self : CaptureInstanceSelf1 [@x] | provenance |  |
+| captured_variables.rb:167:5:171:7 | self in baz : CaptureInstanceSelf1 [@x] | captured_variables.rb:168:18:170:11 | do ... end : [lambda] [captured self, @x] | provenance |  |
+| captured_variables.rb:168:18:170:11 | do ... end : [lambda] [captured self, @x] | captured_variables.rb:163:5:165:7 | &block : [lambda] [captured self, @x] | provenance |  |
+| captured_variables.rb:169:18:169:19 | self : CaptureInstanceSelf1 [@x] | captured_variables.rb:169:18:169:19 | @x | provenance |  |
+| captured_variables.rb:174:1:174:24 | call to new : CaptureInstanceSelf1 [@x] | captured_variables.rb:167:5:171:7 | self in baz : CaptureInstanceSelf1 [@x] | provenance |  |
+| captured_variables.rb:177:5:179:7 | self in foo [Return] : CaptureInstanceSelf2 [@x] | captured_variables.rb:193:1:193:1 | [post] c : CaptureInstanceSelf2 [@x] | provenance |  |
+| captured_variables.rb:178:9:178:10 | [post] self [@x] | captured_variables.rb:177:5:179:7 | self in foo [Return] : CaptureInstanceSelf2 [@x] | provenance |  |
 | captured_variables.rb:178:14:178:22 | call to taint | captured_variables.rb:178:9:178:10 | [post] self [@x] | provenance |  |
-| captured_variables.rb:181:5:183:7 | &block [captured self, @x] | captured_variables.rb:187:18:187:19 | self [@x] | provenance |  |
-| captured_variables.rb:185:5:189:7 | self in baz [@x] | captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | provenance |  |
-| captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | captured_variables.rb:181:5:183:7 | &block [captured self, @x] | provenance |  |
-| captured_variables.rb:187:18:187:19 | self [@x] | captured_variables.rb:187:18:187:19 | @x | provenance |  |
-| captured_variables.rb:193:1:193:1 | [post] c [@x] | captured_variables.rb:194:1:194:1 | c [@x] | provenance |  |
-| captured_variables.rb:194:1:194:1 | c [@x] | captured_variables.rb:185:5:189:7 | self in baz [@x] | provenance |  |
+| captured_variables.rb:181:5:183:7 | &block : [lambda] [captured self, @x] | captured_variables.rb:187:18:187:19 | self : CaptureInstanceSelf2 [@x] | provenance |  |
+| captured_variables.rb:185:5:189:7 | self in baz : CaptureInstanceSelf2 [@x] | captured_variables.rb:186:18:188:11 | do ... end : [lambda] [captured self, @x] | provenance |  |
+| captured_variables.rb:186:18:188:11 | do ... end : [lambda] [captured self, @x] | captured_variables.rb:181:5:183:7 | &block : [lambda] [captured self, @x] | provenance |  |
+| captured_variables.rb:187:18:187:19 | self : CaptureInstanceSelf2 [@x] | captured_variables.rb:187:18:187:19 | @x | provenance |  |
+| captured_variables.rb:193:1:193:1 | [post] c : CaptureInstanceSelf2 [@x] | captured_variables.rb:194:1:194:1 | c : CaptureInstanceSelf2 [@x] | provenance |  |
+| captured_variables.rb:194:1:194:1 | c : CaptureInstanceSelf2 [@x] | captured_variables.rb:185:5:189:7 | self in baz : CaptureInstanceSelf2 [@x] | provenance |  |
 | captured_variables.rb:197:9:197:17 | call to taint | captured_variables.rb:199:10:199:10 | x | provenance |  |
 | captured_variables.rb:206:13:206:21 | call to taint | captured_variables.rb:208:14:208:14 | x | provenance |  |
-| captured_variables.rb:219:9:219:17 | call to taint | captured_variables.rb:226:5:226:7 | fn1 [captured x] | provenance |  |
-| captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | captured_variables.rb:227:10:227:10 | y | provenance |  |
-| captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | provenance |  |
-| captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | provenance |  |
+| captured_variables.rb:219:9:219:17 | call to taint | captured_variables.rb:226:5:226:7 | fn1 : [lambda] [captured x] | provenance |  |
+| captured_variables.rb:226:5:226:7 | [post] fn1 : [lambda] [captured y] | captured_variables.rb:227:10:227:10 | y | provenance |  |
+| captured_variables.rb:226:5:226:7 | fn1 : [lambda] [captured x] | captured_variables.rb:223:13:223:13 | x | provenance |  |
+| captured_variables.rb:226:5:226:7 | fn1 : [lambda] [captured x] | captured_variables.rb:226:5:226:7 | [post] fn1 : [lambda] [captured y] | provenance |  |
 | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:11:18:11:18 | x | provenance |  |
-| instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | provenance |  |
+| instance_variables.rb:11:9:11:14 | [post] self [@field] | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | provenance |  |
 | instance_variables.rb:11:18:11:18 | x | instance_variables.rb:11:9:11:14 | [post] self [@field] | provenance |  |
-| instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:16:14:21 | self [@field] | provenance |  |
+| instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:16:14:21 | self : Foo [@field] | provenance |  |
+| instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:16:14:21 | self : Foo [@field] | provenance |  |
 | instance_variables.rb:14:16:14:21 | @field | instance_variables.rb:14:9:14:21 | return | provenance |  |
-| instance_variables.rb:14:16:14:21 | self [@field] | instance_variables.rb:14:16:14:21 | @field | provenance |  |
-| instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | provenance |  |
+| instance_variables.rb:14:16:14:21 | @field | instance_variables.rb:14:9:14:21 | return | provenance |  |
+| instance_variables.rb:14:16:14:21 | self : Foo [@field] | instance_variables.rb:14:16:14:21 | @field | provenance |  |
+| instance_variables.rb:14:16:14:21 | self : Foo [@field] | instance_variables.rb:14:16:14:21 | @field | provenance |  |
+| instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | provenance |  |
 | instance_variables.rb:17:9:17:14 | [post] self [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | provenance |  |
 | instance_variables.rb:19:5:19:8 | [post] self [@foo] | instance_variables.rb:20:10:20:13 | self [@foo] | provenance |  |
 | instance_variables.rb:19:12:19:21 | call to taint | instance_variables.rb:19:5:19:8 | [post] self [@foo] | provenance |  |
 | instance_variables.rb:20:10:20:13 | self [@foo] | instance_variables.rb:20:10:20:13 | @foo | provenance |  |
 | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:18:23:22 | field | provenance |  |
-| instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | provenance |  |
+| instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:22:5:25:7 | self in initialize [Return] : Foo [@field] | provenance |  |
 | instance_variables.rb:23:18:23:22 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | provenance |  |
 | instance_variables.rb:24:9:24:17 | call to taint | instance_variables.rb:28:9:28:25 | call to initialize | provenance |  |
 | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:28:20:28:24 | field | provenance |  |
-| instance_variables.rb:28:9:28:25 | [post] self [@field] | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | provenance |  |
+| instance_variables.rb:28:9:28:25 | [post] self : Foo [@field] | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] : Foo [@field] | provenance |  |
 | instance_variables.rb:28:9:28:25 | call to initialize | instance_variables.rb:119:6:119:37 | call to call_initialize | provenance |  |
 | instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | provenance |  |
-| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:28:9:28:25 | [post] self [@field] | provenance |  |
+| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:28:9:28:25 | [post] self : Foo [@field] | provenance |  |
 | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:13:33:13 | x | provenance |  |
 | instance_variables.rb:32:13:32:21 | call to taint | instance_variables.rb:48:20:48:20 | x | provenance |  |
 | instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | provenance |  |
-| instance_variables.rb:33:13:33:13 | x | instance_variables.rb:33:9:33:14 | call to new [@field] | provenance |  |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:36:10:36:33 | call to get_field | provenance |  |
+| instance_variables.rb:33:13:33:13 | x | instance_variables.rb:33:9:33:14 | call to new : Foo [@field] | provenance |  |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | instance_variables.rb:36:10:36:33 | call to get_field | provenance |  |
 | instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:22:20:22:24 | field | provenance |  |
-| instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:36:10:36:23 | call to new [@field] | provenance |  |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:39:6:39:33 | call to get_field | provenance |  |
+| instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | provenance |  |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | instance_variables.rb:39:6:39:33 | call to get_field | provenance |  |
 | instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x | provenance |  |
-| instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:39:6:39:23 | call to bar [@field] | provenance |  |
+| instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | provenance |  |
 | instance_variables.rb:43:9:43:17 | call to taint | instance_variables.rb:121:7:121:24 | call to new | provenance |  |
 | instance_variables.rb:48:20:48:20 | x | instance_variables.rb:49:14:49:14 | x | provenance |  |
-| instance_variables.rb:54:1:54:3 | [post] foo [@field] | instance_variables.rb:55:6:55:8 | foo [@field] | provenance |  |
+| instance_variables.rb:54:1:54:3 | [post] foo : Foo [@field] | instance_variables.rb:55:6:55:8 | foo : Foo [@field] | provenance |  |
 | instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:54:1:54:3 | [post] foo [@field] | provenance |  |
-| instance_variables.rb:55:6:55:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:55:6:55:18 | call to get_field | provenance |  |
-| instance_variables.rb:58:1:58:3 | [post] bar [@field] | instance_variables.rb:59:6:59:8 | bar [@field] | provenance |  |
+| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:54:1:54:3 | [post] foo : Foo [@field] | provenance |  |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | instance_variables.rb:55:6:55:18 | call to get_field | provenance |  |
+| instance_variables.rb:58:1:58:3 | [post] bar : Foo [@field] | instance_variables.rb:59:6:59:8 | bar : Foo [@field] | provenance |  |
 | instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:58:1:58:3 | [post] bar [@field] | provenance |  |
-| instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | provenance |  |
-| instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:59:6:59:18 | call to inc_field | provenance |  |
+| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:58:1:58:3 | [post] bar : Foo [@field] | provenance |  |
+| instance_variables.rb:59:6:59:8 | bar : Foo [@field] | instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | provenance |  |
+| instance_variables.rb:59:6:59:8 | bar : Foo [@field] | instance_variables.rb:59:6:59:18 | call to inc_field | provenance |  |
 | instance_variables.rb:62:1:62:4 | [post] foo1 [@field] | instance_variables.rb:63:6:63:9 | foo1 [@field] | provenance |  |
 | instance_variables.rb:62:14:62:22 | call to taint | instance_variables.rb:62:1:62:4 | [post] foo1 [@field] | provenance |  |
 | instance_variables.rb:63:6:63:9 | foo1 [@field] | instance_variables.rb:63:6:63:15 | call to field | provenance |  |
 | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] | instance_variables.rb:67:6:67:9 | foo2 [@field] | provenance |  |
 | instance_variables.rb:66:14:66:22 | call to taint | instance_variables.rb:66:1:66:4 | [post] foo2 [@field] | provenance |  |
-| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:67:6:67:19 | call to get_field | provenance |  |
-| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | instance_variables.rb:71:6:71:9 | foo3 [@field] | provenance |  |
-| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | instance_variables.rb:83:6:83:9 | foo3 [@field] | provenance |  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] | instance_variables.rb:71:6:71:9 | foo3 : Foo [@field] | provenance |  |
+| instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] | instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | provenance |  |
 | instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | provenance |  |
-| instance_variables.rb:71:6:71:9 | foo3 [@field] | instance_variables.rb:71:6:71:15 | call to field | provenance |  |
-| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | instance_variables.rb:79:6:79:9 | foo5 [@field] | provenance |  |
-| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | instance_variables.rb:84:6:84:9 | foo5 [@field] | provenance |  |
+| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] | provenance |  |
+| instance_variables.rb:71:6:71:9 | foo3 : Foo [@field] | instance_variables.rb:71:6:71:15 | call to field | provenance |  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] | instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | provenance |  |
+| instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] | instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | provenance |  |
 | instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | provenance |  |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:79:6:79:19 | call to get_field | provenance |  |
-| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] | instance_variables.rb:85:6:85:9 | foo6 [@field] | provenance |  |
+| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] | provenance |  |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | instance_variables.rb:79:6:79:19 | call to get_field | provenance |  |
+| instance_variables.rb:82:15:82:18 | [post] foo6 : Foo [@field] | instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | provenance |  |
 | instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] | provenance |  |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:83:6:83:19 | call to get_field | provenance |  |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:84:6:84:19 | call to get_field | provenance |  |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:85:6:85:19 | call to get_field | provenance |  |
-| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] | instance_variables.rb:90:6:90:9 | foo7 [@field] | provenance |  |
-| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] | instance_variables.rb:91:6:91:9 | foo8 [@field] | provenance |  |
+| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:82:15:82:18 | [post] foo6 : Foo [@field] | provenance |  |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | instance_variables.rb:83:6:83:19 | call to get_field | provenance |  |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | instance_variables.rb:84:6:84:19 | call to get_field | provenance |  |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | instance_variables.rb:85:6:85:19 | call to get_field | provenance |  |
+| instance_variables.rb:89:15:89:18 | [post] foo7 : Foo [@field] | instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | provenance |  |
+| instance_variables.rb:89:25:89:28 | [post] foo8 : Foo [@field] | instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | provenance |  |
 | instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] | provenance |  |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] | provenance |  |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:90:6:90:19 | call to get_field | provenance |  |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:91:6:91:19 | call to get_field | provenance |  |
-| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] | instance_variables.rb:96:6:96:9 | foo9 [@field] | provenance |  |
-| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] | instance_variables.rb:97:6:97:10 | foo10 [@field] | provenance |  |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:15:89:18 | [post] foo7 : Foo [@field] | provenance |  |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:89:25:89:28 | [post] foo8 : Foo [@field] | provenance |  |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | instance_variables.rb:90:6:90:19 | call to get_field | provenance |  |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | instance_variables.rb:91:6:91:19 | call to get_field | provenance |  |
+| instance_variables.rb:95:22:95:25 | [post] foo9 : Foo [@field] | instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | provenance |  |
+| instance_variables.rb:95:32:95:36 | [post] foo10 : Foo [@field] | instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | provenance |  |
 | instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] | provenance |  |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] | provenance |  |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:96:6:96:19 | call to get_field | provenance |  |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:97:6:97:20 | call to get_field | provenance |  |
-| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | provenance |  |
-| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | provenance |  |
-| instance_variables.rb:99:18:99:18 | x [Return] [@field] | instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | provenance |  |
-| instance_variables.rb:100:5:100:5 | [post] x [@field] | instance_variables.rb:99:18:99:18 | x [Return] [@field] | provenance |  |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:22:95:25 | [post] foo9 : Foo [@field] | provenance |  |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:95:32:95:36 | [post] foo10 : Foo [@field] | provenance |  |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | instance_variables.rb:96:6:96:19 | call to get_field | provenance |  |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | instance_variables.rb:97:6:97:20 | call to get_field | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] : Foo [@field] | instance_variables.rb:104:14:104:18 | [post] foo11 : Foo [@field] | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] : Foo [@field] | instance_variables.rb:108:15:108:19 | [post] foo12 : Foo [@field] | provenance |  |
+| instance_variables.rb:99:18:99:18 | x [Return] : Foo [@field] | instance_variables.rb:113:22:113:26 | [post] foo13 : Foo [@field] | provenance |  |
+| instance_variables.rb:100:5:100:5 | [post] x : Foo [@field] | instance_variables.rb:99:18:99:18 | x [Return] : Foo [@field] | provenance |  |
 | instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | provenance |  |
 | instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | provenance |  |
-| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:100:5:100:5 | [post] x [@field] | provenance |  |
-| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | instance_variables.rb:105:6:105:10 | foo11 [@field] | provenance |  |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:105:6:105:20 | call to get_field | provenance |  |
-| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | instance_variables.rb:109:6:109:10 | foo12 [@field] | provenance |  |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:109:6:109:20 | call to get_field | provenance |  |
-| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | instance_variables.rb:114:6:114:10 | foo13 [@field] | provenance |  |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:114:6:114:20 | call to get_field | provenance |  |
-| instance_variables.rb:116:1:116:5 | foo15 [@field] | instance_variables.rb:117:6:117:10 | foo15 [@field] | provenance |  |
-| instance_variables.rb:116:9:116:26 | call to new [@field] | instance_variables.rb:116:1:116:5 | foo15 [@field] | provenance |  |
+| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:100:5:100:5 | [post] x : Foo [@field] | provenance |  |
+| instance_variables.rb:104:14:104:18 | [post] foo11 : Foo [@field] | instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | provenance |  |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | instance_variables.rb:105:6:105:20 | call to get_field | provenance |  |
+| instance_variables.rb:108:15:108:19 | [post] foo12 : Foo [@field] | instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | provenance |  |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | instance_variables.rb:109:6:109:20 | call to get_field | provenance |  |
+| instance_variables.rb:113:22:113:26 | [post] foo13 : Foo [@field] | instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | provenance |  |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | instance_variables.rb:114:6:114:20 | call to get_field | provenance |  |
+| instance_variables.rb:116:1:116:5 | foo15 : Foo [@field] | instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | provenance |  |
+| instance_variables.rb:116:9:116:26 | call to new : Foo [@field] | instance_variables.rb:116:1:116:5 | foo15 : Foo [@field] | provenance |  |
 | instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field | provenance |  |
-| instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:116:9:116:26 | call to new [@field] | provenance |  |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:117:6:117:20 | call to get_field | provenance |  |
-| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] | instance_variables.rb:120:6:120:10 | foo16 [@field] | provenance |  |
+| instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:116:9:116:26 | call to new : Foo [@field] | provenance |  |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | instance_variables.rb:117:6:117:20 | call to get_field | provenance |  |
+| instance_variables.rb:119:6:119:10 | [post] foo16 : Foo [@field] | instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | provenance |  |
 | instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | provenance |  |
-| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] | provenance |  |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | provenance |  |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:120:6:120:20 | call to get_field | provenance |  |
+| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:119:6:119:10 | [post] foo16 : Foo [@field] | provenance |  |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | provenance |  |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | instance_variables.rb:120:6:120:20 | call to get_field | provenance |  |
 | instance_variables.rb:121:1:121:3 | bar | instance_variables.rb:122:6:122:8 | bar | provenance |  |
 | instance_variables.rb:121:7:121:24 | call to new | instance_variables.rb:121:1:121:3 | bar | provenance |  |
 nodes
@@ -265,68 +274,73 @@ nodes
 | blocks.rb:25:8:25:8 | x | semmle.label | x |
 | captured_variables.rb:9:24:9:24 | x | semmle.label | x |
 | captured_variables.rb:10:20:10:20 | x | semmle.label | x |
-| captured_variables.rb:11:5:11:6 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:11:5:11:6 | fn : [lambda] [captured x] | semmle.label | fn : [lambda] [captured x] |
 | captured_variables.rb:13:20:13:29 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:15:28:15:28 | x | semmle.label | x |
-| captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:16:5:18:5 | -> { ... } : [lambda] [captured x] | semmle.label | -> { ... } : [lambda] [captured x] |
 | captured_variables.rb:17:14:17:14 | x | semmle.label | x |
-| captured_variables.rb:20:1:20:35 | ( ... ) [captured x] | semmle.label | ( ... ) [captured x] |
-| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] | semmle.label | call to capture_escape_return1 [captured x] |
+| captured_variables.rb:20:1:20:35 | ( ... ) : [lambda] [captured x] | semmle.label | ( ... ) : [lambda] [captured x] |
+| captured_variables.rb:20:2:20:34 | call to capture_escape_return1 : [lambda] [captured x] | semmle.label | call to capture_escape_return1 : [lambda] [captured x] |
 | captured_variables.rb:20:25:20:34 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:22:28:22:28 | x | semmle.label | x |
-| captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:23:5:25:5 | -> { ... } : [lambda] [captured x] | semmle.label | -> { ... } : [lambda] [captured x] |
 | captured_variables.rb:24:14:24:14 | x | semmle.label | x |
-| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] | semmle.label | call to capture_escape_return2 [captured x] |
+| captured_variables.rb:27:25:27:57 | call to capture_escape_return2 : [lambda] [captured x] | semmle.label | call to capture_escape_return2 : [lambda] [captured x] |
 | captured_variables.rb:27:48:27:57 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:29:33:29:33 | x | semmle.label | x |
 | captured_variables.rb:31:14:31:14 | x | semmle.label | x |
-| captured_variables.rb:33:29:33:30 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:33:29:33:30 | fn : [lambda] [captured x] | semmle.label | fn : [lambda] [captured x] |
 | captured_variables.rb:35:29:35:38 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:37:13:37:14 | fn [captured x] | semmle.label | fn [captured x] |
-| captured_variables.rb:38:5:38:6 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:37:13:37:14 | fn : [lambda] [captured x] | semmle.label | fn : [lambda] [captured x] |
+| captured_variables.rb:38:5:38:6 | fn : [lambda] [captured x] | semmle.label | fn : [lambda] [captured x] |
 | captured_variables.rb:40:31:40:31 | x | semmle.label | x |
 | captured_variables.rb:42:14:42:14 | x | semmle.label | x |
-| captured_variables.rb:44:13:44:14 | fn [captured x] | semmle.label | fn [captured x] |
+| captured_variables.rb:44:13:44:14 | fn : [lambda] [captured x] | semmle.label | fn : [lambda] [captured x] |
 | captured_variables.rb:46:27:46:36 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:48:5:48:12 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:49:16:52:3 | [post] do ... end [captured x] | semmle.label | [post] do ... end [captured x] |
-| captured_variables.rb:49:16:52:3 | do ... end [captured x] | semmle.label | do ... end [captured x] |
+| captured_variables.rb:49:16:52:3 | [post] do ... end : [lambda] [captured x] | semmle.label | [post] do ... end : [lambda] [captured x] |
+| captured_variables.rb:49:16:52:3 | do ... end : [lambda] [captured x] | semmle.label | do ... end : [lambda] [captured x] |
 | captured_variables.rb:50:10:50:10 | x | semmle.label | x |
 | captured_variables.rb:51:9:51:16 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:54:6:54:6 | x | semmle.label | x |
-| captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | semmle.label | self in set_field [Return] [@field] |
+| captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | semmle.label | self in set_field [Return] : Foo [@field] |
 | captured_variables.rb:57:19:57:19 | x | semmle.label | x |
 | captured_variables.rb:58:9:58:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | captured_variables.rb:58:18:58:18 | x | semmle.label | x |
-| captured_variables.rb:60:5:62:7 | self in get_field [@field] | semmle.label | self in get_field [@field] |
+| captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | semmle.label | self in get_field : Foo [@field] |
+| captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | semmle.label | self in get_field : Foo [@field] |
+| captured_variables.rb:61:9:61:21 | return | semmle.label | return |
 | captured_variables.rb:61:9:61:21 | return | semmle.label | return |
 | captured_variables.rb:61:16:61:21 | @field | semmle.label | @field |
-| captured_variables.rb:61:16:61:21 | self [@field] | semmle.label | self [@field] |
-| captured_variables.rb:66:1:66:3 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:61:16:61:21 | @field | semmle.label | @field |
+| captured_variables.rb:61:16:61:21 | self : Foo [@field] | semmle.label | self : Foo [@field] |
+| captured_variables.rb:61:16:61:21 | self : Foo [@field] | semmle.label | self : Foo [@field] |
+| captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] | semmle.label | [post] foo : Foo [@field] |
 | captured_variables.rb:66:15:66:22 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:67:16:70:3 | [post] do ... end [captured foo, @field] | semmle.label | [post] do ... end [captured foo, @field] |
-| captured_variables.rb:67:16:70:3 | do ... end [captured foo, @field] | semmle.label | do ... end [captured foo, @field] |
+| captured_variables.rb:67:16:70:3 | [post] do ... end : [lambda] [captured foo, @field] | semmle.label | [post] do ... end : [lambda] [captured foo, @field] |
+| captured_variables.rb:67:16:70:3 | do ... end : [lambda] [captured foo, @field] | semmle.label | do ... end : [lambda] [captured foo, @field] |
 | captured_variables.rb:68:10:68:12 | foo [@field] | semmle.label | foo [@field] |
 | captured_variables.rb:68:10:68:22 | call to get_field | semmle.label | call to get_field |
-| captured_variables.rb:69:5:69:7 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] | semmle.label | [post] foo : Foo [@field] |
 | captured_variables.rb:69:19:69:26 | call to taint | semmle.label | call to taint |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | semmle.label | foo : Foo [@field] |
 | captured_variables.rb:72:6:72:8 | foo [@field] | semmle.label | foo [@field] |
 | captured_variables.rb:72:6:72:18 | call to get_field | semmle.label | call to get_field |
-| captured_variables.rb:78:20:80:7 | [post] do ... end [captured foo, @field] | semmle.label | [post] do ... end [captured foo, @field] |
-| captured_variables.rb:79:9:79:11 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| captured_variables.rb:78:20:80:7 | [post] do ... end : [lambda] [captured foo, @field] | semmle.label | [post] do ... end : [lambda] [captured foo, @field] |
+| captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] | semmle.label | [post] foo : Foo [@field] |
 | captured_variables.rb:79:23:79:30 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:83:6:83:8 | foo [@field] | semmle.label | foo [@field] |
 | captured_variables.rb:83:6:83:18 | call to get_field | semmle.label | call to get_field |
 | captured_variables.rb:85:5:85:12 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:87:10:87:10 | y | semmle.label | y |
 | captured_variables.rb:88:9:88:16 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:90:1:90:2 | [post] fn [captured y] | semmle.label | [post] fn [captured y] |
-| captured_variables.rb:90:1:90:2 | fn [captured y] | semmle.label | fn [captured y] |
+| captured_variables.rb:90:1:90:2 | [post] fn : [lambda] [captured y] | semmle.label | [post] fn : [lambda] [captured y] |
+| captured_variables.rb:90:1:90:2 | fn : [lambda] [captured y] | semmle.label | fn : [lambda] [captured y] |
 | captured_variables.rb:91:6:91:6 | y | semmle.label | y |
 | captured_variables.rb:93:17:93:17 | x | semmle.label | x |
-| captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | semmle.label | -> { ... } [captured x] |
+| captured_variables.rb:94:5:96:5 | -> { ... } : [lambda] [captured x] | semmle.label | -> { ... } : [lambda] [captured x] |
 | captured_variables.rb:95:14:95:14 | x | semmle.label | x |
-| captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] | semmle.label | call to capture_arg [captured x] |
+| captured_variables.rb:98:1:98:21 | call to capture_arg : [lambda] [captured x] | semmle.label | call to capture_arg : [lambda] [captured x] |
 | captured_variables.rb:98:13:98:20 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:100:21:100:21 | x | semmle.label | x |
 | captured_variables.rb:101:11:101:11 | x | semmle.label | x |
@@ -336,88 +350,92 @@ nodes
 | captured_variables.rb:109:9:109:17 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:112:18:112:18 | x | semmle.label | x |
 | captured_variables.rb:113:17:113:25 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:115:9:115:13 | [post] inner [captured x] | semmle.label | [post] inner [captured x] |
-| captured_variables.rb:115:9:115:13 | inner [captured x] | semmle.label | inner [captured x] |
-| captured_variables.rb:117:5:117:10 | [post] middle [captured x] | semmle.label | [post] middle [captured x] |
-| captured_variables.rb:117:5:117:10 | middle [captured x] | semmle.label | middle [captured x] |
+| captured_variables.rb:115:9:115:13 | [post] inner : [lambda] [captured x] | semmle.label | [post] inner : [lambda] [captured x] |
+| captured_variables.rb:115:9:115:13 | inner : [lambda] [captured x] | semmle.label | inner : [lambda] [captured x] |
+| captured_variables.rb:117:5:117:10 | [post] middle : [lambda] [captured x] | semmle.label | [post] middle : [lambda] [captured x] |
+| captured_variables.rb:117:5:117:10 | middle : [lambda] [captured x] | semmle.label | middle : [lambda] [captured x] |
 | captured_variables.rb:118:10:118:10 | x | semmle.label | x |
 | captured_variables.rb:147:5:147:6 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:147:10:147:18 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:149:5:151:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
-| captured_variables.rb:153:14:155:7 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
+| captured_variables.rb:149:5:151:7 | &block : [lambda] [captured self, @x] | semmle.label | &block : [lambda] [captured self, @x] |
+| captured_variables.rb:153:14:155:7 | do ... end : [lambda] [captured self, @x] | semmle.label | do ... end : [lambda] [captured self, @x] |
 | captured_variables.rb:154:14:154:15 | @x | semmle.label | @x |
 | captured_variables.rb:154:14:154:15 | self [@x] | semmle.label | self [@x] |
 | captured_variables.rb:160:9:160:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:160:14:160:22 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:163:5:165:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
-| captured_variables.rb:167:5:171:7 | self in baz [@x] | semmle.label | self in baz [@x] |
-| captured_variables.rb:168:18:170:11 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
+| captured_variables.rb:163:5:165:7 | &block : [lambda] [captured self, @x] | semmle.label | &block : [lambda] [captured self, @x] |
+| captured_variables.rb:167:5:171:7 | self in baz : CaptureInstanceSelf1 [@x] | semmle.label | self in baz : CaptureInstanceSelf1 [@x] |
+| captured_variables.rb:168:18:170:11 | do ... end : [lambda] [captured self, @x] | semmle.label | do ... end : [lambda] [captured self, @x] |
 | captured_variables.rb:169:18:169:19 | @x | semmle.label | @x |
-| captured_variables.rb:169:18:169:19 | self [@x] | semmle.label | self [@x] |
-| captured_variables.rb:174:1:174:24 | call to new [@x] | semmle.label | call to new [@x] |
-| captured_variables.rb:177:5:179:7 | self in foo [Return] [@x] | semmle.label | self in foo [Return] [@x] |
+| captured_variables.rb:169:18:169:19 | self : CaptureInstanceSelf1 [@x] | semmle.label | self : CaptureInstanceSelf1 [@x] |
+| captured_variables.rb:174:1:174:24 | call to new : CaptureInstanceSelf1 [@x] | semmle.label | call to new : CaptureInstanceSelf1 [@x] |
+| captured_variables.rb:177:5:179:7 | self in foo [Return] : CaptureInstanceSelf2 [@x] | semmle.label | self in foo [Return] : CaptureInstanceSelf2 [@x] |
 | captured_variables.rb:178:9:178:10 | [post] self [@x] | semmle.label | [post] self [@x] |
 | captured_variables.rb:178:14:178:22 | call to taint | semmle.label | call to taint |
-| captured_variables.rb:181:5:183:7 | &block [captured self, @x] | semmle.label | &block [captured self, @x] |
-| captured_variables.rb:185:5:189:7 | self in baz [@x] | semmle.label | self in baz [@x] |
-| captured_variables.rb:186:18:188:11 | do ... end [captured self, @x] | semmle.label | do ... end [captured self, @x] |
+| captured_variables.rb:181:5:183:7 | &block : [lambda] [captured self, @x] | semmle.label | &block : [lambda] [captured self, @x] |
+| captured_variables.rb:185:5:189:7 | self in baz : CaptureInstanceSelf2 [@x] | semmle.label | self in baz : CaptureInstanceSelf2 [@x] |
+| captured_variables.rb:186:18:188:11 | do ... end : [lambda] [captured self, @x] | semmle.label | do ... end : [lambda] [captured self, @x] |
 | captured_variables.rb:187:18:187:19 | @x | semmle.label | @x |
-| captured_variables.rb:187:18:187:19 | self [@x] | semmle.label | self [@x] |
-| captured_variables.rb:193:1:193:1 | [post] c [@x] | semmle.label | [post] c [@x] |
-| captured_variables.rb:194:1:194:1 | c [@x] | semmle.label | c [@x] |
+| captured_variables.rb:187:18:187:19 | self : CaptureInstanceSelf2 [@x] | semmle.label | self : CaptureInstanceSelf2 [@x] |
+| captured_variables.rb:193:1:193:1 | [post] c : CaptureInstanceSelf2 [@x] | semmle.label | [post] c : CaptureInstanceSelf2 [@x] |
+| captured_variables.rb:194:1:194:1 | c : CaptureInstanceSelf2 [@x] | semmle.label | c : CaptureInstanceSelf2 [@x] |
 | captured_variables.rb:197:9:197:17 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:199:10:199:10 | x | semmle.label | x |
 | captured_variables.rb:206:13:206:21 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:208:14:208:14 | x | semmle.label | x |
 | captured_variables.rb:219:9:219:17 | call to taint | semmle.label | call to taint |
 | captured_variables.rb:223:13:223:13 | x | semmle.label | x |
-| captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] | semmle.label | [post] fn1 [captured y] |
-| captured_variables.rb:226:5:226:7 | fn1 [captured x] | semmle.label | fn1 [captured x] |
+| captured_variables.rb:226:5:226:7 | [post] fn1 : [lambda] [captured y] | semmle.label | [post] fn1 : [lambda] [captured y] |
+| captured_variables.rb:226:5:226:7 | fn1 : [lambda] [captured x] | semmle.label | fn1 : [lambda] [captured x] |
 | captured_variables.rb:227:10:227:10 | y | semmle.label | y |
-| instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | semmle.label | self in set_field [Return] [@field] |
+| instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | semmle.label | self in set_field [Return] : Foo [@field] |
 | instance_variables.rb:10:19:10:19 | x | semmle.label | x |
 | instance_variables.rb:11:9:11:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:11:18:11:18 | x | semmle.label | x |
-| instance_variables.rb:13:5:15:7 | self in get_field [@field] | semmle.label | self in get_field [@field] |
+| instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | semmle.label | self in get_field : Foo [@field] |
+| instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | semmle.label | self in get_field : Foo [@field] |
+| instance_variables.rb:14:9:14:21 | return | semmle.label | return |
 | instance_variables.rb:14:9:14:21 | return | semmle.label | return |
 | instance_variables.rb:14:16:14:21 | @field | semmle.label | @field |
-| instance_variables.rb:14:16:14:21 | self [@field] | semmle.label | self [@field] |
-| instance_variables.rb:16:5:18:7 | self in inc_field [@field] | semmle.label | self in inc_field [@field] |
+| instance_variables.rb:14:16:14:21 | @field | semmle.label | @field |
+| instance_variables.rb:14:16:14:21 | self : Foo [@field] | semmle.label | self : Foo [@field] |
+| instance_variables.rb:14:16:14:21 | self : Foo [@field] | semmle.label | self : Foo [@field] |
+| instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | semmle.label | self in inc_field : Foo [@field] |
 | instance_variables.rb:17:9:17:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:19:5:19:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | instance_variables.rb:19:12:19:21 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:20:10:20:13 | @foo | semmle.label | @foo |
 | instance_variables.rb:20:10:20:13 | self [@foo] | semmle.label | self [@foo] |
-| instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | semmle.label | self in initialize [Return] [@field] |
+| instance_variables.rb:22:5:25:7 | self in initialize [Return] : Foo [@field] | semmle.label | self in initialize [Return] : Foo [@field] |
 | instance_variables.rb:22:20:22:24 | field | semmle.label | field |
 | instance_variables.rb:23:9:23:14 | [post] self [@field] | semmle.label | [post] self [@field] |
 | instance_variables.rb:23:18:23:22 | field | semmle.label | field |
 | instance_variables.rb:24:9:24:17 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | semmle.label | self in call_initialize [Return] [@field] |
+| instance_variables.rb:27:5:29:7 | self in call_initialize [Return] : Foo [@field] | semmle.label | self in call_initialize [Return] : Foo [@field] |
 | instance_variables.rb:27:25:27:29 | field | semmle.label | field |
-| instance_variables.rb:28:9:28:25 | [post] self [@field] | semmle.label | [post] self [@field] |
+| instance_variables.rb:28:9:28:25 | [post] self : Foo [@field] | semmle.label | [post] self : Foo [@field] |
 | instance_variables.rb:28:9:28:25 | call to initialize | semmle.label | call to initialize |
 | instance_variables.rb:28:20:28:24 | field | semmle.label | field |
 | instance_variables.rb:31:18:31:18 | x | semmle.label | x |
 | instance_variables.rb:32:13:32:21 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:33:9:33:14 | call to new [@field] | semmle.label | call to new [@field] |
+| instance_variables.rb:33:9:33:14 | call to new : Foo [@field] | semmle.label | call to new : Foo [@field] |
 | instance_variables.rb:33:13:33:13 | x | semmle.label | x |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | semmle.label | call to new [@field] |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | semmle.label | call to new : Foo [@field] |
 | instance_variables.rb:36:10:36:33 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:36:14:36:22 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | semmle.label | call to bar [@field] |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | semmle.label | call to bar : Foo [@field] |
 | instance_variables.rb:39:6:39:33 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:39:14:39:22 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:43:9:43:17 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:48:20:48:20 | x | semmle.label | x |
 | instance_variables.rb:49:14:49:14 | x | semmle.label | x |
-| instance_variables.rb:54:1:54:3 | [post] foo [@field] | semmle.label | [post] foo [@field] |
+| instance_variables.rb:54:1:54:3 | [post] foo : Foo [@field] | semmle.label | [post] foo : Foo [@field] |
 | instance_variables.rb:54:15:54:23 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:55:6:55:8 | foo [@field] | semmle.label | foo [@field] |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | semmle.label | foo : Foo [@field] |
 | instance_variables.rb:55:6:55:18 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:58:1:58:3 | [post] bar [@field] | semmle.label | [post] bar [@field] |
+| instance_variables.rb:58:1:58:3 | [post] bar : Foo [@field] | semmle.label | [post] bar : Foo [@field] |
 | instance_variables.rb:58:15:58:22 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:59:6:59:8 | bar [@field] | semmle.label | bar [@field] |
+| instance_variables.rb:59:6:59:8 | bar : Foo [@field] | semmle.label | bar : Foo [@field] |
 | instance_variables.rb:59:6:59:18 | call to inc_field | semmle.label | call to inc_field |
 | instance_variables.rb:62:1:62:4 | [post] foo1 [@field] | semmle.label | [post] foo1 [@field] |
 | instance_variables.rb:62:14:62:22 | call to taint | semmle.label | call to taint |
@@ -427,140 +445,142 @@ nodes
 | instance_variables.rb:66:14:66:22 | call to taint | semmle.label | call to taint |
 | instance_variables.rb:67:6:67:9 | foo2 [@field] | semmle.label | foo2 [@field] |
 | instance_variables.rb:67:6:67:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:70:1:70:4 | [post] foo3 [@field] | semmle.label | [post] foo3 [@field] |
+| instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] | semmle.label | [post] foo3 : Foo [@field] |
 | instance_variables.rb:70:16:70:24 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:71:6:71:9 | foo3 [@field] | semmle.label | foo3 [@field] |
+| instance_variables.rb:71:6:71:9 | foo3 : Foo [@field] | semmle.label | foo3 : Foo [@field] |
 | instance_variables.rb:71:6:71:15 | call to field | semmle.label | call to field |
-| instance_variables.rb:78:2:78:5 | [post] foo5 [@field] | semmle.label | [post] foo5 [@field] |
+| instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] | semmle.label | [post] foo5 : Foo [@field] |
 | instance_variables.rb:78:18:78:26 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | semmle.label | foo5 [@field] |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | semmle.label | foo5 : Foo [@field] |
 | instance_variables.rb:79:6:79:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:82:15:82:18 | [post] foo6 [@field] | semmle.label | [post] foo6 [@field] |
+| instance_variables.rb:82:15:82:18 | [post] foo6 : Foo [@field] | semmle.label | [post] foo6 : Foo [@field] |
 | instance_variables.rb:82:32:82:40 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | semmle.label | foo3 [@field] |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | semmle.label | foo3 : Foo [@field] |
 | instance_variables.rb:83:6:83:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | semmle.label | foo5 [@field] |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | semmle.label | foo5 : Foo [@field] |
 | instance_variables.rb:84:6:84:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | semmle.label | foo6 [@field] |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | semmle.label | foo6 : Foo [@field] |
 | instance_variables.rb:85:6:85:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:89:15:89:18 | [post] foo7 [@field] | semmle.label | [post] foo7 [@field] |
-| instance_variables.rb:89:25:89:28 | [post] foo8 [@field] | semmle.label | [post] foo8 [@field] |
+| instance_variables.rb:89:15:89:18 | [post] foo7 : Foo [@field] | semmle.label | [post] foo7 : Foo [@field] |
+| instance_variables.rb:89:25:89:28 | [post] foo8 : Foo [@field] | semmle.label | [post] foo8 : Foo [@field] |
 | instance_variables.rb:89:45:89:53 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | semmle.label | foo7 [@field] |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | semmle.label | foo7 : Foo [@field] |
 | instance_variables.rb:90:6:90:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | semmle.label | foo8 [@field] |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | semmle.label | foo8 : Foo [@field] |
 | instance_variables.rb:91:6:91:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:95:22:95:25 | [post] foo9 [@field] | semmle.label | [post] foo9 [@field] |
-| instance_variables.rb:95:32:95:36 | [post] foo10 [@field] | semmle.label | [post] foo10 [@field] |
+| instance_variables.rb:95:22:95:25 | [post] foo9 : Foo [@field] | semmle.label | [post] foo9 : Foo [@field] |
+| instance_variables.rb:95:32:95:36 | [post] foo10 : Foo [@field] | semmle.label | [post] foo10 : Foo [@field] |
 | instance_variables.rb:95:53:95:61 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | semmle.label | foo9 [@field] |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | semmle.label | foo9 : Foo [@field] |
 | instance_variables.rb:96:6:96:19 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | semmle.label | foo10 [@field] |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | semmle.label | foo10 : Foo [@field] |
 | instance_variables.rb:97:6:97:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:99:18:99:18 | x [Return] [@field] | semmle.label | x [Return] [@field] |
-| instance_variables.rb:100:5:100:5 | [post] x [@field] | semmle.label | [post] x [@field] |
+| instance_variables.rb:99:18:99:18 | x [Return] : Foo [@field] | semmle.label | x [Return] : Foo [@field] |
+| instance_variables.rb:100:5:100:5 | [post] x : Foo [@field] | semmle.label | [post] x : Foo [@field] |
 | instance_variables.rb:100:17:100:25 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:104:14:104:18 | [post] foo11 [@field] | semmle.label | [post] foo11 [@field] |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | semmle.label | foo11 [@field] |
+| instance_variables.rb:104:14:104:18 | [post] foo11 : Foo [@field] | semmle.label | [post] foo11 : Foo [@field] |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | semmle.label | foo11 : Foo [@field] |
 | instance_variables.rb:105:6:105:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:108:15:108:19 | [post] foo12 [@field] | semmle.label | [post] foo12 [@field] |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | semmle.label | foo12 [@field] |
+| instance_variables.rb:108:15:108:19 | [post] foo12 : Foo [@field] | semmle.label | [post] foo12 : Foo [@field] |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | semmle.label | foo12 : Foo [@field] |
 | instance_variables.rb:109:6:109:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:113:22:113:26 | [post] foo13 [@field] | semmle.label | [post] foo13 [@field] |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | semmle.label | foo13 [@field] |
+| instance_variables.rb:113:22:113:26 | [post] foo13 : Foo [@field] | semmle.label | [post] foo13 : Foo [@field] |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | semmle.label | foo13 : Foo [@field] |
 | instance_variables.rb:114:6:114:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:116:1:116:5 | foo15 [@field] | semmle.label | foo15 [@field] |
-| instance_variables.rb:116:9:116:26 | call to new [@field] | semmle.label | call to new [@field] |
+| instance_variables.rb:116:1:116:5 | foo15 : Foo [@field] | semmle.label | foo15 : Foo [@field] |
+| instance_variables.rb:116:9:116:26 | call to new : Foo [@field] | semmle.label | call to new : Foo [@field] |
 | instance_variables.rb:116:17:116:25 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | semmle.label | foo15 [@field] |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | semmle.label | foo15 : Foo [@field] |
 | instance_variables.rb:117:6:117:20 | call to get_field | semmle.label | call to get_field |
-| instance_variables.rb:119:6:119:10 | [post] foo16 [@field] | semmle.label | [post] foo16 [@field] |
+| instance_variables.rb:119:6:119:10 | [post] foo16 : Foo [@field] | semmle.label | [post] foo16 : Foo [@field] |
 | instance_variables.rb:119:6:119:37 | call to call_initialize | semmle.label | call to call_initialize |
 | instance_variables.rb:119:28:119:36 | call to taint | semmle.label | call to taint |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | semmle.label | foo16 [@field] |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | semmle.label | foo16 : Foo [@field] |
 | instance_variables.rb:120:6:120:20 | call to get_field | semmle.label | call to get_field |
 | instance_variables.rb:121:1:121:3 | bar | semmle.label | bar |
 | instance_variables.rb:121:7:121:24 | call to new | semmle.label | call to new |
 | instance_variables.rb:122:6:122:8 | bar | semmle.label | bar |
 subpaths
-| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } [captured x] | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 [captured x] |
-| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } [captured x] | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 [captured x] |
-| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
-| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:66:1:66:3 | [post] foo [@field] |
-| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
-| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
-| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
-| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:69:5:69:7 | [post] foo [@field] |
-| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
-| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
-| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
-| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | captured_variables.rb:79:9:79:11 | [post] foo [@field] |
-| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
-| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
-| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } [captured x] | captured_variables.rb:98:1:98:21 | call to capture_arg [captured x] |
-| captured_variables.rb:226:5:226:7 | fn1 [captured x] | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:226:5:226:7 | [post] fn1 [captured y] |
-| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:22:5:25:7 | self in initialize [Return] [@field] | instance_variables.rb:28:9:28:25 | [post] self [@field] |
-| instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new [@field] |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
-| instance_variables.rb:36:10:36:23 | call to new [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
-| instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:36:10:36:23 | call to new [@field] |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
-| instance_variables.rb:39:6:39:23 | call to bar [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
-| instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:9:33:14 | call to new [@field] | instance_variables.rb:39:6:39:23 | call to bar [@field] |
-| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
-| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:54:1:54:3 | [post] foo [@field] |
-| instance_variables.rb:55:6:55:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
-| instance_variables.rb:55:6:55:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
-| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
-| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:58:1:58:3 | [post] bar [@field] |
-| instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
-| instance_variables.rb:59:6:59:8 | bar [@field] | instance_variables.rb:16:5:18:7 | self in inc_field [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
-| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
-| instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
-| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
-| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 [@field] |
-| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
-| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 [@field] |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
-| instance_variables.rb:79:6:79:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
-| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
-| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 [@field] |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
-| instance_variables.rb:83:6:83:9 | foo3 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
-| instance_variables.rb:84:6:84:9 | foo5 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
-| instance_variables.rb:85:6:85:9 | foo6 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
-| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 [@field] |
-| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 [@field] |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
-| instance_variables.rb:90:6:90:9 | foo7 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
-| instance_variables.rb:91:6:91:9 | foo8 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
-| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 [@field] |
-| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 [@field] |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
-| instance_variables.rb:96:6:96:9 | foo9 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
-| instance_variables.rb:97:6:97:10 | foo10 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
-| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
-| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] [@field] | instance_variables.rb:100:5:100:5 | [post] x [@field] |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
-| instance_variables.rb:105:6:105:10 | foo11 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
-| instance_variables.rb:109:6:109:10 | foo12 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
-| instance_variables.rb:114:6:114:10 | foo13 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
-| instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:116:9:116:26 | call to new [@field] |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
-| instance_variables.rb:117:6:117:10 | foo15 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
-| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] [@field] | instance_variables.rb:119:6:119:10 | [post] foo16 [@field] |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | captured_variables.rb:60:5:62:7 | self in get_field [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
-| instance_variables.rb:120:6:120:10 | foo16 [@field] | instance_variables.rb:13:5:15:7 | self in get_field [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
+| captured_variables.rb:20:25:20:34 | call to taint | captured_variables.rb:15:28:15:28 | x | captured_variables.rb:16:5:18:5 | -> { ... } : [lambda] [captured x] | captured_variables.rb:20:2:20:34 | call to capture_escape_return1 : [lambda] [captured x] |
+| captured_variables.rb:27:48:27:57 | call to taint | captured_variables.rb:22:28:22:28 | x | captured_variables.rb:23:5:25:5 | -> { ... } : [lambda] [captured x] | captured_variables.rb:27:25:27:57 | call to capture_escape_return2 : [lambda] [captured x] |
+| captured_variables.rb:66:15:66:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] |
+| captured_variables.rb:66:15:66:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:66:1:66:3 | [post] foo : Foo [@field] |
+| captured_variables.rb:68:10:68:12 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
+| captured_variables.rb:68:10:68:12 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:68:10:68:22 | call to get_field |
+| captured_variables.rb:69:19:69:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] |
+| captured_variables.rb:69:19:69:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:69:5:69:7 | [post] foo : Foo [@field] |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:72:6:72:8 | foo : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:72:6:72:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:72:6:72:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:72:6:72:18 | call to get_field |
+| captured_variables.rb:79:23:79:30 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] |
+| captured_variables.rb:79:23:79:30 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | captured_variables.rb:79:9:79:11 | [post] foo : Foo [@field] |
+| captured_variables.rb:83:6:83:8 | foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
+| captured_variables.rb:83:6:83:8 | foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | captured_variables.rb:83:6:83:18 | call to get_field |
+| captured_variables.rb:98:13:98:20 | call to taint | captured_variables.rb:93:17:93:17 | x | captured_variables.rb:94:5:96:5 | -> { ... } : [lambda] [captured x] | captured_variables.rb:98:1:98:21 | call to capture_arg : [lambda] [captured x] |
+| captured_variables.rb:226:5:226:7 | fn1 : [lambda] [captured x] | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:223:13:223:13 | x | captured_variables.rb:226:5:226:7 | [post] fn1 : [lambda] [captured y] |
+| instance_variables.rb:28:20:28:24 | field | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:22:5:25:7 | self in initialize [Return] : Foo [@field] | instance_variables.rb:28:9:28:25 | [post] self : Foo [@field] |
+| instance_variables.rb:33:13:33:13 | x | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:33:9:33:14 | call to new : Foo [@field] |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:10:36:23 | call to new : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:36:10:36:33 | call to get_field |
+| instance_variables.rb:36:14:36:22 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:36:10:36:23 | call to new : Foo [@field] |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:39:6:39:33 | call to get_field |
+| instance_variables.rb:39:14:39:22 | call to taint | instance_variables.rb:31:18:31:18 | x | instance_variables.rb:33:9:33:14 | call to new : Foo [@field] | instance_variables.rb:39:6:39:23 | call to bar : Foo [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:54:1:54:3 | [post] foo : Foo [@field] |
+| instance_variables.rb:54:15:54:23 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:54:1:54:3 | [post] foo : Foo [@field] |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:55:6:55:8 | foo : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:55:6:55:18 | call to get_field |
+| instance_variables.rb:58:15:58:22 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:58:1:58:3 | [post] bar : Foo [@field] |
+| instance_variables.rb:58:15:58:22 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:58:1:58:3 | [post] bar : Foo [@field] |
+| instance_variables.rb:59:6:59:8 | bar : Foo [@field] | instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:59:6:59:8 | bar : Foo [@field] | instance_variables.rb:16:5:18:7 | self in inc_field : Foo [@field] | instance_variables.rb:17:9:17:14 | [post] self [@field] | instance_variables.rb:59:6:59:18 | call to inc_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:67:6:67:9 | foo2 [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:67:6:67:19 | call to get_field |
+| instance_variables.rb:70:16:70:24 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] |
+| instance_variables.rb:70:16:70:24 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:70:1:70:4 | [post] foo3 : Foo [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] |
+| instance_variables.rb:78:18:78:26 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:78:2:78:5 | [post] foo5 : Foo [@field] |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:79:6:79:9 | foo5 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:79:6:79:19 | call to get_field |
+| instance_variables.rb:82:32:82:40 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 : Foo [@field] |
+| instance_variables.rb:82:32:82:40 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:82:15:82:18 | [post] foo6 : Foo [@field] |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:83:6:83:9 | foo3 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:83:6:83:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:84:6:84:9 | foo5 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:84:6:84:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:85:6:85:9 | foo6 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:85:6:85:19 | call to get_field |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 : Foo [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 : Foo [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:89:15:89:18 | [post] foo7 : Foo [@field] |
+| instance_variables.rb:89:45:89:53 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:89:25:89:28 | [post] foo8 : Foo [@field] |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:90:6:90:9 | foo7 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:90:6:90:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:91:6:91:9 | foo8 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:91:6:91:19 | call to get_field |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 : Foo [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 : Foo [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:95:22:95:25 | [post] foo9 : Foo [@field] |
+| instance_variables.rb:95:53:95:61 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:95:32:95:36 | [post] foo10 : Foo [@field] |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:96:6:96:9 | foo9 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:96:6:96:19 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:97:6:97:10 | foo10 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:97:6:97:20 | call to get_field |
+| instance_variables.rb:100:17:100:25 | call to taint | captured_variables.rb:57:19:57:19 | x | captured_variables.rb:57:5:59:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:100:5:100:5 | [post] x : Foo [@field] |
+| instance_variables.rb:100:17:100:25 | call to taint | instance_variables.rb:10:19:10:19 | x | instance_variables.rb:10:5:12:7 | self in set_field [Return] : Foo [@field] | instance_variables.rb:100:5:100:5 | [post] x : Foo [@field] |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:105:6:105:10 | foo11 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:105:6:105:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:109:6:109:10 | foo12 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:109:6:109:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:114:6:114:10 | foo13 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:114:6:114:20 | call to get_field |
+| instance_variables.rb:116:17:116:25 | call to taint | instance_variables.rb:22:20:22:24 | field | instance_variables.rb:23:9:23:14 | [post] self [@field] | instance_variables.rb:116:9:116:26 | call to new : Foo [@field] |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:117:6:117:10 | foo15 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:117:6:117:20 | call to get_field |
+| instance_variables.rb:119:28:119:36 | call to taint | instance_variables.rb:27:25:27:29 | field | instance_variables.rb:27:5:29:7 | self in call_initialize [Return] : Foo [@field] | instance_variables.rb:119:6:119:10 | [post] foo16 : Foo [@field] |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | captured_variables.rb:60:5:62:7 | self in get_field : Foo [@field] | captured_variables.rb:61:9:61:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
+| instance_variables.rb:120:6:120:10 | foo16 : Foo [@field] | instance_variables.rb:13:5:15:7 | self in get_field : Foo [@field] | instance_variables.rb:14:9:14:21 | return | instance_variables.rb:120:6:120:20 | call to get_field |
 testFailures
 #select
 | blocks.rb:8:10:8:14 | yield ... | blocks.rb:14:12:14:20 | call to source | blocks.rb:8:10:8:14 | yield ... | $@ | blocks.rb:14:12:14:20 | call to source | call to source |

--- a/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/hash-flow/hash-flow.expected
@@ -1,1366 +1,1366 @@
 models
 edges
-| hash_flow.rb:10:5:10:8 | hash [element 0] | hash_flow.rb:30:10:30:13 | hash [element 0] | provenance |  |
-| hash_flow.rb:10:5:10:8 | hash [element :a] | hash_flow.rb:22:10:22:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:10:5:10:8 | hash [element :c] | hash_flow.rb:24:10:24:13 | hash [element :c] | provenance |  |
-| hash_flow.rb:10:5:10:8 | hash [element e] | hash_flow.rb:26:10:26:13 | hash [element e] | provenance |  |
-| hash_flow.rb:10:5:10:8 | hash [element g] | hash_flow.rb:28:10:28:13 | hash [element g] | provenance |  |
-| hash_flow.rb:10:12:21:5 | call to [] [element 0] | hash_flow.rb:10:5:10:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:10:12:21:5 | call to [] [element :a] | hash_flow.rb:10:5:10:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:10:12:21:5 | call to [] [element :c] | hash_flow.rb:10:5:10:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:10:12:21:5 | call to [] [element e] | hash_flow.rb:10:5:10:8 | hash [element e] | provenance |  |
-| hash_flow.rb:10:12:21:5 | call to [] [element g] | hash_flow.rb:10:5:10:8 | hash [element g] | provenance |  |
-| hash_flow.rb:11:15:11:24 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:13:12:13:21 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:15:14:15:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element e] | provenance |  |
-| hash_flow.rb:17:16:17:25 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element g] | provenance |  |
-| hash_flow.rb:19:14:19:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] [element 0] | provenance |  |
-| hash_flow.rb:22:10:22:13 | hash [element :a] | hash_flow.rb:22:10:22:17 | ...[...] | provenance |  |
-| hash_flow.rb:24:10:24:13 | hash [element :c] | hash_flow.rb:24:10:24:17 | ...[...] | provenance |  |
-| hash_flow.rb:26:10:26:13 | hash [element e] | hash_flow.rb:26:10:26:18 | ...[...] | provenance |  |
-| hash_flow.rb:28:10:28:13 | hash [element g] | hash_flow.rb:28:10:28:18 | ...[...] | provenance |  |
-| hash_flow.rb:30:10:30:13 | hash [element 0] | hash_flow.rb:30:10:30:16 | ...[...] | provenance |  |
-| hash_flow.rb:38:5:38:8 | [post] hash [element 0] | hash_flow.rb:39:5:39:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:38:15:38:24 | call to taint | hash_flow.rb:38:5:38:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:39:5:39:8 | [post] hash [element 0] | hash_flow.rb:40:5:40:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:39:5:39:8 | hash [element 0] | hash_flow.rb:39:5:39:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:40:5:40:8 | [post] hash [element 0] | hash_flow.rb:41:5:41:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:40:5:40:8 | [post] hash [element :a] | hash_flow.rb:41:5:41:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:40:5:40:8 | hash [element 0] | hash_flow.rb:40:5:40:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:40:16:40:25 | call to taint | hash_flow.rb:40:5:40:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:41:5:41:8 | [post] hash [element 0] | hash_flow.rb:42:5:42:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:41:5:41:8 | [post] hash [element :a] | hash_flow.rb:42:5:42:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:41:5:41:8 | hash [element 0] | hash_flow.rb:41:5:41:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:41:5:41:8 | hash [element :a] | hash_flow.rb:41:5:41:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:42:5:42:8 | [post] hash [element 0] | hash_flow.rb:43:5:43:8 | hash [element 0] | provenance |  |
-| hash_flow.rb:42:5:42:8 | [post] hash [element :a] | hash_flow.rb:43:5:43:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:42:5:42:8 | [post] hash [element a] | hash_flow.rb:43:5:43:8 | hash [element a] | provenance |  |
-| hash_flow.rb:42:5:42:8 | hash [element 0] | hash_flow.rb:42:5:42:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:42:5:42:8 | hash [element :a] | hash_flow.rb:42:5:42:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:42:17:42:26 | call to taint | hash_flow.rb:42:5:42:8 | [post] hash [element a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | [post] hash [element 0] | hash_flow.rb:44:10:44:13 | hash [element 0] | provenance |  |
-| hash_flow.rb:43:5:43:8 | [post] hash [element :a] | hash_flow.rb:46:10:46:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | [post] hash [element :a] | hash_flow.rb:48:10:48:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | [post] hash [element a] | hash_flow.rb:46:10:46:13 | hash [element a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | [post] hash [element a] | hash_flow.rb:48:10:48:13 | hash [element a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | hash [element 0] | hash_flow.rb:43:5:43:8 | [post] hash [element 0] | provenance |  |
-| hash_flow.rb:43:5:43:8 | hash [element :a] | hash_flow.rb:43:5:43:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:43:5:43:8 | hash [element a] | hash_flow.rb:43:5:43:8 | [post] hash [element a] | provenance |  |
-| hash_flow.rb:44:10:44:13 | hash [element 0] | hash_flow.rb:44:10:44:16 | ...[...] | provenance |  |
-| hash_flow.rb:46:10:46:13 | hash [element :a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
-| hash_flow.rb:46:10:46:13 | hash [element a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
-| hash_flow.rb:48:10:48:13 | hash [element :a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
-| hash_flow.rb:48:10:48:13 | hash [element a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
-| hash_flow.rb:55:5:55:9 | hash1 [element :a] | hash_flow.rb:56:10:56:14 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:55:13:55:37 | ...[...] [element :a] | hash_flow.rb:55:5:55:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:55:13:55:37 | ...[...] [element :a] | provenance |  |
-| hash_flow.rb:56:10:56:14 | hash1 [element :a] | hash_flow.rb:56:10:56:18 | ...[...] | provenance |  |
-| hash_flow.rb:59:5:59:5 | x [element :a] | hash_flow.rb:60:18:60:18 | x [element :a] | provenance |  |
-| hash_flow.rb:59:9:59:29 | call to [] [element :a] | hash_flow.rb:59:5:59:5 | x [element :a] | provenance |  |
-| hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:59:9:59:29 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:60:5:60:9 | hash2 [element :a] | hash_flow.rb:61:10:61:14 | hash2 [element :a] | provenance |  |
-| hash_flow.rb:60:13:60:19 | ...[...] [element :a] | hash_flow.rb:60:5:60:9 | hash2 [element :a] | provenance |  |
-| hash_flow.rb:60:18:60:18 | x [element :a] | hash_flow.rb:60:13:60:19 | ...[...] [element :a] | provenance |  |
-| hash_flow.rb:61:10:61:14 | hash2 [element :a] | hash_flow.rb:61:10:61:18 | ...[...] | provenance |  |
-| hash_flow.rb:64:5:64:9 | hash3 [element] | hash_flow.rb:65:10:65:14 | hash3 [element] | provenance |  |
-| hash_flow.rb:64:5:64:9 | hash3 [element] | hash_flow.rb:66:10:66:14 | hash3 [element] | provenance |  |
-| hash_flow.rb:64:13:64:45 | ...[...] [element] | hash_flow.rb:64:5:64:9 | hash3 [element] | provenance |  |
-| hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | hash_flow.rb:64:13:64:45 | ...[...] [element] | provenance |  |
-| hash_flow.rb:64:19:64:34 | call to [] [element 1] | hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | provenance |  |
-| hash_flow.rb:64:24:64:33 | call to taint | hash_flow.rb:64:19:64:34 | call to [] [element 1] | provenance |  |
-| hash_flow.rb:65:10:65:14 | hash3 [element] | hash_flow.rb:65:10:65:18 | ...[...] | provenance |  |
-| hash_flow.rb:66:10:66:14 | hash3 [element] | hash_flow.rb:66:10:66:18 | ...[...] | provenance |  |
-| hash_flow.rb:68:5:68:9 | hash4 [element :a] | hash_flow.rb:69:10:69:14 | hash4 [element :a] | provenance |  |
-| hash_flow.rb:68:13:68:39 | ...[...] [element :a] | hash_flow.rb:68:5:68:9 | hash4 [element :a] | provenance |  |
-| hash_flow.rb:68:22:68:31 | call to taint | hash_flow.rb:68:13:68:39 | ...[...] [element :a] | provenance |  |
-| hash_flow.rb:69:10:69:14 | hash4 [element :a] | hash_flow.rb:69:10:69:18 | ...[...] | provenance |  |
-| hash_flow.rb:72:5:72:9 | hash5 [element a] | hash_flow.rb:73:10:73:14 | hash5 [element a] | provenance |  |
-| hash_flow.rb:72:13:72:45 | ...[...] [element a] | hash_flow.rb:72:5:72:9 | hash5 [element a] | provenance |  |
-| hash_flow.rb:72:25:72:34 | call to taint | hash_flow.rb:72:13:72:45 | ...[...] [element a] | provenance |  |
-| hash_flow.rb:73:10:73:14 | hash5 [element a] | hash_flow.rb:73:10:73:19 | ...[...] | provenance |  |
-| hash_flow.rb:76:5:76:9 | hash6 [element a] | hash_flow.rb:77:10:77:14 | hash6 [element a] | provenance |  |
-| hash_flow.rb:76:13:76:47 | ...[...] [element a] | hash_flow.rb:76:5:76:9 | hash6 [element a] | provenance |  |
-| hash_flow.rb:76:18:76:46 | call to [] [element a] | hash_flow.rb:76:13:76:47 | ...[...] [element a] | provenance |  |
-| hash_flow.rb:76:26:76:35 | call to taint | hash_flow.rb:76:18:76:46 | call to [] [element a] | provenance |  |
-| hash_flow.rb:77:10:77:14 | hash6 [element a] | hash_flow.rb:77:10:77:19 | ...[...] | provenance |  |
-| hash_flow.rb:84:5:84:9 | hash1 [element :a] | hash_flow.rb:85:10:85:14 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:84:13:84:42 | call to [] [element :a] | hash_flow.rb:84:5:84:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:84:26:84:35 | call to taint | hash_flow.rb:84:13:84:42 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:85:10:85:14 | hash1 [element :a] | hash_flow.rb:85:10:85:18 | ...[...] | provenance |  |
-| hash_flow.rb:92:5:92:8 | hash [element :a] | hash_flow.rb:96:30:96:33 | hash [element :a] | provenance |  |
-| hash_flow.rb:92:12:95:5 | call to [] [element :a] | hash_flow.rb:92:5:92:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:93:15:93:24 | call to taint | hash_flow.rb:92:12:95:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:96:5:96:9 | hash2 [element :a] | hash_flow.rb:97:10:97:14 | hash2 [element :a] | provenance |  |
-| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | hash_flow.rb:96:5:96:9 | hash2 [element :a] | provenance |  |
-| hash_flow.rb:96:30:96:33 | hash [element :a] | hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | provenance |  |
-| hash_flow.rb:97:10:97:14 | hash2 [element :a] | hash_flow.rb:97:10:97:18 | ...[...] | provenance |  |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element 0] | hash_flow.rb:30:10:30:13 | hash : Hash [element 0] | provenance |  |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element :a] | hash_flow.rb:22:10:22:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element :c] | hash_flow.rb:24:10:24:13 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element e] | hash_flow.rb:26:10:26:13 | hash : Hash [element e] | provenance |  |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element g] | hash_flow.rb:28:10:28:13 | hash : Hash [element g] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element 0] | hash_flow.rb:10:5:10:8 | hash : Hash [element 0] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element :a] | hash_flow.rb:10:5:10:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element :c] | hash_flow.rb:10:5:10:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element e] | hash_flow.rb:10:5:10:8 | hash : Hash [element e] | provenance |  |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element g] | hash_flow.rb:10:5:10:8 | hash : Hash [element g] | provenance |  |
+| hash_flow.rb:11:15:11:24 | call to taint | hash_flow.rb:10:12:21:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:13:12:13:21 | call to taint | hash_flow.rb:10:12:21:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:15:14:15:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] : Hash [element e] | provenance |  |
+| hash_flow.rb:17:16:17:25 | call to taint | hash_flow.rb:10:12:21:5 | call to [] : Hash [element g] | provenance |  |
+| hash_flow.rb:19:14:19:23 | call to taint | hash_flow.rb:10:12:21:5 | call to [] : Hash [element 0] | provenance |  |
+| hash_flow.rb:22:10:22:13 | hash : Hash [element :a] | hash_flow.rb:22:10:22:17 | ...[...] | provenance |  |
+| hash_flow.rb:24:10:24:13 | hash : Hash [element :c] | hash_flow.rb:24:10:24:17 | ...[...] | provenance |  |
+| hash_flow.rb:26:10:26:13 | hash : Hash [element e] | hash_flow.rb:26:10:26:18 | ...[...] | provenance |  |
+| hash_flow.rb:28:10:28:13 | hash : Hash [element g] | hash_flow.rb:28:10:28:18 | ...[...] | provenance |  |
+| hash_flow.rb:30:10:30:13 | hash : Hash [element 0] | hash_flow.rb:30:10:30:16 | ...[...] | provenance |  |
+| hash_flow.rb:38:5:38:8 | [post] hash : [collection] [element 0] | hash_flow.rb:39:5:39:8 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:38:15:38:24 | call to taint | hash_flow.rb:38:5:38:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:39:5:39:8 | [post] hash : [collection] [element 0] | hash_flow.rb:40:5:40:8 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:39:5:39:8 | hash : [collection] [element 0] | hash_flow.rb:39:5:39:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element 0] | hash_flow.rb:41:5:41:8 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element :a] | hash_flow.rb:41:5:41:8 | hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:40:5:40:8 | hash : [collection] [element 0] | hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:40:16:40:25 | call to taint | hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element 0] | hash_flow.rb:42:5:42:8 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element :a] | hash_flow.rb:42:5:42:8 | hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:41:5:41:8 | hash : [collection] [element 0] | hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:41:5:41:8 | hash : [collection] [element :a] | hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element 0] | hash_flow.rb:43:5:43:8 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element :a] | hash_flow.rb:43:5:43:8 | hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element a] | hash_flow.rb:43:5:43:8 | hash : [collection] [element a] | provenance |  |
+| hash_flow.rb:42:5:42:8 | hash : [collection] [element 0] | hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:42:5:42:8 | hash : [collection] [element :a] | hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:42:17:42:26 | call to taint | hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element 0] | hash_flow.rb:44:10:44:13 | hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element :a] | hash_flow.rb:46:10:46:13 | hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element :a] | hash_flow.rb:48:10:48:13 | hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element a] | hash_flow.rb:46:10:46:13 | hash : [collection] [element a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element a] | hash_flow.rb:48:10:48:13 | hash : [collection] [element a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element 0] | hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element 0] | provenance |  |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element :a] | hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element :a] | provenance |  |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element a] | hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element a] | provenance |  |
+| hash_flow.rb:44:10:44:13 | hash : [collection] [element 0] | hash_flow.rb:44:10:44:16 | ...[...] | provenance |  |
+| hash_flow.rb:46:10:46:13 | hash : [collection] [element :a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
+| hash_flow.rb:46:10:46:13 | hash : [collection] [element a] | hash_flow.rb:46:10:46:17 | ...[...] | provenance |  |
+| hash_flow.rb:48:10:48:13 | hash : [collection] [element :a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
+| hash_flow.rb:48:10:48:13 | hash : [collection] [element a] | hash_flow.rb:48:10:48:18 | ...[...] | provenance |  |
+| hash_flow.rb:55:5:55:9 | hash1 : Hash [element :a] | hash_flow.rb:56:10:56:14 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:55:13:55:37 | ...[...] : Hash [element :a] | hash_flow.rb:55:5:55:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:55:21:55:30 | call to taint | hash_flow.rb:55:13:55:37 | ...[...] : Hash [element :a] | provenance |  |
+| hash_flow.rb:56:10:56:14 | hash1 : Hash [element :a] | hash_flow.rb:56:10:56:18 | ...[...] | provenance |  |
+| hash_flow.rb:59:5:59:5 | x : Hash [element :a] | hash_flow.rb:60:18:60:18 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:59:9:59:29 | call to [] : Hash [element :a] | hash_flow.rb:59:5:59:5 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:59:13:59:22 | call to taint | hash_flow.rb:59:9:59:29 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:60:5:60:9 | hash2 : Hash [element :a] | hash_flow.rb:61:10:61:14 | hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:60:13:60:19 | ...[...] : Hash [element :a] | hash_flow.rb:60:5:60:9 | hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:60:18:60:18 | x : Hash [element :a] | hash_flow.rb:60:13:60:19 | ...[...] : Hash [element :a] | provenance |  |
+| hash_flow.rb:61:10:61:14 | hash2 : Hash [element :a] | hash_flow.rb:61:10:61:18 | ...[...] | provenance |  |
+| hash_flow.rb:64:5:64:9 | hash3 : [collection] [element] | hash_flow.rb:65:10:65:14 | hash3 : [collection] [element] | provenance |  |
+| hash_flow.rb:64:5:64:9 | hash3 : [collection] [element] | hash_flow.rb:66:10:66:14 | hash3 : [collection] [element] | provenance |  |
+| hash_flow.rb:64:13:64:45 | ...[...] : [collection] [element] | hash_flow.rb:64:5:64:9 | hash3 : [collection] [element] | provenance |  |
+| hash_flow.rb:64:18:64:44 | call to [] : Array [element 0, element 1] | hash_flow.rb:64:13:64:45 | ...[...] : [collection] [element] | provenance |  |
+| hash_flow.rb:64:19:64:34 | call to [] : Array [element 1] | hash_flow.rb:64:18:64:44 | call to [] : Array [element 0, element 1] | provenance |  |
+| hash_flow.rb:64:24:64:33 | call to taint | hash_flow.rb:64:19:64:34 | call to [] : Array [element 1] | provenance |  |
+| hash_flow.rb:65:10:65:14 | hash3 : [collection] [element] | hash_flow.rb:65:10:65:18 | ...[...] | provenance |  |
+| hash_flow.rb:66:10:66:14 | hash3 : [collection] [element] | hash_flow.rb:66:10:66:18 | ...[...] | provenance |  |
+| hash_flow.rb:68:5:68:9 | hash4 : [collection] [element :a] | hash_flow.rb:69:10:69:14 | hash4 : [collection] [element :a] | provenance |  |
+| hash_flow.rb:68:13:68:39 | ...[...] : [collection] [element :a] | hash_flow.rb:68:5:68:9 | hash4 : [collection] [element :a] | provenance |  |
+| hash_flow.rb:68:22:68:31 | call to taint | hash_flow.rb:68:13:68:39 | ...[...] : [collection] [element :a] | provenance |  |
+| hash_flow.rb:69:10:69:14 | hash4 : [collection] [element :a] | hash_flow.rb:69:10:69:18 | ...[...] | provenance |  |
+| hash_flow.rb:72:5:72:9 | hash5 : Hash [element a] | hash_flow.rb:73:10:73:14 | hash5 : Hash [element a] | provenance |  |
+| hash_flow.rb:72:13:72:45 | ...[...] : Hash [element a] | hash_flow.rb:72:5:72:9 | hash5 : Hash [element a] | provenance |  |
+| hash_flow.rb:72:25:72:34 | call to taint | hash_flow.rb:72:13:72:45 | ...[...] : Hash [element a] | provenance |  |
+| hash_flow.rb:73:10:73:14 | hash5 : Hash [element a] | hash_flow.rb:73:10:73:19 | ...[...] | provenance |  |
+| hash_flow.rb:76:5:76:9 | hash6 : Hash [element a] | hash_flow.rb:77:10:77:14 | hash6 : Hash [element a] | provenance |  |
+| hash_flow.rb:76:13:76:47 | ...[...] : Hash [element a] | hash_flow.rb:76:5:76:9 | hash6 : Hash [element a] | provenance |  |
+| hash_flow.rb:76:18:76:46 | call to [] : Hash [element a] | hash_flow.rb:76:13:76:47 | ...[...] : Hash [element a] | provenance |  |
+| hash_flow.rb:76:26:76:35 | call to taint | hash_flow.rb:76:18:76:46 | call to [] : Hash [element a] | provenance |  |
+| hash_flow.rb:77:10:77:14 | hash6 : Hash [element a] | hash_flow.rb:77:10:77:19 | ...[...] | provenance |  |
+| hash_flow.rb:84:5:84:9 | hash1 : Hash [element :a] | hash_flow.rb:85:10:85:14 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:84:13:84:42 | call to [] : Hash [element :a] | hash_flow.rb:84:5:84:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:84:26:84:35 | call to taint | hash_flow.rb:84:13:84:42 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:85:10:85:14 | hash1 : Hash [element :a] | hash_flow.rb:85:10:85:18 | ...[...] | provenance |  |
+| hash_flow.rb:92:5:92:8 | hash : Hash [element :a] | hash_flow.rb:96:30:96:33 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:92:12:95:5 | call to [] : Hash [element :a] | hash_flow.rb:92:5:92:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:93:15:93:24 | call to taint | hash_flow.rb:92:12:95:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:96:5:96:9 | hash2 : Hash [element :a] | hash_flow.rb:97:10:97:14 | hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:96:13:96:34 | call to try_convert : Hash [element :a] | hash_flow.rb:96:5:96:9 | hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:96:30:96:33 | hash : Hash [element :a] | hash_flow.rb:96:13:96:34 | call to try_convert : Hash [element :a] | provenance |  |
+| hash_flow.rb:97:10:97:14 | hash2 : Hash [element :a] | hash_flow.rb:97:10:97:18 | ...[...] | provenance |  |
 | hash_flow.rb:105:5:105:5 | b | hash_flow.rb:106:10:106:10 | b | provenance |  |
 | hash_flow.rb:105:21:105:30 | call to taint | hash_flow.rb:105:5:105:5 | b | provenance |  |
 | hash_flow.rb:113:5:113:5 | b | hash_flow.rb:115:10:115:10 | b | provenance |  |
-| hash_flow.rb:113:9:113:12 | [post] hash [element :a] | hash_flow.rb:114:10:114:13 | hash [element :a] | provenance |  |
+| hash_flow.rb:113:9:113:12 | [post] hash : [collection] [element :a] | hash_flow.rb:114:10:114:13 | hash : [collection] [element :a] | provenance |  |
 | hash_flow.rb:113:9:113:34 | call to store | hash_flow.rb:113:5:113:5 | b | provenance |  |
-| hash_flow.rb:113:24:113:33 | call to taint | hash_flow.rb:113:9:113:12 | [post] hash [element :a] | provenance |  |
+| hash_flow.rb:113:24:113:33 | call to taint | hash_flow.rb:113:9:113:12 | [post] hash : [collection] [element :a] | provenance |  |
 | hash_flow.rb:113:24:113:33 | call to taint | hash_flow.rb:113:9:113:34 | call to store | provenance |  |
-| hash_flow.rb:114:10:114:13 | hash [element :a] | hash_flow.rb:114:10:114:17 | ...[...] | provenance |  |
+| hash_flow.rb:114:10:114:13 | hash : [collection] [element :a] | hash_flow.rb:114:10:114:17 | ...[...] | provenance |  |
 | hash_flow.rb:118:5:118:5 | c | hash_flow.rb:121:10:121:10 | c | provenance |  |
-| hash_flow.rb:118:9:118:12 | [post] hash [element] | hash_flow.rb:119:10:119:13 | hash [element] | provenance |  |
-| hash_flow.rb:118:9:118:12 | [post] hash [element] | hash_flow.rb:120:10:120:13 | hash [element] | provenance |  |
+| hash_flow.rb:118:9:118:12 | [post] hash : [collection] [element] | hash_flow.rb:119:10:119:13 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:118:9:118:12 | [post] hash : [collection] [element] | hash_flow.rb:120:10:120:13 | hash : [collection] [element] | provenance |  |
 | hash_flow.rb:118:9:118:33 | call to store | hash_flow.rb:118:5:118:5 | c | provenance |  |
-| hash_flow.rb:118:23:118:32 | call to taint | hash_flow.rb:118:9:118:12 | [post] hash [element] | provenance |  |
+| hash_flow.rb:118:23:118:32 | call to taint | hash_flow.rb:118:9:118:12 | [post] hash : [collection] [element] | provenance |  |
 | hash_flow.rb:118:23:118:32 | call to taint | hash_flow.rb:118:9:118:33 | call to store | provenance |  |
-| hash_flow.rb:119:10:119:13 | hash [element] | hash_flow.rb:119:10:119:17 | ...[...] | provenance |  |
-| hash_flow.rb:120:10:120:13 | hash [element] | hash_flow.rb:120:10:120:17 | ...[...] | provenance |  |
-| hash_flow.rb:127:5:127:8 | hash [element :a] | hash_flow.rb:131:5:131:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:127:5:127:8 | hash [element :a] | hash_flow.rb:134:5:134:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:127:12:130:5 | call to [] [element :a] | hash_flow.rb:127:5:127:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:128:15:128:24 | call to taint | hash_flow.rb:127:12:130:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:131:5:131:8 | hash [element :a] | hash_flow.rb:131:18:131:29 | key_or_value | provenance |  |
+| hash_flow.rb:119:10:119:13 | hash : [collection] [element] | hash_flow.rb:119:10:119:17 | ...[...] | provenance |  |
+| hash_flow.rb:120:10:120:13 | hash : [collection] [element] | hash_flow.rb:120:10:120:17 | ...[...] | provenance |  |
+| hash_flow.rb:127:5:127:8 | hash : Hash [element :a] | hash_flow.rb:131:5:131:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:127:5:127:8 | hash : Hash [element :a] | hash_flow.rb:134:5:134:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:127:12:130:5 | call to [] : Hash [element :a] | hash_flow.rb:127:5:127:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:128:15:128:24 | call to taint | hash_flow.rb:127:12:130:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:131:5:131:8 | hash : Hash [element :a] | hash_flow.rb:131:18:131:29 | key_or_value | provenance |  |
 | hash_flow.rb:131:18:131:29 | key_or_value | hash_flow.rb:132:14:132:25 | key_or_value | provenance |  |
-| hash_flow.rb:134:5:134:8 | hash [element :a] | hash_flow.rb:134:22:134:26 | value | provenance |  |
+| hash_flow.rb:134:5:134:8 | hash : Hash [element :a] | hash_flow.rb:134:22:134:26 | value | provenance |  |
 | hash_flow.rb:134:22:134:26 | value | hash_flow.rb:136:14:136:18 | value | provenance |  |
-| hash_flow.rb:143:5:143:8 | hash [element :a] | hash_flow.rb:147:9:147:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:143:5:143:8 | hash [element :a] | hash_flow.rb:151:9:151:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:143:12:146:5 | call to [] [element :a] | hash_flow.rb:143:5:143:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:144:15:144:25 | call to taint | hash_flow.rb:143:12:146:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:147:5:147:5 | b [element 1] | hash_flow.rb:149:10:149:10 | b [element 1] | provenance |  |
-| hash_flow.rb:147:5:147:5 | b [element 1] | hash_flow.rb:150:10:150:10 | b [element 1] | provenance |  |
-| hash_flow.rb:147:9:147:12 | hash [element :a] | hash_flow.rb:147:9:147:22 | call to assoc [element 1] | provenance |  |
-| hash_flow.rb:147:9:147:22 | call to assoc [element 1] | hash_flow.rb:147:5:147:5 | b [element 1] | provenance |  |
-| hash_flow.rb:149:10:149:10 | b [element 1] | hash_flow.rb:149:10:149:13 | ...[...] | provenance |  |
-| hash_flow.rb:150:10:150:10 | b [element 1] | hash_flow.rb:150:10:150:13 | ...[...] | provenance |  |
-| hash_flow.rb:151:5:151:5 | c [element 1] | hash_flow.rb:152:10:152:10 | c [element 1] | provenance |  |
-| hash_flow.rb:151:9:151:12 | hash [element :a] | hash_flow.rb:151:9:151:21 | call to assoc [element 1] | provenance |  |
-| hash_flow.rb:151:9:151:21 | call to assoc [element 1] | hash_flow.rb:151:5:151:5 | c [element 1] | provenance |  |
-| hash_flow.rb:152:10:152:10 | c [element 1] | hash_flow.rb:152:10:152:13 | ...[...] | provenance |  |
-| hash_flow.rb:169:5:169:8 | hash [element :a] | hash_flow.rb:173:9:173:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:169:12:172:5 | call to [] [element :a] | hash_flow.rb:169:5:169:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:170:15:170:25 | call to taint | hash_flow.rb:169:12:172:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:173:5:173:5 | a [element :a] | hash_flow.rb:174:10:174:10 | a [element :a] | provenance |  |
-| hash_flow.rb:173:9:173:12 | hash [element :a] | hash_flow.rb:173:9:173:20 | call to compact [element :a] | provenance |  |
-| hash_flow.rb:173:9:173:20 | call to compact [element :a] | hash_flow.rb:173:5:173:5 | a [element :a] | provenance |  |
-| hash_flow.rb:174:10:174:10 | a [element :a] | hash_flow.rb:174:10:174:14 | ...[...] | provenance |  |
-| hash_flow.rb:181:5:181:8 | hash [element :a] | hash_flow.rb:185:9:185:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:181:12:184:5 | call to [] [element :a] | hash_flow.rb:181:5:181:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:182:15:182:25 | call to taint | hash_flow.rb:181:12:184:5 | call to [] [element :a] | provenance |  |
+| hash_flow.rb:143:5:143:8 | hash : Hash [element :a] | hash_flow.rb:147:9:147:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:143:5:143:8 | hash : Hash [element :a] | hash_flow.rb:151:9:151:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:143:12:146:5 | call to [] : Hash [element :a] | hash_flow.rb:143:5:143:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:144:15:144:25 | call to taint | hash_flow.rb:143:12:146:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:147:5:147:5 | b : [collection] [element 1] | hash_flow.rb:149:10:149:10 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:147:5:147:5 | b : [collection] [element 1] | hash_flow.rb:150:10:150:10 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:147:9:147:12 | hash : Hash [element :a] | hash_flow.rb:147:9:147:22 | call to assoc : [collection] [element 1] | provenance |  |
+| hash_flow.rb:147:9:147:22 | call to assoc : [collection] [element 1] | hash_flow.rb:147:5:147:5 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:149:10:149:10 | b : [collection] [element 1] | hash_flow.rb:149:10:149:13 | ...[...] | provenance |  |
+| hash_flow.rb:150:10:150:10 | b : [collection] [element 1] | hash_flow.rb:150:10:150:13 | ...[...] | provenance |  |
+| hash_flow.rb:151:5:151:5 | c : [collection] [element 1] | hash_flow.rb:152:10:152:10 | c : [collection] [element 1] | provenance |  |
+| hash_flow.rb:151:9:151:12 | hash : Hash [element :a] | hash_flow.rb:151:9:151:21 | call to assoc : [collection] [element 1] | provenance |  |
+| hash_flow.rb:151:9:151:21 | call to assoc : [collection] [element 1] | hash_flow.rb:151:5:151:5 | c : [collection] [element 1] | provenance |  |
+| hash_flow.rb:152:10:152:10 | c : [collection] [element 1] | hash_flow.rb:152:10:152:13 | ...[...] | provenance |  |
+| hash_flow.rb:169:5:169:8 | hash : Hash [element :a] | hash_flow.rb:173:9:173:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:169:12:172:5 | call to [] : Hash [element :a] | hash_flow.rb:169:5:169:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:170:15:170:25 | call to taint | hash_flow.rb:169:12:172:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:173:5:173:5 | a : Hash [element :a] | hash_flow.rb:174:10:174:10 | a : Hash [element :a] | provenance |  |
+| hash_flow.rb:173:9:173:12 | hash : Hash [element :a] | hash_flow.rb:173:9:173:20 | call to compact : Hash [element :a] | provenance |  |
+| hash_flow.rb:173:9:173:20 | call to compact : Hash [element :a] | hash_flow.rb:173:5:173:5 | a : Hash [element :a] | provenance |  |
+| hash_flow.rb:174:10:174:10 | a : Hash [element :a] | hash_flow.rb:174:10:174:14 | ...[...] | provenance |  |
+| hash_flow.rb:181:5:181:8 | hash : Hash [element :a] | hash_flow.rb:185:9:185:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:181:12:184:5 | call to [] : Hash [element :a] | hash_flow.rb:181:5:181:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:182:15:182:25 | call to taint | hash_flow.rb:181:12:184:5 | call to [] : Hash [element :a] | provenance |  |
 | hash_flow.rb:185:5:185:5 | a | hash_flow.rb:186:10:186:10 | a | provenance |  |
-| hash_flow.rb:185:9:185:12 | hash [element :a] | hash_flow.rb:185:9:185:23 | call to delete | provenance |  |
+| hash_flow.rb:185:9:185:12 | hash : Hash [element :a] | hash_flow.rb:185:9:185:23 | call to delete | provenance |  |
 | hash_flow.rb:185:9:185:23 | call to delete | hash_flow.rb:185:5:185:5 | a | provenance |  |
-| hash_flow.rb:193:5:193:8 | hash [element :a] | hash_flow.rb:197:9:197:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:193:12:196:5 | call to [] [element :a] | hash_flow.rb:193:5:193:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:194:15:194:25 | call to taint | hash_flow.rb:193:12:196:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:197:5:197:5 | a [element :a] | hash_flow.rb:201:10:201:10 | a [element :a] | provenance |  |
-| hash_flow.rb:197:9:197:12 | [post] hash [element :a] | hash_flow.rb:202:10:202:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:197:9:197:12 | hash [element :a] | hash_flow.rb:197:9:197:12 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:197:9:197:12 | hash [element :a] | hash_flow.rb:197:9:200:7 | call to delete_if [element :a] | provenance |  |
-| hash_flow.rb:197:9:197:12 | hash [element :a] | hash_flow.rb:197:33:197:37 | value | provenance |  |
-| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] | hash_flow.rb:197:5:197:5 | a [element :a] | provenance |  |
+| hash_flow.rb:193:5:193:8 | hash : Hash [element :a] | hash_flow.rb:197:9:197:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:193:12:196:5 | call to [] : Hash [element :a] | hash_flow.rb:193:5:193:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:194:15:194:25 | call to taint | hash_flow.rb:193:12:196:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:197:5:197:5 | a : Hash [element :a] | hash_flow.rb:201:10:201:10 | a : Hash [element :a] | provenance |  |
+| hash_flow.rb:197:9:197:12 | [post] hash : Hash [element :a] | hash_flow.rb:202:10:202:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:197:9:197:12 | hash : Hash [element :a] | hash_flow.rb:197:9:197:12 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:197:9:197:12 | hash : Hash [element :a] | hash_flow.rb:197:9:200:7 | call to delete_if : Hash [element :a] | provenance |  |
+| hash_flow.rb:197:9:197:12 | hash : Hash [element :a] | hash_flow.rb:197:33:197:37 | value | provenance |  |
+| hash_flow.rb:197:9:200:7 | call to delete_if : Hash [element :a] | hash_flow.rb:197:5:197:5 | a : Hash [element :a] | provenance |  |
 | hash_flow.rb:197:33:197:37 | value | hash_flow.rb:199:14:199:18 | value | provenance |  |
-| hash_flow.rb:201:10:201:10 | a [element :a] | hash_flow.rb:201:10:201:14 | ...[...] | provenance |  |
-| hash_flow.rb:202:10:202:13 | hash [element :a] | hash_flow.rb:202:10:202:17 | ...[...] | provenance |  |
-| hash_flow.rb:209:5:209:8 | hash [element :a] | hash_flow.rb:217:10:217:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | provenance |  |
-| hash_flow.rb:209:12:216:5 | call to [] [element :a] | hash_flow.rb:209:5:209:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | provenance |  |
-| hash_flow.rb:210:15:210:25 | call to taint | hash_flow.rb:209:12:216:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:212:15:215:9 | call to [] [element :d] | hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | provenance |  |
-| hash_flow.rb:213:19:213:29 | call to taint | hash_flow.rb:212:15:215:9 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:217:10:217:13 | hash [element :a] | hash_flow.rb:217:10:217:21 | call to dig | provenance |  |
-| hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | hash_flow.rb:219:10:219:24 | call to dig | provenance |  |
-| hash_flow.rb:226:5:226:8 | hash [element :a] | hash_flow.rb:230:9:230:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:226:12:229:5 | call to [] [element :a] | hash_flow.rb:226:5:226:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:227:15:227:25 | call to taint | hash_flow.rb:226:12:229:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:230:5:230:5 | x [element :a] | hash_flow.rb:234:10:234:10 | x [element :a] | provenance |  |
-| hash_flow.rb:230:9:230:12 | hash [element :a] | hash_flow.rb:230:9:233:7 | call to each [element :a] | provenance |  |
-| hash_flow.rb:230:9:230:12 | hash [element :a] | hash_flow.rb:230:28:230:32 | value | provenance |  |
-| hash_flow.rb:230:9:233:7 | call to each [element :a] | hash_flow.rb:230:5:230:5 | x [element :a] | provenance |  |
+| hash_flow.rb:201:10:201:10 | a : Hash [element :a] | hash_flow.rb:201:10:201:14 | ...[...] | provenance |  |
+| hash_flow.rb:202:10:202:13 | hash : Hash [element :a] | hash_flow.rb:202:10:202:17 | ...[...] | provenance |  |
+| hash_flow.rb:209:5:209:8 | hash : Hash [element :a] | hash_flow.rb:217:10:217:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:209:5:209:8 | hash : Hash [element :c, element :d] | hash_flow.rb:219:10:219:13 | hash : Hash [element :c, element :d] | provenance |  |
+| hash_flow.rb:209:12:216:5 | call to [] : Hash [element :a] | hash_flow.rb:209:5:209:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:209:12:216:5 | call to [] : Hash [element :c, element :d] | hash_flow.rb:209:5:209:8 | hash : Hash [element :c, element :d] | provenance |  |
+| hash_flow.rb:210:15:210:25 | call to taint | hash_flow.rb:209:12:216:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:212:15:215:9 | call to [] : Hash [element :d] | hash_flow.rb:209:12:216:5 | call to [] : Hash [element :c, element :d] | provenance |  |
+| hash_flow.rb:213:19:213:29 | call to taint | hash_flow.rb:212:15:215:9 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:217:10:217:13 | hash : Hash [element :a] | hash_flow.rb:217:10:217:21 | call to dig | provenance |  |
+| hash_flow.rb:219:10:219:13 | hash : Hash [element :c, element :d] | hash_flow.rb:219:10:219:24 | call to dig | provenance |  |
+| hash_flow.rb:226:5:226:8 | hash : Hash [element :a] | hash_flow.rb:230:9:230:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:226:12:229:5 | call to [] : Hash [element :a] | hash_flow.rb:226:5:226:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:227:15:227:25 | call to taint | hash_flow.rb:226:12:229:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:230:5:230:5 | x : Hash [element :a] | hash_flow.rb:234:10:234:10 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:230:9:230:12 | hash : Hash [element :a] | hash_flow.rb:230:9:233:7 | call to each : Hash [element :a] | provenance |  |
+| hash_flow.rb:230:9:230:12 | hash : Hash [element :a] | hash_flow.rb:230:28:230:32 | value | provenance |  |
+| hash_flow.rb:230:9:233:7 | call to each : Hash [element :a] | hash_flow.rb:230:5:230:5 | x : Hash [element :a] | provenance |  |
 | hash_flow.rb:230:28:230:32 | value | hash_flow.rb:232:14:232:18 | value | provenance |  |
-| hash_flow.rb:234:10:234:10 | x [element :a] | hash_flow.rb:234:10:234:14 | ...[...] | provenance |  |
-| hash_flow.rb:241:5:241:8 | hash [element :a] | hash_flow.rb:245:9:245:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:241:12:244:5 | call to [] [element :a] | hash_flow.rb:241:5:241:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:242:15:242:25 | call to taint | hash_flow.rb:241:12:244:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:245:5:245:5 | x [element :a] | hash_flow.rb:248:10:248:10 | x [element :a] | provenance |  |
-| hash_flow.rb:245:9:245:12 | hash [element :a] | hash_flow.rb:245:9:247:7 | call to each_key [element :a] | provenance |  |
-| hash_flow.rb:245:9:247:7 | call to each_key [element :a] | hash_flow.rb:245:5:245:5 | x [element :a] | provenance |  |
-| hash_flow.rb:248:10:248:10 | x [element :a] | hash_flow.rb:248:10:248:14 | ...[...] | provenance |  |
-| hash_flow.rb:255:5:255:8 | hash [element :a] | hash_flow.rb:259:9:259:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:255:12:258:5 | call to [] [element :a] | hash_flow.rb:255:5:255:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:256:15:256:25 | call to taint | hash_flow.rb:255:12:258:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:259:5:259:5 | x [element :a] | hash_flow.rb:263:10:263:10 | x [element :a] | provenance |  |
-| hash_flow.rb:259:9:259:12 | hash [element :a] | hash_flow.rb:259:9:262:7 | call to each_pair [element :a] | provenance |  |
-| hash_flow.rb:259:9:259:12 | hash [element :a] | hash_flow.rb:259:33:259:37 | value | provenance |  |
-| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] | hash_flow.rb:259:5:259:5 | x [element :a] | provenance |  |
+| hash_flow.rb:234:10:234:10 | x : Hash [element :a] | hash_flow.rb:234:10:234:14 | ...[...] | provenance |  |
+| hash_flow.rb:241:5:241:8 | hash : Hash [element :a] | hash_flow.rb:245:9:245:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:241:12:244:5 | call to [] : Hash [element :a] | hash_flow.rb:241:5:241:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:242:15:242:25 | call to taint | hash_flow.rb:241:12:244:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:245:5:245:5 | x : Hash [element :a] | hash_flow.rb:248:10:248:10 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:245:9:245:12 | hash : Hash [element :a] | hash_flow.rb:245:9:247:7 | call to each_key : Hash [element :a] | provenance |  |
+| hash_flow.rb:245:9:247:7 | call to each_key : Hash [element :a] | hash_flow.rb:245:5:245:5 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:248:10:248:10 | x : Hash [element :a] | hash_flow.rb:248:10:248:14 | ...[...] | provenance |  |
+| hash_flow.rb:255:5:255:8 | hash : Hash [element :a] | hash_flow.rb:259:9:259:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:255:12:258:5 | call to [] : Hash [element :a] | hash_flow.rb:255:5:255:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:256:15:256:25 | call to taint | hash_flow.rb:255:12:258:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:259:5:259:5 | x : Hash [element :a] | hash_flow.rb:263:10:263:10 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:259:9:259:12 | hash : Hash [element :a] | hash_flow.rb:259:9:262:7 | call to each_pair : Hash [element :a] | provenance |  |
+| hash_flow.rb:259:9:259:12 | hash : Hash [element :a] | hash_flow.rb:259:33:259:37 | value | provenance |  |
+| hash_flow.rb:259:9:262:7 | call to each_pair : Hash [element :a] | hash_flow.rb:259:5:259:5 | x : Hash [element :a] | provenance |  |
 | hash_flow.rb:259:33:259:37 | value | hash_flow.rb:261:14:261:18 | value | provenance |  |
-| hash_flow.rb:263:10:263:10 | x [element :a] | hash_flow.rb:263:10:263:14 | ...[...] | provenance |  |
-| hash_flow.rb:270:5:270:8 | hash [element :a] | hash_flow.rb:274:9:274:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:270:12:273:5 | call to [] [element :a] | hash_flow.rb:270:5:270:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:271:15:271:25 | call to taint | hash_flow.rb:270:12:273:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:274:5:274:5 | x [element :a] | hash_flow.rb:277:10:277:10 | x [element :a] | provenance |  |
-| hash_flow.rb:274:9:274:12 | hash [element :a] | hash_flow.rb:274:9:276:7 | call to each_value [element :a] | provenance |  |
-| hash_flow.rb:274:9:274:12 | hash [element :a] | hash_flow.rb:274:29:274:33 | value | provenance |  |
-| hash_flow.rb:274:9:276:7 | call to each_value [element :a] | hash_flow.rb:274:5:274:5 | x [element :a] | provenance |  |
+| hash_flow.rb:263:10:263:10 | x : Hash [element :a] | hash_flow.rb:263:10:263:14 | ...[...] | provenance |  |
+| hash_flow.rb:270:5:270:8 | hash : Hash [element :a] | hash_flow.rb:274:9:274:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:270:12:273:5 | call to [] : Hash [element :a] | hash_flow.rb:270:5:270:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:271:15:271:25 | call to taint | hash_flow.rb:270:12:273:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:274:5:274:5 | x : Hash [element :a] | hash_flow.rb:277:10:277:10 | x : Hash [element :a] | provenance |  |
+| hash_flow.rb:274:9:274:12 | hash : Hash [element :a] | hash_flow.rb:274:9:276:7 | call to each_value : Hash [element :a] | provenance |  |
+| hash_flow.rb:274:9:274:12 | hash : Hash [element :a] | hash_flow.rb:274:29:274:33 | value | provenance |  |
+| hash_flow.rb:274:9:276:7 | call to each_value : Hash [element :a] | hash_flow.rb:274:5:274:5 | x : Hash [element :a] | provenance |  |
 | hash_flow.rb:274:29:274:33 | value | hash_flow.rb:275:14:275:18 | value | provenance |  |
-| hash_flow.rb:277:10:277:10 | x [element :a] | hash_flow.rb:277:10:277:14 | ...[...] | provenance |  |
-| hash_flow.rb:284:5:284:8 | hash [element :c] | hash_flow.rb:290:9:290:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:284:12:289:5 | call to [] [element :c] | hash_flow.rb:284:5:284:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:287:15:287:25 | call to taint | hash_flow.rb:284:12:289:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:290:5:290:5 | x [element :c] | hash_flow.rb:293:10:293:10 | x [element :c] | provenance |  |
-| hash_flow.rb:290:9:290:12 | hash [element :c] | hash_flow.rb:290:9:290:28 | call to except [element :c] | provenance |  |
-| hash_flow.rb:290:9:290:28 | call to except [element :c] | hash_flow.rb:290:5:290:5 | x [element :c] | provenance |  |
-| hash_flow.rb:293:10:293:10 | x [element :c] | hash_flow.rb:293:10:293:14 | ...[...] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :a] | hash_flow.rb:305:9:305:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :a] | hash_flow.rb:309:9:309:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :a] | hash_flow.rb:311:9:311:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :a] | hash_flow.rb:315:9:315:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :c] | hash_flow.rb:305:9:305:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:300:5:300:8 | hash [element :c] | hash_flow.rb:315:9:315:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:300:12:304:5 | call to [] [element :a] | hash_flow.rb:300:5:300:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:300:12:304:5 | call to [] [element :c] | hash_flow.rb:300:5:300:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:301:15:301:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:303:15:303:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] [element :c] | provenance |  |
+| hash_flow.rb:277:10:277:10 | x : Hash [element :a] | hash_flow.rb:277:10:277:14 | ...[...] | provenance |  |
+| hash_flow.rb:284:5:284:8 | hash : Hash [element :c] | hash_flow.rb:290:9:290:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:284:12:289:5 | call to [] : Hash [element :c] | hash_flow.rb:284:5:284:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:287:15:287:25 | call to taint | hash_flow.rb:284:12:289:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:290:5:290:5 | x : Hash [element :c] | hash_flow.rb:293:10:293:10 | x : Hash [element :c] | provenance |  |
+| hash_flow.rb:290:9:290:12 | hash : Hash [element :c] | hash_flow.rb:290:9:290:28 | call to except : Hash [element :c] | provenance |  |
+| hash_flow.rb:290:9:290:28 | call to except : Hash [element :c] | hash_flow.rb:290:5:290:5 | x : Hash [element :c] | provenance |  |
+| hash_flow.rb:293:10:293:10 | x : Hash [element :c] | hash_flow.rb:293:10:293:14 | ...[...] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | hash_flow.rb:305:9:305:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | hash_flow.rb:309:9:309:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | hash_flow.rb:311:9:311:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | hash_flow.rb:315:9:315:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :c] | hash_flow.rb:305:9:305:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :c] | hash_flow.rb:315:9:315:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:300:12:304:5 | call to [] : Hash [element :a] | hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:300:12:304:5 | call to [] : Hash [element :c] | hash_flow.rb:300:5:300:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:301:15:301:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:303:15:303:25 | call to taint | hash_flow.rb:300:12:304:5 | call to [] : Hash [element :c] | provenance |  |
 | hash_flow.rb:305:5:305:5 | b | hash_flow.rb:308:10:308:10 | b | provenance |  |
-| hash_flow.rb:305:9:305:12 | hash [element :a] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
-| hash_flow.rb:305:9:305:12 | hash [element :c] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
+| hash_flow.rb:305:9:305:12 | hash : Hash [element :a] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
+| hash_flow.rb:305:9:305:12 | hash : Hash [element :c] | hash_flow.rb:305:9:307:7 | call to fetch | provenance |  |
 | hash_flow.rb:305:9:307:7 | call to fetch | hash_flow.rb:305:5:305:5 | b | provenance |  |
 | hash_flow.rb:305:20:305:30 | call to taint | hash_flow.rb:305:37:305:37 | x | provenance |  |
 | hash_flow.rb:305:37:305:37 | x | hash_flow.rb:306:14:306:14 | x | provenance |  |
 | hash_flow.rb:309:5:309:5 | b | hash_flow.rb:310:10:310:10 | b | provenance |  |
-| hash_flow.rb:309:9:309:12 | hash [element :a] | hash_flow.rb:309:9:309:22 | call to fetch | provenance |  |
+| hash_flow.rb:309:9:309:12 | hash : Hash [element :a] | hash_flow.rb:309:9:309:22 | call to fetch | provenance |  |
 | hash_flow.rb:309:9:309:22 | call to fetch | hash_flow.rb:309:5:309:5 | b | provenance |  |
 | hash_flow.rb:311:5:311:5 | b | hash_flow.rb:312:10:312:10 | b | provenance |  |
-| hash_flow.rb:311:9:311:12 | hash [element :a] | hash_flow.rb:311:9:311:35 | call to fetch | provenance |  |
+| hash_flow.rb:311:9:311:12 | hash : Hash [element :a] | hash_flow.rb:311:9:311:35 | call to fetch | provenance |  |
 | hash_flow.rb:311:9:311:35 | call to fetch | hash_flow.rb:311:5:311:5 | b | provenance |  |
 | hash_flow.rb:311:24:311:34 | call to taint | hash_flow.rb:311:9:311:35 | call to fetch | provenance |  |
 | hash_flow.rb:313:5:313:5 | b | hash_flow.rb:314:10:314:10 | b | provenance |  |
 | hash_flow.rb:313:9:313:35 | call to fetch | hash_flow.rb:313:5:313:5 | b | provenance |  |
 | hash_flow.rb:313:24:313:34 | call to taint | hash_flow.rb:313:9:313:35 | call to fetch | provenance |  |
 | hash_flow.rb:315:5:315:5 | b | hash_flow.rb:316:10:316:10 | b | provenance |  |
-| hash_flow.rb:315:9:315:12 | hash [element :a] | hash_flow.rb:315:9:315:34 | call to fetch | provenance |  |
-| hash_flow.rb:315:9:315:12 | hash [element :c] | hash_flow.rb:315:9:315:34 | call to fetch | provenance |  |
+| hash_flow.rb:315:9:315:12 | hash : Hash [element :a] | hash_flow.rb:315:9:315:34 | call to fetch | provenance |  |
+| hash_flow.rb:315:9:315:12 | hash : Hash [element :c] | hash_flow.rb:315:9:315:34 | call to fetch | provenance |  |
 | hash_flow.rb:315:9:315:34 | call to fetch | hash_flow.rb:315:5:315:5 | b | provenance |  |
 | hash_flow.rb:315:23:315:33 | call to taint | hash_flow.rb:315:9:315:34 | call to fetch | provenance |  |
-| hash_flow.rb:322:5:322:8 | hash [element :a] | hash_flow.rb:327:9:327:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:322:5:322:8 | hash [element :a] | hash_flow.rb:332:9:332:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:322:5:322:8 | hash [element :a] | hash_flow.rb:334:9:334:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:322:5:322:8 | hash [element :c] | hash_flow.rb:327:9:327:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:322:5:322:8 | hash [element :c] | hash_flow.rb:334:9:334:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:322:12:326:5 | call to [] [element :a] | hash_flow.rb:322:5:322:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:322:12:326:5 | call to [] [element :c] | hash_flow.rb:322:5:322:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:323:15:323:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:325:15:325:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:327:5:327:5 | b [element] | hash_flow.rb:331:10:331:10 | b [element] | provenance |  |
-| hash_flow.rb:327:9:327:12 | hash [element :a] | hash_flow.rb:327:9:330:7 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:327:9:327:12 | hash [element :c] | hash_flow.rb:327:9:330:7 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:327:9:330:7 | call to fetch_values [element] | hash_flow.rb:327:5:327:5 | b [element] | provenance |  |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :a] | hash_flow.rb:327:9:327:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :a] | hash_flow.rb:332:9:332:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :a] | hash_flow.rb:334:9:334:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :c] | hash_flow.rb:327:9:327:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :c] | hash_flow.rb:334:9:334:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:322:12:326:5 | call to [] : Hash [element :a] | hash_flow.rb:322:5:322:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:322:12:326:5 | call to [] : Hash [element :c] | hash_flow.rb:322:5:322:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:323:15:323:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:325:15:325:25 | call to taint | hash_flow.rb:322:12:326:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:327:5:327:5 | b : [collection] [element] | hash_flow.rb:331:10:331:10 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:327:9:327:12 | hash : Hash [element :a] | hash_flow.rb:327:9:330:7 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:327:9:327:12 | hash : Hash [element :c] | hash_flow.rb:327:9:330:7 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:327:9:330:7 | call to fetch_values : [collection] [element] | hash_flow.rb:327:5:327:5 | b : [collection] [element] | provenance |  |
 | hash_flow.rb:327:27:327:37 | call to taint | hash_flow.rb:327:44:327:44 | x | provenance |  |
 | hash_flow.rb:327:44:327:44 | x | hash_flow.rb:328:14:328:14 | x | provenance |  |
-| hash_flow.rb:329:9:329:19 | call to taint | hash_flow.rb:327:9:330:7 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:331:10:331:10 | b [element] | hash_flow.rb:331:10:331:13 | ...[...] | provenance |  |
-| hash_flow.rb:332:5:332:5 | b [element] | hash_flow.rb:333:10:333:10 | b [element] | provenance |  |
-| hash_flow.rb:332:9:332:12 | hash [element :a] | hash_flow.rb:332:9:332:29 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:332:9:332:29 | call to fetch_values [element] | hash_flow.rb:332:5:332:5 | b [element] | provenance |  |
-| hash_flow.rb:333:10:333:10 | b [element] | hash_flow.rb:333:10:333:13 | ...[...] | provenance |  |
-| hash_flow.rb:334:5:334:5 | b [element] | hash_flow.rb:335:10:335:10 | b [element] | provenance |  |
-| hash_flow.rb:334:9:334:12 | hash [element :a] | hash_flow.rb:334:9:334:31 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:334:9:334:12 | hash [element :c] | hash_flow.rb:334:9:334:31 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:334:9:334:31 | call to fetch_values [element] | hash_flow.rb:334:5:334:5 | b [element] | provenance |  |
-| hash_flow.rb:335:10:335:10 | b [element] | hash_flow.rb:335:10:335:13 | ...[...] | provenance |  |
-| hash_flow.rb:341:5:341:8 | hash [element :a] | hash_flow.rb:346:9:346:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:341:5:341:8 | hash [element :c] | hash_flow.rb:346:9:346:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:341:12:345:5 | call to [] [element :a] | hash_flow.rb:341:5:341:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:341:12:345:5 | call to [] [element :c] | hash_flow.rb:341:5:341:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:342:15:342:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:344:15:344:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:346:5:346:5 | b [element :a] | hash_flow.rb:351:11:351:11 | b [element :a] | provenance |  |
-| hash_flow.rb:346:9:346:12 | hash [element :a] | hash_flow.rb:346:9:350:7 | call to filter [element :a] | provenance |  |
-| hash_flow.rb:346:9:346:12 | hash [element :a] | hash_flow.rb:346:30:346:34 | value | provenance |  |
-| hash_flow.rb:346:9:346:12 | hash [element :c] | hash_flow.rb:346:30:346:34 | value | provenance |  |
-| hash_flow.rb:346:9:350:7 | call to filter [element :a] | hash_flow.rb:346:5:346:5 | b [element :a] | provenance |  |
+| hash_flow.rb:329:9:329:19 | call to taint | hash_flow.rb:327:9:330:7 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:331:10:331:10 | b : [collection] [element] | hash_flow.rb:331:10:331:13 | ...[...] | provenance |  |
+| hash_flow.rb:332:5:332:5 | b : [collection] [element] | hash_flow.rb:333:10:333:10 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:332:9:332:12 | hash : Hash [element :a] | hash_flow.rb:332:9:332:29 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:332:9:332:29 | call to fetch_values : [collection] [element] | hash_flow.rb:332:5:332:5 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:333:10:333:10 | b : [collection] [element] | hash_flow.rb:333:10:333:13 | ...[...] | provenance |  |
+| hash_flow.rb:334:5:334:5 | b : [collection] [element] | hash_flow.rb:335:10:335:10 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:334:9:334:12 | hash : Hash [element :a] | hash_flow.rb:334:9:334:31 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:334:9:334:12 | hash : Hash [element :c] | hash_flow.rb:334:9:334:31 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:334:9:334:31 | call to fetch_values : [collection] [element] | hash_flow.rb:334:5:334:5 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:335:10:335:10 | b : [collection] [element] | hash_flow.rb:335:10:335:13 | ...[...] | provenance |  |
+| hash_flow.rb:341:5:341:8 | hash : Hash [element :a] | hash_flow.rb:346:9:346:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:341:5:341:8 | hash : Hash [element :c] | hash_flow.rb:346:9:346:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:341:12:345:5 | call to [] : Hash [element :a] | hash_flow.rb:341:5:341:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:341:12:345:5 | call to [] : Hash [element :c] | hash_flow.rb:341:5:341:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:342:15:342:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:344:15:344:25 | call to taint | hash_flow.rb:341:12:345:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:346:5:346:5 | b : Hash [element :a] | hash_flow.rb:351:11:351:11 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:346:9:346:12 | hash : Hash [element :a] | hash_flow.rb:346:9:350:7 | call to filter : Hash [element :a] | provenance |  |
+| hash_flow.rb:346:9:346:12 | hash : Hash [element :a] | hash_flow.rb:346:30:346:34 | value | provenance |  |
+| hash_flow.rb:346:9:346:12 | hash : Hash [element :c] | hash_flow.rb:346:30:346:34 | value | provenance |  |
+| hash_flow.rb:346:9:350:7 | call to filter : Hash [element :a] | hash_flow.rb:346:5:346:5 | b : Hash [element :a] | provenance |  |
 | hash_flow.rb:346:30:346:34 | value | hash_flow.rb:348:14:348:18 | value | provenance |  |
-| hash_flow.rb:351:11:351:11 | b [element :a] | hash_flow.rb:351:11:351:15 | ...[...] | provenance |  |
+| hash_flow.rb:351:11:351:11 | b : Hash [element :a] | hash_flow.rb:351:11:351:15 | ...[...] | provenance |  |
 | hash_flow.rb:351:11:351:15 | ...[...] | hash_flow.rb:351:10:351:16 | ( ... ) | provenance |  |
-| hash_flow.rb:357:5:357:8 | hash [element :a] | hash_flow.rb:362:5:362:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:357:5:357:8 | hash [element :c] | hash_flow.rb:362:5:362:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:357:12:361:5 | call to [] [element :a] | hash_flow.rb:357:5:357:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:357:12:361:5 | call to [] [element :c] | hash_flow.rb:357:5:357:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:358:15:358:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:360:15:360:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:362:5:362:8 | [post] hash [element :a] | hash_flow.rb:367:11:367:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:362:5:362:8 | hash [element :a] | hash_flow.rb:362:5:362:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:362:5:362:8 | hash [element :a] | hash_flow.rb:362:27:362:31 | value | provenance |  |
-| hash_flow.rb:362:5:362:8 | hash [element :c] | hash_flow.rb:362:27:362:31 | value | provenance |  |
+| hash_flow.rb:357:5:357:8 | hash : Hash [element :a] | hash_flow.rb:362:5:362:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:357:5:357:8 | hash : Hash [element :c] | hash_flow.rb:362:5:362:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:357:12:361:5 | call to [] : Hash [element :a] | hash_flow.rb:357:5:357:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:357:12:361:5 | call to [] : Hash [element :c] | hash_flow.rb:357:5:357:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:358:15:358:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:360:15:360:25 | call to taint | hash_flow.rb:357:12:361:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:362:5:362:8 | [post] hash : Hash [element :a] | hash_flow.rb:367:11:367:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:362:5:362:8 | hash : Hash [element :a] | hash_flow.rb:362:5:362:8 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:362:5:362:8 | hash : Hash [element :a] | hash_flow.rb:362:27:362:31 | value | provenance |  |
+| hash_flow.rb:362:5:362:8 | hash : Hash [element :c] | hash_flow.rb:362:27:362:31 | value | provenance |  |
 | hash_flow.rb:362:27:362:31 | value | hash_flow.rb:364:14:364:18 | value | provenance |  |
-| hash_flow.rb:367:11:367:14 | hash [element :a] | hash_flow.rb:367:11:367:18 | ...[...] | provenance |  |
+| hash_flow.rb:367:11:367:14 | hash : Hash [element :a] | hash_flow.rb:367:11:367:18 | ...[...] | provenance |  |
 | hash_flow.rb:367:11:367:18 | ...[...] | hash_flow.rb:367:10:367:19 | ( ... ) | provenance |  |
-| hash_flow.rb:373:5:373:8 | hash [element :a] | hash_flow.rb:378:9:378:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:373:5:373:8 | hash [element :c] | hash_flow.rb:378:9:378:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:373:12:377:5 | call to [] [element :a] | hash_flow.rb:373:5:373:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:373:12:377:5 | call to [] [element :c] | hash_flow.rb:373:5:373:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:374:15:374:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:376:15:376:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:378:5:378:5 | b [element] | hash_flow.rb:379:11:379:11 | b [element] | provenance |  |
-| hash_flow.rb:378:9:378:12 | hash [element :a] | hash_flow.rb:378:9:378:20 | call to flatten [element] | provenance |  |
-| hash_flow.rb:378:9:378:12 | hash [element :c] | hash_flow.rb:378:9:378:20 | call to flatten [element] | provenance |  |
-| hash_flow.rb:378:9:378:20 | call to flatten [element] | hash_flow.rb:378:5:378:5 | b [element] | provenance |  |
-| hash_flow.rb:379:11:379:11 | b [element] | hash_flow.rb:379:11:379:14 | ...[...] | provenance |  |
-| hash_flow.rb:379:11:379:14 | ...[...] | hash_flow.rb:379:10:379:15 | ( ... ) | provenance |  |
-| hash_flow.rb:385:5:385:8 | hash [element :a] | hash_flow.rb:390:9:390:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:385:5:385:8 | hash [element :c] | hash_flow.rb:390:9:390:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:385:12:389:5 | call to [] [element :a] | hash_flow.rb:385:5:385:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:385:12:389:5 | call to [] [element :c] | hash_flow.rb:385:5:385:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:386:15:386:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:388:15:388:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:390:5:390:5 | b [element :a] | hash_flow.rb:396:11:396:11 | b [element :a] | provenance |  |
-| hash_flow.rb:390:9:390:12 | [post] hash [element :a] | hash_flow.rb:395:11:395:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:390:9:390:12 | hash [element :a] | hash_flow.rb:390:9:390:12 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:390:9:390:12 | hash [element :a] | hash_flow.rb:390:9:394:7 | call to keep_if [element :a] | provenance |  |
-| hash_flow.rb:390:9:390:12 | hash [element :a] | hash_flow.rb:390:31:390:35 | value | provenance |  |
-| hash_flow.rb:390:9:390:12 | hash [element :c] | hash_flow.rb:390:31:390:35 | value | provenance |  |
-| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] | hash_flow.rb:390:5:390:5 | b [element :a] | provenance |  |
+| hash_flow.rb:373:5:373:8 | hash : Hash [element :a] | hash_flow.rb:378:9:378:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:373:5:373:8 | hash : Hash [element :c] | hash_flow.rb:378:9:378:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:373:12:377:5 | call to [] : Hash [element :a] | hash_flow.rb:373:5:373:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:373:12:377:5 | call to [] : Hash [element :c] | hash_flow.rb:373:5:373:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:374:15:374:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:376:15:376:25 | call to taint | hash_flow.rb:373:12:377:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:378:5:378:5 | b : [collection] [element] : [collection] | hash_flow.rb:379:11:379:11 | b : [collection] [element] : [collection] | provenance |  |
+| hash_flow.rb:378:9:378:12 | hash : Hash [element :a] | hash_flow.rb:378:9:378:20 | call to flatten : [collection] [element] : [collection] | provenance |  |
+| hash_flow.rb:378:9:378:12 | hash : Hash [element :c] | hash_flow.rb:378:9:378:20 | call to flatten : [collection] [element] : [collection] | provenance |  |
+| hash_flow.rb:378:9:378:20 | call to flatten : [collection] [element] : [collection] | hash_flow.rb:378:5:378:5 | b : [collection] [element] : [collection] | provenance |  |
+| hash_flow.rb:379:11:379:11 | b : [collection] [element] : [collection] | hash_flow.rb:379:11:379:14 | ...[...] : [collection] | provenance |  |
+| hash_flow.rb:379:11:379:14 | ...[...] : [collection] | hash_flow.rb:379:10:379:15 | ( ... ) | provenance |  |
+| hash_flow.rb:385:5:385:8 | hash : Hash [element :a] | hash_flow.rb:390:9:390:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:385:5:385:8 | hash : Hash [element :c] | hash_flow.rb:390:9:390:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:385:12:389:5 | call to [] : Hash [element :a] | hash_flow.rb:385:5:385:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:385:12:389:5 | call to [] : Hash [element :c] | hash_flow.rb:385:5:385:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:386:15:386:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:388:15:388:25 | call to taint | hash_flow.rb:385:12:389:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:390:5:390:5 | b : Hash [element :a] | hash_flow.rb:396:11:396:11 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:390:9:390:12 | [post] hash : Hash [element :a] | hash_flow.rb:395:11:395:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :a] | hash_flow.rb:390:9:390:12 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :a] | hash_flow.rb:390:9:394:7 | call to keep_if : Hash [element :a] | provenance |  |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :a] | hash_flow.rb:390:31:390:35 | value | provenance |  |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :c] | hash_flow.rb:390:31:390:35 | value | provenance |  |
+| hash_flow.rb:390:9:394:7 | call to keep_if : Hash [element :a] | hash_flow.rb:390:5:390:5 | b : Hash [element :a] | provenance |  |
 | hash_flow.rb:390:31:390:35 | value | hash_flow.rb:392:14:392:18 | value | provenance |  |
-| hash_flow.rb:395:11:395:14 | hash [element :a] | hash_flow.rb:395:11:395:18 | ...[...] | provenance |  |
+| hash_flow.rb:395:11:395:14 | hash : Hash [element :a] | hash_flow.rb:395:11:395:18 | ...[...] | provenance |  |
 | hash_flow.rb:395:11:395:18 | ...[...] | hash_flow.rb:395:10:395:19 | ( ... ) | provenance |  |
-| hash_flow.rb:396:11:396:11 | b [element :a] | hash_flow.rb:396:11:396:15 | ...[...] | provenance |  |
+| hash_flow.rb:396:11:396:11 | b : Hash [element :a] | hash_flow.rb:396:11:396:15 | ...[...] | provenance |  |
 | hash_flow.rb:396:11:396:15 | ...[...] | hash_flow.rb:396:10:396:16 | ( ... ) | provenance |  |
-| hash_flow.rb:402:5:402:9 | hash1 [element :a] | hash_flow.rb:412:12:412:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:402:5:402:9 | hash1 [element :c] | hash_flow.rb:412:12:412:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:402:13:406:5 | call to [] [element :a] | hash_flow.rb:402:5:402:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:402:13:406:5 | call to [] [element :c] | hash_flow.rb:402:5:402:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:403:15:403:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:405:15:405:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:407:5:407:9 | hash2 [element :d] | hash_flow.rb:412:24:412:28 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:407:5:407:9 | hash2 [element :f] | hash_flow.rb:412:24:412:28 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:407:13:411:5 | call to [] [element :d] | hash_flow.rb:407:5:407:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:407:13:411:5 | call to [] [element :f] | hash_flow.rb:407:5:407:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:408:15:408:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:410:15:410:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:412:5:412:8 | hash [element :a] | hash_flow.rb:417:11:417:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:412:5:412:8 | hash [element :c] | hash_flow.rb:419:11:419:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:412:5:412:8 | hash [element :d] | hash_flow.rb:420:11:420:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:412:5:412:8 | hash [element :f] | hash_flow.rb:422:11:422:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :a] | hash_flow.rb:412:12:416:7 | call to merge [element :a] | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :a] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :a] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :c] | hash_flow.rb:412:12:416:7 | call to merge [element :c] | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :c] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
-| hash_flow.rb:412:12:412:16 | hash1 [element :c] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :a] | hash_flow.rb:412:5:412:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :c] | hash_flow.rb:412:5:412:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :d] | hash_flow.rb:412:5:412:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:412:12:416:7 | call to merge [element :f] | hash_flow.rb:412:5:412:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :d] | hash_flow.rb:412:12:416:7 | call to merge [element :d] | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :d] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :d] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :f] | hash_flow.rb:412:12:416:7 | call to merge [element :f] | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :f] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
-| hash_flow.rb:412:24:412:28 | hash2 [element :f] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
+| hash_flow.rb:402:5:402:9 | hash1 : Hash [element :a] | hash_flow.rb:412:12:412:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:402:5:402:9 | hash1 : Hash [element :c] | hash_flow.rb:412:12:412:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:402:13:406:5 | call to [] : Hash [element :a] | hash_flow.rb:402:5:402:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:402:13:406:5 | call to [] : Hash [element :c] | hash_flow.rb:402:5:402:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:403:15:403:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:405:15:405:25 | call to taint | hash_flow.rb:402:13:406:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:407:5:407:9 | hash2 : Hash [element :d] | hash_flow.rb:412:24:412:28 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:407:5:407:9 | hash2 : Hash [element :f] | hash_flow.rb:412:24:412:28 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:407:13:411:5 | call to [] : Hash [element :d] | hash_flow.rb:407:5:407:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:407:13:411:5 | call to [] : Hash [element :f] | hash_flow.rb:407:5:407:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:408:15:408:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:410:15:410:25 | call to taint | hash_flow.rb:407:13:411:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :a] | hash_flow.rb:417:11:417:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :c] | hash_flow.rb:419:11:419:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :d] | hash_flow.rb:420:11:420:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :f] | hash_flow.rb:422:11:422:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :a] | hash_flow.rb:412:12:416:7 | call to merge : Hash [element :a] | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :a] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :a] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :c] | hash_flow.rb:412:12:416:7 | call to merge : Hash [element :c] | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :c] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :c] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :a] | hash_flow.rb:412:5:412:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :c] | hash_flow.rb:412:5:412:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :d] | hash_flow.rb:412:5:412:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :f] | hash_flow.rb:412:5:412:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :d] | hash_flow.rb:412:12:416:7 | call to merge : Hash [element :d] | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :d] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :d] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :f] | hash_flow.rb:412:12:416:7 | call to merge : Hash [element :f] | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :f] | hash_flow.rb:412:40:412:48 | old_value | provenance |  |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :f] | hash_flow.rb:412:51:412:59 | new_value | provenance |  |
 | hash_flow.rb:412:40:412:48 | old_value | hash_flow.rb:414:14:414:22 | old_value | provenance |  |
 | hash_flow.rb:412:51:412:59 | new_value | hash_flow.rb:415:14:415:22 | new_value | provenance |  |
-| hash_flow.rb:417:11:417:14 | hash [element :a] | hash_flow.rb:417:11:417:18 | ...[...] | provenance |  |
+| hash_flow.rb:417:11:417:14 | hash : Hash [element :a] | hash_flow.rb:417:11:417:18 | ...[...] | provenance |  |
 | hash_flow.rb:417:11:417:18 | ...[...] | hash_flow.rb:417:10:417:19 | ( ... ) | provenance |  |
-| hash_flow.rb:419:11:419:14 | hash [element :c] | hash_flow.rb:419:11:419:18 | ...[...] | provenance |  |
+| hash_flow.rb:419:11:419:14 | hash : Hash [element :c] | hash_flow.rb:419:11:419:18 | ...[...] | provenance |  |
 | hash_flow.rb:419:11:419:18 | ...[...] | hash_flow.rb:419:10:419:19 | ( ... ) | provenance |  |
-| hash_flow.rb:420:11:420:14 | hash [element :d] | hash_flow.rb:420:11:420:18 | ...[...] | provenance |  |
+| hash_flow.rb:420:11:420:14 | hash : Hash [element :d] | hash_flow.rb:420:11:420:18 | ...[...] | provenance |  |
 | hash_flow.rb:420:11:420:18 | ...[...] | hash_flow.rb:420:10:420:19 | ( ... ) | provenance |  |
-| hash_flow.rb:422:11:422:14 | hash [element :f] | hash_flow.rb:422:11:422:18 | ...[...] | provenance |  |
+| hash_flow.rb:422:11:422:14 | hash : Hash [element :f] | hash_flow.rb:422:11:422:18 | ...[...] | provenance |  |
 | hash_flow.rb:422:11:422:18 | ...[...] | hash_flow.rb:422:10:422:19 | ( ... ) | provenance |  |
-| hash_flow.rb:428:5:428:9 | hash1 [element :a] | hash_flow.rb:438:12:438:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:428:5:428:9 | hash1 [element :c] | hash_flow.rb:438:12:438:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:428:13:432:5 | call to [] [element :a] | hash_flow.rb:428:5:428:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:428:13:432:5 | call to [] [element :c] | hash_flow.rb:428:5:428:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:429:15:429:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:431:15:431:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:433:5:433:9 | hash2 [element :d] | hash_flow.rb:438:25:438:29 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:433:5:433:9 | hash2 [element :f] | hash_flow.rb:438:25:438:29 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:433:13:437:5 | call to [] [element :d] | hash_flow.rb:433:5:433:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:433:13:437:5 | call to [] [element :f] | hash_flow.rb:433:5:433:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:434:15:434:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:436:15:436:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:438:5:438:8 | hash [element :a] | hash_flow.rb:443:11:443:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:438:5:438:8 | hash [element :c] | hash_flow.rb:445:11:445:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:438:5:438:8 | hash [element :d] | hash_flow.rb:446:11:446:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:438:5:438:8 | hash [element :f] | hash_flow.rb:448:11:448:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] | hash_flow.rb:450:11:450:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] | hash_flow.rb:452:11:452:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] | hash_flow.rb:453:11:453:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] | hash_flow.rb:455:11:455:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :a] | hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :a] | hash_flow.rb:438:12:442:7 | call to merge! [element :a] | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :a] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :a] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :c] | hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :c] | hash_flow.rb:438:12:442:7 | call to merge! [element :c] | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :c] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
-| hash_flow.rb:438:12:438:16 | hash1 [element :c] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :a] | hash_flow.rb:438:5:438:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :c] | hash_flow.rb:438:5:438:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :d] | hash_flow.rb:438:5:438:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :f] | hash_flow.rb:438:5:438:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :d] | hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :d] | hash_flow.rb:438:12:442:7 | call to merge! [element :d] | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :d] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :d] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :f] | hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :f] | hash_flow.rb:438:12:442:7 | call to merge! [element :f] | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :f] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
-| hash_flow.rb:438:25:438:29 | hash2 [element :f] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
+| hash_flow.rb:428:5:428:9 | hash1 : Hash [element :a] | hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:428:5:428:9 | hash1 : Hash [element :c] | hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:428:13:432:5 | call to [] : Hash [element :a] | hash_flow.rb:428:5:428:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:428:13:432:5 | call to [] : Hash [element :c] | hash_flow.rb:428:5:428:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:429:15:429:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:431:15:431:25 | call to taint | hash_flow.rb:428:13:432:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:433:5:433:9 | hash2 : Hash [element :d] | hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:433:5:433:9 | hash2 : Hash [element :f] | hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:433:13:437:5 | call to [] : Hash [element :d] | hash_flow.rb:433:5:433:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:433:13:437:5 | call to [] : Hash [element :f] | hash_flow.rb:433:5:433:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:434:15:434:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:436:15:436:25 | call to taint | hash_flow.rb:433:13:437:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :a] | hash_flow.rb:443:11:443:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :c] | hash_flow.rb:445:11:445:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :d] | hash_flow.rb:446:11:446:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :f] | hash_flow.rb:448:11:448:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:450:11:450:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:452:11:452:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:453:11:453:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:455:11:455:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :a] | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :c] | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :a] | hash_flow.rb:438:5:438:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :c] | hash_flow.rb:438:5:438:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :d] | hash_flow.rb:438:5:438:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :f] | hash_flow.rb:438:5:438:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :d] | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :f] | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | hash_flow.rb:438:41:438:49 | old_value | provenance |  |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | hash_flow.rb:438:52:438:60 | new_value | provenance |  |
 | hash_flow.rb:438:41:438:49 | old_value | hash_flow.rb:440:14:440:22 | old_value | provenance |  |
 | hash_flow.rb:438:52:438:60 | new_value | hash_flow.rb:441:14:441:22 | new_value | provenance |  |
-| hash_flow.rb:443:11:443:14 | hash [element :a] | hash_flow.rb:443:11:443:18 | ...[...] | provenance |  |
+| hash_flow.rb:443:11:443:14 | hash : Hash [element :a] | hash_flow.rb:443:11:443:18 | ...[...] | provenance |  |
 | hash_flow.rb:443:11:443:18 | ...[...] | hash_flow.rb:443:10:443:19 | ( ... ) | provenance |  |
-| hash_flow.rb:445:11:445:14 | hash [element :c] | hash_flow.rb:445:11:445:18 | ...[...] | provenance |  |
+| hash_flow.rb:445:11:445:14 | hash : Hash [element :c] | hash_flow.rb:445:11:445:18 | ...[...] | provenance |  |
 | hash_flow.rb:445:11:445:18 | ...[...] | hash_flow.rb:445:10:445:19 | ( ... ) | provenance |  |
-| hash_flow.rb:446:11:446:14 | hash [element :d] | hash_flow.rb:446:11:446:18 | ...[...] | provenance |  |
+| hash_flow.rb:446:11:446:14 | hash : Hash [element :d] | hash_flow.rb:446:11:446:18 | ...[...] | provenance |  |
 | hash_flow.rb:446:11:446:18 | ...[...] | hash_flow.rb:446:10:446:19 | ( ... ) | provenance |  |
-| hash_flow.rb:448:11:448:14 | hash [element :f] | hash_flow.rb:448:11:448:18 | ...[...] | provenance |  |
+| hash_flow.rb:448:11:448:14 | hash : Hash [element :f] | hash_flow.rb:448:11:448:18 | ...[...] | provenance |  |
 | hash_flow.rb:448:11:448:18 | ...[...] | hash_flow.rb:448:10:448:19 | ( ... ) | provenance |  |
-| hash_flow.rb:450:11:450:15 | hash1 [element :a] | hash_flow.rb:450:11:450:19 | ...[...] | provenance |  |
+| hash_flow.rb:450:11:450:15 | hash1 : Hash [element :a] | hash_flow.rb:450:11:450:19 | ...[...] | provenance |  |
 | hash_flow.rb:450:11:450:19 | ...[...] | hash_flow.rb:450:10:450:20 | ( ... ) | provenance |  |
-| hash_flow.rb:452:11:452:15 | hash1 [element :c] | hash_flow.rb:452:11:452:19 | ...[...] | provenance |  |
+| hash_flow.rb:452:11:452:15 | hash1 : Hash [element :c] | hash_flow.rb:452:11:452:19 | ...[...] | provenance |  |
 | hash_flow.rb:452:11:452:19 | ...[...] | hash_flow.rb:452:10:452:20 | ( ... ) | provenance |  |
-| hash_flow.rb:453:11:453:15 | hash1 [element :d] | hash_flow.rb:453:11:453:19 | ...[...] | provenance |  |
+| hash_flow.rb:453:11:453:15 | hash1 : Hash [element :d] | hash_flow.rb:453:11:453:19 | ...[...] | provenance |  |
 | hash_flow.rb:453:11:453:19 | ...[...] | hash_flow.rb:453:10:453:20 | ( ... ) | provenance |  |
-| hash_flow.rb:455:11:455:15 | hash1 [element :f] | hash_flow.rb:455:11:455:19 | ...[...] | provenance |  |
+| hash_flow.rb:455:11:455:15 | hash1 : Hash [element :f] | hash_flow.rb:455:11:455:19 | ...[...] | provenance |  |
 | hash_flow.rb:455:11:455:19 | ...[...] | hash_flow.rb:455:10:455:20 | ( ... ) | provenance |  |
-| hash_flow.rb:461:5:461:8 | hash [element :a] | hash_flow.rb:465:9:465:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:461:12:464:5 | call to [] [element :a] | hash_flow.rb:461:5:461:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:462:15:462:25 | call to taint | hash_flow.rb:461:12:464:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:465:5:465:5 | b [element 1] | hash_flow.rb:467:10:467:10 | b [element 1] | provenance |  |
-| hash_flow.rb:465:9:465:12 | hash [element :a] | hash_flow.rb:465:9:465:22 | call to rassoc [element 1] | provenance |  |
-| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] | hash_flow.rb:465:5:465:5 | b [element 1] | provenance |  |
-| hash_flow.rb:467:10:467:10 | b [element 1] | hash_flow.rb:467:10:467:13 | ...[...] | provenance |  |
-| hash_flow.rb:473:5:473:8 | hash [element :a] | hash_flow.rb:477:9:477:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:473:12:476:5 | call to [] [element :a] | hash_flow.rb:473:5:473:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:474:15:474:25 | call to taint | hash_flow.rb:473:12:476:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:477:5:477:5 | b [element :a] | hash_flow.rb:482:10:482:10 | b [element :a] | provenance |  |
-| hash_flow.rb:477:9:477:12 | hash [element :a] | hash_flow.rb:477:9:481:7 | call to reject [element :a] | provenance |  |
-| hash_flow.rb:477:9:477:12 | hash [element :a] | hash_flow.rb:477:29:477:33 | value | provenance |  |
-| hash_flow.rb:477:9:481:7 | call to reject [element :a] | hash_flow.rb:477:5:477:5 | b [element :a] | provenance |  |
+| hash_flow.rb:461:5:461:8 | hash : Hash [element :a] | hash_flow.rb:465:9:465:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:461:12:464:5 | call to [] : Hash [element :a] | hash_flow.rb:461:5:461:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:462:15:462:25 | call to taint | hash_flow.rb:461:12:464:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:465:5:465:5 | b : [collection] [element 1] | hash_flow.rb:467:10:467:10 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:465:9:465:12 | hash : Hash [element :a] | hash_flow.rb:465:9:465:22 | call to rassoc : [collection] [element 1] | provenance |  |
+| hash_flow.rb:465:9:465:22 | call to rassoc : [collection] [element 1] | hash_flow.rb:465:5:465:5 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:467:10:467:10 | b : [collection] [element 1] | hash_flow.rb:467:10:467:13 | ...[...] | provenance |  |
+| hash_flow.rb:473:5:473:8 | hash : Hash [element :a] | hash_flow.rb:477:9:477:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:473:12:476:5 | call to [] : Hash [element :a] | hash_flow.rb:473:5:473:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:474:15:474:25 | call to taint | hash_flow.rb:473:12:476:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:477:5:477:5 | b : Hash [element :a] | hash_flow.rb:482:10:482:10 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:477:9:477:12 | hash : Hash [element :a] | hash_flow.rb:477:9:481:7 | call to reject : Hash [element :a] | provenance |  |
+| hash_flow.rb:477:9:477:12 | hash : Hash [element :a] | hash_flow.rb:477:29:477:33 | value | provenance |  |
+| hash_flow.rb:477:9:481:7 | call to reject : Hash [element :a] | hash_flow.rb:477:5:477:5 | b : Hash [element :a] | provenance |  |
 | hash_flow.rb:477:29:477:33 | value | hash_flow.rb:479:14:479:18 | value | provenance |  |
-| hash_flow.rb:482:10:482:10 | b [element :a] | hash_flow.rb:482:10:482:14 | ...[...] | provenance |  |
-| hash_flow.rb:488:5:488:8 | hash [element :a] | hash_flow.rb:492:9:492:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:488:12:491:5 | call to [] [element :a] | hash_flow.rb:488:5:488:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:489:15:489:25 | call to taint | hash_flow.rb:488:12:491:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:492:5:492:5 | b [element :a] | hash_flow.rb:497:10:497:10 | b [element :a] | provenance |  |
-| hash_flow.rb:492:9:492:12 | [post] hash [element :a] | hash_flow.rb:498:10:498:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:492:9:492:12 | hash [element :a] | hash_flow.rb:492:9:492:12 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:492:9:492:12 | hash [element :a] | hash_flow.rb:492:9:496:7 | call to reject! [element :a] | provenance |  |
-| hash_flow.rb:492:9:492:12 | hash [element :a] | hash_flow.rb:492:30:492:34 | value | provenance |  |
-| hash_flow.rb:492:9:496:7 | call to reject! [element :a] | hash_flow.rb:492:5:492:5 | b [element :a] | provenance |  |
+| hash_flow.rb:482:10:482:10 | b : Hash [element :a] | hash_flow.rb:482:10:482:14 | ...[...] | provenance |  |
+| hash_flow.rb:488:5:488:8 | hash : Hash [element :a] | hash_flow.rb:492:9:492:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:488:12:491:5 | call to [] : Hash [element :a] | hash_flow.rb:488:5:488:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:489:15:489:25 | call to taint | hash_flow.rb:488:12:491:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:492:5:492:5 | b : Hash [element :a] | hash_flow.rb:497:10:497:10 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:492:9:492:12 | [post] hash : Hash [element :a] | hash_flow.rb:498:10:498:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:492:9:492:12 | hash : Hash [element :a] | hash_flow.rb:492:9:492:12 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:492:9:492:12 | hash : Hash [element :a] | hash_flow.rb:492:9:496:7 | call to reject! : Hash [element :a] | provenance |  |
+| hash_flow.rb:492:9:492:12 | hash : Hash [element :a] | hash_flow.rb:492:30:492:34 | value | provenance |  |
+| hash_flow.rb:492:9:496:7 | call to reject! : Hash [element :a] | hash_flow.rb:492:5:492:5 | b : Hash [element :a] | provenance |  |
 | hash_flow.rb:492:30:492:34 | value | hash_flow.rb:494:14:494:18 | value | provenance |  |
-| hash_flow.rb:497:10:497:10 | b [element :a] | hash_flow.rb:497:10:497:14 | ...[...] | provenance |  |
-| hash_flow.rb:498:10:498:13 | hash [element :a] | hash_flow.rb:498:10:498:17 | ...[...] | provenance |  |
-| hash_flow.rb:504:5:504:8 | hash [element :a] | hash_flow.rb:512:19:512:22 | hash [element :a] | provenance |  |
-| hash_flow.rb:504:5:504:8 | hash [element :c] | hash_flow.rb:512:19:512:22 | hash [element :c] | provenance |  |
-| hash_flow.rb:504:12:508:5 | call to [] [element :a] | hash_flow.rb:504:5:504:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:504:12:508:5 | call to [] [element :c] | hash_flow.rb:504:5:504:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:505:15:505:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:507:15:507:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | hash_flow.rb:513:11:513:15 | hash2 [element :a] | provenance |  |
-| hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] | hash_flow.rb:515:11:515:15 | hash2 [element :c] | provenance |  |
-| hash_flow.rb:512:19:512:22 | hash [element :a] | hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | provenance |  |
-| hash_flow.rb:512:19:512:22 | hash [element :c] | hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] | provenance |  |
-| hash_flow.rb:513:11:513:15 | hash2 [element :a] | hash_flow.rb:513:11:513:19 | ...[...] | provenance |  |
+| hash_flow.rb:497:10:497:10 | b : Hash [element :a] | hash_flow.rb:497:10:497:14 | ...[...] | provenance |  |
+| hash_flow.rb:498:10:498:13 | hash : Hash [element :a] | hash_flow.rb:498:10:498:17 | ...[...] | provenance |  |
+| hash_flow.rb:504:5:504:8 | hash : Hash [element :a] | hash_flow.rb:512:19:512:22 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:504:5:504:8 | hash : Hash [element :c] | hash_flow.rb:512:19:512:22 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:504:12:508:5 | call to [] : Hash [element :a] | hash_flow.rb:504:5:504:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:504:12:508:5 | call to [] : Hash [element :c] | hash_flow.rb:504:5:504:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:505:15:505:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:507:15:507:25 | call to taint | hash_flow.rb:504:12:508:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :a] | hash_flow.rb:513:11:513:15 | hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :c] | hash_flow.rb:515:11:515:15 | hash2 : Hash [element :c] | provenance |  |
+| hash_flow.rb:512:19:512:22 | hash : Hash [element :a] | hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :a] | provenance |  |
+| hash_flow.rb:512:19:512:22 | hash : Hash [element :c] | hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :c] | provenance |  |
+| hash_flow.rb:513:11:513:15 | hash2 : Hash [element :a] | hash_flow.rb:513:11:513:19 | ...[...] | provenance |  |
 | hash_flow.rb:513:11:513:19 | ...[...] | hash_flow.rb:513:10:513:20 | ( ... ) | provenance |  |
-| hash_flow.rb:515:11:515:15 | hash2 [element :c] | hash_flow.rb:515:11:515:19 | ...[...] | provenance |  |
+| hash_flow.rb:515:11:515:15 | hash2 : Hash [element :c] | hash_flow.rb:515:11:515:19 | ...[...] | provenance |  |
 | hash_flow.rb:515:11:515:19 | ...[...] | hash_flow.rb:515:10:515:20 | ( ... ) | provenance |  |
-| hash_flow.rb:519:5:519:8 | hash [element :a] | hash_flow.rb:524:9:524:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:519:5:519:8 | hash [element :c] | hash_flow.rb:524:9:524:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:519:12:523:5 | call to [] [element :a] | hash_flow.rb:519:5:519:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:519:12:523:5 | call to [] [element :c] | hash_flow.rb:519:5:519:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:520:15:520:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:522:15:522:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:524:5:524:5 | b [element :a] | hash_flow.rb:529:11:529:11 | b [element :a] | provenance |  |
-| hash_flow.rb:524:9:524:12 | hash [element :a] | hash_flow.rb:524:9:528:7 | call to select [element :a] | provenance |  |
-| hash_flow.rb:524:9:524:12 | hash [element :a] | hash_flow.rb:524:30:524:34 | value | provenance |  |
-| hash_flow.rb:524:9:524:12 | hash [element :c] | hash_flow.rb:524:30:524:34 | value | provenance |  |
-| hash_flow.rb:524:9:528:7 | call to select [element :a] | hash_flow.rb:524:5:524:5 | b [element :a] | provenance |  |
+| hash_flow.rb:519:5:519:8 | hash : Hash [element :a] | hash_flow.rb:524:9:524:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:519:5:519:8 | hash : Hash [element :c] | hash_flow.rb:524:9:524:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:519:12:523:5 | call to [] : Hash [element :a] | hash_flow.rb:519:5:519:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:519:12:523:5 | call to [] : Hash [element :c] | hash_flow.rb:519:5:519:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:520:15:520:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:522:15:522:25 | call to taint | hash_flow.rb:519:12:523:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:524:5:524:5 | b : Hash [element :a] | hash_flow.rb:529:11:529:11 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:524:9:524:12 | hash : Hash [element :a] | hash_flow.rb:524:9:528:7 | call to select : Hash [element :a] | provenance |  |
+| hash_flow.rb:524:9:524:12 | hash : Hash [element :a] | hash_flow.rb:524:30:524:34 | value | provenance |  |
+| hash_flow.rb:524:9:524:12 | hash : Hash [element :c] | hash_flow.rb:524:30:524:34 | value | provenance |  |
+| hash_flow.rb:524:9:528:7 | call to select : Hash [element :a] | hash_flow.rb:524:5:524:5 | b : Hash [element :a] | provenance |  |
 | hash_flow.rb:524:30:524:34 | value | hash_flow.rb:526:14:526:18 | value | provenance |  |
-| hash_flow.rb:529:11:529:11 | b [element :a] | hash_flow.rb:529:11:529:15 | ...[...] | provenance |  |
+| hash_flow.rb:529:11:529:11 | b : Hash [element :a] | hash_flow.rb:529:11:529:15 | ...[...] | provenance |  |
 | hash_flow.rb:529:11:529:15 | ...[...] | hash_flow.rb:529:10:529:16 | ( ... ) | provenance |  |
-| hash_flow.rb:535:5:535:8 | hash [element :a] | hash_flow.rb:540:5:540:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:535:5:535:8 | hash [element :c] | hash_flow.rb:540:5:540:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:535:12:539:5 | call to [] [element :a] | hash_flow.rb:535:5:535:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:535:12:539:5 | call to [] [element :c] | hash_flow.rb:535:5:535:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:536:15:536:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:538:15:538:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:540:5:540:8 | [post] hash [element :a] | hash_flow.rb:545:11:545:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:540:5:540:8 | hash [element :a] | hash_flow.rb:540:5:540:8 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:540:5:540:8 | hash [element :a] | hash_flow.rb:540:27:540:31 | value | provenance |  |
-| hash_flow.rb:540:5:540:8 | hash [element :c] | hash_flow.rb:540:27:540:31 | value | provenance |  |
+| hash_flow.rb:535:5:535:8 | hash : Hash [element :a] | hash_flow.rb:540:5:540:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:535:5:535:8 | hash : Hash [element :c] | hash_flow.rb:540:5:540:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:535:12:539:5 | call to [] : Hash [element :a] | hash_flow.rb:535:5:535:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:535:12:539:5 | call to [] : Hash [element :c] | hash_flow.rb:535:5:535:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:536:15:536:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:538:15:538:25 | call to taint | hash_flow.rb:535:12:539:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:540:5:540:8 | [post] hash : Hash [element :a] | hash_flow.rb:545:11:545:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:540:5:540:8 | hash : Hash [element :a] | hash_flow.rb:540:5:540:8 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:540:5:540:8 | hash : Hash [element :a] | hash_flow.rb:540:27:540:31 | value | provenance |  |
+| hash_flow.rb:540:5:540:8 | hash : Hash [element :c] | hash_flow.rb:540:27:540:31 | value | provenance |  |
 | hash_flow.rb:540:27:540:31 | value | hash_flow.rb:542:14:542:18 | value | provenance |  |
-| hash_flow.rb:545:11:545:14 | hash [element :a] | hash_flow.rb:545:11:545:18 | ...[...] | provenance |  |
+| hash_flow.rb:545:11:545:14 | hash : Hash [element :a] | hash_flow.rb:545:11:545:18 | ...[...] | provenance |  |
 | hash_flow.rb:545:11:545:18 | ...[...] | hash_flow.rb:545:10:545:19 | ( ... ) | provenance |  |
-| hash_flow.rb:551:5:551:8 | hash [element :a] | hash_flow.rb:556:9:556:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:551:5:551:8 | hash [element :c] | hash_flow.rb:556:9:556:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:551:12:555:5 | call to [] [element :a] | hash_flow.rb:551:5:551:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:551:12:555:5 | call to [] [element :c] | hash_flow.rb:551:5:551:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:552:15:552:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:554:15:554:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:556:5:556:5 | b [element 1] | hash_flow.rb:559:11:559:11 | b [element 1] | provenance |  |
-| hash_flow.rb:556:9:556:12 | [post] hash [element :a] | hash_flow.rb:557:11:557:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:556:9:556:12 | hash [element :a] | hash_flow.rb:556:9:556:12 | [post] hash [element :a] | provenance |  |
-| hash_flow.rb:556:9:556:12 | hash [element :a] | hash_flow.rb:556:9:556:18 | call to shift [element 1] | provenance |  |
-| hash_flow.rb:556:9:556:12 | hash [element :c] | hash_flow.rb:556:9:556:18 | call to shift [element 1] | provenance |  |
-| hash_flow.rb:556:9:556:18 | call to shift [element 1] | hash_flow.rb:556:5:556:5 | b [element 1] | provenance |  |
-| hash_flow.rb:557:11:557:14 | hash [element :a] | hash_flow.rb:557:11:557:18 | ...[...] | provenance |  |
+| hash_flow.rb:551:5:551:8 | hash : Hash [element :a] | hash_flow.rb:556:9:556:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:551:5:551:8 | hash : Hash [element :c] | hash_flow.rb:556:9:556:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:551:12:555:5 | call to [] : Hash [element :a] | hash_flow.rb:551:5:551:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:551:12:555:5 | call to [] : Hash [element :c] | hash_flow.rb:551:5:551:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:552:15:552:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:554:15:554:25 | call to taint | hash_flow.rb:551:12:555:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:556:5:556:5 | b : [collection] [element 1] | hash_flow.rb:559:11:559:11 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:556:9:556:12 | [post] hash : Hash [element :a] | hash_flow.rb:557:11:557:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:556:9:556:12 | hash : Hash [element :a] | hash_flow.rb:556:9:556:12 | [post] hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:556:9:556:12 | hash : Hash [element :a] | hash_flow.rb:556:9:556:18 | call to shift : [collection] [element 1] | provenance |  |
+| hash_flow.rb:556:9:556:12 | hash : Hash [element :c] | hash_flow.rb:556:9:556:18 | call to shift : [collection] [element 1] | provenance |  |
+| hash_flow.rb:556:9:556:18 | call to shift : [collection] [element 1] | hash_flow.rb:556:5:556:5 | b : [collection] [element 1] | provenance |  |
+| hash_flow.rb:557:11:557:14 | hash : Hash [element :a] | hash_flow.rb:557:11:557:18 | ...[...] | provenance |  |
 | hash_flow.rb:557:11:557:18 | ...[...] | hash_flow.rb:557:10:557:19 | ( ... ) | provenance |  |
-| hash_flow.rb:559:11:559:11 | b [element 1] | hash_flow.rb:559:11:559:14 | ...[...] | provenance |  |
+| hash_flow.rb:559:11:559:11 | b : [collection] [element 1] | hash_flow.rb:559:11:559:14 | ...[...] | provenance |  |
 | hash_flow.rb:559:11:559:14 | ...[...] | hash_flow.rb:559:10:559:15 | ( ... ) | provenance |  |
-| hash_flow.rb:565:5:565:8 | hash [element :a] | hash_flow.rb:570:9:570:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:565:5:565:8 | hash [element :a] | hash_flow.rb:575:9:575:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:565:5:565:8 | hash [element :c] | hash_flow.rb:575:9:575:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:565:12:569:5 | call to [] [element :a] | hash_flow.rb:565:5:565:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:565:12:569:5 | call to [] [element :c] | hash_flow.rb:565:5:565:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:566:15:566:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:568:15:568:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:570:5:570:5 | b [element :a] | hash_flow.rb:571:11:571:11 | b [element :a] | provenance |  |
-| hash_flow.rb:570:9:570:12 | hash [element :a] | hash_flow.rb:570:9:570:26 | call to slice [element :a] | provenance |  |
-| hash_flow.rb:570:9:570:26 | call to slice [element :a] | hash_flow.rb:570:5:570:5 | b [element :a] | provenance |  |
-| hash_flow.rb:571:11:571:11 | b [element :a] | hash_flow.rb:571:11:571:15 | ...[...] | provenance |  |
+| hash_flow.rb:565:5:565:8 | hash : Hash [element :a] | hash_flow.rb:570:9:570:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:565:5:565:8 | hash : Hash [element :a] | hash_flow.rb:575:9:575:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:565:5:565:8 | hash : Hash [element :c] | hash_flow.rb:575:9:575:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:565:12:569:5 | call to [] : Hash [element :a] | hash_flow.rb:565:5:565:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:565:12:569:5 | call to [] : Hash [element :c] | hash_flow.rb:565:5:565:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:566:15:566:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:568:15:568:25 | call to taint | hash_flow.rb:565:12:569:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:570:5:570:5 | b : Hash [element :a] | hash_flow.rb:571:11:571:11 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:570:9:570:12 | hash : Hash [element :a] | hash_flow.rb:570:9:570:26 | call to slice : Hash [element :a] | provenance |  |
+| hash_flow.rb:570:9:570:26 | call to slice : Hash [element :a] | hash_flow.rb:570:5:570:5 | b : Hash [element :a] | provenance |  |
+| hash_flow.rb:571:11:571:11 | b : Hash [element :a] | hash_flow.rb:571:11:571:15 | ...[...] | provenance |  |
 | hash_flow.rb:571:11:571:15 | ...[...] | hash_flow.rb:571:10:571:16 | ( ... ) | provenance |  |
-| hash_flow.rb:575:5:575:5 | c [element :a] | hash_flow.rb:576:11:576:11 | c [element :a] | provenance |  |
-| hash_flow.rb:575:5:575:5 | c [element :c] | hash_flow.rb:578:11:578:11 | c [element :c] | provenance |  |
-| hash_flow.rb:575:9:575:12 | hash [element :a] | hash_flow.rb:575:9:575:25 | call to slice [element :a] | provenance |  |
-| hash_flow.rb:575:9:575:12 | hash [element :c] | hash_flow.rb:575:9:575:25 | call to slice [element :c] | provenance |  |
-| hash_flow.rb:575:9:575:25 | call to slice [element :a] | hash_flow.rb:575:5:575:5 | c [element :a] | provenance |  |
-| hash_flow.rb:575:9:575:25 | call to slice [element :c] | hash_flow.rb:575:5:575:5 | c [element :c] | provenance |  |
-| hash_flow.rb:576:11:576:11 | c [element :a] | hash_flow.rb:576:11:576:15 | ...[...] | provenance |  |
+| hash_flow.rb:575:5:575:5 | c : Hash [element :a] | hash_flow.rb:576:11:576:11 | c : Hash [element :a] | provenance |  |
+| hash_flow.rb:575:5:575:5 | c : Hash [element :c] | hash_flow.rb:578:11:578:11 | c : Hash [element :c] | provenance |  |
+| hash_flow.rb:575:9:575:12 | hash : Hash [element :a] | hash_flow.rb:575:9:575:25 | call to slice : Hash [element :a] | provenance |  |
+| hash_flow.rb:575:9:575:12 | hash : Hash [element :c] | hash_flow.rb:575:9:575:25 | call to slice : Hash [element :c] | provenance |  |
+| hash_flow.rb:575:9:575:25 | call to slice : Hash [element :a] | hash_flow.rb:575:5:575:5 | c : Hash [element :a] | provenance |  |
+| hash_flow.rb:575:9:575:25 | call to slice : Hash [element :c] | hash_flow.rb:575:5:575:5 | c : Hash [element :c] | provenance |  |
+| hash_flow.rb:576:11:576:11 | c : Hash [element :a] | hash_flow.rb:576:11:576:15 | ...[...] | provenance |  |
 | hash_flow.rb:576:11:576:15 | ...[...] | hash_flow.rb:576:10:576:16 | ( ... ) | provenance |  |
-| hash_flow.rb:578:11:578:11 | c [element :c] | hash_flow.rb:578:11:578:15 | ...[...] | provenance |  |
+| hash_flow.rb:578:11:578:11 | c : Hash [element :c] | hash_flow.rb:578:11:578:15 | ...[...] | provenance |  |
 | hash_flow.rb:578:11:578:15 | ...[...] | hash_flow.rb:578:10:578:16 | ( ... ) | provenance |  |
-| hash_flow.rb:584:5:584:8 | hash [element :a] | hash_flow.rb:589:9:589:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:584:5:584:8 | hash [element :c] | hash_flow.rb:589:9:589:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:584:12:588:5 | call to [] [element :a] | hash_flow.rb:584:5:584:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:584:12:588:5 | call to [] [element :c] | hash_flow.rb:584:5:584:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:585:15:585:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:587:15:587:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:589:5:589:5 | a [element, element 1] | hash_flow.rb:591:11:591:11 | a [element, element 1] | provenance |  |
-| hash_flow.rb:589:9:589:12 | hash [element :a] | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | provenance |  |
-| hash_flow.rb:589:9:589:12 | hash [element :c] | hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | provenance |  |
-| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | hash_flow.rb:589:5:589:5 | a [element, element 1] | provenance |  |
-| hash_flow.rb:591:11:591:11 | a [element, element 1] | hash_flow.rb:591:11:591:14 | ...[...] [element 1] | provenance |  |
+| hash_flow.rb:584:5:584:8 | hash : Hash [element :a] | hash_flow.rb:589:9:589:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:584:5:584:8 | hash : Hash [element :c] | hash_flow.rb:589:9:589:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:584:12:588:5 | call to [] : Hash [element :a] | hash_flow.rb:584:5:584:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:584:12:588:5 | call to [] : Hash [element :c] | hash_flow.rb:584:5:584:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:585:15:585:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:587:15:587:25 | call to taint | hash_flow.rb:584:12:588:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:589:5:589:5 | a : [collection] [element, element 1] | hash_flow.rb:591:11:591:11 | a : [collection] [element, element 1] | provenance |  |
+| hash_flow.rb:589:9:589:12 | hash : Hash [element :a] | hash_flow.rb:589:9:589:17 | call to to_a : [collection] [element, element 1] | provenance |  |
+| hash_flow.rb:589:9:589:12 | hash : Hash [element :c] | hash_flow.rb:589:9:589:17 | call to to_a : [collection] [element, element 1] | provenance |  |
+| hash_flow.rb:589:9:589:17 | call to to_a : [collection] [element, element 1] | hash_flow.rb:589:5:589:5 | a : [collection] [element, element 1] | provenance |  |
+| hash_flow.rb:591:11:591:11 | a : [collection] [element, element 1] | hash_flow.rb:591:11:591:14 | ...[...] [element 1] | provenance |  |
 | hash_flow.rb:591:11:591:14 | ...[...] [element 1] | hash_flow.rb:591:11:591:17 | ...[...] | provenance |  |
 | hash_flow.rb:591:11:591:17 | ...[...] | hash_flow.rb:591:10:591:18 | ( ... ) | provenance |  |
-| hash_flow.rb:597:5:597:8 | hash [element :a] | hash_flow.rb:602:9:602:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:597:5:597:8 | hash [element :a] | hash_flow.rb:607:9:607:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:597:5:597:8 | hash [element :c] | hash_flow.rb:602:9:602:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:597:5:597:8 | hash [element :c] | hash_flow.rb:607:9:607:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:597:12:601:5 | call to [] [element :a] | hash_flow.rb:597:5:597:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:597:12:601:5 | call to [] [element :c] | hash_flow.rb:597:5:597:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:598:15:598:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:600:15:600:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:602:5:602:5 | a [element :a] | hash_flow.rb:603:11:603:11 | a [element :a] | provenance |  |
-| hash_flow.rb:602:5:602:5 | a [element :c] | hash_flow.rb:605:11:605:11 | a [element :c] | provenance |  |
-| hash_flow.rb:602:9:602:12 | hash [element :a] | hash_flow.rb:602:9:602:17 | call to to_h [element :a] | provenance |  |
-| hash_flow.rb:602:9:602:12 | hash [element :c] | hash_flow.rb:602:9:602:17 | call to to_h [element :c] | provenance |  |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :a] | hash_flow.rb:602:5:602:5 | a [element :a] | provenance |  |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :c] | hash_flow.rb:602:5:602:5 | a [element :c] | provenance |  |
-| hash_flow.rb:603:11:603:11 | a [element :a] | hash_flow.rb:603:11:603:15 | ...[...] | provenance |  |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :a] | hash_flow.rb:602:9:602:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :a] | hash_flow.rb:607:9:607:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :c] | hash_flow.rb:602:9:602:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :c] | hash_flow.rb:607:9:607:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:597:12:601:5 | call to [] : Hash [element :a] | hash_flow.rb:597:5:597:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:597:12:601:5 | call to [] : Hash [element :c] | hash_flow.rb:597:5:597:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:598:15:598:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:600:15:600:25 | call to taint | hash_flow.rb:597:12:601:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:602:5:602:5 | a : Hash [element :a] | hash_flow.rb:603:11:603:11 | a : Hash [element :a] | provenance |  |
+| hash_flow.rb:602:5:602:5 | a : Hash [element :c] | hash_flow.rb:605:11:605:11 | a : Hash [element :c] | provenance |  |
+| hash_flow.rb:602:9:602:12 | hash : Hash [element :a] | hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :a] | provenance |  |
+| hash_flow.rb:602:9:602:12 | hash : Hash [element :c] | hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :c] | provenance |  |
+| hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :a] | hash_flow.rb:602:5:602:5 | a : Hash [element :a] | provenance |  |
+| hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :c] | hash_flow.rb:602:5:602:5 | a : Hash [element :c] | provenance |  |
+| hash_flow.rb:603:11:603:11 | a : Hash [element :a] | hash_flow.rb:603:11:603:15 | ...[...] | provenance |  |
 | hash_flow.rb:603:11:603:15 | ...[...] | hash_flow.rb:603:10:603:16 | ( ... ) | provenance |  |
-| hash_flow.rb:605:11:605:11 | a [element :c] | hash_flow.rb:605:11:605:15 | ...[...] | provenance |  |
+| hash_flow.rb:605:11:605:11 | a : Hash [element :c] | hash_flow.rb:605:11:605:15 | ...[...] | provenance |  |
 | hash_flow.rb:605:11:605:15 | ...[...] | hash_flow.rb:605:10:605:16 | ( ... ) | provenance |  |
-| hash_flow.rb:607:5:607:5 | b [element] | hash_flow.rb:612:11:612:11 | b [element] | provenance |  |
-| hash_flow.rb:607:9:607:12 | hash [element :a] | hash_flow.rb:607:28:607:32 | value | provenance |  |
-| hash_flow.rb:607:9:607:12 | hash [element :c] | hash_flow.rb:607:28:607:32 | value | provenance |  |
-| hash_flow.rb:607:9:611:7 | call to to_h [element] | hash_flow.rb:607:5:607:5 | b [element] | provenance |  |
+| hash_flow.rb:607:5:607:5 | b : [collection] [element] | hash_flow.rb:612:11:612:11 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:607:9:607:12 | hash : Hash [element :a] | hash_flow.rb:607:28:607:32 | value | provenance |  |
+| hash_flow.rb:607:9:607:12 | hash : Hash [element :c] | hash_flow.rb:607:28:607:32 | value | provenance |  |
+| hash_flow.rb:607:9:611:7 | call to to_h : [collection] [element] | hash_flow.rb:607:5:607:5 | b : [collection] [element] | provenance |  |
 | hash_flow.rb:607:28:607:32 | value | hash_flow.rb:609:14:609:18 | value | provenance |  |
-| hash_flow.rb:610:9:610:25 | call to [] [element 1] | hash_flow.rb:607:9:611:7 | call to to_h [element] | provenance |  |
-| hash_flow.rb:610:14:610:24 | call to taint | hash_flow.rb:610:9:610:25 | call to [] [element 1] | provenance |  |
-| hash_flow.rb:612:11:612:11 | b [element] | hash_flow.rb:612:11:612:15 | ...[...] | provenance |  |
+| hash_flow.rb:610:9:610:25 | call to [] : Array [element 1] | hash_flow.rb:607:9:611:7 | call to to_h : [collection] [element] | provenance |  |
+| hash_flow.rb:610:14:610:24 | call to taint | hash_flow.rb:610:9:610:25 | call to [] : Array [element 1] | provenance |  |
+| hash_flow.rb:612:11:612:11 | b : [collection] [element] | hash_flow.rb:612:11:612:15 | ...[...] | provenance |  |
 | hash_flow.rb:612:11:612:15 | ...[...] | hash_flow.rb:612:10:612:16 | ( ... ) | provenance |  |
-| hash_flow.rb:618:5:618:8 | hash [element :a] | hash_flow.rb:623:9:623:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:618:5:618:8 | hash [element :c] | hash_flow.rb:623:9:623:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:618:12:622:5 | call to [] [element :a] | hash_flow.rb:618:5:618:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:618:12:622:5 | call to [] [element :c] | hash_flow.rb:618:5:618:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:619:15:619:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:621:15:621:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:624:11:624:11 | a [element] | provenance |  |
-| hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:625:11:625:11 | a [element] | provenance |  |
-| hash_flow.rb:623:5:623:5 | a [element] | hash_flow.rb:626:11:626:11 | a [element] | provenance |  |
-| hash_flow.rb:623:9:623:12 | hash [element :a] | hash_flow.rb:623:9:623:45 | call to transform_keys [element] | provenance |  |
-| hash_flow.rb:623:9:623:12 | hash [element :c] | hash_flow.rb:623:9:623:45 | call to transform_keys [element] | provenance |  |
-| hash_flow.rb:623:9:623:45 | call to transform_keys [element] | hash_flow.rb:623:5:623:5 | a [element] | provenance |  |
-| hash_flow.rb:624:11:624:11 | a [element] | hash_flow.rb:624:11:624:16 | ...[...] | provenance |  |
+| hash_flow.rb:618:5:618:8 | hash : Hash [element :a] | hash_flow.rb:623:9:623:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:618:5:618:8 | hash : Hash [element :c] | hash_flow.rb:623:9:623:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:618:12:622:5 | call to [] : Hash [element :a] | hash_flow.rb:618:5:618:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:618:12:622:5 | call to [] : Hash [element :c] | hash_flow.rb:618:5:618:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:619:15:619:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:621:15:621:25 | call to taint | hash_flow.rb:618:12:622:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:623:5:623:5 | a : [collection] [element] | hash_flow.rb:624:11:624:11 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:623:5:623:5 | a : [collection] [element] | hash_flow.rb:625:11:625:11 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:623:5:623:5 | a : [collection] [element] | hash_flow.rb:626:11:626:11 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:623:9:623:12 | hash : Hash [element :a] | hash_flow.rb:623:9:623:45 | call to transform_keys : [collection] [element] | provenance |  |
+| hash_flow.rb:623:9:623:12 | hash : Hash [element :c] | hash_flow.rb:623:9:623:45 | call to transform_keys : [collection] [element] | provenance |  |
+| hash_flow.rb:623:9:623:45 | call to transform_keys : [collection] [element] | hash_flow.rb:623:5:623:5 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:624:11:624:11 | a : [collection] [element] | hash_flow.rb:624:11:624:16 | ...[...] | provenance |  |
 | hash_flow.rb:624:11:624:16 | ...[...] | hash_flow.rb:624:10:624:17 | ( ... ) | provenance |  |
-| hash_flow.rb:625:11:625:11 | a [element] | hash_flow.rb:625:11:625:16 | ...[...] | provenance |  |
+| hash_flow.rb:625:11:625:11 | a : [collection] [element] | hash_flow.rb:625:11:625:16 | ...[...] | provenance |  |
 | hash_flow.rb:625:11:625:16 | ...[...] | hash_flow.rb:625:10:625:17 | ( ... ) | provenance |  |
-| hash_flow.rb:626:11:626:11 | a [element] | hash_flow.rb:626:11:626:16 | ...[...] | provenance |  |
+| hash_flow.rb:626:11:626:11 | a : [collection] [element] | hash_flow.rb:626:11:626:16 | ...[...] | provenance |  |
 | hash_flow.rb:626:11:626:16 | ...[...] | hash_flow.rb:626:10:626:17 | ( ... ) | provenance |  |
-| hash_flow.rb:632:5:632:8 | hash [element :a] | hash_flow.rb:639:5:639:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:632:5:632:8 | hash [element :a] | hash_flow.rb:640:11:640:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:632:5:632:8 | hash [element :c] | hash_flow.rb:639:5:639:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:632:5:632:8 | hash [element :c] | hash_flow.rb:642:11:642:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:632:12:636:5 | call to [] [element :a] | hash_flow.rb:632:5:632:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:632:12:636:5 | call to [] [element :c] | hash_flow.rb:632:5:632:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:633:15:633:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:635:15:635:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:639:5:639:8 | hash [element] | provenance |  |
-| hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:640:11:640:14 | hash [element] | provenance |  |
-| hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:641:11:641:14 | hash [element] | provenance |  |
-| hash_flow.rb:637:5:637:8 | [post] hash [element] | hash_flow.rb:642:11:642:14 | hash [element] | provenance |  |
-| hash_flow.rb:637:15:637:25 | call to taint | hash_flow.rb:637:5:637:8 | [post] hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | [post] hash [element] | hash_flow.rb:640:11:640:14 | hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | [post] hash [element] | hash_flow.rb:641:11:641:14 | hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | [post] hash [element] | hash_flow.rb:642:11:642:14 | hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | hash [element :a] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | hash [element :c] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
-| hash_flow.rb:639:5:639:8 | hash [element] | hash_flow.rb:639:5:639:8 | [post] hash [element] | provenance |  |
-| hash_flow.rb:640:11:640:14 | hash [element :a] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
-| hash_flow.rb:640:11:640:14 | hash [element] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :a] | hash_flow.rb:639:5:639:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :a] | hash_flow.rb:640:11:640:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :c] | hash_flow.rb:639:5:639:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :c] | hash_flow.rb:642:11:642:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:632:12:636:5 | call to [] : Hash [element :a] | hash_flow.rb:632:5:632:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:632:12:636:5 | call to [] : Hash [element :c] | hash_flow.rb:632:5:632:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:633:15:633:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:635:15:635:25 | call to taint | hash_flow.rb:632:12:636:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | hash_flow.rb:639:5:639:8 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | hash_flow.rb:640:11:640:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | hash_flow.rb:641:11:641:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | hash_flow.rb:642:11:642:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:637:15:637:25 | call to taint | hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | hash_flow.rb:640:11:640:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | hash_flow.rb:641:11:641:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | hash_flow.rb:642:11:642:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | hash : Hash [element :a] | hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | hash : Hash [element :c] | hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | provenance |  |
+| hash_flow.rb:639:5:639:8 | hash : [collection] [element] | hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | provenance |  |
+| hash_flow.rb:640:11:640:14 | hash : Hash [element :a] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
+| hash_flow.rb:640:11:640:14 | hash : [collection] [element] | hash_flow.rb:640:11:640:19 | ...[...] | provenance |  |
 | hash_flow.rb:640:11:640:19 | ...[...] | hash_flow.rb:640:10:640:20 | ( ... ) | provenance |  |
-| hash_flow.rb:641:11:641:14 | hash [element] | hash_flow.rb:641:11:641:19 | ...[...] | provenance |  |
+| hash_flow.rb:641:11:641:14 | hash : [collection] [element] | hash_flow.rb:641:11:641:19 | ...[...] | provenance |  |
 | hash_flow.rb:641:11:641:19 | ...[...] | hash_flow.rb:641:10:641:20 | ( ... ) | provenance |  |
-| hash_flow.rb:642:11:642:14 | hash [element :c] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
-| hash_flow.rb:642:11:642:14 | hash [element] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
+| hash_flow.rb:642:11:642:14 | hash : Hash [element :c] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
+| hash_flow.rb:642:11:642:14 | hash : [collection] [element] | hash_flow.rb:642:11:642:19 | ...[...] | provenance |  |
 | hash_flow.rb:642:11:642:19 | ...[...] | hash_flow.rb:642:10:642:20 | ( ... ) | provenance |  |
-| hash_flow.rb:648:5:648:8 | hash [element :a] | hash_flow.rb:653:9:653:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:648:5:648:8 | hash [element :a] | hash_flow.rb:657:11:657:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:648:5:648:8 | hash [element :c] | hash_flow.rb:653:9:653:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:648:12:652:5 | call to [] [element :a] | hash_flow.rb:648:5:648:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:648:12:652:5 | call to [] [element :c] | hash_flow.rb:648:5:648:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:649:15:649:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:651:15:651:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:653:5:653:5 | b [element] | hash_flow.rb:658:11:658:11 | b [element] | provenance |  |
-| hash_flow.rb:653:9:653:12 | hash [element :a] | hash_flow.rb:653:35:653:39 | value | provenance |  |
-| hash_flow.rb:653:9:653:12 | hash [element :c] | hash_flow.rb:653:35:653:39 | value | provenance |  |
-| hash_flow.rb:653:9:656:7 | call to transform_values [element] | hash_flow.rb:653:5:653:5 | b [element] | provenance |  |
+| hash_flow.rb:648:5:648:8 | hash : Hash [element :a] | hash_flow.rb:653:9:653:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:648:5:648:8 | hash : Hash [element :a] | hash_flow.rb:657:11:657:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:648:5:648:8 | hash : Hash [element :c] | hash_flow.rb:653:9:653:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:648:12:652:5 | call to [] : Hash [element :a] | hash_flow.rb:648:5:648:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:648:12:652:5 | call to [] : Hash [element :c] | hash_flow.rb:648:5:648:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:649:15:649:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:651:15:651:25 | call to taint | hash_flow.rb:648:12:652:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:653:5:653:5 | b : [collection] [element] | hash_flow.rb:658:11:658:11 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:653:9:653:12 | hash : Hash [element :a] | hash_flow.rb:653:35:653:39 | value | provenance |  |
+| hash_flow.rb:653:9:653:12 | hash : Hash [element :c] | hash_flow.rb:653:35:653:39 | value | provenance |  |
+| hash_flow.rb:653:9:656:7 | call to transform_values : [collection] [element] | hash_flow.rb:653:5:653:5 | b : [collection] [element] | provenance |  |
 | hash_flow.rb:653:35:653:39 | value | hash_flow.rb:654:14:654:18 | value | provenance |  |
-| hash_flow.rb:655:9:655:19 | call to taint | hash_flow.rb:653:9:656:7 | call to transform_values [element] | provenance |  |
-| hash_flow.rb:657:11:657:14 | hash [element :a] | hash_flow.rb:657:11:657:18 | ...[...] | provenance |  |
+| hash_flow.rb:655:9:655:19 | call to taint | hash_flow.rb:653:9:656:7 | call to transform_values : [collection] [element] | provenance |  |
+| hash_flow.rb:657:11:657:14 | hash : Hash [element :a] | hash_flow.rb:657:11:657:18 | ...[...] | provenance |  |
 | hash_flow.rb:657:11:657:18 | ...[...] | hash_flow.rb:657:10:657:19 | ( ... ) | provenance |  |
-| hash_flow.rb:658:11:658:11 | b [element] | hash_flow.rb:658:11:658:15 | ...[...] | provenance |  |
+| hash_flow.rb:658:11:658:11 | b : [collection] [element] | hash_flow.rb:658:11:658:15 | ...[...] | provenance |  |
 | hash_flow.rb:658:11:658:15 | ...[...] | hash_flow.rb:658:10:658:16 | ( ... ) | provenance |  |
-| hash_flow.rb:664:5:664:8 | hash [element :a] | hash_flow.rb:669:5:669:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:664:5:664:8 | hash [element :c] | hash_flow.rb:669:5:669:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:664:12:668:5 | call to [] [element :a] | hash_flow.rb:664:5:664:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:664:12:668:5 | call to [] [element :c] | hash_flow.rb:664:5:664:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:665:15:665:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:667:15:667:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:669:5:669:8 | [post] hash [element] | hash_flow.rb:673:11:673:14 | hash [element] | provenance |  |
-| hash_flow.rb:669:5:669:8 | hash [element :a] | hash_flow.rb:669:32:669:36 | value | provenance |  |
-| hash_flow.rb:669:5:669:8 | hash [element :c] | hash_flow.rb:669:32:669:36 | value | provenance |  |
+| hash_flow.rb:664:5:664:8 | hash : Hash [element :a] | hash_flow.rb:669:5:669:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:664:5:664:8 | hash : Hash [element :c] | hash_flow.rb:669:5:669:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:664:12:668:5 | call to [] : Hash [element :a] | hash_flow.rb:664:5:664:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:664:12:668:5 | call to [] : Hash [element :c] | hash_flow.rb:664:5:664:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:665:15:665:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:667:15:667:25 | call to taint | hash_flow.rb:664:12:668:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:669:5:669:8 | [post] hash : [collection] [element] | hash_flow.rb:673:11:673:14 | hash : [collection] [element] | provenance |  |
+| hash_flow.rb:669:5:669:8 | hash : Hash [element :a] | hash_flow.rb:669:32:669:36 | value | provenance |  |
+| hash_flow.rb:669:5:669:8 | hash : Hash [element :c] | hash_flow.rb:669:32:669:36 | value | provenance |  |
 | hash_flow.rb:669:32:669:36 | value | hash_flow.rb:670:14:670:18 | value | provenance |  |
-| hash_flow.rb:671:9:671:19 | call to taint | hash_flow.rb:669:5:669:8 | [post] hash [element] | provenance |  |
-| hash_flow.rb:673:11:673:14 | hash [element] | hash_flow.rb:673:11:673:18 | ...[...] | provenance |  |
+| hash_flow.rb:671:9:671:19 | call to taint | hash_flow.rb:669:5:669:8 | [post] hash : [collection] [element] | provenance |  |
+| hash_flow.rb:673:11:673:14 | hash : [collection] [element] | hash_flow.rb:673:11:673:18 | ...[...] | provenance |  |
 | hash_flow.rb:673:11:673:18 | ...[...] | hash_flow.rb:673:10:673:19 | ( ... ) | provenance |  |
-| hash_flow.rb:679:5:679:9 | hash1 [element :a] | hash_flow.rb:689:12:689:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:679:5:679:9 | hash1 [element :c] | hash_flow.rb:689:12:689:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:679:13:683:5 | call to [] [element :a] | hash_flow.rb:679:5:679:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:679:13:683:5 | call to [] [element :c] | hash_flow.rb:679:5:679:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:680:15:680:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:682:15:682:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:684:5:684:9 | hash2 [element :d] | hash_flow.rb:689:25:689:29 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:684:5:684:9 | hash2 [element :f] | hash_flow.rb:689:25:689:29 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:684:13:688:5 | call to [] [element :d] | hash_flow.rb:684:5:684:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:684:13:688:5 | call to [] [element :f] | hash_flow.rb:684:5:684:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:685:15:685:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:687:15:687:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:689:5:689:8 | hash [element :a] | hash_flow.rb:694:11:694:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:689:5:689:8 | hash [element :c] | hash_flow.rb:696:11:696:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:689:5:689:8 | hash [element :d] | hash_flow.rb:697:11:697:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:689:5:689:8 | hash [element :f] | hash_flow.rb:699:11:699:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :a] | hash_flow.rb:701:11:701:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :c] | hash_flow.rb:703:11:703:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] | hash_flow.rb:704:11:704:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :f] | hash_flow.rb:706:11:706:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :a] | hash_flow.rb:689:12:689:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :a] | hash_flow.rb:689:12:693:7 | call to update [element :a] | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :a] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :a] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :c] | hash_flow.rb:689:12:689:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :c] | hash_flow.rb:689:12:693:7 | call to update [element :c] | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :c] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
-| hash_flow.rb:689:12:689:16 | hash1 [element :c] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
-| hash_flow.rb:689:12:693:7 | call to update [element :a] | hash_flow.rb:689:5:689:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:689:12:693:7 | call to update [element :c] | hash_flow.rb:689:5:689:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:689:12:693:7 | call to update [element :d] | hash_flow.rb:689:5:689:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:689:12:693:7 | call to update [element :f] | hash_flow.rb:689:5:689:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :d] | hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :d] | hash_flow.rb:689:12:693:7 | call to update [element :d] | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :d] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :d] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :f] | hash_flow.rb:689:12:689:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :f] | hash_flow.rb:689:12:693:7 | call to update [element :f] | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :f] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
-| hash_flow.rb:689:25:689:29 | hash2 [element :f] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
+| hash_flow.rb:679:5:679:9 | hash1 : Hash [element :a] | hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:679:5:679:9 | hash1 : Hash [element :c] | hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:679:13:683:5 | call to [] : Hash [element :a] | hash_flow.rb:679:5:679:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:679:13:683:5 | call to [] : Hash [element :c] | hash_flow.rb:679:5:679:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:680:15:680:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:682:15:682:25 | call to taint | hash_flow.rb:679:13:683:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:684:5:684:9 | hash2 : Hash [element :d] | hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:684:5:684:9 | hash2 : Hash [element :f] | hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:684:13:688:5 | call to [] : Hash [element :d] | hash_flow.rb:684:5:684:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:684:13:688:5 | call to [] : Hash [element :f] | hash_flow.rb:684:5:684:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:685:15:685:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:687:15:687:25 | call to taint | hash_flow.rb:684:13:688:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :a] | hash_flow.rb:694:11:694:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :c] | hash_flow.rb:696:11:696:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :d] | hash_flow.rb:697:11:697:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :f] | hash_flow.rb:699:11:699:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:701:11:701:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:703:11:703:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:704:11:704:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:706:11:706:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | hash_flow.rb:689:12:693:7 | call to update : Hash [element :a] | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | hash_flow.rb:689:12:693:7 | call to update : Hash [element :c] | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :a] | hash_flow.rb:689:5:689:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :c] | hash_flow.rb:689:5:689:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :d] | hash_flow.rb:689:5:689:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :f] | hash_flow.rb:689:5:689:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | hash_flow.rb:689:12:693:7 | call to update : Hash [element :d] | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | hash_flow.rb:689:12:693:7 | call to update : Hash [element :f] | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | hash_flow.rb:689:41:689:49 | old_value | provenance |  |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | hash_flow.rb:689:52:689:60 | new_value | provenance |  |
 | hash_flow.rb:689:41:689:49 | old_value | hash_flow.rb:691:14:691:22 | old_value | provenance |  |
 | hash_flow.rb:689:52:689:60 | new_value | hash_flow.rb:692:14:692:22 | new_value | provenance |  |
-| hash_flow.rb:694:11:694:14 | hash [element :a] | hash_flow.rb:694:11:694:18 | ...[...] | provenance |  |
+| hash_flow.rb:694:11:694:14 | hash : Hash [element :a] | hash_flow.rb:694:11:694:18 | ...[...] | provenance |  |
 | hash_flow.rb:694:11:694:18 | ...[...] | hash_flow.rb:694:10:694:19 | ( ... ) | provenance |  |
-| hash_flow.rb:696:11:696:14 | hash [element :c] | hash_flow.rb:696:11:696:18 | ...[...] | provenance |  |
+| hash_flow.rb:696:11:696:14 | hash : Hash [element :c] | hash_flow.rb:696:11:696:18 | ...[...] | provenance |  |
 | hash_flow.rb:696:11:696:18 | ...[...] | hash_flow.rb:696:10:696:19 | ( ... ) | provenance |  |
-| hash_flow.rb:697:11:697:14 | hash [element :d] | hash_flow.rb:697:11:697:18 | ...[...] | provenance |  |
+| hash_flow.rb:697:11:697:14 | hash : Hash [element :d] | hash_flow.rb:697:11:697:18 | ...[...] | provenance |  |
 | hash_flow.rb:697:11:697:18 | ...[...] | hash_flow.rb:697:10:697:19 | ( ... ) | provenance |  |
-| hash_flow.rb:699:11:699:14 | hash [element :f] | hash_flow.rb:699:11:699:18 | ...[...] | provenance |  |
+| hash_flow.rb:699:11:699:14 | hash : Hash [element :f] | hash_flow.rb:699:11:699:18 | ...[...] | provenance |  |
 | hash_flow.rb:699:11:699:18 | ...[...] | hash_flow.rb:699:10:699:19 | ( ... ) | provenance |  |
-| hash_flow.rb:701:11:701:15 | hash1 [element :a] | hash_flow.rb:701:11:701:19 | ...[...] | provenance |  |
+| hash_flow.rb:701:11:701:15 | hash1 : Hash [element :a] | hash_flow.rb:701:11:701:19 | ...[...] | provenance |  |
 | hash_flow.rb:701:11:701:19 | ...[...] | hash_flow.rb:701:10:701:20 | ( ... ) | provenance |  |
-| hash_flow.rb:703:11:703:15 | hash1 [element :c] | hash_flow.rb:703:11:703:19 | ...[...] | provenance |  |
+| hash_flow.rb:703:11:703:15 | hash1 : Hash [element :c] | hash_flow.rb:703:11:703:19 | ...[...] | provenance |  |
 | hash_flow.rb:703:11:703:19 | ...[...] | hash_flow.rb:703:10:703:20 | ( ... ) | provenance |  |
-| hash_flow.rb:704:11:704:15 | hash1 [element :d] | hash_flow.rb:704:11:704:19 | ...[...] | provenance |  |
+| hash_flow.rb:704:11:704:15 | hash1 : Hash [element :d] | hash_flow.rb:704:11:704:19 | ...[...] | provenance |  |
 | hash_flow.rb:704:11:704:19 | ...[...] | hash_flow.rb:704:10:704:20 | ( ... ) | provenance |  |
-| hash_flow.rb:706:11:706:15 | hash1 [element :f] | hash_flow.rb:706:11:706:19 | ...[...] | provenance |  |
+| hash_flow.rb:706:11:706:15 | hash1 : Hash [element :f] | hash_flow.rb:706:11:706:19 | ...[...] | provenance |  |
 | hash_flow.rb:706:11:706:19 | ...[...] | hash_flow.rb:706:10:706:20 | ( ... ) | provenance |  |
-| hash_flow.rb:712:5:712:8 | hash [element :a] | hash_flow.rb:717:9:717:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:712:5:712:8 | hash [element :c] | hash_flow.rb:717:9:717:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:712:12:716:5 | call to [] [element :a] | hash_flow.rb:712:5:712:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:712:12:716:5 | call to [] [element :c] | hash_flow.rb:712:5:712:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:713:15:713:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:715:15:715:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:717:5:717:5 | a [element] | hash_flow.rb:718:11:718:11 | a [element] | provenance |  |
-| hash_flow.rb:717:9:717:12 | hash [element :a] | hash_flow.rb:717:9:717:19 | call to values [element] | provenance |  |
-| hash_flow.rb:717:9:717:12 | hash [element :c] | hash_flow.rb:717:9:717:19 | call to values [element] | provenance |  |
-| hash_flow.rb:717:9:717:19 | call to values [element] | hash_flow.rb:717:5:717:5 | a [element] | provenance |  |
-| hash_flow.rb:718:11:718:11 | a [element] | hash_flow.rb:718:11:718:14 | ...[...] | provenance |  |
+| hash_flow.rb:712:5:712:8 | hash : Hash [element :a] | hash_flow.rb:717:9:717:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:712:5:712:8 | hash : Hash [element :c] | hash_flow.rb:717:9:717:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:712:12:716:5 | call to [] : Hash [element :a] | hash_flow.rb:712:5:712:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:712:12:716:5 | call to [] : Hash [element :c] | hash_flow.rb:712:5:712:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:713:15:713:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:715:15:715:25 | call to taint | hash_flow.rb:712:12:716:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:717:5:717:5 | a : [collection] [element] | hash_flow.rb:718:11:718:11 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:717:9:717:12 | hash : Hash [element :a] | hash_flow.rb:717:9:717:19 | call to values : [collection] [element] | provenance |  |
+| hash_flow.rb:717:9:717:12 | hash : Hash [element :c] | hash_flow.rb:717:9:717:19 | call to values : [collection] [element] | provenance |  |
+| hash_flow.rb:717:9:717:19 | call to values : [collection] [element] | hash_flow.rb:717:5:717:5 | a : [collection] [element] | provenance |  |
+| hash_flow.rb:718:11:718:11 | a : [collection] [element] | hash_flow.rb:718:11:718:14 | ...[...] | provenance |  |
 | hash_flow.rb:718:11:718:14 | ...[...] | hash_flow.rb:718:10:718:15 | ( ... ) | provenance |  |
-| hash_flow.rb:724:5:724:8 | hash [element :a] | hash_flow.rb:729:9:729:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:724:5:724:8 | hash [element :a] | hash_flow.rb:731:9:731:12 | hash [element :a] | provenance |  |
-| hash_flow.rb:724:5:724:8 | hash [element :c] | hash_flow.rb:731:9:731:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:724:12:728:5 | call to [] [element :a] | hash_flow.rb:724:5:724:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:724:12:728:5 | call to [] [element :c] | hash_flow.rb:724:5:724:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:725:15:725:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:727:15:727:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:729:5:729:5 | b [element 0] | hash_flow.rb:730:10:730:10 | b [element 0] | provenance |  |
-| hash_flow.rb:729:9:729:12 | hash [element :a] | hash_flow.rb:729:9:729:26 | call to values_at [element 0] | provenance |  |
-| hash_flow.rb:729:9:729:26 | call to values_at [element 0] | hash_flow.rb:729:5:729:5 | b [element 0] | provenance |  |
-| hash_flow.rb:730:10:730:10 | b [element 0] | hash_flow.rb:730:10:730:13 | ...[...] | provenance |  |
-| hash_flow.rb:731:5:731:5 | b [element] | hash_flow.rb:732:10:732:10 | b [element] | provenance |  |
-| hash_flow.rb:731:9:731:12 | hash [element :a] | hash_flow.rb:731:9:731:31 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:731:9:731:12 | hash [element :c] | hash_flow.rb:731:9:731:31 | call to fetch_values [element] | provenance |  |
-| hash_flow.rb:731:9:731:31 | call to fetch_values [element] | hash_flow.rb:731:5:731:5 | b [element] | provenance |  |
-| hash_flow.rb:732:10:732:10 | b [element] | hash_flow.rb:732:10:732:13 | ...[...] | provenance |  |
-| hash_flow.rb:738:5:738:9 | hash1 [element :a] | hash_flow.rb:748:16:748:20 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:738:5:738:9 | hash1 [element :c] | hash_flow.rb:748:16:748:20 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:738:13:742:5 | call to [] [element :a] | hash_flow.rb:738:5:738:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:738:13:742:5 | call to [] [element :c] | hash_flow.rb:738:5:738:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:739:15:739:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:741:15:741:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:743:5:743:9 | hash2 [element :d] | hash_flow.rb:748:44:748:48 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:743:5:743:9 | hash2 [element :f] | hash_flow.rb:748:44:748:48 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:743:13:747:5 | call to [] [element :d] | hash_flow.rb:743:5:743:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:743:13:747:5 | call to [] [element :f] | hash_flow.rb:743:5:743:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:744:15:744:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:746:15:746:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:748:5:748:8 | hash [element :a] | hash_flow.rb:749:10:749:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:748:5:748:8 | hash [element :c] | hash_flow.rb:751:10:751:13 | hash [element :c] | provenance |  |
-| hash_flow.rb:748:5:748:8 | hash [element :d] | hash_flow.rb:752:10:752:13 | hash [element :d] | provenance |  |
-| hash_flow.rb:748:5:748:8 | hash [element :f] | hash_flow.rb:754:10:754:13 | hash [element :f] | provenance |  |
-| hash_flow.rb:748:5:748:8 | hash [element :g] | hash_flow.rb:755:10:755:13 | hash [element :g] | provenance |  |
-| hash_flow.rb:748:12:748:59 | call to [] [element :a] | hash_flow.rb:748:5:748:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:748:12:748:59 | call to [] [element :c] | hash_flow.rb:748:5:748:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:748:12:748:59 | call to [] [element :d] | hash_flow.rb:748:5:748:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:748:12:748:59 | call to [] [element :f] | hash_flow.rb:748:5:748:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:748:12:748:59 | call to [] [element :g] | hash_flow.rb:748:5:748:8 | hash [element :g] | provenance |  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :a] | hash_flow.rb:748:12:748:59 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:748:14:748:20 | ** ... [element :c] | hash_flow.rb:748:12:748:59 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:748:16:748:20 | hash1 [element :a] | hash_flow.rb:748:14:748:20 | ** ... [element :a] | provenance |  |
-| hash_flow.rb:748:16:748:20 | hash1 [element :c] | hash_flow.rb:748:14:748:20 | ** ... [element :c] | provenance |  |
-| hash_flow.rb:748:29:748:39 | call to taint | hash_flow.rb:748:12:748:59 | call to [] [element :g] | provenance |  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :d] | hash_flow.rb:748:12:748:59 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:748:42:748:48 | ** ... [element :f] | hash_flow.rb:748:12:748:59 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:748:44:748:48 | hash2 [element :d] | hash_flow.rb:748:42:748:48 | ** ... [element :d] | provenance |  |
-| hash_flow.rb:748:44:748:48 | hash2 [element :f] | hash_flow.rb:748:42:748:48 | ** ... [element :f] | provenance |  |
-| hash_flow.rb:749:10:749:13 | hash [element :a] | hash_flow.rb:749:10:749:17 | ...[...] | provenance |  |
-| hash_flow.rb:751:10:751:13 | hash [element :c] | hash_flow.rb:751:10:751:17 | ...[...] | provenance |  |
-| hash_flow.rb:752:10:752:13 | hash [element :d] | hash_flow.rb:752:10:752:17 | ...[...] | provenance |  |
-| hash_flow.rb:754:10:754:13 | hash [element :f] | hash_flow.rb:754:10:754:17 | ...[...] | provenance |  |
-| hash_flow.rb:755:10:755:13 | hash [element :g] | hash_flow.rb:755:10:755:17 | ...[...] | provenance |  |
-| hash_flow.rb:762:5:762:8 | hash [element :a] | hash_flow.rb:769:10:769:13 | hash [element :a] | provenance |  |
-| hash_flow.rb:762:5:762:8 | hash [element :c] | hash_flow.rb:771:10:771:13 | hash [element :c] | provenance |  |
-| hash_flow.rb:762:5:762:8 | hash [element :c] | hash_flow.rb:774:9:774:12 | hash [element :c] | provenance |  |
-| hash_flow.rb:762:5:762:8 | hash [element :d] | hash_flow.rb:772:10:772:13 | hash [element :d] | provenance |  |
-| hash_flow.rb:762:12:767:5 | call to [] [element :a] | hash_flow.rb:762:5:762:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:762:12:767:5 | call to [] [element :c] | hash_flow.rb:762:5:762:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:762:12:767:5 | call to [] [element :d] | hash_flow.rb:762:5:762:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:763:15:763:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:765:15:765:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:766:15:766:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:769:10:769:13 | hash [element :a] | hash_flow.rb:769:10:769:17 | ...[...] | provenance |  |
-| hash_flow.rb:771:10:771:13 | hash [element :c] | hash_flow.rb:771:10:771:17 | ...[...] | provenance |  |
-| hash_flow.rb:772:10:772:13 | hash [element :d] | hash_flow.rb:772:10:772:17 | ...[...] | provenance |  |
-| hash_flow.rb:774:5:774:5 | x [element :c] | hash_flow.rb:778:10:778:10 | x [element :c] | provenance |  |
-| hash_flow.rb:774:9:774:12 | [post] hash [element :c] | hash_flow.rb:783:10:783:13 | hash [element :c] | provenance |  |
-| hash_flow.rb:774:9:774:12 | hash [element :c] | hash_flow.rb:774:9:774:12 | [post] hash [element :c] | provenance |  |
-| hash_flow.rb:774:9:774:12 | hash [element :c] | hash_flow.rb:774:9:774:31 | call to except! [element :c] | provenance |  |
-| hash_flow.rb:774:9:774:31 | call to except! [element :c] | hash_flow.rb:774:5:774:5 | x [element :c] | provenance |  |
-| hash_flow.rb:778:10:778:10 | x [element :c] | hash_flow.rb:778:10:778:14 | ...[...] | provenance |  |
-| hash_flow.rb:783:10:783:13 | hash [element :c] | hash_flow.rb:783:10:783:17 | ...[...] | provenance |  |
-| hash_flow.rb:790:5:790:9 | hash1 [element :a] | hash_flow.rb:800:12:800:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:790:5:790:9 | hash1 [element :c] | hash_flow.rb:800:12:800:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:790:13:794:5 | call to [] [element :a] | hash_flow.rb:790:5:790:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:790:13:794:5 | call to [] [element :c] | hash_flow.rb:790:5:790:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:791:15:791:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:793:15:793:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:795:5:795:9 | hash2 [element :d] | hash_flow.rb:800:29:800:33 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:795:5:795:9 | hash2 [element :f] | hash_flow.rb:800:29:800:33 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:795:13:799:5 | call to [] [element :d] | hash_flow.rb:795:5:795:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:795:13:799:5 | call to [] [element :f] | hash_flow.rb:795:5:795:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:796:15:796:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:798:15:798:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:800:5:800:8 | hash [element :a] | hash_flow.rb:805:11:805:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:800:5:800:8 | hash [element :c] | hash_flow.rb:807:11:807:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:800:5:800:8 | hash [element :d] | hash_flow.rb:808:11:808:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:800:5:800:8 | hash [element :f] | hash_flow.rb:810:11:810:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :a] | hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :a] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :a] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :c] | hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :c] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
-| hash_flow.rb:800:12:800:16 | hash1 [element :c] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] | hash_flow.rb:800:5:800:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] | hash_flow.rb:800:5:800:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] | hash_flow.rb:800:5:800:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :f] | hash_flow.rb:800:5:800:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :d] | hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :d] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :d] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :f] | hash_flow.rb:800:12:804:7 | call to deep_merge [element :f] | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :f] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
-| hash_flow.rb:800:29:800:33 | hash2 [element :f] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
+| hash_flow.rb:724:5:724:8 | hash : Hash [element :a] | hash_flow.rb:729:9:729:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:724:5:724:8 | hash : Hash [element :a] | hash_flow.rb:731:9:731:12 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:724:5:724:8 | hash : Hash [element :c] | hash_flow.rb:731:9:731:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:724:12:728:5 | call to [] : Hash [element :a] | hash_flow.rb:724:5:724:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:724:12:728:5 | call to [] : Hash [element :c] | hash_flow.rb:724:5:724:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:725:15:725:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:727:15:727:25 | call to taint | hash_flow.rb:724:12:728:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:729:5:729:5 | b : [collection] [element 0] | hash_flow.rb:730:10:730:10 | b : [collection] [element 0] | provenance |  |
+| hash_flow.rb:729:9:729:12 | hash : Hash [element :a] | hash_flow.rb:729:9:729:26 | call to values_at : [collection] [element 0] | provenance |  |
+| hash_flow.rb:729:9:729:26 | call to values_at : [collection] [element 0] | hash_flow.rb:729:5:729:5 | b : [collection] [element 0] | provenance |  |
+| hash_flow.rb:730:10:730:10 | b : [collection] [element 0] | hash_flow.rb:730:10:730:13 | ...[...] | provenance |  |
+| hash_flow.rb:731:5:731:5 | b : [collection] [element] | hash_flow.rb:732:10:732:10 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:731:9:731:12 | hash : Hash [element :a] | hash_flow.rb:731:9:731:31 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:731:9:731:12 | hash : Hash [element :c] | hash_flow.rb:731:9:731:31 | call to fetch_values : [collection] [element] | provenance |  |
+| hash_flow.rb:731:9:731:31 | call to fetch_values : [collection] [element] | hash_flow.rb:731:5:731:5 | b : [collection] [element] | provenance |  |
+| hash_flow.rb:732:10:732:10 | b : [collection] [element] | hash_flow.rb:732:10:732:13 | ...[...] | provenance |  |
+| hash_flow.rb:738:5:738:9 | hash1 : Hash [element :a] | hash_flow.rb:748:16:748:20 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:738:5:738:9 | hash1 : Hash [element :c] | hash_flow.rb:748:16:748:20 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:738:13:742:5 | call to [] : Hash [element :a] | hash_flow.rb:738:5:738:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:738:13:742:5 | call to [] : Hash [element :c] | hash_flow.rb:738:5:738:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:739:15:739:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:741:15:741:25 | call to taint | hash_flow.rb:738:13:742:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:743:5:743:9 | hash2 : Hash [element :d] | hash_flow.rb:748:44:748:48 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:743:5:743:9 | hash2 : Hash [element :f] | hash_flow.rb:748:44:748:48 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:743:13:747:5 | call to [] : Hash [element :d] | hash_flow.rb:743:5:743:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:743:13:747:5 | call to [] : Hash [element :f] | hash_flow.rb:743:5:743:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:744:15:744:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:746:15:746:25 | call to taint | hash_flow.rb:743:13:747:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :a] | hash_flow.rb:749:10:749:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :c] | hash_flow.rb:751:10:751:13 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :d] | hash_flow.rb:752:10:752:13 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :f] | hash_flow.rb:754:10:754:13 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :g] | hash_flow.rb:755:10:755:13 | hash : Hash [element :g] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :a] | hash_flow.rb:748:5:748:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :c] | hash_flow.rb:748:5:748:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :d] | hash_flow.rb:748:5:748:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :f] | hash_flow.rb:748:5:748:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :g] | hash_flow.rb:748:5:748:8 | hash : Hash [element :g] | provenance |  |
+| hash_flow.rb:748:14:748:20 | ** ... : Hash [element :a] | hash_flow.rb:748:12:748:59 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:748:14:748:20 | ** ... : Hash [element :c] | hash_flow.rb:748:12:748:59 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:748:16:748:20 | hash1 : Hash [element :a] | hash_flow.rb:748:14:748:20 | ** ... : Hash [element :a] | provenance |  |
+| hash_flow.rb:748:16:748:20 | hash1 : Hash [element :c] | hash_flow.rb:748:14:748:20 | ** ... : Hash [element :c] | provenance |  |
+| hash_flow.rb:748:29:748:39 | call to taint | hash_flow.rb:748:12:748:59 | call to [] : Hash [element :g] | provenance |  |
+| hash_flow.rb:748:42:748:48 | ** ... : Hash [element :d] | hash_flow.rb:748:12:748:59 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:748:42:748:48 | ** ... : Hash [element :f] | hash_flow.rb:748:12:748:59 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:748:44:748:48 | hash2 : Hash [element :d] | hash_flow.rb:748:42:748:48 | ** ... : Hash [element :d] | provenance |  |
+| hash_flow.rb:748:44:748:48 | hash2 : Hash [element :f] | hash_flow.rb:748:42:748:48 | ** ... : Hash [element :f] | provenance |  |
+| hash_flow.rb:749:10:749:13 | hash : Hash [element :a] | hash_flow.rb:749:10:749:17 | ...[...] | provenance |  |
+| hash_flow.rb:751:10:751:13 | hash : Hash [element :c] | hash_flow.rb:751:10:751:17 | ...[...] | provenance |  |
+| hash_flow.rb:752:10:752:13 | hash : Hash [element :d] | hash_flow.rb:752:10:752:17 | ...[...] | provenance |  |
+| hash_flow.rb:754:10:754:13 | hash : Hash [element :f] | hash_flow.rb:754:10:754:17 | ...[...] | provenance |  |
+| hash_flow.rb:755:10:755:13 | hash : Hash [element :g] | hash_flow.rb:755:10:755:17 | ...[...] | provenance |  |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :a] | hash_flow.rb:769:10:769:13 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :c] | hash_flow.rb:771:10:771:13 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :c] | hash_flow.rb:774:9:774:12 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :d] | hash_flow.rb:772:10:772:13 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :a] | hash_flow.rb:762:5:762:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :c] | hash_flow.rb:762:5:762:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :d] | hash_flow.rb:762:5:762:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:763:15:763:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:765:15:765:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:766:15:766:25 | call to taint | hash_flow.rb:762:12:767:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:769:10:769:13 | hash : Hash [element :a] | hash_flow.rb:769:10:769:17 | ...[...] | provenance |  |
+| hash_flow.rb:771:10:771:13 | hash : Hash [element :c] | hash_flow.rb:771:10:771:17 | ...[...] | provenance |  |
+| hash_flow.rb:772:10:772:13 | hash : Hash [element :d] | hash_flow.rb:772:10:772:17 | ...[...] | provenance |  |
+| hash_flow.rb:774:5:774:5 | x : Hash [element :c] | hash_flow.rb:778:10:778:10 | x : Hash [element :c] | provenance |  |
+| hash_flow.rb:774:9:774:12 | [post] hash : Hash [element :c] | hash_flow.rb:783:10:783:13 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:774:9:774:12 | hash : Hash [element :c] | hash_flow.rb:774:9:774:12 | [post] hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:774:9:774:12 | hash : Hash [element :c] | hash_flow.rb:774:9:774:31 | call to except! : Hash [element :c] | provenance |  |
+| hash_flow.rb:774:9:774:31 | call to except! : Hash [element :c] | hash_flow.rb:774:5:774:5 | x : Hash [element :c] | provenance |  |
+| hash_flow.rb:778:10:778:10 | x : Hash [element :c] | hash_flow.rb:778:10:778:14 | ...[...] | provenance |  |
+| hash_flow.rb:783:10:783:13 | hash : Hash [element :c] | hash_flow.rb:783:10:783:17 | ...[...] | provenance |  |
+| hash_flow.rb:790:5:790:9 | hash1 : Hash [element :a] | hash_flow.rb:800:12:800:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:790:5:790:9 | hash1 : Hash [element :c] | hash_flow.rb:800:12:800:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:790:13:794:5 | call to [] : Hash [element :a] | hash_flow.rb:790:5:790:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:790:13:794:5 | call to [] : Hash [element :c] | hash_flow.rb:790:5:790:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:791:15:791:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:793:15:793:25 | call to taint | hash_flow.rb:790:13:794:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:795:5:795:9 | hash2 : Hash [element :d] | hash_flow.rb:800:29:800:33 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:795:5:795:9 | hash2 : Hash [element :f] | hash_flow.rb:800:29:800:33 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:795:13:799:5 | call to [] : Hash [element :d] | hash_flow.rb:795:5:795:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:795:13:799:5 | call to [] : Hash [element :f] | hash_flow.rb:795:5:795:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:796:15:796:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:798:15:798:25 | call to taint | hash_flow.rb:795:13:799:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :a] | hash_flow.rb:805:11:805:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :c] | hash_flow.rb:807:11:807:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :d] | hash_flow.rb:808:11:808:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :f] | hash_flow.rb:810:11:810:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :a] | hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :a] | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :a] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :a] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :c] | hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :c] | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :c] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :c] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :a] | hash_flow.rb:800:5:800:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :c] | hash_flow.rb:800:5:800:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :d] | hash_flow.rb:800:5:800:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :f] | hash_flow.rb:800:5:800:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :d] | hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :d] | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :d] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :d] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :f] | hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :f] | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :f] | hash_flow.rb:800:45:800:53 | old_value | provenance |  |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :f] | hash_flow.rb:800:56:800:64 | new_value | provenance |  |
 | hash_flow.rb:800:45:800:53 | old_value | hash_flow.rb:802:14:802:22 | old_value | provenance |  |
 | hash_flow.rb:800:56:800:64 | new_value | hash_flow.rb:803:14:803:22 | new_value | provenance |  |
-| hash_flow.rb:805:11:805:14 | hash [element :a] | hash_flow.rb:805:11:805:18 | ...[...] | provenance |  |
+| hash_flow.rb:805:11:805:14 | hash : Hash [element :a] | hash_flow.rb:805:11:805:18 | ...[...] | provenance |  |
 | hash_flow.rb:805:11:805:18 | ...[...] | hash_flow.rb:805:10:805:19 | ( ... ) | provenance |  |
-| hash_flow.rb:807:11:807:14 | hash [element :c] | hash_flow.rb:807:11:807:18 | ...[...] | provenance |  |
+| hash_flow.rb:807:11:807:14 | hash : Hash [element :c] | hash_flow.rb:807:11:807:18 | ...[...] | provenance |  |
 | hash_flow.rb:807:11:807:18 | ...[...] | hash_flow.rb:807:10:807:19 | ( ... ) | provenance |  |
-| hash_flow.rb:808:11:808:14 | hash [element :d] | hash_flow.rb:808:11:808:18 | ...[...] | provenance |  |
+| hash_flow.rb:808:11:808:14 | hash : Hash [element :d] | hash_flow.rb:808:11:808:18 | ...[...] | provenance |  |
 | hash_flow.rb:808:11:808:18 | ...[...] | hash_flow.rb:808:10:808:19 | ( ... ) | provenance |  |
-| hash_flow.rb:810:11:810:14 | hash [element :f] | hash_flow.rb:810:11:810:18 | ...[...] | provenance |  |
+| hash_flow.rb:810:11:810:14 | hash : Hash [element :f] | hash_flow.rb:810:11:810:18 | ...[...] | provenance |  |
 | hash_flow.rb:810:11:810:18 | ...[...] | hash_flow.rb:810:10:810:19 | ( ... ) | provenance |  |
-| hash_flow.rb:816:5:816:9 | hash1 [element :a] | hash_flow.rb:826:12:826:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:816:5:816:9 | hash1 [element :c] | hash_flow.rb:826:12:826:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:816:13:820:5 | call to [] [element :a] | hash_flow.rb:816:5:816:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:816:13:820:5 | call to [] [element :c] | hash_flow.rb:816:5:816:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:817:15:817:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:819:15:819:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:821:5:821:9 | hash2 [element :d] | hash_flow.rb:826:30:826:34 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:821:5:821:9 | hash2 [element :f] | hash_flow.rb:826:30:826:34 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:821:13:825:5 | call to [] [element :d] | hash_flow.rb:821:5:821:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:821:13:825:5 | call to [] [element :f] | hash_flow.rb:821:5:821:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:822:15:822:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:824:15:824:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:826:5:826:8 | hash [element :a] | hash_flow.rb:831:11:831:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:826:5:826:8 | hash [element :c] | hash_flow.rb:833:11:833:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:826:5:826:8 | hash [element :d] | hash_flow.rb:834:11:834:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:826:5:826:8 | hash [element :f] | hash_flow.rb:836:11:836:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :a] | hash_flow.rb:838:11:838:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :c] | hash_flow.rb:840:11:840:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] | hash_flow.rb:841:11:841:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :f] | hash_flow.rb:843:11:843:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :a] | hash_flow.rb:826:12:826:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :a] | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :a] | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :a] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :a] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :c] | hash_flow.rb:826:12:826:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :c] | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :c] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
-| hash_flow.rb:826:12:826:16 | hash1 [element :c] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :a] | hash_flow.rb:826:5:826:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] | hash_flow.rb:826:5:826:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] | hash_flow.rb:826:5:826:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :f] | hash_flow.rb:826:5:826:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :d] | hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :d] | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :d] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :d] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :f] | hash_flow.rb:826:12:826:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :f] | hash_flow.rb:826:12:830:7 | call to deep_merge! [element :f] | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :f] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
-| hash_flow.rb:826:30:826:34 | hash2 [element :f] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
+| hash_flow.rb:816:5:816:9 | hash1 : Hash [element :a] | hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:816:5:816:9 | hash1 : Hash [element :c] | hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:816:13:820:5 | call to [] : Hash [element :a] | hash_flow.rb:816:5:816:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:816:13:820:5 | call to [] : Hash [element :c] | hash_flow.rb:816:5:816:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:817:15:817:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:819:15:819:25 | call to taint | hash_flow.rb:816:13:820:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:821:5:821:9 | hash2 : Hash [element :d] | hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:821:5:821:9 | hash2 : Hash [element :f] | hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:821:13:825:5 | call to [] : Hash [element :d] | hash_flow.rb:821:5:821:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:821:13:825:5 | call to [] : Hash [element :f] | hash_flow.rb:821:5:821:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:822:15:822:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:824:15:824:25 | call to taint | hash_flow.rb:821:13:825:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :a] | hash_flow.rb:831:11:831:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :c] | hash_flow.rb:833:11:833:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :d] | hash_flow.rb:834:11:834:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :f] | hash_flow.rb:836:11:836:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:838:11:838:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:840:11:840:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:841:11:841:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:843:11:843:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :a] | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :c] | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :a] | hash_flow.rb:826:5:826:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :c] | hash_flow.rb:826:5:826:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :d] | hash_flow.rb:826:5:826:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :f] | hash_flow.rb:826:5:826:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :d] | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :f] | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | hash_flow.rb:826:46:826:54 | old_value | provenance |  |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | hash_flow.rb:826:57:826:65 | new_value | provenance |  |
 | hash_flow.rb:826:46:826:54 | old_value | hash_flow.rb:828:14:828:22 | old_value | provenance |  |
 | hash_flow.rb:826:57:826:65 | new_value | hash_flow.rb:829:14:829:22 | new_value | provenance |  |
-| hash_flow.rb:831:11:831:14 | hash [element :a] | hash_flow.rb:831:11:831:18 | ...[...] | provenance |  |
+| hash_flow.rb:831:11:831:14 | hash : Hash [element :a] | hash_flow.rb:831:11:831:18 | ...[...] | provenance |  |
 | hash_flow.rb:831:11:831:18 | ...[...] | hash_flow.rb:831:10:831:19 | ( ... ) | provenance |  |
-| hash_flow.rb:833:11:833:14 | hash [element :c] | hash_flow.rb:833:11:833:18 | ...[...] | provenance |  |
+| hash_flow.rb:833:11:833:14 | hash : Hash [element :c] | hash_flow.rb:833:11:833:18 | ...[...] | provenance |  |
 | hash_flow.rb:833:11:833:18 | ...[...] | hash_flow.rb:833:10:833:19 | ( ... ) | provenance |  |
-| hash_flow.rb:834:11:834:14 | hash [element :d] | hash_flow.rb:834:11:834:18 | ...[...] | provenance |  |
+| hash_flow.rb:834:11:834:14 | hash : Hash [element :d] | hash_flow.rb:834:11:834:18 | ...[...] | provenance |  |
 | hash_flow.rb:834:11:834:18 | ...[...] | hash_flow.rb:834:10:834:19 | ( ... ) | provenance |  |
-| hash_flow.rb:836:11:836:14 | hash [element :f] | hash_flow.rb:836:11:836:18 | ...[...] | provenance |  |
+| hash_flow.rb:836:11:836:14 | hash : Hash [element :f] | hash_flow.rb:836:11:836:18 | ...[...] | provenance |  |
 | hash_flow.rb:836:11:836:18 | ...[...] | hash_flow.rb:836:10:836:19 | ( ... ) | provenance |  |
-| hash_flow.rb:838:11:838:15 | hash1 [element :a] | hash_flow.rb:838:11:838:19 | ...[...] | provenance |  |
+| hash_flow.rb:838:11:838:15 | hash1 : Hash [element :a] | hash_flow.rb:838:11:838:19 | ...[...] | provenance |  |
 | hash_flow.rb:838:11:838:19 | ...[...] | hash_flow.rb:838:10:838:20 | ( ... ) | provenance |  |
-| hash_flow.rb:840:11:840:15 | hash1 [element :c] | hash_flow.rb:840:11:840:19 | ...[...] | provenance |  |
+| hash_flow.rb:840:11:840:15 | hash1 : Hash [element :c] | hash_flow.rb:840:11:840:19 | ...[...] | provenance |  |
 | hash_flow.rb:840:11:840:19 | ...[...] | hash_flow.rb:840:10:840:20 | ( ... ) | provenance |  |
-| hash_flow.rb:841:11:841:15 | hash1 [element :d] | hash_flow.rb:841:11:841:19 | ...[...] | provenance |  |
+| hash_flow.rb:841:11:841:15 | hash1 : Hash [element :d] | hash_flow.rb:841:11:841:19 | ...[...] | provenance |  |
 | hash_flow.rb:841:11:841:19 | ...[...] | hash_flow.rb:841:10:841:20 | ( ... ) | provenance |  |
-| hash_flow.rb:843:11:843:15 | hash1 [element :f] | hash_flow.rb:843:11:843:19 | ...[...] | provenance |  |
+| hash_flow.rb:843:11:843:15 | hash1 : Hash [element :f] | hash_flow.rb:843:11:843:19 | ...[...] | provenance |  |
 | hash_flow.rb:843:11:843:19 | ...[...] | hash_flow.rb:843:10:843:20 | ( ... ) | provenance |  |
-| hash_flow.rb:849:5:849:9 | hash1 [element :a] | hash_flow.rb:860:13:860:17 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:849:5:849:9 | hash1 [element :a] | hash_flow.rb:869:13:869:17 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:849:5:849:9 | hash1 [element :c] | hash_flow.rb:860:13:860:17 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:849:5:849:9 | hash1 [element :c] | hash_flow.rb:869:13:869:17 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:849:13:853:5 | call to [] [element :a] | hash_flow.rb:849:5:849:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:849:13:853:5 | call to [] [element :c] | hash_flow.rb:849:5:849:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:850:12:850:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:852:12:852:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:854:5:854:9 | hash2 [element :d] | hash_flow.rb:860:33:860:37 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:854:5:854:9 | hash2 [element :d] | hash_flow.rb:869:33:869:37 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:854:5:854:9 | hash2 [element :f] | hash_flow.rb:860:33:860:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:854:5:854:9 | hash2 [element :f] | hash_flow.rb:869:33:869:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:854:13:858:5 | call to [] [element :d] | hash_flow.rb:854:5:854:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:854:13:858:5 | call to [] [element :f] | hash_flow.rb:854:5:854:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:855:12:855:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:857:12:857:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:860:5:860:9 | hash3 [element :a] | hash_flow.rb:861:11:861:15 | hash3 [element :a] | provenance |  |
-| hash_flow.rb:860:5:860:9 | hash3 [element :c] | hash_flow.rb:863:11:863:15 | hash3 [element :c] | provenance |  |
-| hash_flow.rb:860:5:860:9 | hash3 [element :d] | hash_flow.rb:864:11:864:15 | hash3 [element :d] | provenance |  |
-| hash_flow.rb:860:5:860:9 | hash3 [element :f] | hash_flow.rb:866:11:866:15 | hash3 [element :f] | provenance |  |
-| hash_flow.rb:860:13:860:17 | hash1 [element :a] | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] | provenance |  |
-| hash_flow.rb:860:13:860:17 | hash1 [element :c] | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] | provenance |  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] | hash_flow.rb:860:5:860:9 | hash3 [element :a] | provenance |  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] | hash_flow.rb:860:5:860:9 | hash3 [element :c] | provenance |  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] | hash_flow.rb:860:5:860:9 | hash3 [element :d] | provenance |  |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] | hash_flow.rb:860:5:860:9 | hash3 [element :f] | provenance |  |
-| hash_flow.rb:860:33:860:37 | hash2 [element :d] | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] | provenance |  |
-| hash_flow.rb:860:33:860:37 | hash2 [element :f] | hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] | provenance |  |
-| hash_flow.rb:861:11:861:15 | hash3 [element :a] | hash_flow.rb:861:11:861:19 | ...[...] | provenance |  |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :a] | hash_flow.rb:860:13:860:17 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :a] | hash_flow.rb:869:13:869:17 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :c] | hash_flow.rb:860:13:860:17 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :c] | hash_flow.rb:869:13:869:17 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:849:13:853:5 | call to [] : Hash [element :a] | hash_flow.rb:849:5:849:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:849:13:853:5 | call to [] : Hash [element :c] | hash_flow.rb:849:5:849:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:850:12:850:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:852:12:852:22 | call to taint | hash_flow.rb:849:13:853:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :d] | hash_flow.rb:860:33:860:37 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :d] | hash_flow.rb:869:33:869:37 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :f] | hash_flow.rb:860:33:860:37 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :f] | hash_flow.rb:869:33:869:37 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:854:13:858:5 | call to [] : Hash [element :d] | hash_flow.rb:854:5:854:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:854:13:858:5 | call to [] : Hash [element :f] | hash_flow.rb:854:5:854:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:855:12:855:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:857:12:857:22 | call to taint | hash_flow.rb:854:13:858:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :a] | hash_flow.rb:861:11:861:15 | hash3 : Hash [element :a] | provenance |  |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :c] | hash_flow.rb:863:11:863:15 | hash3 : Hash [element :c] | provenance |  |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :d] | hash_flow.rb:864:11:864:15 | hash3 : Hash [element :d] | provenance |  |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :f] | hash_flow.rb:866:11:866:15 | hash3 : Hash [element :f] | provenance |  |
+| hash_flow.rb:860:13:860:17 | hash1 : Hash [element :a] | hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :a] | provenance |  |
+| hash_flow.rb:860:13:860:17 | hash1 : Hash [element :c] | hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :c] | provenance |  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :a] | hash_flow.rb:860:5:860:9 | hash3 : Hash [element :a] | provenance |  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :c] | hash_flow.rb:860:5:860:9 | hash3 : Hash [element :c] | provenance |  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :d] | hash_flow.rb:860:5:860:9 | hash3 : Hash [element :d] | provenance |  |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :f] | hash_flow.rb:860:5:860:9 | hash3 : Hash [element :f] | provenance |  |
+| hash_flow.rb:860:33:860:37 | hash2 : Hash [element :d] | hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :d] | provenance |  |
+| hash_flow.rb:860:33:860:37 | hash2 : Hash [element :f] | hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :f] | provenance |  |
+| hash_flow.rb:861:11:861:15 | hash3 : Hash [element :a] | hash_flow.rb:861:11:861:19 | ...[...] | provenance |  |
 | hash_flow.rb:861:11:861:19 | ...[...] | hash_flow.rb:861:10:861:20 | ( ... ) | provenance |  |
-| hash_flow.rb:863:11:863:15 | hash3 [element :c] | hash_flow.rb:863:11:863:19 | ...[...] | provenance |  |
+| hash_flow.rb:863:11:863:15 | hash3 : Hash [element :c] | hash_flow.rb:863:11:863:19 | ...[...] | provenance |  |
 | hash_flow.rb:863:11:863:19 | ...[...] | hash_flow.rb:863:10:863:20 | ( ... ) | provenance |  |
-| hash_flow.rb:864:11:864:15 | hash3 [element :d] | hash_flow.rb:864:11:864:19 | ...[...] | provenance |  |
+| hash_flow.rb:864:11:864:15 | hash3 : Hash [element :d] | hash_flow.rb:864:11:864:19 | ...[...] | provenance |  |
 | hash_flow.rb:864:11:864:19 | ...[...] | hash_flow.rb:864:10:864:20 | ( ... ) | provenance |  |
-| hash_flow.rb:866:11:866:15 | hash3 [element :f] | hash_flow.rb:866:11:866:19 | ...[...] | provenance |  |
+| hash_flow.rb:866:11:866:15 | hash3 : Hash [element :f] | hash_flow.rb:866:11:866:19 | ...[...] | provenance |  |
 | hash_flow.rb:866:11:866:19 | ...[...] | hash_flow.rb:866:10:866:20 | ( ... ) | provenance |  |
-| hash_flow.rb:869:5:869:9 | hash4 [element :a] | hash_flow.rb:870:11:870:15 | hash4 [element :a] | provenance |  |
-| hash_flow.rb:869:5:869:9 | hash4 [element :c] | hash_flow.rb:872:11:872:15 | hash4 [element :c] | provenance |  |
-| hash_flow.rb:869:5:869:9 | hash4 [element :d] | hash_flow.rb:873:11:873:15 | hash4 [element :d] | provenance |  |
-| hash_flow.rb:869:5:869:9 | hash4 [element :f] | hash_flow.rb:875:11:875:15 | hash4 [element :f] | provenance |  |
-| hash_flow.rb:869:13:869:17 | hash1 [element :a] | hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] | provenance |  |
-| hash_flow.rb:869:13:869:17 | hash1 [element :c] | hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] | provenance |  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] | hash_flow.rb:869:5:869:9 | hash4 [element :a] | provenance |  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] | hash_flow.rb:869:5:869:9 | hash4 [element :c] | provenance |  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] | hash_flow.rb:869:5:869:9 | hash4 [element :d] | provenance |  |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] | hash_flow.rb:869:5:869:9 | hash4 [element :f] | provenance |  |
-| hash_flow.rb:869:33:869:37 | hash2 [element :d] | hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] | provenance |  |
-| hash_flow.rb:869:33:869:37 | hash2 [element :f] | hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] | provenance |  |
-| hash_flow.rb:870:11:870:15 | hash4 [element :a] | hash_flow.rb:870:11:870:19 | ...[...] | provenance |  |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :a] | hash_flow.rb:870:11:870:15 | hash4 : Hash [element :a] | provenance |  |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :c] | hash_flow.rb:872:11:872:15 | hash4 : Hash [element :c] | provenance |  |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :d] | hash_flow.rb:873:11:873:15 | hash4 : Hash [element :d] | provenance |  |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :f] | hash_flow.rb:875:11:875:15 | hash4 : Hash [element :f] | provenance |  |
+| hash_flow.rb:869:13:869:17 | hash1 : Hash [element :a] | hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :a] | provenance |  |
+| hash_flow.rb:869:13:869:17 | hash1 : Hash [element :c] | hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :c] | provenance |  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :a] | hash_flow.rb:869:5:869:9 | hash4 : Hash [element :a] | provenance |  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :c] | hash_flow.rb:869:5:869:9 | hash4 : Hash [element :c] | provenance |  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :d] | hash_flow.rb:869:5:869:9 | hash4 : Hash [element :d] | provenance |  |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :f] | hash_flow.rb:869:5:869:9 | hash4 : Hash [element :f] | provenance |  |
+| hash_flow.rb:869:33:869:37 | hash2 : Hash [element :d] | hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :d] | provenance |  |
+| hash_flow.rb:869:33:869:37 | hash2 : Hash [element :f] | hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :f] | provenance |  |
+| hash_flow.rb:870:11:870:15 | hash4 : Hash [element :a] | hash_flow.rb:870:11:870:19 | ...[...] | provenance |  |
 | hash_flow.rb:870:11:870:19 | ...[...] | hash_flow.rb:870:10:870:20 | ( ... ) | provenance |  |
-| hash_flow.rb:872:11:872:15 | hash4 [element :c] | hash_flow.rb:872:11:872:19 | ...[...] | provenance |  |
+| hash_flow.rb:872:11:872:15 | hash4 : Hash [element :c] | hash_flow.rb:872:11:872:19 | ...[...] | provenance |  |
 | hash_flow.rb:872:11:872:19 | ...[...] | hash_flow.rb:872:10:872:20 | ( ... ) | provenance |  |
-| hash_flow.rb:873:11:873:15 | hash4 [element :d] | hash_flow.rb:873:11:873:19 | ...[...] | provenance |  |
+| hash_flow.rb:873:11:873:15 | hash4 : Hash [element :d] | hash_flow.rb:873:11:873:19 | ...[...] | provenance |  |
 | hash_flow.rb:873:11:873:19 | ...[...] | hash_flow.rb:873:10:873:20 | ( ... ) | provenance |  |
-| hash_flow.rb:875:11:875:15 | hash4 [element :f] | hash_flow.rb:875:11:875:19 | ...[...] | provenance |  |
+| hash_flow.rb:875:11:875:15 | hash4 : Hash [element :f] | hash_flow.rb:875:11:875:19 | ...[...] | provenance |  |
 | hash_flow.rb:875:11:875:19 | ...[...] | hash_flow.rb:875:10:875:20 | ( ... ) | provenance |  |
-| hash_flow.rb:881:5:881:9 | hash1 [element :a] | hash_flow.rb:892:12:892:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:881:5:881:9 | hash1 [element :c] | hash_flow.rb:892:12:892:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:881:13:885:5 | call to [] [element :a] | hash_flow.rb:881:5:881:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:881:13:885:5 | call to [] [element :c] | hash_flow.rb:881:5:881:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:882:12:882:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:884:12:884:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:886:5:886:9 | hash2 [element :d] | hash_flow.rb:892:33:892:37 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:886:5:886:9 | hash2 [element :f] | hash_flow.rb:892:33:892:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:886:13:890:5 | call to [] [element :d] | hash_flow.rb:886:5:886:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:886:13:890:5 | call to [] [element :f] | hash_flow.rb:886:5:886:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:887:12:887:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:889:12:889:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:892:5:892:8 | hash [element :a] | hash_flow.rb:893:11:893:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:892:5:892:8 | hash [element :c] | hash_flow.rb:895:11:895:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:892:5:892:8 | hash [element :d] | hash_flow.rb:896:11:896:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:892:5:892:8 | hash [element :f] | hash_flow.rb:898:11:898:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :a] | hash_flow.rb:900:11:900:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] | hash_flow.rb:902:11:902:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] | hash_flow.rb:903:11:903:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :f] | hash_flow.rb:905:11:905:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:892:12:892:16 | hash1 [element :a] | hash_flow.rb:892:12:892:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:892:12:892:16 | hash1 [element :a] | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] | provenance |  |
-| hash_flow.rb:892:12:892:16 | hash1 [element :c] | hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:892:12:892:16 | hash1 [element :c] | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] | provenance |  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] | hash_flow.rb:892:5:892:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] | hash_flow.rb:892:5:892:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] | hash_flow.rb:892:5:892:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :f] | hash_flow.rb:892:5:892:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:892:33:892:37 | hash2 [element :d] | hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:892:33:892:37 | hash2 [element :d] | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] | provenance |  |
-| hash_flow.rb:892:33:892:37 | hash2 [element :f] | hash_flow.rb:892:12:892:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:892:33:892:37 | hash2 [element :f] | hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :f] | provenance |  |
-| hash_flow.rb:893:11:893:14 | hash [element :a] | hash_flow.rb:893:11:893:18 | ...[...] | provenance |  |
+| hash_flow.rb:881:5:881:9 | hash1 : Hash [element :a] | hash_flow.rb:892:12:892:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:881:5:881:9 | hash1 : Hash [element :c] | hash_flow.rb:892:12:892:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:881:13:885:5 | call to [] : Hash [element :a] | hash_flow.rb:881:5:881:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:881:13:885:5 | call to [] : Hash [element :c] | hash_flow.rb:881:5:881:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:882:12:882:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:884:12:884:22 | call to taint | hash_flow.rb:881:13:885:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:886:5:886:9 | hash2 : Hash [element :d] | hash_flow.rb:892:33:892:37 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:886:5:886:9 | hash2 : Hash [element :f] | hash_flow.rb:892:33:892:37 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:886:13:890:5 | call to [] : Hash [element :d] | hash_flow.rb:886:5:886:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:886:13:890:5 | call to [] : Hash [element :f] | hash_flow.rb:886:5:886:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:887:12:887:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:889:12:889:22 | call to taint | hash_flow.rb:886:13:890:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :a] | hash_flow.rb:893:11:893:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :c] | hash_flow.rb:895:11:895:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :d] | hash_flow.rb:896:11:896:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :f] | hash_flow.rb:898:11:898:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:900:11:900:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:902:11:902:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:903:11:903:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:905:11:905:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :a] | hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :a] | hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :a] | provenance |  |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :c] | hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :c] | hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :c] | provenance |  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :a] | hash_flow.rb:892:5:892:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :c] | hash_flow.rb:892:5:892:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :d] | hash_flow.rb:892:5:892:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :f] | hash_flow.rb:892:5:892:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :d] | hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :d] | hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :d] | provenance |  |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :f] | hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :f] | hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :f] | provenance |  |
+| hash_flow.rb:893:11:893:14 | hash : Hash [element :a] | hash_flow.rb:893:11:893:18 | ...[...] | provenance |  |
 | hash_flow.rb:893:11:893:18 | ...[...] | hash_flow.rb:893:10:893:19 | ( ... ) | provenance |  |
-| hash_flow.rb:895:11:895:14 | hash [element :c] | hash_flow.rb:895:11:895:18 | ...[...] | provenance |  |
+| hash_flow.rb:895:11:895:14 | hash : Hash [element :c] | hash_flow.rb:895:11:895:18 | ...[...] | provenance |  |
 | hash_flow.rb:895:11:895:18 | ...[...] | hash_flow.rb:895:10:895:19 | ( ... ) | provenance |  |
-| hash_flow.rb:896:11:896:14 | hash [element :d] | hash_flow.rb:896:11:896:18 | ...[...] | provenance |  |
+| hash_flow.rb:896:11:896:14 | hash : Hash [element :d] | hash_flow.rb:896:11:896:18 | ...[...] | provenance |  |
 | hash_flow.rb:896:11:896:18 | ...[...] | hash_flow.rb:896:10:896:19 | ( ... ) | provenance |  |
-| hash_flow.rb:898:11:898:14 | hash [element :f] | hash_flow.rb:898:11:898:18 | ...[...] | provenance |  |
+| hash_flow.rb:898:11:898:14 | hash : Hash [element :f] | hash_flow.rb:898:11:898:18 | ...[...] | provenance |  |
 | hash_flow.rb:898:11:898:18 | ...[...] | hash_flow.rb:898:10:898:19 | ( ... ) | provenance |  |
-| hash_flow.rb:900:11:900:15 | hash1 [element :a] | hash_flow.rb:900:11:900:19 | ...[...] | provenance |  |
+| hash_flow.rb:900:11:900:15 | hash1 : Hash [element :a] | hash_flow.rb:900:11:900:19 | ...[...] | provenance |  |
 | hash_flow.rb:900:11:900:19 | ...[...] | hash_flow.rb:900:10:900:20 | ( ... ) | provenance |  |
-| hash_flow.rb:902:11:902:15 | hash1 [element :c] | hash_flow.rb:902:11:902:19 | ...[...] | provenance |  |
+| hash_flow.rb:902:11:902:15 | hash1 : Hash [element :c] | hash_flow.rb:902:11:902:19 | ...[...] | provenance |  |
 | hash_flow.rb:902:11:902:19 | ...[...] | hash_flow.rb:902:10:902:20 | ( ... ) | provenance |  |
-| hash_flow.rb:903:11:903:15 | hash1 [element :d] | hash_flow.rb:903:11:903:19 | ...[...] | provenance |  |
+| hash_flow.rb:903:11:903:15 | hash1 : Hash [element :d] | hash_flow.rb:903:11:903:19 | ...[...] | provenance |  |
 | hash_flow.rb:903:11:903:19 | ...[...] | hash_flow.rb:903:10:903:20 | ( ... ) | provenance |  |
-| hash_flow.rb:905:11:905:15 | hash1 [element :f] | hash_flow.rb:905:11:905:19 | ...[...] | provenance |  |
+| hash_flow.rb:905:11:905:15 | hash1 : Hash [element :f] | hash_flow.rb:905:11:905:19 | ...[...] | provenance |  |
 | hash_flow.rb:905:11:905:19 | ...[...] | hash_flow.rb:905:10:905:20 | ( ... ) | provenance |  |
-| hash_flow.rb:911:5:911:9 | hash1 [element :a] | hash_flow.rb:922:12:922:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:911:5:911:9 | hash1 [element :c] | hash_flow.rb:922:12:922:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:911:13:915:5 | call to [] [element :a] | hash_flow.rb:911:5:911:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:911:13:915:5 | call to [] [element :c] | hash_flow.rb:911:5:911:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:912:12:912:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:914:12:914:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:916:5:916:9 | hash2 [element :d] | hash_flow.rb:922:33:922:37 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:916:5:916:9 | hash2 [element :f] | hash_flow.rb:922:33:922:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:916:13:920:5 | call to [] [element :d] | hash_flow.rb:916:5:916:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:916:13:920:5 | call to [] [element :f] | hash_flow.rb:916:5:916:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:917:12:917:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:919:12:919:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:922:5:922:8 | hash [element :a] | hash_flow.rb:923:11:923:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:922:5:922:8 | hash [element :c] | hash_flow.rb:925:11:925:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:922:5:922:8 | hash [element :d] | hash_flow.rb:926:11:926:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:922:5:922:8 | hash [element :f] | hash_flow.rb:928:11:928:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :a] | hash_flow.rb:930:11:930:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] | hash_flow.rb:932:11:932:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] | hash_flow.rb:933:11:933:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :f] | hash_flow.rb:935:11:935:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:922:12:922:16 | hash1 [element :a] | hash_flow.rb:922:12:922:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:922:12:922:16 | hash1 [element :a] | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] | provenance |  |
-| hash_flow.rb:922:12:922:16 | hash1 [element :c] | hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:922:12:922:16 | hash1 [element :c] | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] | provenance |  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] | hash_flow.rb:922:5:922:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] | hash_flow.rb:922:5:922:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] | hash_flow.rb:922:5:922:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :f] | hash_flow.rb:922:5:922:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:922:33:922:37 | hash2 [element :d] | hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:922:33:922:37 | hash2 [element :d] | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] | provenance |  |
-| hash_flow.rb:922:33:922:37 | hash2 [element :f] | hash_flow.rb:922:12:922:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:922:33:922:37 | hash2 [element :f] | hash_flow.rb:922:12:922:38 | call to with_defaults! [element :f] | provenance |  |
-| hash_flow.rb:923:11:923:14 | hash [element :a] | hash_flow.rb:923:11:923:18 | ...[...] | provenance |  |
+| hash_flow.rb:911:5:911:9 | hash1 : Hash [element :a] | hash_flow.rb:922:12:922:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:911:5:911:9 | hash1 : Hash [element :c] | hash_flow.rb:922:12:922:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:911:13:915:5 | call to [] : Hash [element :a] | hash_flow.rb:911:5:911:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:911:13:915:5 | call to [] : Hash [element :c] | hash_flow.rb:911:5:911:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:912:12:912:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:914:12:914:22 | call to taint | hash_flow.rb:911:13:915:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:916:5:916:9 | hash2 : Hash [element :d] | hash_flow.rb:922:33:922:37 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:916:5:916:9 | hash2 : Hash [element :f] | hash_flow.rb:922:33:922:37 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:916:13:920:5 | call to [] : Hash [element :d] | hash_flow.rb:916:5:916:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:916:13:920:5 | call to [] : Hash [element :f] | hash_flow.rb:916:5:916:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:917:12:917:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:919:12:919:22 | call to taint | hash_flow.rb:916:13:920:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :a] | hash_flow.rb:923:11:923:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :c] | hash_flow.rb:925:11:925:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :d] | hash_flow.rb:926:11:926:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :f] | hash_flow.rb:928:11:928:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:930:11:930:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:932:11:932:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:933:11:933:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:935:11:935:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :a] | hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :a] | hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :a] | provenance |  |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :c] | hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :c] | hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :c] | provenance |  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :a] | hash_flow.rb:922:5:922:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :c] | hash_flow.rb:922:5:922:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :d] | hash_flow.rb:922:5:922:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :f] | hash_flow.rb:922:5:922:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :d] | hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :d] | hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :d] | provenance |  |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :f] | hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :f] | hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :f] | provenance |  |
+| hash_flow.rb:923:11:923:14 | hash : Hash [element :a] | hash_flow.rb:923:11:923:18 | ...[...] | provenance |  |
 | hash_flow.rb:923:11:923:18 | ...[...] | hash_flow.rb:923:10:923:19 | ( ... ) | provenance |  |
-| hash_flow.rb:925:11:925:14 | hash [element :c] | hash_flow.rb:925:11:925:18 | ...[...] | provenance |  |
+| hash_flow.rb:925:11:925:14 | hash : Hash [element :c] | hash_flow.rb:925:11:925:18 | ...[...] | provenance |  |
 | hash_flow.rb:925:11:925:18 | ...[...] | hash_flow.rb:925:10:925:19 | ( ... ) | provenance |  |
-| hash_flow.rb:926:11:926:14 | hash [element :d] | hash_flow.rb:926:11:926:18 | ...[...] | provenance |  |
+| hash_flow.rb:926:11:926:14 | hash : Hash [element :d] | hash_flow.rb:926:11:926:18 | ...[...] | provenance |  |
 | hash_flow.rb:926:11:926:18 | ...[...] | hash_flow.rb:926:10:926:19 | ( ... ) | provenance |  |
-| hash_flow.rb:928:11:928:14 | hash [element :f] | hash_flow.rb:928:11:928:18 | ...[...] | provenance |  |
+| hash_flow.rb:928:11:928:14 | hash : Hash [element :f] | hash_flow.rb:928:11:928:18 | ...[...] | provenance |  |
 | hash_flow.rb:928:11:928:18 | ...[...] | hash_flow.rb:928:10:928:19 | ( ... ) | provenance |  |
-| hash_flow.rb:930:11:930:15 | hash1 [element :a] | hash_flow.rb:930:11:930:19 | ...[...] | provenance |  |
+| hash_flow.rb:930:11:930:15 | hash1 : Hash [element :a] | hash_flow.rb:930:11:930:19 | ...[...] | provenance |  |
 | hash_flow.rb:930:11:930:19 | ...[...] | hash_flow.rb:930:10:930:20 | ( ... ) | provenance |  |
-| hash_flow.rb:932:11:932:15 | hash1 [element :c] | hash_flow.rb:932:11:932:19 | ...[...] | provenance |  |
+| hash_flow.rb:932:11:932:15 | hash1 : Hash [element :c] | hash_flow.rb:932:11:932:19 | ...[...] | provenance |  |
 | hash_flow.rb:932:11:932:19 | ...[...] | hash_flow.rb:932:10:932:20 | ( ... ) | provenance |  |
-| hash_flow.rb:933:11:933:15 | hash1 [element :d] | hash_flow.rb:933:11:933:19 | ...[...] | provenance |  |
+| hash_flow.rb:933:11:933:15 | hash1 : Hash [element :d] | hash_flow.rb:933:11:933:19 | ...[...] | provenance |  |
 | hash_flow.rb:933:11:933:19 | ...[...] | hash_flow.rb:933:10:933:20 | ( ... ) | provenance |  |
-| hash_flow.rb:935:11:935:15 | hash1 [element :f] | hash_flow.rb:935:11:935:19 | ...[...] | provenance |  |
+| hash_flow.rb:935:11:935:15 | hash1 : Hash [element :f] | hash_flow.rb:935:11:935:19 | ...[...] | provenance |  |
 | hash_flow.rb:935:11:935:19 | ...[...] | hash_flow.rb:935:10:935:20 | ( ... ) | provenance |  |
-| hash_flow.rb:941:5:941:9 | hash1 [element :a] | hash_flow.rb:952:12:952:16 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:941:5:941:9 | hash1 [element :c] | hash_flow.rb:952:12:952:16 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:941:13:945:5 | call to [] [element :a] | hash_flow.rb:941:5:941:9 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:941:13:945:5 | call to [] [element :c] | hash_flow.rb:941:5:941:9 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:942:12:942:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:944:12:944:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] [element :c] | provenance |  |
-| hash_flow.rb:946:5:946:9 | hash2 [element :d] | hash_flow.rb:952:33:952:37 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:946:5:946:9 | hash2 [element :f] | hash_flow.rb:952:33:952:37 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:946:13:950:5 | call to [] [element :d] | hash_flow.rb:946:5:946:9 | hash2 [element :d] | provenance |  |
-| hash_flow.rb:946:13:950:5 | call to [] [element :f] | hash_flow.rb:946:5:946:9 | hash2 [element :f] | provenance |  |
-| hash_flow.rb:947:12:947:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] [element :d] | provenance |  |
-| hash_flow.rb:949:12:949:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] [element :f] | provenance |  |
-| hash_flow.rb:952:5:952:8 | hash [element :a] | hash_flow.rb:953:11:953:14 | hash [element :a] | provenance |  |
-| hash_flow.rb:952:5:952:8 | hash [element :c] | hash_flow.rb:955:11:955:14 | hash [element :c] | provenance |  |
-| hash_flow.rb:952:5:952:8 | hash [element :d] | hash_flow.rb:956:11:956:14 | hash [element :d] | provenance |  |
-| hash_flow.rb:952:5:952:8 | hash [element :f] | hash_flow.rb:958:11:958:14 | hash [element :f] | provenance |  |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :a] | hash_flow.rb:960:11:960:15 | hash1 [element :a] | provenance |  |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] | hash_flow.rb:962:11:962:15 | hash1 [element :c] | provenance |  |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] | hash_flow.rb:963:11:963:15 | hash1 [element :d] | provenance |  |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :f] | hash_flow.rb:965:11:965:15 | hash1 [element :f] | provenance |  |
-| hash_flow.rb:952:12:952:16 | hash1 [element :a] | hash_flow.rb:952:12:952:16 | [post] hash1 [element :a] | provenance |  |
-| hash_flow.rb:952:12:952:16 | hash1 [element :a] | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] | provenance |  |
-| hash_flow.rb:952:12:952:16 | hash1 [element :c] | hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] | provenance |  |
-| hash_flow.rb:952:12:952:16 | hash1 [element :c] | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] | provenance |  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] | hash_flow.rb:952:5:952:8 | hash [element :a] | provenance |  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] | hash_flow.rb:952:5:952:8 | hash [element :c] | provenance |  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] | hash_flow.rb:952:5:952:8 | hash [element :d] | provenance |  |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :f] | hash_flow.rb:952:5:952:8 | hash [element :f] | provenance |  |
-| hash_flow.rb:952:33:952:37 | hash2 [element :d] | hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] | provenance |  |
-| hash_flow.rb:952:33:952:37 | hash2 [element :d] | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] | provenance |  |
-| hash_flow.rb:952:33:952:37 | hash2 [element :f] | hash_flow.rb:952:12:952:16 | [post] hash1 [element :f] | provenance |  |
-| hash_flow.rb:952:33:952:37 | hash2 [element :f] | hash_flow.rb:952:12:952:38 | call to with_defaults! [element :f] | provenance |  |
-| hash_flow.rb:953:11:953:14 | hash [element :a] | hash_flow.rb:953:11:953:18 | ...[...] | provenance |  |
+| hash_flow.rb:941:5:941:9 | hash1 : Hash [element :a] | hash_flow.rb:952:12:952:16 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:941:5:941:9 | hash1 : Hash [element :c] | hash_flow.rb:952:12:952:16 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:941:13:945:5 | call to [] : Hash [element :a] | hash_flow.rb:941:5:941:9 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:941:13:945:5 | call to [] : Hash [element :c] | hash_flow.rb:941:5:941:9 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:942:12:942:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:944:12:944:22 | call to taint | hash_flow.rb:941:13:945:5 | call to [] : Hash [element :c] | provenance |  |
+| hash_flow.rb:946:5:946:9 | hash2 : Hash [element :d] | hash_flow.rb:952:33:952:37 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:946:5:946:9 | hash2 : Hash [element :f] | hash_flow.rb:952:33:952:37 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:946:13:950:5 | call to [] : Hash [element :d] | hash_flow.rb:946:5:946:9 | hash2 : Hash [element :d] | provenance |  |
+| hash_flow.rb:946:13:950:5 | call to [] : Hash [element :f] | hash_flow.rb:946:5:946:9 | hash2 : Hash [element :f] | provenance |  |
+| hash_flow.rb:947:12:947:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] : Hash [element :d] | provenance |  |
+| hash_flow.rb:949:12:949:22 | call to taint | hash_flow.rb:946:13:950:5 | call to [] : Hash [element :f] | provenance |  |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :a] | hash_flow.rb:953:11:953:14 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :c] | hash_flow.rb:955:11:955:14 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :d] | hash_flow.rb:956:11:956:14 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :f] | hash_flow.rb:958:11:958:14 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :a] | hash_flow.rb:960:11:960:15 | hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :c] | hash_flow.rb:962:11:962:15 | hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :d] | hash_flow.rb:963:11:963:15 | hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :f] | hash_flow.rb:965:11:965:15 | hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :a] | hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :a] | provenance |  |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :a] | hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :a] | provenance |  |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :c] | hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :c] | provenance |  |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :c] | hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :c] | provenance |  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :a] | hash_flow.rb:952:5:952:8 | hash : Hash [element :a] | provenance |  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :c] | hash_flow.rb:952:5:952:8 | hash : Hash [element :c] | provenance |  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :d] | hash_flow.rb:952:5:952:8 | hash : Hash [element :d] | provenance |  |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :f] | hash_flow.rb:952:5:952:8 | hash : Hash [element :f] | provenance |  |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :d] | hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :d] | provenance |  |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :d] | hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :d] | provenance |  |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :f] | hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :f] | provenance |  |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :f] | hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :f] | provenance |  |
+| hash_flow.rb:953:11:953:14 | hash : Hash [element :a] | hash_flow.rb:953:11:953:18 | ...[...] | provenance |  |
 | hash_flow.rb:953:11:953:18 | ...[...] | hash_flow.rb:953:10:953:19 | ( ... ) | provenance |  |
-| hash_flow.rb:955:11:955:14 | hash [element :c] | hash_flow.rb:955:11:955:18 | ...[...] | provenance |  |
+| hash_flow.rb:955:11:955:14 | hash : Hash [element :c] | hash_flow.rb:955:11:955:18 | ...[...] | provenance |  |
 | hash_flow.rb:955:11:955:18 | ...[...] | hash_flow.rb:955:10:955:19 | ( ... ) | provenance |  |
-| hash_flow.rb:956:11:956:14 | hash [element :d] | hash_flow.rb:956:11:956:18 | ...[...] | provenance |  |
+| hash_flow.rb:956:11:956:14 | hash : Hash [element :d] | hash_flow.rb:956:11:956:18 | ...[...] | provenance |  |
 | hash_flow.rb:956:11:956:18 | ...[...] | hash_flow.rb:956:10:956:19 | ( ... ) | provenance |  |
-| hash_flow.rb:958:11:958:14 | hash [element :f] | hash_flow.rb:958:11:958:18 | ...[...] | provenance |  |
+| hash_flow.rb:958:11:958:14 | hash : Hash [element :f] | hash_flow.rb:958:11:958:18 | ...[...] | provenance |  |
 | hash_flow.rb:958:11:958:18 | ...[...] | hash_flow.rb:958:10:958:19 | ( ... ) | provenance |  |
-| hash_flow.rb:960:11:960:15 | hash1 [element :a] | hash_flow.rb:960:11:960:19 | ...[...] | provenance |  |
+| hash_flow.rb:960:11:960:15 | hash1 : Hash [element :a] | hash_flow.rb:960:11:960:19 | ...[...] | provenance |  |
 | hash_flow.rb:960:11:960:19 | ...[...] | hash_flow.rb:960:10:960:20 | ( ... ) | provenance |  |
-| hash_flow.rb:962:11:962:15 | hash1 [element :c] | hash_flow.rb:962:11:962:19 | ...[...] | provenance |  |
+| hash_flow.rb:962:11:962:15 | hash1 : Hash [element :c] | hash_flow.rb:962:11:962:19 | ...[...] | provenance |  |
 | hash_flow.rb:962:11:962:19 | ...[...] | hash_flow.rb:962:10:962:20 | ( ... ) | provenance |  |
-| hash_flow.rb:963:11:963:15 | hash1 [element :d] | hash_flow.rb:963:11:963:19 | ...[...] | provenance |  |
+| hash_flow.rb:963:11:963:15 | hash1 : Hash [element :d] | hash_flow.rb:963:11:963:19 | ...[...] | provenance |  |
 | hash_flow.rb:963:11:963:19 | ...[...] | hash_flow.rb:963:10:963:20 | ( ... ) | provenance |  |
-| hash_flow.rb:965:11:965:15 | hash1 [element :f] | hash_flow.rb:965:11:965:19 | ...[...] | provenance |  |
+| hash_flow.rb:965:11:965:15 | hash1 : Hash [element :f] | hash_flow.rb:965:11:965:19 | ...[...] | provenance |  |
 | hash_flow.rb:965:11:965:19 | ...[...] | hash_flow.rb:965:10:965:20 | ( ... ) | provenance |  |
-| hash_flow.rb:971:5:971:5 | h [element :b] | hash_flow.rb:973:10:973:10 | h [element :b] | provenance |  |
-| hash_flow.rb:971:5:971:5 | h [element :b] | hash_flow.rb:975:10:975:10 | h [element :b] | provenance |  |
-| hash_flow.rb:971:9:971:38 | ...[...] [element :b] | hash_flow.rb:971:5:971:5 | h [element :b] | provenance |  |
-| hash_flow.rb:971:23:971:31 | call to taint | hash_flow.rb:971:9:971:38 | ...[...] [element :b] | provenance |  |
-| hash_flow.rb:973:10:973:10 | h [element :b] | hash_flow.rb:973:10:973:14 | ...[...] | provenance |  |
-| hash_flow.rb:975:10:975:10 | h [element :b] | hash_flow.rb:975:10:975:13 | ...[...] | provenance |  |
-| hash_flow.rb:994:9:994:10 | h2 [element :b] | hash_flow.rb:996:14:996:15 | h2 [element :b] | provenance |  |
-| hash_flow.rb:994:9:994:10 | h2 [element :b] | hash_flow.rb:998:14:998:15 | h2 [element :b] | provenance |  |
-| hash_flow.rb:994:14:994:47 | ...[...] [element :b] | hash_flow.rb:994:9:994:10 | h2 [element :b] | provenance |  |
-| hash_flow.rb:994:30:994:40 | call to taint | hash_flow.rb:994:14:994:47 | ...[...] [element :b] | provenance |  |
-| hash_flow.rb:996:14:996:15 | h2 [element :b] | hash_flow.rb:996:14:996:19 | ...[...] | provenance |  |
-| hash_flow.rb:998:14:998:15 | h2 [element :b] | hash_flow.rb:998:14:998:18 | ...[...] | provenance |  |
-| hash_flow.rb:1011:5:1011:5 | h [element :a] | hash_flow.rb:1012:5:1012:5 | h [element :a] | provenance |  |
-| hash_flow.rb:1011:9:1011:45 | call to [] [element :a] | hash_flow.rb:1011:5:1011:5 | h [element :a] | provenance |  |
-| hash_flow.rb:1011:14:1011:24 | call to taint | hash_flow.rb:1011:9:1011:45 | call to [] [element :a] | provenance |  |
-| hash_flow.rb:1012:5:1012:5 | h [element :a] | hash_flow.rb:1012:15:1012:15 | k | provenance |  |
-| hash_flow.rb:1012:5:1012:5 | h [element :a] | hash_flow.rb:1012:18:1012:18 | v | provenance |  |
+| hash_flow.rb:971:5:971:5 | h : Hash [element :b] | hash_flow.rb:973:10:973:10 | h : Hash [element :b] | provenance |  |
+| hash_flow.rb:971:5:971:5 | h : Hash [element :b] | hash_flow.rb:975:10:975:10 | h : Hash [element :b] | provenance |  |
+| hash_flow.rb:971:9:971:38 | ...[...] : Hash [element :b] | hash_flow.rb:971:5:971:5 | h : Hash [element :b] | provenance |  |
+| hash_flow.rb:971:23:971:31 | call to taint | hash_flow.rb:971:9:971:38 | ...[...] : Hash [element :b] | provenance |  |
+| hash_flow.rb:973:10:973:10 | h : Hash [element :b] | hash_flow.rb:973:10:973:14 | ...[...] | provenance |  |
+| hash_flow.rb:975:10:975:10 | h : Hash [element :b] | hash_flow.rb:975:10:975:13 | ...[...] | provenance |  |
+| hash_flow.rb:994:9:994:10 | h2 : Hash [element :b] | hash_flow.rb:996:14:996:15 | h2 : Hash [element :b] | provenance |  |
+| hash_flow.rb:994:9:994:10 | h2 : Hash [element :b] | hash_flow.rb:998:14:998:15 | h2 : Hash [element :b] | provenance |  |
+| hash_flow.rb:994:14:994:47 | ...[...] : Hash [element :b] | hash_flow.rb:994:9:994:10 | h2 : Hash [element :b] | provenance |  |
+| hash_flow.rb:994:30:994:40 | call to taint | hash_flow.rb:994:14:994:47 | ...[...] : Hash [element :b] | provenance |  |
+| hash_flow.rb:996:14:996:15 | h2 : Hash [element :b] | hash_flow.rb:996:14:996:19 | ...[...] | provenance |  |
+| hash_flow.rb:998:14:998:15 | h2 : Hash [element :b] | hash_flow.rb:998:14:998:18 | ...[...] | provenance |  |
+| hash_flow.rb:1011:5:1011:5 | h : Hash [element :a] | hash_flow.rb:1012:5:1012:5 | h : Hash [element :a] | provenance |  |
+| hash_flow.rb:1011:9:1011:45 | call to [] : Hash [element :a] | hash_flow.rb:1011:5:1011:5 | h : Hash [element :a] | provenance |  |
+| hash_flow.rb:1011:14:1011:24 | call to taint | hash_flow.rb:1011:9:1011:45 | call to [] : Hash [element :a] | provenance |  |
+| hash_flow.rb:1012:5:1012:5 | h : Hash [element :a] | hash_flow.rb:1012:15:1012:15 | k | provenance |  |
+| hash_flow.rb:1012:5:1012:5 | h : Hash [element :a] | hash_flow.rb:1012:18:1012:18 | v | provenance |  |
 | hash_flow.rb:1012:15:1012:15 | k | hash_flow.rb:1014:14:1014:14 | k | provenance |  |
 | hash_flow.rb:1012:18:1012:18 | v | hash_flow.rb:1013:14:1013:14 | v | provenance |  |
 nodes
-| hash_flow.rb:10:5:10:8 | hash [element 0] | semmle.label | hash [element 0] |
-| hash_flow.rb:10:5:10:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:10:5:10:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:10:5:10:8 | hash [element e] | semmle.label | hash [element e] |
-| hash_flow.rb:10:5:10:8 | hash [element g] | semmle.label | hash [element g] |
-| hash_flow.rb:10:12:21:5 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| hash_flow.rb:10:12:21:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:10:12:21:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
-| hash_flow.rb:10:12:21:5 | call to [] [element e] | semmle.label | call to [] [element e] |
-| hash_flow.rb:10:12:21:5 | call to [] [element g] | semmle.label | call to [] [element g] |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element 0] | semmle.label | hash : Hash [element 0] |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element e] | semmle.label | hash : Hash [element e] |
+| hash_flow.rb:10:5:10:8 | hash : Hash [element g] | semmle.label | hash : Hash [element g] |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element 0] | semmle.label | call to [] : Hash [element 0] |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element e] | semmle.label | call to [] : Hash [element e] |
+| hash_flow.rb:10:12:21:5 | call to [] : Hash [element g] | semmle.label | call to [] : Hash [element g] |
 | hash_flow.rb:11:15:11:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:13:12:13:21 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:15:14:15:23 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:17:16:17:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:19:14:19:23 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:22:10:22:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:22:10:22:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:22:10:22:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:24:10:24:13 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:24:10:24:13 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:24:10:24:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:26:10:26:13 | hash [element e] | semmle.label | hash [element e] |
+| hash_flow.rb:26:10:26:13 | hash : Hash [element e] | semmle.label | hash : Hash [element e] |
 | hash_flow.rb:26:10:26:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:28:10:28:13 | hash [element g] | semmle.label | hash [element g] |
+| hash_flow.rb:28:10:28:13 | hash : Hash [element g] | semmle.label | hash : Hash [element g] |
 | hash_flow.rb:28:10:28:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:30:10:30:13 | hash [element 0] | semmle.label | hash [element 0] |
+| hash_flow.rb:30:10:30:13 | hash : Hash [element 0] | semmle.label | hash : Hash [element 0] |
 | hash_flow.rb:30:10:30:16 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:38:5:38:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
+| hash_flow.rb:38:5:38:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
 | hash_flow.rb:38:15:38:24 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:39:5:39:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
-| hash_flow.rb:39:5:39:8 | hash [element 0] | semmle.label | hash [element 0] |
-| hash_flow.rb:40:5:40:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
-| hash_flow.rb:40:5:40:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:40:5:40:8 | hash [element 0] | semmle.label | hash [element 0] |
+| hash_flow.rb:39:5:39:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
+| hash_flow.rb:39:5:39:8 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
+| hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
+| hash_flow.rb:40:5:40:8 | [post] hash : [collection] [element :a] | semmle.label | [post] hash : [collection] [element :a] |
+| hash_flow.rb:40:5:40:8 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
 | hash_flow.rb:40:16:40:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:41:5:41:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
-| hash_flow.rb:41:5:41:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:41:5:41:8 | hash [element 0] | semmle.label | hash [element 0] |
-| hash_flow.rb:41:5:41:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:42:5:42:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
-| hash_flow.rb:42:5:42:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:42:5:42:8 | [post] hash [element a] | semmle.label | [post] hash [element a] |
-| hash_flow.rb:42:5:42:8 | hash [element 0] | semmle.label | hash [element 0] |
-| hash_flow.rb:42:5:42:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
+| hash_flow.rb:41:5:41:8 | [post] hash : [collection] [element :a] | semmle.label | [post] hash : [collection] [element :a] |
+| hash_flow.rb:41:5:41:8 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
+| hash_flow.rb:41:5:41:8 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element :a] | semmle.label | [post] hash : [collection] [element :a] |
+| hash_flow.rb:42:5:42:8 | [post] hash : [collection] [element a] | semmle.label | [post] hash : [collection] [element a] |
+| hash_flow.rb:42:5:42:8 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
+| hash_flow.rb:42:5:42:8 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
 | hash_flow.rb:42:17:42:26 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:43:5:43:8 | [post] hash [element 0] | semmle.label | [post] hash [element 0] |
-| hash_flow.rb:43:5:43:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:43:5:43:8 | [post] hash [element a] | semmle.label | [post] hash [element a] |
-| hash_flow.rb:43:5:43:8 | hash [element 0] | semmle.label | hash [element 0] |
-| hash_flow.rb:43:5:43:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:43:5:43:8 | hash [element a] | semmle.label | hash [element a] |
-| hash_flow.rb:44:10:44:13 | hash [element 0] | semmle.label | hash [element 0] |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element 0] | semmle.label | [post] hash : [collection] [element 0] |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element :a] | semmle.label | [post] hash : [collection] [element :a] |
+| hash_flow.rb:43:5:43:8 | [post] hash : [collection] [element a] | semmle.label | [post] hash : [collection] [element a] |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
+| hash_flow.rb:43:5:43:8 | hash : [collection] [element a] | semmle.label | hash : [collection] [element a] |
+| hash_flow.rb:44:10:44:13 | hash : [collection] [element 0] | semmle.label | hash : [collection] [element 0] |
 | hash_flow.rb:44:10:44:16 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:46:10:46:13 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:46:10:46:13 | hash [element a] | semmle.label | hash [element a] |
+| hash_flow.rb:46:10:46:13 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
+| hash_flow.rb:46:10:46:13 | hash : [collection] [element a] | semmle.label | hash : [collection] [element a] |
 | hash_flow.rb:46:10:46:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:48:10:48:13 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:48:10:48:13 | hash [element a] | semmle.label | hash [element a] |
+| hash_flow.rb:48:10:48:13 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
+| hash_flow.rb:48:10:48:13 | hash : [collection] [element a] | semmle.label | hash : [collection] [element a] |
 | hash_flow.rb:48:10:48:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:55:5:55:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:55:13:55:37 | ...[...] [element :a] | semmle.label | ...[...] [element :a] |
+| hash_flow.rb:55:5:55:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:55:13:55:37 | ...[...] : Hash [element :a] | semmle.label | ...[...] : Hash [element :a] |
 | hash_flow.rb:55:21:55:30 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:56:10:56:14 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:56:10:56:14 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:56:10:56:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:59:5:59:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:59:9:59:29 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:59:5:59:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:59:9:59:29 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:59:13:59:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:60:5:60:9 | hash2 [element :a] | semmle.label | hash2 [element :a] |
-| hash_flow.rb:60:13:60:19 | ...[...] [element :a] | semmle.label | ...[...] [element :a] |
-| hash_flow.rb:60:18:60:18 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:61:10:61:14 | hash2 [element :a] | semmle.label | hash2 [element :a] |
+| hash_flow.rb:60:5:60:9 | hash2 : Hash [element :a] | semmle.label | hash2 : Hash [element :a] |
+| hash_flow.rb:60:13:60:19 | ...[...] : Hash [element :a] | semmle.label | ...[...] : Hash [element :a] |
+| hash_flow.rb:60:18:60:18 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:61:10:61:14 | hash2 : Hash [element :a] | semmle.label | hash2 : Hash [element :a] |
 | hash_flow.rb:61:10:61:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:64:5:64:9 | hash3 [element] | semmle.label | hash3 [element] |
-| hash_flow.rb:64:13:64:45 | ...[...] [element] | semmle.label | ...[...] [element] |
-| hash_flow.rb:64:18:64:44 | call to [] [element 0, element 1] | semmle.label | call to [] [element 0, element 1] |
-| hash_flow.rb:64:19:64:34 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| hash_flow.rb:64:5:64:9 | hash3 : [collection] [element] | semmle.label | hash3 : [collection] [element] |
+| hash_flow.rb:64:13:64:45 | ...[...] : [collection] [element] | semmle.label | ...[...] : [collection] [element] |
+| hash_flow.rb:64:18:64:44 | call to [] : Array [element 0, element 1] | semmle.label | call to [] : Array [element 0, element 1] |
+| hash_flow.rb:64:19:64:34 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | hash_flow.rb:64:24:64:33 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:65:10:65:14 | hash3 [element] | semmle.label | hash3 [element] |
+| hash_flow.rb:65:10:65:14 | hash3 : [collection] [element] | semmle.label | hash3 : [collection] [element] |
 | hash_flow.rb:65:10:65:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:66:10:66:14 | hash3 [element] | semmle.label | hash3 [element] |
+| hash_flow.rb:66:10:66:14 | hash3 : [collection] [element] | semmle.label | hash3 : [collection] [element] |
 | hash_flow.rb:66:10:66:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:68:5:68:9 | hash4 [element :a] | semmle.label | hash4 [element :a] |
-| hash_flow.rb:68:13:68:39 | ...[...] [element :a] | semmle.label | ...[...] [element :a] |
+| hash_flow.rb:68:5:68:9 | hash4 : [collection] [element :a] | semmle.label | hash4 : [collection] [element :a] |
+| hash_flow.rb:68:13:68:39 | ...[...] : [collection] [element :a] | semmle.label | ...[...] : [collection] [element :a] |
 | hash_flow.rb:68:22:68:31 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:69:10:69:14 | hash4 [element :a] | semmle.label | hash4 [element :a] |
+| hash_flow.rb:69:10:69:14 | hash4 : [collection] [element :a] | semmle.label | hash4 : [collection] [element :a] |
 | hash_flow.rb:69:10:69:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:72:5:72:9 | hash5 [element a] | semmle.label | hash5 [element a] |
-| hash_flow.rb:72:13:72:45 | ...[...] [element a] | semmle.label | ...[...] [element a] |
+| hash_flow.rb:72:5:72:9 | hash5 : Hash [element a] | semmle.label | hash5 : Hash [element a] |
+| hash_flow.rb:72:13:72:45 | ...[...] : Hash [element a] | semmle.label | ...[...] : Hash [element a] |
 | hash_flow.rb:72:25:72:34 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:73:10:73:14 | hash5 [element a] | semmle.label | hash5 [element a] |
+| hash_flow.rb:73:10:73:14 | hash5 : Hash [element a] | semmle.label | hash5 : Hash [element a] |
 | hash_flow.rb:73:10:73:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:76:5:76:9 | hash6 [element a] | semmle.label | hash6 [element a] |
-| hash_flow.rb:76:13:76:47 | ...[...] [element a] | semmle.label | ...[...] [element a] |
-| hash_flow.rb:76:18:76:46 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_flow.rb:76:5:76:9 | hash6 : Hash [element a] | semmle.label | hash6 : Hash [element a] |
+| hash_flow.rb:76:13:76:47 | ...[...] : Hash [element a] | semmle.label | ...[...] : Hash [element a] |
+| hash_flow.rb:76:18:76:46 | call to [] : Hash [element a] | semmle.label | call to [] : Hash [element a] |
 | hash_flow.rb:76:26:76:35 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:77:10:77:14 | hash6 [element a] | semmle.label | hash6 [element a] |
+| hash_flow.rb:77:10:77:14 | hash6 : Hash [element a] | semmle.label | hash6 : Hash [element a] |
 | hash_flow.rb:77:10:77:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:84:5:84:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:84:13:84:42 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:84:5:84:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:84:13:84:42 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:84:26:84:35 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:85:10:85:14 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:85:10:85:14 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:85:10:85:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:92:5:92:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:92:12:95:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:92:5:92:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:92:12:95:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:93:15:93:24 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:96:5:96:9 | hash2 [element :a] | semmle.label | hash2 [element :a] |
-| hash_flow.rb:96:13:96:34 | call to try_convert [element :a] | semmle.label | call to try_convert [element :a] |
-| hash_flow.rb:96:30:96:33 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:97:10:97:14 | hash2 [element :a] | semmle.label | hash2 [element :a] |
+| hash_flow.rb:96:5:96:9 | hash2 : Hash [element :a] | semmle.label | hash2 : Hash [element :a] |
+| hash_flow.rb:96:13:96:34 | call to try_convert : Hash [element :a] | semmle.label | call to try_convert : Hash [element :a] |
+| hash_flow.rb:96:30:96:33 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:97:10:97:14 | hash2 : Hash [element :a] | semmle.label | hash2 : Hash [element :a] |
 | hash_flow.rb:97:10:97:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:105:5:105:5 | b | semmle.label | b |
 | hash_flow.rb:105:21:105:30 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:106:10:106:10 | b | semmle.label | b |
 | hash_flow.rb:113:5:113:5 | b | semmle.label | b |
-| hash_flow.rb:113:9:113:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
+| hash_flow.rb:113:9:113:12 | [post] hash : [collection] [element :a] | semmle.label | [post] hash : [collection] [element :a] |
 | hash_flow.rb:113:9:113:34 | call to store | semmle.label | call to store |
 | hash_flow.rb:113:24:113:33 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:114:10:114:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:114:10:114:13 | hash : [collection] [element :a] | semmle.label | hash : [collection] [element :a] |
 | hash_flow.rb:114:10:114:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:115:10:115:10 | b | semmle.label | b |
 | hash_flow.rb:118:5:118:5 | c | semmle.label | c |
-| hash_flow.rb:118:9:118:12 | [post] hash [element] | semmle.label | [post] hash [element] |
+| hash_flow.rb:118:9:118:12 | [post] hash : [collection] [element] | semmle.label | [post] hash : [collection] [element] |
 | hash_flow.rb:118:9:118:33 | call to store | semmle.label | call to store |
 | hash_flow.rb:118:23:118:32 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:119:10:119:13 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:119:10:119:13 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:119:10:119:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:120:10:120:13 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:120:10:120:13 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:120:10:120:17 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:121:10:121:10 | c | semmle.label | c |
-| hash_flow.rb:127:5:127:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:127:12:130:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:127:5:127:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:127:12:130:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:128:15:128:24 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:131:5:131:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:131:5:131:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:131:18:131:29 | key_or_value | semmle.label | key_or_value |
 | hash_flow.rb:132:14:132:25 | key_or_value | semmle.label | key_or_value |
-| hash_flow.rb:134:5:134:8 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:134:5:134:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:134:22:134:26 | value | semmle.label | value |
 | hash_flow.rb:136:14:136:18 | value | semmle.label | value |
-| hash_flow.rb:143:5:143:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:143:12:146:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:143:5:143:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:143:12:146:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:144:15:144:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:147:5:147:5 | b [element 1] | semmle.label | b [element 1] |
-| hash_flow.rb:147:9:147:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:147:9:147:22 | call to assoc [element 1] | semmle.label | call to assoc [element 1] |
-| hash_flow.rb:149:10:149:10 | b [element 1] | semmle.label | b [element 1] |
+| hash_flow.rb:147:5:147:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| hash_flow.rb:147:9:147:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:147:9:147:22 | call to assoc : [collection] [element 1] | semmle.label | call to assoc : [collection] [element 1] |
+| hash_flow.rb:149:10:149:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | hash_flow.rb:149:10:149:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:150:10:150:10 | b [element 1] | semmle.label | b [element 1] |
+| hash_flow.rb:150:10:150:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | hash_flow.rb:150:10:150:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:151:5:151:5 | c [element 1] | semmle.label | c [element 1] |
-| hash_flow.rb:151:9:151:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:151:9:151:21 | call to assoc [element 1] | semmle.label | call to assoc [element 1] |
-| hash_flow.rb:152:10:152:10 | c [element 1] | semmle.label | c [element 1] |
+| hash_flow.rb:151:5:151:5 | c : [collection] [element 1] | semmle.label | c : [collection] [element 1] |
+| hash_flow.rb:151:9:151:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:151:9:151:21 | call to assoc : [collection] [element 1] | semmle.label | call to assoc : [collection] [element 1] |
+| hash_flow.rb:152:10:152:10 | c : [collection] [element 1] | semmle.label | c : [collection] [element 1] |
 | hash_flow.rb:152:10:152:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:169:5:169:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:169:12:172:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:169:5:169:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:169:12:172:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:170:15:170:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:173:5:173:5 | a [element :a] | semmle.label | a [element :a] |
-| hash_flow.rb:173:9:173:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:173:9:173:20 | call to compact [element :a] | semmle.label | call to compact [element :a] |
-| hash_flow.rb:174:10:174:10 | a [element :a] | semmle.label | a [element :a] |
+| hash_flow.rb:173:5:173:5 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
+| hash_flow.rb:173:9:173:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:173:9:173:20 | call to compact : Hash [element :a] | semmle.label | call to compact : Hash [element :a] |
+| hash_flow.rb:174:10:174:10 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
 | hash_flow.rb:174:10:174:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:181:5:181:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:181:12:184:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:181:5:181:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:181:12:184:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:182:15:182:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:185:5:185:5 | a | semmle.label | a |
-| hash_flow.rb:185:9:185:12 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:185:9:185:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:185:9:185:23 | call to delete | semmle.label | call to delete |
 | hash_flow.rb:186:10:186:10 | a | semmle.label | a |
-| hash_flow.rb:193:5:193:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:193:12:196:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:193:5:193:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:193:12:196:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:194:15:194:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:197:5:197:5 | a [element :a] | semmle.label | a [element :a] |
-| hash_flow.rb:197:9:197:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:197:9:197:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:197:9:200:7 | call to delete_if [element :a] | semmle.label | call to delete_if [element :a] |
+| hash_flow.rb:197:5:197:5 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
+| hash_flow.rb:197:9:197:12 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:197:9:197:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:197:9:200:7 | call to delete_if : Hash [element :a] | semmle.label | call to delete_if : Hash [element :a] |
 | hash_flow.rb:197:33:197:37 | value | semmle.label | value |
 | hash_flow.rb:199:14:199:18 | value | semmle.label | value |
-| hash_flow.rb:201:10:201:10 | a [element :a] | semmle.label | a [element :a] |
+| hash_flow.rb:201:10:201:10 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
 | hash_flow.rb:201:10:201:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:202:10:202:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:202:10:202:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:202:10:202:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:209:5:209:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:209:5:209:8 | hash [element :c, element :d] | semmle.label | hash [element :c, element :d] |
-| hash_flow.rb:209:12:216:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:209:12:216:5 | call to [] [element :c, element :d] | semmle.label | call to [] [element :c, element :d] |
+| hash_flow.rb:209:5:209:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:209:5:209:8 | hash : Hash [element :c, element :d] | semmle.label | hash : Hash [element :c, element :d] |
+| hash_flow.rb:209:12:216:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:209:12:216:5 | call to [] : Hash [element :c, element :d] | semmle.label | call to [] : Hash [element :c, element :d] |
 | hash_flow.rb:210:15:210:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:212:15:215:9 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:212:15:215:9 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
 | hash_flow.rb:213:19:213:29 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:217:10:217:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:217:10:217:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:217:10:217:21 | call to dig | semmle.label | call to dig |
-| hash_flow.rb:219:10:219:13 | hash [element :c, element :d] | semmle.label | hash [element :c, element :d] |
+| hash_flow.rb:219:10:219:13 | hash : Hash [element :c, element :d] | semmle.label | hash : Hash [element :c, element :d] |
 | hash_flow.rb:219:10:219:24 | call to dig | semmle.label | call to dig |
-| hash_flow.rb:226:5:226:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:226:12:229:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:226:5:226:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:226:12:229:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:227:15:227:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:230:5:230:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:230:9:230:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:230:9:233:7 | call to each [element :a] | semmle.label | call to each [element :a] |
+| hash_flow.rb:230:5:230:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:230:9:230:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:230:9:233:7 | call to each : Hash [element :a] | semmle.label | call to each : Hash [element :a] |
 | hash_flow.rb:230:28:230:32 | value | semmle.label | value |
 | hash_flow.rb:232:14:232:18 | value | semmle.label | value |
-| hash_flow.rb:234:10:234:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_flow.rb:234:10:234:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_flow.rb:234:10:234:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:241:5:241:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:241:12:244:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:241:5:241:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:241:12:244:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:242:15:242:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:245:5:245:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:245:9:245:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:245:9:247:7 | call to each_key [element :a] | semmle.label | call to each_key [element :a] |
-| hash_flow.rb:248:10:248:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_flow.rb:245:5:245:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:245:9:245:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:245:9:247:7 | call to each_key : Hash [element :a] | semmle.label | call to each_key : Hash [element :a] |
+| hash_flow.rb:248:10:248:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_flow.rb:248:10:248:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:255:5:255:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:255:12:258:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:255:5:255:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:255:12:258:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:256:15:256:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:259:5:259:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:259:9:259:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:259:9:262:7 | call to each_pair [element :a] | semmle.label | call to each_pair [element :a] |
+| hash_flow.rb:259:5:259:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:259:9:259:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:259:9:262:7 | call to each_pair : Hash [element :a] | semmle.label | call to each_pair : Hash [element :a] |
 | hash_flow.rb:259:33:259:37 | value | semmle.label | value |
 | hash_flow.rb:261:14:261:18 | value | semmle.label | value |
-| hash_flow.rb:263:10:263:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_flow.rb:263:10:263:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_flow.rb:263:10:263:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:270:5:270:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:270:12:273:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:270:5:270:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:270:12:273:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:271:15:271:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:274:5:274:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_flow.rb:274:9:274:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:274:9:276:7 | call to each_value [element :a] | semmle.label | call to each_value [element :a] |
+| hash_flow.rb:274:5:274:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_flow.rb:274:9:274:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:274:9:276:7 | call to each_value : Hash [element :a] | semmle.label | call to each_value : Hash [element :a] |
 | hash_flow.rb:274:29:274:33 | value | semmle.label | value |
 | hash_flow.rb:275:14:275:18 | value | semmle.label | value |
-| hash_flow.rb:277:10:277:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_flow.rb:277:10:277:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_flow.rb:277:10:277:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:284:5:284:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:284:12:289:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:284:5:284:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:284:12:289:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:287:15:287:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:290:5:290:5 | x [element :c] | semmle.label | x [element :c] |
-| hash_flow.rb:290:9:290:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:290:9:290:28 | call to except [element :c] | semmle.label | call to except [element :c] |
-| hash_flow.rb:293:10:293:10 | x [element :c] | semmle.label | x [element :c] |
+| hash_flow.rb:290:5:290:5 | x : Hash [element :c] | semmle.label | x : Hash [element :c] |
+| hash_flow.rb:290:9:290:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:290:9:290:28 | call to except : Hash [element :c] | semmle.label | call to except : Hash [element :c] |
+| hash_flow.rb:293:10:293:10 | x : Hash [element :c] | semmle.label | x : Hash [element :c] |
 | hash_flow.rb:293:10:293:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:300:5:300:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:300:5:300:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:300:12:304:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:300:12:304:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:300:5:300:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:300:12:304:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:300:12:304:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:301:15:301:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:303:15:303:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:305:5:305:5 | b | semmle.label | b |
-| hash_flow.rb:305:9:305:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:305:9:305:12 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:305:9:305:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:305:9:305:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:305:9:307:7 | call to fetch | semmle.label | call to fetch |
 | hash_flow.rb:305:20:305:30 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:305:37:305:37 | x | semmle.label | x |
 | hash_flow.rb:306:14:306:14 | x | semmle.label | x |
 | hash_flow.rb:308:10:308:10 | b | semmle.label | b |
 | hash_flow.rb:309:5:309:5 | b | semmle.label | b |
-| hash_flow.rb:309:9:309:12 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:309:9:309:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:309:9:309:22 | call to fetch | semmle.label | call to fetch |
 | hash_flow.rb:310:10:310:10 | b | semmle.label | b |
 | hash_flow.rb:311:5:311:5 | b | semmle.label | b |
-| hash_flow.rb:311:9:311:12 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:311:9:311:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:311:9:311:35 | call to fetch | semmle.label | call to fetch |
 | hash_flow.rb:311:24:311:34 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:312:10:312:10 | b | semmle.label | b |
@@ -1369,911 +1369,911 @@ nodes
 | hash_flow.rb:313:24:313:34 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:314:10:314:10 | b | semmle.label | b |
 | hash_flow.rb:315:5:315:5 | b | semmle.label | b |
-| hash_flow.rb:315:9:315:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:315:9:315:12 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:315:9:315:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:315:9:315:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:315:9:315:34 | call to fetch | semmle.label | call to fetch |
 | hash_flow.rb:315:23:315:33 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:316:10:316:10 | b | semmle.label | b |
-| hash_flow.rb:322:5:322:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:322:5:322:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:322:12:326:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:322:12:326:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:322:5:322:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:322:12:326:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:322:12:326:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:323:15:323:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:325:15:325:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:327:5:327:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:327:9:327:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:327:9:327:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:327:9:330:7 | call to fetch_values [element] | semmle.label | call to fetch_values [element] |
+| hash_flow.rb:327:5:327:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:327:9:327:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:327:9:327:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:327:9:330:7 | call to fetch_values : [collection] [element] | semmle.label | call to fetch_values : [collection] [element] |
 | hash_flow.rb:327:27:327:37 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:327:44:327:44 | x | semmle.label | x |
 | hash_flow.rb:328:14:328:14 | x | semmle.label | x |
 | hash_flow.rb:329:9:329:19 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:331:10:331:10 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:331:10:331:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:331:10:331:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:332:5:332:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:332:9:332:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:332:9:332:29 | call to fetch_values [element] | semmle.label | call to fetch_values [element] |
-| hash_flow.rb:333:10:333:10 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:332:5:332:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:332:9:332:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:332:9:332:29 | call to fetch_values : [collection] [element] | semmle.label | call to fetch_values : [collection] [element] |
+| hash_flow.rb:333:10:333:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:333:10:333:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:334:5:334:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:334:9:334:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:334:9:334:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:334:9:334:31 | call to fetch_values [element] | semmle.label | call to fetch_values [element] |
-| hash_flow.rb:335:10:335:10 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:334:5:334:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:334:9:334:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:334:9:334:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:334:9:334:31 | call to fetch_values : [collection] [element] | semmle.label | call to fetch_values : [collection] [element] |
+| hash_flow.rb:335:10:335:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:335:10:335:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:341:5:341:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:341:5:341:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:341:12:345:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:341:12:345:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:341:5:341:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:341:5:341:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:341:12:345:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:341:12:345:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:342:15:342:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:344:15:344:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:346:5:346:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:346:9:346:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:346:9:346:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:346:9:350:7 | call to filter [element :a] | semmle.label | call to filter [element :a] |
+| hash_flow.rb:346:5:346:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:346:9:346:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:346:9:346:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:346:9:350:7 | call to filter : Hash [element :a] | semmle.label | call to filter : Hash [element :a] |
 | hash_flow.rb:346:30:346:34 | value | semmle.label | value |
 | hash_flow.rb:348:14:348:18 | value | semmle.label | value |
 | hash_flow.rb:351:10:351:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:351:11:351:11 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:351:11:351:11 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:351:11:351:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:357:5:357:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:357:5:357:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:357:12:361:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:357:12:361:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:357:5:357:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:357:5:357:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:357:12:361:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:357:12:361:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:358:15:358:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:360:15:360:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:362:5:362:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:362:5:362:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:362:5:362:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:362:5:362:8 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:362:5:362:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:362:5:362:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:362:27:362:31 | value | semmle.label | value |
 | hash_flow.rb:364:14:364:18 | value | semmle.label | value |
 | hash_flow.rb:367:10:367:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:367:11:367:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:367:11:367:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:367:11:367:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:373:5:373:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:373:5:373:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:373:12:377:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:373:12:377:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:373:5:373:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:373:5:373:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:373:12:377:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:373:12:377:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:374:15:374:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:376:15:376:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:378:5:378:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:378:9:378:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:378:9:378:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:378:9:378:20 | call to flatten [element] | semmle.label | call to flatten [element] |
+| hash_flow.rb:378:5:378:5 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| hash_flow.rb:378:9:378:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:378:9:378:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:378:9:378:20 | call to flatten : [collection] [element] : [collection] | semmle.label | call to flatten : [collection] [element] : [collection] |
 | hash_flow.rb:379:10:379:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:379:11:379:11 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:379:11:379:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:385:5:385:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:385:5:385:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:385:12:389:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:385:12:389:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:379:11:379:11 | b : [collection] [element] : [collection] | semmle.label | b : [collection] [element] : [collection] |
+| hash_flow.rb:379:11:379:14 | ...[...] : [collection] | semmle.label | ...[...] : [collection] |
+| hash_flow.rb:385:5:385:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:385:5:385:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:385:12:389:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:385:12:389:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:386:15:386:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:388:15:388:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:390:5:390:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:390:9:390:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:390:9:390:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:390:9:390:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:390:9:394:7 | call to keep_if [element :a] | semmle.label | call to keep_if [element :a] |
+| hash_flow.rb:390:5:390:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:390:9:390:12 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:390:9:390:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:390:9:394:7 | call to keep_if : Hash [element :a] | semmle.label | call to keep_if : Hash [element :a] |
 | hash_flow.rb:390:31:390:35 | value | semmle.label | value |
 | hash_flow.rb:392:14:392:18 | value | semmle.label | value |
 | hash_flow.rb:395:10:395:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:395:11:395:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:395:11:395:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:395:11:395:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:396:10:396:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:396:11:396:11 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:396:11:396:11 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:396:11:396:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:402:5:402:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:402:5:402:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:402:13:406:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:402:13:406:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:402:5:402:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:402:5:402:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:402:13:406:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:402:13:406:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:403:15:403:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:405:15:405:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:407:5:407:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:407:5:407:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:407:13:411:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:407:13:411:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:407:5:407:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:407:5:407:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:407:13:411:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:407:13:411:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:408:15:408:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:410:15:410:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:412:5:412:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:412:5:412:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:412:5:412:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:412:5:412:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:412:12:412:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:412:12:412:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:412:12:416:7 | call to merge [element :a] | semmle.label | call to merge [element :a] |
-| hash_flow.rb:412:12:416:7 | call to merge [element :c] | semmle.label | call to merge [element :c] |
-| hash_flow.rb:412:12:416:7 | call to merge [element :d] | semmle.label | call to merge [element :d] |
-| hash_flow.rb:412:12:416:7 | call to merge [element :f] | semmle.label | call to merge [element :f] |
-| hash_flow.rb:412:24:412:28 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:412:24:412:28 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:412:5:412:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:412:12:412:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :a] | semmle.label | call to merge : Hash [element :a] |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :c] | semmle.label | call to merge : Hash [element :c] |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :d] | semmle.label | call to merge : Hash [element :d] |
+| hash_flow.rb:412:12:416:7 | call to merge : Hash [element :f] | semmle.label | call to merge : Hash [element :f] |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:412:24:412:28 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:412:40:412:48 | old_value | semmle.label | old_value |
 | hash_flow.rb:412:51:412:59 | new_value | semmle.label | new_value |
 | hash_flow.rb:414:14:414:22 | old_value | semmle.label | old_value |
 | hash_flow.rb:415:14:415:22 | new_value | semmle.label | new_value |
 | hash_flow.rb:417:10:417:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:417:11:417:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:417:11:417:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:417:11:417:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:419:10:419:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:419:11:419:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:419:11:419:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:419:11:419:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:420:10:420:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:420:11:420:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:420:11:420:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:420:11:420:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:422:10:422:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:422:11:422:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:422:11:422:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:422:11:422:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:428:5:428:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:428:5:428:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:428:13:432:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:428:13:432:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:428:5:428:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:428:5:428:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:428:13:432:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:428:13:432:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:429:15:429:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:431:15:431:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:433:5:433:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:433:5:433:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:433:13:437:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:433:13:437:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:433:5:433:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:433:5:433:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:433:13:437:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:433:13:437:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:434:15:434:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:436:15:436:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:438:5:438:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:438:5:438:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:438:5:438:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:438:5:438:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:438:12:438:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:438:12:438:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:438:12:438:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :a] | semmle.label | call to merge! [element :a] |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :c] | semmle.label | call to merge! [element :c] |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :d] | semmle.label | call to merge! [element :d] |
-| hash_flow.rb:438:12:442:7 | call to merge! [element :f] | semmle.label | call to merge! [element :f] |
-| hash_flow.rb:438:25:438:29 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:438:25:438:29 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:438:5:438:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:438:12:438:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:438:12:438:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :a] | semmle.label | call to merge! : Hash [element :a] |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :c] | semmle.label | call to merge! : Hash [element :c] |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :d] | semmle.label | call to merge! : Hash [element :d] |
+| hash_flow.rb:438:12:442:7 | call to merge! : Hash [element :f] | semmle.label | call to merge! : Hash [element :f] |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:438:25:438:29 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:438:41:438:49 | old_value | semmle.label | old_value |
 | hash_flow.rb:438:52:438:60 | new_value | semmle.label | new_value |
 | hash_flow.rb:440:14:440:22 | old_value | semmle.label | old_value |
 | hash_flow.rb:441:14:441:22 | new_value | semmle.label | new_value |
 | hash_flow.rb:443:10:443:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:443:11:443:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:443:11:443:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:443:11:443:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:445:10:445:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:445:11:445:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:445:11:445:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:445:11:445:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:446:10:446:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:446:11:446:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:446:11:446:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:446:11:446:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:448:10:448:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:448:11:448:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:448:11:448:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:448:11:448:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:450:10:450:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:450:11:450:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:450:11:450:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:450:11:450:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:452:10:452:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:452:11:452:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:452:11:452:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:452:11:452:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:453:10:453:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:453:11:453:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:453:11:453:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:453:11:453:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:455:10:455:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:455:11:455:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:455:11:455:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:455:11:455:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:461:5:461:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:461:12:464:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:461:5:461:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:461:12:464:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:462:15:462:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:465:5:465:5 | b [element 1] | semmle.label | b [element 1] |
-| hash_flow.rb:465:9:465:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:465:9:465:22 | call to rassoc [element 1] | semmle.label | call to rassoc [element 1] |
-| hash_flow.rb:467:10:467:10 | b [element 1] | semmle.label | b [element 1] |
+| hash_flow.rb:465:5:465:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| hash_flow.rb:465:9:465:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:465:9:465:22 | call to rassoc : [collection] [element 1] | semmle.label | call to rassoc : [collection] [element 1] |
+| hash_flow.rb:467:10:467:10 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | hash_flow.rb:467:10:467:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:473:5:473:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:473:12:476:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:473:5:473:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:473:12:476:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:474:15:474:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:477:5:477:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:477:9:477:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:477:9:481:7 | call to reject [element :a] | semmle.label | call to reject [element :a] |
+| hash_flow.rb:477:5:477:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:477:9:477:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:477:9:481:7 | call to reject : Hash [element :a] | semmle.label | call to reject : Hash [element :a] |
 | hash_flow.rb:477:29:477:33 | value | semmle.label | value |
 | hash_flow.rb:479:14:479:18 | value | semmle.label | value |
-| hash_flow.rb:482:10:482:10 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:482:10:482:10 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:482:10:482:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:488:5:488:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:488:12:491:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:488:5:488:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:488:12:491:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:489:15:489:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:492:5:492:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:492:9:492:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:492:9:492:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:492:9:496:7 | call to reject! [element :a] | semmle.label | call to reject! [element :a] |
+| hash_flow.rb:492:5:492:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:492:9:492:12 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:492:9:492:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:492:9:496:7 | call to reject! : Hash [element :a] | semmle.label | call to reject! : Hash [element :a] |
 | hash_flow.rb:492:30:492:34 | value | semmle.label | value |
 | hash_flow.rb:494:14:494:18 | value | semmle.label | value |
-| hash_flow.rb:497:10:497:10 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:497:10:497:10 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:497:10:497:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:498:10:498:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:498:10:498:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:498:10:498:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:504:5:504:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:504:5:504:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:504:12:508:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:504:12:508:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:504:5:504:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:504:5:504:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:504:12:508:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:504:12:508:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:505:15:505:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:507:15:507:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:512:5:512:9 | [post] hash2 [element :a] | semmle.label | [post] hash2 [element :a] |
-| hash_flow.rb:512:5:512:9 | [post] hash2 [element :c] | semmle.label | [post] hash2 [element :c] |
-| hash_flow.rb:512:19:512:22 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:512:19:512:22 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :a] | semmle.label | [post] hash2 : Hash [element :a] |
+| hash_flow.rb:512:5:512:9 | [post] hash2 : Hash [element :c] | semmle.label | [post] hash2 : Hash [element :c] |
+| hash_flow.rb:512:19:512:22 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:512:19:512:22 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:513:10:513:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:513:11:513:15 | hash2 [element :a] | semmle.label | hash2 [element :a] |
+| hash_flow.rb:513:11:513:15 | hash2 : Hash [element :a] | semmle.label | hash2 : Hash [element :a] |
 | hash_flow.rb:513:11:513:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:515:10:515:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:515:11:515:15 | hash2 [element :c] | semmle.label | hash2 [element :c] |
+| hash_flow.rb:515:11:515:15 | hash2 : Hash [element :c] | semmle.label | hash2 : Hash [element :c] |
 | hash_flow.rb:515:11:515:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:519:5:519:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:519:5:519:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:519:12:523:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:519:12:523:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:519:5:519:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:519:5:519:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:519:12:523:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:519:12:523:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:520:15:520:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:522:15:522:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:524:5:524:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:524:9:524:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:524:9:524:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:524:9:528:7 | call to select [element :a] | semmle.label | call to select [element :a] |
+| hash_flow.rb:524:5:524:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:524:9:524:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:524:9:524:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:524:9:528:7 | call to select : Hash [element :a] | semmle.label | call to select : Hash [element :a] |
 | hash_flow.rb:524:30:524:34 | value | semmle.label | value |
 | hash_flow.rb:526:14:526:18 | value | semmle.label | value |
 | hash_flow.rb:529:10:529:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:529:11:529:11 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:529:11:529:11 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:529:11:529:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:535:5:535:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:535:5:535:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:535:12:539:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:535:12:539:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:535:5:535:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:535:5:535:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:535:12:539:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:535:12:539:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:536:15:536:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:538:15:538:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:540:5:540:8 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:540:5:540:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:540:5:540:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:540:5:540:8 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:540:5:540:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:540:5:540:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:540:27:540:31 | value | semmle.label | value |
 | hash_flow.rb:542:14:542:18 | value | semmle.label | value |
 | hash_flow.rb:545:10:545:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:545:11:545:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:545:11:545:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:545:11:545:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:551:5:551:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:551:5:551:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:551:12:555:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:551:12:555:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:551:5:551:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:551:5:551:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:551:12:555:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:551:12:555:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:552:15:552:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:554:15:554:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:556:5:556:5 | b [element 1] | semmle.label | b [element 1] |
-| hash_flow.rb:556:9:556:12 | [post] hash [element :a] | semmle.label | [post] hash [element :a] |
-| hash_flow.rb:556:9:556:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:556:9:556:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:556:9:556:18 | call to shift [element 1] | semmle.label | call to shift [element 1] |
+| hash_flow.rb:556:5:556:5 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
+| hash_flow.rb:556:9:556:12 | [post] hash : Hash [element :a] | semmle.label | [post] hash : Hash [element :a] |
+| hash_flow.rb:556:9:556:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:556:9:556:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:556:9:556:18 | call to shift : [collection] [element 1] | semmle.label | call to shift : [collection] [element 1] |
 | hash_flow.rb:557:10:557:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:557:11:557:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:557:11:557:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:557:11:557:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:559:10:559:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:559:11:559:11 | b [element 1] | semmle.label | b [element 1] |
+| hash_flow.rb:559:11:559:11 | b : [collection] [element 1] | semmle.label | b : [collection] [element 1] |
 | hash_flow.rb:559:11:559:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:565:5:565:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:565:5:565:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:565:12:569:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:565:12:569:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:565:5:565:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:565:5:565:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:565:12:569:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:565:12:569:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:566:15:566:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:568:15:568:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:570:5:570:5 | b [element :a] | semmle.label | b [element :a] |
-| hash_flow.rb:570:9:570:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:570:9:570:26 | call to slice [element :a] | semmle.label | call to slice [element :a] |
+| hash_flow.rb:570:5:570:5 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
+| hash_flow.rb:570:9:570:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:570:9:570:26 | call to slice : Hash [element :a] | semmle.label | call to slice : Hash [element :a] |
 | hash_flow.rb:571:10:571:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:571:11:571:11 | b [element :a] | semmle.label | b [element :a] |
+| hash_flow.rb:571:11:571:11 | b : Hash [element :a] | semmle.label | b : Hash [element :a] |
 | hash_flow.rb:571:11:571:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:575:5:575:5 | c [element :a] | semmle.label | c [element :a] |
-| hash_flow.rb:575:5:575:5 | c [element :c] | semmle.label | c [element :c] |
-| hash_flow.rb:575:9:575:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:575:9:575:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:575:9:575:25 | call to slice [element :a] | semmle.label | call to slice [element :a] |
-| hash_flow.rb:575:9:575:25 | call to slice [element :c] | semmle.label | call to slice [element :c] |
+| hash_flow.rb:575:5:575:5 | c : Hash [element :a] | semmle.label | c : Hash [element :a] |
+| hash_flow.rb:575:5:575:5 | c : Hash [element :c] | semmle.label | c : Hash [element :c] |
+| hash_flow.rb:575:9:575:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:575:9:575:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:575:9:575:25 | call to slice : Hash [element :a] | semmle.label | call to slice : Hash [element :a] |
+| hash_flow.rb:575:9:575:25 | call to slice : Hash [element :c] | semmle.label | call to slice : Hash [element :c] |
 | hash_flow.rb:576:10:576:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:576:11:576:11 | c [element :a] | semmle.label | c [element :a] |
+| hash_flow.rb:576:11:576:11 | c : Hash [element :a] | semmle.label | c : Hash [element :a] |
 | hash_flow.rb:576:11:576:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:578:10:578:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:578:11:578:11 | c [element :c] | semmle.label | c [element :c] |
+| hash_flow.rb:578:11:578:11 | c : Hash [element :c] | semmle.label | c : Hash [element :c] |
 | hash_flow.rb:578:11:578:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:584:5:584:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:584:5:584:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:584:12:588:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:584:12:588:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:584:5:584:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:584:5:584:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:584:12:588:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:584:12:588:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:585:15:585:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:587:15:587:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:589:5:589:5 | a [element, element 1] | semmle.label | a [element, element 1] |
-| hash_flow.rb:589:9:589:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:589:9:589:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:589:9:589:17 | call to to_a [element, element 1] | semmle.label | call to to_a [element, element 1] |
+| hash_flow.rb:589:5:589:5 | a : [collection] [element, element 1] | semmle.label | a : [collection] [element, element 1] |
+| hash_flow.rb:589:9:589:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:589:9:589:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:589:9:589:17 | call to to_a : [collection] [element, element 1] | semmle.label | call to to_a : [collection] [element, element 1] |
 | hash_flow.rb:591:10:591:18 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:591:11:591:11 | a [element, element 1] | semmle.label | a [element, element 1] |
+| hash_flow.rb:591:11:591:11 | a : [collection] [element, element 1] | semmle.label | a : [collection] [element, element 1] |
 | hash_flow.rb:591:11:591:14 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | hash_flow.rb:591:11:591:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:597:5:597:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:597:5:597:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:597:12:601:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:597:12:601:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:597:5:597:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:597:12:601:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:597:12:601:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:598:15:598:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:600:15:600:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:602:5:602:5 | a [element :a] | semmle.label | a [element :a] |
-| hash_flow.rb:602:5:602:5 | a [element :c] | semmle.label | a [element :c] |
-| hash_flow.rb:602:9:602:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:602:9:602:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :a] | semmle.label | call to to_h [element :a] |
-| hash_flow.rb:602:9:602:17 | call to to_h [element :c] | semmle.label | call to to_h [element :c] |
+| hash_flow.rb:602:5:602:5 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
+| hash_flow.rb:602:5:602:5 | a : Hash [element :c] | semmle.label | a : Hash [element :c] |
+| hash_flow.rb:602:9:602:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:602:9:602:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :a] | semmle.label | call to to_h : Hash [element :a] |
+| hash_flow.rb:602:9:602:17 | call to to_h : Hash [element :c] | semmle.label | call to to_h : Hash [element :c] |
 | hash_flow.rb:603:10:603:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:603:11:603:11 | a [element :a] | semmle.label | a [element :a] |
+| hash_flow.rb:603:11:603:11 | a : Hash [element :a] | semmle.label | a : Hash [element :a] |
 | hash_flow.rb:603:11:603:15 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:605:10:605:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:605:11:605:11 | a [element :c] | semmle.label | a [element :c] |
+| hash_flow.rb:605:11:605:11 | a : Hash [element :c] | semmle.label | a : Hash [element :c] |
 | hash_flow.rb:605:11:605:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:607:5:607:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:607:9:607:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:607:9:607:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:607:9:611:7 | call to to_h [element] | semmle.label | call to to_h [element] |
+| hash_flow.rb:607:5:607:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:607:9:607:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:607:9:607:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:607:9:611:7 | call to to_h : [collection] [element] | semmle.label | call to to_h : [collection] [element] |
 | hash_flow.rb:607:28:607:32 | value | semmle.label | value |
 | hash_flow.rb:609:14:609:18 | value | semmle.label | value |
-| hash_flow.rb:610:9:610:25 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| hash_flow.rb:610:9:610:25 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | hash_flow.rb:610:14:610:24 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:612:10:612:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:612:11:612:11 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:612:11:612:11 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:612:11:612:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:618:5:618:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:618:5:618:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:618:12:622:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:618:12:622:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:618:5:618:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:618:5:618:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:618:12:622:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:618:12:622:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:619:15:619:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:621:15:621:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:623:5:623:5 | a [element] | semmle.label | a [element] |
-| hash_flow.rb:623:9:623:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:623:9:623:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:623:9:623:45 | call to transform_keys [element] | semmle.label | call to transform_keys [element] |
+| hash_flow.rb:623:5:623:5 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| hash_flow.rb:623:9:623:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:623:9:623:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:623:9:623:45 | call to transform_keys : [collection] [element] | semmle.label | call to transform_keys : [collection] [element] |
 | hash_flow.rb:624:10:624:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:624:11:624:11 | a [element] | semmle.label | a [element] |
+| hash_flow.rb:624:11:624:11 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | hash_flow.rb:624:11:624:16 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:625:10:625:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:625:11:625:11 | a [element] | semmle.label | a [element] |
+| hash_flow.rb:625:11:625:11 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | hash_flow.rb:625:11:625:16 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:626:10:626:17 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:626:11:626:11 | a [element] | semmle.label | a [element] |
+| hash_flow.rb:626:11:626:11 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | hash_flow.rb:626:11:626:16 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:632:5:632:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:632:5:632:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:632:12:636:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:632:12:636:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:632:5:632:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:632:12:636:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:632:12:636:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:633:15:633:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:635:15:635:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:637:5:637:8 | [post] hash [element] | semmle.label | [post] hash [element] |
+| hash_flow.rb:637:5:637:8 | [post] hash : [collection] [element] | semmle.label | [post] hash : [collection] [element] |
 | hash_flow.rb:637:15:637:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:639:5:639:8 | [post] hash [element] | semmle.label | [post] hash [element] |
-| hash_flow.rb:639:5:639:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:639:5:639:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:639:5:639:8 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:639:5:639:8 | [post] hash : [collection] [element] | semmle.label | [post] hash : [collection] [element] |
+| hash_flow.rb:639:5:639:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:639:5:639:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:639:5:639:8 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:640:10:640:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:640:11:640:14 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:640:11:640:14 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:640:11:640:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:640:11:640:14 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:640:11:640:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:641:10:641:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:641:11:641:14 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:641:11:641:14 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:641:11:641:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:642:10:642:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:642:11:642:14 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:642:11:642:14 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:642:11:642:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:642:11:642:14 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:642:11:642:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:648:5:648:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:648:5:648:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:648:12:652:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:648:12:652:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:648:5:648:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:648:5:648:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:648:12:652:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:648:12:652:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:649:15:649:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:651:15:651:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:653:5:653:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:653:9:653:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:653:9:653:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:653:9:656:7 | call to transform_values [element] | semmle.label | call to transform_values [element] |
+| hash_flow.rb:653:5:653:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:653:9:653:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:653:9:653:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:653:9:656:7 | call to transform_values : [collection] [element] | semmle.label | call to transform_values : [collection] [element] |
 | hash_flow.rb:653:35:653:39 | value | semmle.label | value |
 | hash_flow.rb:654:14:654:18 | value | semmle.label | value |
 | hash_flow.rb:655:9:655:19 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:657:10:657:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:657:11:657:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:657:11:657:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:657:11:657:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:658:10:658:16 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:658:11:658:11 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:658:11:658:11 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:658:11:658:15 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:664:5:664:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:664:5:664:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:664:12:668:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:664:12:668:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:664:5:664:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:664:5:664:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:664:12:668:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:664:12:668:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:665:15:665:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:667:15:667:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:669:5:669:8 | [post] hash [element] | semmle.label | [post] hash [element] |
-| hash_flow.rb:669:5:669:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:669:5:669:8 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:669:5:669:8 | [post] hash : [collection] [element] | semmle.label | [post] hash : [collection] [element] |
+| hash_flow.rb:669:5:669:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:669:5:669:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:669:32:669:36 | value | semmle.label | value |
 | hash_flow.rb:670:14:670:18 | value | semmle.label | value |
 | hash_flow.rb:671:9:671:19 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:673:10:673:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:673:11:673:14 | hash [element] | semmle.label | hash [element] |
+| hash_flow.rb:673:11:673:14 | hash : [collection] [element] | semmle.label | hash : [collection] [element] |
 | hash_flow.rb:673:11:673:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:679:5:679:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:679:5:679:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:679:13:683:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:679:13:683:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:679:5:679:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:679:5:679:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:679:13:683:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:679:13:683:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:680:15:680:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:682:15:682:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:684:5:684:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:684:5:684:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:684:13:688:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:684:13:688:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:684:5:684:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:684:5:684:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:684:13:688:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:684:13:688:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:685:15:685:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:687:15:687:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:689:5:689:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:689:5:689:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:689:5:689:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:689:5:689:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:689:12:689:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:689:12:689:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:689:12:689:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:689:12:693:7 | call to update [element :a] | semmle.label | call to update [element :a] |
-| hash_flow.rb:689:12:693:7 | call to update [element :c] | semmle.label | call to update [element :c] |
-| hash_flow.rb:689:12:693:7 | call to update [element :d] | semmle.label | call to update [element :d] |
-| hash_flow.rb:689:12:693:7 | call to update [element :f] | semmle.label | call to update [element :f] |
-| hash_flow.rb:689:25:689:29 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:689:25:689:29 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:689:5:689:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:689:12:689:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:689:12:689:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :a] | semmle.label | call to update : Hash [element :a] |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :c] | semmle.label | call to update : Hash [element :c] |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :d] | semmle.label | call to update : Hash [element :d] |
+| hash_flow.rb:689:12:693:7 | call to update : Hash [element :f] | semmle.label | call to update : Hash [element :f] |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:689:25:689:29 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:689:41:689:49 | old_value | semmle.label | old_value |
 | hash_flow.rb:689:52:689:60 | new_value | semmle.label | new_value |
 | hash_flow.rb:691:14:691:22 | old_value | semmle.label | old_value |
 | hash_flow.rb:692:14:692:22 | new_value | semmle.label | new_value |
 | hash_flow.rb:694:10:694:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:694:11:694:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:694:11:694:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:694:11:694:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:696:10:696:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:696:11:696:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:696:11:696:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:696:11:696:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:697:10:697:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:697:11:697:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:697:11:697:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:697:11:697:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:699:10:699:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:699:11:699:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:699:11:699:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:699:11:699:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:701:10:701:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:701:11:701:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:701:11:701:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:701:11:701:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:703:10:703:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:703:11:703:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:703:11:703:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:703:11:703:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:704:10:704:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:704:11:704:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:704:11:704:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:704:11:704:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:706:10:706:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:706:11:706:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:706:11:706:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:706:11:706:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:712:5:712:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:712:5:712:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:712:12:716:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:712:12:716:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:712:5:712:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:712:5:712:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:712:12:716:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:712:12:716:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:713:15:713:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:715:15:715:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:717:5:717:5 | a [element] | semmle.label | a [element] |
-| hash_flow.rb:717:9:717:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:717:9:717:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:717:9:717:19 | call to values [element] | semmle.label | call to values [element] |
+| hash_flow.rb:717:5:717:5 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| hash_flow.rb:717:9:717:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:717:9:717:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:717:9:717:19 | call to values : [collection] [element] | semmle.label | call to values : [collection] [element] |
 | hash_flow.rb:718:10:718:15 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:718:11:718:11 | a [element] | semmle.label | a [element] |
+| hash_flow.rb:718:11:718:11 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | hash_flow.rb:718:11:718:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:724:5:724:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:724:5:724:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:724:12:728:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:724:12:728:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:724:5:724:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:724:5:724:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:724:12:728:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:724:12:728:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:725:15:725:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:727:15:727:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:729:5:729:5 | b [element 0] | semmle.label | b [element 0] |
-| hash_flow.rb:729:9:729:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:729:9:729:26 | call to values_at [element 0] | semmle.label | call to values_at [element 0] |
-| hash_flow.rb:730:10:730:10 | b [element 0] | semmle.label | b [element 0] |
+| hash_flow.rb:729:5:729:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| hash_flow.rb:729:9:729:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:729:9:729:26 | call to values_at : [collection] [element 0] | semmle.label | call to values_at : [collection] [element 0] |
+| hash_flow.rb:730:10:730:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | hash_flow.rb:730:10:730:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:731:5:731:5 | b [element] | semmle.label | b [element] |
-| hash_flow.rb:731:9:731:12 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:731:9:731:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:731:9:731:31 | call to fetch_values [element] | semmle.label | call to fetch_values [element] |
-| hash_flow.rb:732:10:732:10 | b [element] | semmle.label | b [element] |
+| hash_flow.rb:731:5:731:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| hash_flow.rb:731:9:731:12 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:731:9:731:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:731:9:731:31 | call to fetch_values : [collection] [element] | semmle.label | call to fetch_values : [collection] [element] |
+| hash_flow.rb:732:10:732:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | hash_flow.rb:732:10:732:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:738:5:738:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:738:5:738:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:738:13:742:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:738:13:742:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:738:5:738:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:738:5:738:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:738:13:742:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:738:13:742:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:739:15:739:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:741:15:741:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:743:5:743:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:743:5:743:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:743:13:747:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:743:13:747:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:743:5:743:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:743:5:743:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:743:13:747:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:743:13:747:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:744:15:744:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:746:15:746:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:748:5:748:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:748:5:748:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:748:5:748:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:748:5:748:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:748:5:748:8 | hash [element :g] | semmle.label | hash [element :g] |
-| hash_flow.rb:748:12:748:59 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:748:12:748:59 | call to [] [element :c] | semmle.label | call to [] [element :c] |
-| hash_flow.rb:748:12:748:59 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:748:12:748:59 | call to [] [element :f] | semmle.label | call to [] [element :f] |
-| hash_flow.rb:748:12:748:59 | call to [] [element :g] | semmle.label | call to [] [element :g] |
-| hash_flow.rb:748:14:748:20 | ** ... [element :a] | semmle.label | ** ... [element :a] |
-| hash_flow.rb:748:14:748:20 | ** ... [element :c] | semmle.label | ** ... [element :c] |
-| hash_flow.rb:748:16:748:20 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:748:16:748:20 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:748:5:748:8 | hash : Hash [element :g] | semmle.label | hash : Hash [element :g] |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
+| hash_flow.rb:748:12:748:59 | call to [] : Hash [element :g] | semmle.label | call to [] : Hash [element :g] |
+| hash_flow.rb:748:14:748:20 | ** ... : Hash [element :a] | semmle.label | ** ... : Hash [element :a] |
+| hash_flow.rb:748:14:748:20 | ** ... : Hash [element :c] | semmle.label | ** ... : Hash [element :c] |
+| hash_flow.rb:748:16:748:20 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:748:16:748:20 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:748:29:748:39 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:748:42:748:48 | ** ... [element :d] | semmle.label | ** ... [element :d] |
-| hash_flow.rb:748:42:748:48 | ** ... [element :f] | semmle.label | ** ... [element :f] |
-| hash_flow.rb:748:44:748:48 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:748:44:748:48 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:749:10:749:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:748:42:748:48 | ** ... : Hash [element :d] | semmle.label | ** ... : Hash [element :d] |
+| hash_flow.rb:748:42:748:48 | ** ... : Hash [element :f] | semmle.label | ** ... : Hash [element :f] |
+| hash_flow.rb:748:44:748:48 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:748:44:748:48 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:749:10:749:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:749:10:749:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:751:10:751:13 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:751:10:751:13 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:751:10:751:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:752:10:752:13 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:752:10:752:13 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:752:10:752:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:754:10:754:13 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:754:10:754:13 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:754:10:754:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:755:10:755:13 | hash [element :g] | semmle.label | hash [element :g] |
+| hash_flow.rb:755:10:755:13 | hash : Hash [element :g] | semmle.label | hash : Hash [element :g] |
 | hash_flow.rb:755:10:755:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:762:5:762:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:762:5:762:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:762:5:762:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:762:12:767:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:762:12:767:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
-| hash_flow.rb:762:12:767:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:762:5:762:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
+| hash_flow.rb:762:12:767:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
 | hash_flow.rb:763:15:763:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:765:15:765:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:766:15:766:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:769:10:769:13 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:769:10:769:13 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:769:10:769:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:771:10:771:13 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:771:10:771:13 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:771:10:771:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:772:10:772:13 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:772:10:772:13 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:772:10:772:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:774:5:774:5 | x [element :c] | semmle.label | x [element :c] |
-| hash_flow.rb:774:9:774:12 | [post] hash [element :c] | semmle.label | [post] hash [element :c] |
-| hash_flow.rb:774:9:774:12 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:774:9:774:31 | call to except! [element :c] | semmle.label | call to except! [element :c] |
-| hash_flow.rb:778:10:778:10 | x [element :c] | semmle.label | x [element :c] |
+| hash_flow.rb:774:5:774:5 | x : Hash [element :c] | semmle.label | x : Hash [element :c] |
+| hash_flow.rb:774:9:774:12 | [post] hash : Hash [element :c] | semmle.label | [post] hash : Hash [element :c] |
+| hash_flow.rb:774:9:774:12 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:774:9:774:31 | call to except! : Hash [element :c] | semmle.label | call to except! : Hash [element :c] |
+| hash_flow.rb:778:10:778:10 | x : Hash [element :c] | semmle.label | x : Hash [element :c] |
 | hash_flow.rb:778:10:778:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:783:10:783:13 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:783:10:783:13 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:783:10:783:17 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:790:5:790:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:790:5:790:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:790:13:794:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:790:13:794:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:790:5:790:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:790:5:790:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:790:13:794:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:790:13:794:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:791:15:791:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:793:15:793:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:795:5:795:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:795:5:795:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:795:13:799:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:795:13:799:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:795:5:795:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:795:5:795:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:795:13:799:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:795:13:799:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:796:15:796:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:798:15:798:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:800:5:800:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:800:5:800:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:800:5:800:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:800:5:800:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:800:12:800:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:800:12:800:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :a] | semmle.label | call to deep_merge [element :a] |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :c] | semmle.label | call to deep_merge [element :c] |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :d] | semmle.label | call to deep_merge [element :d] |
-| hash_flow.rb:800:12:804:7 | call to deep_merge [element :f] | semmle.label | call to deep_merge [element :f] |
-| hash_flow.rb:800:29:800:33 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:800:29:800:33 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:800:5:800:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:800:12:800:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :a] | semmle.label | call to deep_merge : Hash [element :a] |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :c] | semmle.label | call to deep_merge : Hash [element :c] |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :d] | semmle.label | call to deep_merge : Hash [element :d] |
+| hash_flow.rb:800:12:804:7 | call to deep_merge : Hash [element :f] | semmle.label | call to deep_merge : Hash [element :f] |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:800:29:800:33 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:800:45:800:53 | old_value | semmle.label | old_value |
 | hash_flow.rb:800:56:800:64 | new_value | semmle.label | new_value |
 | hash_flow.rb:802:14:802:22 | old_value | semmle.label | old_value |
 | hash_flow.rb:803:14:803:22 | new_value | semmle.label | new_value |
 | hash_flow.rb:805:10:805:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:805:11:805:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:805:11:805:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:805:11:805:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:807:10:807:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:807:11:807:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:807:11:807:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:807:11:807:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:808:10:808:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:808:11:808:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:808:11:808:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:808:11:808:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:810:10:810:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:810:11:810:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:810:11:810:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:810:11:810:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:816:5:816:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:816:5:816:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:816:13:820:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:816:13:820:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:816:5:816:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:816:5:816:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:816:13:820:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:816:13:820:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:817:15:817:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:819:15:819:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:821:5:821:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:821:5:821:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:821:13:825:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:821:13:825:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:821:5:821:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:821:5:821:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:821:13:825:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:821:13:825:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:822:15:822:25 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:824:15:824:25 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:826:5:826:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:826:5:826:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:826:5:826:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:826:5:826:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:826:12:826:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:826:12:826:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:826:12:826:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :a] | semmle.label | call to deep_merge! [element :a] |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :c] | semmle.label | call to deep_merge! [element :c] |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :d] | semmle.label | call to deep_merge! [element :d] |
-| hash_flow.rb:826:12:830:7 | call to deep_merge! [element :f] | semmle.label | call to deep_merge! [element :f] |
-| hash_flow.rb:826:30:826:34 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:826:30:826:34 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:826:5:826:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:826:12:826:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:826:12:826:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :a] | semmle.label | call to deep_merge! : Hash [element :a] |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :c] | semmle.label | call to deep_merge! : Hash [element :c] |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :d] | semmle.label | call to deep_merge! : Hash [element :d] |
+| hash_flow.rb:826:12:830:7 | call to deep_merge! : Hash [element :f] | semmle.label | call to deep_merge! : Hash [element :f] |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:826:30:826:34 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:826:46:826:54 | old_value | semmle.label | old_value |
 | hash_flow.rb:826:57:826:65 | new_value | semmle.label | new_value |
 | hash_flow.rb:828:14:828:22 | old_value | semmle.label | old_value |
 | hash_flow.rb:829:14:829:22 | new_value | semmle.label | new_value |
 | hash_flow.rb:831:10:831:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:831:11:831:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:831:11:831:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:831:11:831:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:833:10:833:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:833:11:833:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:833:11:833:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:833:11:833:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:834:10:834:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:834:11:834:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:834:11:834:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:834:11:834:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:836:10:836:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:836:11:836:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:836:11:836:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:836:11:836:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:838:10:838:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:838:11:838:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:838:11:838:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:838:11:838:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:840:10:840:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:840:11:840:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:840:11:840:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:840:11:840:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:841:10:841:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:841:11:841:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:841:11:841:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:841:11:841:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:843:10:843:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:843:11:843:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:843:11:843:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:843:11:843:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:849:5:849:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:849:5:849:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:849:13:853:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:849:13:853:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:849:5:849:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:849:13:853:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:849:13:853:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:850:12:850:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:852:12:852:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:854:5:854:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:854:5:854:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:854:13:858:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:854:13:858:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:854:5:854:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:854:13:858:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:854:13:858:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:855:12:855:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:857:12:857:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:860:5:860:9 | hash3 [element :a] | semmle.label | hash3 [element :a] |
-| hash_flow.rb:860:5:860:9 | hash3 [element :c] | semmle.label | hash3 [element :c] |
-| hash_flow.rb:860:5:860:9 | hash3 [element :d] | semmle.label | hash3 [element :d] |
-| hash_flow.rb:860:5:860:9 | hash3 [element :f] | semmle.label | hash3 [element :f] |
-| hash_flow.rb:860:13:860:17 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:860:13:860:17 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :a] | semmle.label | call to reverse_merge [element :a] |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :c] | semmle.label | call to reverse_merge [element :c] |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :d] | semmle.label | call to reverse_merge [element :d] |
-| hash_flow.rb:860:13:860:38 | call to reverse_merge [element :f] | semmle.label | call to reverse_merge [element :f] |
-| hash_flow.rb:860:33:860:37 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:860:33:860:37 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :a] | semmle.label | hash3 : Hash [element :a] |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :c] | semmle.label | hash3 : Hash [element :c] |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :d] | semmle.label | hash3 : Hash [element :d] |
+| hash_flow.rb:860:5:860:9 | hash3 : Hash [element :f] | semmle.label | hash3 : Hash [element :f] |
+| hash_flow.rb:860:13:860:17 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:860:13:860:17 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :a] | semmle.label | call to reverse_merge : Hash [element :a] |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :c] | semmle.label | call to reverse_merge : Hash [element :c] |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :d] | semmle.label | call to reverse_merge : Hash [element :d] |
+| hash_flow.rb:860:13:860:38 | call to reverse_merge : Hash [element :f] | semmle.label | call to reverse_merge : Hash [element :f] |
+| hash_flow.rb:860:33:860:37 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:860:33:860:37 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:861:10:861:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:861:11:861:15 | hash3 [element :a] | semmle.label | hash3 [element :a] |
+| hash_flow.rb:861:11:861:15 | hash3 : Hash [element :a] | semmle.label | hash3 : Hash [element :a] |
 | hash_flow.rb:861:11:861:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:863:10:863:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:863:11:863:15 | hash3 [element :c] | semmle.label | hash3 [element :c] |
+| hash_flow.rb:863:11:863:15 | hash3 : Hash [element :c] | semmle.label | hash3 : Hash [element :c] |
 | hash_flow.rb:863:11:863:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:864:10:864:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:864:11:864:15 | hash3 [element :d] | semmle.label | hash3 [element :d] |
+| hash_flow.rb:864:11:864:15 | hash3 : Hash [element :d] | semmle.label | hash3 : Hash [element :d] |
 | hash_flow.rb:864:11:864:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:866:10:866:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:866:11:866:15 | hash3 [element :f] | semmle.label | hash3 [element :f] |
+| hash_flow.rb:866:11:866:15 | hash3 : Hash [element :f] | semmle.label | hash3 : Hash [element :f] |
 | hash_flow.rb:866:11:866:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:869:5:869:9 | hash4 [element :a] | semmle.label | hash4 [element :a] |
-| hash_flow.rb:869:5:869:9 | hash4 [element :c] | semmle.label | hash4 [element :c] |
-| hash_flow.rb:869:5:869:9 | hash4 [element :d] | semmle.label | hash4 [element :d] |
-| hash_flow.rb:869:5:869:9 | hash4 [element :f] | semmle.label | hash4 [element :f] |
-| hash_flow.rb:869:13:869:17 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:869:13:869:17 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :a] | semmle.label | call to with_defaults [element :a] |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :c] | semmle.label | call to with_defaults [element :c] |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :d] | semmle.label | call to with_defaults [element :d] |
-| hash_flow.rb:869:13:869:38 | call to with_defaults [element :f] | semmle.label | call to with_defaults [element :f] |
-| hash_flow.rb:869:33:869:37 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:869:33:869:37 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :a] | semmle.label | hash4 : Hash [element :a] |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :c] | semmle.label | hash4 : Hash [element :c] |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :d] | semmle.label | hash4 : Hash [element :d] |
+| hash_flow.rb:869:5:869:9 | hash4 : Hash [element :f] | semmle.label | hash4 : Hash [element :f] |
+| hash_flow.rb:869:13:869:17 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:869:13:869:17 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :a] | semmle.label | call to with_defaults : Hash [element :a] |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :c] | semmle.label | call to with_defaults : Hash [element :c] |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :d] | semmle.label | call to with_defaults : Hash [element :d] |
+| hash_flow.rb:869:13:869:38 | call to with_defaults : Hash [element :f] | semmle.label | call to with_defaults : Hash [element :f] |
+| hash_flow.rb:869:33:869:37 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:869:33:869:37 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:870:10:870:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:870:11:870:15 | hash4 [element :a] | semmle.label | hash4 [element :a] |
+| hash_flow.rb:870:11:870:15 | hash4 : Hash [element :a] | semmle.label | hash4 : Hash [element :a] |
 | hash_flow.rb:870:11:870:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:872:10:872:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:872:11:872:15 | hash4 [element :c] | semmle.label | hash4 [element :c] |
+| hash_flow.rb:872:11:872:15 | hash4 : Hash [element :c] | semmle.label | hash4 : Hash [element :c] |
 | hash_flow.rb:872:11:872:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:873:10:873:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:873:11:873:15 | hash4 [element :d] | semmle.label | hash4 [element :d] |
+| hash_flow.rb:873:11:873:15 | hash4 : Hash [element :d] | semmle.label | hash4 : Hash [element :d] |
 | hash_flow.rb:873:11:873:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:875:10:875:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:875:11:875:15 | hash4 [element :f] | semmle.label | hash4 [element :f] |
+| hash_flow.rb:875:11:875:15 | hash4 : Hash [element :f] | semmle.label | hash4 : Hash [element :f] |
 | hash_flow.rb:875:11:875:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:881:5:881:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:881:5:881:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:881:13:885:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:881:13:885:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:881:5:881:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:881:5:881:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:881:13:885:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:881:13:885:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:882:12:882:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:884:12:884:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:886:5:886:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:886:5:886:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:886:13:890:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:886:13:890:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:886:5:886:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:886:5:886:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:886:13:890:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:886:13:890:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:887:12:887:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:889:12:889:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:892:5:892:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:892:5:892:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:892:5:892:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:892:5:892:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:892:12:892:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:892:12:892:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:892:12:892:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :a] | semmle.label | call to reverse_merge! [element :a] |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :c] | semmle.label | call to reverse_merge! [element :c] |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :d] | semmle.label | call to reverse_merge! [element :d] |
-| hash_flow.rb:892:12:892:38 | call to reverse_merge! [element :f] | semmle.label | call to reverse_merge! [element :f] |
-| hash_flow.rb:892:33:892:37 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:892:33:892:37 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:892:5:892:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:892:12:892:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:892:12:892:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :a] | semmle.label | call to reverse_merge! : Hash [element :a] |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :c] | semmle.label | call to reverse_merge! : Hash [element :c] |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :d] | semmle.label | call to reverse_merge! : Hash [element :d] |
+| hash_flow.rb:892:12:892:38 | call to reverse_merge! : Hash [element :f] | semmle.label | call to reverse_merge! : Hash [element :f] |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:892:33:892:37 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:893:10:893:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:893:11:893:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:893:11:893:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:893:11:893:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:895:10:895:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:895:11:895:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:895:11:895:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:895:11:895:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:896:10:896:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:896:11:896:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:896:11:896:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:896:11:896:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:898:10:898:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:898:11:898:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:898:11:898:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:898:11:898:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:900:10:900:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:900:11:900:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:900:11:900:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:900:11:900:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:902:10:902:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:902:11:902:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:902:11:902:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:902:11:902:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:903:10:903:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:903:11:903:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:903:11:903:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:903:11:903:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:905:10:905:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:905:11:905:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:905:11:905:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:905:11:905:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:911:5:911:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:911:5:911:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:911:13:915:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:911:13:915:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:911:5:911:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:911:5:911:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:911:13:915:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:911:13:915:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:912:12:912:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:914:12:914:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:916:5:916:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:916:5:916:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:916:13:920:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:916:13:920:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:916:5:916:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:916:5:916:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:916:13:920:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:916:13:920:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:917:12:917:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:919:12:919:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:922:5:922:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:922:5:922:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:922:5:922:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:922:5:922:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:922:12:922:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:922:12:922:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:922:12:922:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :a] | semmle.label | call to with_defaults! [element :a] |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :c] | semmle.label | call to with_defaults! [element :c] |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :d] | semmle.label | call to with_defaults! [element :d] |
-| hash_flow.rb:922:12:922:38 | call to with_defaults! [element :f] | semmle.label | call to with_defaults! [element :f] |
-| hash_flow.rb:922:33:922:37 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:922:33:922:37 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:922:5:922:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:922:12:922:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:922:12:922:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :a] | semmle.label | call to with_defaults! : Hash [element :a] |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :c] | semmle.label | call to with_defaults! : Hash [element :c] |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :d] | semmle.label | call to with_defaults! : Hash [element :d] |
+| hash_flow.rb:922:12:922:38 | call to with_defaults! : Hash [element :f] | semmle.label | call to with_defaults! : Hash [element :f] |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:922:33:922:37 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:923:10:923:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:923:11:923:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:923:11:923:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:923:11:923:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:925:10:925:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:925:11:925:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:925:11:925:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:925:11:925:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:926:10:926:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:926:11:926:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:926:11:926:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:926:11:926:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:928:10:928:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:928:11:928:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:928:11:928:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:928:11:928:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:930:10:930:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:930:11:930:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:930:11:930:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:930:11:930:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:932:10:932:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:932:11:932:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:932:11:932:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:932:11:932:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:933:10:933:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:933:11:933:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:933:11:933:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:933:11:933:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:935:10:935:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:935:11:935:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:935:11:935:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:935:11:935:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:941:5:941:9 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:941:5:941:9 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:941:13:945:5 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_flow.rb:941:13:945:5 | call to [] [element :c] | semmle.label | call to [] [element :c] |
+| hash_flow.rb:941:5:941:9 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:941:5:941:9 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:941:13:945:5 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_flow.rb:941:13:945:5 | call to [] : Hash [element :c] | semmle.label | call to [] : Hash [element :c] |
 | hash_flow.rb:942:12:942:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:944:12:944:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:946:5:946:9 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:946:5:946:9 | hash2 [element :f] | semmle.label | hash2 [element :f] |
-| hash_flow.rb:946:13:950:5 | call to [] [element :d] | semmle.label | call to [] [element :d] |
-| hash_flow.rb:946:13:950:5 | call to [] [element :f] | semmle.label | call to [] [element :f] |
+| hash_flow.rb:946:5:946:9 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:946:5:946:9 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
+| hash_flow.rb:946:13:950:5 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
+| hash_flow.rb:946:13:950:5 | call to [] : Hash [element :f] | semmle.label | call to [] : Hash [element :f] |
 | hash_flow.rb:947:12:947:22 | call to taint | semmle.label | call to taint |
 | hash_flow.rb:949:12:949:22 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:952:5:952:8 | hash [element :a] | semmle.label | hash [element :a] |
-| hash_flow.rb:952:5:952:8 | hash [element :c] | semmle.label | hash [element :c] |
-| hash_flow.rb:952:5:952:8 | hash [element :d] | semmle.label | hash [element :d] |
-| hash_flow.rb:952:5:952:8 | hash [element :f] | semmle.label | hash [element :f] |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :a] | semmle.label | [post] hash1 [element :a] |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :c] | semmle.label | [post] hash1 [element :c] |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :d] | semmle.label | [post] hash1 [element :d] |
-| hash_flow.rb:952:12:952:16 | [post] hash1 [element :f] | semmle.label | [post] hash1 [element :f] |
-| hash_flow.rb:952:12:952:16 | hash1 [element :a] | semmle.label | hash1 [element :a] |
-| hash_flow.rb:952:12:952:16 | hash1 [element :c] | semmle.label | hash1 [element :c] |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :a] | semmle.label | call to with_defaults! [element :a] |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :c] | semmle.label | call to with_defaults! [element :c] |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :d] | semmle.label | call to with_defaults! [element :d] |
-| hash_flow.rb:952:12:952:38 | call to with_defaults! [element :f] | semmle.label | call to with_defaults! [element :f] |
-| hash_flow.rb:952:33:952:37 | hash2 [element :d] | semmle.label | hash2 [element :d] |
-| hash_flow.rb:952:33:952:37 | hash2 [element :f] | semmle.label | hash2 [element :f] |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
+| hash_flow.rb:952:5:952:8 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :a] | semmle.label | [post] hash1 : Hash [element :a] |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :c] | semmle.label | [post] hash1 : Hash [element :c] |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :d] | semmle.label | [post] hash1 : Hash [element :d] |
+| hash_flow.rb:952:12:952:16 | [post] hash1 : Hash [element :f] | semmle.label | [post] hash1 : Hash [element :f] |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
+| hash_flow.rb:952:12:952:16 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :a] | semmle.label | call to with_defaults! : Hash [element :a] |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :c] | semmle.label | call to with_defaults! : Hash [element :c] |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :d] | semmle.label | call to with_defaults! : Hash [element :d] |
+| hash_flow.rb:952:12:952:38 | call to with_defaults! : Hash [element :f] | semmle.label | call to with_defaults! : Hash [element :f] |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :d] | semmle.label | hash2 : Hash [element :d] |
+| hash_flow.rb:952:33:952:37 | hash2 : Hash [element :f] | semmle.label | hash2 : Hash [element :f] |
 | hash_flow.rb:953:10:953:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:953:11:953:14 | hash [element :a] | semmle.label | hash [element :a] |
+| hash_flow.rb:953:11:953:14 | hash : Hash [element :a] | semmle.label | hash : Hash [element :a] |
 | hash_flow.rb:953:11:953:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:955:10:955:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:955:11:955:14 | hash [element :c] | semmle.label | hash [element :c] |
+| hash_flow.rb:955:11:955:14 | hash : Hash [element :c] | semmle.label | hash : Hash [element :c] |
 | hash_flow.rb:955:11:955:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:956:10:956:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:956:11:956:14 | hash [element :d] | semmle.label | hash [element :d] |
+| hash_flow.rb:956:11:956:14 | hash : Hash [element :d] | semmle.label | hash : Hash [element :d] |
 | hash_flow.rb:956:11:956:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:958:10:958:19 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:958:11:958:14 | hash [element :f] | semmle.label | hash [element :f] |
+| hash_flow.rb:958:11:958:14 | hash : Hash [element :f] | semmle.label | hash : Hash [element :f] |
 | hash_flow.rb:958:11:958:18 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:960:10:960:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:960:11:960:15 | hash1 [element :a] | semmle.label | hash1 [element :a] |
+| hash_flow.rb:960:11:960:15 | hash1 : Hash [element :a] | semmle.label | hash1 : Hash [element :a] |
 | hash_flow.rb:960:11:960:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:962:10:962:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:962:11:962:15 | hash1 [element :c] | semmle.label | hash1 [element :c] |
+| hash_flow.rb:962:11:962:15 | hash1 : Hash [element :c] | semmle.label | hash1 : Hash [element :c] |
 | hash_flow.rb:962:11:962:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:963:10:963:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:963:11:963:15 | hash1 [element :d] | semmle.label | hash1 [element :d] |
+| hash_flow.rb:963:11:963:15 | hash1 : Hash [element :d] | semmle.label | hash1 : Hash [element :d] |
 | hash_flow.rb:963:11:963:19 | ...[...] | semmle.label | ...[...] |
 | hash_flow.rb:965:10:965:20 | ( ... ) | semmle.label | ( ... ) |
-| hash_flow.rb:965:11:965:15 | hash1 [element :f] | semmle.label | hash1 [element :f] |
+| hash_flow.rb:965:11:965:15 | hash1 : Hash [element :f] | semmle.label | hash1 : Hash [element :f] |
 | hash_flow.rb:965:11:965:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:971:5:971:5 | h [element :b] | semmle.label | h [element :b] |
-| hash_flow.rb:971:9:971:38 | ...[...] [element :b] | semmle.label | ...[...] [element :b] |
+| hash_flow.rb:971:5:971:5 | h : Hash [element :b] | semmle.label | h : Hash [element :b] |
+| hash_flow.rb:971:9:971:38 | ...[...] : Hash [element :b] | semmle.label | ...[...] : Hash [element :b] |
 | hash_flow.rb:971:23:971:31 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:973:10:973:10 | h [element :b] | semmle.label | h [element :b] |
+| hash_flow.rb:973:10:973:10 | h : Hash [element :b] | semmle.label | h : Hash [element :b] |
 | hash_flow.rb:973:10:973:14 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:975:10:975:10 | h [element :b] | semmle.label | h [element :b] |
+| hash_flow.rb:975:10:975:10 | h : Hash [element :b] | semmle.label | h : Hash [element :b] |
 | hash_flow.rb:975:10:975:13 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:994:9:994:10 | h2 [element :b] | semmle.label | h2 [element :b] |
-| hash_flow.rb:994:14:994:47 | ...[...] [element :b] | semmle.label | ...[...] [element :b] |
+| hash_flow.rb:994:9:994:10 | h2 : Hash [element :b] | semmle.label | h2 : Hash [element :b] |
+| hash_flow.rb:994:14:994:47 | ...[...] : Hash [element :b] | semmle.label | ...[...] : Hash [element :b] |
 | hash_flow.rb:994:30:994:40 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:996:14:996:15 | h2 [element :b] | semmle.label | h2 [element :b] |
+| hash_flow.rb:996:14:996:15 | h2 : Hash [element :b] | semmle.label | h2 : Hash [element :b] |
 | hash_flow.rb:996:14:996:19 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:998:14:998:15 | h2 [element :b] | semmle.label | h2 [element :b] |
+| hash_flow.rb:998:14:998:15 | h2 : Hash [element :b] | semmle.label | h2 : Hash [element :b] |
 | hash_flow.rb:998:14:998:18 | ...[...] | semmle.label | ...[...] |
-| hash_flow.rb:1011:5:1011:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_flow.rb:1011:9:1011:45 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_flow.rb:1011:5:1011:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_flow.rb:1011:9:1011:45 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_flow.rb:1011:14:1011:24 | call to taint | semmle.label | call to taint |
-| hash_flow.rb:1012:5:1012:5 | h [element :a] | semmle.label | h [element :a] |
+| hash_flow.rb:1012:5:1012:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
 | hash_flow.rb:1012:15:1012:15 | k | semmle.label | k |
 | hash_flow.rb:1012:18:1012:18 | v | semmle.label | v |
 | hash_flow.rb:1013:14:1013:14 | v | semmle.label | v |

--- a/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/params/params-flow.expected
@@ -13,165 +13,167 @@ edges
 | params_flow.rb:23:16:23:23 | call to taint | params_flow.rb:16:18:16:19 | p2 | provenance |  |
 | params_flow.rb:23:33:23:40 | call to taint | params_flow.rb:16:13:16:14 | p1 | provenance |  |
 | params_flow.rb:25:12:25:13 | p1 | params_flow.rb:26:10:26:11 | p1 | provenance |  |
-| params_flow.rb:25:17:25:24 | **kwargs [element :p2] | params_flow.rb:28:11:28:16 | kwargs [element :p2] | provenance |  |
-| params_flow.rb:25:17:25:24 | **kwargs [element :p3] | params_flow.rb:29:11:29:16 | kwargs [element :p3] | provenance |  |
-| params_flow.rb:28:11:28:16 | kwargs [element :p2] | params_flow.rb:28:11:28:21 | ...[...] | provenance |  |
+| params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p2] | params_flow.rb:28:11:28:16 | kwargs : Hash [element :p2] | provenance |  |
+| params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p3] | params_flow.rb:29:11:29:16 | kwargs : Hash [element :p3] | provenance |  |
+| params_flow.rb:28:11:28:16 | kwargs : Hash [element :p2] | params_flow.rb:28:11:28:21 | ...[...] | provenance |  |
 | params_flow.rb:28:11:28:21 | ...[...] | params_flow.rb:28:10:28:22 | ( ... ) | provenance |  |
-| params_flow.rb:29:11:29:16 | kwargs [element :p3] | params_flow.rb:29:11:29:21 | ...[...] | provenance |  |
+| params_flow.rb:29:11:29:16 | kwargs : Hash [element :p3] | params_flow.rb:29:11:29:21 | ...[...] | provenance |  |
 | params_flow.rb:29:11:29:21 | ...[...] | params_flow.rb:29:10:29:22 | ( ... ) | provenance |  |
 | params_flow.rb:33:12:33:19 | call to taint | params_flow.rb:25:12:25:13 | p1 | provenance |  |
-| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | provenance |  |
-| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | provenance |  |
-| params_flow.rb:34:1:34:4 | args [element :p3] | params_flow.rb:35:25:35:28 | args [element :p3] | provenance |  |
-| params_flow.rb:34:8:34:32 | call to [] [element :p3] | params_flow.rb:34:1:34:4 | args [element :p3] | provenance |  |
-| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:8:34:32 | call to [] [element :p3] | provenance |  |
+| params_flow.rb:33:26:33:34 | call to taint | params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p2] | provenance |  |
+| params_flow.rb:33:41:33:49 | call to taint | params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p3] | provenance |  |
+| params_flow.rb:34:1:34:4 | args : Hash [element :p3] | params_flow.rb:35:25:35:28 | args : Hash [element :p3] | provenance |  |
+| params_flow.rb:34:8:34:32 | call to [] : Hash [element :p3] | params_flow.rb:34:1:34:4 | args : Hash [element :p3] | provenance |  |
+| params_flow.rb:34:14:34:22 | call to taint | params_flow.rb:34:8:34:32 | call to [] : Hash [element :p3] | provenance |  |
 | params_flow.rb:35:12:35:20 | call to taint | params_flow.rb:25:12:25:13 | p1 | provenance |  |
-| params_flow.rb:35:23:35:28 | ** ... [element :p3] | params_flow.rb:25:17:25:24 | **kwargs [element :p3] | provenance |  |
-| params_flow.rb:35:25:35:28 | args [element :p3] | params_flow.rb:35:23:35:28 | ** ... [element :p3] | provenance |  |
-| params_flow.rb:37:1:37:4 | args [element :p1] | params_flow.rb:38:10:38:13 | args [element :p1] | provenance |  |
-| params_flow.rb:37:1:37:4 | args [element :p2] | params_flow.rb:38:10:38:13 | args [element :p2] | provenance |  |
-| params_flow.rb:37:8:37:44 | call to [] [element :p1] | params_flow.rb:37:1:37:4 | args [element :p1] | provenance |  |
-| params_flow.rb:37:8:37:44 | call to [] [element :p2] | params_flow.rb:37:1:37:4 | args [element :p2] | provenance |  |
-| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:8:37:44 | call to [] [element :p1] | provenance |  |
-| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:8:37:44 | call to [] [element :p2] | provenance |  |
-| params_flow.rb:38:8:38:13 | ** ... [element :p1] | params_flow.rb:25:12:25:13 | p1 | provenance |  |
-| params_flow.rb:38:8:38:13 | ** ... [element :p2] | params_flow.rb:25:17:25:24 | **kwargs [element :p2] | provenance |  |
-| params_flow.rb:38:10:38:13 | args [element :p1] | params_flow.rb:38:8:38:13 | ** ... [element :p1] | provenance |  |
-| params_flow.rb:38:10:38:13 | args [element :p2] | params_flow.rb:38:8:38:13 | ** ... [element :p2] | provenance |  |
-| params_flow.rb:40:1:40:4 | args [element :p1] | params_flow.rb:41:26:41:29 | args [element :p1] | provenance |  |
-| params_flow.rb:40:8:40:26 | call to [] [element :p1] | params_flow.rb:40:1:40:4 | args [element :p1] | provenance |  |
-| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:8:40:26 | call to [] [element :p1] | provenance |  |
+| params_flow.rb:35:23:35:28 | ** ... : Hash [element :p3] | params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p3] | provenance |  |
+| params_flow.rb:35:25:35:28 | args : Hash [element :p3] | params_flow.rb:35:23:35:28 | ** ... : Hash [element :p3] | provenance |  |
+| params_flow.rb:37:1:37:4 | args : Hash [element :p1] | params_flow.rb:38:10:38:13 | args : Hash [element :p1] | provenance |  |
+| params_flow.rb:37:1:37:4 | args : Hash [element :p2] | params_flow.rb:38:10:38:13 | args : Hash [element :p2] | provenance |  |
+| params_flow.rb:37:8:37:44 | call to [] : Hash [element :p1] | params_flow.rb:37:1:37:4 | args : Hash [element :p1] | provenance |  |
+| params_flow.rb:37:8:37:44 | call to [] : Hash [element :p2] | params_flow.rb:37:1:37:4 | args : Hash [element :p2] | provenance |  |
+| params_flow.rb:37:16:37:24 | call to taint | params_flow.rb:37:8:37:44 | call to [] : Hash [element :p1] | provenance |  |
+| params_flow.rb:37:34:37:42 | call to taint | params_flow.rb:37:8:37:44 | call to [] : Hash [element :p2] | provenance |  |
+| params_flow.rb:38:8:38:13 | ** ... : Hash [element :p1] | params_flow.rb:25:12:25:13 | p1 | provenance |  |
+| params_flow.rb:38:8:38:13 | ** ... : Hash [element :p2] | params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p2] | provenance |  |
+| params_flow.rb:38:10:38:13 | args : Hash [element :p1] | params_flow.rb:38:8:38:13 | ** ... : Hash [element :p1] | provenance |  |
+| params_flow.rb:38:10:38:13 | args : Hash [element :p2] | params_flow.rb:38:8:38:13 | ** ... : Hash [element :p2] | provenance |  |
+| params_flow.rb:40:1:40:4 | args : Hash [element :p1] | params_flow.rb:41:26:41:29 | args : Hash [element :p1] | provenance |  |
+| params_flow.rb:40:8:40:26 | call to [] : Hash [element :p1] | params_flow.rb:40:1:40:4 | args : Hash [element :p1] | provenance |  |
+| params_flow.rb:40:16:40:24 | call to taint | params_flow.rb:40:8:40:26 | call to [] : Hash [element :p1] | provenance |  |
 | params_flow.rb:41:13:41:21 | call to taint | params_flow.rb:16:18:16:19 | p2 | provenance |  |
-| params_flow.rb:41:24:41:29 | ** ... [element :p1] | params_flow.rb:16:13:16:14 | p1 | provenance |  |
-| params_flow.rb:41:26:41:29 | args [element :p1] | params_flow.rb:41:24:41:29 | ** ... [element :p1] | provenance |  |
-| params_flow.rb:43:1:43:4 | args [element 0] | params_flow.rb:44:24:44:27 | args [element 0] | provenance |  |
-| params_flow.rb:43:8:43:18 | call to [] [element 0] | params_flow.rb:43:1:43:4 | args [element 0] | provenance |  |
-| params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:8:43:18 | call to [] [element 0] | provenance |  |
+| params_flow.rb:41:24:41:29 | ** ... : Hash [element :p1] | params_flow.rb:16:13:16:14 | p1 | provenance |  |
+| params_flow.rb:41:26:41:29 | args : Hash [element :p1] | params_flow.rb:41:24:41:29 | ** ... : Hash [element :p1] | provenance |  |
+| params_flow.rb:43:1:43:4 | args : Array [element 0] | params_flow.rb:44:24:44:27 | args : Array [element 0] | provenance |  |
+| params_flow.rb:43:8:43:18 | call to [] : Array [element 0] | params_flow.rb:43:1:43:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:43:9:43:17 | call to taint | params_flow.rb:43:8:43:18 | call to [] : Array [element 0] | provenance |  |
 | params_flow.rb:44:12:44:20 | call to taint | params_flow.rb:9:16:9:17 | p1 | provenance |  |
-| params_flow.rb:44:23:44:27 | * ... [element 0] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
-| params_flow.rb:44:24:44:27 | args [element 0] | params_flow.rb:44:23:44:27 | * ... [element 0] | provenance |  |
-| params_flow.rb:46:1:46:4 | args [element 0] | params_flow.rb:47:13:47:16 | args [element 0] | provenance |  |
-| params_flow.rb:46:1:46:4 | args [element 1] | params_flow.rb:47:13:47:16 | args [element 1] | provenance |  |
-| params_flow.rb:46:8:46:29 | call to [] [element 0] | params_flow.rb:46:1:46:4 | args [element 0] | provenance |  |
-| params_flow.rb:46:8:46:29 | call to [] [element 1] | params_flow.rb:46:1:46:4 | args [element 1] | provenance |  |
-| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:8:46:29 | call to [] [element 0] | provenance |  |
-| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:8:46:29 | call to [] [element 1] | provenance |  |
-| params_flow.rb:47:12:47:16 | * ... [element 0] | params_flow.rb:9:16:9:17 | p1 | provenance |  |
-| params_flow.rb:47:12:47:16 | * ... [element 1] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
-| params_flow.rb:47:13:47:16 | args [element 0] | params_flow.rb:47:12:47:16 | * ... [element 0] | provenance |  |
-| params_flow.rb:47:13:47:16 | args [element 1] | params_flow.rb:47:12:47:16 | * ... [element 1] | provenance |  |
+| params_flow.rb:44:23:44:27 | * ... : Array [element 0] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
+| params_flow.rb:44:24:44:27 | args : Array [element 0] | params_flow.rb:44:23:44:27 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:46:1:46:4 | args : Array [element 0] | params_flow.rb:47:13:47:16 | args : Array [element 0] | provenance |  |
+| params_flow.rb:46:1:46:4 | args : Array [element 1] | params_flow.rb:47:13:47:16 | args : Array [element 1] | provenance |  |
+| params_flow.rb:46:8:46:29 | call to [] : Array [element 0] | params_flow.rb:46:1:46:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:46:8:46:29 | call to [] : Array [element 1] | params_flow.rb:46:1:46:4 | args : Array [element 1] | provenance |  |
+| params_flow.rb:46:9:46:17 | call to taint | params_flow.rb:46:8:46:29 | call to [] : Array [element 0] | provenance |  |
+| params_flow.rb:46:20:46:28 | call to taint | params_flow.rb:46:8:46:29 | call to [] : Array [element 1] | provenance |  |
+| params_flow.rb:47:12:47:16 | * ... : Array [element 0] | params_flow.rb:9:16:9:17 | p1 | provenance |  |
+| params_flow.rb:47:12:47:16 | * ... : Array [element 1] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
+| params_flow.rb:47:13:47:16 | args : Array [element 0] | params_flow.rb:47:12:47:16 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:47:13:47:16 | args : Array [element 1] | params_flow.rb:47:12:47:16 | * ... : Array [element 1] | provenance |  |
 | params_flow.rb:49:13:49:14 | p1 | params_flow.rb:50:10:50:11 | p1 | provenance |  |
-| params_flow.rb:49:17:49:24 | *posargs [element 0] | params_flow.rb:51:11:51:17 | posargs [element 0] | provenance |  |
-| params_flow.rb:51:11:51:17 | posargs [element 0] | params_flow.rb:51:11:51:20 | ...[...] | provenance |  |
+| params_flow.rb:49:17:49:24 | *posargs : Array [element 0] | params_flow.rb:51:11:51:17 | posargs : Array [element 0] | provenance |  |
+| params_flow.rb:49:17:49:24 | *posargs : [collection] [element 0] | params_flow.rb:51:11:51:17 | posargs : [collection] [element 0] | provenance |  |
+| params_flow.rb:51:11:51:17 | posargs : Array [element 0] | params_flow.rb:51:11:51:20 | ...[...] | provenance |  |
+| params_flow.rb:51:11:51:17 | posargs : [collection] [element 0] | params_flow.rb:51:11:51:20 | ...[...] | provenance |  |
 | params_flow.rb:51:11:51:20 | ...[...] | params_flow.rb:51:10:51:21 | ( ... ) | provenance |  |
 | params_flow.rb:55:9:55:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
-| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
-| params_flow.rb:57:1:57:4 | args [element 0] | params_flow.rb:58:21:58:24 | args [element 0] | provenance |  |
-| params_flow.rb:57:8:57:18 | call to [] [element 0] | params_flow.rb:57:1:57:4 | args [element 0] | provenance |  |
-| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:8:57:18 | call to [] [element 0] | provenance |  |
+| params_flow.rb:55:20:55:28 | call to taint | params_flow.rb:49:17:49:24 | *posargs : [collection] [element 0] | provenance |  |
+| params_flow.rb:57:1:57:4 | args : Array [element 0] | params_flow.rb:58:21:58:24 | args : Array [element 0] | provenance |  |
+| params_flow.rb:57:8:57:18 | call to [] : Array [element 0] | params_flow.rb:57:1:57:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:57:9:57:17 | call to taint | params_flow.rb:57:8:57:18 | call to [] : Array [element 0] | provenance |  |
 | params_flow.rb:58:9:58:17 | call to taint | params_flow.rb:49:13:49:14 | p1 | provenance |  |
-| params_flow.rb:58:20:58:24 | * ... [element 0] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
-| params_flow.rb:58:21:58:24 | args [element 0] | params_flow.rb:58:20:58:24 | * ... [element 0] | provenance |  |
-| params_flow.rb:60:1:60:4 | args [element 0] | params_flow.rb:61:10:61:13 | args [element 0] | provenance |  |
-| params_flow.rb:60:1:60:4 | args [element 1] | params_flow.rb:61:10:61:13 | args [element 1] | provenance |  |
-| params_flow.rb:60:8:60:29 | call to [] [element 0] | params_flow.rb:60:1:60:4 | args [element 0] | provenance |  |
-| params_flow.rb:60:8:60:29 | call to [] [element 1] | params_flow.rb:60:1:60:4 | args [element 1] | provenance |  |
-| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:8:60:29 | call to [] [element 0] | provenance |  |
-| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:8:60:29 | call to [] [element 1] | provenance |  |
-| params_flow.rb:61:9:61:13 | * ... [element 0] | params_flow.rb:49:13:49:14 | p1 | provenance |  |
-| params_flow.rb:61:9:61:13 | * ... [element 1] | params_flow.rb:49:17:49:24 | *posargs [element 0] | provenance |  |
-| params_flow.rb:61:10:61:13 | args [element 0] | params_flow.rb:61:9:61:13 | * ... [element 0] | provenance |  |
-| params_flow.rb:61:10:61:13 | args [element 1] | params_flow.rb:61:9:61:13 | * ... [element 1] | provenance |  |
+| params_flow.rb:58:20:58:24 | * ... : Array [element 0] | params_flow.rb:49:17:49:24 | *posargs : Array [element 0] | provenance |  |
+| params_flow.rb:58:21:58:24 | args : Array [element 0] | params_flow.rb:58:20:58:24 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:60:1:60:4 | args : Array [element 0] | params_flow.rb:61:10:61:13 | args : Array [element 0] | provenance |  |
+| params_flow.rb:60:1:60:4 | args : Array [element 1] | params_flow.rb:61:10:61:13 | args : Array [element 1] | provenance |  |
+| params_flow.rb:60:8:60:29 | call to [] : Array [element 0] | params_flow.rb:60:1:60:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:60:8:60:29 | call to [] : Array [element 1] | params_flow.rb:60:1:60:4 | args : Array [element 1] | provenance |  |
+| params_flow.rb:60:9:60:17 | call to taint | params_flow.rb:60:8:60:29 | call to [] : Array [element 0] | provenance |  |
+| params_flow.rb:60:20:60:28 | call to taint | params_flow.rb:60:8:60:29 | call to [] : Array [element 1] | provenance |  |
+| params_flow.rb:61:9:61:13 | * ... : Array [element 0] | params_flow.rb:49:13:49:14 | p1 | provenance |  |
+| params_flow.rb:61:9:61:13 | * ... : Array [element 1] | params_flow.rb:49:17:49:24 | *posargs : [collection] [element 0] | provenance |  |
+| params_flow.rb:61:10:61:13 | args : Array [element 0] | params_flow.rb:61:9:61:13 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:61:10:61:13 | args : Array [element 1] | params_flow.rb:61:9:61:13 | * ... : Array [element 1] | provenance |  |
 | params_flow.rb:63:1:63:4 | args | params_flow.rb:67:13:67:16 | args | provenance |  |
 | params_flow.rb:63:8:63:16 | call to taint | params_flow.rb:63:1:63:4 | args | provenance |  |
-| params_flow.rb:64:16:64:17 | *x [element 0] | params_flow.rb:65:10:65:10 | x [element 0] | provenance |  |
-| params_flow.rb:65:10:65:10 | x [element 0] | params_flow.rb:65:10:65:13 | ...[...] | provenance |  |
-| params_flow.rb:67:12:67:16 | * ... [element 0] | params_flow.rb:64:16:64:17 | *x [element 0] | provenance |  |
-| params_flow.rb:67:13:67:16 | args | params_flow.rb:67:12:67:16 | * ... [element 0] | provenance |  |
+| params_flow.rb:64:16:64:17 | *x : [collection] [element 0] | params_flow.rb:65:10:65:10 | x : [collection] [element 0] | provenance |  |
+| params_flow.rb:65:10:65:10 | x : [collection] [element 0] | params_flow.rb:65:10:65:13 | ...[...] | provenance |  |
+| params_flow.rb:67:12:67:16 | * ... : [collection] [element 0] | params_flow.rb:64:16:64:17 | *x : [collection] [element 0] | provenance |  |
+| params_flow.rb:67:13:67:16 | args | params_flow.rb:67:12:67:16 | * ... : [collection] [element 0] | provenance |  |
 | params_flow.rb:69:14:69:14 | x | params_flow.rb:70:10:70:10 | x | provenance |  |
 | params_flow.rb:69:17:69:17 | y | params_flow.rb:71:10:71:10 | y | provenance |  |
 | params_flow.rb:78:10:78:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
 | params_flow.rb:78:21:78:29 | call to taint | params_flow.rb:69:17:69:17 | y | provenance |  |
-| params_flow.rb:80:1:80:4 | args [element 0] | params_flow.rb:81:22:81:25 | args [element 0] | provenance |  |
-| params_flow.rb:80:8:80:51 | call to [] [element 0] | params_flow.rb:80:1:80:4 | args [element 0] | provenance |  |
-| params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:8:80:51 | call to [] [element 0] | provenance |  |
+| params_flow.rb:80:1:80:4 | args : Array [element 0] | params_flow.rb:81:22:81:25 | args : Array [element 0] | provenance |  |
+| params_flow.rb:80:8:80:51 | call to [] : Array [element 0] | params_flow.rb:80:1:80:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:80:9:80:17 | call to taint | params_flow.rb:80:8:80:51 | call to [] : Array [element 0] | provenance |  |
 | params_flow.rb:81:10:81:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
-| params_flow.rb:81:21:81:25 | * ... [element 0] | params_flow.rb:69:17:69:17 | y | provenance |  |
-| params_flow.rb:81:22:81:25 | args [element 0] | params_flow.rb:81:21:81:25 | * ... [element 0] | provenance |  |
+| params_flow.rb:81:21:81:25 | * ... : Array [element 0] | params_flow.rb:69:17:69:17 | y | provenance |  |
+| params_flow.rb:81:22:81:25 | args : Array [element 0] | params_flow.rb:81:21:81:25 | * ... : Array [element 0] | provenance |  |
 | params_flow.rb:83:14:83:14 | t | params_flow.rb:84:10:84:10 | t | provenance |  |
 | params_flow.rb:83:17:83:17 | u | params_flow.rb:85:10:85:10 | u | provenance |  |
 | params_flow.rb:83:20:83:20 | v | params_flow.rb:86:10:86:10 | v | provenance |  |
 | params_flow.rb:83:23:83:23 | w | params_flow.rb:87:10:87:10 | w | provenance |  |
 | params_flow.rb:83:26:83:26 | x | params_flow.rb:88:10:88:10 | x | provenance |  |
 | params_flow.rb:83:29:83:29 | y | params_flow.rb:89:10:89:10 | y | provenance |  |
-| params_flow.rb:93:1:93:4 | args [element 0] | params_flow.rb:94:33:94:36 | args [element 0] | provenance |  |
-| params_flow.rb:93:1:93:4 | args [element 1] | params_flow.rb:94:33:94:36 | args [element 1] | provenance |  |
-| params_flow.rb:93:1:93:4 | args [element 2] | params_flow.rb:94:33:94:36 | args [element 2] | provenance |  |
-| params_flow.rb:93:1:93:4 | args [element 3] | params_flow.rb:94:33:94:36 | args [element 3] | provenance |  |
-| params_flow.rb:93:8:93:51 | call to [] [element 0] | params_flow.rb:93:1:93:4 | args [element 0] | provenance |  |
-| params_flow.rb:93:8:93:51 | call to [] [element 1] | params_flow.rb:93:1:93:4 | args [element 1] | provenance |  |
-| params_flow.rb:93:8:93:51 | call to [] [element 2] | params_flow.rb:93:1:93:4 | args [element 2] | provenance |  |
-| params_flow.rb:93:8:93:51 | call to [] [element 3] | params_flow.rb:93:1:93:4 | args [element 3] | provenance |  |
-| params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 0] | provenance |  |
-| params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 1] | provenance |  |
-| params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 2] | provenance |  |
-| params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:8:93:51 | call to [] [element 3] | provenance |  |
+| params_flow.rb:93:1:93:4 | args : Array [element 0] | params_flow.rb:94:33:94:36 | args : Array [element 0] | provenance |  |
+| params_flow.rb:93:1:93:4 | args : Array [element 1] | params_flow.rb:94:33:94:36 | args : Array [element 1] | provenance |  |
+| params_flow.rb:93:1:93:4 | args : Array [element 2] | params_flow.rb:94:33:94:36 | args : Array [element 2] | provenance |  |
+| params_flow.rb:93:1:93:4 | args : Array [element 3] | params_flow.rb:94:33:94:36 | args : Array [element 3] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 0] | params_flow.rb:93:1:93:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 1] | params_flow.rb:93:1:93:4 | args : Array [element 1] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 2] | params_flow.rb:93:1:93:4 | args : Array [element 2] | provenance |  |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 3] | params_flow.rb:93:1:93:4 | args : Array [element 3] | provenance |  |
+| params_flow.rb:93:9:93:17 | call to taint | params_flow.rb:93:8:93:51 | call to [] : Array [element 0] | provenance |  |
+| params_flow.rb:93:20:93:28 | call to taint | params_flow.rb:93:8:93:51 | call to [] : Array [element 1] | provenance |  |
+| params_flow.rb:93:31:93:39 | call to taint | params_flow.rb:93:8:93:51 | call to [] : Array [element 2] | provenance |  |
+| params_flow.rb:93:42:93:50 | call to taint | params_flow.rb:93:8:93:51 | call to [] : Array [element 3] | provenance |  |
 | params_flow.rb:94:10:94:18 | call to taint | params_flow.rb:83:14:83:14 | t | provenance |  |
 | params_flow.rb:94:21:94:29 | call to taint | params_flow.rb:83:17:83:17 | u | provenance |  |
-| params_flow.rb:94:32:94:36 | * ... [element 0] | params_flow.rb:83:20:83:20 | v | provenance |  |
-| params_flow.rb:94:32:94:36 | * ... [element 1] | params_flow.rb:83:23:83:23 | w | provenance |  |
-| params_flow.rb:94:32:94:36 | * ... [element 2] | params_flow.rb:83:26:83:26 | x | provenance |  |
-| params_flow.rb:94:32:94:36 | * ... [element 3] | params_flow.rb:83:29:83:29 | y | provenance |  |
-| params_flow.rb:94:33:94:36 | args [element 0] | params_flow.rb:94:32:94:36 | * ... [element 0] | provenance |  |
-| params_flow.rb:94:33:94:36 | args [element 1] | params_flow.rb:94:32:94:36 | * ... [element 1] | provenance |  |
-| params_flow.rb:94:33:94:36 | args [element 2] | params_flow.rb:94:32:94:36 | * ... [element 2] | provenance |  |
-| params_flow.rb:94:33:94:36 | args [element 3] | params_flow.rb:94:32:94:36 | * ... [element 3] | provenance |  |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 0] | params_flow.rb:83:20:83:20 | v | provenance |  |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 1] | params_flow.rb:83:23:83:23 | w | provenance |  |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 2] | params_flow.rb:83:26:83:26 | x | provenance |  |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 3] | params_flow.rb:83:29:83:29 | y | provenance |  |
+| params_flow.rb:94:33:94:36 | args : Array [element 0] | params_flow.rb:94:32:94:36 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:94:33:94:36 | args : Array [element 1] | params_flow.rb:94:32:94:36 | * ... : Array [element 1] | provenance |  |
+| params_flow.rb:94:33:94:36 | args : Array [element 2] | params_flow.rb:94:32:94:36 | * ... : Array [element 2] | provenance |  |
+| params_flow.rb:94:33:94:36 | args : Array [element 3] | params_flow.rb:94:32:94:36 | * ... : Array [element 3] | provenance |  |
 | params_flow.rb:96:10:96:18 | call to taint | params_flow.rb:69:14:69:14 | x | provenance |  |
 | params_flow.rb:96:21:96:29 | call to taint | params_flow.rb:69:17:69:17 | y | provenance |  |
 | params_flow.rb:98:19:98:19 | a | params_flow.rb:99:10:99:10 | a | provenance |  |
 | params_flow.rb:105:15:105:23 | call to taint | params_flow.rb:98:19:98:19 | a | provenance |  |
 | params_flow.rb:106:15:106:23 | call to taint | params_flow.rb:98:19:98:19 | a | provenance |  |
 | params_flow.rb:108:37:108:37 | a | params_flow.rb:109:10:109:10 | a | provenance |  |
-| params_flow.rb:108:40:108:41 | *b [element 0] | params_flow.rb:110:10:110:10 | b [element 0] | provenance |  |
+| params_flow.rb:108:40:108:41 | *b : [collection] [element 0] | params_flow.rb:110:10:110:10 | b : [collection] [element 0] | provenance |  |
 | params_flow.rb:108:44:108:44 | c | params_flow.rb:111:10:111:10 | c | provenance |  |
-| params_flow.rb:110:10:110:10 | b [element 0] | params_flow.rb:110:10:110:13 | ...[...] | provenance |  |
+| params_flow.rb:110:10:110:10 | b : [collection] [element 0] | params_flow.rb:110:10:110:13 | ...[...] | provenance |  |
 | params_flow.rb:114:33:114:41 | call to taint | params_flow.rb:108:37:108:37 | a | provenance |  |
-| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:108:40:108:41 | *b [element 0] | provenance |  |
+| params_flow.rb:114:44:114:52 | call to taint | params_flow.rb:108:40:108:41 | *b : [collection] [element 0] | provenance |  |
 | params_flow.rb:114:58:114:66 | call to taint | params_flow.rb:108:44:108:44 | c | provenance |  |
-| params_flow.rb:117:1:117:1 | [post] x [element] | params_flow.rb:118:13:118:13 | x [element] | provenance |  |
-| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:1 | [post] x [element] | provenance |  |
-| params_flow.rb:118:12:118:13 | * ... [element] | params_flow.rb:9:16:9:17 | p1 | provenance |  |
-| params_flow.rb:118:12:118:13 | * ... [element] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
-| params_flow.rb:118:13:118:13 | x [element] | params_flow.rb:118:12:118:13 | * ... [element] | provenance |  |
-| params_flow.rb:130:1:130:4 | args [element 0] | params_flow.rb:131:11:131:14 | args [element 0] | provenance |  |
-| params_flow.rb:130:1:130:4 | args [element 1] | params_flow.rb:131:11:131:14 | args [element 1] | provenance |  |
-| params_flow.rb:130:8:130:29 | call to [] [element 0] | params_flow.rb:130:1:130:4 | args [element 0] | provenance |  |
-| params_flow.rb:130:8:130:29 | call to [] [element 1] | params_flow.rb:130:1:130:4 | args [element 1] | provenance |  |
-| params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:8:130:29 | call to [] [element 0] | provenance |  |
-| params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:8:130:29 | call to [] [element 1] | provenance |  |
-| params_flow.rb:131:10:131:14 | * ... [element 0] | params_flow.rb:83:14:83:14 | t | provenance |  |
-| params_flow.rb:131:10:131:14 | * ... [element 1] | params_flow.rb:83:17:83:17 | u | provenance |  |
-| params_flow.rb:131:11:131:14 | args [element 0] | params_flow.rb:131:10:131:14 | * ... [element 0] | provenance |  |
-| params_flow.rb:131:11:131:14 | args [element 1] | params_flow.rb:131:10:131:14 | * ... [element 1] | provenance |  |
-| params_flow.rb:133:14:133:18 | *args [element 1] | params_flow.rb:134:10:134:13 | args [element 1] | provenance |  |
-| params_flow.rb:134:10:134:13 | args [element 1] | params_flow.rb:134:10:134:16 | ...[...] | provenance |  |
-| params_flow.rb:137:10:137:43 | * ... [element 1] | params_flow.rb:133:14:133:18 | *args [element 1] | provenance |  |
-| params_flow.rb:137:11:137:43 | call to [] [element 1] | params_flow.rb:137:10:137:43 | * ... [element 1] | provenance |  |
-| params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:11:137:43 | call to [] [element 1] | provenance |  |
+| params_flow.rb:117:1:117:1 | [post] x : [collection] [element] | params_flow.rb:118:13:118:13 | x : [collection] [element] | provenance |  |
+| params_flow.rb:117:19:117:27 | call to taint | params_flow.rb:117:1:117:1 | [post] x : [collection] [element] | provenance |  |
+| params_flow.rb:118:12:118:13 | * ... : [collection] [element] | params_flow.rb:9:16:9:17 | p1 | provenance |  |
+| params_flow.rb:118:12:118:13 | * ... : [collection] [element] | params_flow.rb:9:20:9:21 | p2 | provenance |  |
+| params_flow.rb:118:13:118:13 | x : [collection] [element] | params_flow.rb:118:12:118:13 | * ... : [collection] [element] | provenance |  |
+| params_flow.rb:130:1:130:4 | args : Array [element 0] | params_flow.rb:131:11:131:14 | args : Array [element 0] | provenance |  |
+| params_flow.rb:130:1:130:4 | args : Array [element 1] | params_flow.rb:131:11:131:14 | args : Array [element 1] | provenance |  |
+| params_flow.rb:130:8:130:29 | call to [] : Array [element 0] | params_flow.rb:130:1:130:4 | args : Array [element 0] | provenance |  |
+| params_flow.rb:130:8:130:29 | call to [] : Array [element 1] | params_flow.rb:130:1:130:4 | args : Array [element 1] | provenance |  |
+| params_flow.rb:130:9:130:17 | call to taint | params_flow.rb:130:8:130:29 | call to [] : Array [element 0] | provenance |  |
+| params_flow.rb:130:20:130:28 | call to taint | params_flow.rb:130:8:130:29 | call to [] : Array [element 1] | provenance |  |
+| params_flow.rb:131:10:131:14 | * ... : Array [element 0] | params_flow.rb:83:14:83:14 | t | provenance |  |
+| params_flow.rb:131:10:131:14 | * ... : Array [element 1] | params_flow.rb:83:17:83:17 | u | provenance |  |
+| params_flow.rb:131:11:131:14 | args : Array [element 0] | params_flow.rb:131:10:131:14 | * ... : Array [element 0] | provenance |  |
+| params_flow.rb:131:11:131:14 | args : Array [element 1] | params_flow.rb:131:10:131:14 | * ... : Array [element 1] | provenance |  |
+| params_flow.rb:133:14:133:18 | *args : Array [element 1] | params_flow.rb:134:10:134:13 | args : Array [element 1] | provenance |  |
+| params_flow.rb:134:10:134:13 | args : Array [element 1] | params_flow.rb:134:10:134:16 | ...[...] | provenance |  |
+| params_flow.rb:137:10:137:43 | * ... : Array [element 1] | params_flow.rb:133:14:133:18 | *args : Array [element 1] | provenance |  |
+| params_flow.rb:137:11:137:43 | call to [] : Array [element 1] | params_flow.rb:137:10:137:43 | * ... : Array [element 1] | provenance |  |
+| params_flow.rb:137:23:137:31 | call to taint | params_flow.rb:137:11:137:43 | call to [] : Array [element 1] | provenance |  |
 | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:154:18:154:19 | p2 | provenance |  |
-| params_flow.rb:154:5:154:6 | [post] p1 [element 0] | params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | provenance |  |
-| params_flow.rb:154:18:154:19 | p2 | params_flow.rb:154:5:154:6 | [post] p1 [element 0] | provenance |  |
-| params_flow.rb:164:23:164:24 | [post] p1 [element 0] | params_flow.rb:165:6:165:7 | p1 [element 0] | provenance |  |
+| params_flow.rb:154:5:154:6 | [post] p1 : [collection] [element 0] | params_flow.rb:153:23:153:24 | p1 [Return] : [collection] [element 0] | provenance |  |
+| params_flow.rb:154:18:154:19 | p2 | params_flow.rb:154:5:154:6 | [post] p1 : [collection] [element 0] | provenance |  |
+| params_flow.rb:164:23:164:24 | [post] p1 : [collection] [element 0] | params_flow.rb:165:6:165:7 | p1 : [collection] [element 0] | provenance |  |
 | params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | provenance |  |
-| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:164:23:164:24 | [post] p1 [element 0] | provenance |  |
-| params_flow.rb:165:6:165:7 | p1 [element 0] | params_flow.rb:165:6:165:10 | ...[...] | provenance |  |
+| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:164:23:164:24 | [post] p1 : [collection] [element 0] | provenance |  |
+| params_flow.rb:165:6:165:7 | p1 : [collection] [element 0] | params_flow.rb:165:6:165:10 | ...[...] | provenance |  |
 | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:182:18:182:19 | p2 | provenance |  |
-| params_flow.rb:182:5:182:6 | [post] p1 [element 0] | params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | provenance |  |
-| params_flow.rb:182:18:182:19 | p2 | params_flow.rb:182:5:182:6 | [post] p1 [element 0] | provenance |  |
-| params_flow.rb:192:20:192:21 | [post] p1 [element 0] | params_flow.rb:193:6:193:7 | p1 [element 0] | provenance |  |
+| params_flow.rb:182:5:182:6 | [post] p1 : [collection] [element 0] | params_flow.rb:181:24:181:25 | p1 [Return] : [collection] [element 0] | provenance |  |
+| params_flow.rb:182:18:182:19 | p2 | params_flow.rb:182:5:182:6 | [post] p1 : [collection] [element 0] | provenance |  |
+| params_flow.rb:192:20:192:21 | [post] p1 : [collection] [element 0] | params_flow.rb:193:6:193:7 | p1 : [collection] [element 0] | provenance |  |
 | params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | provenance |  |
-| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:192:20:192:21 | [post] p1 [element 0] | provenance |  |
-| params_flow.rb:193:6:193:7 | p1 [element 0] | params_flow.rb:193:6:193:10 | ...[...] | provenance |  |
+| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:192:20:192:21 | [post] p1 : [collection] [element 0] | provenance |  |
+| params_flow.rb:193:6:193:7 | p1 : [collection] [element 0] | params_flow.rb:193:6:193:10 | ...[...] | provenance |  |
 nodes
 | params_flow.rb:9:16:9:17 | p1 | semmle.label | p1 |
 | params_flow.rb:9:20:9:21 | p2 | semmle.label | p2 |
@@ -190,86 +192,88 @@ nodes
 | params_flow.rb:23:16:23:23 | call to taint | semmle.label | call to taint |
 | params_flow.rb:23:33:23:40 | call to taint | semmle.label | call to taint |
 | params_flow.rb:25:12:25:13 | p1 | semmle.label | p1 |
-| params_flow.rb:25:17:25:24 | **kwargs [element :p2] | semmle.label | **kwargs [element :p2] |
-| params_flow.rb:25:17:25:24 | **kwargs [element :p3] | semmle.label | **kwargs [element :p3] |
+| params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p2] | semmle.label | **kwargs : Hash [element :p2] |
+| params_flow.rb:25:17:25:24 | **kwargs : Hash [element :p3] | semmle.label | **kwargs : Hash [element :p3] |
 | params_flow.rb:26:10:26:11 | p1 | semmle.label | p1 |
 | params_flow.rb:28:10:28:22 | ( ... ) | semmle.label | ( ... ) |
-| params_flow.rb:28:11:28:16 | kwargs [element :p2] | semmle.label | kwargs [element :p2] |
+| params_flow.rb:28:11:28:16 | kwargs : Hash [element :p2] | semmle.label | kwargs : Hash [element :p2] |
 | params_flow.rb:28:11:28:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:29:10:29:22 | ( ... ) | semmle.label | ( ... ) |
-| params_flow.rb:29:11:29:16 | kwargs [element :p3] | semmle.label | kwargs [element :p3] |
+| params_flow.rb:29:11:29:16 | kwargs : Hash [element :p3] | semmle.label | kwargs : Hash [element :p3] |
 | params_flow.rb:29:11:29:21 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:33:12:33:19 | call to taint | semmle.label | call to taint |
 | params_flow.rb:33:26:33:34 | call to taint | semmle.label | call to taint |
 | params_flow.rb:33:41:33:49 | call to taint | semmle.label | call to taint |
-| params_flow.rb:34:1:34:4 | args [element :p3] | semmle.label | args [element :p3] |
-| params_flow.rb:34:8:34:32 | call to [] [element :p3] | semmle.label | call to [] [element :p3] |
+| params_flow.rb:34:1:34:4 | args : Hash [element :p3] | semmle.label | args : Hash [element :p3] |
+| params_flow.rb:34:8:34:32 | call to [] : Hash [element :p3] | semmle.label | call to [] : Hash [element :p3] |
 | params_flow.rb:34:14:34:22 | call to taint | semmle.label | call to taint |
 | params_flow.rb:35:12:35:20 | call to taint | semmle.label | call to taint |
-| params_flow.rb:35:23:35:28 | ** ... [element :p3] | semmle.label | ** ... [element :p3] |
-| params_flow.rb:35:25:35:28 | args [element :p3] | semmle.label | args [element :p3] |
-| params_flow.rb:37:1:37:4 | args [element :p1] | semmle.label | args [element :p1] |
-| params_flow.rb:37:1:37:4 | args [element :p2] | semmle.label | args [element :p2] |
-| params_flow.rb:37:8:37:44 | call to [] [element :p1] | semmle.label | call to [] [element :p1] |
-| params_flow.rb:37:8:37:44 | call to [] [element :p2] | semmle.label | call to [] [element :p2] |
+| params_flow.rb:35:23:35:28 | ** ... : Hash [element :p3] | semmle.label | ** ... : Hash [element :p3] |
+| params_flow.rb:35:25:35:28 | args : Hash [element :p3] | semmle.label | args : Hash [element :p3] |
+| params_flow.rb:37:1:37:4 | args : Hash [element :p1] | semmle.label | args : Hash [element :p1] |
+| params_flow.rb:37:1:37:4 | args : Hash [element :p2] | semmle.label | args : Hash [element :p2] |
+| params_flow.rb:37:8:37:44 | call to [] : Hash [element :p1] | semmle.label | call to [] : Hash [element :p1] |
+| params_flow.rb:37:8:37:44 | call to [] : Hash [element :p2] | semmle.label | call to [] : Hash [element :p2] |
 | params_flow.rb:37:16:37:24 | call to taint | semmle.label | call to taint |
 | params_flow.rb:37:34:37:42 | call to taint | semmle.label | call to taint |
-| params_flow.rb:38:8:38:13 | ** ... [element :p1] | semmle.label | ** ... [element :p1] |
-| params_flow.rb:38:8:38:13 | ** ... [element :p2] | semmle.label | ** ... [element :p2] |
-| params_flow.rb:38:10:38:13 | args [element :p1] | semmle.label | args [element :p1] |
-| params_flow.rb:38:10:38:13 | args [element :p2] | semmle.label | args [element :p2] |
-| params_flow.rb:40:1:40:4 | args [element :p1] | semmle.label | args [element :p1] |
-| params_flow.rb:40:8:40:26 | call to [] [element :p1] | semmle.label | call to [] [element :p1] |
+| params_flow.rb:38:8:38:13 | ** ... : Hash [element :p1] | semmle.label | ** ... : Hash [element :p1] |
+| params_flow.rb:38:8:38:13 | ** ... : Hash [element :p2] | semmle.label | ** ... : Hash [element :p2] |
+| params_flow.rb:38:10:38:13 | args : Hash [element :p1] | semmle.label | args : Hash [element :p1] |
+| params_flow.rb:38:10:38:13 | args : Hash [element :p2] | semmle.label | args : Hash [element :p2] |
+| params_flow.rb:40:1:40:4 | args : Hash [element :p1] | semmle.label | args : Hash [element :p1] |
+| params_flow.rb:40:8:40:26 | call to [] : Hash [element :p1] | semmle.label | call to [] : Hash [element :p1] |
 | params_flow.rb:40:16:40:24 | call to taint | semmle.label | call to taint |
 | params_flow.rb:41:13:41:21 | call to taint | semmle.label | call to taint |
-| params_flow.rb:41:24:41:29 | ** ... [element :p1] | semmle.label | ** ... [element :p1] |
-| params_flow.rb:41:26:41:29 | args [element :p1] | semmle.label | args [element :p1] |
-| params_flow.rb:43:1:43:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:43:8:43:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:41:24:41:29 | ** ... : Hash [element :p1] | semmle.label | ** ... : Hash [element :p1] |
+| params_flow.rb:41:26:41:29 | args : Hash [element :p1] | semmle.label | args : Hash [element :p1] |
+| params_flow.rb:43:1:43:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:43:8:43:18 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | params_flow.rb:43:9:43:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:44:12:44:20 | call to taint | semmle.label | call to taint |
-| params_flow.rb:44:23:44:27 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:44:24:44:27 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:46:1:46:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:46:1:46:4 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:46:8:46:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| params_flow.rb:46:8:46:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| params_flow.rb:44:23:44:27 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:44:24:44:27 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:46:1:46:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:46:1:46:4 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:46:8:46:29 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| params_flow.rb:46:8:46:29 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | params_flow.rb:46:9:46:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:46:20:46:28 | call to taint | semmle.label | call to taint |
-| params_flow.rb:47:12:47:16 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:47:12:47:16 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:47:13:47:16 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:47:13:47:16 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:47:12:47:16 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:47:12:47:16 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| params_flow.rb:47:13:47:16 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:47:13:47:16 | args : Array [element 1] | semmle.label | args : Array [element 1] |
 | params_flow.rb:49:13:49:14 | p1 | semmle.label | p1 |
-| params_flow.rb:49:17:49:24 | *posargs [element 0] | semmle.label | *posargs [element 0] |
+| params_flow.rb:49:17:49:24 | *posargs : Array [element 0] | semmle.label | *posargs : Array [element 0] |
+| params_flow.rb:49:17:49:24 | *posargs : [collection] [element 0] | semmle.label | *posargs : [collection] [element 0] |
 | params_flow.rb:50:10:50:11 | p1 | semmle.label | p1 |
 | params_flow.rb:51:10:51:21 | ( ... ) | semmle.label | ( ... ) |
-| params_flow.rb:51:11:51:17 | posargs [element 0] | semmle.label | posargs [element 0] |
+| params_flow.rb:51:11:51:17 | posargs : Array [element 0] | semmle.label | posargs : Array [element 0] |
+| params_flow.rb:51:11:51:17 | posargs : [collection] [element 0] | semmle.label | posargs : [collection] [element 0] |
 | params_flow.rb:51:11:51:20 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:55:9:55:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:55:20:55:28 | call to taint | semmle.label | call to taint |
-| params_flow.rb:57:1:57:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:57:8:57:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:57:1:57:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:57:8:57:18 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | params_flow.rb:57:9:57:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:58:9:58:17 | call to taint | semmle.label | call to taint |
-| params_flow.rb:58:20:58:24 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:58:21:58:24 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:60:1:60:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:60:1:60:4 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:60:8:60:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| params_flow.rb:60:8:60:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| params_flow.rb:58:20:58:24 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:58:21:58:24 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:60:1:60:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:60:1:60:4 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:60:8:60:29 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| params_flow.rb:60:8:60:29 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | params_flow.rb:60:9:60:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:60:20:60:28 | call to taint | semmle.label | call to taint |
-| params_flow.rb:61:9:61:13 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:61:9:61:13 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:61:10:61:13 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:61:10:61:13 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:61:9:61:13 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:61:9:61:13 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| params_flow.rb:61:10:61:13 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:61:10:61:13 | args : Array [element 1] | semmle.label | args : Array [element 1] |
 | params_flow.rb:63:1:63:4 | args | semmle.label | args |
 | params_flow.rb:63:8:63:16 | call to taint | semmle.label | call to taint |
-| params_flow.rb:64:16:64:17 | *x [element 0] | semmle.label | *x [element 0] |
-| params_flow.rb:65:10:65:10 | x [element 0] | semmle.label | x [element 0] |
+| params_flow.rb:64:16:64:17 | *x : [collection] [element 0] | semmle.label | *x : [collection] [element 0] |
+| params_flow.rb:65:10:65:10 | x : [collection] [element 0] | semmle.label | x : [collection] [element 0] |
 | params_flow.rb:65:10:65:13 | ...[...] | semmle.label | ...[...] |
-| params_flow.rb:67:12:67:16 | * ... [element 0] | semmle.label | * ... [element 0] |
+| params_flow.rb:67:12:67:16 | * ... : [collection] [element 0] | semmle.label | * ... : [collection] [element 0] |
 | params_flow.rb:67:13:67:16 | args | semmle.label | args |
 | params_flow.rb:69:14:69:14 | x | semmle.label | x |
 | params_flow.rb:69:17:69:17 | y | semmle.label | y |
@@ -277,12 +281,12 @@ nodes
 | params_flow.rb:71:10:71:10 | y | semmle.label | y |
 | params_flow.rb:78:10:78:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:78:21:78:29 | call to taint | semmle.label | call to taint |
-| params_flow.rb:80:1:80:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:80:8:80:51 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| params_flow.rb:80:1:80:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:80:8:80:51 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | params_flow.rb:80:9:80:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:81:10:81:18 | call to taint | semmle.label | call to taint |
-| params_flow.rb:81:21:81:25 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:81:22:81:25 | args [element 0] | semmle.label | args [element 0] |
+| params_flow.rb:81:21:81:25 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:81:22:81:25 | args : Array [element 0] | semmle.label | args : Array [element 0] |
 | params_flow.rb:83:14:83:14 | t | semmle.label | t |
 | params_flow.rb:83:17:83:17 | u | semmle.label | u |
 | params_flow.rb:83:20:83:20 | v | semmle.label | v |
@@ -295,28 +299,28 @@ nodes
 | params_flow.rb:87:10:87:10 | w | semmle.label | w |
 | params_flow.rb:88:10:88:10 | x | semmle.label | x |
 | params_flow.rb:89:10:89:10 | y | semmle.label | y |
-| params_flow.rb:93:1:93:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:93:1:93:4 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:93:1:93:4 | args [element 2] | semmle.label | args [element 2] |
-| params_flow.rb:93:1:93:4 | args [element 3] | semmle.label | args [element 3] |
-| params_flow.rb:93:8:93:51 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| params_flow.rb:93:8:93:51 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| params_flow.rb:93:8:93:51 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| params_flow.rb:93:8:93:51 | call to [] [element 3] | semmle.label | call to [] [element 3] |
+| params_flow.rb:93:1:93:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:93:1:93:4 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:93:1:93:4 | args : Array [element 2] | semmle.label | args : Array [element 2] |
+| params_flow.rb:93:1:93:4 | args : Array [element 3] | semmle.label | args : Array [element 3] |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| params_flow.rb:93:8:93:51 | call to [] : Array [element 3] | semmle.label | call to [] : Array [element 3] |
 | params_flow.rb:93:9:93:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:20:93:28 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:31:93:39 | call to taint | semmle.label | call to taint |
 | params_flow.rb:93:42:93:50 | call to taint | semmle.label | call to taint |
 | params_flow.rb:94:10:94:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:94:21:94:29 | call to taint | semmle.label | call to taint |
-| params_flow.rb:94:32:94:36 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:94:32:94:36 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:94:32:94:36 | * ... [element 2] | semmle.label | * ... [element 2] |
-| params_flow.rb:94:32:94:36 | * ... [element 3] | semmle.label | * ... [element 3] |
-| params_flow.rb:94:33:94:36 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:94:33:94:36 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:94:33:94:36 | args [element 2] | semmle.label | args [element 2] |
-| params_flow.rb:94:33:94:36 | args [element 3] | semmle.label | args [element 3] |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 2] | semmle.label | * ... : Array [element 2] |
+| params_flow.rb:94:32:94:36 | * ... : Array [element 3] | semmle.label | * ... : Array [element 3] |
+| params_flow.rb:94:33:94:36 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:94:33:94:36 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:94:33:94:36 | args : Array [element 2] | semmle.label | args : Array [element 2] |
+| params_flow.rb:94:33:94:36 | args : Array [element 3] | semmle.label | args : Array [element 3] |
 | params_flow.rb:96:10:96:18 | call to taint | semmle.label | call to taint |
 | params_flow.rb:96:21:96:29 | call to taint | semmle.label | call to taint |
 | params_flow.rb:98:19:98:19 | a | semmle.label | a |
@@ -324,54 +328,54 @@ nodes
 | params_flow.rb:105:15:105:23 | call to taint | semmle.label | call to taint |
 | params_flow.rb:106:15:106:23 | call to taint | semmle.label | call to taint |
 | params_flow.rb:108:37:108:37 | a | semmle.label | a |
-| params_flow.rb:108:40:108:41 | *b [element 0] | semmle.label | *b [element 0] |
+| params_flow.rb:108:40:108:41 | *b : [collection] [element 0] | semmle.label | *b : [collection] [element 0] |
 | params_flow.rb:108:44:108:44 | c | semmle.label | c |
 | params_flow.rb:109:10:109:10 | a | semmle.label | a |
-| params_flow.rb:110:10:110:10 | b [element 0] | semmle.label | b [element 0] |
+| params_flow.rb:110:10:110:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
 | params_flow.rb:110:10:110:13 | ...[...] | semmle.label | ...[...] |
 | params_flow.rb:111:10:111:10 | c | semmle.label | c |
 | params_flow.rb:114:33:114:41 | call to taint | semmle.label | call to taint |
 | params_flow.rb:114:44:114:52 | call to taint | semmle.label | call to taint |
 | params_flow.rb:114:58:114:66 | call to taint | semmle.label | call to taint |
-| params_flow.rb:117:1:117:1 | [post] x [element] | semmle.label | [post] x [element] |
+| params_flow.rb:117:1:117:1 | [post] x : [collection] [element] | semmle.label | [post] x : [collection] [element] |
 | params_flow.rb:117:19:117:27 | call to taint | semmle.label | call to taint |
-| params_flow.rb:118:12:118:13 | * ... [element] | semmle.label | * ... [element] |
-| params_flow.rb:118:13:118:13 | x [element] | semmle.label | x [element] |
-| params_flow.rb:130:1:130:4 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:130:1:130:4 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:130:8:130:29 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| params_flow.rb:130:8:130:29 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| params_flow.rb:118:12:118:13 | * ... : [collection] [element] | semmle.label | * ... : [collection] [element] |
+| params_flow.rb:118:13:118:13 | x : [collection] [element] | semmle.label | x : [collection] [element] |
+| params_flow.rb:130:1:130:4 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:130:1:130:4 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:130:8:130:29 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| params_flow.rb:130:8:130:29 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | params_flow.rb:130:9:130:17 | call to taint | semmle.label | call to taint |
 | params_flow.rb:130:20:130:28 | call to taint | semmle.label | call to taint |
-| params_flow.rb:131:10:131:14 | * ... [element 0] | semmle.label | * ... [element 0] |
-| params_flow.rb:131:10:131:14 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:131:11:131:14 | args [element 0] | semmle.label | args [element 0] |
-| params_flow.rb:131:11:131:14 | args [element 1] | semmle.label | args [element 1] |
-| params_flow.rb:133:14:133:18 | *args [element 1] | semmle.label | *args [element 1] |
-| params_flow.rb:134:10:134:13 | args [element 1] | semmle.label | args [element 1] |
+| params_flow.rb:131:10:131:14 | * ... : Array [element 0] | semmle.label | * ... : Array [element 0] |
+| params_flow.rb:131:10:131:14 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| params_flow.rb:131:11:131:14 | args : Array [element 0] | semmle.label | args : Array [element 0] |
+| params_flow.rb:131:11:131:14 | args : Array [element 1] | semmle.label | args : Array [element 1] |
+| params_flow.rb:133:14:133:18 | *args : Array [element 1] | semmle.label | *args : Array [element 1] |
+| params_flow.rb:134:10:134:13 | args : Array [element 1] | semmle.label | args : Array [element 1] |
 | params_flow.rb:134:10:134:16 | ...[...] | semmle.label | ...[...] |
-| params_flow.rb:137:10:137:43 | * ... [element 1] | semmle.label | * ... [element 1] |
-| params_flow.rb:137:11:137:43 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| params_flow.rb:137:10:137:43 | * ... : Array [element 1] | semmle.label | * ... : Array [element 1] |
+| params_flow.rb:137:11:137:43 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | params_flow.rb:137:23:137:31 | call to taint | semmle.label | call to taint |
-| params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | semmle.label | p1 [Return] [element 0] |
+| params_flow.rb:153:23:153:24 | p1 [Return] : [collection] [element 0] | semmle.label | p1 [Return] : [collection] [element 0] |
 | params_flow.rb:153:28:153:29 | p2 | semmle.label | p2 |
-| params_flow.rb:154:5:154:6 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
+| params_flow.rb:154:5:154:6 | [post] p1 : [collection] [element 0] | semmle.label | [post] p1 : [collection] [element 0] |
 | params_flow.rb:154:18:154:19 | p2 | semmle.label | p2 |
-| params_flow.rb:164:23:164:24 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
+| params_flow.rb:164:23:164:24 | [post] p1 : [collection] [element 0] | semmle.label | [post] p1 : [collection] [element 0] |
 | params_flow.rb:164:31:164:39 | call to taint | semmle.label | call to taint |
-| params_flow.rb:165:6:165:7 | p1 [element 0] | semmle.label | p1 [element 0] |
+| params_flow.rb:165:6:165:7 | p1 : [collection] [element 0] | semmle.label | p1 : [collection] [element 0] |
 | params_flow.rb:165:6:165:10 | ...[...] | semmle.label | ...[...] |
-| params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | semmle.label | p1 [Return] [element 0] |
+| params_flow.rb:181:24:181:25 | p1 [Return] : [collection] [element 0] | semmle.label | p1 [Return] : [collection] [element 0] |
 | params_flow.rb:181:28:181:29 | p2 | semmle.label | p2 |
-| params_flow.rb:182:5:182:6 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
+| params_flow.rb:182:5:182:6 | [post] p1 : [collection] [element 0] | semmle.label | [post] p1 : [collection] [element 0] |
 | params_flow.rb:182:18:182:19 | p2 | semmle.label | p2 |
-| params_flow.rb:192:20:192:21 | [post] p1 [element 0] | semmle.label | [post] p1 [element 0] |
+| params_flow.rb:192:20:192:21 | [post] p1 : [collection] [element 0] | semmle.label | [post] p1 : [collection] [element 0] |
 | params_flow.rb:192:24:192:32 | call to taint | semmle.label | call to taint |
-| params_flow.rb:193:6:193:7 | p1 [element 0] | semmle.label | p1 [element 0] |
+| params_flow.rb:193:6:193:7 | p1 : [collection] [element 0] | semmle.label | p1 : [collection] [element 0] |
 | params_flow.rb:193:6:193:10 | ...[...] | semmle.label | ...[...] |
 subpaths
-| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:153:23:153:24 | p1 [Return] [element 0] | params_flow.rb:164:23:164:24 | [post] p1 [element 0] |
-| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:181:24:181:25 | p1 [Return] [element 0] | params_flow.rb:192:20:192:21 | [post] p1 [element 0] |
+| params_flow.rb:164:31:164:39 | call to taint | params_flow.rb:153:28:153:29 | p2 | params_flow.rb:153:23:153:24 | p1 [Return] : [collection] [element 0] | params_flow.rb:164:23:164:24 | [post] p1 : [collection] [element 0] |
+| params_flow.rb:192:24:192:32 | call to taint | params_flow.rb:181:28:181:29 | p2 | params_flow.rb:181:24:181:25 | p1 [Return] : [collection] [element 0] | params_flow.rb:192:20:192:21 | [post] p1 : [collection] [element 0] |
 testFailures
 #select
 | params_flow.rb:10:10:10:11 | p1 | params_flow.rb:14:12:14:19 | call to taint | params_flow.rb:10:10:10:11 | p1 | $@ | params_flow.rb:14:12:14:19 | call to taint | call to taint |

--- a/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/ssa-flow/ssa-flow.expected
@@ -1,12 +1,12 @@
 models
 edges
-| ssa_flow.rb:12:9:12:9 | [post] a [element 0] | ssa_flow.rb:16:10:16:10 | a [element 0] | provenance |  |
-| ssa_flow.rb:12:16:12:23 | call to taint | ssa_flow.rb:12:9:12:9 | [post] a [element 0] | provenance |  |
-| ssa_flow.rb:16:10:16:10 | a [element 0] | ssa_flow.rb:16:10:16:13 | ...[...] | provenance |  |
+| ssa_flow.rb:12:9:12:9 | [post] a : [collection] [element 0] | ssa_flow.rb:16:10:16:10 | a : [collection] [element 0] | provenance |  |
+| ssa_flow.rb:12:16:12:23 | call to taint | ssa_flow.rb:12:9:12:9 | [post] a : [collection] [element 0] | provenance |  |
+| ssa_flow.rb:16:10:16:10 | a : [collection] [element 0] | ssa_flow.rb:16:10:16:13 | ...[...] | provenance |  |
 nodes
-| ssa_flow.rb:12:9:12:9 | [post] a [element 0] | semmle.label | [post] a [element 0] |
+| ssa_flow.rb:12:9:12:9 | [post] a : [collection] [element 0] | semmle.label | [post] a : [collection] [element 0] |
 | ssa_flow.rb:12:16:12:23 | call to taint | semmle.label | call to taint |
-| ssa_flow.rb:16:10:16:10 | a [element 0] | semmle.label | a [element 0] |
+| ssa_flow.rb:16:10:16:10 | a : [collection] [element 0] | semmle.label | a : [collection] [element 0] |
 | ssa_flow.rb:16:10:16:13 | ...[...] | semmle.label | ...[...] |
 subpaths
 testFailures

--- a/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
+++ b/ruby/ql/test/library-tests/dataflow/summaries/Summaries.expected
@@ -83,8 +83,8 @@ edges
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:155:28:155:34 | tainted | provenance | Sink:MaD:6 |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:156:27:156:33 | tainted | provenance | Sink:MaD:6 |
 | summaries.rb:1:11:1:36 | call to identity | summaries.rb:156:27:156:33 | tainted | provenance | Sink:MaD:6 |
-| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end [captured tainted] | provenance |  |
-| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end [captured tainted] | provenance |  |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | provenance |  |
+| summaries.rb:1:11:1:36 | call to identity | summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | provenance |  |
 | summaries.rb:1:20:1:36 | call to source | summaries.rb:1:11:1:36 | call to identity | provenance |  |
 | summaries.rb:1:20:1:36 | call to source | summaries.rb:1:11:1:36 | call to identity | provenance |  |
 | summaries.rb:4:1:4:8 | tainted2 | summaries.rb:9:6:9:13 | tainted2 | provenance |  |
@@ -128,11 +128,11 @@ edges
 | summaries.rb:44:8:44:8 | t | summaries.rb:44:8:44:27 | call to matchedByNameRcv | provenance | MaD:23 |
 | summaries.rb:48:24:48:41 | call to source | summaries.rb:48:8:48:42 | call to preserveTaint | provenance | MaD:11 |
 | summaries.rb:51:24:51:30 | tainted | summaries.rb:51:6:51:31 | call to namedArg | provenance | MaD:14 |
-| summaries.rb:53:1:53:4 | args [element :foo] | summaries.rb:54:21:54:24 | args [element :foo] | provenance |  |
-| summaries.rb:53:8:53:33 | call to [] [element :foo] | summaries.rb:53:1:53:4 | args [element :foo] | provenance |  |
-| summaries.rb:53:15:53:31 | call to source | summaries.rb:53:8:53:33 | call to [] [element :foo] | provenance |  |
-| summaries.rb:54:19:54:24 | ** ... [element :foo] | summaries.rb:54:6:54:25 | call to namedArg | provenance | MaD:14 |
-| summaries.rb:54:21:54:24 | args [element :foo] | summaries.rb:54:19:54:24 | ** ... [element :foo] | provenance |  |
+| summaries.rb:53:1:53:4 | args : Hash [element :foo] | summaries.rb:54:21:54:24 | args : Hash [element :foo] | provenance |  |
+| summaries.rb:53:8:53:33 | call to [] : Hash [element :foo] | summaries.rb:53:1:53:4 | args : Hash [element :foo] | provenance |  |
+| summaries.rb:53:15:53:31 | call to source | summaries.rb:53:8:53:33 | call to [] : Hash [element :foo] | provenance |  |
+| summaries.rb:54:19:54:24 | ** ... : Hash [element :foo] | summaries.rb:54:6:54:25 | call to namedArg | provenance | MaD:14 |
+| summaries.rb:54:21:54:24 | args : Hash [element :foo] | summaries.rb:54:19:54:24 | ** ... : Hash [element :foo] | provenance |  |
 | summaries.rb:56:22:56:28 | tainted | summaries.rb:56:6:56:29 | call to anyArg | provenance | MaD:8 |
 | summaries.rb:57:17:57:23 | tainted | summaries.rb:57:6:57:24 | call to anyArg | provenance | MaD:8 |
 | summaries.rb:59:27:59:33 | tainted | summaries.rb:59:6:59:34 | call to anyNamedArg | provenance | MaD:9 |
@@ -141,128 +141,128 @@ edges
 | summaries.rb:65:40:65:40 | x | summaries.rb:66:8:66:8 | x | provenance |  |
 | summaries.rb:73:24:73:53 | call to source | summaries.rb:73:8:73:54 | call to preserveTaint | provenance | MaD:18 |
 | summaries.rb:76:26:76:56 | call to source | summaries.rb:76:8:76:57 | call to preserveTaint | provenance | MaD:19 |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:82:6:82:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:82:6:82:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:83:6:83:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:83:6:83:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:85:6:85:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:85:6:85:6 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:87:5:87:5 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:87:5:87:5 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:91:5:91:5 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 1] | summaries.rb:91:5:91:5 | a [element 1] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:86:6:86:6 | a [element 2] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:86:6:86:6 | a [element 2] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:95:1:95:1 | a [element 2] | provenance |  |
-| summaries.rb:79:1:79:1 | a [element 2] | summaries.rb:95:1:95:1 | a [element 2] | provenance |  |
-| summaries.rb:79:5:79:47 | call to [] [element 1] | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
-| summaries.rb:79:5:79:47 | call to [] [element 1] | summaries.rb:79:1:79:1 | a [element 1] | provenance |  |
-| summaries.rb:79:5:79:47 | call to [] [element 2] | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
-| summaries.rb:79:5:79:47 | call to [] [element 2] | summaries.rb:79:1:79:1 | a [element 2] | provenance |  |
-| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] [element 1] | provenance |  |
-| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] [element 1] | provenance |  |
-| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] [element 2] | provenance |  |
-| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] [element 2] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:82:6:82:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:82:6:82:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:84:6:84:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:84:6:84:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:85:6:85:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:85:6:85:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:86:6:86:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:86:6:86:6 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:87:5:87:5 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:87:5:87:5 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:95:1:95:1 | a [element] | provenance |  |
-| summaries.rb:81:1:81:1 | [post] a [element] | summaries.rb:95:1:95:1 | a [element] | provenance |  |
-| summaries.rb:81:13:81:27 | call to source | summaries.rb:81:1:81:1 | [post] a [element] | provenance |  |
-| summaries.rb:81:13:81:27 | call to source | summaries.rb:81:1:81:1 | [post] a [element] | provenance |  |
-| summaries.rb:82:6:82:6 | a [element 1] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
-| summaries.rb:82:6:82:6 | a [element 1] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
-| summaries.rb:82:6:82:6 | a [element] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
-| summaries.rb:82:6:82:6 | a [element] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
-| summaries.rb:83:6:83:6 | a [element 1] | summaries.rb:83:6:83:31 | call to readExactlyElementOne | provenance | MaD:26 |
-| summaries.rb:83:6:83:6 | a [element 1] | summaries.rb:83:6:83:31 | call to readExactlyElementOne | provenance | MaD:26 |
-| summaries.rb:84:6:84:6 | a [element] | summaries.rb:84:6:84:9 | ...[...] | provenance |  |
-| summaries.rb:84:6:84:6 | a [element] | summaries.rb:84:6:84:9 | ...[...] | provenance |  |
-| summaries.rb:85:6:85:6 | a [element 1] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
-| summaries.rb:85:6:85:6 | a [element 1] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
-| summaries.rb:85:6:85:6 | a [element] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
-| summaries.rb:85:6:85:6 | a [element] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
-| summaries.rb:86:6:86:6 | a [element 2] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
-| summaries.rb:86:6:86:6 | a [element 2] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
-| summaries.rb:86:6:86:6 | a [element] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
-| summaries.rb:86:6:86:6 | a [element] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element 1] | summaries.rb:89:6:89:6 | b [element 1] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element 1] | summaries.rb:89:6:89:6 | b [element 1] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:88:6:88:6 | b [element] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:88:6:88:6 | b [element] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:89:6:89:6 | b [element] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:89:6:89:6 | b [element] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:90:6:90:6 | b [element] | provenance |  |
-| summaries.rb:87:1:87:1 | b [element] | summaries.rb:90:6:90:6 | b [element] | provenance |  |
-| summaries.rb:87:5:87:5 | a [element 1] | summaries.rb:87:5:87:22 | call to withElementOne [element 1] | provenance | MaD:28 |
-| summaries.rb:87:5:87:5 | a [element 1] | summaries.rb:87:5:87:22 | call to withElementOne [element 1] | provenance | MaD:28 |
-| summaries.rb:87:5:87:5 | a [element] | summaries.rb:87:5:87:22 | call to withElementOne [element] | provenance | MaD:28 |
-| summaries.rb:87:5:87:5 | a [element] | summaries.rb:87:5:87:22 | call to withElementOne [element] | provenance | MaD:28 |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] | summaries.rb:87:1:87:1 | b [element 1] | provenance |  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] | summaries.rb:87:1:87:1 | b [element 1] | provenance |  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] | summaries.rb:87:1:87:1 | b [element] | provenance |  |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] | summaries.rb:87:1:87:1 | b [element] | provenance |  |
-| summaries.rb:88:6:88:6 | b [element] | summaries.rb:88:6:88:9 | ...[...] | provenance |  |
-| summaries.rb:88:6:88:6 | b [element] | summaries.rb:88:6:88:9 | ...[...] | provenance |  |
-| summaries.rb:89:6:89:6 | b [element 1] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
-| summaries.rb:89:6:89:6 | b [element 1] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
-| summaries.rb:89:6:89:6 | b [element] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
-| summaries.rb:89:6:89:6 | b [element] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
-| summaries.rb:90:6:90:6 | b [element] | summaries.rb:90:6:90:9 | ...[...] | provenance |  |
-| summaries.rb:90:6:90:6 | b [element] | summaries.rb:90:6:90:9 | ...[...] | provenance |  |
-| summaries.rb:91:1:91:1 | c [element 1] | summaries.rb:93:6:93:6 | c [element 1] | provenance |  |
-| summaries.rb:91:1:91:1 | c [element 1] | summaries.rb:93:6:93:6 | c [element 1] | provenance |  |
-| summaries.rb:91:5:91:5 | a [element 1] | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | provenance | MaD:29 |
-| summaries.rb:91:5:91:5 | a [element 1] | summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | provenance | MaD:29 |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | summaries.rb:91:1:91:1 | c [element 1] | provenance |  |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | summaries.rb:91:1:91:1 | c [element 1] | provenance |  |
-| summaries.rb:93:6:93:6 | c [element 1] | summaries.rb:93:6:93:9 | ...[...] | provenance |  |
-| summaries.rb:93:6:93:6 | c [element 1] | summaries.rb:93:6:93:9 | ...[...] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | summaries.rb:98:6:98:6 | a [element 2] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | summaries.rb:98:6:98:6 | a [element 2] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | summaries.rb:99:1:99:1 | a [element 2] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | summaries.rb:99:1:99:1 | a [element 2] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:96:6:96:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:96:6:96:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:97:6:97:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:97:6:97:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:98:6:98:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | [post] a [element] | summaries.rb:98:6:98:6 | a [element] | provenance |  |
-| summaries.rb:95:1:95:1 | a [element 2] | summaries.rb:95:1:95:1 | [post] a [element 2] | provenance | MaD:32 |
-| summaries.rb:95:1:95:1 | a [element 2] | summaries.rb:95:1:95:1 | [post] a [element 2] | provenance | MaD:32 |
-| summaries.rb:95:1:95:1 | a [element] | summaries.rb:95:1:95:1 | [post] a [element] | provenance | MaD:32 |
-| summaries.rb:95:1:95:1 | a [element] | summaries.rb:95:1:95:1 | [post] a [element] | provenance | MaD:32 |
-| summaries.rb:96:6:96:6 | a [element] | summaries.rb:96:6:96:9 | ...[...] | provenance |  |
-| summaries.rb:96:6:96:6 | a [element] | summaries.rb:96:6:96:9 | ...[...] | provenance |  |
-| summaries.rb:97:6:97:6 | a [element] | summaries.rb:97:6:97:9 | ...[...] | provenance |  |
-| summaries.rb:97:6:97:6 | a [element] | summaries.rb:97:6:97:9 | ...[...] | provenance |  |
-| summaries.rb:98:6:98:6 | a [element 2] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
-| summaries.rb:98:6:98:6 | a [element 2] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
-| summaries.rb:98:6:98:6 | a [element] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
-| summaries.rb:98:6:98:6 | a [element] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
-| summaries.rb:99:1:99:1 | [post] a [element 2] | summaries.rb:102:6:102:6 | a [element 2] | provenance |  |
-| summaries.rb:99:1:99:1 | [post] a [element 2] | summaries.rb:102:6:102:6 | a [element 2] | provenance |  |
-| summaries.rb:99:1:99:1 | a [element 2] | summaries.rb:99:1:99:1 | [post] a [element 2] | provenance | MaD:31 |
-| summaries.rb:99:1:99:1 | a [element 2] | summaries.rb:99:1:99:1 | [post] a [element 2] | provenance | MaD:31 |
-| summaries.rb:102:6:102:6 | a [element 2] | summaries.rb:102:6:102:9 | ...[...] | provenance |  |
-| summaries.rb:102:6:102:6 | a [element 2] | summaries.rb:102:6:102:9 | ...[...] | provenance |  |
-| summaries.rb:103:1:103:1 | [post] d [element 3] | summaries.rb:104:1:104:1 | d [element 3] | provenance |  |
-| summaries.rb:103:1:103:1 | [post] d [element 3] | summaries.rb:104:1:104:1 | d [element 3] | provenance |  |
-| summaries.rb:103:8:103:22 | call to source | summaries.rb:103:1:103:1 | [post] d [element 3] | provenance |  |
-| summaries.rb:103:8:103:22 | call to source | summaries.rb:103:1:103:1 | [post] d [element 3] | provenance |  |
-| summaries.rb:104:1:104:1 | [post] d [element 3] | summaries.rb:108:6:108:6 | d [element 3] | provenance |  |
-| summaries.rb:104:1:104:1 | [post] d [element 3] | summaries.rb:108:6:108:6 | d [element 3] | provenance |  |
-| summaries.rb:104:1:104:1 | d [element 3] | summaries.rb:104:1:104:1 | [post] d [element 3] | provenance | MaD:30 |
-| summaries.rb:104:1:104:1 | d [element 3] | summaries.rb:104:1:104:1 | [post] d [element 3] | provenance | MaD:30 |
-| summaries.rb:108:6:108:6 | d [element 3] | summaries.rb:108:6:108:9 | ...[...] | provenance |  |
-| summaries.rb:108:6:108:6 | d [element 3] | summaries.rb:108:6:108:9 | ...[...] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:82:6:82:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:82:6:82:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:83:6:83:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:83:6:83:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:85:6:85:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:85:6:85:6 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:87:5:87:5 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:87:5:87:5 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:91:5:91:5 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | summaries.rb:91:5:91:5 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | summaries.rb:86:6:86:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | summaries.rb:86:6:86:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | summaries.rb:95:1:95:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | summaries.rb:95:1:95:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 1] | summaries.rb:79:1:79:1 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 1] | summaries.rb:79:1:79:1 | a : Array [element 1] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 2] | summaries.rb:79:1:79:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 2] | summaries.rb:79:1:79:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] : Array [element 1] | provenance |  |
+| summaries.rb:79:15:79:29 | call to source | summaries.rb:79:5:79:47 | call to [] : Array [element 1] | provenance |  |
+| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] : Array [element 2] | provenance |  |
+| summaries.rb:79:32:79:46 | call to source | summaries.rb:79:5:79:47 | call to [] : Array [element 2] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:82:6:82:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:82:6:82:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:84:6:84:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:84:6:84:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:85:6:85:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:85:6:85:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:86:6:86:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:86:6:86:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:87:5:87:5 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:87:5:87:5 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:95:1:95:1 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | summaries.rb:95:1:95:1 | a : [collection] [element] | provenance |  |
+| summaries.rb:81:13:81:27 | call to source | summaries.rb:81:1:81:1 | [post] a : [collection] [element] | provenance |  |
+| summaries.rb:81:13:81:27 | call to source | summaries.rb:81:1:81:1 | [post] a : [collection] [element] | provenance |  |
+| summaries.rb:82:6:82:6 | a : Array [element 1] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
+| summaries.rb:82:6:82:6 | a : Array [element 1] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
+| summaries.rb:82:6:82:6 | a : [collection] [element] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
+| summaries.rb:82:6:82:6 | a : [collection] [element] | summaries.rb:82:6:82:24 | call to readElementOne | provenance | MaD:25 |
+| summaries.rb:83:6:83:6 | a : Array [element 1] | summaries.rb:83:6:83:31 | call to readExactlyElementOne | provenance | MaD:26 |
+| summaries.rb:83:6:83:6 | a : Array [element 1] | summaries.rb:83:6:83:31 | call to readExactlyElementOne | provenance | MaD:26 |
+| summaries.rb:84:6:84:6 | a : [collection] [element] | summaries.rb:84:6:84:9 | ...[...] | provenance |  |
+| summaries.rb:84:6:84:6 | a : [collection] [element] | summaries.rb:84:6:84:9 | ...[...] | provenance |  |
+| summaries.rb:85:6:85:6 | a : Array [element 1] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
+| summaries.rb:85:6:85:6 | a : Array [element 1] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
+| summaries.rb:85:6:85:6 | a : [collection] [element] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
+| summaries.rb:85:6:85:6 | a : [collection] [element] | summaries.rb:85:6:85:9 | ...[...] | provenance |  |
+| summaries.rb:86:6:86:6 | a : Array [element 2] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
+| summaries.rb:86:6:86:6 | a : Array [element 2] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
+| summaries.rb:86:6:86:6 | a : [collection] [element] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
+| summaries.rb:86:6:86:6 | a : [collection] [element] | summaries.rb:86:6:86:9 | ...[...] | provenance |  |
+| summaries.rb:87:1:87:1 | b : Array [element 1] | summaries.rb:89:6:89:6 | b : Array [element 1] | provenance |  |
+| summaries.rb:87:1:87:1 | b : Array [element 1] | summaries.rb:89:6:89:6 | b : Array [element 1] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:88:6:88:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:88:6:88:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:89:6:89:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:89:6:89:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:90:6:90:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | summaries.rb:90:6:90:6 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:5:87:5 | a : Array [element 1] | summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | provenance | MaD:28 |
+| summaries.rb:87:5:87:5 | a : Array [element 1] | summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | provenance | MaD:28 |
+| summaries.rb:87:5:87:5 | a : [collection] [element] | summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | provenance | MaD:28 |
+| summaries.rb:87:5:87:5 | a : [collection] [element] | summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | provenance | MaD:28 |
+| summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | summaries.rb:87:1:87:1 | b : Array [element 1] | provenance |  |
+| summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | summaries.rb:87:1:87:1 | b : Array [element 1] | provenance |  |
+| summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | summaries.rb:87:1:87:1 | b : [collection] [element] | provenance |  |
+| summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | summaries.rb:87:1:87:1 | b : [collection] [element] | provenance |  |
+| summaries.rb:88:6:88:6 | b : [collection] [element] | summaries.rb:88:6:88:9 | ...[...] | provenance |  |
+| summaries.rb:88:6:88:6 | b : [collection] [element] | summaries.rb:88:6:88:9 | ...[...] | provenance |  |
+| summaries.rb:89:6:89:6 | b : Array [element 1] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
+| summaries.rb:89:6:89:6 | b : Array [element 1] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
+| summaries.rb:89:6:89:6 | b : [collection] [element] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
+| summaries.rb:89:6:89:6 | b : [collection] [element] | summaries.rb:89:6:89:9 | ...[...] | provenance |  |
+| summaries.rb:90:6:90:6 | b : [collection] [element] | summaries.rb:90:6:90:9 | ...[...] | provenance |  |
+| summaries.rb:90:6:90:6 | b : [collection] [element] | summaries.rb:90:6:90:9 | ...[...] | provenance |  |
+| summaries.rb:91:1:91:1 | c : Array [element 1] | summaries.rb:93:6:93:6 | c : Array [element 1] | provenance |  |
+| summaries.rb:91:1:91:1 | c : Array [element 1] | summaries.rb:93:6:93:6 | c : Array [element 1] | provenance |  |
+| summaries.rb:91:5:91:5 | a : Array [element 1] | summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | provenance | MaD:29 |
+| summaries.rb:91:5:91:5 | a : Array [element 1] | summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | provenance | MaD:29 |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | summaries.rb:91:1:91:1 | c : Array [element 1] | provenance |  |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | summaries.rb:91:1:91:1 | c : Array [element 1] | provenance |  |
+| summaries.rb:93:6:93:6 | c : Array [element 1] | summaries.rb:93:6:93:9 | ...[...] | provenance |  |
+| summaries.rb:93:6:93:6 | c : Array [element 1] | summaries.rb:93:6:93:9 | ...[...] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | summaries.rb:98:6:98:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | summaries.rb:98:6:98:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | summaries.rb:99:1:99:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | summaries.rb:99:1:99:1 | a : Array [element 2] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:96:6:96:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:96:6:96:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:97:6:97:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:97:6:97:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:98:6:98:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | summaries.rb:98:6:98:6 | a : [collection] [element] | provenance |  |
+| summaries.rb:95:1:95:1 | a : Array [element 2] | summaries.rb:95:1:95:1 | [post] a : Array [element 2] | provenance | MaD:32 |
+| summaries.rb:95:1:95:1 | a : Array [element 2] | summaries.rb:95:1:95:1 | [post] a : Array [element 2] | provenance | MaD:32 |
+| summaries.rb:95:1:95:1 | a : [collection] [element] | summaries.rb:95:1:95:1 | [post] a : [collection] [element] | provenance | MaD:32 |
+| summaries.rb:95:1:95:1 | a : [collection] [element] | summaries.rb:95:1:95:1 | [post] a : [collection] [element] | provenance | MaD:32 |
+| summaries.rb:96:6:96:6 | a : [collection] [element] | summaries.rb:96:6:96:9 | ...[...] | provenance |  |
+| summaries.rb:96:6:96:6 | a : [collection] [element] | summaries.rb:96:6:96:9 | ...[...] | provenance |  |
+| summaries.rb:97:6:97:6 | a : [collection] [element] | summaries.rb:97:6:97:9 | ...[...] | provenance |  |
+| summaries.rb:97:6:97:6 | a : [collection] [element] | summaries.rb:97:6:97:9 | ...[...] | provenance |  |
+| summaries.rb:98:6:98:6 | a : Array [element 2] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
+| summaries.rb:98:6:98:6 | a : Array [element 2] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
+| summaries.rb:98:6:98:6 | a : [collection] [element] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
+| summaries.rb:98:6:98:6 | a : [collection] [element] | summaries.rb:98:6:98:9 | ...[...] | provenance |  |
+| summaries.rb:99:1:99:1 | [post] a : Array [element 2] | summaries.rb:102:6:102:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:99:1:99:1 | [post] a : Array [element 2] | summaries.rb:102:6:102:6 | a : Array [element 2] | provenance |  |
+| summaries.rb:99:1:99:1 | a : Array [element 2] | summaries.rb:99:1:99:1 | [post] a : Array [element 2] | provenance | MaD:31 |
+| summaries.rb:99:1:99:1 | a : Array [element 2] | summaries.rb:99:1:99:1 | [post] a : Array [element 2] | provenance | MaD:31 |
+| summaries.rb:102:6:102:6 | a : Array [element 2] | summaries.rb:102:6:102:9 | ...[...] | provenance |  |
+| summaries.rb:102:6:102:6 | a : Array [element 2] | summaries.rb:102:6:102:9 | ...[...] | provenance |  |
+| summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | summaries.rb:104:1:104:1 | d : [collection] [element 3] | provenance |  |
+| summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | summaries.rb:104:1:104:1 | d : [collection] [element 3] | provenance |  |
+| summaries.rb:103:8:103:22 | call to source | summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | provenance |  |
+| summaries.rb:103:8:103:22 | call to source | summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | provenance |  |
+| summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | summaries.rb:108:6:108:6 | d : [collection] [element 3] | provenance |  |
+| summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | summaries.rb:108:6:108:6 | d : [collection] [element 3] | provenance |  |
+| summaries.rb:104:1:104:1 | d : [collection] [element 3] | summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | provenance | MaD:30 |
+| summaries.rb:104:1:104:1 | d : [collection] [element 3] | summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | provenance | MaD:30 |
+| summaries.rb:108:6:108:6 | d : [collection] [element 3] | summaries.rb:108:6:108:9 | ...[...] | provenance |  |
+| summaries.rb:108:6:108:6 | d : [collection] [element 3] | summaries.rb:108:6:108:9 | ...[...] | provenance |  |
 | summaries.rb:111:1:111:1 | [post] x [@value] | summaries.rb:112:6:112:6 | x [@value] | provenance |  |
 | summaries.rb:111:1:111:1 | [post] x [@value] | summaries.rb:112:6:112:6 | x [@value] | provenance |  |
 | summaries.rb:111:13:111:26 | call to source | summaries.rb:111:1:111:1 | [post] x [@value] | provenance | MaD:27 |
@@ -283,7 +283,7 @@ edges
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:154:20:154:26 | tainted | provenance | Sink:MaD:6 |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:155:28:155:34 | tainted | provenance | Sink:MaD:6 |
 | summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:156:27:156:33 | tainted | provenance | Sink:MaD:6 |
-| summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:157:14:160:3 | do ... end [captured tainted] | provenance |  |
+| summaries.rb:122:16:122:22 | [post] tainted | summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | provenance |  |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:16:122:22 | [post] tainted | provenance | MaD:20 |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:25:122:25 | [post] y | provenance | MaD:20 |
 | summaries.rb:122:16:122:22 | tainted | summaries.rb:122:33:122:33 | [post] z | provenance | MaD:20 |
@@ -292,8 +292,8 @@ edges
 | summaries.rb:128:1:128:1 | [post] x | summaries.rb:129:6:129:6 | x | provenance |  |
 | summaries.rb:128:14:128:20 | tainted | summaries.rb:128:1:128:1 | [post] x | provenance | MaD:21 |
 | summaries.rb:131:16:131:22 | tainted | summaries.rb:131:1:131:23 | synthetic splat argument | provenance | Sink:MaD:4 |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
+| summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
+| summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | summaries.rb:158:15:158:21 | tainted | provenance | heuristic-callback Sink:MaD:6 |
 nodes
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |
 | summaries.rb:1:11:1:36 | call to identity | semmle.label | call to identity |
@@ -361,12 +361,12 @@ nodes
 | summaries.rb:48:24:48:41 | call to source | semmle.label | call to source |
 | summaries.rb:51:6:51:31 | call to namedArg | semmle.label | call to namedArg |
 | summaries.rb:51:24:51:30 | tainted | semmle.label | tainted |
-| summaries.rb:53:1:53:4 | args [element :foo] | semmle.label | args [element :foo] |
-| summaries.rb:53:8:53:33 | call to [] [element :foo] | semmle.label | call to [] [element :foo] |
+| summaries.rb:53:1:53:4 | args : Hash [element :foo] | semmle.label | args : Hash [element :foo] |
+| summaries.rb:53:8:53:33 | call to [] : Hash [element :foo] | semmle.label | call to [] : Hash [element :foo] |
 | summaries.rb:53:15:53:31 | call to source | semmle.label | call to source |
 | summaries.rb:54:6:54:25 | call to namedArg | semmle.label | call to namedArg |
-| summaries.rb:54:19:54:24 | ** ... [element :foo] | semmle.label | ** ... [element :foo] |
-| summaries.rb:54:21:54:24 | args [element :foo] | semmle.label | args [element :foo] |
+| summaries.rb:54:19:54:24 | ** ... : Hash [element :foo] | semmle.label | ** ... : Hash [element :foo] |
+| summaries.rb:54:21:54:24 | args : Hash [element :foo] | semmle.label | args : Hash [element :foo] |
 | summaries.rb:56:6:56:29 | call to anyArg | semmle.label | call to anyArg |
 | summaries.rb:56:22:56:28 | tainted | semmle.label | tainted |
 | summaries.rb:57:6:57:24 | call to anyArg | semmle.label | call to anyArg |
@@ -382,124 +382,124 @@ nodes
 | summaries.rb:73:24:73:53 | call to source | semmle.label | call to source |
 | summaries.rb:76:8:76:57 | call to preserveTaint | semmle.label | call to preserveTaint |
 | summaries.rb:76:26:76:56 | call to source | semmle.label | call to source |
-| summaries.rb:79:1:79:1 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:79:1:79:1 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:79:1:79:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:79:1:79:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:79:5:79:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| summaries.rb:79:5:79:47 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| summaries.rb:79:5:79:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
-| summaries.rb:79:5:79:47 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:79:1:79:1 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:79:1:79:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
+| summaries.rb:79:5:79:47 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | summaries.rb:79:15:79:29 | call to source | semmle.label | call to source |
 | summaries.rb:79:15:79:29 | call to source | semmle.label | call to source |
 | summaries.rb:79:32:79:46 | call to source | semmle.label | call to source |
 | summaries.rb:79:32:79:46 | call to source | semmle.label | call to source |
-| summaries.rb:81:1:81:1 | [post] a [element] | semmle.label | [post] a [element] |
-| summaries.rb:81:1:81:1 | [post] a [element] | semmle.label | [post] a [element] |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| summaries.rb:81:1:81:1 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
 | summaries.rb:81:13:81:27 | call to source | semmle.label | call to source |
 | summaries.rb:81:13:81:27 | call to source | semmle.label | call to source |
-| summaries.rb:82:6:82:6 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:82:6:82:6 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:82:6:82:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:82:6:82:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:82:6:82:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:82:6:82:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:82:6:82:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:82:6:82:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:82:6:82:24 | call to readElementOne | semmle.label | call to readElementOne |
 | summaries.rb:82:6:82:24 | call to readElementOne | semmle.label | call to readElementOne |
-| summaries.rb:83:6:83:6 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:83:6:83:6 | a [element 1] | semmle.label | a [element 1] |
+| summaries.rb:83:6:83:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:83:6:83:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
 | summaries.rb:83:6:83:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
 | summaries.rb:83:6:83:31 | call to readExactlyElementOne | semmle.label | call to readExactlyElementOne |
-| summaries.rb:84:6:84:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:84:6:84:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:84:6:84:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:84:6:84:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:84:6:84:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:84:6:84:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:85:6:85:6 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:85:6:85:6 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:85:6:85:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:85:6:85:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:85:6:85:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:85:6:85:6 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:85:6:85:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:85:6:85:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:85:6:85:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:85:6:85:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:86:6:86:6 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:86:6:86:6 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:86:6:86:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:86:6:86:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:86:6:86:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:86:6:86:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:86:6:86:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:86:6:86:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:86:6:86:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:87:1:87:1 | b [element 1] | semmle.label | b [element 1] |
-| summaries.rb:87:1:87:1 | b [element 1] | semmle.label | b [element 1] |
-| summaries.rb:87:1:87:1 | b [element] | semmle.label | b [element] |
-| summaries.rb:87:1:87:1 | b [element] | semmle.label | b [element] |
-| summaries.rb:87:5:87:5 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:87:5:87:5 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:87:5:87:5 | a [element] | semmle.label | a [element] |
-| summaries.rb:87:5:87:5 | a [element] | semmle.label | a [element] |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] | semmle.label | call to withElementOne [element 1] |
-| summaries.rb:87:5:87:22 | call to withElementOne [element 1] | semmle.label | call to withElementOne [element 1] |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] | semmle.label | call to withElementOne [element] |
-| summaries.rb:87:5:87:22 | call to withElementOne [element] | semmle.label | call to withElementOne [element] |
-| summaries.rb:88:6:88:6 | b [element] | semmle.label | b [element] |
-| summaries.rb:88:6:88:6 | b [element] | semmle.label | b [element] |
+| summaries.rb:87:1:87:1 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| summaries.rb:87:1:87:1 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| summaries.rb:87:1:87:1 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| summaries.rb:87:5:87:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:87:5:87:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:87:5:87:5 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:87:5:87:5 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | semmle.label | call to withElementOne : Array [element 1] |
+| summaries.rb:87:5:87:22 | call to withElementOne : Array [element 1] | semmle.label | call to withElementOne : Array [element 1] |
+| summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | semmle.label | call to withElementOne : [collection] [element] |
+| summaries.rb:87:5:87:22 | call to withElementOne : [collection] [element] | semmle.label | call to withElementOne : [collection] [element] |
+| summaries.rb:88:6:88:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| summaries.rb:88:6:88:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | summaries.rb:88:6:88:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:88:6:88:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:89:6:89:6 | b [element 1] | semmle.label | b [element 1] |
-| summaries.rb:89:6:89:6 | b [element 1] | semmle.label | b [element 1] |
-| summaries.rb:89:6:89:6 | b [element] | semmle.label | b [element] |
-| summaries.rb:89:6:89:6 | b [element] | semmle.label | b [element] |
+| summaries.rb:89:6:89:6 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| summaries.rb:89:6:89:6 | b : Array [element 1] | semmle.label | b : Array [element 1] |
+| summaries.rb:89:6:89:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| summaries.rb:89:6:89:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | summaries.rb:89:6:89:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:89:6:89:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:90:6:90:6 | b [element] | semmle.label | b [element] |
-| summaries.rb:90:6:90:6 | b [element] | semmle.label | b [element] |
+| summaries.rb:90:6:90:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| summaries.rb:90:6:90:6 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:90:6:90:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:91:1:91:1 | c [element 1] | semmle.label | c [element 1] |
-| summaries.rb:91:1:91:1 | c [element 1] | semmle.label | c [element 1] |
-| summaries.rb:91:5:91:5 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:91:5:91:5 | a [element 1] | semmle.label | a [element 1] |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | semmle.label | call to withExactlyElementOne [element 1] |
-| summaries.rb:91:5:91:29 | call to withExactlyElementOne [element 1] | semmle.label | call to withExactlyElementOne [element 1] |
-| summaries.rb:93:6:93:6 | c [element 1] | semmle.label | c [element 1] |
-| summaries.rb:93:6:93:6 | c [element 1] | semmle.label | c [element 1] |
+| summaries.rb:91:1:91:1 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| summaries.rb:91:1:91:1 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| summaries.rb:91:5:91:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:91:5:91:5 | a : Array [element 1] | semmle.label | a : Array [element 1] |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | semmle.label | call to withExactlyElementOne : Array [element 1] |
+| summaries.rb:91:5:91:29 | call to withExactlyElementOne : Array [element 1] | semmle.label | call to withExactlyElementOne : Array [element 1] |
+| summaries.rb:93:6:93:6 | c : Array [element 1] | semmle.label | c : Array [element 1] |
+| summaries.rb:93:6:93:6 | c : Array [element 1] | semmle.label | c : Array [element 1] |
 | summaries.rb:93:6:93:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:93:6:93:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| summaries.rb:95:1:95:1 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| summaries.rb:95:1:95:1 | [post] a [element] | semmle.label | [post] a [element] |
-| summaries.rb:95:1:95:1 | [post] a [element] | semmle.label | [post] a [element] |
-| summaries.rb:95:1:95:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:95:1:95:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:95:1:95:1 | a [element] | semmle.label | a [element] |
-| summaries.rb:95:1:95:1 | a [element] | semmle.label | a [element] |
-| summaries.rb:96:6:96:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:96:6:96:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | semmle.label | [post] a : Array [element 2] |
+| summaries.rb:95:1:95:1 | [post] a : Array [element 2] | semmle.label | [post] a : Array [element 2] |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| summaries.rb:95:1:95:1 | [post] a : [collection] [element] | semmle.label | [post] a : [collection] [element] |
+| summaries.rb:95:1:95:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:95:1:95:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:95:1:95:1 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:95:1:95:1 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:96:6:96:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:96:6:96:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:96:6:96:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:96:6:96:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:97:6:97:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:97:6:97:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:97:6:97:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:97:6:97:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:97:6:97:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:97:6:97:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:98:6:98:6 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:98:6:98:6 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:98:6:98:6 | a [element] | semmle.label | a [element] |
-| summaries.rb:98:6:98:6 | a [element] | semmle.label | a [element] |
+| summaries.rb:98:6:98:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:98:6:98:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:98:6:98:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
+| summaries.rb:98:6:98:6 | a : [collection] [element] | semmle.label | a : [collection] [element] |
 | summaries.rb:98:6:98:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:98:6:98:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:99:1:99:1 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| summaries.rb:99:1:99:1 | [post] a [element 2] | semmle.label | [post] a [element 2] |
-| summaries.rb:99:1:99:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:99:1:99:1 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:102:6:102:6 | a [element 2] | semmle.label | a [element 2] |
-| summaries.rb:102:6:102:6 | a [element 2] | semmle.label | a [element 2] |
+| summaries.rb:99:1:99:1 | [post] a : Array [element 2] | semmle.label | [post] a : Array [element 2] |
+| summaries.rb:99:1:99:1 | [post] a : Array [element 2] | semmle.label | [post] a : Array [element 2] |
+| summaries.rb:99:1:99:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:99:1:99:1 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:102:6:102:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
+| summaries.rb:102:6:102:6 | a : Array [element 2] | semmle.label | a : Array [element 2] |
 | summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:102:6:102:9 | ...[...] | semmle.label | ...[...] |
-| summaries.rb:103:1:103:1 | [post] d [element 3] | semmle.label | [post] d [element 3] |
-| summaries.rb:103:1:103:1 | [post] d [element 3] | semmle.label | [post] d [element 3] |
+| summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | semmle.label | [post] d : [collection] [element 3] |
+| summaries.rb:103:1:103:1 | [post] d : [collection] [element 3] | semmle.label | [post] d : [collection] [element 3] |
 | summaries.rb:103:8:103:22 | call to source | semmle.label | call to source |
 | summaries.rb:103:8:103:22 | call to source | semmle.label | call to source |
-| summaries.rb:104:1:104:1 | [post] d [element 3] | semmle.label | [post] d [element 3] |
-| summaries.rb:104:1:104:1 | [post] d [element 3] | semmle.label | [post] d [element 3] |
-| summaries.rb:104:1:104:1 | d [element 3] | semmle.label | d [element 3] |
-| summaries.rb:104:1:104:1 | d [element 3] | semmle.label | d [element 3] |
-| summaries.rb:108:6:108:6 | d [element 3] | semmle.label | d [element 3] |
-| summaries.rb:108:6:108:6 | d [element 3] | semmle.label | d [element 3] |
+| summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | semmle.label | [post] d : [collection] [element 3] |
+| summaries.rb:104:1:104:1 | [post] d : [collection] [element 3] | semmle.label | [post] d : [collection] [element 3] |
+| summaries.rb:104:1:104:1 | d : [collection] [element 3] | semmle.label | d : [collection] [element 3] |
+| summaries.rb:104:1:104:1 | d : [collection] [element 3] | semmle.label | d : [collection] [element 3] |
+| summaries.rb:108:6:108:6 | d : [collection] [element 3] | semmle.label | d : [collection] [element 3] |
+| summaries.rb:108:6:108:6 | d : [collection] [element 3] | semmle.label | d : [collection] [element 3] |
 | summaries.rb:108:6:108:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:108:6:108:9 | ...[...] | semmle.label | ...[...] |
 | summaries.rb:111:1:111:1 | [post] x [@value] | semmle.label | [post] x [@value] |
@@ -545,8 +545,8 @@ nodes
 | summaries.rb:155:28:155:34 | tainted | semmle.label | tainted |
 | summaries.rb:156:27:156:33 | tainted | semmle.label | tainted |
 | summaries.rb:156:27:156:33 | tainted | semmle.label | tainted |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | semmle.label | do ... end [captured tainted] |
-| summaries.rb:157:14:160:3 | do ... end [captured tainted] | semmle.label | do ... end [captured tainted] |
+| summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | semmle.label | do ... end : [lambda] [captured tainted] |
+| summaries.rb:157:14:160:3 | do ... end : [lambda] [captured tainted] | semmle.label | do ... end : [lambda] [captured tainted] |
 | summaries.rb:158:15:158:21 | tainted | semmle.label | tainted |
 | summaries.rb:158:15:158:21 | tainted | semmle.label | tainted |
 | summaries.rb:163:20:163:36 | call to source | semmle.label | call to source |

--- a/ruby/ql/test/library-tests/dataflow/type-flow/Flow.expected
+++ b/ruby/ql/test/library-tests/dataflow/type-flow/Flow.expected
@@ -1,0 +1,373 @@
+models
+edges
+| types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | provenance |  |
+| types.rb:1:11:1:11 | x : C2 | types.rb:2:5:2:5 | x : C2 | provenance |  |
+| types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | provenance |  |
+| types.rb:20:5:22:7 | self in call_foo : C1 | types.rb:21:13:21:16 | self : C1 | provenance |  |
+| types.rb:20:5:22:7 | self in call_foo : C3 | types.rb:21:13:21:16 | self : C3 | provenance |  |
+| types.rb:21:13:21:16 | self : C1 | types.rb:52:9:52:9 | x : C1 | provenance |  |
+| types.rb:21:13:21:16 | self : C1 | types.rb:52:9:52:9 | x : C1 | provenance |  |
+| types.rb:21:13:21:16 | self : C3 | types.rb:52:9:52:9 | x : C3 | provenance |  |
+| types.rb:24:5:26:7 | self in call_bar : C1 | types.rb:25:13:25:16 | self : C1 | provenance |  |
+| types.rb:24:5:26:7 | self in call_bar : C3 | types.rb:25:13:25:16 | self : C3 | provenance |  |
+| types.rb:25:13:25:16 | self : C1 | types.rb:61:9:61:9 | x : C1 | provenance |  |
+| types.rb:25:13:25:16 | self : C1 | types.rb:61:9:61:9 | x : C1 | provenance |  |
+| types.rb:25:13:25:16 | self : C3 | types.rb:61:9:61:9 | x : C3 | provenance |  |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C1 | types.rb:32:9:32:18 | self : C1 | provenance |  |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C2 | types.rb:32:9:32:18 | self : C2 | provenance |  |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C3 | types.rb:32:9:32:18 | self : C3 | provenance |  |
+| types.rb:32:9:32:18 | self : C1 | types.rb:41:5:43:7 | self in maybe_sink : C2 | provenance |  |
+| types.rb:32:9:32:18 | self : C1 | types.rb:47:5:49:7 | self in maybe_sink : C3 | provenance |  |
+| types.rb:32:9:32:18 | self : C2 | types.rb:41:5:43:7 | self in maybe_sink : C2 | provenance |  |
+| types.rb:32:9:32:18 | self : C3 | types.rb:47:5:49:7 | self in maybe_sink : C3 | provenance |  |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C1 | types.rb:36:9:36:23 | self : C1 | provenance |  |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C2 | types.rb:36:9:36:23 | self : C2 | provenance |  |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C3 | types.rb:36:9:36:23 | self : C3 | provenance |  |
+| types.rb:36:9:36:23 | self : C1 | types.rb:31:5:33:7 | self in call_maybe_sink : C1 | provenance |  |
+| types.rb:36:9:36:23 | self : C2 | types.rb:31:5:33:7 | self in call_maybe_sink : C2 | provenance |  |
+| types.rb:36:9:36:23 | self : C3 | types.rb:31:5:33:7 | self in call_maybe_sink : C3 | provenance |  |
+| types.rb:41:5:43:7 | self in maybe_sink : C2 | types.rb:42:14:42:17 | self | provenance |  |
+| types.rb:47:5:49:7 | self in maybe_sink : C3 | types.rb:48:14:48:17 | self | provenance |  |
+| types.rb:52:9:52:9 | x : C1 | types.rb:55:18:55:18 | x | provenance |  |
+| types.rb:52:9:52:9 | x : C3 | types.rb:55:18:55:18 | x | provenance |  |
+| types.rb:61:9:61:9 | x : C1 | types.rb:63:18:63:19 | c3 : C3 | provenance |  |
+| types.rb:61:9:61:9 | x : C3 | types.rb:63:18:63:19 | c3 : C3 | provenance |  |
+| types.rb:63:18:63:19 | c3 : C3 | types.rb:64:18:64:19 | c3 | provenance |  |
+| types.rb:71:5:71:19 | call to taint : C1 | types.rb:52:9:52:9 | x : C1 | provenance |  |
+| types.rb:71:11:71:18 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | provenance |  |
+| types.rb:71:11:71:18 | call to new : C1 | types.rb:71:5:71:19 | call to taint : C1 | provenance |  |
+| types.rb:73:5:73:19 | call to taint : C3 | types.rb:52:9:52:9 | x : C3 | provenance |  |
+| types.rb:73:11:73:18 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | provenance |  |
+| types.rb:73:11:73:18 | call to new : C3 | types.rb:73:5:73:19 | call to taint : C3 | provenance |  |
+| types.rb:75:1:75:15 | call to taint : C1 | types.rb:20:5:22:7 | self in call_foo : C1 | provenance |  |
+| types.rb:75:7:75:14 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | provenance |  |
+| types.rb:75:7:75:14 | call to new : C1 | types.rb:75:1:75:15 | call to taint : C1 | provenance |  |
+| types.rb:77:1:77:15 | call to taint : C3 | types.rb:20:5:22:7 | self in call_foo : C3 | provenance |  |
+| types.rb:77:7:77:14 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | provenance |  |
+| types.rb:77:7:77:14 | call to new : C3 | types.rb:77:1:77:15 | call to taint : C3 | provenance |  |
+| types.rb:79:5:79:19 | call to taint : C1 | types.rb:61:9:61:9 | x : C1 | provenance |  |
+| types.rb:79:11:79:18 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | provenance |  |
+| types.rb:79:11:79:18 | call to new : C1 | types.rb:79:5:79:19 | call to taint : C1 | provenance |  |
+| types.rb:81:5:81:19 | call to taint : C3 | types.rb:61:9:61:9 | x : C3 | provenance |  |
+| types.rb:81:11:81:18 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | provenance |  |
+| types.rb:81:11:81:18 | call to new : C3 | types.rb:81:5:81:19 | call to taint : C3 | provenance |  |
+| types.rb:83:1:83:15 | call to taint : C1 | types.rb:24:5:26:7 | self in call_bar : C1 | provenance |  |
+| types.rb:83:7:83:14 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | provenance |  |
+| types.rb:83:7:83:14 | call to new : C1 | types.rb:83:1:83:15 | call to taint : C1 | provenance |  |
+| types.rb:85:1:85:16 | call to taint : C3 | types.rb:24:5:26:7 | self in call_bar : C3 | provenance |  |
+| types.rb:85:7:85:15 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | provenance |  |
+| types.rb:85:7:85:15 | call to new : C3 | types.rb:85:1:85:16 | call to taint : C3 | provenance |  |
+| types.rb:87:1:87:16 | call to taint : C1 | types.rb:35:5:37:7 | self in call_call_maybe_sink : C1 | provenance |  |
+| types.rb:87:7:87:15 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | provenance |  |
+| types.rb:87:7:87:15 | call to new : C1 | types.rb:87:1:87:16 | call to taint : C1 | provenance |  |
+| types.rb:88:1:88:16 | call to taint : C2 | types.rb:35:5:37:7 | self in call_call_maybe_sink : C2 | provenance |  |
+| types.rb:88:7:88:15 | call to new : C2 | types.rb:1:11:1:11 | x : C2 | provenance |  |
+| types.rb:88:7:88:15 | call to new : C2 | types.rb:88:1:88:16 | call to taint : C2 | provenance |  |
+| types.rb:89:1:89:16 | call to taint : C3 | types.rb:35:5:37:7 | self in call_call_maybe_sink : C3 | provenance |  |
+| types.rb:89:7:89:15 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | provenance |  |
+| types.rb:89:7:89:15 | call to new : C3 | types.rb:89:1:89:16 | call to taint : C3 | provenance |  |
+nodes
+| types.rb:1:11:1:11 | x : C1 | semmle.label | x : C1 |
+| types.rb:1:11:1:11 | x : C2 | semmle.label | x : C2 |
+| types.rb:1:11:1:11 | x : C3 | semmle.label | x : C3 |
+| types.rb:2:5:2:5 | x : C1 | semmle.label | x : C1 |
+| types.rb:2:5:2:5 | x : C2 | semmle.label | x : C2 |
+| types.rb:2:5:2:5 | x : C3 | semmle.label | x : C3 |
+| types.rb:20:5:22:7 | self in call_foo : C1 | semmle.label | self in call_foo : C1 |
+| types.rb:20:5:22:7 | self in call_foo : C3 | semmle.label | self in call_foo : C3 |
+| types.rb:21:13:21:16 | self : C1 | semmle.label | self : C1 |
+| types.rb:21:13:21:16 | self : C1 | semmle.label | self : C1 |
+| types.rb:21:13:21:16 | self : C3 | semmle.label | self : C3 |
+| types.rb:24:5:26:7 | self in call_bar : C1 | semmle.label | self in call_bar : C1 |
+| types.rb:24:5:26:7 | self in call_bar : C3 | semmle.label | self in call_bar : C3 |
+| types.rb:25:13:25:16 | self : C1 | semmle.label | self : C1 |
+| types.rb:25:13:25:16 | self : C1 | semmle.label | self : C1 |
+| types.rb:25:13:25:16 | self : C3 | semmle.label | self : C3 |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C1 | semmle.label | self in call_maybe_sink : C1 |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C2 | semmle.label | self in call_maybe_sink : C2 |
+| types.rb:31:5:33:7 | self in call_maybe_sink : C3 | semmle.label | self in call_maybe_sink : C3 |
+| types.rb:32:9:32:18 | self : C1 | semmle.label | self : C1 |
+| types.rb:32:9:32:18 | self : C2 | semmle.label | self : C2 |
+| types.rb:32:9:32:18 | self : C3 | semmle.label | self : C3 |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C1 | semmle.label | self in call_call_maybe_sink : C1 |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C2 | semmle.label | self in call_call_maybe_sink : C2 |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink : C3 | semmle.label | self in call_call_maybe_sink : C3 |
+| types.rb:36:9:36:23 | self : C1 | semmle.label | self : C1 |
+| types.rb:36:9:36:23 | self : C2 | semmle.label | self : C2 |
+| types.rb:36:9:36:23 | self : C3 | semmle.label | self : C3 |
+| types.rb:41:5:43:7 | self in maybe_sink : C2 | semmle.label | self in maybe_sink : C2 |
+| types.rb:42:14:42:17 | self | semmle.label | self |
+| types.rb:47:5:49:7 | self in maybe_sink : C3 | semmle.label | self in maybe_sink : C3 |
+| types.rb:48:14:48:17 | self | semmle.label | self |
+| types.rb:52:9:52:9 | x : C1 | semmle.label | x : C1 |
+| types.rb:52:9:52:9 | x : C3 | semmle.label | x : C3 |
+| types.rb:55:18:55:18 | x | semmle.label | x |
+| types.rb:61:9:61:9 | x : C1 | semmle.label | x : C1 |
+| types.rb:61:9:61:9 | x : C3 | semmle.label | x : C3 |
+| types.rb:63:18:63:19 | c3 : C3 | semmle.label | c3 : C3 |
+| types.rb:64:18:64:19 | c3 | semmle.label | c3 |
+| types.rb:71:5:71:19 | call to taint : C1 | semmle.label | call to taint : C1 |
+| types.rb:71:11:71:18 | call to new : C1 | semmle.label | call to new : C1 |
+| types.rb:73:5:73:19 | call to taint : C3 | semmle.label | call to taint : C3 |
+| types.rb:73:11:73:18 | call to new : C3 | semmle.label | call to new : C3 |
+| types.rb:75:1:75:15 | call to taint : C1 | semmle.label | call to taint : C1 |
+| types.rb:75:7:75:14 | call to new : C1 | semmle.label | call to new : C1 |
+| types.rb:77:1:77:15 | call to taint : C3 | semmle.label | call to taint : C3 |
+| types.rb:77:7:77:14 | call to new : C3 | semmle.label | call to new : C3 |
+| types.rb:79:5:79:19 | call to taint : C1 | semmle.label | call to taint : C1 |
+| types.rb:79:11:79:18 | call to new : C1 | semmle.label | call to new : C1 |
+| types.rb:81:5:81:19 | call to taint : C3 | semmle.label | call to taint : C3 |
+| types.rb:81:11:81:18 | call to new : C3 | semmle.label | call to new : C3 |
+| types.rb:83:1:83:15 | call to taint : C1 | semmle.label | call to taint : C1 |
+| types.rb:83:7:83:14 | call to new : C1 | semmle.label | call to new : C1 |
+| types.rb:85:1:85:16 | call to taint : C3 | semmle.label | call to taint : C3 |
+| types.rb:85:7:85:15 | call to new : C3 | semmle.label | call to new : C3 |
+| types.rb:87:1:87:16 | call to taint : C1 | semmle.label | call to taint : C1 |
+| types.rb:87:7:87:15 | call to new : C1 | semmle.label | call to new : C1 |
+| types.rb:88:1:88:16 | call to taint : C2 | semmle.label | call to taint : C2 |
+| types.rb:88:7:88:15 | call to new : C2 | semmle.label | call to new : C2 |
+| types.rb:89:1:89:16 | call to taint : C3 | semmle.label | call to taint : C3 |
+| types.rb:89:7:89:15 | call to new : C3 | semmle.label | call to new : C3 |
+subpaths
+| types.rb:71:11:71:18 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | types.rb:71:5:71:19 | call to taint : C1 |
+| types.rb:73:11:73:18 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | types.rb:73:5:73:19 | call to taint : C3 |
+| types.rb:75:7:75:14 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | types.rb:75:1:75:15 | call to taint : C1 |
+| types.rb:77:7:77:14 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | types.rb:77:1:77:15 | call to taint : C3 |
+| types.rb:79:11:79:18 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | types.rb:79:5:79:19 | call to taint : C1 |
+| types.rb:81:11:81:18 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | types.rb:81:5:81:19 | call to taint : C3 |
+| types.rb:83:7:83:14 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | types.rb:83:1:83:15 | call to taint : C1 |
+| types.rb:85:7:85:15 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | types.rb:85:1:85:16 | call to taint : C3 |
+| types.rb:87:7:87:15 | call to new : C1 | types.rb:1:11:1:11 | x : C1 | types.rb:2:5:2:5 | x : C1 | types.rb:87:1:87:16 | call to taint : C1 |
+| types.rb:88:7:88:15 | call to new : C2 | types.rb:1:11:1:11 | x : C2 | types.rb:2:5:2:5 | x : C2 | types.rb:88:1:88:16 | call to taint : C2 |
+| types.rb:89:7:89:15 | call to new : C3 | types.rb:1:11:1:11 | x : C3 | types.rb:2:5:2:5 | x : C3 | types.rb:89:1:89:16 | call to taint : C3 |
+testFailures
+nodeType
+| file://:0:0:0:0 | [summary param] * (position 0) in Array.[] | file://:0:0:0:0 | Array |
+| file://:0:0:0:0 | [summary param] ** in Hash.[] | file://:0:0:0:0 | Hash |
+| file://:0:0:0:0 | [summary param] ** in I18n.translate | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] position 0 in & | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] position 0 in + | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] position 0 in Hash[] | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] position 0 in \| | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] self in & | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] self in * | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] self in - | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] self in \| | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary param] self in assoc-unknown-arg | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].Element[any] in Hash[] | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].WithElement[0..] in Array() | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].WithElement[any] in Array.new | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].WithElement[any] in Array.try_convert | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].WithElement[any] in Hash.try_convert | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[0].WithElement[any] in Hash[] | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[self].WithElement[any] in *(splat) | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[self].WithElement[any] in **(hash-splat) | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[self].WithElement[any] in + | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] read: Argument[self].WithElement[any] in << | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: Argument[self] in << | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in & | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in * | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in *(splat) | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in + | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in - | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in << | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in Array() | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in Array.new | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in Hash[] | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in \| | file://:0:0:0:0 | [collection] |
+| file://:0:0:0:0 | [summary] to write: ReturnValue in assoc-unknown-arg | file://:0:0:0:0 | [collection] |
+| types.rb:1:1:3:3 | &block | file://:0:0:0:0 | Proc |
+| types.rb:1:1:3:3 | self in taint | file://:0:0:0:0 | Object |
+| types.rb:1:1:3:3 | synthetic splat parameter | file://:0:0:0:0 | Array |
+| types.rb:1:1:3:3 | taint | file://:0:0:0:0 | Symbol |
+| types.rb:1:1:89:38 | self (types.rb) | file://:0:0:0:0 | Object |
+| types.rb:1:1:89:38 | self in types.rb | file://:0:0:0:0 | Object |
+| types.rb:5:1:7:3 | &block | file://:0:0:0:0 | Proc |
+| types.rb:5:1:7:3 | self (sink) | file://:0:0:0:0 | Object |
+| types.rb:5:1:7:3 | self in sink | file://:0:0:0:0 | Object |
+| types.rb:5:1:7:3 | sink | file://:0:0:0:0 | Symbol |
+| types.rb:5:1:7:3 | synthetic splat parameter | file://:0:0:0:0 | Array |
+| types.rb:6:5:6:31 | self | file://:0:0:0:0 | Object |
+| types.rb:6:5:6:31 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:6:10:6:31 | "SINK: #{...}" | file://:0:0:0:0 | String |
+| types.rb:12:5:14:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:12:5:14:7 | initialize | file://:0:0:0:0 | Symbol |
+| types.rb:12:5:14:7 | self (initialize) | types.rb:9:1:38:3 | C1 |
+| types.rb:12:5:14:7 | self in initialize | types.rb:9:1:38:3 | C1 |
+| types.rb:12:5:14:7 | synthetic splat parameter | file://:0:0:0:0 | Array |
+| types.rb:13:9:13:14 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:16:5:18:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:16:5:18:7 | get_field | file://:0:0:0:0 | Symbol |
+| types.rb:16:5:18:7 | self (get_field) | types.rb:9:1:38:3 | C1 |
+| types.rb:16:5:18:7 | self in get_field | types.rb:9:1:38:3 | C1 |
+| types.rb:17:9:17:14 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:20:5:22:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:20:5:22:7 | call_foo | file://:0:0:0:0 | Symbol |
+| types.rb:20:5:22:7 | self (call_foo) | types.rb:9:1:38:3 | C1 |
+| types.rb:20:5:22:7 | self in call_foo | types.rb:9:1:38:3 | C1 |
+| types.rb:21:9:21:17 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:21:9:21:17 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:21:13:21:16 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:24:5:26:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:24:5:26:7 | call_bar | file://:0:0:0:0 | Symbol |
+| types.rb:24:5:26:7 | self (call_bar) | types.rb:9:1:38:3 | C1 |
+| types.rb:24:5:26:7 | self in call_bar | types.rb:9:1:38:3 | C1 |
+| types.rb:25:9:25:17 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:25:9:25:17 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:25:13:25:16 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:28:5:29:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:28:5:29:7 | maybe_sink | file://:0:0:0:0 | Symbol |
+| types.rb:28:5:29:7 | self in maybe_sink | types.rb:9:1:38:3 | C1 |
+| types.rb:31:5:33:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:31:5:33:7 | call_maybe_sink | file://:0:0:0:0 | Symbol |
+| types.rb:31:5:33:7 | self (call_maybe_sink) | types.rb:9:1:38:3 | C1 |
+| types.rb:31:5:33:7 | self in call_maybe_sink | types.rb:9:1:38:3 | C1 |
+| types.rb:32:9:32:18 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:35:5:37:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:35:5:37:7 | call_call_maybe_sink | file://:0:0:0:0 | Symbol |
+| types.rb:35:5:37:7 | self (call_call_maybe_sink) | types.rb:9:1:38:3 | C1 |
+| types.rb:35:5:37:7 | self in call_call_maybe_sink | types.rb:9:1:38:3 | C1 |
+| types.rb:36:9:36:23 | self | types.rb:9:1:38:3 | C1 |
+| types.rb:41:5:43:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:41:5:43:7 | maybe_sink | file://:0:0:0:0 | Symbol |
+| types.rb:41:5:43:7 | self (maybe_sink) | types.rb:40:1:44:3 | C2 |
+| types.rb:41:5:43:7 | self in maybe_sink | types.rb:40:1:44:3 | C2 |
+| types.rb:42:9:42:17 | self | types.rb:40:1:44:3 | C2 |
+| types.rb:42:9:42:17 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:42:14:42:17 | self | types.rb:40:1:44:3 | C2 |
+| types.rb:47:5:49:7 | &block | file://:0:0:0:0 | Proc |
+| types.rb:47:5:49:7 | maybe_sink | file://:0:0:0:0 | Symbol |
+| types.rb:47:5:49:7 | self (maybe_sink) | types.rb:46:1:50:3 | C3 |
+| types.rb:47:5:49:7 | self in maybe_sink | types.rb:46:1:50:3 | C3 |
+| types.rb:48:9:48:17 | self | types.rb:46:1:50:3 | C3 |
+| types.rb:48:9:48:17 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:48:14:48:17 | self | types.rb:46:1:50:3 | C3 |
+| types.rb:52:1:59:3 | &block | file://:0:0:0:0 | Proc |
+| types.rb:52:1:59:3 | foo | file://:0:0:0:0 | Symbol |
+| types.rb:52:1:59:3 | self (foo) | file://:0:0:0:0 | Object |
+| types.rb:52:1:59:3 | self in foo | file://:0:0:0:0 | Object |
+| types.rb:52:1:59:3 | synthetic splat parameter | file://:0:0:0:0 | Array |
+| types.rb:55:13:55:19 | self | file://:0:0:0:0 | Object |
+| types.rb:55:13:55:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:55:18:55:18 | x | types.rb:46:1:50:3 | C3 |
+| types.rb:56:18:56:18 | x | types.rb:46:1:50:3 | C3 |
+| types.rb:56:33:56:39 | self | file://:0:0:0:0 | Object |
+| types.rb:56:33:56:39 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:56:38:56:38 | x | types.rb:40:1:44:3 | C2 |
+| types.rb:61:1:69:3 | &block | file://:0:0:0:0 | Proc |
+| types.rb:61:1:69:3 | bar | file://:0:0:0:0 | Symbol |
+| types.rb:61:1:69:3 | self (bar) | file://:0:0:0:0 | Object |
+| types.rb:61:1:69:3 | self in bar | file://:0:0:0:0 | Object |
+| types.rb:61:1:69:3 | synthetic splat parameter | file://:0:0:0:0 | Array |
+| types.rb:63:18:63:19 | c3 | types.rb:46:1:50:3 | C3 |
+| types.rb:64:13:64:20 | self | file://:0:0:0:0 | Object |
+| types.rb:64:13:64:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:64:18:64:19 | c3 | types.rb:46:1:50:3 | C3 |
+| types.rb:65:18:65:19 | c3 | types.rb:46:1:50:3 | C3 |
+| types.rb:65:34:65:41 | self | file://:0:0:0:0 | Object |
+| types.rb:65:34:65:41 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:65:39:65:40 | c3 | types.rb:40:1:44:3 | C2 |
+| types.rb:71:1:71:20 | self | file://:0:0:0:0 | Object |
+| types.rb:71:1:71:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:71:5:71:19 | self | file://:0:0:0:0 | Object |
+| types.rb:71:5:71:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:71:11:71:18 | call to new | types.rb:9:1:38:3 | C1 |
+| types.rb:71:11:71:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:71:18:71:18 | 0 | file://:0:0:0:0 | Integer |
+| types.rb:72:1:72:20 | self | file://:0:0:0:0 | Object |
+| types.rb:72:1:72:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:72:5:72:19 | self | file://:0:0:0:0 | Object |
+| types.rb:72:5:72:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:72:11:72:18 | call to new | types.rb:40:1:44:3 | C2 |
+| types.rb:72:11:72:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:72:18:72:18 | 1 | file://:0:0:0:0 | Integer |
+| types.rb:73:1:73:20 | self | file://:0:0:0:0 | Object |
+| types.rb:73:1:73:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:73:5:73:19 | self | file://:0:0:0:0 | Object |
+| types.rb:73:5:73:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:73:11:73:18 | call to new | types.rb:46:1:50:3 | C3 |
+| types.rb:73:11:73:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:73:18:73:18 | 2 | file://:0:0:0:0 | Integer |
+| types.rb:75:1:75:15 | self | file://:0:0:0:0 | Object |
+| types.rb:75:1:75:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:75:7:75:14 | call to new | types.rb:9:1:38:3 | C1 |
+| types.rb:75:7:75:14 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:75:14:75:14 | 3 | file://:0:0:0:0 | Integer |
+| types.rb:76:1:76:15 | self | file://:0:0:0:0 | Object |
+| types.rb:76:1:76:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:76:7:76:14 | call to new | types.rb:40:1:44:3 | C2 |
+| types.rb:76:7:76:14 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:76:14:76:14 | 4 | file://:0:0:0:0 | Integer |
+| types.rb:77:1:77:15 | self | file://:0:0:0:0 | Object |
+| types.rb:77:1:77:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:77:7:77:14 | call to new | types.rb:46:1:50:3 | C3 |
+| types.rb:77:7:77:14 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:77:14:77:14 | 5 | file://:0:0:0:0 | Integer |
+| types.rb:79:1:79:20 | self | file://:0:0:0:0 | Object |
+| types.rb:79:1:79:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:79:5:79:19 | self | file://:0:0:0:0 | Object |
+| types.rb:79:5:79:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:79:11:79:18 | call to new | types.rb:9:1:38:3 | C1 |
+| types.rb:79:11:79:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:79:18:79:18 | 6 | file://:0:0:0:0 | Integer |
+| types.rb:80:1:80:20 | self | file://:0:0:0:0 | Object |
+| types.rb:80:1:80:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:80:5:80:19 | self | file://:0:0:0:0 | Object |
+| types.rb:80:5:80:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:80:11:80:18 | call to new | types.rb:40:1:44:3 | C2 |
+| types.rb:80:11:80:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:80:18:80:18 | 7 | file://:0:0:0:0 | Integer |
+| types.rb:81:1:81:20 | self | file://:0:0:0:0 | Object |
+| types.rb:81:1:81:20 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:81:5:81:19 | self | file://:0:0:0:0 | Object |
+| types.rb:81:5:81:19 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:81:11:81:18 | call to new | types.rb:46:1:50:3 | C3 |
+| types.rb:81:11:81:18 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:81:18:81:18 | 8 | file://:0:0:0:0 | Integer |
+| types.rb:83:1:83:15 | self | file://:0:0:0:0 | Object |
+| types.rb:83:1:83:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:83:7:83:14 | call to new | types.rb:9:1:38:3 | C1 |
+| types.rb:83:7:83:14 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:83:14:83:14 | 9 | file://:0:0:0:0 | Integer |
+| types.rb:84:1:84:16 | self | file://:0:0:0:0 | Object |
+| types.rb:84:1:84:16 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:84:7:84:15 | call to new | types.rb:40:1:44:3 | C2 |
+| types.rb:84:7:84:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:84:14:84:15 | 10 | file://:0:0:0:0 | Integer |
+| types.rb:85:1:85:16 | self | file://:0:0:0:0 | Object |
+| types.rb:85:1:85:16 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:85:7:85:15 | call to new | types.rb:46:1:50:3 | C3 |
+| types.rb:85:7:85:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:85:14:85:15 | 11 | file://:0:0:0:0 | Integer |
+| types.rb:87:1:87:16 | self | file://:0:0:0:0 | Object |
+| types.rb:87:1:87:16 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:87:7:87:15 | call to new | types.rb:9:1:38:3 | C1 |
+| types.rb:87:7:87:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:87:14:87:15 | 12 | file://:0:0:0:0 | Integer |
+| types.rb:88:1:88:16 | self | file://:0:0:0:0 | Object |
+| types.rb:88:1:88:16 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:88:7:88:15 | call to new | types.rb:40:1:44:3 | C2 |
+| types.rb:88:7:88:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:88:14:88:15 | 13 | file://:0:0:0:0 | Integer |
+| types.rb:89:1:89:16 | self | file://:0:0:0:0 | Object |
+| types.rb:89:1:89:16 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:89:7:89:15 | call to new | types.rb:46:1:50:3 | C3 |
+| types.rb:89:7:89:15 | synthetic splat argument | file://:0:0:0:0 | Array |
+| types.rb:89:14:89:15 | 14 | file://:0:0:0:0 | Integer |
+#select
+| types.rb:42:14:42:17 | self | types.rb:42:14:42:17 | self | types.rb:42:14:42:17 | self | $@ | types.rb:42:14:42:17 | self | self |
+| types.rb:42:14:42:17 | self | types.rb:87:7:87:15 | call to new : C1 | types.rb:42:14:42:17 | self | $@ | types.rb:87:7:87:15 | call to new : C1 | call to new : C1 |
+| types.rb:42:14:42:17 | self | types.rb:88:7:88:15 | call to new : C2 | types.rb:42:14:42:17 | self | $@ | types.rb:88:7:88:15 | call to new : C2 | call to new : C2 |
+| types.rb:48:14:48:17 | self | types.rb:48:14:48:17 | self | types.rb:48:14:48:17 | self | $@ | types.rb:48:14:48:17 | self | self |
+| types.rb:48:14:48:17 | self | types.rb:87:7:87:15 | call to new : C1 | types.rb:48:14:48:17 | self | $@ | types.rb:87:7:87:15 | call to new : C1 | call to new : C1 |
+| types.rb:48:14:48:17 | self | types.rb:89:7:89:15 | call to new : C3 | types.rb:48:14:48:17 | self | $@ | types.rb:89:7:89:15 | call to new : C3 | call to new : C3 |
+| types.rb:55:18:55:18 | x | types.rb:21:13:21:16 | self : C1 | types.rb:55:18:55:18 | x | $@ | types.rb:21:13:21:16 | self : C1 | self : C1 |
+| types.rb:55:18:55:18 | x | types.rb:71:11:71:18 | call to new : C1 | types.rb:55:18:55:18 | x | $@ | types.rb:71:11:71:18 | call to new : C1 | call to new : C1 |
+| types.rb:55:18:55:18 | x | types.rb:73:11:73:18 | call to new : C3 | types.rb:55:18:55:18 | x | $@ | types.rb:73:11:73:18 | call to new : C3 | call to new : C3 |
+| types.rb:55:18:55:18 | x | types.rb:75:7:75:14 | call to new : C1 | types.rb:55:18:55:18 | x | $@ | types.rb:75:7:75:14 | call to new : C1 | call to new : C1 |
+| types.rb:55:18:55:18 | x | types.rb:77:7:77:14 | call to new : C3 | types.rb:55:18:55:18 | x | $@ | types.rb:77:7:77:14 | call to new : C3 | call to new : C3 |
+| types.rb:64:18:64:19 | c3 | types.rb:25:13:25:16 | self : C1 | types.rb:64:18:64:19 | c3 | $@ | types.rb:25:13:25:16 | self : C1 | self : C1 |
+| types.rb:64:18:64:19 | c3 | types.rb:79:11:79:18 | call to new : C1 | types.rb:64:18:64:19 | c3 | $@ | types.rb:79:11:79:18 | call to new : C1 | call to new : C1 |
+| types.rb:64:18:64:19 | c3 | types.rb:81:11:81:18 | call to new : C3 | types.rb:64:18:64:19 | c3 | $@ | types.rb:81:11:81:18 | call to new : C3 | call to new : C3 |
+| types.rb:64:18:64:19 | c3 | types.rb:83:7:83:14 | call to new : C1 | types.rb:64:18:64:19 | c3 | $@ | types.rb:83:7:83:14 | call to new : C1 | call to new : C1 |
+| types.rb:64:18:64:19 | c3 | types.rb:85:7:85:15 | call to new : C3 | types.rb:64:18:64:19 | c3 | $@ | types.rb:85:7:85:15 | call to new : C3 | call to new : C3 |

--- a/ruby/ql/test/library-tests/dataflow/type-flow/Flow.ql
+++ b/ruby/ql/test/library-tests/dataflow/type-flow/Flow.ql
@@ -1,0 +1,54 @@
+/**
+ * @kind path-problem
+ */
+
+import codeql.ruby.AST
+import codeql.ruby.DataFlow
+private import utils.test.InlineFlowTest
+private import codeql.ruby.dataflow.internal.DataFlowPrivate
+private import codeql.ruby.dataflow.internal.DataFlowDispatch
+
+query predicate nodeType(DataFlow::Node node, DataFlowType tp) {
+  tp = getNodeType(node) and
+  not tp.isUnknown()
+}
+
+private predicate isSource(DataFlow::Node source, string s) {
+  exists(MethodCall taint, MethodCall new |
+    taint.getMethodName() = "taint" and
+    new.getMethodName() = "new" and
+    source.asExpr().getExpr() = new and
+    new = taint.getAnArgument() and
+    s = new.getAnArgument().getConstantValue().toString()
+  )
+  or
+  exists(SelfVariableAccess self, Module m |
+    self = source.asExpr().getExpr() and
+    not self.isSynthesized() and
+    selfInMethod(self.getVariable(), _, m) and
+    s = "self(" + m.getQualifiedName() + ")"
+  )
+}
+
+private module FlowConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { isSource(source, _) }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(MethodCall mc | mc.getMethodName() = "sink" |
+      sink.asExpr().getExpr() = mc.getAnArgument()
+    )
+  }
+}
+
+bindingset[src, sink]
+pragma[inline_late]
+string getArgString(DataFlow::Node src, DataFlow::Node sink) {
+  isSource(src, result) and exists(sink)
+}
+
+import ValueFlowTestArgString<FlowConfig, getArgString/2>
+import PathGraph
+
+from PathNode source, PathNode sink
+where flowPath(source, sink)
+select sink, source, sink, "$@", source, source.toString()

--- a/ruby/ql/test/library-tests/dataflow/type-flow/types.rb
+++ b/ruby/ql/test/library-tests/dataflow/type-flow/types.rb
@@ -1,0 +1,89 @@
+def taint x
+    x
+end
+
+def sink x
+    puts "SINK: #{x.get_field}"
+end
+
+class C1
+    @field
+
+    def initialize(x)
+        @field = x
+    end
+
+    def get_field
+        @field
+    end
+
+    def call_foo
+        foo(self)
+    end
+
+    def call_bar
+        bar(self)
+    end
+
+    def maybe_sink
+    end
+
+    def call_maybe_sink
+        maybe_sink
+    end
+
+    def call_call_maybe_sink
+        call_maybe_sink
+    end
+end
+
+class C2 < C1
+    def maybe_sink
+        sink self # $ hasValueFlow=13 $ hasValueFlow=self(C2) $ SPURIOUS: hasValueFlow=12
+    end
+end
+
+class C3 < C1
+    def maybe_sink
+        sink self # $ hasValueFlow=14 $ hasValueFlow=self(C3) $ SPURIOUS: hasValueFlow=12
+    end
+end
+
+def foo x
+    case x
+        when C3 then
+            sink(x) # $ hasValueFlow=2 $ hasValueFlow=5 $ hasValueFlow=self(C1) $ SPURIOUS: hasValueFlow=0 $ SPURIOUS: hasValueFlow=3
+            case x when C2 then sink(x) # dead code
+        end
+    end
+end
+
+def bar x
+    case x
+        in C3 => c3 then
+            sink(c3) # $ hasValueFlow=8 $ hasValueFlow=11 $ hasValueFlow=self(C1) $ SPURIOUS: hasValueFlow=6 $ SPURIOUS: hasValueFlow=9
+            case c3 when C2 then sink(c3) # dead code
+        end
+        else return
+    end
+end
+
+foo(taint(C1.new 0))
+foo(taint(C2.new 1))
+foo(taint(C3.new 2))
+
+taint(C1.new 3).call_foo
+taint(C2.new 4).call_foo
+taint(C3.new 5).call_foo
+
+bar(taint(C1.new 6))
+bar(taint(C2.new 7))
+bar(taint(C3.new 8))
+
+taint(C1.new 9).call_bar
+taint(C2.new 10).call_bar
+taint(C3.new 11).call_bar
+
+taint(C1.new 12).call_call_maybe_sink
+taint(C2.new 13).call_call_maybe_sink
+taint(C3.new 14).call_call_maybe_sink

--- a/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/action_controller/params-flow.expected
@@ -1,37 +1,37 @@
 models
 edges
-| filter_flow.rb:14:5:14:8 | [post] self [@foo] | filter_flow.rb:17:3:18:5 | self in b [@foo] | provenance |  |
+| filter_flow.rb:14:5:14:8 | [post] self [@foo] | filter_flow.rb:17:3:18:5 | self in b : OneController [@foo] | provenance |  |
 | filter_flow.rb:14:12:14:17 | call to params | filter_flow.rb:14:12:14:23 | ...[...] | provenance |  |
 | filter_flow.rb:14:12:14:23 | ...[...] | filter_flow.rb:14:5:14:8 | [post] self [@foo] | provenance |  |
-| filter_flow.rb:17:3:18:5 | self in b [@foo] | filter_flow.rb:20:3:22:5 | self in c [@foo] | provenance |  |
-| filter_flow.rb:20:3:22:5 | self in c [@foo] | filter_flow.rb:21:10:21:13 | self [@foo] | provenance |  |
-| filter_flow.rb:21:10:21:13 | self [@foo] | filter_flow.rb:21:10:21:13 | @foo | provenance |  |
-| filter_flow.rb:30:5:30:8 | [post] self [@foo] | filter_flow.rb:33:3:35:5 | self in b [@foo] | provenance |  |
+| filter_flow.rb:17:3:18:5 | self in b : OneController [@foo] | filter_flow.rb:20:3:22:5 | self in c : OneController [@foo] | provenance |  |
+| filter_flow.rb:20:3:22:5 | self in c : OneController [@foo] | filter_flow.rb:21:10:21:13 | self : OneController [@foo] | provenance |  |
+| filter_flow.rb:21:10:21:13 | self : OneController [@foo] | filter_flow.rb:21:10:21:13 | @foo | provenance |  |
+| filter_flow.rb:30:5:30:8 | [post] self [@foo] | filter_flow.rb:33:3:35:5 | self in b : TwoController [@foo] | provenance |  |
 | filter_flow.rb:30:12:30:17 | call to params | filter_flow.rb:30:12:30:23 | ...[...] | provenance |  |
 | filter_flow.rb:30:12:30:23 | ...[...] | filter_flow.rb:30:5:30:8 | [post] self [@foo] | provenance |  |
-| filter_flow.rb:33:3:35:5 | self in b [@foo] | filter_flow.rb:37:3:39:5 | self in c [@foo] | provenance |  |
-| filter_flow.rb:37:3:39:5 | self in c [@foo] | filter_flow.rb:38:10:38:13 | self [@foo] | provenance |  |
-| filter_flow.rb:38:10:38:13 | self [@foo] | filter_flow.rb:38:10:38:13 | @foo | provenance |  |
-| filter_flow.rb:47:5:47:8 | [post] self [@foo] | filter_flow.rb:51:3:52:5 | self in b [@foo] | provenance |  |
+| filter_flow.rb:33:3:35:5 | self in b : TwoController [@foo] | filter_flow.rb:37:3:39:5 | self in c : TwoController [@foo] | provenance |  |
+| filter_flow.rb:37:3:39:5 | self in c : TwoController [@foo] | filter_flow.rb:38:10:38:13 | self : TwoController [@foo] | provenance |  |
+| filter_flow.rb:38:10:38:13 | self : TwoController [@foo] | filter_flow.rb:38:10:38:13 | @foo | provenance |  |
+| filter_flow.rb:47:5:47:8 | [post] self [@foo] | filter_flow.rb:51:3:52:5 | self in b : ThreeController [@foo] | provenance |  |
 | filter_flow.rb:47:12:47:17 | call to params | filter_flow.rb:47:12:47:23 | ...[...] | provenance |  |
 | filter_flow.rb:47:12:47:23 | ...[...] | filter_flow.rb:47:5:47:8 | [post] self [@foo] | provenance |  |
-| filter_flow.rb:51:3:52:5 | self in b [@foo] | filter_flow.rb:54:3:56:5 | self in c [@foo] | provenance |  |
-| filter_flow.rb:54:3:56:5 | self in c [@foo] | filter_flow.rb:55:10:55:13 | self [@foo] | provenance |  |
-| filter_flow.rb:55:10:55:13 | self [@foo] | filter_flow.rb:55:10:55:13 | @foo | provenance |  |
-| filter_flow.rb:64:5:64:8 | [post] @foo [@bar] | filter_flow.rb:64:5:64:8 | [post] self [@foo, @bar] | provenance |  |
-| filter_flow.rb:64:5:64:8 | [post] self [@foo, @bar] | filter_flow.rb:67:3:68:5 | self in b [@foo, @bar] | provenance |  |
+| filter_flow.rb:51:3:52:5 | self in b : ThreeController [@foo] | filter_flow.rb:54:3:56:5 | self in c : ThreeController [@foo] | provenance |  |
+| filter_flow.rb:54:3:56:5 | self in c : ThreeController [@foo] | filter_flow.rb:55:10:55:13 | self : ThreeController [@foo] | provenance |  |
+| filter_flow.rb:55:10:55:13 | self : ThreeController [@foo] | filter_flow.rb:55:10:55:13 | @foo | provenance |  |
+| filter_flow.rb:64:5:64:8 | [post] @foo [@bar] | filter_flow.rb:64:5:64:8 | [post] self : FourController [@foo, @bar] | provenance |  |
+| filter_flow.rb:64:5:64:8 | [post] self : FourController [@foo, @bar] | filter_flow.rb:67:3:68:5 | self in b : FourController [@foo, @bar] | provenance |  |
 | filter_flow.rb:64:16:64:21 | call to params | filter_flow.rb:64:16:64:27 | ...[...] | provenance |  |
 | filter_flow.rb:64:16:64:27 | ...[...] | filter_flow.rb:64:5:64:8 | [post] @foo [@bar] | provenance |  |
-| filter_flow.rb:67:3:68:5 | self in b [@foo, @bar] | filter_flow.rb:70:3:72:5 | self in c [@foo, @bar] | provenance |  |
-| filter_flow.rb:70:3:72:5 | self in c [@foo, @bar] | filter_flow.rb:71:10:71:13 | self [@foo, @bar] | provenance |  |
+| filter_flow.rb:67:3:68:5 | self in b : FourController [@foo, @bar] | filter_flow.rb:70:3:72:5 | self in c : FourController [@foo, @bar] | provenance |  |
+| filter_flow.rb:70:3:72:5 | self in c : FourController [@foo, @bar] | filter_flow.rb:71:10:71:13 | self : FourController [@foo, @bar] | provenance |  |
 | filter_flow.rb:71:10:71:13 | @foo [@bar] | filter_flow.rb:71:10:71:17 | call to bar | provenance |  |
-| filter_flow.rb:71:10:71:13 | self [@foo, @bar] | filter_flow.rb:71:10:71:13 | @foo [@bar] | provenance |  |
-| filter_flow.rb:80:5:80:8 | [post] self [@foo] | filter_flow.rb:83:3:84:5 | self in b [@foo] | provenance |  |
-| filter_flow.rb:83:3:84:5 | self in b [@foo] | filter_flow.rb:86:3:88:5 | self in c [@foo] | provenance |  |
-| filter_flow.rb:86:3:88:5 | self in c [@foo] | filter_flow.rb:87:11:87:14 | self [@foo] | provenance |  |
-| filter_flow.rb:87:11:87:14 | self [@foo] | filter_flow.rb:87:11:87:14 | @foo | provenance |  |
-| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | filter_flow.rb:80:5:80:8 | [post] self [@foo] | provenance |  |
-| filter_flow.rb:91:5:91:8 | [post] self [@foo] | filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | provenance |  |
+| filter_flow.rb:71:10:71:13 | self : FourController [@foo, @bar] | filter_flow.rb:71:10:71:13 | @foo [@bar] | provenance |  |
+| filter_flow.rb:80:5:80:8 | [post] self : FiveController [@foo] | filter_flow.rb:83:3:84:5 | self in b : FiveController [@foo] | provenance |  |
+| filter_flow.rb:83:3:84:5 | self in b : FiveController [@foo] | filter_flow.rb:86:3:88:5 | self in c : FiveController [@foo] | provenance |  |
+| filter_flow.rb:86:3:88:5 | self in c : FiveController [@foo] | filter_flow.rb:87:11:87:14 | self : FiveController [@foo] | provenance |  |
+| filter_flow.rb:87:11:87:14 | self : FiveController [@foo] | filter_flow.rb:87:11:87:14 | @foo | provenance |  |
+| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] : FiveController [@foo] | filter_flow.rb:80:5:80:8 | [post] self : FiveController [@foo] | provenance |  |
+| filter_flow.rb:91:5:91:8 | [post] self [@foo] | filter_flow.rb:90:3:92:5 | self in taint_foo [Return] : FiveController [@foo] | provenance |  |
 | filter_flow.rb:91:12:91:17 | call to params | filter_flow.rb:91:12:91:23 | ...[...] | provenance |  |
 | filter_flow.rb:91:12:91:23 | ...[...] | filter_flow.rb:91:5:91:8 | [post] self [@foo] | provenance |  |
 | params_flow.rb:3:10:3:15 | call to params | params_flow.rb:3:10:3:19 | ...[...] | provenance |  |
@@ -69,9 +69,9 @@ edges
 | params_flow.rb:126:10:126:15 | call to params | params_flow.rb:126:10:126:30 | call to merge! | provenance |  |
 | params_flow.rb:127:24:127:29 | call to params | params_flow.rb:127:10:127:30 | call to merge! | provenance |  |
 | params_flow.rb:130:5:130:5 | [post] p | params_flow.rb:131:10:131:10 | p | provenance |  |
-| params_flow.rb:130:5:130:5 | [post] p [element 0] | params_flow.rb:131:10:131:10 | p | provenance |  |
+| params_flow.rb:130:5:130:5 | [post] p : Array [element 0] | params_flow.rb:131:10:131:10 | p | provenance |  |
 | params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p | provenance |  |
-| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p [element 0] | provenance |  |
+| params_flow.rb:130:14:130:19 | call to params | params_flow.rb:130:5:130:5 | [post] p : Array [element 0] | provenance |  |
 | params_flow.rb:135:10:135:15 | call to params | params_flow.rb:135:10:135:38 | call to reverse_merge! | provenance |  |
 | params_flow.rb:136:32:136:37 | call to params | params_flow.rb:136:10:136:38 | call to reverse_merge! | provenance |  |
 | params_flow.rb:139:5:139:5 | [post] p | params_flow.rb:140:10:140:10 | p | provenance |  |
@@ -109,39 +109,39 @@ nodes
 | filter_flow.rb:14:5:14:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | filter_flow.rb:14:12:14:17 | call to params | semmle.label | call to params |
 | filter_flow.rb:14:12:14:23 | ...[...] | semmle.label | ...[...] |
-| filter_flow.rb:17:3:18:5 | self in b [@foo] | semmle.label | self in b [@foo] |
-| filter_flow.rb:20:3:22:5 | self in c [@foo] | semmle.label | self in c [@foo] |
+| filter_flow.rb:17:3:18:5 | self in b : OneController [@foo] | semmle.label | self in b : OneController [@foo] |
+| filter_flow.rb:20:3:22:5 | self in c : OneController [@foo] | semmle.label | self in c : OneController [@foo] |
 | filter_flow.rb:21:10:21:13 | @foo | semmle.label | @foo |
-| filter_flow.rb:21:10:21:13 | self [@foo] | semmle.label | self [@foo] |
+| filter_flow.rb:21:10:21:13 | self : OneController [@foo] | semmle.label | self : OneController [@foo] |
 | filter_flow.rb:30:5:30:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | filter_flow.rb:30:12:30:17 | call to params | semmle.label | call to params |
 | filter_flow.rb:30:12:30:23 | ...[...] | semmle.label | ...[...] |
-| filter_flow.rb:33:3:35:5 | self in b [@foo] | semmle.label | self in b [@foo] |
-| filter_flow.rb:37:3:39:5 | self in c [@foo] | semmle.label | self in c [@foo] |
+| filter_flow.rb:33:3:35:5 | self in b : TwoController [@foo] | semmle.label | self in b : TwoController [@foo] |
+| filter_flow.rb:37:3:39:5 | self in c : TwoController [@foo] | semmle.label | self in c : TwoController [@foo] |
 | filter_flow.rb:38:10:38:13 | @foo | semmle.label | @foo |
-| filter_flow.rb:38:10:38:13 | self [@foo] | semmle.label | self [@foo] |
+| filter_flow.rb:38:10:38:13 | self : TwoController [@foo] | semmle.label | self : TwoController [@foo] |
 | filter_flow.rb:47:5:47:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | filter_flow.rb:47:12:47:17 | call to params | semmle.label | call to params |
 | filter_flow.rb:47:12:47:23 | ...[...] | semmle.label | ...[...] |
-| filter_flow.rb:51:3:52:5 | self in b [@foo] | semmle.label | self in b [@foo] |
-| filter_flow.rb:54:3:56:5 | self in c [@foo] | semmle.label | self in c [@foo] |
+| filter_flow.rb:51:3:52:5 | self in b : ThreeController [@foo] | semmle.label | self in b : ThreeController [@foo] |
+| filter_flow.rb:54:3:56:5 | self in c : ThreeController [@foo] | semmle.label | self in c : ThreeController [@foo] |
 | filter_flow.rb:55:10:55:13 | @foo | semmle.label | @foo |
-| filter_flow.rb:55:10:55:13 | self [@foo] | semmle.label | self [@foo] |
+| filter_flow.rb:55:10:55:13 | self : ThreeController [@foo] | semmle.label | self : ThreeController [@foo] |
 | filter_flow.rb:64:5:64:8 | [post] @foo [@bar] | semmle.label | [post] @foo [@bar] |
-| filter_flow.rb:64:5:64:8 | [post] self [@foo, @bar] | semmle.label | [post] self [@foo, @bar] |
+| filter_flow.rb:64:5:64:8 | [post] self : FourController [@foo, @bar] | semmle.label | [post] self : FourController [@foo, @bar] |
 | filter_flow.rb:64:16:64:21 | call to params | semmle.label | call to params |
 | filter_flow.rb:64:16:64:27 | ...[...] | semmle.label | ...[...] |
-| filter_flow.rb:67:3:68:5 | self in b [@foo, @bar] | semmle.label | self in b [@foo, @bar] |
-| filter_flow.rb:70:3:72:5 | self in c [@foo, @bar] | semmle.label | self in c [@foo, @bar] |
+| filter_flow.rb:67:3:68:5 | self in b : FourController [@foo, @bar] | semmle.label | self in b : FourController [@foo, @bar] |
+| filter_flow.rb:70:3:72:5 | self in c : FourController [@foo, @bar] | semmle.label | self in c : FourController [@foo, @bar] |
 | filter_flow.rb:71:10:71:13 | @foo [@bar] | semmle.label | @foo [@bar] |
-| filter_flow.rb:71:10:71:13 | self [@foo, @bar] | semmle.label | self [@foo, @bar] |
+| filter_flow.rb:71:10:71:13 | self : FourController [@foo, @bar] | semmle.label | self : FourController [@foo, @bar] |
 | filter_flow.rb:71:10:71:17 | call to bar | semmle.label | call to bar |
-| filter_flow.rb:80:5:80:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
-| filter_flow.rb:83:3:84:5 | self in b [@foo] | semmle.label | self in b [@foo] |
-| filter_flow.rb:86:3:88:5 | self in c [@foo] | semmle.label | self in c [@foo] |
+| filter_flow.rb:80:5:80:8 | [post] self : FiveController [@foo] | semmle.label | [post] self : FiveController [@foo] |
+| filter_flow.rb:83:3:84:5 | self in b : FiveController [@foo] | semmle.label | self in b : FiveController [@foo] |
+| filter_flow.rb:86:3:88:5 | self in c : FiveController [@foo] | semmle.label | self in c : FiveController [@foo] |
 | filter_flow.rb:87:11:87:14 | @foo | semmle.label | @foo |
-| filter_flow.rb:87:11:87:14 | self [@foo] | semmle.label | self [@foo] |
-| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] [@foo] | semmle.label | self in taint_foo [Return] [@foo] |
+| filter_flow.rb:87:11:87:14 | self : FiveController [@foo] | semmle.label | self : FiveController [@foo] |
+| filter_flow.rb:90:3:92:5 | self in taint_foo [Return] : FiveController [@foo] | semmle.label | self in taint_foo [Return] : FiveController [@foo] |
 | filter_flow.rb:91:5:91:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | filter_flow.rb:91:12:91:17 | call to params | semmle.label | call to params |
 | filter_flow.rb:91:12:91:23 | ...[...] | semmle.label | ...[...] |
@@ -214,7 +214,7 @@ nodes
 | params_flow.rb:127:10:127:30 | call to merge! | semmle.label | call to merge! |
 | params_flow.rb:127:24:127:29 | call to params | semmle.label | call to params |
 | params_flow.rb:130:5:130:5 | [post] p | semmle.label | [post] p |
-| params_flow.rb:130:5:130:5 | [post] p [element 0] | semmle.label | [post] p [element 0] |
+| params_flow.rb:130:5:130:5 | [post] p : Array [element 0] | semmle.label | [post] p : Array [element 0] |
 | params_flow.rb:130:14:130:19 | call to params | semmle.label | call to params |
 | params_flow.rb:131:10:131:10 | p | semmle.label | p |
 | params_flow.rb:135:10:135:15 | call to params | semmle.label | call to params |

--- a/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
+++ b/ruby/ql/test/library-tests/frameworks/active_support/ActiveSupportDataFlow.expected
@@ -1,53 +1,53 @@
 models
 edges
-| active_support.rb:180:5:180:5 | x [element 0] | active_support.rb:181:9:181:9 | x [element 0] | provenance |  |
-| active_support.rb:180:9:180:18 | call to [] [element 0] | active_support.rb:180:5:180:5 | x [element 0] | provenance |  |
-| active_support.rb:180:10:180:17 | call to source | active_support.rb:180:9:180:18 | call to [] [element 0] | provenance |  |
-| active_support.rb:181:5:181:5 | y [element] | active_support.rb:182:10:182:10 | y [element] | provenance |  |
-| active_support.rb:181:9:181:9 | x [element 0] | active_support.rb:181:9:181:23 | call to compact_blank [element] | provenance |  |
-| active_support.rb:181:9:181:23 | call to compact_blank [element] | active_support.rb:181:5:181:5 | y [element] | provenance |  |
-| active_support.rb:182:10:182:10 | y [element] | active_support.rb:182:10:182:13 | ...[...] | provenance |  |
-| active_support.rb:186:5:186:5 | x [element 0] | active_support.rb:187:9:187:9 | x [element 0] | provenance |  |
-| active_support.rb:186:9:186:22 | call to [] [element 0] | active_support.rb:186:5:186:5 | x [element 0] | provenance |  |
-| active_support.rb:186:10:186:18 | call to source | active_support.rb:186:9:186:22 | call to [] [element 0] | provenance |  |
-| active_support.rb:187:5:187:5 | y [element] | active_support.rb:188:10:188:10 | y [element] | provenance |  |
-| active_support.rb:187:9:187:9 | x [element 0] | active_support.rb:187:9:187:21 | call to excluding [element] | provenance |  |
-| active_support.rb:187:9:187:21 | call to excluding [element] | active_support.rb:187:5:187:5 | y [element] | provenance |  |
-| active_support.rb:188:10:188:10 | y [element] | active_support.rb:188:10:188:13 | ...[...] | provenance |  |
-| active_support.rb:192:5:192:5 | x [element 0] | active_support.rb:193:9:193:9 | x [element 0] | provenance |  |
-| active_support.rb:192:9:192:22 | call to [] [element 0] | active_support.rb:192:5:192:5 | x [element 0] | provenance |  |
-| active_support.rb:192:10:192:18 | call to source | active_support.rb:192:9:192:22 | call to [] [element 0] | provenance |  |
-| active_support.rb:193:5:193:5 | y [element] | active_support.rb:194:10:194:10 | y [element] | provenance |  |
-| active_support.rb:193:9:193:9 | x [element 0] | active_support.rb:193:9:193:19 | call to without [element] | provenance |  |
-| active_support.rb:193:9:193:19 | call to without [element] | active_support.rb:193:5:193:5 | y [element] | provenance |  |
-| active_support.rb:194:10:194:10 | y [element] | active_support.rb:194:10:194:13 | ...[...] | provenance |  |
-| active_support.rb:198:5:198:5 | x [element 0] | active_support.rb:199:9:199:9 | x [element 0] | provenance |  |
-| active_support.rb:198:9:198:22 | call to [] [element 0] | active_support.rb:198:5:198:5 | x [element 0] | provenance |  |
-| active_support.rb:198:10:198:18 | call to source | active_support.rb:198:9:198:22 | call to [] [element 0] | provenance |  |
-| active_support.rb:199:5:199:5 | y [element] | active_support.rb:200:10:200:10 | y [element] | provenance |  |
-| active_support.rb:199:9:199:9 | x [element 0] | active_support.rb:199:9:199:37 | call to in_order_of [element] | provenance |  |
-| active_support.rb:199:9:199:37 | call to in_order_of [element] | active_support.rb:199:5:199:5 | y [element] | provenance |  |
-| active_support.rb:200:10:200:10 | y [element] | active_support.rb:200:10:200:13 | ...[...] | provenance |  |
-| active_support.rb:204:5:204:5 | a [element 0] | active_support.rb:205:9:205:9 | a [element 0] | provenance |  |
-| active_support.rb:204:5:204:5 | a [element 0] | active_support.rb:206:10:206:10 | a [element 0] | provenance |  |
-| active_support.rb:204:9:204:22 | call to [] [element 0] | active_support.rb:204:5:204:5 | a [element 0] | provenance |  |
-| active_support.rb:204:10:204:18 | call to source | active_support.rb:204:9:204:22 | call to [] [element 0] | provenance |  |
-| active_support.rb:205:5:205:5 | b [element 0] | active_support.rb:208:10:208:10 | b [element 0] | provenance |  |
-| active_support.rb:205:5:205:5 | b [element] | active_support.rb:208:10:208:10 | b [element] | provenance |  |
-| active_support.rb:205:5:205:5 | b [element] | active_support.rb:209:10:209:10 | b [element] | provenance |  |
-| active_support.rb:205:5:205:5 | b [element] | active_support.rb:210:10:210:10 | b [element] | provenance |  |
-| active_support.rb:205:5:205:5 | b [element] | active_support.rb:211:10:211:10 | b [element] | provenance |  |
-| active_support.rb:205:9:205:9 | a [element 0] | active_support.rb:205:9:205:41 | call to including [element 0] | provenance |  |
-| active_support.rb:205:9:205:41 | call to including [element 0] | active_support.rb:205:5:205:5 | b [element 0] | provenance |  |
-| active_support.rb:205:9:205:41 | call to including [element] | active_support.rb:205:5:205:5 | b [element] | provenance |  |
-| active_support.rb:205:21:205:29 | call to source | active_support.rb:205:9:205:41 | call to including [element] | provenance |  |
-| active_support.rb:205:32:205:40 | call to source | active_support.rb:205:9:205:41 | call to including [element] | provenance |  |
-| active_support.rb:206:10:206:10 | a [element 0] | active_support.rb:206:10:206:13 | ...[...] | provenance |  |
-| active_support.rb:208:10:208:10 | b [element 0] | active_support.rb:208:10:208:13 | ...[...] | provenance |  |
-| active_support.rb:208:10:208:10 | b [element] | active_support.rb:208:10:208:13 | ...[...] | provenance |  |
-| active_support.rb:209:10:209:10 | b [element] | active_support.rb:209:10:209:13 | ...[...] | provenance |  |
-| active_support.rb:210:10:210:10 | b [element] | active_support.rb:210:10:210:13 | ...[...] | provenance |  |
-| active_support.rb:211:10:211:10 | b [element] | active_support.rb:211:10:211:13 | ...[...] | provenance |  |
+| active_support.rb:180:5:180:5 | x : Array [element 0] | active_support.rb:181:9:181:9 | x : Array [element 0] | provenance |  |
+| active_support.rb:180:9:180:18 | call to [] : Array [element 0] | active_support.rb:180:5:180:5 | x : Array [element 0] | provenance |  |
+| active_support.rb:180:10:180:17 | call to source | active_support.rb:180:9:180:18 | call to [] : Array [element 0] | provenance |  |
+| active_support.rb:181:5:181:5 | y : [collection] [element] | active_support.rb:182:10:182:10 | y : [collection] [element] | provenance |  |
+| active_support.rb:181:9:181:9 | x : Array [element 0] | active_support.rb:181:9:181:23 | call to compact_blank : [collection] [element] | provenance |  |
+| active_support.rb:181:9:181:23 | call to compact_blank : [collection] [element] | active_support.rb:181:5:181:5 | y : [collection] [element] | provenance |  |
+| active_support.rb:182:10:182:10 | y : [collection] [element] | active_support.rb:182:10:182:13 | ...[...] | provenance |  |
+| active_support.rb:186:5:186:5 | x : Array [element 0] | active_support.rb:187:9:187:9 | x : Array [element 0] | provenance |  |
+| active_support.rb:186:9:186:22 | call to [] : Array [element 0] | active_support.rb:186:5:186:5 | x : Array [element 0] | provenance |  |
+| active_support.rb:186:10:186:18 | call to source | active_support.rb:186:9:186:22 | call to [] : Array [element 0] | provenance |  |
+| active_support.rb:187:5:187:5 | y : [collection] [element] | active_support.rb:188:10:188:10 | y : [collection] [element] | provenance |  |
+| active_support.rb:187:9:187:9 | x : Array [element 0] | active_support.rb:187:9:187:21 | call to excluding : [collection] [element] | provenance |  |
+| active_support.rb:187:9:187:21 | call to excluding : [collection] [element] | active_support.rb:187:5:187:5 | y : [collection] [element] | provenance |  |
+| active_support.rb:188:10:188:10 | y : [collection] [element] | active_support.rb:188:10:188:13 | ...[...] | provenance |  |
+| active_support.rb:192:5:192:5 | x : Array [element 0] | active_support.rb:193:9:193:9 | x : Array [element 0] | provenance |  |
+| active_support.rb:192:9:192:22 | call to [] : Array [element 0] | active_support.rb:192:5:192:5 | x : Array [element 0] | provenance |  |
+| active_support.rb:192:10:192:18 | call to source | active_support.rb:192:9:192:22 | call to [] : Array [element 0] | provenance |  |
+| active_support.rb:193:5:193:5 | y : [collection] [element] | active_support.rb:194:10:194:10 | y : [collection] [element] | provenance |  |
+| active_support.rb:193:9:193:9 | x : Array [element 0] | active_support.rb:193:9:193:19 | call to without : [collection] [element] | provenance |  |
+| active_support.rb:193:9:193:19 | call to without : [collection] [element] | active_support.rb:193:5:193:5 | y : [collection] [element] | provenance |  |
+| active_support.rb:194:10:194:10 | y : [collection] [element] | active_support.rb:194:10:194:13 | ...[...] | provenance |  |
+| active_support.rb:198:5:198:5 | x : Array [element 0] | active_support.rb:199:9:199:9 | x : Array [element 0] | provenance |  |
+| active_support.rb:198:9:198:22 | call to [] : Array [element 0] | active_support.rb:198:5:198:5 | x : Array [element 0] | provenance |  |
+| active_support.rb:198:10:198:18 | call to source | active_support.rb:198:9:198:22 | call to [] : Array [element 0] | provenance |  |
+| active_support.rb:199:5:199:5 | y : [collection] [element] | active_support.rb:200:10:200:10 | y : [collection] [element] | provenance |  |
+| active_support.rb:199:9:199:9 | x : Array [element 0] | active_support.rb:199:9:199:37 | call to in_order_of : [collection] [element] | provenance |  |
+| active_support.rb:199:9:199:37 | call to in_order_of : [collection] [element] | active_support.rb:199:5:199:5 | y : [collection] [element] | provenance |  |
+| active_support.rb:200:10:200:10 | y : [collection] [element] | active_support.rb:200:10:200:13 | ...[...] | provenance |  |
+| active_support.rb:204:5:204:5 | a : Array [element 0] | active_support.rb:205:9:205:9 | a : Array [element 0] | provenance |  |
+| active_support.rb:204:5:204:5 | a : Array [element 0] | active_support.rb:206:10:206:10 | a : Array [element 0] | provenance |  |
+| active_support.rb:204:9:204:22 | call to [] : Array [element 0] | active_support.rb:204:5:204:5 | a : Array [element 0] | provenance |  |
+| active_support.rb:204:10:204:18 | call to source | active_support.rb:204:9:204:22 | call to [] : Array [element 0] | provenance |  |
+| active_support.rb:205:5:205:5 | b : [collection] [element 0] | active_support.rb:208:10:208:10 | b : [collection] [element 0] | provenance |  |
+| active_support.rb:205:5:205:5 | b : [collection] [element] | active_support.rb:208:10:208:10 | b : [collection] [element] | provenance |  |
+| active_support.rb:205:5:205:5 | b : [collection] [element] | active_support.rb:209:10:209:10 | b : [collection] [element] | provenance |  |
+| active_support.rb:205:5:205:5 | b : [collection] [element] | active_support.rb:210:10:210:10 | b : [collection] [element] | provenance |  |
+| active_support.rb:205:5:205:5 | b : [collection] [element] | active_support.rb:211:10:211:10 | b : [collection] [element] | provenance |  |
+| active_support.rb:205:9:205:9 | a : Array [element 0] | active_support.rb:205:9:205:41 | call to including : [collection] [element 0] | provenance |  |
+| active_support.rb:205:9:205:41 | call to including : [collection] [element 0] | active_support.rb:205:5:205:5 | b : [collection] [element 0] | provenance |  |
+| active_support.rb:205:9:205:41 | call to including : [collection] [element] | active_support.rb:205:5:205:5 | b : [collection] [element] | provenance |  |
+| active_support.rb:205:21:205:29 | call to source | active_support.rb:205:9:205:41 | call to including : [collection] [element] | provenance |  |
+| active_support.rb:205:32:205:40 | call to source | active_support.rb:205:9:205:41 | call to including : [collection] [element] | provenance |  |
+| active_support.rb:206:10:206:10 | a : Array [element 0] | active_support.rb:206:10:206:13 | ...[...] | provenance |  |
+| active_support.rb:208:10:208:10 | b : [collection] [element 0] | active_support.rb:208:10:208:13 | ...[...] | provenance |  |
+| active_support.rb:208:10:208:10 | b : [collection] [element] | active_support.rb:208:10:208:13 | ...[...] | provenance |  |
+| active_support.rb:209:10:209:10 | b : [collection] [element] | active_support.rb:209:10:209:13 | ...[...] | provenance |  |
+| active_support.rb:210:10:210:10 | b : [collection] [element] | active_support.rb:210:10:210:13 | ...[...] | provenance |  |
+| active_support.rb:211:10:211:10 | b : [collection] [element] | active_support.rb:211:10:211:13 | ...[...] | provenance |  |
 | active_support.rb:282:3:282:3 | x | active_support.rb:283:8:283:8 | x | provenance |  |
 | active_support.rb:282:7:282:16 | call to source | active_support.rb:282:3:282:3 | x | provenance |  |
 | active_support.rb:283:8:283:8 | x | active_support.rb:283:8:283:17 | call to presence | provenance |  |
@@ -57,238 +57,238 @@ edges
 | active_support.rb:290:3:290:3 | x | active_support.rb:291:8:291:8 | x | provenance |  |
 | active_support.rb:290:7:290:16 | call to source | active_support.rb:290:3:290:3 | x | provenance |  |
 | active_support.rb:291:8:291:8 | x | active_support.rb:291:8:291:17 | call to deep_dup | provenance |  |
-| hash_extensions.rb:2:5:2:5 | h [element :a] | hash_extensions.rb:3:9:3:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:2:9:2:26 | call to [] [element :a] | hash_extensions.rb:2:5:2:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:2:9:2:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:3:5:3:5 | x [element :a] | hash_extensions.rb:4:10:4:10 | x [element :a] | provenance |  |
-| hash_extensions.rb:3:9:3:9 | h [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | provenance |  |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | hash_extensions.rb:3:5:3:5 | x [element :a] | provenance |  |
-| hash_extensions.rb:4:10:4:10 | x [element :a] | hash_extensions.rb:4:10:4:15 | ...[...] | provenance |  |
-| hash_extensions.rb:10:5:10:5 | h [element a] | hash_extensions.rb:11:9:11:9 | h [element a] | provenance |  |
-| hash_extensions.rb:10:9:10:30 | call to [] [element a] | hash_extensions.rb:10:5:10:5 | h [element a] | provenance |  |
-| hash_extensions.rb:10:18:10:28 | call to source | hash_extensions.rb:10:9:10:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:11:5:11:5 | x [element a] | hash_extensions.rb:12:10:12:10 | x [element a] | provenance |  |
-| hash_extensions.rb:11:9:11:9 | h [element a] | hash_extensions.rb:11:9:11:20 | call to to_options [element a] | provenance |  |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element a] | hash_extensions.rb:11:5:11:5 | x [element a] | provenance |  |
-| hash_extensions.rb:12:10:12:10 | x [element a] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
-| hash_extensions.rb:18:5:18:5 | h [element a] | hash_extensions.rb:19:9:19:9 | h [element a] | provenance |  |
-| hash_extensions.rb:18:9:18:30 | call to [] [element a] | hash_extensions.rb:18:5:18:5 | h [element a] | provenance |  |
-| hash_extensions.rb:18:18:18:28 | call to source | hash_extensions.rb:18:9:18:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:19:5:19:5 | x [element a] | hash_extensions.rb:20:10:20:10 | x [element a] | provenance |  |
-| hash_extensions.rb:19:9:19:9 | h [element a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | provenance |  |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | hash_extensions.rb:19:5:19:5 | x [element a] | provenance |  |
-| hash_extensions.rb:20:10:20:10 | x [element a] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
-| hash_extensions.rb:26:5:26:5 | h [element :a] | hash_extensions.rb:27:9:27:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:26:9:26:26 | call to [] [element :a] | hash_extensions.rb:26:5:26:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:26:9:26:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:27:5:27:5 | x [element :a] | hash_extensions.rb:28:10:28:10 | x [element :a] | provenance |  |
-| hash_extensions.rb:27:9:27:9 | h [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | provenance |  |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | hash_extensions.rb:27:5:27:5 | x [element :a] | provenance |  |
-| hash_extensions.rb:28:10:28:10 | x [element :a] | hash_extensions.rb:28:10:28:15 | ...[...] | provenance |  |
-| hash_extensions.rb:34:5:34:5 | h [element a] | hash_extensions.rb:35:9:35:9 | h [element a] | provenance |  |
-| hash_extensions.rb:34:9:34:30 | call to [] [element a] | hash_extensions.rb:34:5:34:5 | h [element a] | provenance |  |
-| hash_extensions.rb:34:18:34:28 | call to source | hash_extensions.rb:34:9:34:30 | call to [] [element a] | provenance |  |
-| hash_extensions.rb:35:5:35:5 | x [element a] | hash_extensions.rb:36:10:36:10 | x [element a] | provenance |  |
-| hash_extensions.rb:35:9:35:9 | h [element a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | provenance |  |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | hash_extensions.rb:35:5:35:5 | x [element a] | provenance |  |
-| hash_extensions.rb:36:10:36:10 | x [element a] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
-| hash_extensions.rb:42:5:42:5 | h [element :a] | hash_extensions.rb:43:9:43:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:42:9:42:26 | call to [] [element :a] | hash_extensions.rb:42:5:42:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:42:9:42:26 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:43:5:43:5 | x [element :a] | hash_extensions.rb:44:10:44:10 | x [element :a] | provenance |  |
-| hash_extensions.rb:43:9:43:9 | h [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | provenance |  |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | hash_extensions.rb:43:5:43:5 | x [element :a] | provenance |  |
-| hash_extensions.rb:44:10:44:10 | x [element :a] | hash_extensions.rb:44:10:44:15 | ...[...] | provenance |  |
-| hash_extensions.rb:50:5:50:5 | h [element :a] | hash_extensions.rb:51:9:51:9 | h [element :a] | provenance |  |
-| hash_extensions.rb:50:5:50:5 | h [element :b] | hash_extensions.rb:51:9:51:9 | h [element :b] | provenance |  |
-| hash_extensions.rb:50:5:50:5 | h [element :d] | hash_extensions.rb:51:9:51:9 | h [element :d] | provenance |  |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :a] | hash_extensions.rb:50:5:50:5 | h [element :a] | provenance |  |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :b] | hash_extensions.rb:50:5:50:5 | h [element :b] | provenance |  |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :d] | hash_extensions.rb:50:5:50:5 | h [element :d] | provenance |  |
-| hash_extensions.rb:50:14:50:23 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :a] | provenance |  |
-| hash_extensions.rb:50:29:50:38 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :b] | provenance |  |
-| hash_extensions.rb:50:52:50:61 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] [element :d] | provenance |  |
-| hash_extensions.rb:51:5:51:5 | x [element :a] | hash_extensions.rb:58:10:58:10 | x [element :a] | provenance |  |
-| hash_extensions.rb:51:5:51:5 | x [element :b] | hash_extensions.rb:59:10:59:10 | x [element :b] | provenance |  |
-| hash_extensions.rb:51:9:51:9 | [post] h [element :d] | hash_extensions.rb:56:10:56:10 | h [element :d] | provenance |  |
-| hash_extensions.rb:51:9:51:9 | h [element :a] | hash_extensions.rb:51:9:51:29 | call to extract! [element :a] | provenance |  |
-| hash_extensions.rb:51:9:51:9 | h [element :b] | hash_extensions.rb:51:9:51:29 | call to extract! [element :b] | provenance |  |
-| hash_extensions.rb:51:9:51:9 | h [element :d] | hash_extensions.rb:51:9:51:9 | [post] h [element :d] | provenance |  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] | hash_extensions.rb:51:5:51:5 | x [element :a] | provenance |  |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] | hash_extensions.rb:51:5:51:5 | x [element :b] | provenance |  |
-| hash_extensions.rb:56:10:56:10 | h [element :d] | hash_extensions.rb:56:10:56:14 | ...[...] | provenance |  |
-| hash_extensions.rb:58:10:58:10 | x [element :a] | hash_extensions.rb:58:10:58:14 | ...[...] | provenance |  |
-| hash_extensions.rb:59:10:59:10 | x [element :b] | hash_extensions.rb:59:10:59:14 | ...[...] | provenance |  |
-| hash_extensions.rb:67:5:67:10 | values [element 0] | hash_extensions.rb:68:9:68:14 | values [element 0] | provenance |  |
-| hash_extensions.rb:67:5:67:10 | values [element 1] | hash_extensions.rb:68:9:68:14 | values [element 1] | provenance |  |
-| hash_extensions.rb:67:5:67:10 | values [element 2] | hash_extensions.rb:68:9:68:14 | values [element 2] | provenance |  |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 0] | hash_extensions.rb:67:5:67:10 | values [element 0] | provenance |  |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 1] | hash_extensions.rb:67:5:67:10 | values [element 1] | provenance |  |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 2] | hash_extensions.rb:67:5:67:10 | values [element 2] | provenance |  |
-| hash_extensions.rb:67:15:67:25 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 0] | provenance |  |
-| hash_extensions.rb:67:28:67:38 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 1] | provenance |  |
-| hash_extensions.rb:67:41:67:51 | call to source | hash_extensions.rb:67:14:67:52 | call to [] [element 2] | provenance |  |
-| hash_extensions.rb:68:5:68:5 | h [element] | hash_extensions.rb:73:10:73:10 | h [element] | provenance |  |
-| hash_extensions.rb:68:5:68:5 | h [element] | hash_extensions.rb:74:10:74:10 | h [element] | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 0] | hash_extensions.rb:68:9:71:7 | call to index_by [element] | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 0] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 1] | hash_extensions.rb:68:9:71:7 | call to index_by [element] | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 1] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 2] | hash_extensions.rb:68:9:71:7 | call to index_by [element] | provenance |  |
-| hash_extensions.rb:68:9:68:14 | values [element 2] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] | hash_extensions.rb:68:5:68:5 | h [element] | provenance |  |
+| hash_extensions.rb:2:5:2:5 | h : Hash [element :a] | hash_extensions.rb:3:9:3:9 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:2:9:2:26 | call to [] : Hash [element :a] | hash_extensions.rb:2:5:2:5 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:2:14:2:24 | call to source | hash_extensions.rb:2:9:2:26 | call to [] : Hash [element :a] | provenance |  |
+| hash_extensions.rb:3:5:3:5 | x : Hash [element :a] | hash_extensions.rb:4:10:4:10 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:3:9:3:9 | h : Hash [element :a] | hash_extensions.rb:3:9:3:24 | call to stringify_keys : Hash [element :a] | provenance |  |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys : Hash [element :a] | hash_extensions.rb:3:5:3:5 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:4:10:4:10 | x : Hash [element :a] | hash_extensions.rb:4:10:4:15 | ...[...] | provenance |  |
+| hash_extensions.rb:10:5:10:5 | h : Hash [element a] | hash_extensions.rb:11:9:11:9 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:10:9:10:30 | call to [] : Hash [element a] | hash_extensions.rb:10:5:10:5 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:10:18:10:28 | call to source | hash_extensions.rb:10:9:10:30 | call to [] : Hash [element a] | provenance |  |
+| hash_extensions.rb:11:5:11:5 | x : Hash [element a] | hash_extensions.rb:12:10:12:10 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:11:9:11:9 | h : Hash [element a] | hash_extensions.rb:11:9:11:20 | call to to_options : Hash [element a] | provenance |  |
+| hash_extensions.rb:11:9:11:20 | call to to_options : Hash [element a] | hash_extensions.rb:11:5:11:5 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:12:10:12:10 | x : Hash [element a] | hash_extensions.rb:12:10:12:14 | ...[...] | provenance |  |
+| hash_extensions.rb:18:5:18:5 | h : Hash [element a] | hash_extensions.rb:19:9:19:9 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:18:9:18:30 | call to [] : Hash [element a] | hash_extensions.rb:18:5:18:5 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:18:18:18:28 | call to source | hash_extensions.rb:18:9:18:30 | call to [] : Hash [element a] | provenance |  |
+| hash_extensions.rb:19:5:19:5 | x : Hash [element a] | hash_extensions.rb:20:10:20:10 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:19:9:19:9 | h : Hash [element a] | hash_extensions.rb:19:9:19:24 | call to symbolize_keys : Hash [element a] | provenance |  |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys : Hash [element a] | hash_extensions.rb:19:5:19:5 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:20:10:20:10 | x : Hash [element a] | hash_extensions.rb:20:10:20:14 | ...[...] | provenance |  |
+| hash_extensions.rb:26:5:26:5 | h : Hash [element :a] | hash_extensions.rb:27:9:27:9 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:26:9:26:26 | call to [] : Hash [element :a] | hash_extensions.rb:26:5:26:5 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:26:14:26:24 | call to source | hash_extensions.rb:26:9:26:26 | call to [] : Hash [element :a] | provenance |  |
+| hash_extensions.rb:27:5:27:5 | x : Hash [element :a] | hash_extensions.rb:28:10:28:10 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:27:9:27:9 | h : Hash [element :a] | hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys : Hash [element :a] | provenance |  |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys : Hash [element :a] | hash_extensions.rb:27:5:27:5 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:28:10:28:10 | x : Hash [element :a] | hash_extensions.rb:28:10:28:15 | ...[...] | provenance |  |
+| hash_extensions.rb:34:5:34:5 | h : Hash [element a] | hash_extensions.rb:35:9:35:9 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:34:9:34:30 | call to [] : Hash [element a] | hash_extensions.rb:34:5:34:5 | h : Hash [element a] | provenance |  |
+| hash_extensions.rb:34:18:34:28 | call to source | hash_extensions.rb:34:9:34:30 | call to [] : Hash [element a] | provenance |  |
+| hash_extensions.rb:35:5:35:5 | x : Hash [element a] | hash_extensions.rb:36:10:36:10 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:35:9:35:9 | h : Hash [element a] | hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys : Hash [element a] | provenance |  |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys : Hash [element a] | hash_extensions.rb:35:5:35:5 | x : Hash [element a] | provenance |  |
+| hash_extensions.rb:36:10:36:10 | x : Hash [element a] | hash_extensions.rb:36:10:36:14 | ...[...] | provenance |  |
+| hash_extensions.rb:42:5:42:5 | h : Hash [element :a] | hash_extensions.rb:43:9:43:9 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:42:9:42:26 | call to [] : Hash [element :a] | hash_extensions.rb:42:5:42:5 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:42:14:42:24 | call to source | hash_extensions.rb:42:9:42:26 | call to [] : Hash [element :a] | provenance |  |
+| hash_extensions.rb:43:5:43:5 | x : Hash [element :a] | hash_extensions.rb:44:10:44:10 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:43:9:43:9 | h : Hash [element :a] | hash_extensions.rb:43:9:43:33 | call to with_indifferent_access : Hash [element :a] | provenance |  |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access : Hash [element :a] | hash_extensions.rb:43:5:43:5 | x : Hash [element :a] | provenance |  |
+| hash_extensions.rb:44:10:44:10 | x : Hash [element :a] | hash_extensions.rb:44:10:44:15 | ...[...] | provenance |  |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :a] | hash_extensions.rb:51:9:51:9 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :b] | hash_extensions.rb:51:9:51:9 | h : Hash [element :b] | provenance |  |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :d] | hash_extensions.rb:51:9:51:9 | h : Hash [element :d] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :a] | hash_extensions.rb:50:5:50:5 | h : Hash [element :a] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :b] | hash_extensions.rb:50:5:50:5 | h : Hash [element :b] | provenance |  |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :d] | hash_extensions.rb:50:5:50:5 | h : Hash [element :d] | provenance |  |
+| hash_extensions.rb:50:14:50:23 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :a] | provenance |  |
+| hash_extensions.rb:50:29:50:38 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :b] | provenance |  |
+| hash_extensions.rb:50:52:50:61 | call to taint | hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :d] | provenance |  |
+| hash_extensions.rb:51:5:51:5 | x : [collection] [element :a] | hash_extensions.rb:58:10:58:10 | x : [collection] [element :a] | provenance |  |
+| hash_extensions.rb:51:5:51:5 | x : [collection] [element :b] | hash_extensions.rb:59:10:59:10 | x : [collection] [element :b] | provenance |  |
+| hash_extensions.rb:51:9:51:9 | [post] h : Hash [element :d] | hash_extensions.rb:56:10:56:10 | h : Hash [element :d] | provenance |  |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :a] | hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :a] | provenance |  |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :b] | hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :b] | provenance |  |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :d] | hash_extensions.rb:51:9:51:9 | [post] h : Hash [element :d] | provenance |  |
+| hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :a] | hash_extensions.rb:51:5:51:5 | x : [collection] [element :a] | provenance |  |
+| hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :b] | hash_extensions.rb:51:5:51:5 | x : [collection] [element :b] | provenance |  |
+| hash_extensions.rb:56:10:56:10 | h : Hash [element :d] | hash_extensions.rb:56:10:56:14 | ...[...] | provenance |  |
+| hash_extensions.rb:58:10:58:10 | x : [collection] [element :a] | hash_extensions.rb:58:10:58:14 | ...[...] | provenance |  |
+| hash_extensions.rb:59:10:59:10 | x : [collection] [element :b] | hash_extensions.rb:59:10:59:14 | ...[...] | provenance |  |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 0] | hash_extensions.rb:68:9:68:14 | values : Array [element 0] | provenance |  |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 1] | hash_extensions.rb:68:9:68:14 | values : Array [element 1] | provenance |  |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 2] | hash_extensions.rb:68:9:68:14 | values : Array [element 2] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 0] | hash_extensions.rb:67:5:67:10 | values : Array [element 0] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 1] | hash_extensions.rb:67:5:67:10 | values : Array [element 1] | provenance |  |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 2] | hash_extensions.rb:67:5:67:10 | values : Array [element 2] | provenance |  |
+| hash_extensions.rb:67:15:67:25 | call to source | hash_extensions.rb:67:14:67:52 | call to [] : Array [element 0] | provenance |  |
+| hash_extensions.rb:67:28:67:38 | call to source | hash_extensions.rb:67:14:67:52 | call to [] : Array [element 1] | provenance |  |
+| hash_extensions.rb:67:41:67:51 | call to source | hash_extensions.rb:67:14:67:52 | call to [] : Array [element 2] | provenance |  |
+| hash_extensions.rb:68:5:68:5 | h : [collection] [element] | hash_extensions.rb:73:10:73:10 | h : [collection] [element] | provenance |  |
+| hash_extensions.rb:68:5:68:5 | h : [collection] [element] | hash_extensions.rb:74:10:74:10 | h : [collection] [element] | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 0] | hash_extensions.rb:68:9:71:7 | call to index_by : [collection] [element] | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 0] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 1] | hash_extensions.rb:68:9:71:7 | call to index_by : [collection] [element] | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 1] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 2] | hash_extensions.rb:68:9:71:7 | call to index_by : [collection] [element] | provenance |  |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 2] | hash_extensions.rb:68:29:68:33 | value | provenance |  |
+| hash_extensions.rb:68:9:71:7 | call to index_by : [collection] [element] | hash_extensions.rb:68:5:68:5 | h : [collection] [element] | provenance |  |
 | hash_extensions.rb:68:29:68:33 | value | hash_extensions.rb:69:14:69:18 | value | provenance |  |
-| hash_extensions.rb:73:10:73:10 | h [element] | hash_extensions.rb:73:10:73:16 | ...[...] | provenance |  |
-| hash_extensions.rb:74:10:74:10 | h [element] | hash_extensions.rb:74:10:74:16 | ...[...] | provenance |  |
-| hash_extensions.rb:80:5:80:10 | values [element 0] | hash_extensions.rb:81:9:81:14 | values [element 0] | provenance |  |
-| hash_extensions.rb:80:5:80:10 | values [element 1] | hash_extensions.rb:81:9:81:14 | values [element 1] | provenance |  |
-| hash_extensions.rb:80:5:80:10 | values [element 2] | hash_extensions.rb:81:9:81:14 | values [element 2] | provenance |  |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 0] | hash_extensions.rb:80:5:80:10 | values [element 0] | provenance |  |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 1] | hash_extensions.rb:80:5:80:10 | values [element 1] | provenance |  |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 2] | hash_extensions.rb:80:5:80:10 | values [element 2] | provenance |  |
-| hash_extensions.rb:80:15:80:25 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 0] | provenance |  |
-| hash_extensions.rb:80:28:80:38 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 1] | provenance |  |
-| hash_extensions.rb:80:41:80:51 | call to source | hash_extensions.rb:80:14:80:52 | call to [] [element 2] | provenance |  |
-| hash_extensions.rb:81:5:81:5 | h [element] | hash_extensions.rb:86:10:86:10 | h [element] | provenance |  |
-| hash_extensions.rb:81:5:81:5 | h [element] | hash_extensions.rb:87:10:87:10 | h [element] | provenance |  |
-| hash_extensions.rb:81:9:81:14 | values [element 0] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
-| hash_extensions.rb:81:9:81:14 | values [element 1] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
-| hash_extensions.rb:81:9:81:14 | values [element 2] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] | hash_extensions.rb:81:5:81:5 | h [element] | provenance |  |
+| hash_extensions.rb:73:10:73:10 | h : [collection] [element] | hash_extensions.rb:73:10:73:16 | ...[...] | provenance |  |
+| hash_extensions.rb:74:10:74:10 | h : [collection] [element] | hash_extensions.rb:74:10:74:16 | ...[...] | provenance |  |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 0] | hash_extensions.rb:81:9:81:14 | values : Array [element 0] | provenance |  |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 1] | hash_extensions.rb:81:9:81:14 | values : Array [element 1] | provenance |  |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 2] | hash_extensions.rb:81:9:81:14 | values : Array [element 2] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 0] | hash_extensions.rb:80:5:80:10 | values : Array [element 0] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 1] | hash_extensions.rb:80:5:80:10 | values : Array [element 1] | provenance |  |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 2] | hash_extensions.rb:80:5:80:10 | values : Array [element 2] | provenance |  |
+| hash_extensions.rb:80:15:80:25 | call to source | hash_extensions.rb:80:14:80:52 | call to [] : Array [element 0] | provenance |  |
+| hash_extensions.rb:80:28:80:38 | call to source | hash_extensions.rb:80:14:80:52 | call to [] : Array [element 1] | provenance |  |
+| hash_extensions.rb:80:41:80:51 | call to source | hash_extensions.rb:80:14:80:52 | call to [] : Array [element 2] | provenance |  |
+| hash_extensions.rb:81:5:81:5 | h : [collection] [element] | hash_extensions.rb:86:10:86:10 | h : [collection] [element] | provenance |  |
+| hash_extensions.rb:81:5:81:5 | h : [collection] [element] | hash_extensions.rb:87:10:87:10 | h : [collection] [element] | provenance |  |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 0] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 1] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 2] | hash_extensions.rb:81:31:81:33 | key | provenance |  |
+| hash_extensions.rb:81:9:84:7 | call to index_with : [collection] [element] | hash_extensions.rb:81:5:81:5 | h : [collection] [element] | provenance |  |
 | hash_extensions.rb:81:31:81:33 | key | hash_extensions.rb:82:14:82:16 | key | provenance |  |
-| hash_extensions.rb:83:9:83:19 | call to source | hash_extensions.rb:81:9:84:7 | call to index_with [element] | provenance |  |
-| hash_extensions.rb:86:10:86:10 | h [element] | hash_extensions.rb:86:10:86:16 | ...[...] | provenance |  |
-| hash_extensions.rb:87:10:87:10 | h [element] | hash_extensions.rb:87:10:87:16 | ...[...] | provenance |  |
-| hash_extensions.rb:89:5:89:5 | j [element] | hash_extensions.rb:91:10:91:10 | j [element] | provenance |  |
-| hash_extensions.rb:89:5:89:5 | j [element] | hash_extensions.rb:92:10:92:10 | j [element] | provenance |  |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] | hash_extensions.rb:89:5:89:5 | j [element] | provenance |  |
-| hash_extensions.rb:89:27:89:37 | call to source | hash_extensions.rb:89:9:89:38 | call to index_with [element] | provenance |  |
-| hash_extensions.rb:91:10:91:10 | j [element] | hash_extensions.rb:91:10:91:16 | ...[...] | provenance |  |
-| hash_extensions.rb:92:10:92:10 | j [element] | hash_extensions.rb:92:10:92:16 | ...[...] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | hash_extensions.rb:99:10:99:15 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | hash_extensions.rb:101:10:101:15 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | hash_extensions.rb:104:10:104:15 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:100:10:100:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:102:10:102:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | hash_extensions.rb:103:10:103:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:15:98:56 | call to [] [element :id] | hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | provenance |  |
-| hash_extensions.rb:98:15:98:56 | call to [] [element :name] | hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | provenance |  |
-| hash_extensions.rb:98:21:98:31 | call to source | hash_extensions.rb:98:15:98:56 | call to [] [element :id] | provenance |  |
-| hash_extensions.rb:98:40:98:54 | call to source | hash_extensions.rb:98:15:98:56 | call to [] [element :name] | provenance |  |
-| hash_extensions.rb:99:10:99:15 | values [element 0, element :id] | hash_extensions.rb:99:10:99:25 | call to pick | provenance |  |
-| hash_extensions.rb:100:10:100:15 | values [element 0, element :name] | hash_extensions.rb:100:10:100:27 | call to pick | provenance |  |
-| hash_extensions.rb:101:10:101:15 | values [element 0, element :id] | hash_extensions.rb:101:10:101:32 | call to pick [element 0] | provenance |  |
-| hash_extensions.rb:101:10:101:32 | call to pick [element 0] | hash_extensions.rb:101:10:101:35 | ...[...] | provenance |  |
-| hash_extensions.rb:102:10:102:15 | values [element 0, element :name] | hash_extensions.rb:102:10:102:32 | call to pick [element 1] | provenance |  |
-| hash_extensions.rb:102:10:102:32 | call to pick [element 1] | hash_extensions.rb:102:10:102:35 | ...[...] | provenance |  |
-| hash_extensions.rb:103:10:103:15 | values [element 0, element :name] | hash_extensions.rb:103:10:103:32 | call to pick [element 0] | provenance |  |
-| hash_extensions.rb:103:10:103:32 | call to pick [element 0] | hash_extensions.rb:103:10:103:35 | ...[...] | provenance |  |
-| hash_extensions.rb:104:10:104:15 | values [element 0, element :id] | hash_extensions.rb:104:10:104:32 | call to pick [element 1] | provenance |  |
-| hash_extensions.rb:104:10:104:32 | call to pick [element 1] | hash_extensions.rb:104:10:104:35 | ...[...] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | hash_extensions.rb:112:10:112:15 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | hash_extensions.rb:115:10:115:15 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | hash_extensions.rb:111:10:111:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | hash_extensions.rb:113:10:113:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | hash_extensions.rb:114:10:114:15 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | hash_extensions.rb:112:10:112:15 | values [element 1, element :id] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | hash_extensions.rb:115:10:115:15 | values [element 1, element :id] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:111:10:111:15 | values [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:113:10:113:15 | values [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | hash_extensions.rb:114:10:114:15 | values [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | provenance |  |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | provenance |  |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:15:110:56 | call to [] [element :id] | hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | provenance |  |
-| hash_extensions.rb:110:15:110:56 | call to [] [element :name] | hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | provenance |  |
-| hash_extensions.rb:110:21:110:31 | call to source | hash_extensions.rb:110:15:110:56 | call to [] [element :id] | provenance |  |
-| hash_extensions.rb:110:40:110:54 | call to source | hash_extensions.rb:110:15:110:56 | call to [] [element :name] | provenance |  |
-| hash_extensions.rb:110:59:110:101 | call to [] [element :id] | hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | provenance |  |
-| hash_extensions.rb:110:59:110:101 | call to [] [element :name] | hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | provenance |  |
-| hash_extensions.rb:110:65:110:75 | call to source | hash_extensions.rb:110:59:110:101 | call to [] [element :id] | provenance |  |
-| hash_extensions.rb:110:84:110:99 | call to source | hash_extensions.rb:110:59:110:101 | call to [] [element :name] | provenance |  |
-| hash_extensions.rb:111:10:111:15 | values [element 0, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck [element] | provenance |  |
-| hash_extensions.rb:111:10:111:15 | values [element 1, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck [element] | provenance |  |
-| hash_extensions.rb:111:10:111:28 | call to pluck [element] | hash_extensions.rb:111:10:111:31 | ...[...] | provenance |  |
-| hash_extensions.rb:112:10:112:15 | values [element 0, element :id] | hash_extensions.rb:112:10:112:33 | call to pluck [element, element 0] | provenance |  |
-| hash_extensions.rb:112:10:112:15 | values [element 1, element :id] | hash_extensions.rb:112:10:112:33 | call to pluck [element, element 0] | provenance |  |
-| hash_extensions.rb:112:10:112:33 | call to pluck [element, element 0] | hash_extensions.rb:112:10:112:36 | ...[...] [element 0] | provenance |  |
+| hash_extensions.rb:83:9:83:19 | call to source | hash_extensions.rb:81:9:84:7 | call to index_with : [collection] [element] | provenance |  |
+| hash_extensions.rb:86:10:86:10 | h : [collection] [element] | hash_extensions.rb:86:10:86:16 | ...[...] | provenance |  |
+| hash_extensions.rb:87:10:87:10 | h : [collection] [element] | hash_extensions.rb:87:10:87:16 | ...[...] | provenance |  |
+| hash_extensions.rb:89:5:89:5 | j : [collection] [element] | hash_extensions.rb:91:10:91:10 | j : [collection] [element] | provenance |  |
+| hash_extensions.rb:89:5:89:5 | j : [collection] [element] | hash_extensions.rb:92:10:92:10 | j : [collection] [element] | provenance |  |
+| hash_extensions.rb:89:9:89:38 | call to index_with : [collection] [element] | hash_extensions.rb:89:5:89:5 | j : [collection] [element] | provenance |  |
+| hash_extensions.rb:89:27:89:37 | call to source | hash_extensions.rb:89:9:89:38 | call to index_with : [collection] [element] | provenance |  |
+| hash_extensions.rb:91:10:91:10 | j : [collection] [element] | hash_extensions.rb:91:10:91:16 | ...[...] | provenance |  |
+| hash_extensions.rb:92:10:92:10 | j : [collection] [element] | hash_extensions.rb:92:10:92:16 | ...[...] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :id] | hash_extensions.rb:99:10:99:15 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :id] | hash_extensions.rb:101:10:101:15 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :id] | hash_extensions.rb:104:10:104:15 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :name] | hash_extensions.rb:100:10:100:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :name] | hash_extensions.rb:102:10:102:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :name] | hash_extensions.rb:103:10:103:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :id] | hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :name] | hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :id] | hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :name] | hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:98:21:98:31 | call to source | hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :id] | provenance |  |
+| hash_extensions.rb:98:40:98:54 | call to source | hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :name] | provenance |  |
+| hash_extensions.rb:99:10:99:15 | values : Array [element 0, element :id] | hash_extensions.rb:99:10:99:25 | call to pick | provenance |  |
+| hash_extensions.rb:100:10:100:15 | values : Array [element 0, element :name] | hash_extensions.rb:100:10:100:27 | call to pick | provenance |  |
+| hash_extensions.rb:101:10:101:15 | values : Array [element 0, element :id] | hash_extensions.rb:101:10:101:32 | call to pick : [collection] [element 0] | provenance |  |
+| hash_extensions.rb:101:10:101:32 | call to pick : [collection] [element 0] | hash_extensions.rb:101:10:101:35 | ...[...] | provenance |  |
+| hash_extensions.rb:102:10:102:15 | values : Array [element 0, element :name] | hash_extensions.rb:102:10:102:32 | call to pick : [collection] [element 1] | provenance |  |
+| hash_extensions.rb:102:10:102:32 | call to pick : [collection] [element 1] | hash_extensions.rb:102:10:102:35 | ...[...] | provenance |  |
+| hash_extensions.rb:103:10:103:15 | values : Array [element 0, element :name] | hash_extensions.rb:103:10:103:32 | call to pick : [collection] [element 0] | provenance |  |
+| hash_extensions.rb:103:10:103:32 | call to pick : [collection] [element 0] | hash_extensions.rb:103:10:103:35 | ...[...] | provenance |  |
+| hash_extensions.rb:104:10:104:15 | values : Array [element 0, element :id] | hash_extensions.rb:104:10:104:32 | call to pick : [collection] [element 1] | provenance |  |
+| hash_extensions.rb:104:10:104:32 | call to pick : [collection] [element 1] | hash_extensions.rb:104:10:104:35 | ...[...] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :id] | hash_extensions.rb:112:10:112:15 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :id] | hash_extensions.rb:115:10:115:15 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :name] | hash_extensions.rb:111:10:111:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :name] | hash_extensions.rb:113:10:113:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :name] | hash_extensions.rb:114:10:114:15 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :id] | hash_extensions.rb:112:10:112:15 | values : Array [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :id] | hash_extensions.rb:115:10:115:15 | values : Array [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :name] | hash_extensions.rb:111:10:111:15 | values : Array [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :name] | hash_extensions.rb:113:10:113:15 | values : Array [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :name] | hash_extensions.rb:114:10:114:15 | values : Array [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :id] | hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :name] | hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :id] | hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :name] | hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :id] | hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :id] | provenance |  |
+| hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :name] | hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :name] | provenance |  |
+| hash_extensions.rb:110:21:110:31 | call to source | hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :id] | provenance |  |
+| hash_extensions.rb:110:40:110:54 | call to source | hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :name] | provenance |  |
+| hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :id] | hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :id] | provenance |  |
+| hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :name] | hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :name] | provenance |  |
+| hash_extensions.rb:110:65:110:75 | call to source | hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :id] | provenance |  |
+| hash_extensions.rb:110:84:110:99 | call to source | hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :name] | provenance |  |
+| hash_extensions.rb:111:10:111:15 | values : Array [element 0, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck : [collection] [element] | provenance |  |
+| hash_extensions.rb:111:10:111:15 | values : Array [element 1, element :name] | hash_extensions.rb:111:10:111:28 | call to pluck : [collection] [element] | provenance |  |
+| hash_extensions.rb:111:10:111:28 | call to pluck : [collection] [element] | hash_extensions.rb:111:10:111:31 | ...[...] | provenance |  |
+| hash_extensions.rb:112:10:112:15 | values : Array [element 0, element :id] | hash_extensions.rb:112:10:112:33 | call to pluck : [collection] [element, element 0] | provenance |  |
+| hash_extensions.rb:112:10:112:15 | values : Array [element 1, element :id] | hash_extensions.rb:112:10:112:33 | call to pluck : [collection] [element, element 0] | provenance |  |
+| hash_extensions.rb:112:10:112:33 | call to pluck : [collection] [element, element 0] | hash_extensions.rb:112:10:112:36 | ...[...] [element 0] | provenance |  |
 | hash_extensions.rb:112:10:112:36 | ...[...] [element 0] | hash_extensions.rb:112:10:112:39 | ...[...] | provenance |  |
-| hash_extensions.rb:113:10:113:15 | values [element 0, element :name] | hash_extensions.rb:113:10:113:33 | call to pluck [element, element 1] | provenance |  |
-| hash_extensions.rb:113:10:113:15 | values [element 1, element :name] | hash_extensions.rb:113:10:113:33 | call to pluck [element, element 1] | provenance |  |
-| hash_extensions.rb:113:10:113:33 | call to pluck [element, element 1] | hash_extensions.rb:113:10:113:36 | ...[...] [element 1] | provenance |  |
+| hash_extensions.rb:113:10:113:15 | values : Array [element 0, element :name] | hash_extensions.rb:113:10:113:33 | call to pluck : [collection] [element, element 1] | provenance |  |
+| hash_extensions.rb:113:10:113:15 | values : Array [element 1, element :name] | hash_extensions.rb:113:10:113:33 | call to pluck : [collection] [element, element 1] | provenance |  |
+| hash_extensions.rb:113:10:113:33 | call to pluck : [collection] [element, element 1] | hash_extensions.rb:113:10:113:36 | ...[...] [element 1] | provenance |  |
 | hash_extensions.rb:113:10:113:36 | ...[...] [element 1] | hash_extensions.rb:113:10:113:39 | ...[...] | provenance |  |
-| hash_extensions.rb:114:10:114:15 | values [element 0, element :name] | hash_extensions.rb:114:10:114:33 | call to pluck [element, element 0] | provenance |  |
-| hash_extensions.rb:114:10:114:15 | values [element 1, element :name] | hash_extensions.rb:114:10:114:33 | call to pluck [element, element 0] | provenance |  |
-| hash_extensions.rb:114:10:114:33 | call to pluck [element, element 0] | hash_extensions.rb:114:10:114:36 | ...[...] [element 0] | provenance |  |
+| hash_extensions.rb:114:10:114:15 | values : Array [element 0, element :name] | hash_extensions.rb:114:10:114:33 | call to pluck : [collection] [element, element 0] | provenance |  |
+| hash_extensions.rb:114:10:114:15 | values : Array [element 1, element :name] | hash_extensions.rb:114:10:114:33 | call to pluck : [collection] [element, element 0] | provenance |  |
+| hash_extensions.rb:114:10:114:33 | call to pluck : [collection] [element, element 0] | hash_extensions.rb:114:10:114:36 | ...[...] [element 0] | provenance |  |
 | hash_extensions.rb:114:10:114:36 | ...[...] [element 0] | hash_extensions.rb:114:10:114:39 | ...[...] | provenance |  |
-| hash_extensions.rb:115:10:115:15 | values [element 0, element :id] | hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] | provenance |  |
-| hash_extensions.rb:115:10:115:15 | values [element 1, element :id] | hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] | provenance |  |
-| hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | provenance |  |
+| hash_extensions.rb:115:10:115:15 | values : Array [element 0, element :id] | hash_extensions.rb:115:10:115:33 | call to pluck : [collection] [element, element 1] | provenance |  |
+| hash_extensions.rb:115:10:115:15 | values : Array [element 1, element :id] | hash_extensions.rb:115:10:115:33 | call to pluck : [collection] [element, element 1] | provenance |  |
+| hash_extensions.rb:115:10:115:33 | call to pluck : [collection] [element, element 1] | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | provenance |  |
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | hash_extensions.rb:115:10:115:39 | ...[...] | provenance |  |
-| hash_extensions.rb:122:5:122:10 | single [element 0] | hash_extensions.rb:125:10:125:15 | single [element 0] | provenance |  |
-| hash_extensions.rb:122:14:122:26 | call to [] [element 0] | hash_extensions.rb:122:5:122:10 | single [element 0] | provenance |  |
-| hash_extensions.rb:122:15:122:25 | call to source | hash_extensions.rb:122:14:122:26 | call to [] [element 0] | provenance |  |
-| hash_extensions.rb:123:5:123:9 | multi [element 0] | hash_extensions.rb:126:10:126:14 | multi [element 0] | provenance |  |
-| hash_extensions.rb:123:13:123:38 | call to [] [element 0] | hash_extensions.rb:123:5:123:9 | multi [element 0] | provenance |  |
-| hash_extensions.rb:123:14:123:24 | call to source | hash_extensions.rb:123:13:123:38 | call to [] [element 0] | provenance |  |
-| hash_extensions.rb:125:10:125:15 | single [element 0] | hash_extensions.rb:125:10:125:20 | call to sole | provenance |  |
-| hash_extensions.rb:126:10:126:14 | multi [element 0] | hash_extensions.rb:126:10:126:19 | call to sole | provenance |  |
+| hash_extensions.rb:122:5:122:10 | single : Array [element 0] | hash_extensions.rb:125:10:125:15 | single : Array [element 0] | provenance |  |
+| hash_extensions.rb:122:14:122:26 | call to [] : Array [element 0] | hash_extensions.rb:122:5:122:10 | single : Array [element 0] | provenance |  |
+| hash_extensions.rb:122:15:122:25 | call to source | hash_extensions.rb:122:14:122:26 | call to [] : Array [element 0] | provenance |  |
+| hash_extensions.rb:123:5:123:9 | multi : Array [element 0] | hash_extensions.rb:126:10:126:14 | multi : Array [element 0] | provenance |  |
+| hash_extensions.rb:123:13:123:38 | call to [] : Array [element 0] | hash_extensions.rb:123:5:123:9 | multi : Array [element 0] | provenance |  |
+| hash_extensions.rb:123:14:123:24 | call to source | hash_extensions.rb:123:13:123:38 | call to [] : Array [element 0] | provenance |  |
+| hash_extensions.rb:125:10:125:15 | single : Array [element 0] | hash_extensions.rb:125:10:125:20 | call to sole | provenance |  |
+| hash_extensions.rb:126:10:126:14 | multi : Array [element 0] | hash_extensions.rb:126:10:126:19 | call to sole | provenance |  |
 nodes
-| active_support.rb:180:5:180:5 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:180:9:180:18 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| active_support.rb:180:5:180:5 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:180:9:180:18 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | active_support.rb:180:10:180:17 | call to source | semmle.label | call to source |
-| active_support.rb:181:5:181:5 | y [element] | semmle.label | y [element] |
-| active_support.rb:181:9:181:9 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:181:9:181:23 | call to compact_blank [element] | semmle.label | call to compact_blank [element] |
-| active_support.rb:182:10:182:10 | y [element] | semmle.label | y [element] |
+| active_support.rb:181:5:181:5 | y : [collection] [element] | semmle.label | y : [collection] [element] |
+| active_support.rb:181:9:181:9 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:181:9:181:23 | call to compact_blank : [collection] [element] | semmle.label | call to compact_blank : [collection] [element] |
+| active_support.rb:182:10:182:10 | y : [collection] [element] | semmle.label | y : [collection] [element] |
 | active_support.rb:182:10:182:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:186:5:186:5 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:186:9:186:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| active_support.rb:186:5:186:5 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:186:9:186:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | active_support.rb:186:10:186:18 | call to source | semmle.label | call to source |
-| active_support.rb:187:5:187:5 | y [element] | semmle.label | y [element] |
-| active_support.rb:187:9:187:9 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:187:9:187:21 | call to excluding [element] | semmle.label | call to excluding [element] |
-| active_support.rb:188:10:188:10 | y [element] | semmle.label | y [element] |
+| active_support.rb:187:5:187:5 | y : [collection] [element] | semmle.label | y : [collection] [element] |
+| active_support.rb:187:9:187:9 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:187:9:187:21 | call to excluding : [collection] [element] | semmle.label | call to excluding : [collection] [element] |
+| active_support.rb:188:10:188:10 | y : [collection] [element] | semmle.label | y : [collection] [element] |
 | active_support.rb:188:10:188:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:192:5:192:5 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:192:9:192:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| active_support.rb:192:5:192:5 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:192:9:192:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | active_support.rb:192:10:192:18 | call to source | semmle.label | call to source |
-| active_support.rb:193:5:193:5 | y [element] | semmle.label | y [element] |
-| active_support.rb:193:9:193:9 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:193:9:193:19 | call to without [element] | semmle.label | call to without [element] |
-| active_support.rb:194:10:194:10 | y [element] | semmle.label | y [element] |
+| active_support.rb:193:5:193:5 | y : [collection] [element] | semmle.label | y : [collection] [element] |
+| active_support.rb:193:9:193:9 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:193:9:193:19 | call to without : [collection] [element] | semmle.label | call to without : [collection] [element] |
+| active_support.rb:194:10:194:10 | y : [collection] [element] | semmle.label | y : [collection] [element] |
 | active_support.rb:194:10:194:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:198:5:198:5 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:198:9:198:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| active_support.rb:198:5:198:5 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:198:9:198:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | active_support.rb:198:10:198:18 | call to source | semmle.label | call to source |
-| active_support.rb:199:5:199:5 | y [element] | semmle.label | y [element] |
-| active_support.rb:199:9:199:9 | x [element 0] | semmle.label | x [element 0] |
-| active_support.rb:199:9:199:37 | call to in_order_of [element] | semmle.label | call to in_order_of [element] |
-| active_support.rb:200:10:200:10 | y [element] | semmle.label | y [element] |
+| active_support.rb:199:5:199:5 | y : [collection] [element] | semmle.label | y : [collection] [element] |
+| active_support.rb:199:9:199:9 | x : Array [element 0] | semmle.label | x : Array [element 0] |
+| active_support.rb:199:9:199:37 | call to in_order_of : [collection] [element] | semmle.label | call to in_order_of : [collection] [element] |
+| active_support.rb:200:10:200:10 | y : [collection] [element] | semmle.label | y : [collection] [element] |
 | active_support.rb:200:10:200:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:204:5:204:5 | a [element 0] | semmle.label | a [element 0] |
-| active_support.rb:204:9:204:22 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| active_support.rb:204:5:204:5 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| active_support.rb:204:9:204:22 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | active_support.rb:204:10:204:18 | call to source | semmle.label | call to source |
-| active_support.rb:205:5:205:5 | b [element 0] | semmle.label | b [element 0] |
-| active_support.rb:205:5:205:5 | b [element] | semmle.label | b [element] |
-| active_support.rb:205:9:205:9 | a [element 0] | semmle.label | a [element 0] |
-| active_support.rb:205:9:205:41 | call to including [element 0] | semmle.label | call to including [element 0] |
-| active_support.rb:205:9:205:41 | call to including [element] | semmle.label | call to including [element] |
+| active_support.rb:205:5:205:5 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| active_support.rb:205:5:205:5 | b : [collection] [element] | semmle.label | b : [collection] [element] |
+| active_support.rb:205:9:205:9 | a : Array [element 0] | semmle.label | a : Array [element 0] |
+| active_support.rb:205:9:205:41 | call to including : [collection] [element 0] | semmle.label | call to including : [collection] [element 0] |
+| active_support.rb:205:9:205:41 | call to including : [collection] [element] | semmle.label | call to including : [collection] [element] |
 | active_support.rb:205:21:205:29 | call to source | semmle.label | call to source |
 | active_support.rb:205:32:205:40 | call to source | semmle.label | call to source |
-| active_support.rb:206:10:206:10 | a [element 0] | semmle.label | a [element 0] |
+| active_support.rb:206:10:206:10 | a : Array [element 0] | semmle.label | a : Array [element 0] |
 | active_support.rb:206:10:206:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:208:10:208:10 | b [element 0] | semmle.label | b [element 0] |
-| active_support.rb:208:10:208:10 | b [element] | semmle.label | b [element] |
+| active_support.rb:208:10:208:10 | b : [collection] [element 0] | semmle.label | b : [collection] [element 0] |
+| active_support.rb:208:10:208:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | active_support.rb:208:10:208:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:209:10:209:10 | b [element] | semmle.label | b [element] |
+| active_support.rb:209:10:209:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | active_support.rb:209:10:209:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:210:10:210:10 | b [element] | semmle.label | b [element] |
+| active_support.rb:210:10:210:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | active_support.rb:210:10:210:13 | ...[...] | semmle.label | ...[...] |
-| active_support.rb:211:10:211:10 | b [element] | semmle.label | b [element] |
+| active_support.rb:211:10:211:10 | b : [collection] [element] | semmle.label | b : [collection] [element] |
 | active_support.rb:211:10:211:13 | ...[...] | semmle.label | ...[...] |
 | active_support.rb:282:3:282:3 | x | semmle.label | x |
 | active_support.rb:282:7:282:16 | call to source | semmle.label | call to source |
@@ -302,198 +302,198 @@ nodes
 | active_support.rb:290:7:290:16 | call to source | semmle.label | call to source |
 | active_support.rb:291:8:291:8 | x | semmle.label | x |
 | active_support.rb:291:8:291:17 | call to deep_dup | semmle.label | call to deep_dup |
-| hash_extensions.rb:2:5:2:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:2:9:2:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_extensions.rb:2:5:2:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:2:9:2:26 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_extensions.rb:2:14:2:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:3:5:3:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_extensions.rb:3:9:3:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:3:9:3:24 | call to stringify_keys [element :a] | semmle.label | call to stringify_keys [element :a] |
-| hash_extensions.rb:4:10:4:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_extensions.rb:3:5:3:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_extensions.rb:3:9:3:9 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:3:9:3:24 | call to stringify_keys : Hash [element :a] | semmle.label | call to stringify_keys : Hash [element :a] |
+| hash_extensions.rb:4:10:4:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_extensions.rb:4:10:4:15 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:10:5:10:5 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:10:9:10:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:10:5:10:5 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:10:9:10:30 | call to [] : Hash [element a] | semmle.label | call to [] : Hash [element a] |
 | hash_extensions.rb:10:18:10:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:11:5:11:5 | x [element a] | semmle.label | x [element a] |
-| hash_extensions.rb:11:9:11:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:11:9:11:20 | call to to_options [element a] | semmle.label | call to to_options [element a] |
-| hash_extensions.rb:12:10:12:10 | x [element a] | semmle.label | x [element a] |
+| hash_extensions.rb:11:5:11:5 | x : Hash [element a] | semmle.label | x : Hash [element a] |
+| hash_extensions.rb:11:9:11:9 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:11:9:11:20 | call to to_options : Hash [element a] | semmle.label | call to to_options : Hash [element a] |
+| hash_extensions.rb:12:10:12:10 | x : Hash [element a] | semmle.label | x : Hash [element a] |
 | hash_extensions.rb:12:10:12:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:18:5:18:5 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:18:9:18:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:18:5:18:5 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:18:9:18:30 | call to [] : Hash [element a] | semmle.label | call to [] : Hash [element a] |
 | hash_extensions.rb:18:18:18:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:19:5:19:5 | x [element a] | semmle.label | x [element a] |
-| hash_extensions.rb:19:9:19:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:19:9:19:24 | call to symbolize_keys [element a] | semmle.label | call to symbolize_keys [element a] |
-| hash_extensions.rb:20:10:20:10 | x [element a] | semmle.label | x [element a] |
+| hash_extensions.rb:19:5:19:5 | x : Hash [element a] | semmle.label | x : Hash [element a] |
+| hash_extensions.rb:19:9:19:9 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:19:9:19:24 | call to symbolize_keys : Hash [element a] | semmle.label | call to symbolize_keys : Hash [element a] |
+| hash_extensions.rb:20:10:20:10 | x : Hash [element a] | semmle.label | x : Hash [element a] |
 | hash_extensions.rb:20:10:20:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:26:5:26:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:26:9:26:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_extensions.rb:26:5:26:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:26:9:26:26 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_extensions.rb:26:14:26:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:27:5:27:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_extensions.rb:27:9:27:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys [element :a] | semmle.label | call to deep_stringify_keys [element :a] |
-| hash_extensions.rb:28:10:28:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_extensions.rb:27:5:27:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_extensions.rb:27:9:27:9 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:27:9:27:29 | call to deep_stringify_keys : Hash [element :a] | semmle.label | call to deep_stringify_keys : Hash [element :a] |
+| hash_extensions.rb:28:10:28:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_extensions.rb:28:10:28:15 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:34:5:34:5 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:34:9:34:30 | call to [] [element a] | semmle.label | call to [] [element a] |
+| hash_extensions.rb:34:5:34:5 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:34:9:34:30 | call to [] : Hash [element a] | semmle.label | call to [] : Hash [element a] |
 | hash_extensions.rb:34:18:34:28 | call to source | semmle.label | call to source |
-| hash_extensions.rb:35:5:35:5 | x [element a] | semmle.label | x [element a] |
-| hash_extensions.rb:35:9:35:9 | h [element a] | semmle.label | h [element a] |
-| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys [element a] | semmle.label | call to deep_symbolize_keys [element a] |
-| hash_extensions.rb:36:10:36:10 | x [element a] | semmle.label | x [element a] |
+| hash_extensions.rb:35:5:35:5 | x : Hash [element a] | semmle.label | x : Hash [element a] |
+| hash_extensions.rb:35:9:35:9 | h : Hash [element a] | semmle.label | h : Hash [element a] |
+| hash_extensions.rb:35:9:35:29 | call to deep_symbolize_keys : Hash [element a] | semmle.label | call to deep_symbolize_keys : Hash [element a] |
+| hash_extensions.rb:36:10:36:10 | x : Hash [element a] | semmle.label | x : Hash [element a] |
 | hash_extensions.rb:36:10:36:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:42:5:42:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:42:9:42:26 | call to [] [element :a] | semmle.label | call to [] [element :a] |
+| hash_extensions.rb:42:5:42:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:42:9:42:26 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
 | hash_extensions.rb:42:14:42:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:43:5:43:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_extensions.rb:43:9:43:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access [element :a] | semmle.label | call to with_indifferent_access [element :a] |
-| hash_extensions.rb:44:10:44:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_extensions.rb:43:5:43:5 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
+| hash_extensions.rb:43:9:43:9 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:43:9:43:33 | call to with_indifferent_access : Hash [element :a] | semmle.label | call to with_indifferent_access : Hash [element :a] |
+| hash_extensions.rb:44:10:44:10 | x : Hash [element :a] | semmle.label | x : Hash [element :a] |
 | hash_extensions.rb:44:10:44:15 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:50:5:50:5 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:50:5:50:5 | h [element :b] | semmle.label | h [element :b] |
-| hash_extensions.rb:50:5:50:5 | h [element :d] | semmle.label | h [element :d] |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :a] | semmle.label | call to [] [element :a] |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :b] | semmle.label | call to [] [element :b] |
-| hash_extensions.rb:50:9:50:63 | call to [] [element :d] | semmle.label | call to [] [element :d] |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :b] | semmle.label | h : Hash [element :b] |
+| hash_extensions.rb:50:5:50:5 | h : Hash [element :d] | semmle.label | h : Hash [element :d] |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :a] | semmle.label | call to [] : Hash [element :a] |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :b] | semmle.label | call to [] : Hash [element :b] |
+| hash_extensions.rb:50:9:50:63 | call to [] : Hash [element :d] | semmle.label | call to [] : Hash [element :d] |
 | hash_extensions.rb:50:14:50:23 | call to taint | semmle.label | call to taint |
 | hash_extensions.rb:50:29:50:38 | call to taint | semmle.label | call to taint |
 | hash_extensions.rb:50:52:50:61 | call to taint | semmle.label | call to taint |
-| hash_extensions.rb:51:5:51:5 | x [element :a] | semmle.label | x [element :a] |
-| hash_extensions.rb:51:5:51:5 | x [element :b] | semmle.label | x [element :b] |
-| hash_extensions.rb:51:9:51:9 | [post] h [element :d] | semmle.label | [post] h [element :d] |
-| hash_extensions.rb:51:9:51:9 | h [element :a] | semmle.label | h [element :a] |
-| hash_extensions.rb:51:9:51:9 | h [element :b] | semmle.label | h [element :b] |
-| hash_extensions.rb:51:9:51:9 | h [element :d] | semmle.label | h [element :d] |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :a] | semmle.label | call to extract! [element :a] |
-| hash_extensions.rb:51:9:51:29 | call to extract! [element :b] | semmle.label | call to extract! [element :b] |
-| hash_extensions.rb:56:10:56:10 | h [element :d] | semmle.label | h [element :d] |
+| hash_extensions.rb:51:5:51:5 | x : [collection] [element :a] | semmle.label | x : [collection] [element :a] |
+| hash_extensions.rb:51:5:51:5 | x : [collection] [element :b] | semmle.label | x : [collection] [element :b] |
+| hash_extensions.rb:51:9:51:9 | [post] h : Hash [element :d] | semmle.label | [post] h : Hash [element :d] |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :a] | semmle.label | h : Hash [element :a] |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :b] | semmle.label | h : Hash [element :b] |
+| hash_extensions.rb:51:9:51:9 | h : Hash [element :d] | semmle.label | h : Hash [element :d] |
+| hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :a] | semmle.label | call to extract! : [collection] [element :a] |
+| hash_extensions.rb:51:9:51:29 | call to extract! : [collection] [element :b] | semmle.label | call to extract! : [collection] [element :b] |
+| hash_extensions.rb:56:10:56:10 | h : Hash [element :d] | semmle.label | h : Hash [element :d] |
 | hash_extensions.rb:56:10:56:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:58:10:58:10 | x [element :a] | semmle.label | x [element :a] |
+| hash_extensions.rb:58:10:58:10 | x : [collection] [element :a] | semmle.label | x : [collection] [element :a] |
 | hash_extensions.rb:58:10:58:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:59:10:59:10 | x [element :b] | semmle.label | x [element :b] |
+| hash_extensions.rb:59:10:59:10 | x : [collection] [element :b] | semmle.label | x : [collection] [element :b] |
 | hash_extensions.rb:59:10:59:14 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:67:5:67:10 | values [element 0] | semmle.label | values [element 0] |
-| hash_extensions.rb:67:5:67:10 | values [element 1] | semmle.label | values [element 1] |
-| hash_extensions.rb:67:5:67:10 | values [element 2] | semmle.label | values [element 2] |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| hash_extensions.rb:67:14:67:52 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 0] | semmle.label | values : Array [element 0] |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 1] | semmle.label | values : Array [element 1] |
+| hash_extensions.rb:67:5:67:10 | values : Array [element 2] | semmle.label | values : Array [element 2] |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| hash_extensions.rb:67:14:67:52 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | hash_extensions.rb:67:15:67:25 | call to source | semmle.label | call to source |
 | hash_extensions.rb:67:28:67:38 | call to source | semmle.label | call to source |
 | hash_extensions.rb:67:41:67:51 | call to source | semmle.label | call to source |
-| hash_extensions.rb:68:5:68:5 | h [element] | semmle.label | h [element] |
-| hash_extensions.rb:68:9:68:14 | values [element 0] | semmle.label | values [element 0] |
-| hash_extensions.rb:68:9:68:14 | values [element 1] | semmle.label | values [element 1] |
-| hash_extensions.rb:68:9:68:14 | values [element 2] | semmle.label | values [element 2] |
-| hash_extensions.rb:68:9:71:7 | call to index_by [element] | semmle.label | call to index_by [element] |
+| hash_extensions.rb:68:5:68:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 0] | semmle.label | values : Array [element 0] |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 1] | semmle.label | values : Array [element 1] |
+| hash_extensions.rb:68:9:68:14 | values : Array [element 2] | semmle.label | values : Array [element 2] |
+| hash_extensions.rb:68:9:71:7 | call to index_by : [collection] [element] | semmle.label | call to index_by : [collection] [element] |
 | hash_extensions.rb:68:29:68:33 | value | semmle.label | value |
 | hash_extensions.rb:69:14:69:18 | value | semmle.label | value |
-| hash_extensions.rb:73:10:73:10 | h [element] | semmle.label | h [element] |
+| hash_extensions.rb:73:10:73:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | hash_extensions.rb:73:10:73:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:74:10:74:10 | h [element] | semmle.label | h [element] |
+| hash_extensions.rb:74:10:74:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | hash_extensions.rb:74:10:74:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:80:5:80:10 | values [element 0] | semmle.label | values [element 0] |
-| hash_extensions.rb:80:5:80:10 | values [element 1] | semmle.label | values [element 1] |
-| hash_extensions.rb:80:5:80:10 | values [element 2] | semmle.label | values [element 2] |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 1] | semmle.label | call to [] [element 1] |
-| hash_extensions.rb:80:14:80:52 | call to [] [element 2] | semmle.label | call to [] [element 2] |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 0] | semmle.label | values : Array [element 0] |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 1] | semmle.label | values : Array [element 1] |
+| hash_extensions.rb:80:5:80:10 | values : Array [element 2] | semmle.label | values : Array [element 2] |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
+| hash_extensions.rb:80:14:80:52 | call to [] : Array [element 2] | semmle.label | call to [] : Array [element 2] |
 | hash_extensions.rb:80:15:80:25 | call to source | semmle.label | call to source |
 | hash_extensions.rb:80:28:80:38 | call to source | semmle.label | call to source |
 | hash_extensions.rb:80:41:80:51 | call to source | semmle.label | call to source |
-| hash_extensions.rb:81:5:81:5 | h [element] | semmle.label | h [element] |
-| hash_extensions.rb:81:9:81:14 | values [element 0] | semmle.label | values [element 0] |
-| hash_extensions.rb:81:9:81:14 | values [element 1] | semmle.label | values [element 1] |
-| hash_extensions.rb:81:9:81:14 | values [element 2] | semmle.label | values [element 2] |
-| hash_extensions.rb:81:9:84:7 | call to index_with [element] | semmle.label | call to index_with [element] |
+| hash_extensions.rb:81:5:81:5 | h : [collection] [element] | semmle.label | h : [collection] [element] |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 0] | semmle.label | values : Array [element 0] |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 1] | semmle.label | values : Array [element 1] |
+| hash_extensions.rb:81:9:81:14 | values : Array [element 2] | semmle.label | values : Array [element 2] |
+| hash_extensions.rb:81:9:84:7 | call to index_with : [collection] [element] | semmle.label | call to index_with : [collection] [element] |
 | hash_extensions.rb:81:31:81:33 | key | semmle.label | key |
 | hash_extensions.rb:82:14:82:16 | key | semmle.label | key |
 | hash_extensions.rb:83:9:83:19 | call to source | semmle.label | call to source |
-| hash_extensions.rb:86:10:86:10 | h [element] | semmle.label | h [element] |
+| hash_extensions.rb:86:10:86:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | hash_extensions.rb:86:10:86:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:87:10:87:10 | h [element] | semmle.label | h [element] |
+| hash_extensions.rb:87:10:87:10 | h : [collection] [element] | semmle.label | h : [collection] [element] |
 | hash_extensions.rb:87:10:87:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:89:5:89:5 | j [element] | semmle.label | j [element] |
-| hash_extensions.rb:89:9:89:38 | call to index_with [element] | semmle.label | call to index_with [element] |
+| hash_extensions.rb:89:5:89:5 | j : [collection] [element] | semmle.label | j : [collection] [element] |
+| hash_extensions.rb:89:9:89:38 | call to index_with : [collection] [element] | semmle.label | call to index_with : [collection] [element] |
 | hash_extensions.rb:89:27:89:37 | call to source | semmle.label | call to source |
-| hash_extensions.rb:91:10:91:10 | j [element] | semmle.label | j [element] |
+| hash_extensions.rb:91:10:91:10 | j : [collection] [element] | semmle.label | j : [collection] [element] |
 | hash_extensions.rb:91:10:91:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:92:10:92:10 | j [element] | semmle.label | j [element] |
+| hash_extensions.rb:92:10:92:10 | j : [collection] [element] | semmle.label | j : [collection] [element] |
 | hash_extensions.rb:92:10:92:16 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:98:5:98:10 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :id] | semmle.label | call to [] [element 0, element :id] |
-| hash_extensions.rb:98:14:98:102 | call to [] [element 0, element :name] | semmle.label | call to [] [element 0, element :name] |
-| hash_extensions.rb:98:15:98:56 | call to [] [element :id] | semmle.label | call to [] [element :id] |
-| hash_extensions.rb:98:15:98:56 | call to [] [element :name] | semmle.label | call to [] [element :name] |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:98:5:98:10 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :id] | semmle.label | call to [] : Array [element 0, element :id] |
+| hash_extensions.rb:98:14:98:102 | call to [] : Array [element 0, element :name] | semmle.label | call to [] : Array [element 0, element :name] |
+| hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :id] | semmle.label | call to [] : Hash [element :id] |
+| hash_extensions.rb:98:15:98:56 | call to [] : Hash [element :name] | semmle.label | call to [] : Hash [element :name] |
 | hash_extensions.rb:98:21:98:31 | call to source | semmle.label | call to source |
 | hash_extensions.rb:98:40:98:54 | call to source | semmle.label | call to source |
-| hash_extensions.rb:99:10:99:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
+| hash_extensions.rb:99:10:99:15 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
 | hash_extensions.rb:99:10:99:25 | call to pick | semmle.label | call to pick |
-| hash_extensions.rb:100:10:100:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
+| hash_extensions.rb:100:10:100:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
 | hash_extensions.rb:100:10:100:27 | call to pick | semmle.label | call to pick |
-| hash_extensions.rb:101:10:101:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:101:10:101:32 | call to pick [element 0] | semmle.label | call to pick [element 0] |
+| hash_extensions.rb:101:10:101:15 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:101:10:101:32 | call to pick : [collection] [element 0] | semmle.label | call to pick : [collection] [element 0] |
 | hash_extensions.rb:101:10:101:35 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:102:10:102:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:102:10:102:32 | call to pick [element 1] | semmle.label | call to pick [element 1] |
+| hash_extensions.rb:102:10:102:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:102:10:102:32 | call to pick : [collection] [element 1] | semmle.label | call to pick : [collection] [element 1] |
 | hash_extensions.rb:102:10:102:35 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:103:10:103:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:103:10:103:32 | call to pick [element 0] | semmle.label | call to pick [element 0] |
+| hash_extensions.rb:103:10:103:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:103:10:103:32 | call to pick : [collection] [element 0] | semmle.label | call to pick : [collection] [element 0] |
 | hash_extensions.rb:103:10:103:35 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:104:10:104:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:104:10:104:32 | call to pick [element 1] | semmle.label | call to pick [element 1] |
+| hash_extensions.rb:104:10:104:15 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:104:10:104:32 | call to pick : [collection] [element 1] | semmle.label | call to pick : [collection] [element 1] |
 | hash_extensions.rb:104:10:104:35 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:110:5:110:10 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :id] | semmle.label | values [element 1, element :id] |
-| hash_extensions.rb:110:5:110:10 | values [element 1, element :name] | semmle.label | values [element 1, element :name] |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :id] | semmle.label | call to [] [element 0, element :id] |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 0, element :name] | semmle.label | call to [] [element 0, element :name] |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :id] | semmle.label | call to [] [element 1, element :id] |
-| hash_extensions.rb:110:14:110:102 | call to [] [element 1, element :name] | semmle.label | call to [] [element 1, element :name] |
-| hash_extensions.rb:110:15:110:56 | call to [] [element :id] | semmle.label | call to [] [element :id] |
-| hash_extensions.rb:110:15:110:56 | call to [] [element :name] | semmle.label | call to [] [element :name] |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :id] | semmle.label | values : Array [element 1, element :id] |
+| hash_extensions.rb:110:5:110:10 | values : Array [element 1, element :name] | semmle.label | values : Array [element 1, element :name] |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :id] | semmle.label | call to [] : Array [element 0, element :id] |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 0, element :name] | semmle.label | call to [] : Array [element 0, element :name] |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :id] | semmle.label | call to [] : Array [element 1, element :id] |
+| hash_extensions.rb:110:14:110:102 | call to [] : Array [element 1, element :name] | semmle.label | call to [] : Array [element 1, element :name] |
+| hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :id] | semmle.label | call to [] : Hash [element :id] |
+| hash_extensions.rb:110:15:110:56 | call to [] : Hash [element :name] | semmle.label | call to [] : Hash [element :name] |
 | hash_extensions.rb:110:21:110:31 | call to source | semmle.label | call to source |
 | hash_extensions.rb:110:40:110:54 | call to source | semmle.label | call to source |
-| hash_extensions.rb:110:59:110:101 | call to [] [element :id] | semmle.label | call to [] [element :id] |
-| hash_extensions.rb:110:59:110:101 | call to [] [element :name] | semmle.label | call to [] [element :name] |
+| hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :id] | semmle.label | call to [] : Hash [element :id] |
+| hash_extensions.rb:110:59:110:101 | call to [] : Hash [element :name] | semmle.label | call to [] : Hash [element :name] |
 | hash_extensions.rb:110:65:110:75 | call to source | semmle.label | call to source |
 | hash_extensions.rb:110:84:110:99 | call to source | semmle.label | call to source |
-| hash_extensions.rb:111:10:111:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:111:10:111:15 | values [element 1, element :name] | semmle.label | values [element 1, element :name] |
-| hash_extensions.rb:111:10:111:28 | call to pluck [element] | semmle.label | call to pluck [element] |
+| hash_extensions.rb:111:10:111:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:111:10:111:15 | values : Array [element 1, element :name] | semmle.label | values : Array [element 1, element :name] |
+| hash_extensions.rb:111:10:111:28 | call to pluck : [collection] [element] | semmle.label | call to pluck : [collection] [element] |
 | hash_extensions.rb:111:10:111:31 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:112:10:112:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:112:10:112:15 | values [element 1, element :id] | semmle.label | values [element 1, element :id] |
-| hash_extensions.rb:112:10:112:33 | call to pluck [element, element 0] | semmle.label | call to pluck [element, element 0] |
+| hash_extensions.rb:112:10:112:15 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:112:10:112:15 | values : Array [element 1, element :id] | semmle.label | values : Array [element 1, element :id] |
+| hash_extensions.rb:112:10:112:33 | call to pluck : [collection] [element, element 0] | semmle.label | call to pluck : [collection] [element, element 0] |
 | hash_extensions.rb:112:10:112:36 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | hash_extensions.rb:112:10:112:39 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:113:10:113:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:113:10:113:15 | values [element 1, element :name] | semmle.label | values [element 1, element :name] |
-| hash_extensions.rb:113:10:113:33 | call to pluck [element, element 1] | semmle.label | call to pluck [element, element 1] |
+| hash_extensions.rb:113:10:113:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:113:10:113:15 | values : Array [element 1, element :name] | semmle.label | values : Array [element 1, element :name] |
+| hash_extensions.rb:113:10:113:33 | call to pluck : [collection] [element, element 1] | semmle.label | call to pluck : [collection] [element, element 1] |
 | hash_extensions.rb:113:10:113:36 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | hash_extensions.rb:113:10:113:39 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:114:10:114:15 | values [element 0, element :name] | semmle.label | values [element 0, element :name] |
-| hash_extensions.rb:114:10:114:15 | values [element 1, element :name] | semmle.label | values [element 1, element :name] |
-| hash_extensions.rb:114:10:114:33 | call to pluck [element, element 0] | semmle.label | call to pluck [element, element 0] |
+| hash_extensions.rb:114:10:114:15 | values : Array [element 0, element :name] | semmle.label | values : Array [element 0, element :name] |
+| hash_extensions.rb:114:10:114:15 | values : Array [element 1, element :name] | semmle.label | values : Array [element 1, element :name] |
+| hash_extensions.rb:114:10:114:33 | call to pluck : [collection] [element, element 0] | semmle.label | call to pluck : [collection] [element, element 0] |
 | hash_extensions.rb:114:10:114:36 | ...[...] [element 0] | semmle.label | ...[...] [element 0] |
 | hash_extensions.rb:114:10:114:39 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:115:10:115:15 | values [element 0, element :id] | semmle.label | values [element 0, element :id] |
-| hash_extensions.rb:115:10:115:15 | values [element 1, element :id] | semmle.label | values [element 1, element :id] |
-| hash_extensions.rb:115:10:115:33 | call to pluck [element, element 1] | semmle.label | call to pluck [element, element 1] |
+| hash_extensions.rb:115:10:115:15 | values : Array [element 0, element :id] | semmle.label | values : Array [element 0, element :id] |
+| hash_extensions.rb:115:10:115:15 | values : Array [element 1, element :id] | semmle.label | values : Array [element 1, element :id] |
+| hash_extensions.rb:115:10:115:33 | call to pluck : [collection] [element, element 1] | semmle.label | call to pluck : [collection] [element, element 1] |
 | hash_extensions.rb:115:10:115:36 | ...[...] [element 1] | semmle.label | ...[...] [element 1] |
 | hash_extensions.rb:115:10:115:39 | ...[...] | semmle.label | ...[...] |
-| hash_extensions.rb:122:5:122:10 | single [element 0] | semmle.label | single [element 0] |
-| hash_extensions.rb:122:14:122:26 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| hash_extensions.rb:122:5:122:10 | single : Array [element 0] | semmle.label | single : Array [element 0] |
+| hash_extensions.rb:122:14:122:26 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | hash_extensions.rb:122:15:122:25 | call to source | semmle.label | call to source |
-| hash_extensions.rb:123:5:123:9 | multi [element 0] | semmle.label | multi [element 0] |
-| hash_extensions.rb:123:13:123:38 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| hash_extensions.rb:123:5:123:9 | multi : Array [element 0] | semmle.label | multi : Array [element 0] |
+| hash_extensions.rb:123:13:123:38 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | hash_extensions.rb:123:14:123:24 | call to source | semmle.label | call to source |
-| hash_extensions.rb:125:10:125:15 | single [element 0] | semmle.label | single [element 0] |
+| hash_extensions.rb:125:10:125:15 | single : Array [element 0] | semmle.label | single : Array [element 0] |
 | hash_extensions.rb:125:10:125:20 | call to sole | semmle.label | call to sole |
-| hash_extensions.rb:126:10:126:14 | multi [element 0] | semmle.label | multi [element 0] |
+| hash_extensions.rb:126:10:126:14 | multi : Array [element 0] | semmle.label | multi : Array [element 0] |
 | hash_extensions.rb:126:10:126:19 | call to sole | semmle.label | call to sole |
 subpaths
 testFailures

--- a/ruby/ql/test/library-tests/frameworks/pathname/Pathname.expected
+++ b/ruby/ql/test/library-tests/frameworks/pathname/Pathname.expected
@@ -57,7 +57,6 @@ pathnameInstances
 | Pathname.rb:39:12:39:19 | foo_path |
 | Pathname.rb:41:1:41:3 | p08 |
 | Pathname.rb:42:1:42:3 | p01 |
-| file://:0:0:0:0 | [summary param] position 0 in + |
 | file://:0:0:0:0 | [summary param] self in + |
 | file://:0:0:0:0 | [summary param] self in Pathname;Method[cleanpath] |
 | file://:0:0:0:0 | [summary param] self in Pathname;Method[expand_path] |
@@ -134,7 +133,6 @@ fileNameSources
 | Pathname.rb:39:12:39:19 | foo_path |
 | Pathname.rb:41:1:41:3 | p08 |
 | Pathname.rb:42:1:42:3 | p01 |
-| file://:0:0:0:0 | [summary param] position 0 in + |
 | file://:0:0:0:0 | [summary param] self in + |
 | file://:0:0:0:0 | [summary param] self in Pathname;Method[cleanpath] |
 | file://:0:0:0:0 | [summary param] self in Pathname;Method[expand_path] |

--- a/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
+++ b/ruby/ql/test/library-tests/frameworks/sinatra/Flow.expected
@@ -3,8 +3,8 @@ edges
 | app.rb:75:5:75:8 | [post] self [@foo] | app.rb:76:32:76:35 | self [@foo] | provenance |  |
 | app.rb:75:12:75:17 | call to params | app.rb:75:12:75:24 | ...[...] | provenance |  |
 | app.rb:75:12:75:24 | ...[...] | app.rb:75:5:75:8 | [post] self [@foo] | provenance |  |
-| app.rb:76:25:76:36 | call to [] [element :foo] | views/index.erb:2:10:2:12 | call to foo | provenance |  |
-| app.rb:76:32:76:35 | @foo | app.rb:76:25:76:36 | call to [] [element :foo] | provenance |  |
+| app.rb:76:25:76:36 | call to [] : Hash [element :foo] | views/index.erb:2:10:2:12 | call to foo | provenance |  |
+| app.rb:76:32:76:35 | @foo | app.rb:76:25:76:36 | call to [] : Hash [element :foo] | provenance |  |
 | app.rb:76:32:76:35 | self [@foo] | app.rb:76:32:76:35 | @foo | provenance |  |
 | app.rb:95:10:95:14 | self [@user] | app.rb:95:10:95:14 | @user | provenance |  |
 | app.rb:103:5:103:9 | [post] self [@user] | app.rb:95:10:95:14 | self [@user] | provenance |  |
@@ -13,7 +13,7 @@ nodes
 | app.rb:75:5:75:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | app.rb:75:12:75:17 | call to params | semmle.label | call to params |
 | app.rb:75:12:75:24 | ...[...] | semmle.label | ...[...] |
-| app.rb:76:25:76:36 | call to [] [element :foo] | semmle.label | call to [] [element :foo] |
+| app.rb:76:25:76:36 | call to [] : Hash [element :foo] | semmle.label | call to [] : Hash [element :foo] |
 | app.rb:76:32:76:35 | @foo | semmle.label | @foo |
 | app.rb:76:32:76:35 | self [@foo] | semmle.label | self [@foo] |
 | app.rb:95:10:95:14 | @user | semmle.label | @user |

--- a/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
+++ b/ruby/ql/test/query-tests/experimental/TemplateInjection/TemplateInjection.expected
@@ -8,14 +8,14 @@ edges
 | ErbInjection.rb:8:16:11:14 | ... % ... | ErbInjection.rb:8:5:8:12 | bad_text | provenance |  |
 | ErbInjection.rb:11:11:11:14 | name | ErbInjection.rb:8:16:11:14 | ... % ... | provenance |  |
 | SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:11:11:11:14 | name | provenance |  |
-| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | provenance |  |
-| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] | provenance | AdditionalTaintStep |
+| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:14:23:14:34 | { ... } : [lambda] [captured bad_text] | provenance |  |
+| SlimInjection.rb:5:5:5:8 | name | SlimInjection.rb:23:23:23:35 | { ... } : [lambda] [captured bad2_text] : String | provenance | AdditionalTaintStep |
 | SlimInjection.rb:5:12:5:17 | call to params | SlimInjection.rb:5:12:5:24 | ...[...] | provenance |  |
 | SlimInjection.rb:5:12:5:24 | ...[...] | SlimInjection.rb:5:5:5:8 | name | provenance |  |
-| SlimInjection.rb:8:16:11:14 | ... % ... | SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | provenance |  |
+| SlimInjection.rb:8:16:11:14 | ... % ... | SlimInjection.rb:14:23:14:34 | { ... } : [lambda] [captured bad_text] | provenance |  |
 | SlimInjection.rb:11:11:11:14 | name | SlimInjection.rb:8:16:11:14 | ... % ... | provenance |  |
-| SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | SlimInjection.rb:14:25:14:32 | bad_text | provenance | heuristic-callback |
-| SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] | SlimInjection.rb:23:25:23:33 | bad2_text | provenance | heuristic-callback |
+| SlimInjection.rb:14:23:14:34 | { ... } : [lambda] [captured bad_text] | SlimInjection.rb:14:25:14:32 | bad_text | provenance | heuristic-callback |
+| SlimInjection.rb:23:23:23:35 | { ... } : [lambda] [captured bad2_text] : String | SlimInjection.rb:23:25:23:33 | bad2_text | provenance | heuristic-callback |
 nodes
 | ErbInjection.rb:5:5:5:8 | name | semmle.label | name |
 | ErbInjection.rb:5:12:5:17 | call to params | semmle.label | call to params |
@@ -30,9 +30,9 @@ nodes
 | SlimInjection.rb:5:12:5:24 | ...[...] | semmle.label | ...[...] |
 | SlimInjection.rb:8:16:11:14 | ... % ... | semmle.label | ... % ... |
 | SlimInjection.rb:11:11:11:14 | name | semmle.label | name |
-| SlimInjection.rb:14:23:14:34 | { ... } [captured bad_text] | semmle.label | { ... } [captured bad_text] |
+| SlimInjection.rb:14:23:14:34 | { ... } : [lambda] [captured bad_text] | semmle.label | { ... } : [lambda] [captured bad_text] |
 | SlimInjection.rb:14:25:14:32 | bad_text | semmle.label | bad_text |
-| SlimInjection.rb:23:23:23:35 | { ... } [captured bad2_text] | semmle.label | { ... } [captured bad2_text] |
+| SlimInjection.rb:23:23:23:35 | { ... } : [lambda] [captured bad2_text] : String | semmle.label | { ... } : [lambda] [captured bad2_text] : String |
 | SlimInjection.rb:23:25:23:33 | bad2_text | semmle.label | bad2_text |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-022/PathInjection.expected
@@ -24,10 +24,10 @@ edges
 | ArchiveApiPathTraversal.rb:10:11:10:23 | ...[...] | ArchiveApiPathTraversal.rb:67:13:67:16 | file | provenance |  |
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] | provenance |  |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] | ArchiveApiPathTraversal.rb:75:11:75:18 | filename | provenance |  |
-| ArchiveApiPathTraversal.rb:49:17:49:27 | destination | ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] | provenance |  |
-| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] | ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | provenance | heuristic-callback |
-| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | provenance |  |
-| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | provenance | heuristic-callback |
+| ArchiveApiPathTraversal.rb:49:17:49:27 | destination | ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end : [lambda] [captured destination] | provenance |  |
+| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end : [lambda] [captured destination] | ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end : [lambda] [captured destination] | provenance | heuristic-callback |
+| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end : [lambda] [captured destination] | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | provenance |  |
+| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end : [lambda] [captured destination] | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | provenance | heuristic-callback |
 | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file | ArchiveApiPathTraversal.rb:59:21:59:36 | destination_file | provenance |  |
 | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file | provenance |  |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join | provenance |  |
@@ -40,8 +40,8 @@ edges
 | tainted_path.rb:10:12:10:43 | call to absolute_path | tainted_path.rb:10:5:10:8 | path | provenance |  |
 | tainted_path.rb:10:31:10:36 | call to params | tainted_path.rb:10:31:10:43 | ...[...] | provenance |  |
 | tainted_path.rb:10:31:10:43 | ...[...] | tainted_path.rb:10:12:10:43 | call to absolute_path | provenance |  |
-| tainted_path.rb:16:5:16:8 | path | tainted_path.rb:17:26:17:29 | path | provenance |  |
-| tainted_path.rb:16:15:16:41 | call to dirname | tainted_path.rb:16:5:16:8 | path | provenance | AdditionalTaintStep |
+| tainted_path.rb:16:5:16:8 | path : String | tainted_path.rb:17:26:17:29 | path | provenance |  |
+| tainted_path.rb:16:15:16:41 | call to dirname | tainted_path.rb:16:5:16:8 | path : String | provenance | AdditionalTaintStep |
 | tainted_path.rb:16:28:16:33 | call to params | tainted_path.rb:16:28:16:40 | ...[...] | provenance |  |
 | tainted_path.rb:16:28:16:40 | ...[...] | tainted_path.rb:16:15:16:41 | call to dirname | provenance |  |
 | tainted_path.rb:22:5:22:8 | path | tainted_path.rb:23:26:23:29 | path | provenance |  |
@@ -94,8 +94,8 @@ nodes
 | ArchiveApiPathTraversal.rb:15:9:15:14 | call to params | semmle.label | call to params |
 | ArchiveApiPathTraversal.rb:15:9:15:25 | ...[...] | semmle.label | ...[...] |
 | ArchiveApiPathTraversal.rb:49:17:49:27 | destination | semmle.label | destination |
-| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end [captured destination] | semmle.label | do ... end [captured destination] |
-| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end [captured destination] | semmle.label | do ... end [captured destination] |
+| ArchiveApiPathTraversal.rb:50:36:64:7 | do ... end : [lambda] [captured destination] | semmle.label | do ... end : [lambda] [captured destination] |
+| ArchiveApiPathTraversal.rb:51:16:63:9 | do ... end : [lambda] [captured destination] | semmle.label | do ... end : [lambda] [captured destination] |
 | ArchiveApiPathTraversal.rb:52:9:52:24 | destination_file | semmle.label | destination_file |
 | ArchiveApiPathTraversal.rb:52:28:52:67 | call to join | semmle.label | call to join |
 | ArchiveApiPathTraversal.rb:52:38:52:48 | destination | semmle.label | destination |
@@ -113,7 +113,7 @@ nodes
 | tainted_path.rb:10:31:10:36 | call to params | semmle.label | call to params |
 | tainted_path.rb:10:31:10:43 | ...[...] | semmle.label | ...[...] |
 | tainted_path.rb:11:26:11:29 | path | semmle.label | path |
-| tainted_path.rb:16:5:16:8 | path | semmle.label | path |
+| tainted_path.rb:16:5:16:8 | path : String | semmle.label | path : String |
 | tainted_path.rb:16:15:16:41 | call to dirname | semmle.label | call to dirname |
 | tainted_path.rb:16:28:16:33 | call to params | semmle.label | call to params |
 | tainted_path.rb:16:28:16:40 | ...[...] | semmle.label | ...[...] |

--- a/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/ruby/ql/test/query-tests/security/cwe-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -13,9 +13,9 @@ edges
 | impl/unsafeShell.rb:51:17:51:17 | x | impl/unsafeShell.rb:54:29:54:29 | x | provenance |  |
 | impl/unsafeShell.rb:57:21:57:21 | x | impl/unsafeShell.rb:58:23:58:23 | x | provenance |  |
 | impl/unsafeShell.rb:61:20:61:20 | x | impl/unsafeShell.rb:63:14:63:14 | x | provenance |  |
-| impl/unsafeShell.rb:63:5:63:7 | [post] arr [element] | impl/unsafeShell.rb:64:14:64:16 | arr | provenance |  |
-| impl/unsafeShell.rb:63:5:63:7 | [post] arr [element] | impl/unsafeShell.rb:68:14:68:16 | arr | provenance |  |
-| impl/unsafeShell.rb:63:14:63:14 | x | impl/unsafeShell.rb:63:5:63:7 | [post] arr [element] | provenance |  |
+| impl/unsafeShell.rb:63:5:63:7 | [post] arr : [collection] [element] | impl/unsafeShell.rb:64:14:64:16 | arr | provenance |  |
+| impl/unsafeShell.rb:63:5:63:7 | [post] arr : [collection] [element] | impl/unsafeShell.rb:68:14:68:16 | arr | provenance |  |
+| impl/unsafeShell.rb:63:14:63:14 | x | impl/unsafeShell.rb:63:5:63:7 | [post] arr : [collection] [element] | provenance |  |
 nodes
 | impl/sub/notImported.rb:2:12:2:17 | target | semmle.label | target |
 | impl/sub/notImported.rb:3:19:3:27 | #{...} | semmle.label | #{...} |
@@ -43,7 +43,7 @@ nodes
 | impl/unsafeShell.rb:57:21:57:21 | x | semmle.label | x |
 | impl/unsafeShell.rb:58:23:58:23 | x | semmle.label | x |
 | impl/unsafeShell.rb:61:20:61:20 | x | semmle.label | x |
-| impl/unsafeShell.rb:63:5:63:7 | [post] arr [element] | semmle.label | [post] arr [element] |
+| impl/unsafeShell.rb:63:5:63:7 | [post] arr : [collection] [element] | semmle.label | [post] arr : [collection] [element] |
 | impl/unsafeShell.rb:63:14:63:14 | x | semmle.label | x |
 | impl/unsafeShell.rb:64:14:64:16 | arr | semmle.label | arr |
 | impl/unsafeShell.rb:68:14:68:16 | arr | semmle.label | arr |

--- a/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/ReflectedXSS.expected
@@ -15,16 +15,16 @@ edges
 | app/controllers/foo/bars_controller.rb:19:22:19:23 | dt | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text | provenance | Config |
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:82:6:82:17 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:85:36:85:47 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | app/views/foo/bars/show.html.erb:86:28:86:39 | call to display_text | provenance |  |
-| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:82:6:82:17 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:85:36:85:47 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | app/views/foo/bars/show.html.erb:86:28:86:39 | call to display_text | provenance |  |
+| app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | app/controllers/foo/bars_controller.rb:31:5:31:7 | str | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:30:11:30:28 | ...[...] | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | provenance |  |
@@ -36,19 +36,19 @@ edges
 | app/controllers/foo/bars_controller.rb:36:34:36:51 | ...[...] | app/controllers/foo/bars_controller.rb:36:5:36:52 | call to t | provenance |  |
 | app/controllers/foo/bars_controller.rb:37:42:37:47 | call to params | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | provenance |  |
 | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | app/controllers/foo/bars_controller.rb:37:5:37:60 | call to translate | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | provenance |  |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
+| app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] | provenance |  |
+| app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] | provenance |  |
+| app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns : Hash [element :display_text] | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... : [collection] [element] | app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text, element] | provenance |  |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | provenance |  |
-| app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | provenance |  |
+| app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... : [collection] [element] | provenance |  |
 | app/views/foo/bars/show.html.erb:53:29:53:34 | call to params | app/views/foo/bars/show.html.erb:53:29:53:44 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:56:13:56:18 | call to params | app/views/foo/bars/show.html.erb:56:13:56:28 | ...[...] | provenance |  |
 | app/views/foo/bars/show.html.erb:73:19:73:24 | call to params | app/views/foo/bars/show.html.erb:73:19:73:34 | ...[...] | provenance |  |
@@ -70,7 +70,7 @@ nodes
 | app/controllers/foo/bars_controller.rb:24:39:24:44 | call to params | semmle.label | call to params |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ... = ... | semmle.label | ... = ... |
 | app/controllers/foo/bars_controller.rb:24:39:24:59 | ...[...] | semmle.label | ...[...] |
-| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
+| app/controllers/foo/bars_controller.rb:26:37:26:76 | call to [] : Hash [element :display_text] | semmle.label | call to [] : Hash [element :display_text] |
 | app/controllers/foo/bars_controller.rb:26:53:26:54 | dt | semmle.label | dt |
 | app/controllers/foo/bars_controller.rb:30:5:30:7 | str | semmle.label | str |
 | app/controllers/foo/bars_controller.rb:30:11:30:16 | call to params | semmle.label | call to params |
@@ -89,23 +89,23 @@ nodes
 | app/controllers/foo/bars_controller.rb:37:42:37:47 | call to params | semmle.label | call to params |
 | app/controllers/foo/bars_controller.rb:37:42:37:59 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | semmle.label | call to local_assigns : Hash [element :display_text, element] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/show.html.erb:2:18:2:30 | @user_website | semmle.label | @user_website |
 | app/views/foo/bars/show.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/bars/show.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/bars/show.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/bars/show.html.erb:12:9:12:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/bars/show.html.erb:12:9:12:26 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/bars/show.html.erb:17:15:17:27 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/bars/show.html.erb:17:15:17:32 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/bars/show.html.erb:35:3:35:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:40:3:40:16 | @instance_text | semmle.label | @instance_text |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text, element] | semmle.label | call to [] [element :display_text, element] |
-| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text, element] | semmle.label | call to [] : Hash [element :display_text, element] |
+| app/views/foo/bars/show.html.erb:43:48:43:89 | call to [] : Hash [element :display_text] | semmle.label | call to [] : Hash [element :display_text] |
 | app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... | semmle.label | ... + ... |
-| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... [element] | semmle.label | ... + ... [element] |
+| app/views/foo/bars/show.html.erb:43:64:43:87 | ... + ... : [collection] [element] | semmle.label | ... + ... : [collection] [element] |
 | app/views/foo/bars/show.html.erb:43:76:43:87 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/bars/show.html.erb:46:5:46:13 | call to user_name | semmle.label | call to user_name |
 | app/views/foo/bars/show.html.erb:50:5:50:18 | call to user_name_memo | semmle.label | call to user_name_memo |

--- a/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
+++ b/ruby/ql/test/query-tests/security/cwe-079/StoredXSS.expected
@@ -3,50 +3,50 @@ edges
 | app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt | provenance |  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | provenance |  |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text | provenance | Config |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | provenance |  |
-| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | provenance |  |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | provenance |  |
+| app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | provenance |  |
+| app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | provenance |  |
+| app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns : Hash [element :display_text] | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] | provenance |  |
+| app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns : Hash [element :display_text] | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text, element] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | provenance |  |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text] | app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... : [collection] [element] | app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text, element] | provenance |  |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | provenance |  |
-| app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | provenance |  |
+| app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... : [collection] [element] | provenance |  |
 | app/views/foo/stores/show.html.erb:86:17:86:28 | call to handle | app/views/foo/stores/show.html.erb:86:3:86:29 | call to sprintf | provenance | AdditionalTaintStep |
 nodes
 | app/controllers/foo/stores_controller.rb:8:5:8:6 | dt | semmle.label | dt |
 | app/controllers/foo/stores_controller.rb:8:10:8:29 | call to read | semmle.label | call to read |
 | app/controllers/foo/stores_controller.rb:9:22:9:23 | dt | semmle.label | dt |
-| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
+| app/controllers/foo/stores_controller.rb:13:39:13:78 | call to [] : Hash [element :display_text] | semmle.label | call to [] : Hash [element :display_text] |
 | app/controllers/foo/stores_controller.rb:13:55:13:56 | dt | semmle.label | dt |
 | app/views/foo/bars/_widget.html.erb:5:9:5:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text, element] | semmle.label | call to local_assigns [element :display_text, element] |
-| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text, element] | semmle.label | call to local_assigns : Hash [element :display_text, element] |
+| app/views/foo/bars/_widget.html.erb:8:9:8:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/bars/_widget.html.erb:8:9:8:36 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/stores/show.html.erb:2:9:2:20 | call to display_text | semmle.label | call to display_text |
-| app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/stores/show.html.erb:5:9:5:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/stores/show.html.erb:5:9:5:36 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/stores/show.html.erb:9:9:9:21 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/stores/show.html.erb:9:9:9:26 | ...[...] | semmle.label | ...[...] |
-| app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns [element :display_text] | semmle.label | call to local_assigns [element :display_text] |
+| app/views/foo/stores/show.html.erb:14:15:14:27 | call to local_assigns : Hash [element :display_text] | semmle.label | call to local_assigns : Hash [element :display_text] |
 | app/views/foo/stores/show.html.erb:14:15:14:32 | ...[...] | semmle.label | ...[...] |
 | app/views/foo/stores/show.html.erb:32:3:32:14 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:37:3:37:16 | @instance_text | semmle.label | @instance_text |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text, element] | semmle.label | call to [] [element :display_text, element] |
-| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] [element :display_text] | semmle.label | call to [] [element :display_text] |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text, element] | semmle.label | call to [] : Hash [element :display_text, element] |
+| app/views/foo/stores/show.html.erb:40:48:40:89 | call to [] : Hash [element :display_text] | semmle.label | call to [] : Hash [element :display_text] |
 | app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... | semmle.label | ... + ... |
-| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... [element] | semmle.label | ... + ... [element] |
+| app/views/foo/stores/show.html.erb:40:64:40:87 | ... + ... : [collection] [element] | semmle.label | ... + ... : [collection] [element] |
 | app/views/foo/stores/show.html.erb:40:76:40:87 | call to display_text | semmle.label | call to display_text |
 | app/views/foo/stores/show.html.erb:46:5:46:16 | call to handle | semmle.label | call to handle |
 | app/views/foo/stores/show.html.erb:63:3:63:18 | call to handle | semmle.label | call to handle |

--- a/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-089/SqlInjection.expected
@@ -11,12 +11,12 @@ edges
 | ActiveRecordInjection.rb:50:29:50:39 | ...[...] | ActiveRecordInjection.rb:50:20:50:42 | "id = '#{...}'" | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:55:30:55:35 | call to params | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | ActiveRecordInjection.rb:55:21:55:43 | "id = '#{...}'" | provenance | AdditionalTaintStep |
-| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | ActiveRecordInjection.rb:59:21:59:45 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" : String | ActiveRecordInjection.rb:59:21:59:45 | call to [] | provenance |  |
 | ActiveRecordInjection.rb:59:31:59:36 | call to params | ActiveRecordInjection.rb:59:31:59:41 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:59:31:59:41 | ...[...] | ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | provenance | AdditionalTaintStep |
-| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | ActiveRecordInjection.rb:64:22:64:46 | call to [] | provenance |  |
+| ActiveRecordInjection.rb:59:31:59:41 | ...[...] | ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" : String | provenance | AdditionalTaintStep |
+| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" : String | ActiveRecordInjection.rb:64:22:64:46 | call to [] | provenance |  |
 | ActiveRecordInjection.rb:64:32:64:37 | call to params | ActiveRecordInjection.rb:64:32:64:42 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:64:32:64:42 | ...[...] | ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | provenance | AdditionalTaintStep |
+| ActiveRecordInjection.rb:64:32:64:42 | ...[...] | ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" : String | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:69:21:69:26 | call to params | ActiveRecordInjection.rb:69:21:69:35 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:69:21:69:35 | ...[...] | ActiveRecordInjection.rb:68:16:68:21 | <<-SQL | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:75:34:75:39 | call to params | ActiveRecordInjection.rb:75:34:75:44 | ...[...] | provenance |  |
@@ -51,12 +51,10 @@ edges
 | ActiveRecordInjection.rb:129:29:129:34 | call to params | ActiveRecordInjection.rb:129:29:129:39 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:135:5:135:6 | ps | ActiveRecordInjection.rb:136:11:136:12 | ps | provenance |  |
 | ActiveRecordInjection.rb:135:10:135:15 | call to params | ActiveRecordInjection.rb:135:5:135:6 | ps | provenance |  |
-| ActiveRecordInjection.rb:136:5:136:7 | uid | ActiveRecordInjection.rb:137:5:137:9 | uidEq | provenance | AdditionalTaintStep |
+| ActiveRecordInjection.rb:136:5:136:7 | uid | ActiveRecordInjection.rb:137:5:137:9 | uidEq : String | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:136:11:136:12 | ps | ActiveRecordInjection.rb:136:11:136:17 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:136:11:136:17 | ...[...] | ActiveRecordInjection.rb:136:5:136:7 | uid | provenance |  |
-| ActiveRecordInjection.rb:137:5:137:9 | uidEq | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
-| ActiveRecordInjection.rb:137:5:137:9 | uidEq | ActiveRecordInjection.rb:141:28:141:32 | uidEq | provenance |  |
-| ActiveRecordInjection.rb:141:28:141:32 | uidEq | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
+| ActiveRecordInjection.rb:137:5:137:9 | uidEq : String | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | provenance |  |
 | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | ActiveRecordInjection.rb:27:22:27:30 | condition | provenance |  |
@@ -64,9 +62,9 @@ edges
 | ActiveRecordInjection.rb:188:59:188:74 | ...[...] | ActiveRecordInjection.rb:188:27:188:76 | "this is an unsafe annotation:..." | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:199:5:199:13 | my_params | ActiveRecordInjection.rb:200:47:200:55 | my_params | provenance |  |
 | ActiveRecordInjection.rb:199:17:199:32 | call to permitted_params | ActiveRecordInjection.rb:199:5:199:13 | my_params | provenance |  |
-| ActiveRecordInjection.rb:200:5:200:9 | query | ActiveRecordInjection.rb:201:37:201:41 | query | provenance |  |
+| ActiveRecordInjection.rb:200:5:200:9 | query : String | ActiveRecordInjection.rb:201:37:201:41 | query | provenance |  |
 | ActiveRecordInjection.rb:200:47:200:55 | my_params | ActiveRecordInjection.rb:200:47:200:65 | ...[...] | provenance |  |
-| ActiveRecordInjection.rb:200:47:200:65 | ...[...] | ActiveRecordInjection.rb:200:5:200:9 | query | provenance | AdditionalTaintStep |
+| ActiveRecordInjection.rb:200:47:200:65 | ...[...] | ActiveRecordInjection.rb:200:5:200:9 | query : String | provenance | AdditionalTaintStep |
 | ActiveRecordInjection.rb:206:5:206:10 | call to params | ActiveRecordInjection.rb:206:5:206:27 | call to require | provenance |  |
 | ActiveRecordInjection.rb:206:5:206:27 | call to require | ActiveRecordInjection.rb:206:5:206:59 | call to permit | provenance |  |
 | ActiveRecordInjection.rb:206:5:206:59 | call to permit | ActiveRecordInjection.rb:199:17:199:32 | call to permitted_params | provenance |  |
@@ -83,18 +81,18 @@ edges
 | ArelInjection.rb:4:5:4:8 | name | ArelInjection.rb:7:39:7:80 | "SELECT * FROM users WHERE nam..." | provenance | AdditionalTaintStep |
 | ArelInjection.rb:4:12:4:17 | call to params | ArelInjection.rb:4:12:4:29 | ...[...] | provenance |  |
 | ArelInjection.rb:4:12:4:29 | ...[...] | ArelInjection.rb:4:5:4:8 | name | provenance |  |
-| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:13:5:13:8 | qry1 | provenance | AdditionalTaintStep |
-| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:19:5:19:8 | qry2 | provenance | AdditionalTaintStep |
-| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:31:5:31:8 | qry3 | provenance | AdditionalTaintStep |
-| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:43:5:43:8 | qry3 | provenance | AdditionalTaintStep |
+| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:13:5:13:8 | qry1 : String | provenance | AdditionalTaintStep |
+| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:19:5:19:8 | qry2 : String | provenance | AdditionalTaintStep |
+| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:31:5:31:8 | qry3 : String | provenance | AdditionalTaintStep |
+| PgInjection.rb:6:5:6:8 | name | PgInjection.rb:43:5:43:8 | qry3 : String | provenance | AdditionalTaintStep |
 | PgInjection.rb:6:12:6:17 | call to params | PgInjection.rb:6:12:6:24 | ...[...] | provenance |  |
 | PgInjection.rb:6:12:6:24 | ...[...] | PgInjection.rb:6:5:6:8 | name | provenance |  |
-| PgInjection.rb:13:5:13:8 | qry1 | PgInjection.rb:14:15:14:18 | qry1 | provenance |  |
-| PgInjection.rb:13:5:13:8 | qry1 | PgInjection.rb:15:21:15:24 | qry1 | provenance |  |
-| PgInjection.rb:19:5:19:8 | qry2 | PgInjection.rb:20:22:20:25 | qry2 | provenance |  |
-| PgInjection.rb:19:5:19:8 | qry2 | PgInjection.rb:21:28:21:31 | qry2 | provenance |  |
-| PgInjection.rb:31:5:31:8 | qry3 | PgInjection.rb:32:29:32:32 | qry3 | provenance |  |
-| PgInjection.rb:43:5:43:8 | qry3 | PgInjection.rb:44:29:44:32 | qry3 | provenance |  |
+| PgInjection.rb:13:5:13:8 | qry1 : String | PgInjection.rb:14:15:14:18 | qry1 | provenance |  |
+| PgInjection.rb:13:5:13:8 | qry1 : String | PgInjection.rb:15:21:15:24 | qry1 | provenance |  |
+| PgInjection.rb:19:5:19:8 | qry2 : String | PgInjection.rb:20:22:20:25 | qry2 | provenance |  |
+| PgInjection.rb:19:5:19:8 | qry2 : String | PgInjection.rb:21:28:21:31 | qry2 | provenance |  |
+| PgInjection.rb:31:5:31:8 | qry3 : String | PgInjection.rb:32:29:32:32 | qry3 | provenance |  |
+| PgInjection.rb:43:5:43:8 | qry3 : String | PgInjection.rb:44:29:44:32 | qry3 | provenance |  |
 nodes
 | ActiveRecordInjection.rb:8:25:8:28 | name | semmle.label | name |
 | ActiveRecordInjection.rb:8:31:8:34 | pass | semmle.label | pass |
@@ -114,11 +112,11 @@ nodes
 | ActiveRecordInjection.rb:55:30:55:35 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:55:30:55:40 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:59:21:59:45 | call to [] | semmle.label | call to [] |
-| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
+| ActiveRecordInjection.rb:59:22:59:44 | "id = '#{...}'" : String | semmle.label | "id = '#{...}'" : String |
 | ActiveRecordInjection.rb:59:31:59:36 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:59:31:59:41 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:64:22:64:46 | call to [] | semmle.label | call to [] |
-| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" | semmle.label | "id = '#{...}'" |
+| ActiveRecordInjection.rb:64:23:64:45 | "id = '#{...}'" : String | semmle.label | "id = '#{...}'" : String |
 | ActiveRecordInjection.rb:64:32:64:37 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:64:32:64:42 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:68:16:68:21 | <<-SQL | semmle.label | <<-SQL |
@@ -179,9 +177,8 @@ nodes
 | ActiveRecordInjection.rb:136:5:136:7 | uid | semmle.label | uid |
 | ActiveRecordInjection.rb:136:11:136:12 | ps | semmle.label | ps |
 | ActiveRecordInjection.rb:136:11:136:17 | ...[...] | semmle.label | ...[...] |
-| ActiveRecordInjection.rb:137:5:137:9 | uidEq | semmle.label | uidEq |
+| ActiveRecordInjection.rb:137:5:137:9 | uidEq : String | semmle.label | uidEq : String |
 | ActiveRecordInjection.rb:141:20:141:32 | ... + ... | semmle.label | ... + ... |
-| ActiveRecordInjection.rb:141:28:141:32 | uidEq | semmle.label | uidEq |
 | ActiveRecordInjection.rb:174:21:174:26 | call to params | semmle.label | call to params |
 | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:174:21:174:44 | ...[...] | semmle.label | ...[...] |
@@ -190,7 +187,7 @@ nodes
 | ActiveRecordInjection.rb:188:59:188:74 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:199:5:199:13 | my_params | semmle.label | my_params |
 | ActiveRecordInjection.rb:199:17:199:32 | call to permitted_params | semmle.label | call to permitted_params |
-| ActiveRecordInjection.rb:200:5:200:9 | query | semmle.label | query |
+| ActiveRecordInjection.rb:200:5:200:9 | query : String | semmle.label | query : String |
 | ActiveRecordInjection.rb:200:47:200:55 | my_params | semmle.label | my_params |
 | ActiveRecordInjection.rb:200:47:200:65 | ...[...] | semmle.label | ...[...] |
 | ActiveRecordInjection.rb:201:37:201:41 | query | semmle.label | query |
@@ -215,15 +212,15 @@ nodes
 | PgInjection.rb:6:5:6:8 | name | semmle.label | name |
 | PgInjection.rb:6:12:6:17 | call to params | semmle.label | call to params |
 | PgInjection.rb:6:12:6:24 | ...[...] | semmle.label | ...[...] |
-| PgInjection.rb:13:5:13:8 | qry1 | semmle.label | qry1 |
+| PgInjection.rb:13:5:13:8 | qry1 : String | semmle.label | qry1 : String |
 | PgInjection.rb:14:15:14:18 | qry1 | semmle.label | qry1 |
 | PgInjection.rb:15:21:15:24 | qry1 | semmle.label | qry1 |
-| PgInjection.rb:19:5:19:8 | qry2 | semmle.label | qry2 |
+| PgInjection.rb:19:5:19:8 | qry2 : String | semmle.label | qry2 : String |
 | PgInjection.rb:20:22:20:25 | qry2 | semmle.label | qry2 |
 | PgInjection.rb:21:28:21:31 | qry2 | semmle.label | qry2 |
-| PgInjection.rb:31:5:31:8 | qry3 | semmle.label | qry3 |
+| PgInjection.rb:31:5:31:8 | qry3 : String | semmle.label | qry3 : String |
 | PgInjection.rb:32:29:32:32 | qry3 | semmle.label | qry3 |
-| PgInjection.rb:43:5:43:8 | qry3 | semmle.label | qry3 |
+| PgInjection.rb:43:5:43:8 | qry3 : String | semmle.label | qry3 : String |
 | PgInjection.rb:44:29:44:32 | qry3 | semmle.label | qry3 |
 subpaths
 #select

--- a/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/CodeInjection/CodeInjection.expected
@@ -15,19 +15,19 @@ nodes
 | CodeInjection.rb:78:12:78:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:78:12:78:24 | ...[...] | semmle.label | ...[...] |
 | CodeInjection.rb:80:16:80:19 | code | semmle.label | code |
-| CodeInjection.rb:86:10:86:25 | ... + ... [element] | semmle.label | ... + ... [element] |
+| CodeInjection.rb:86:10:86:25 | ... + ... : [collection] [element] | semmle.label | ... + ... : [collection] [element] |
 | CodeInjection.rb:86:10:86:37 | ... + ... | semmle.label | ... + ... |
 | CodeInjection.rb:86:22:86:25 | code | semmle.label | code |
 | CodeInjection.rb:88:10:88:32 | "prefix_#{...}_suffix" | semmle.label | "prefix_#{...}_suffix" |
 | CodeInjection.rb:90:10:90:13 | code | semmle.label | code |
-| CodeInjection.rb:101:3:102:5 | self in index [@foo] | semmle.label | self in index [@foo] |
+| CodeInjection.rb:101:3:102:5 | self in index : PostsController [@foo] | semmle.label | self in index : PostsController [@foo] |
 | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | semmle.label | [post] self [@foo] |
 | CodeInjection.rb:105:12:105:17 | call to params | semmle.label | call to params |
 | CodeInjection.rb:105:12:105:23 | ...[...] | semmle.label | ...[...] |
-| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | semmle.label | self in bar [@foo] |
-| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | semmle.label | self in baz [@foo] |
+| CodeInjection.rb:108:3:109:5 | self in bar : PostsController [@foo] | semmle.label | self in bar : PostsController [@foo] |
+| CodeInjection.rb:111:3:113:5 | self in baz : PostsController [@foo] | semmle.label | self in baz : PostsController [@foo] |
 | CodeInjection.rb:112:10:112:13 | @foo | semmle.label | @foo |
-| CodeInjection.rb:112:10:112:13 | self [@foo] | semmle.label | self [@foo] |
+| CodeInjection.rb:112:10:112:13 | self : PostsController [@foo] | semmle.label | self : PostsController [@foo] |
 edges
 | CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:8:10:8:13 | code | provenance |  |
 | CodeInjection.rb:5:5:5:8 | code | CodeInjection.rb:20:20:20:23 | code | provenance |  |
@@ -46,15 +46,15 @@ edges
 | CodeInjection.rb:78:5:78:8 | code | CodeInjection.rb:90:10:90:13 | code | provenance |  |
 | CodeInjection.rb:78:12:78:17 | call to params | CodeInjection.rb:78:12:78:24 | ...[...] | provenance |  |
 | CodeInjection.rb:78:12:78:24 | ...[...] | CodeInjection.rb:78:5:78:8 | code | provenance |  |
-| CodeInjection.rb:86:10:86:25 | ... + ... [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
-| CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... [element] | provenance |  |
-| CodeInjection.rb:101:3:102:5 | self in index [@foo] | CodeInjection.rb:111:3:113:5 | self in baz [@foo] | provenance |  |
-| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar [@foo] | provenance |  |
+| CodeInjection.rb:86:10:86:25 | ... + ... : [collection] [element] | CodeInjection.rb:86:10:86:37 | ... + ... | provenance |  |
+| CodeInjection.rb:86:22:86:25 | code | CodeInjection.rb:86:10:86:25 | ... + ... : [collection] [element] | provenance |  |
+| CodeInjection.rb:101:3:102:5 | self in index : PostsController [@foo] | CodeInjection.rb:111:3:113:5 | self in baz : PostsController [@foo] | provenance |  |
+| CodeInjection.rb:105:5:105:8 | [post] self [@foo] | CodeInjection.rb:108:3:109:5 | self in bar : PostsController [@foo] | provenance |  |
 | CodeInjection.rb:105:12:105:17 | call to params | CodeInjection.rb:105:12:105:23 | ...[...] | provenance |  |
 | CodeInjection.rb:105:12:105:23 | ...[...] | CodeInjection.rb:105:5:105:8 | [post] self [@foo] | provenance |  |
-| CodeInjection.rb:108:3:109:5 | self in bar [@foo] | CodeInjection.rb:101:3:102:5 | self in index [@foo] | provenance |  |
-| CodeInjection.rb:111:3:113:5 | self in baz [@foo] | CodeInjection.rb:112:10:112:13 | self [@foo] | provenance |  |
-| CodeInjection.rb:112:10:112:13 | self [@foo] | CodeInjection.rb:112:10:112:13 | @foo | provenance |  |
+| CodeInjection.rb:108:3:109:5 | self in bar : PostsController [@foo] | CodeInjection.rb:101:3:102:5 | self in index : PostsController [@foo] | provenance |  |
+| CodeInjection.rb:111:3:113:5 | self in baz : PostsController [@foo] | CodeInjection.rb:112:10:112:13 | self : PostsController [@foo] | provenance |  |
+| CodeInjection.rb:112:10:112:13 | self : PostsController [@foo] | CodeInjection.rb:112:10:112:13 | @foo | provenance |  |
 subpaths
 #select
 | CodeInjection.rb:8:10:8:13 | code | CodeInjection.rb:5:12:5:17 | call to params | CodeInjection.rb:8:10:8:13 | code | This code execution depends on a $@. | CodeInjection.rb:5:12:5:17 | call to params | user-provided value |

--- a/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
+++ b/ruby/ql/test/query-tests/security/cwe-094/UnsafeCodeConstruction/UnsafeCodeConstruction.expected
@@ -4,26 +4,26 @@ edges
 | impl/unsafeCode.rb:12:12:12:12 | x | impl/unsafeCode.rb:13:33:13:33 | x | provenance |  |
 | impl/unsafeCode.rb:28:17:28:22 | my_arr | impl/unsafeCode.rb:29:10:29:15 | my_arr | provenance |  |
 | impl/unsafeCode.rb:32:21:32:21 | x | impl/unsafeCode.rb:33:12:33:12 | x | provenance |  |
-| impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | impl/unsafeCode.rb:34:10:34:12 | arr | provenance |  |
-| impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | provenance |  |
-| impl/unsafeCode.rb:33:12:33:12 | x | impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | provenance |  |
+| impl/unsafeCode.rb:33:5:33:7 | arr : Array [element 0] | impl/unsafeCode.rb:34:10:34:12 | arr | provenance |  |
+| impl/unsafeCode.rb:33:11:33:23 | call to [] : Array [element 0] | impl/unsafeCode.rb:33:5:33:7 | arr : Array [element 0] | provenance |  |
+| impl/unsafeCode.rb:33:12:33:12 | x | impl/unsafeCode.rb:33:11:33:23 | call to [] : Array [element 0] | provenance |  |
 | impl/unsafeCode.rb:37:15:37:15 | x | impl/unsafeCode.rb:39:14:39:14 | x | provenance |  |
-| impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | impl/unsafeCode.rb:40:10:40:12 | arr | provenance |  |
-| impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | impl/unsafeCode.rb:44:10:44:12 | arr | provenance |  |
-| impl/unsafeCode.rb:39:14:39:14 | x | impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | provenance |  |
+| impl/unsafeCode.rb:39:5:39:7 | [post] arr : [collection] [element] | impl/unsafeCode.rb:40:10:40:12 | arr | provenance |  |
+| impl/unsafeCode.rb:39:5:39:7 | [post] arr : [collection] [element] | impl/unsafeCode.rb:44:10:44:12 | arr | provenance |  |
+| impl/unsafeCode.rb:39:14:39:14 | x | impl/unsafeCode.rb:39:5:39:7 | [post] arr : [collection] [element] | provenance |  |
 | impl/unsafeCode.rb:47:15:47:15 | x | impl/unsafeCode.rb:49:9:49:12 | #{...} | provenance |  |
 | impl/unsafeCode.rb:54:21:54:21 | x | impl/unsafeCode.rb:55:22:55:22 | x | provenance |  |
 | impl/unsafeCode.rb:59:21:59:21 | x | impl/unsafeCode.rb:60:17:60:17 | x | provenance |  |
 | impl/unsafeCode.rb:59:24:59:24 | y | impl/unsafeCode.rb:63:30:63:30 | y | provenance |  |
-| impl/unsafeCode.rb:60:5:60:7 | arr [element 0] | impl/unsafeCode.rb:61:10:61:12 | arr | provenance |  |
-| impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] | impl/unsafeCode.rb:60:5:60:7 | arr [element 0] | provenance |  |
-| impl/unsafeCode.rb:60:17:60:17 | x | impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] | provenance |  |
-| impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | impl/unsafeCode.rb:64:10:64:13 | arr2 | provenance |  |
-| impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | provenance |  |
-| impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | impl/unsafeCode.rb:63:13:63:42 | call to join | provenance |  |
-| impl/unsafeCode.rb:63:13:63:42 | call to join | impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | provenance |  |
-| impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | provenance |  |
-| impl/unsafeCode.rb:63:30:63:30 | y | impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | provenance |  |
+| impl/unsafeCode.rb:60:5:60:7 | arr : [collection] [element 0] | impl/unsafeCode.rb:61:10:61:12 | arr | provenance |  |
+| impl/unsafeCode.rb:60:11:60:18 | call to Array : [collection] [element 0] | impl/unsafeCode.rb:60:5:60:7 | arr : [collection] [element 0] | provenance |  |
+| impl/unsafeCode.rb:60:17:60:17 | x | impl/unsafeCode.rb:60:11:60:18 | call to Array : [collection] [element 0] | provenance |  |
+| impl/unsafeCode.rb:63:5:63:8 | arr2 : Array [element 0] | impl/unsafeCode.rb:64:10:64:13 | arr2 | provenance |  |
+| impl/unsafeCode.rb:63:12:63:43 | call to [] : Array [element 0] | impl/unsafeCode.rb:63:5:63:8 | arr2 : Array [element 0] | provenance |  |
+| impl/unsafeCode.rb:63:13:63:32 | call to Array : Array [element 1] | impl/unsafeCode.rb:63:13:63:42 | call to join | provenance |  |
+| impl/unsafeCode.rb:63:13:63:42 | call to join | impl/unsafeCode.rb:63:12:63:43 | call to [] : Array [element 0] | provenance |  |
+| impl/unsafeCode.rb:63:19:63:31 | call to [] : Array [element 1] | impl/unsafeCode.rb:63:13:63:32 | call to Array : Array [element 1] | provenance |  |
+| impl/unsafeCode.rb:63:30:63:30 | y | impl/unsafeCode.rb:63:19:63:31 | call to [] : Array [element 1] | provenance |  |
 nodes
 | impl/unsafeCode.rb:2:12:2:17 | target | semmle.label | target |
 | impl/unsafeCode.rb:3:17:3:25 | #{...} | semmle.label | #{...} |
@@ -34,12 +34,12 @@ nodes
 | impl/unsafeCode.rb:28:17:28:22 | my_arr | semmle.label | my_arr |
 | impl/unsafeCode.rb:29:10:29:15 | my_arr | semmle.label | my_arr |
 | impl/unsafeCode.rb:32:21:32:21 | x | semmle.label | x |
-| impl/unsafeCode.rb:33:5:33:7 | arr [element 0] | semmle.label | arr [element 0] |
-| impl/unsafeCode.rb:33:11:33:23 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| impl/unsafeCode.rb:33:5:33:7 | arr : Array [element 0] | semmle.label | arr : Array [element 0] |
+| impl/unsafeCode.rb:33:11:33:23 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
 | impl/unsafeCode.rb:33:12:33:12 | x | semmle.label | x |
 | impl/unsafeCode.rb:34:10:34:12 | arr | semmle.label | arr |
 | impl/unsafeCode.rb:37:15:37:15 | x | semmle.label | x |
-| impl/unsafeCode.rb:39:5:39:7 | [post] arr [element] | semmle.label | [post] arr [element] |
+| impl/unsafeCode.rb:39:5:39:7 | [post] arr : [collection] [element] | semmle.label | [post] arr : [collection] [element] |
 | impl/unsafeCode.rb:39:14:39:14 | x | semmle.label | x |
 | impl/unsafeCode.rb:40:10:40:12 | arr | semmle.label | arr |
 | impl/unsafeCode.rb:44:10:44:12 | arr | semmle.label | arr |
@@ -49,15 +49,15 @@ nodes
 | impl/unsafeCode.rb:55:22:55:22 | x | semmle.label | x |
 | impl/unsafeCode.rb:59:21:59:21 | x | semmle.label | x |
 | impl/unsafeCode.rb:59:24:59:24 | y | semmle.label | y |
-| impl/unsafeCode.rb:60:5:60:7 | arr [element 0] | semmle.label | arr [element 0] |
-| impl/unsafeCode.rb:60:11:60:18 | call to Array [element 0] | semmle.label | call to Array [element 0] |
+| impl/unsafeCode.rb:60:5:60:7 | arr : [collection] [element 0] | semmle.label | arr : [collection] [element 0] |
+| impl/unsafeCode.rb:60:11:60:18 | call to Array : [collection] [element 0] | semmle.label | call to Array : [collection] [element 0] |
 | impl/unsafeCode.rb:60:17:60:17 | x | semmle.label | x |
 | impl/unsafeCode.rb:61:10:61:12 | arr | semmle.label | arr |
-| impl/unsafeCode.rb:63:5:63:8 | arr2 [element 0] | semmle.label | arr2 [element 0] |
-| impl/unsafeCode.rb:63:12:63:43 | call to [] [element 0] | semmle.label | call to [] [element 0] |
-| impl/unsafeCode.rb:63:13:63:32 | call to Array [element 1] | semmle.label | call to Array [element 1] |
+| impl/unsafeCode.rb:63:5:63:8 | arr2 : Array [element 0] | semmle.label | arr2 : Array [element 0] |
+| impl/unsafeCode.rb:63:12:63:43 | call to [] : Array [element 0] | semmle.label | call to [] : Array [element 0] |
+| impl/unsafeCode.rb:63:13:63:32 | call to Array : Array [element 1] | semmle.label | call to Array : Array [element 1] |
 | impl/unsafeCode.rb:63:13:63:42 | call to join | semmle.label | call to join |
-| impl/unsafeCode.rb:63:19:63:31 | call to [] [element 1] | semmle.label | call to [] [element 1] |
+| impl/unsafeCode.rb:63:19:63:31 | call to [] : Array [element 1] | semmle.label | call to [] : Array [element 1] |
 | impl/unsafeCode.rb:63:30:63:30 | y | semmle.label | y |
 | impl/unsafeCode.rb:64:10:64:13 | arr2 | semmle.label | arr2 |
 subpaths

--- a/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
+++ b/ruby/ql/test/query-tests/security/cwe-117/LogInjection.expected
@@ -7,16 +7,16 @@ edges
 | app/controllers/users_controller.rb:15:19:15:30 | ...[...] | app/controllers/users_controller.rb:15:5:15:15 | unsanitized | provenance |  |
 | app/controllers/users_controller.rb:17:31:17:41 | unsanitized | app/controllers/users_controller.rb:17:19:17:41 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | app/controllers/users_controller.rb:23:20:23:44 | call to sub | provenance |  |
-| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | provenance |  |
+| app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:24:18:26:7 | do ... end : [lambda] [captured unsanitized2] | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | provenance |  |
-| app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | provenance | heuristic-callback |
+| app/controllers/users_controller.rb:24:18:26:7 | do ... end : [lambda] [captured unsanitized2] | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | provenance | heuristic-callback |
 | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | provenance |  |
-| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | provenance |  |
-| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | provenance |  |
-| app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | provenance | heuristic-callback |
-| app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | provenance | heuristic-callback |
+| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:34:31:34:45 | { ... } : [lambda] [captured unsanitized] | provenance |  |
+| app/controllers/users_controller.rb:33:19:33:31 | ...[...] | app/controllers/users_controller.rb:35:31:35:57 | { ... } : [lambda] [captured unsanitized] | provenance |  |
+| app/controllers/users_controller.rb:34:31:34:45 | { ... } : [lambda] [captured unsanitized] | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | provenance | heuristic-callback |
+| app/controllers/users_controller.rb:35:31:35:57 | { ... } : [lambda] [captured unsanitized] | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | provenance | heuristic-callback |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | provenance |  |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | app/controllers/users_controller.rb:49:19:49:30 | ...[...] | provenance |  |
 nodes
@@ -28,15 +28,15 @@ nodes
 | app/controllers/users_controller.rb:17:31:17:41 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:30 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:23:20:23:44 | call to sub | semmle.label | call to sub |
-| app/controllers/users_controller.rb:24:18:26:7 | do ... end [captured unsanitized2] | semmle.label | do ... end [captured unsanitized2] |
+| app/controllers/users_controller.rb:24:18:26:7 | do ... end : [lambda] [captured unsanitized2] | semmle.label | do ... end : [lambda] [captured unsanitized2] |
 | app/controllers/users_controller.rb:25:7:25:18 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:27:16:27:39 | ... + ... | semmle.label | ... + ... |
 | app/controllers/users_controller.rb:27:28:27:39 | unsanitized2 | semmle.label | unsanitized2 |
 | app/controllers/users_controller.rb:33:19:33:25 | call to cookies | semmle.label | call to cookies |
 | app/controllers/users_controller.rb:33:19:33:31 | ...[...] | semmle.label | ...[...] |
-| app/controllers/users_controller.rb:34:31:34:45 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
+| app/controllers/users_controller.rb:34:31:34:45 | { ... } : [lambda] [captured unsanitized] | semmle.label | { ... } : [lambda] [captured unsanitized] |
 | app/controllers/users_controller.rb:34:33:34:43 | unsanitized | semmle.label | unsanitized |
-| app/controllers/users_controller.rb:35:31:35:57 | { ... } [captured unsanitized] | semmle.label | { ... } [captured unsanitized] |
+| app/controllers/users_controller.rb:35:31:35:57 | { ... } : [lambda] [captured unsanitized] | semmle.label | { ... } : [lambda] [captured unsanitized] |
 | app/controllers/users_controller.rb:35:33:35:55 | ... + ... | semmle.label | ... + ... |
 | app/controllers/users_controller.rb:35:45:35:55 | unsanitized | semmle.label | unsanitized |
 | app/controllers/users_controller.rb:49:19:49:24 | call to params | semmle.label | call to params |

--- a/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
+++ b/ruby/ql/test/query-tests/security/cwe-312/CleartextLogging.expected
@@ -1,47 +1,47 @@
 edges
-| logging.rb:3:1:3:8 | password | logging.rb:6:20:6:27 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:8:21:8:28 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:10:21:10:28 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:12:21:12:28 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:14:23:14:30 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:16:20:16:27 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:19:33:19:40 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:21:44:21:51 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:23:33:23:40 | password | provenance |  |
-| logging.rb:3:1:3:8 | password | logging.rb:26:18:26:34 | "pw: #{...}" | provenance | AdditionalTaintStep |
-| logging.rb:3:1:3:8 | password | logging.rb:28:26:28:33 | password | provenance |  |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:3:1:3:8 | password | provenance |  |
-| logging.rb:30:1:30:4 | hsh1 [element :password] | logging.rb:38:20:38:23 | hsh1 [element :password] | provenance |  |
-| logging.rb:30:8:30:55 | call to [] [element :password] | logging.rb:30:1:30:4 | hsh1 [element :password] | provenance |  |
-| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | logging.rb:30:8:30:55 | call to [] [element :password] | provenance |  |
-| logging.rb:34:1:34:4 | [post] hsh2 [element :password] | logging.rb:35:1:35:4 | hsh3 [element :password] | provenance |  |
-| logging.rb:34:1:34:4 | [post] hsh2 [element :password] | logging.rb:40:20:40:23 | hsh2 [element :password] | provenance |  |
-| logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | logging.rb:34:1:34:4 | [post] hsh2 [element :password] | provenance |  |
-| logging.rb:35:1:35:4 | hsh3 [element :password] | logging.rb:42:20:42:23 | hsh3 [element :password] | provenance |  |
-| logging.rb:38:20:38:23 | hsh1 [element :password] | logging.rb:38:20:38:34 | ...[...] | provenance |  |
-| logging.rb:40:20:40:23 | hsh2 [element :password] | logging.rb:40:20:40:34 | ...[...] | provenance |  |
-| logging.rb:42:20:42:23 | hsh3 [element :password] | logging.rb:42:20:42:34 | ...[...] | provenance |  |
-| logging.rb:64:1:64:31 | password_masked_ineffective_sub | logging.rb:68:35:68:65 | password_masked_ineffective_sub | provenance |  |
-| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" | logging.rb:64:1:64:31 | password_masked_ineffective_sub | provenance |  |
-| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | provenance |  |
-| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" | logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex | provenance |  |
-| logging.rb:66:1:66:32 | password_masked_ineffective_gsub | logging.rb:70:36:70:67 | password_masked_ineffective_gsub | provenance |  |
-| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" | logging.rb:66:1:66:32 | password_masked_ineffective_gsub | provenance |  |
-| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | provenance |  |
-| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" | logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:6:20:6:27 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:8:21:8:28 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:10:21:10:28 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:12:21:12:28 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:14:23:14:30 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:16:20:16:27 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:19:33:19:40 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:21:44:21:51 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:23:33:23:40 | password | provenance |  |
+| logging.rb:3:1:3:8 | password : String | logging.rb:26:18:26:34 | "pw: #{...}" | provenance | AdditionalTaintStep |
+| logging.rb:3:1:3:8 | password : String | logging.rb:28:26:28:33 | password | provenance |  |
+| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:3:1:3:8 | password : String | provenance |  |
+| logging.rb:30:1:30:4 | hsh1 : Hash [element :password] : String | logging.rb:38:20:38:23 | hsh1 : Hash [element :password] : String | provenance |  |
+| logging.rb:30:8:30:55 | call to [] : Hash [element :password] : String | logging.rb:30:1:30:4 | hsh1 : Hash [element :password] : String | provenance |  |
+| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" : String | logging.rb:30:8:30:55 | call to [] : Hash [element :password] : String | provenance |  |
+| logging.rb:34:1:34:4 | [post] hsh2 : [collection] [element :password] : String | logging.rb:35:1:35:4 | hsh3 : [collection] [element :password] : String | provenance |  |
+| logging.rb:34:1:34:4 | [post] hsh2 : [collection] [element :password] : String | logging.rb:40:20:40:23 | hsh2 : [collection] [element :password] : String | provenance |  |
+| logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" : String | logging.rb:34:1:34:4 | [post] hsh2 : [collection] [element :password] : String | provenance |  |
+| logging.rb:35:1:35:4 | hsh3 : [collection] [element :password] : String | logging.rb:42:20:42:23 | hsh3 : [collection] [element :password] : String | provenance |  |
+| logging.rb:38:20:38:23 | hsh1 : Hash [element :password] : String | logging.rb:38:20:38:34 | ...[...] | provenance |  |
+| logging.rb:40:20:40:23 | hsh2 : [collection] [element :password] : String | logging.rb:40:20:40:34 | ...[...] | provenance |  |
+| logging.rb:42:20:42:23 | hsh3 : [collection] [element :password] : String | logging.rb:42:20:42:34 | ...[...] | provenance |  |
+| logging.rb:64:1:64:31 | password_masked_ineffective_sub : String | logging.rb:68:35:68:65 | password_masked_ineffective_sub : String | provenance |  |
+| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" : String | logging.rb:64:1:64:31 | password_masked_ineffective_sub : String | provenance |  |
+| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex : String | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | provenance |  |
+| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" : String | logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex : String | provenance |  |
+| logging.rb:66:1:66:32 | password_masked_ineffective_gsub : String | logging.rb:70:36:70:67 | password_masked_ineffective_gsub : String | provenance |  |
+| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" : String | logging.rb:66:1:66:32 | password_masked_ineffective_gsub : String | provenance |  |
+| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex : String | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | provenance |  |
+| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" : String | logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex : String | provenance |  |
 | logging.rb:68:1:68:31 | password_masked_ineffective_sub | logging.rb:74:20:74:50 | password_masked_ineffective_sub | provenance |  |
-| logging.rb:68:35:68:65 | password_masked_ineffective_sub | logging.rb:68:35:68:88 | call to sub | provenance |  |
+| logging.rb:68:35:68:65 | password_masked_ineffective_sub : String | logging.rb:68:35:68:88 | call to sub | provenance |  |
 | logging.rb:68:35:68:88 | call to sub | logging.rb:68:1:68:31 | password_masked_ineffective_sub | provenance |  |
 | logging.rb:70:1:70:32 | password_masked_ineffective_gsub | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | provenance |  |
-| logging.rb:70:36:70:67 | password_masked_ineffective_gsub | logging.rb:70:36:70:86 | call to gsub | provenance |  |
+| logging.rb:70:36:70:67 | password_masked_ineffective_gsub : String | logging.rb:70:36:70:86 | call to gsub | provenance |  |
 | logging.rb:70:36:70:86 | call to gsub | logging.rb:70:1:70:32 | password_masked_ineffective_gsub | provenance |  |
-| logging.rb:82:9:82:16 | password | logging.rb:84:15:84:22 | password | provenance |  |
-| logging.rb:87:1:87:12 | password_arg | logging.rb:88:5:88:16 | password_arg | provenance |  |
-| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" | logging.rb:87:1:87:12 | password_arg | provenance |  |
-| logging.rb:88:5:88:16 | password_arg | logging.rb:82:9:82:16 | password | provenance |  |
+| logging.rb:82:9:82:16 | password : String | logging.rb:84:15:84:22 | password | provenance |  |
+| logging.rb:87:1:87:12 | password_arg : String | logging.rb:88:5:88:16 | password_arg : String | provenance |  |
+| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" : String | logging.rb:87:1:87:12 | password_arg : String | provenance |  |
+| logging.rb:88:5:88:16 | password_arg : String | logging.rb:82:9:82:16 | password : String | provenance |  |
 nodes
-| logging.rb:3:1:3:8 | password | semmle.label | password |
-| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | semmle.label | "043697b96909e03ca907599d6420555f" |
+| logging.rb:3:1:3:8 | password : String | semmle.label | password : String |
+| logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | semmle.label | "043697b96909e03ca907599d6420555f" : String |
 | logging.rb:6:20:6:27 | password | semmle.label | password |
 | logging.rb:8:21:8:28 | password | semmle.label | password |
 | logging.rb:10:21:10:28 | password | semmle.label | password |
@@ -53,62 +53,62 @@ nodes
 | logging.rb:23:33:23:40 | password | semmle.label | password |
 | logging.rb:26:18:26:34 | "pw: #{...}" | semmle.label | "pw: #{...}" |
 | logging.rb:28:26:28:33 | password | semmle.label | password |
-| logging.rb:30:1:30:4 | hsh1 [element :password] | semmle.label | hsh1 [element :password] |
-| logging.rb:30:8:30:55 | call to [] [element :password] | semmle.label | call to [] [element :password] |
-| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | semmle.label | "aec5058e61f7f122998b1a30ee2c66b6" |
-| logging.rb:34:1:34:4 | [post] hsh2 [element :password] | semmle.label | [post] hsh2 [element :password] |
-| logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | semmle.label | "beeda625d7306b45784d91ea0336e201" |
-| logging.rb:35:1:35:4 | hsh3 [element :password] | semmle.label | hsh3 [element :password] |
-| logging.rb:38:20:38:23 | hsh1 [element :password] | semmle.label | hsh1 [element :password] |
+| logging.rb:30:1:30:4 | hsh1 : Hash [element :password] : String | semmle.label | hsh1 : Hash [element :password] : String |
+| logging.rb:30:8:30:55 | call to [] : Hash [element :password] : String | semmle.label | call to [] : Hash [element :password] : String |
+| logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" : String | semmle.label | "aec5058e61f7f122998b1a30ee2c66b6" : String |
+| logging.rb:34:1:34:4 | [post] hsh2 : [collection] [element :password] : String | semmle.label | [post] hsh2 : [collection] [element :password] : String |
+| logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" : String | semmle.label | "beeda625d7306b45784d91ea0336e201" : String |
+| logging.rb:35:1:35:4 | hsh3 : [collection] [element :password] : String | semmle.label | hsh3 : [collection] [element :password] : String |
+| logging.rb:38:20:38:23 | hsh1 : Hash [element :password] : String | semmle.label | hsh1 : Hash [element :password] : String |
 | logging.rb:38:20:38:34 | ...[...] | semmle.label | ...[...] |
-| logging.rb:40:20:40:23 | hsh2 [element :password] | semmle.label | hsh2 [element :password] |
+| logging.rb:40:20:40:23 | hsh2 : [collection] [element :password] : String | semmle.label | hsh2 : [collection] [element :password] : String |
 | logging.rb:40:20:40:34 | ...[...] | semmle.label | ...[...] |
-| logging.rb:42:20:42:23 | hsh3 [element :password] | semmle.label | hsh3 [element :password] |
+| logging.rb:42:20:42:23 | hsh3 : [collection] [element :password] : String | semmle.label | hsh3 : [collection] [element :password] : String |
 | logging.rb:42:20:42:34 | ...[...] | semmle.label | ...[...] |
-| logging.rb:64:1:64:31 | password_masked_ineffective_sub | semmle.label | password_masked_ineffective_sub |
-| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" |
-| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex | semmle.label | password_masked_ineffective_sub_ex |
-| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" |
-| logging.rb:66:1:66:32 | password_masked_ineffective_gsub | semmle.label | password_masked_ineffective_gsub |
-| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" | semmle.label | "a7e3747b19930d4f4b8181047194832f" |
-| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex | semmle.label | password_masked_ineffective_gsub_ex |
-| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" | semmle.label | "a7e3747b19930d4f4b8181047194832f" |
+| logging.rb:64:1:64:31 | password_masked_ineffective_sub : String | semmle.label | password_masked_ineffective_sub : String |
+| logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" : String | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" : String |
+| logging.rb:65:1:65:34 | password_masked_ineffective_sub_ex : String | semmle.label | password_masked_ineffective_sub_ex : String |
+| logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" : String | semmle.label | "ca497451f5e883662fb1a37bc9ec7838" : String |
+| logging.rb:66:1:66:32 | password_masked_ineffective_gsub : String | semmle.label | password_masked_ineffective_gsub : String |
+| logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" : String | semmle.label | "a7e3747b19930d4f4b8181047194832f" : String |
+| logging.rb:67:1:67:35 | password_masked_ineffective_gsub_ex : String | semmle.label | password_masked_ineffective_gsub_ex : String |
+| logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" : String | semmle.label | "a7e3747b19930d4f4b8181047194832f" : String |
 | logging.rb:68:1:68:31 | password_masked_ineffective_sub | semmle.label | password_masked_ineffective_sub |
-| logging.rb:68:35:68:65 | password_masked_ineffective_sub | semmle.label | password_masked_ineffective_sub |
+| logging.rb:68:35:68:65 | password_masked_ineffective_sub : String | semmle.label | password_masked_ineffective_sub : String |
 | logging.rb:68:35:68:88 | call to sub | semmle.label | call to sub |
 | logging.rb:70:1:70:32 | password_masked_ineffective_gsub | semmle.label | password_masked_ineffective_gsub |
-| logging.rb:70:36:70:67 | password_masked_ineffective_gsub | semmle.label | password_masked_ineffective_gsub |
+| logging.rb:70:36:70:67 | password_masked_ineffective_gsub : String | semmle.label | password_masked_ineffective_gsub : String |
 | logging.rb:70:36:70:86 | call to gsub | semmle.label | call to gsub |
 | logging.rb:74:20:74:50 | password_masked_ineffective_sub | semmle.label | password_masked_ineffective_sub |
 | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | semmle.label | password_masked_ineffective_gsub |
 | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | semmle.label | password_masked_ineffective_sub_ex |
 | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | semmle.label | password_masked_ineffective_gsub_ex |
-| logging.rb:82:9:82:16 | password | semmle.label | password |
+| logging.rb:82:9:82:16 | password : String | semmle.label | password : String |
 | logging.rb:84:15:84:22 | password | semmle.label | password |
-| logging.rb:87:1:87:12 | password_arg | semmle.label | password_arg |
-| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" | semmle.label | "65f2950df2f0e2c38d7ba2ccca767291" |
-| logging.rb:88:5:88:16 | password_arg | semmle.label | password_arg |
+| logging.rb:87:1:87:12 | password_arg : String | semmle.label | password_arg : String |
+| logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" : String | semmle.label | "65f2950df2f0e2c38d7ba2ccca767291" : String |
+| logging.rb:88:5:88:16 | password_arg : String | semmle.label | password_arg : String |
 subpaths
 #select
-| logging.rb:6:20:6:27 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:6:20:6:27 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:8:21:8:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:8:21:8:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:10:21:10:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:10:21:10:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:12:21:12:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:12:21:12:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:14:23:14:30 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:14:23:14:30 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:16:20:16:27 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:16:20:16:27 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:19:33:19:40 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:19:33:19:40 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:21:44:21:51 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:21:44:21:51 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:23:33:23:40 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:23:33:23:40 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:26:18:26:34 | "pw: #{...}" | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:26:18:26:34 | "pw: #{...}" | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:28:26:28:33 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | logging.rb:28:26:28:33 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
-| logging.rb:38:20:38:34 | ...[...] | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | logging.rb:38:20:38:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | a write to password |
-| logging.rb:40:20:40:34 | ...[...] | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | logging.rb:40:20:40:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | a write to password |
-| logging.rb:42:20:42:34 | ...[...] | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | logging.rb:42:20:42:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | a write to password |
-| logging.rb:74:20:74:50 | password_masked_ineffective_sub | logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" | logging.rb:74:20:74:50 | password_masked_ineffective_sub | This logs sensitive data returned by $@ as clear text. | logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" | an assignment to password_masked_ineffective_sub |
+| logging.rb:6:20:6:27 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:6:20:6:27 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:8:21:8:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:8:21:8:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:10:21:10:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:10:21:10:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:12:21:12:28 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:12:21:12:28 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:14:23:14:30 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:14:23:14:30 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:16:20:16:27 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:16:20:16:27 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:19:33:19:40 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:19:33:19:40 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:21:44:21:51 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:21:44:21:51 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:23:33:23:40 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:23:33:23:40 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:26:18:26:34 | "pw: #{...}" | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:26:18:26:34 | "pw: #{...}" | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:28:26:28:33 | password | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" : String | logging.rb:28:26:28:33 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:3:12:3:45 | "043697b96909e03ca907599d6420555f" | an assignment to password |
+| logging.rb:38:20:38:34 | ...[...] | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" : String | logging.rb:38:20:38:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:30:20:30:53 | "aec5058e61f7f122998b1a30ee2c66b6" | a write to password |
+| logging.rb:40:20:40:34 | ...[...] | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" : String | logging.rb:40:20:40:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | a write to password |
+| logging.rb:42:20:42:34 | ...[...] | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" : String | logging.rb:42:20:42:34 | ...[...] | This logs sensitive data returned by $@ as clear text. | logging.rb:34:19:34:52 | "beeda625d7306b45784d91ea0336e201" | a write to password |
+| logging.rb:74:20:74:50 | password_masked_ineffective_sub | logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" : String | logging.rb:74:20:74:50 | password_masked_ineffective_sub | This logs sensitive data returned by $@ as clear text. | logging.rb:64:35:64:68 | "ca497451f5e883662fb1a37bc9ec7838" | an assignment to password_masked_ineffective_sub |
 | logging.rb:74:20:74:50 | password_masked_ineffective_sub | logging.rb:68:35:68:88 | call to sub | logging.rb:74:20:74:50 | password_masked_ineffective_sub | This logs sensitive data returned by $@ as clear text. | logging.rb:68:35:68:88 | call to sub | an assignment to password_masked_ineffective_sub |
-| logging.rb:76:20:76:51 | password_masked_ineffective_gsub | logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | This logs sensitive data returned by $@ as clear text. | logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" | an assignment to password_masked_ineffective_gsub |
+| logging.rb:76:20:76:51 | password_masked_ineffective_gsub | logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" : String | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | This logs sensitive data returned by $@ as clear text. | logging.rb:66:36:66:69 | "a7e3747b19930d4f4b8181047194832f" | an assignment to password_masked_ineffective_gsub |
 | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | logging.rb:70:36:70:86 | call to gsub | logging.rb:76:20:76:51 | password_masked_ineffective_gsub | This logs sensitive data returned by $@ as clear text. | logging.rb:70:36:70:86 | call to gsub | an assignment to password_masked_ineffective_gsub |
-| logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | This logs sensitive data returned by $@ as clear text. | logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" | an assignment to password_masked_ineffective_sub_ex |
-| logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | This logs sensitive data returned by $@ as clear text. | logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" | an assignment to password_masked_ineffective_gsub_ex |
+| logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" : String | logging.rb:78:20:78:53 | password_masked_ineffective_sub_ex | This logs sensitive data returned by $@ as clear text. | logging.rb:65:38:65:71 | "ca497451f5e883662fb1a37bc9ec7838" | an assignment to password_masked_ineffective_sub_ex |
+| logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" : String | logging.rb:80:20:80:54 | password_masked_ineffective_gsub_ex | This logs sensitive data returned by $@ as clear text. | logging.rb:67:39:67:72 | "a7e3747b19930d4f4b8181047194832f" | an assignment to password_masked_ineffective_gsub_ex |
 | logging.rb:84:15:84:22 | password | logging.rb:84:15:84:22 | password | logging.rb:84:15:84:22 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:84:15:84:22 | password | a parameter password |
-| logging.rb:84:15:84:22 | password | logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" | logging.rb:84:15:84:22 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" | an assignment to password_arg |
+| logging.rb:84:15:84:22 | password | logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" : String | logging.rb:84:15:84:22 | password | This logs sensitive data returned by $@ as clear text. | logging.rb:87:16:87:49 | "65f2950df2f0e2c38d7ba2ccca767291" | an assignment to password_arg |

--- a/ruby/ql/test/query-tests/security/cwe-312/CleartextStorage.expected
+++ b/ruby/ql/test/query-tests/security/cwe-312/CleartextStorage.expected
@@ -1,147 +1,151 @@
 edges
-| app/controllers/users_controller.rb:3:5:3:16 | new_password | app/controllers/users_controller.rb:5:39:5:50 | new_password | provenance |  |
-| app/controllers/users_controller.rb:3:5:3:16 | new_password | app/controllers/users_controller.rb:7:41:7:52 | new_password | provenance |  |
-| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | app/controllers/users_controller.rb:3:5:3:16 | new_password | provenance |  |
-| app/controllers/users_controller.rb:11:5:11:16 | new_password | app/controllers/users_controller.rb:13:42:13:53 | new_password | provenance |  |
-| app/controllers/users_controller.rb:11:5:11:16 | new_password | app/controllers/users_controller.rb:15:49:15:60 | new_password | provenance |  |
-| app/controllers/users_controller.rb:11:5:11:16 | new_password | app/controllers/users_controller.rb:15:49:15:60 | new_password | provenance |  |
-| app/controllers/users_controller.rb:11:5:11:16 | new_password | app/controllers/users_controller.rb:15:87:15:98 | new_password | provenance |  |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | app/controllers/users_controller.rb:11:5:11:16 | new_password | provenance |  |
+| app/controllers/users_controller.rb:3:5:3:16 | new_password : String | app/controllers/users_controller.rb:5:39:5:50 | new_password | provenance |  |
+| app/controllers/users_controller.rb:3:5:3:16 | new_password : String | app/controllers/users_controller.rb:7:41:7:52 | new_password | provenance |  |
+| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" : String | app/controllers/users_controller.rb:3:5:3:16 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password : String | app/controllers/users_controller.rb:13:42:13:53 | new_password | provenance |  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password : String | app/controllers/users_controller.rb:15:49:15:60 | new_password | provenance |  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password : String | app/controllers/users_controller.rb:15:49:15:60 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password : String | app/controllers/users_controller.rb:15:87:15:98 | new_password | provenance |  |
+| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String | app/controllers/users_controller.rb:11:5:11:16 | new_password : String | provenance |  |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:15:87:15:98 | new_password | provenance |  |
-| app/controllers/users_controller.rb:19:5:19:16 | new_password | app/controllers/users_controller.rb:21:45:21:56 | new_password | provenance |  |
-| app/controllers/users_controller.rb:19:5:19:16 | new_password | app/controllers/users_controller.rb:21:45:21:56 | new_password | provenance |  |
-| app/controllers/users_controller.rb:19:5:19:16 | new_password | app/controllers/users_controller.rb:21:83:21:94 | new_password | provenance |  |
-| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | app/controllers/users_controller.rb:19:5:19:16 | new_password | provenance |  |
+| app/controllers/users_controller.rb:15:49:15:60 | new_password : String | app/controllers/users_controller.rb:15:87:15:98 | new_password | provenance |  |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password : String | app/controllers/users_controller.rb:21:45:21:56 | new_password | provenance |  |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password : String | app/controllers/users_controller.rb:21:45:21:56 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password : String | app/controllers/users_controller.rb:21:83:21:94 | new_password | provenance |  |
+| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" : String | app/controllers/users_controller.rb:19:5:19:16 | new_password : String | provenance |  |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:21:83:21:94 | new_password | provenance |  |
-| app/controllers/users_controller.rb:26:5:26:16 | new_password | app/controllers/users_controller.rb:28:27:28:38 | new_password | provenance |  |
-| app/controllers/users_controller.rb:26:5:26:16 | new_password | app/controllers/users_controller.rb:30:28:30:39 | new_password | provenance |  |
-| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | app/controllers/users_controller.rb:26:5:26:16 | new_password | provenance |  |
-| app/controllers/users_controller.rb:35:5:35:16 | new_password | app/controllers/users_controller.rb:37:39:37:50 | new_password | provenance |  |
-| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" | app/controllers/users_controller.rb:35:5:35:16 | new_password | provenance |  |
-| app/controllers/users_controller.rb:42:5:42:16 | new_password | app/controllers/users_controller.rb:44:21:44:32 | new_password | provenance |  |
-| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" | app/controllers/users_controller.rb:42:5:42:16 | new_password | provenance |  |
-| app/controllers/users_controller.rb:58:5:58:16 | new_password | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | provenance | AdditionalTaintStep |
-| app/controllers/users_controller.rb:58:5:58:16 | new_password | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | provenance | AdditionalTaintStep |
-| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | app/controllers/users_controller.rb:58:5:58:16 | new_password | provenance |  |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :SSN] | app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :SSN] | provenance |  |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :credit_card_number] | app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :credit_card_number] | provenance |  |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :password] | app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :password] | provenance |  |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 1, element :password] | app/controllers/users_controller.rb:85:5:85:8 | info [element 1, element :password] | provenance |  |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :SSN] | app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :SSN] | provenance |  |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :credit_card_number] | app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :credit_card_number] | provenance |  |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :password] | app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :password] | provenance |  |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 1, element :password] | app/controllers/users_controller.rb:76:5:76:8 | info [element 1, element :password] | provenance |  |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :SSN] | app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :SSN] | provenance |  |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :credit_card_number] | app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :credit_card_number] | provenance |  |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :password] | app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :password] | provenance |  |
-| app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" | app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :password] | provenance |  |
-| app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" | app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :credit_card_number] | provenance |  |
-| app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" | app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :SSN] | provenance |  |
-| app/controllers/users_controller.rb:83:7:83:39 | call to [] [element :password] | app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 1, element :password] | provenance |  |
-| app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" | app/controllers/users_controller.rb:83:7:83:39 | call to [] [element :password] | provenance |  |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :SSN] | app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] | provenance |  |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :credit_card_number] | app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] | provenance |  |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :password] | app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] | provenance |  |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 1, element :password] | app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] | provenance |  |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
-| app/models/user.rb:3:5:3:16 | new_password | app/models/user.rb:5:27:5:38 | new_password | provenance |  |
-| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" | app/models/user.rb:3:5:3:16 | new_password | provenance |  |
-| app/models/user.rb:9:5:9:16 | new_password | app/models/user.rb:11:22:11:33 | new_password | provenance |  |
-| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" | app/models/user.rb:9:5:9:16 | new_password | provenance |  |
-| app/models/user.rb:15:5:15:16 | new_password | app/models/user.rb:17:21:17:32 | new_password | provenance |  |
-| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" | app/models/user.rb:15:5:15:16 | new_password | provenance |  |
+| app/controllers/users_controller.rb:21:45:21:56 | new_password : String | app/controllers/users_controller.rb:21:83:21:94 | new_password | provenance |  |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password : String | app/controllers/users_controller.rb:28:27:28:38 | new_password | provenance |  |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password : String | app/controllers/users_controller.rb:30:28:30:39 | new_password | provenance |  |
+| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" : String | app/controllers/users_controller.rb:26:5:26:16 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:35:5:35:16 | new_password : String | app/controllers/users_controller.rb:37:39:37:50 | new_password | provenance |  |
+| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" : String | app/controllers/users_controller.rb:35:5:35:16 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:42:5:42:16 | new_password : String | app/controllers/users_controller.rb:44:21:44:32 | new_password | provenance |  |
+| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" : String | app/controllers/users_controller.rb:42:5:42:16 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password : String | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | provenance | AdditionalTaintStep |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password : String | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | provenance | AdditionalTaintStep |
+| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" : String | app/controllers/users_controller.rb:58:5:58:16 | new_password : String | provenance |  |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :SSN] : String | app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :SSN] : String | provenance |  |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :credit_card_number] : String | app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :credit_card_number] : String | provenance |  |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :password] : String | app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 1, element :password] : String | app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 1, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :SSN] : String | app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :SSN] : String | provenance |  |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :credit_card_number] : String | app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :credit_card_number] : String | provenance |  |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :password] : String | app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 1, element :password] : String | app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 1, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :SSN] : String | app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :SSN] : String | provenance |  |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :credit_card_number] : String | app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :credit_card_number] : String | provenance |  |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :password] : String | app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" : String | app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" : String | app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :credit_card_number] : String | provenance |  |
+| app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" : String | app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :SSN] : String | provenance |  |
+| app/controllers/users_controller.rb:83:7:83:39 | call to [] : Hash [element :password] : String | app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 1, element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" : String | app/controllers/users_controller.rb:83:7:83:39 | call to [] : Hash [element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :SSN] : String | app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] : String | provenance |  |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :credit_card_number] : String | app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] : String | provenance |  |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :password] : String | app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 1, element :password] : String | app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] : String | provenance |  |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] : String | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] : String | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] : String | app/controllers/users_controller.rb:87:20:87:22 | inf | provenance |  |
+| app/models/user.rb:3:5:3:16 | new_password : String | app/models/user.rb:5:27:5:38 | new_password | provenance |  |
+| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" : String | app/models/user.rb:3:5:3:16 | new_password : String | provenance |  |
+| app/models/user.rb:9:5:9:16 | new_password : String | app/models/user.rb:11:22:11:33 | new_password | provenance |  |
+| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" : String | app/models/user.rb:9:5:9:16 | new_password : String | provenance |  |
+| app/models/user.rb:15:5:15:16 | new_password : String | app/models/user.rb:17:21:17:32 | new_password | provenance |  |
+| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" : String | app/models/user.rb:15:5:15:16 | new_password : String | provenance |  |
 nodes
-| app/controllers/users_controller.rb:3:5:3:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | semmle.label | "043697b96909e03ca907599d6420555f" |
+| app/controllers/users_controller.rb:3:5:3:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" : String | semmle.label | "043697b96909e03ca907599d6420555f" : String |
 | app/controllers/users_controller.rb:5:39:5:50 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:7:41:7:52 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:11:5:11:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | semmle.label | "083c9e1da4cc0c2f5480bb4dbe6ff141" |
+| app/controllers/users_controller.rb:11:5:11:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String | semmle.label | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String |
 | app/controllers/users_controller.rb:13:42:13:53 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:15:49:15:60 | new_password : String | semmle.label | new_password : String |
 | app/controllers/users_controller.rb:15:87:15:98 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:19:5:19:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | semmle.label | "504d224a806cf8073cd14ef08242d422" |
+| app/controllers/users_controller.rb:19:5:19:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" : String | semmle.label | "504d224a806cf8073cd14ef08242d422" : String |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password | semmle.label | new_password |
+| app/controllers/users_controller.rb:21:45:21:56 | new_password : String | semmle.label | new_password : String |
 | app/controllers/users_controller.rb:21:83:21:94 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:26:5:26:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | semmle.label | "7d6ae08394c3f284506dca70f05995f6" |
+| app/controllers/users_controller.rb:26:5:26:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" : String | semmle.label | "7d6ae08394c3f284506dca70f05995f6" : String |
 | app/controllers/users_controller.rb:28:27:28:38 | new_password | semmle.label | new_password |
 | app/controllers/users_controller.rb:30:28:30:39 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:35:5:35:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" | semmle.label | "ff295f8648a406c37fbe378377320e4c" |
+| app/controllers/users_controller.rb:35:5:35:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" : String | semmle.label | "ff295f8648a406c37fbe378377320e4c" : String |
 | app/controllers/users_controller.rb:37:39:37:50 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:42:5:42:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" | semmle.label | "78ffbec583b546bd073efd898f833184" |
+| app/controllers/users_controller.rb:42:5:42:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" : String | semmle.label | "78ffbec583b546bd073efd898f833184" : String |
 | app/controllers/users_controller.rb:44:21:44:32 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:58:5:58:16 | new_password | semmle.label | new_password |
-| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | semmle.label | "0157af7c38cbdd24f1616de4e5321861" |
+| app/controllers/users_controller.rb:58:5:58:16 | new_password : String | semmle.label | new_password : String |
+| app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" : String | semmle.label | "0157af7c38cbdd24f1616de4e5321861" : String |
 | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | semmle.label | "password: #{...}\\n" |
 | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | semmle.label | "password: #{...}" |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :SSN] | semmle.label | info [element 0, element :SSN] |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :credit_card_number] | semmle.label | info [element 0, element :credit_card_number] |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 0, element :password] | semmle.label | info [element 0, element :password] |
-| app/controllers/users_controller.rb:76:5:76:8 | info [element 1, element :password] | semmle.label | info [element 1, element :password] |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :SSN] | semmle.label | call to [] [element 0, element :SSN] |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :credit_card_number] | semmle.label | call to [] [element 0, element :credit_card_number] |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 0, element :password] | semmle.label | call to [] [element 0, element :password] |
-| app/controllers/users_controller.rb:76:12:84:5 | call to [] [element 1, element :password] | semmle.label | call to [] [element 1, element :password] |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :SSN] | semmle.label | call to [] [element :SSN] |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :credit_card_number] | semmle.label | call to [] [element :credit_card_number] |
-| app/controllers/users_controller.rb:77:7:82:7 | call to [] [element :password] | semmle.label | call to [] [element :password] |
-| app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" | semmle.label | "aaaaaaaaaa" |
-| app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" | semmle.label | "0000-0000-0000-0000" |
-| app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" | semmle.label | "000-00-00000" |
-| app/controllers/users_controller.rb:83:7:83:39 | call to [] [element :password] | semmle.label | call to [] [element :password] |
-| app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" | semmle.label | "bbbbbbb" |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :SSN] | semmle.label | info [element 0, element :SSN] |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :credit_card_number] | semmle.label | info [element 0, element :credit_card_number] |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 0, element :password] | semmle.label | info [element 0, element :password] |
-| app/controllers/users_controller.rb:85:5:85:8 | info [element 1, element :password] | semmle.label | info [element 1, element :password] |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] | semmle.label | inf [element :SSN] |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] | semmle.label | inf [element :credit_card_number] |
-| app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] | semmle.label | inf [element :password] |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :SSN] : String | semmle.label | info : Array [element 0, element :SSN] : String |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :credit_card_number] : String | semmle.label | info : Array [element 0, element :credit_card_number] : String |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 0, element :password] : String | semmle.label | info : Array [element 0, element :password] : String |
+| app/controllers/users_controller.rb:76:5:76:8 | info : Array [element 1, element :password] : String | semmle.label | info : Array [element 1, element :password] : String |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :SSN] : String | semmle.label | call to [] : Array [element 0, element :SSN] : String |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :credit_card_number] : String | semmle.label | call to [] : Array [element 0, element :credit_card_number] : String |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 0, element :password] : String | semmle.label | call to [] : Array [element 0, element :password] : String |
+| app/controllers/users_controller.rb:76:12:84:5 | call to [] : Array [element 1, element :password] : String | semmle.label | call to [] : Array [element 1, element :password] : String |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :SSN] : String | semmle.label | call to [] : Hash [element :SSN] : String |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :credit_card_number] : String | semmle.label | call to [] : Hash [element :credit_card_number] : String |
+| app/controllers/users_controller.rb:77:7:82:7 | call to [] : Hash [element :password] : String | semmle.label | call to [] : Hash [element :password] : String |
+| app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" : String | semmle.label | "aaaaaaaaaa" : String |
+| app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" : String | semmle.label | "0000-0000-0000-0000" : String |
+| app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" : String | semmle.label | "000-00-00000" : String |
+| app/controllers/users_controller.rb:83:7:83:39 | call to [] : Hash [element :password] : String | semmle.label | call to [] : Hash [element :password] : String |
+| app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" : String | semmle.label | "bbbbbbb" : String |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :SSN] : String | semmle.label | info : Array [element 0, element :SSN] : String |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :credit_card_number] : String | semmle.label | info : Array [element 0, element :credit_card_number] : String |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 0, element :password] : String | semmle.label | info : Array [element 0, element :password] : String |
+| app/controllers/users_controller.rb:85:5:85:8 | info : Array [element 1, element :password] : String | semmle.label | info : Array [element 1, element :password] : String |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :SSN] : String | semmle.label | inf [element :SSN] : String |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :credit_card_number] : String | semmle.label | inf [element :credit_card_number] : String |
+| app/controllers/users_controller.rb:85:19:85:21 | inf [element :password] : String | semmle.label | inf [element :password] : String |
 | app/controllers/users_controller.rb:87:20:87:22 | inf | semmle.label | inf |
-| app/models/user.rb:3:5:3:16 | new_password | semmle.label | new_password |
-| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" | semmle.label | "06c38c6a8a9c11a9d3b209a3193047b4" |
+| app/models/user.rb:3:5:3:16 | new_password : String | semmle.label | new_password : String |
+| app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" : String | semmle.label | "06c38c6a8a9c11a9d3b209a3193047b4" : String |
 | app/models/user.rb:5:27:5:38 | new_password | semmle.label | new_password |
-| app/models/user.rb:9:5:9:16 | new_password | semmle.label | new_password |
-| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" | semmle.label | "52652fb5c709fb6b9b5a0194af7c6067" |
+| app/models/user.rb:9:5:9:16 | new_password : String | semmle.label | new_password : String |
+| app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" : String | semmle.label | "52652fb5c709fb6b9b5a0194af7c6067" : String |
 | app/models/user.rb:11:22:11:33 | new_password | semmle.label | new_password |
-| app/models/user.rb:15:5:15:16 | new_password | semmle.label | new_password |
-| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" | semmle.label | "f982bf2531c149a8a1444a951b12e830" |
+| app/models/user.rb:15:5:15:16 | new_password : String | semmle.label | new_password : String |
+| app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" : String | semmle.label | "f982bf2531c149a8a1444a951b12e830" : String |
 | app/models/user.rb:17:21:17:32 | new_password | semmle.label | new_password |
 subpaths
 #select
-| app/controllers/users_controller.rb:5:39:5:50 | new_password | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | app/controllers/users_controller.rb:5:39:5:50 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | an assignment to new_password |
-| app/controllers/users_controller.rb:7:41:7:52 | new_password | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | app/controllers/users_controller.rb:7:41:7:52 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | an assignment to new_password |
+| app/controllers/users_controller.rb:5:39:5:50 | new_password | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" : String | app/controllers/users_controller.rb:5:39:5:50 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | an assignment to new_password |
+| app/controllers/users_controller.rb:7:41:7:52 | new_password | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" : String | app/controllers/users_controller.rb:7:41:7:52 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:3:20:3:53 | "043697b96909e03ca907599d6420555f" | an assignment to new_password |
 | app/controllers/users_controller.rb:7:41:7:52 | new_password | app/controllers/users_controller.rb:7:41:7:52 | new_password | app/controllers/users_controller.rb:7:41:7:52 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:7:41:7:52 | new_password | a write to password |
-| app/controllers/users_controller.rb:13:42:13:53 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | app/controllers/users_controller.rb:13:42:13:53 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
-| app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | app/controllers/users_controller.rb:15:49:15:60 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
+| app/controllers/users_controller.rb:13:42:13:53 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String | app/controllers/users_controller.rb:13:42:13:53 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
+| app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String | app/controllers/users_controller.rb:15:49:15:60 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
 | app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:15:49:15:60 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:15:49:15:60 | new_password | a write to password |
-| app/controllers/users_controller.rb:15:87:15:98 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | app/controllers/users_controller.rb:15:87:15:98 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
+| app/controllers/users_controller.rb:15:87:15:98 | new_password | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" : String | app/controllers/users_controller.rb:15:87:15:98 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:11:20:11:53 | "083c9e1da4cc0c2f5480bb4dbe6ff141" | an assignment to new_password |
 | app/controllers/users_controller.rb:15:87:15:98 | new_password | app/controllers/users_controller.rb:15:49:15:60 | new_password | app/controllers/users_controller.rb:15:87:15:98 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:15:49:15:60 | new_password | a write to password |
 | app/controllers/users_controller.rb:15:87:15:98 | new_password | app/controllers/users_controller.rb:15:87:15:98 | new_password | app/controllers/users_controller.rb:15:87:15:98 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:15:87:15:98 | new_password | a write to password |
-| app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | app/controllers/users_controller.rb:21:45:21:56 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | an assignment to new_password |
+| app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" : String | app/controllers/users_controller.rb:21:45:21:56 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | an assignment to new_password |
 | app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:21:45:21:56 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:21:45:21:56 | new_password | a write to password |
-| app/controllers/users_controller.rb:21:83:21:94 | new_password | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | app/controllers/users_controller.rb:21:83:21:94 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | an assignment to new_password |
+| app/controllers/users_controller.rb:21:83:21:94 | new_password | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" : String | app/controllers/users_controller.rb:21:83:21:94 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:19:20:19:53 | "504d224a806cf8073cd14ef08242d422" | an assignment to new_password |
 | app/controllers/users_controller.rb:21:83:21:94 | new_password | app/controllers/users_controller.rb:21:45:21:56 | new_password | app/controllers/users_controller.rb:21:83:21:94 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:21:45:21:56 | new_password | a write to password |
 | app/controllers/users_controller.rb:21:83:21:94 | new_password | app/controllers/users_controller.rb:21:83:21:94 | new_password | app/controllers/users_controller.rb:21:83:21:94 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:21:83:21:94 | new_password | a write to password |
-| app/controllers/users_controller.rb:28:27:28:38 | new_password | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | app/controllers/users_controller.rb:28:27:28:38 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | an assignment to new_password |
-| app/controllers/users_controller.rb:30:28:30:39 | new_password | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | app/controllers/users_controller.rb:30:28:30:39 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | an assignment to new_password |
+| app/controllers/users_controller.rb:28:27:28:38 | new_password | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" : String | app/controllers/users_controller.rb:28:27:28:38 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | an assignment to new_password |
+| app/controllers/users_controller.rb:30:28:30:39 | new_password | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" : String | app/controllers/users_controller.rb:30:28:30:39 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:26:20:26:53 | "7d6ae08394c3f284506dca70f05995f6" | an assignment to new_password |
 | app/controllers/users_controller.rb:30:28:30:39 | new_password | app/controllers/users_controller.rb:30:28:30:39 | new_password | app/controllers/users_controller.rb:30:28:30:39 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:30:28:30:39 | new_password | a write to password |
-| app/controllers/users_controller.rb:37:39:37:50 | new_password | app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" | app/controllers/users_controller.rb:37:39:37:50 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" | an assignment to new_password |
-| app/controllers/users_controller.rb:44:21:44:32 | new_password | app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" | app/controllers/users_controller.rb:44:21:44:32 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" | an assignment to new_password |
-| app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | an assignment to new_password |
-| app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | an assignment to new_password |
-| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" | a write to password |
-| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" | a write to credit_card_number |
-| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" | a write to SSN |
-| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" | a write to password |
-| app/models/user.rb:5:27:5:38 | new_password | app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" | app/models/user.rb:5:27:5:38 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" | an assignment to new_password |
-| app/models/user.rb:11:22:11:33 | new_password | app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" | app/models/user.rb:11:22:11:33 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" | an assignment to new_password |
-| app/models/user.rb:17:21:17:32 | new_password | app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" | app/models/user.rb:17:21:17:32 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" | an assignment to new_password |
+| app/controllers/users_controller.rb:37:39:37:50 | new_password | app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" : String | app/controllers/users_controller.rb:37:39:37:50 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:35:20:35:53 | "ff295f8648a406c37fbe378377320e4c" | an assignment to new_password |
+| app/controllers/users_controller.rb:44:21:44:32 | new_password | app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" : String | app/controllers/users_controller.rb:44:21:44:32 | new_password | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:42:20:42:53 | "78ffbec583b546bd073efd898f833184" | an assignment to new_password |
+| app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" : String | app/controllers/users_controller.rb:61:25:61:53 | "password: #{...}\\n" | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | an assignment to new_password |
+| app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" : String | app/controllers/users_controller.rb:64:35:64:61 | "password: #{...}" | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:58:20:58:53 | "0157af7c38cbdd24f1616de4e5321861" | an assignment to new_password |
+| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" : String | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:79:19:79:30 | "aaaaaaaaaa" | a write to password |
+| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" : String | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:80:29:80:49 | "0000-0000-0000-0000" | a write to credit_card_number |
+| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" : String | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:81:14:81:27 | "000-00-00000" | a write to SSN |
+| app/controllers/users_controller.rb:87:20:87:22 | inf | app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" : String | app/controllers/users_controller.rb:87:20:87:22 | inf | This stores sensitive data returned by $@ as clear text. | app/controllers/users_controller.rb:83:30:83:38 | "bbbbbbb" | a write to password |
+| app/models/user.rb:5:27:5:38 | new_password | app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" : String | app/models/user.rb:5:27:5:38 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:3:20:3:53 | "06c38c6a8a9c11a9d3b209a3193047b4" | an assignment to new_password |
+| app/models/user.rb:11:22:11:33 | new_password | app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" : String | app/models/user.rb:11:22:11:33 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:9:20:9:53 | "52652fb5c709fb6b9b5a0194af7c6067" | an assignment to new_password |
+| app/models/user.rb:17:21:17:32 | new_password | app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" : String | app/models/user.rb:17:21:17:32 | new_password | This stores sensitive data returned by $@ as clear text. | app/models/user.rb:15:20:15:53 | "f982bf2531c149a8a1444a951b12e830" | an assignment to new_password |

--- a/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
+++ b/ruby/ql/test/query-tests/security/cwe-506/HardcodedDataInterpretedAsCode.expected
@@ -1,35 +1,35 @@
 edges
-| tst.rb:1:7:1:7 | r | tst.rb:2:4:2:4 | r | provenance |  |
-| tst.rb:2:3:2:5 | call to [] [element 0] | tst.rb:2:3:2:15 | call to pack | provenance | Config |
-| tst.rb:2:4:2:4 | r | tst.rb:2:3:2:5 | call to [] [element 0] | provenance |  |
-| tst.rb:5:1:5:23 | totally_harmless_string | tst.rb:7:8:7:30 | totally_harmless_string | provenance |  |
-| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | tst.rb:5:1:5:23 | totally_harmless_string | provenance |  |
-| tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:1:7:1:7 | r | provenance |  |
-| tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:7:6:7:31 | call to e | provenance | Config |
-| tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:1:7:1:7 | r | provenance |  |
-| tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:10:9:10:25 | call to e | provenance | Config |
-| tst.rb:16:1:16:27 | another_questionable_string | tst.rb:17:6:17:32 | another_questionable_string | provenance |  |
-| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | tst.rb:16:1:16:27 | another_questionable_string | provenance |  |
-| tst.rb:17:6:17:32 | another_questionable_string | tst.rb:17:6:17:38 | call to strip | provenance | Config |
+| tst.rb:1:7:1:7 | r : String | tst.rb:2:4:2:4 | r : String | provenance |  |
+| tst.rb:2:3:2:5 | call to [] : Array [element 0] : String | tst.rb:2:3:2:15 | call to pack | provenance | Config |
+| tst.rb:2:4:2:4 | r : String | tst.rb:2:3:2:5 | call to [] : Array [element 0] : String | provenance |  |
+| tst.rb:5:1:5:23 | totally_harmless_string : String | tst.rb:7:8:7:30 | totally_harmless_string : String | provenance |  |
+| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." : String | tst.rb:5:1:5:23 | totally_harmless_string : String | provenance |  |
+| tst.rb:7:8:7:30 | totally_harmless_string : String | tst.rb:1:7:1:7 | r : String | provenance |  |
+| tst.rb:7:8:7:30 | totally_harmless_string : String | tst.rb:7:6:7:31 | call to e | provenance | Config |
+| tst.rb:10:11:10:24 | "666f6f626172" : String | tst.rb:1:7:1:7 | r : String | provenance |  |
+| tst.rb:10:11:10:24 | "666f6f626172" : String | tst.rb:10:9:10:25 | call to e | provenance | Config |
+| tst.rb:16:1:16:27 | another_questionable_string : String | tst.rb:17:6:17:32 | another_questionable_string : String | provenance |  |
+| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." : String | tst.rb:16:1:16:27 | another_questionable_string : String | provenance |  |
+| tst.rb:17:6:17:32 | another_questionable_string : String | tst.rb:17:6:17:38 | call to strip | provenance | Config |
 nodes
-| tst.rb:1:7:1:7 | r | semmle.label | r |
-| tst.rb:2:3:2:5 | call to [] [element 0] | semmle.label | call to [] [element 0] |
+| tst.rb:1:7:1:7 | r : String | semmle.label | r : String |
+| tst.rb:2:3:2:5 | call to [] : Array [element 0] : String | semmle.label | call to [] : Array [element 0] : String |
 | tst.rb:2:3:2:15 | call to pack | semmle.label | call to pack |
-| tst.rb:2:4:2:4 | r | semmle.label | r |
-| tst.rb:5:1:5:23 | totally_harmless_string | semmle.label | totally_harmless_string |
-| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | semmle.label | "707574732822636f646520696e6a6..." |
+| tst.rb:2:4:2:4 | r : String | semmle.label | r : String |
+| tst.rb:5:1:5:23 | totally_harmless_string : String | semmle.label | totally_harmless_string : String |
+| tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." : String | semmle.label | "707574732822636f646520696e6a6..." : String |
 | tst.rb:7:6:7:31 | call to e | semmle.label | call to e |
-| tst.rb:7:8:7:30 | totally_harmless_string | semmle.label | totally_harmless_string |
+| tst.rb:7:8:7:30 | totally_harmless_string : String | semmle.label | totally_harmless_string : String |
 | tst.rb:10:9:10:25 | call to e | semmle.label | call to e |
-| tst.rb:10:11:10:24 | "666f6f626172" | semmle.label | "666f6f626172" |
-| tst.rb:16:1:16:27 | another_questionable_string | semmle.label | another_questionable_string |
-| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | semmle.label | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." |
-| tst.rb:17:6:17:32 | another_questionable_string | semmle.label | another_questionable_string |
+| tst.rb:10:11:10:24 | "666f6f626172" : String | semmle.label | "666f6f626172" : String |
+| tst.rb:16:1:16:27 | another_questionable_string : String | semmle.label | another_questionable_string : String |
+| tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." : String | semmle.label | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." : String |
+| tst.rb:17:6:17:32 | another_questionable_string : String | semmle.label | another_questionable_string : String |
 | tst.rb:17:6:17:38 | call to strip | semmle.label | call to strip |
 subpaths
-| tst.rb:7:8:7:30 | totally_harmless_string | tst.rb:1:7:1:7 | r | tst.rb:2:3:2:15 | call to pack | tst.rb:7:6:7:31 | call to e |
-| tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:1:7:1:7 | r | tst.rb:2:3:2:15 | call to pack | tst.rb:10:9:10:25 | call to e |
+| tst.rb:7:8:7:30 | totally_harmless_string : String | tst.rb:1:7:1:7 | r : String | tst.rb:2:3:2:15 | call to pack | tst.rb:7:6:7:31 | call to e |
+| tst.rb:10:11:10:24 | "666f6f626172" : String | tst.rb:1:7:1:7 | r : String | tst.rb:2:3:2:15 | call to pack | tst.rb:10:9:10:25 | call to e |
 #select
-| tst.rb:7:6:7:31 | call to e | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | tst.rb:7:6:7:31 | call to e | $@ is interpreted as code. | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | Hard-coded data |
-| tst.rb:10:9:10:25 | call to e | tst.rb:10:11:10:24 | "666f6f626172" | tst.rb:10:9:10:25 | call to e | $@ is interpreted as an import path. | tst.rb:10:11:10:24 | "666f6f626172" | Hard-coded data |
-| tst.rb:17:6:17:38 | call to strip | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | tst.rb:17:6:17:38 | call to strip | $@ is interpreted as code. | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | Hard-coded data |
+| tst.rb:7:6:7:31 | call to e | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." : String | tst.rb:7:6:7:31 | call to e | $@ is interpreted as code. | tst.rb:5:27:5:72 | "707574732822636f646520696e6a6..." | Hard-coded data |
+| tst.rb:10:9:10:25 | call to e | tst.rb:10:11:10:24 | "666f6f626172" : String | tst.rb:10:9:10:25 | call to e | $@ is interpreted as an import path. | tst.rb:10:11:10:24 | "666f6f626172" | Hard-coded data |
+| tst.rb:17:6:17:38 | call to strip | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." : String | tst.rb:17:6:17:38 | call to strip | $@ is interpreted as code. | tst.rb:16:31:16:84 | "\\x70\\x75\\x74\\x73\\x28\\x27\\x68\\..." | Hard-coded data |

--- a/ruby/ql/test/query-tests/security/cwe-732/WeakFilePermissions.expected
+++ b/ruby/ql/test/query-tests/security/cwe-732/WeakFilePermissions.expected
@@ -1,25 +1,25 @@
 edges
-| FilePermissions.rb:51:3:51:6 | perm | FilePermissions.rb:53:19:53:22 | perm | provenance |  |
-| FilePermissions.rb:51:3:51:6 | perm | FilePermissions.rb:54:3:54:7 | perm2 | provenance |  |
-| FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:51:3:51:6 | perm | provenance |  |
-| FilePermissions.rb:54:3:54:7 | perm2 | FilePermissions.rb:56:19:56:23 | perm2 | provenance |  |
-| FilePermissions.rb:58:3:58:6 | perm | FilePermissions.rb:59:3:59:7 | perm2 | provenance |  |
-| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" | FilePermissions.rb:58:3:58:6 | perm | provenance |  |
-| FilePermissions.rb:59:3:59:7 | perm2 | FilePermissions.rb:61:19:61:23 | perm2 | provenance |  |
+| FilePermissions.rb:51:3:51:6 | perm : Integer | FilePermissions.rb:53:19:53:22 | perm | provenance |  |
+| FilePermissions.rb:51:3:51:6 | perm : Integer | FilePermissions.rb:54:3:54:7 | perm2 : Integer | provenance |  |
+| FilePermissions.rb:51:10:51:13 | 0777 : Integer | FilePermissions.rb:51:3:51:6 | perm : Integer | provenance |  |
+| FilePermissions.rb:54:3:54:7 | perm2 : Integer | FilePermissions.rb:56:19:56:23 | perm2 | provenance |  |
+| FilePermissions.rb:58:3:58:6 | perm : String | FilePermissions.rb:59:3:59:7 | perm2 : String | provenance |  |
+| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" : String | FilePermissions.rb:58:3:58:6 | perm : String | provenance |  |
+| FilePermissions.rb:59:3:59:7 | perm2 : String | FilePermissions.rb:61:19:61:23 | perm2 | provenance |  |
 nodes
 | FilePermissions.rb:5:19:5:22 | 0222 | semmle.label | 0222 |
 | FilePermissions.rb:7:19:7:22 | 0622 | semmle.label | 0622 |
 | FilePermissions.rb:9:19:9:22 | 0755 | semmle.label | 0755 |
 | FilePermissions.rb:11:19:11:22 | 0777 | semmle.label | 0777 |
 | FilePermissions.rb:28:13:28:16 | 0755 | semmle.label | 0755 |
-| FilePermissions.rb:51:3:51:6 | perm | semmle.label | perm |
-| FilePermissions.rb:51:10:51:13 | 0777 | semmle.label | 0777 |
+| FilePermissions.rb:51:3:51:6 | perm : Integer | semmle.label | perm : Integer |
+| FilePermissions.rb:51:10:51:13 | 0777 : Integer | semmle.label | 0777 : Integer |
 | FilePermissions.rb:53:19:53:22 | perm | semmle.label | perm |
-| FilePermissions.rb:54:3:54:7 | perm2 | semmle.label | perm2 |
+| FilePermissions.rb:54:3:54:7 | perm2 : Integer | semmle.label | perm2 : Integer |
 | FilePermissions.rb:56:19:56:23 | perm2 | semmle.label | perm2 |
-| FilePermissions.rb:58:3:58:6 | perm | semmle.label | perm |
-| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" | semmle.label | "u=wrx,g=rwx,o=x" |
-| FilePermissions.rb:59:3:59:7 | perm2 | semmle.label | perm2 |
+| FilePermissions.rb:58:3:58:6 | perm : String | semmle.label | perm : String |
+| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" : String | semmle.label | "u=wrx,g=rwx,o=x" : String |
+| FilePermissions.rb:59:3:59:7 | perm2 : String | semmle.label | perm2 : String |
 | FilePermissions.rb:61:19:61:23 | perm2 | semmle.label | perm2 |
 | FilePermissions.rb:63:19:63:29 | "u=rwx,o+r" | semmle.label | "u=rwx,o+r" |
 | FilePermissions.rb:67:19:67:24 | "a+rw" | semmle.label | "a+rw" |
@@ -31,9 +31,9 @@ subpaths
 | FilePermissions.rb:9:19:9:22 | 0755 | FilePermissions.rb:9:19:9:22 | 0755 | FilePermissions.rb:9:19:9:22 | 0755 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:9:3:9:32 | call to chmod | call to chmod |
 | FilePermissions.rb:11:19:11:22 | 0777 | FilePermissions.rb:11:19:11:22 | 0777 | FilePermissions.rb:11:19:11:22 | 0777 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:11:3:11:32 | call to chmod | call to chmod |
 | FilePermissions.rb:28:13:28:16 | 0755 | FilePermissions.rb:28:13:28:16 | 0755 | FilePermissions.rb:28:13:28:16 | 0755 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:28:3:28:26 | call to chmod | call to chmod |
-| FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:53:19:53:22 | perm | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:53:3:53:32 | call to chmod | call to chmod |
-| FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:56:19:56:23 | perm2 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:56:3:56:33 | call to chmod | call to chmod |
-| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" | FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" | FilePermissions.rb:61:19:61:23 | perm2 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:61:3:61:33 | call to chmod | call to chmod |
+| FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:51:10:51:13 | 0777 : Integer | FilePermissions.rb:53:19:53:22 | perm | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:53:3:53:32 | call to chmod | call to chmod |
+| FilePermissions.rb:51:10:51:13 | 0777 | FilePermissions.rb:51:10:51:13 | 0777 : Integer | FilePermissions.rb:56:19:56:23 | perm2 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:56:3:56:33 | call to chmod | call to chmod |
+| FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" | FilePermissions.rb:58:10:58:26 | "u=wrx,g=rwx,o=x" : String | FilePermissions.rb:61:19:61:23 | perm2 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:61:3:61:33 | call to chmod | call to chmod |
 | FilePermissions.rb:63:19:63:29 | "u=rwx,o+r" | FilePermissions.rb:63:19:63:29 | "u=rwx,o+r" | FilePermissions.rb:63:19:63:29 | "u=rwx,o+r" | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:63:3:63:39 | call to chmod | call to chmod |
 | FilePermissions.rb:67:19:67:24 | "a+rw" | FilePermissions.rb:67:19:67:24 | "a+rw" | FilePermissions.rb:67:19:67:24 | "a+rw" | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:67:3:67:34 | call to chmod | call to chmod |
 | FilePermissions.rb:72:21:72:24 | 0755 | FilePermissions.rb:72:21:72:24 | 0755 | FilePermissions.rb:72:21:72:24 | 0755 | This overly permissive mask used in $@ allows read or write access to others. | FilePermissions.rb:72:3:72:34 | call to chmod_R | call to chmod_R |

--- a/ruby/ql/test/query-tests/security/cwe-798/HardcodedCredentials.expected
+++ b/ruby/ql/test/query-tests/security/cwe-798/HardcodedCredentials.expected
@@ -1,55 +1,55 @@
 edges
-| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." | HardcodedCredentials.rb:1:23:1:30 | password | provenance |  |
-| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:1:33:1:36 | cert | provenance |  |
+| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." : String | HardcodedCredentials.rb:1:23:1:30 | password | provenance |  |
+| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." : String | HardcodedCredentials.rb:1:33:1:36 | cert | provenance |  |
 | HardcodedCredentials.rb:18:19:18:72 | ... + ... | HardcodedCredentials.rb:1:23:1:30 | password | provenance |  |
-| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." | HardcodedCredentials.rb:18:19:18:72 | ... + ... | provenance | Config |
-| HardcodedCredentials.rb:20:1:20:7 | pw_left | HardcodedCredentials.rb:22:6:22:12 | pw_left | provenance |  |
-| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." | HardcodedCredentials.rb:20:1:20:7 | pw_left | provenance |  |
-| HardcodedCredentials.rb:21:1:21:8 | pw_right | HardcodedCredentials.rb:22:16:22:23 | pw_right | provenance |  |
-| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" | HardcodedCredentials.rb:21:1:21:8 | pw_right | provenance |  |
+| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." : String | HardcodedCredentials.rb:18:19:18:72 | ... + ... | provenance | Config |
+| HardcodedCredentials.rb:20:1:20:7 | pw_left : String | HardcodedCredentials.rb:22:6:22:12 | pw_left : String | provenance |  |
+| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." : String | HardcodedCredentials.rb:20:1:20:7 | pw_left : String | provenance |  |
+| HardcodedCredentials.rb:21:1:21:8 | pw_right : String | HardcodedCredentials.rb:22:16:22:23 | pw_right : String | provenance |  |
+| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" : String | HardcodedCredentials.rb:21:1:21:8 | pw_right : String | provenance |  |
 | HardcodedCredentials.rb:22:1:22:2 | pw | HardcodedCredentials.rb:23:19:23:20 | pw | provenance |  |
-| HardcodedCredentials.rb:22:6:22:12 | pw_left | HardcodedCredentials.rb:22:6:22:23 | ... + ... | provenance | Config |
+| HardcodedCredentials.rb:22:6:22:12 | pw_left : String | HardcodedCredentials.rb:22:6:22:23 | ... + ... | provenance | Config |
 | HardcodedCredentials.rb:22:6:22:23 | ... + ... | HardcodedCredentials.rb:22:1:22:2 | pw | provenance |  |
-| HardcodedCredentials.rb:22:16:22:23 | pw_right | HardcodedCredentials.rb:22:6:22:23 | ... + ... | provenance | Config |
+| HardcodedCredentials.rb:22:16:22:23 | pw_right : String | HardcodedCredentials.rb:22:6:22:23 | ... + ... | provenance | Config |
 | HardcodedCredentials.rb:23:19:23:20 | pw | HardcodedCredentials.rb:1:23:1:30 | password | provenance |  |
-| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." | HardcodedCredentials.rb:31:18:31:23 | passwd | provenance |  |
-| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" | HardcodedCredentials.rb:43:18:43:25 | username | provenance |  |
-| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" | HardcodedCredentials.rb:43:46:43:53 | password | provenance |  |
+| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." : String | HardcodedCredentials.rb:31:18:31:23 | passwd | provenance |  |
+| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" : String | HardcodedCredentials.rb:43:18:43:25 | username | provenance |  |
+| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" : String | HardcodedCredentials.rb:43:46:43:53 | password | provenance |  |
 nodes
 | HardcodedCredentials.rb:1:23:1:30 | password | semmle.label | password |
 | HardcodedCredentials.rb:1:33:1:36 | cert | semmle.label | cert |
 | HardcodedCredentials.rb:4:20:4:65 | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." | semmle.label | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." |
 | HardcodedCredentials.rb:8:30:8:75 | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." | semmle.label | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." |
-| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." | semmle.label | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." |
+| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." : String | semmle.label | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." : String |
 | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | semmle.label | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." |
-| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | semmle.label | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." |
+| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." : String | semmle.label | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." : String |
 | HardcodedCredentials.rb:18:19:18:72 | ... + ... | semmle.label | ... + ... |
-| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." | semmle.label | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." |
-| HardcodedCredentials.rb:20:1:20:7 | pw_left | semmle.label | pw_left |
-| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." | semmle.label | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." |
-| HardcodedCredentials.rb:21:1:21:8 | pw_right | semmle.label | pw_right |
-| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" | semmle.label | "4fQuzXef4f2yow8KWvIJTA==" |
+| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." : String | semmle.label | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." : String |
+| HardcodedCredentials.rb:20:1:20:7 | pw_left : String | semmle.label | pw_left : String |
+| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." : String | semmle.label | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." : String |
+| HardcodedCredentials.rb:21:1:21:8 | pw_right : String | semmle.label | pw_right : String |
+| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" : String | semmle.label | "4fQuzXef4f2yow8KWvIJTA==" : String |
 | HardcodedCredentials.rb:22:1:22:2 | pw | semmle.label | pw |
-| HardcodedCredentials.rb:22:6:22:12 | pw_left | semmle.label | pw_left |
+| HardcodedCredentials.rb:22:6:22:12 | pw_left : String | semmle.label | pw_left : String |
 | HardcodedCredentials.rb:22:6:22:23 | ... + ... | semmle.label | ... + ... |
-| HardcodedCredentials.rb:22:16:22:23 | pw_right | semmle.label | pw_right |
+| HardcodedCredentials.rb:22:16:22:23 | pw_right : String | semmle.label | pw_right : String |
 | HardcodedCredentials.rb:23:19:23:20 | pw | semmle.label | pw |
 | HardcodedCredentials.rb:31:18:31:23 | passwd | semmle.label | passwd |
-| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." | semmle.label | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." |
+| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." : String | semmle.label | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." : String |
 | HardcodedCredentials.rb:43:18:43:25 | username | semmle.label | username |
-| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" | semmle.label | "user@test.com" |
+| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" : String | semmle.label | "user@test.com" : String |
 | HardcodedCredentials.rb:43:46:43:53 | password | semmle.label | password |
-| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" | semmle.label | "abcdef123456" |
+| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" : String | semmle.label | "abcdef123456" : String |
 subpaths
 #select
 | HardcodedCredentials.rb:4:20:4:65 | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." | HardcodedCredentials.rb:4:20:4:65 | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." | HardcodedCredentials.rb:4:20:4:65 | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." | This hardcoded value is $@. | HardcodedCredentials.rb:4:20:4:65 | "xwjVWdfzfRlbcgKkbSfG/xSrUeHYq..." | used as credentials |
 | HardcodedCredentials.rb:8:30:8:75 | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." | HardcodedCredentials.rb:8:30:8:75 | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." | HardcodedCredentials.rb:8:30:8:75 | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." | This hardcoded value is $@. | HardcodedCredentials.rb:8:30:8:75 | "X6BLgRWSAtAWG/GaHS+WGGW2K7zZF..." | used as credentials |
-| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." | HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
-| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:1:33:1:36 | cert | This hardcoded value is $@. | HardcodedCredentials.rb:1:33:1:36 | cert | used as credentials |
+| HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." | HardcodedCredentials.rb:12:19:12:64 | "4NQX/CqB5Ae98zFUmwj1DMpF7azsh..." : String | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
 | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | This hardcoded value is $@. | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | used as credentials |
-| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." | HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
-| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." | HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
-| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" | HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
-| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." | HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." | HardcodedCredentials.rb:31:18:31:23 | passwd | This hardcoded value is $@. | HardcodedCredentials.rb:31:18:31:23 | passwd | used as credentials |
-| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" | HardcodedCredentials.rb:43:29:43:43 | "user@test.com" | HardcodedCredentials.rb:43:18:43:25 | username | This hardcoded value is $@. | HardcodedCredentials.rb:43:18:43:25 | username | used as credentials |
-| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" | HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" | HardcodedCredentials.rb:43:46:43:53 | password | This hardcoded value is $@. | HardcodedCredentials.rb:43:46:43:53 | password | used as credentials |
+| HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." | HardcodedCredentials.rb:15:30:15:75 | "WLC17dLQ9P8YlQvqm77qplOMm5pd1..." : String | HardcodedCredentials.rb:1:33:1:36 | cert | This hardcoded value is $@. | HardcodedCredentials.rb:1:33:1:36 | cert | used as credentials |
+| HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." | HardcodedCredentials.rb:18:27:18:72 | "ogH6qSYWGdbR/2WOGYa7eZ/tObL+G..." : String | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
+| HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." | HardcodedCredentials.rb:20:11:20:76 | "3jOe7sXKX6Tx52qHWUVqh2t9LNsE+..." : String | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
+| HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" | HardcodedCredentials.rb:21:12:21:37 | "4fQuzXef4f2yow8KWvIJTA==" : String | HardcodedCredentials.rb:1:23:1:30 | password | This hardcoded value is $@. | HardcodedCredentials.rb:1:23:1:30 | password | used as credentials |
+| HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." | HardcodedCredentials.rb:38:40:38:85 | "kdW/xVhiv6y1fQQNevDpUaq+2rfPK..." : String | HardcodedCredentials.rb:31:18:31:23 | passwd | This hardcoded value is $@. | HardcodedCredentials.rb:31:18:31:23 | passwd | used as credentials |
+| HardcodedCredentials.rb:43:29:43:43 | "user@test.com" | HardcodedCredentials.rb:43:29:43:43 | "user@test.com" : String | HardcodedCredentials.rb:43:18:43:25 | username | This hardcoded value is $@. | HardcodedCredentials.rb:43:18:43:25 | username | used as credentials |
+| HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" | HardcodedCredentials.rb:43:57:43:70 | "abcdef123456" : String | HardcodedCredentials.rb:43:46:43:53 | password | This hardcoded value is $@. | HardcodedCredentials.rb:43:46:43:53 | password | used as credentials |

--- a/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
+++ b/ruby/ql/test/query-tests/security/cwe-829/InsecureDownload.expected
@@ -1,16 +1,16 @@
 testFailures
 edges
-| insecure_download.rb:31:5:31:7 | url | insecure_download.rb:33:15:33:17 | url | provenance |  |
-| insecure_download.rb:31:5:31:7 | url | insecure_download.rb:33:15:33:17 | url | provenance |  |
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | insecure_download.rb:31:5:31:7 | url | provenance |  |
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | insecure_download.rb:31:5:31:7 | url | provenance |  |
+| insecure_download.rb:31:5:31:7 | url : String | insecure_download.rb:33:15:33:17 | url | provenance |  |
+| insecure_download.rb:31:5:31:7 | url : String | insecure_download.rb:33:15:33:17 | url | provenance |  |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | insecure_download.rb:31:5:31:7 | url : String | provenance |  |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | insecure_download.rb:31:5:31:7 | url : String | provenance |  |
 nodes
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
-| insecure_download.rb:31:5:31:7 | url | semmle.label | url |
-| insecure_download.rb:31:5:31:7 | url | semmle.label | url |
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
-| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | semmle.label | "http://example.org/unsafe.APK" |
+| insecure_download.rb:31:5:31:7 | url : String | semmle.label | url : String |
+| insecure_download.rb:31:5:31:7 | url : String | semmle.label | url : String |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | semmle.label | "http://example.org/unsafe.APK" : String |
+| insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | semmle.label | "http://example.org/unsafe.APK" : String |
 | insecure_download.rb:33:15:33:17 | url | semmle.label | url |
 | insecure_download.rb:33:15:33:17 | url | semmle.label | url |
 | insecure_download.rb:37:42:37:68 | "http://example.org/unsafe" | semmle.label | "http://example.org/unsafe" |
@@ -21,8 +21,8 @@ subpaths
 #select
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | $@ | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |
 | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | $@ | insecure_download.rb:27:15:27:45 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |
-| insecure_download.rb:33:15:33:17 | url | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |
-| insecure_download.rb:33:15:33:17 | url | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" | "http://example.org/unsafe.APK" |
+| insecure_download.rb:33:15:33:17 | url | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | "http://example.org/unsafe.APK" : String |
+| insecure_download.rb:33:15:33:17 | url | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:31:11:31:41 | "http://example.org/unsafe.APK" : String | "http://example.org/unsafe.APK" : String |
 | insecure_download.rb:33:15:33:17 | url | insecure_download.rb:33:15:33:17 | url | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:33:15:33:17 | url | url |
 | insecure_download.rb:33:15:33:17 | url | insecure_download.rb:33:15:33:17 | url | insecure_download.rb:33:15:33:17 | url | $@ | insecure_download.rb:33:15:33:17 | url | url |
 | insecure_download.rb:37:42:37:68 | "http://example.org/unsafe" | insecure_download.rb:37:42:37:68 | "http://example.org/unsafe" | insecure_download.rb:37:42:37:68 | "http://example.org/unsafe" | $@ | insecure_download.rb:37:42:37:68 | "http://example.org/unsafe" | "http://example.org/unsafe" |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
@@ -14,6 +14,9 @@ signature module InputSig<LocationSig Location, DF::InputSig<Location> DataFlowL
   /** Holds if `call` should be excluded from the consistency test `uniqueCallEnclosingCallable`. */
   default predicate uniqueCallEnclosingCallableExclude(DataFlowLang::DataFlowCall call) { none() }
 
+  /** Holds if `n` should be excluded from the consistency test `uniqueType`. */
+  default predicate uniqueTypeExclude(DataFlowLang::Node n) { none() }
+
   /** Holds if `n` should be excluded from the consistency test `uniqueNodeLocation`. */
   default predicate uniqueNodeLocationExclude(DataFlowLang::Node n) { none() }
 
@@ -123,6 +126,7 @@ module MakeConsistency<
       n instanceof RelevantNode and
       c = count(getNodeType(n)) and
       c != 1 and
+      not Input::uniqueTypeExclude(n) and
       msg = "Node should have one type but has " + c + "."
     )
   }


### PR DESCRIPTION
Extracted from https://github.com/github/codeql/pull/15118.

This PR implements tracking of types in data flow for Ruby, which may help reduce false-positive results when type incompatibility can be established. DCA looks good; performance is (mostly) maintained while we are able to eliminate some false positives.