### PR TITLE
Fix typo in `NavigationManager` name in models

### DIFF
--- a/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
+++ b/csharp/ql/lib/ext/Microsoft.AspNetCore.Components.model.yml
@@ -3,13 +3,13 @@ extensions:
       pack: codeql/csharp-all
       extensible: sourceModel
     data:
-      - ["Microsoft.AspNetCore.Components", "NagivationManager", True, "get_BaseUri", "", "", "ReturnValue", "remote", "manual"]
-      - ["Microsoft.AspNetCore.Components", "NagivationManager", True, "get_Uri", "", "", "ReturnValue", "remote", "manual"]
+      - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_BaseUri", "", "", "ReturnValue", "remote", "manual"]
+      - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "get_Uri", "", "", "ReturnValue", "remote", "manual"]
   - addsTo:
       pack: codeql/csharp-all
       extensible: summaryModel
     data:
-      - ["Microsoft.AspNetCore.Components", "NagivationManager", True, "ToAbsoluteUri", "(System.String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
+      - ["Microsoft.AspNetCore.Components", "NavigationManager", True, "ToAbsoluteUri", "(System.String)", "", "Argument[0]", "ReturnValue", "taint", "manual"]
   - addsTo:
       pack: codeql/csharp-all
       extensible: sinkModel

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -191,6 +191,7 @@
 | Microsoft.AspNetCore.Components.Forms;ValidationMessageStore;get_Item;(System.Linq.Expressions.Expression<System.Func<System.Object>>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;add_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;remove_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
+| Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentParameter;(System.Int32,System.String,System.Object);Argument[2];Argument[1];taint;manual |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentReferenceCapture;(System.Int32,System.Action<System.Object>);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent<TValue>;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment<TValue>,TValue);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
@@ -321,6 +322,7 @@
 | Microsoft.AspNetCore.Components;LayoutComponentBase;set_Body;(Microsoft.AspNetCore.Components.RenderFragment);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components;LayoutView;set_ChildContent;(Microsoft.AspNetCore.Components.RenderFragment);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components;NavigationManager;RegisterLocationChangingHandler;(System.Func<Microsoft.AspNetCore.Components.Routing.LocationChangingContext,System.Threading.Tasks.ValueTask>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
+| Microsoft.AspNetCore.Components;NavigationManager;ToAbsoluteUri;(System.String);Argument[0];ReturnValue;taint;manual |
 | Microsoft.AspNetCore.Components;NavigationManager;add_LocationChanged;(System.EventHandler<Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components;NavigationManager;remove_LocationChanged;(System.EventHandler<Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components;PersistentComponentState;RegisterOnPersisting;(System.Func<System.Threading.Tasks.Task>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |

--- a/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
+++ b/csharp/ql/test/library-tests/dataflow/library/FlowSummariesFiltered.expected
@@ -191,7 +191,6 @@
 | Microsoft.AspNetCore.Components.Forms;ValidationMessageStore;get_Item;(System.Linq.Expressions.Expression<System.Func<System.Object>>);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;add_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.RenderTree;Renderer;remove_UnhandledSynchronizationException;(System.UnhandledExceptionEventHandler);Argument[0];Argument[0].Parameter[delegate-self];value;hq-generated |
-| Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentParameter;(System.Int32,System.String,System.Object);Argument[2];Argument[1];taint;manual |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddComponentReferenceCapture;(System.Int32,System.Action<System.Object>);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |
 | Microsoft.AspNetCore.Components.Rendering;RenderTreeBuilder;AddContent<TValue>;(System.Int32,Microsoft.AspNetCore.Components.RenderFragment<TValue>,TValue);Argument[1];Argument[1].Parameter[delegate-self];value;hq-generated |


### PR DESCRIPTION
The `NavigationManager` was accidentally spelled `NagivationManager`.
