### PR TITLE
C#: Add common sources for Blazor components

### DIFF
--- a/csharp/ql/lib/change-notes/2024-12-18-blazor-attribute-sources.md
+++ b/csharp/ql/lib/change-notes/2024-12-18-blazor-attribute-sources.md
@@ -1,0 +1,7 @@
+---
+category: minorAnalysis
+---
+* Added `remote` flow source models for properties of Blazor components annotated with any of the following attributes from `Microsoft.AspNetCore.Components`:
+  - `[Parameter]`
+  - `[SupplyParameterFromForm]`
+  - `[SupplyParameterFromQuery]`

--- a/csharp/ql/lib/change-notes/2024-12-18-blazor-attribute-sources.md
+++ b/csharp/ql/lib/change-notes/2024-12-18-blazor-attribute-sources.md
@@ -2,6 +2,5 @@
 category: minorAnalysis
 ---
 * Added `remote` flow source models for properties of Blazor components annotated with any of the following attributes from `Microsoft.AspNetCore.Components`:
-  - `[Parameter]`
   - `[SupplyParameterFromForm]`
   - `[SupplyParameterFromQuery]`

--- a/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
@@ -5,6 +5,9 @@ extensions:
     data:
       - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_BaseUri", "", "", "ReturnValue", "remote", "manual"]
       - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_Uri", "", "", "ReturnValue", "remote", "manual"]
+      - ["Microsoft.AspNetCore.Components", "ParameterAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
+      - ["Microsoft.AspNetCore.Components", "SupplyParameterFromFormAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
+      - ["Microsoft.AspNetCore.Components", "SupplyParameterFromQueryAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/csharp-all
       extensible: summaryModel

--- a/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
@@ -5,7 +5,6 @@ extensions:
     data:
       - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_BaseUri", "", "", "ReturnValue", "remote", "manual"]
       - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_Uri", "", "", "ReturnValue", "remote", "manual"]
-      - ["Microsoft.AspNetCore.Components", "ParameterAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
       - ["Microsoft.AspNetCore.Components", "SupplyParameterFromFormAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
       - ["Microsoft.AspNetCore.Components", "SupplyParameterFromQueryAttribute", False, "", "", "Attribute.Getter", "ReturnValue", "remote", "manual"]
   - addsTo:

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -191,6 +191,7 @@
 | Microsoft.AspNetCore.Components.Forms;ValidationMessageStore;get_Item;(System.Linq.Expressions.Expression<System.Func<System.Object>>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;add_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;remove_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
+| Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentParameter;(System.Int32,System.String,System.Object);Argument[2];Argument[1];taint;manual |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentReferenceCapture;(System.Int32,System.Action<System.Object>);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent<TValue>;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment<TValue>,TValue);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -191,7 +191,6 @@
 | Microsoft.AspNetCore.Components.Forms;ValidationMessageStore;get_Item;(System.Linq.Expressions.Expression<System.Func<System.Object>>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;add_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;remove_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
-| Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentParameter;(System.Int32,System.String,System.Object);Argument[2];Argument[1];taint;manual |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentReferenceCapture;(System.Int32,System.Action<System.Object>);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent<TValue>;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment<TValue>,TValue);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |


### PR DESCRIPTION
The attributes

~- [`[Parameter]`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.parameterattribute?view=aspnetcore-8.0)~
- [`[SupplyParameterFromFormAttribute]`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.SupplyParameterFromFormAttribute?view=aspnetcore-8.0)
- [`[SupplyParameterFromQueryAttribute]`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.SupplyParameterFromQueryAttribute?view=aspnetcore-8.0)

Tell Blazor to initialize the variables with parameters defined by the route/form values/query parameters/etc. Values derived from the URI or form should be classified as `remote` flow sources.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
~- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.~
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
~- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.~

#### Internal query authors only

~- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).~
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
~- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).~
