### PR TITLE
Data flow: Prune parameter-self flow in stage 1

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -557,7 +557,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
         or
         // flow into a callable
-        fwdFlowInParam(_, node, _) and
+        fwdFlowIn(_, _, _, node) and
         cc = true
         or
         // flow out of a callable
@@ -595,11 +595,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       }
 
       pragma[nomagic]
-      private predicate fwdFlowInParam(DataFlowCall call, ParamNodeEx p, Cc cc) {
-        fwdFlowIn(call, _, cc, p)
-      }
-
-      pragma[nomagic]
       private ReturnKindExtOption getDisallowedReturnKind(ParamNodeEx p) {
         if allowParameterReturnInSelfEx(p)
         then result.isNone()
@@ -614,7 +609,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         DataFlowCall call, ReturnKindExtOption disallowReturnKind, Cc cc
       ) {
         exists(ParamNodeEx p |
-          fwdFlowInParam(call, p, cc) and
+          fwdFlowIn(call, _, cc, p) and
           disallowReturnKind = getDisallowedReturnKind(p)
         )
       }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -557,17 +557,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
         or
         // flow into a callable
-        fwdFlowIn(_, _, _, node) and
+        fwdFlowInParam(_, node, _) and
         cc = true
         or
         // flow out of a callable
-        fwdFlowOut(_, node, false) and
+        fwdFlowOut(_, _, node, false) and
         cc = false
         or
         // flow through a callable
-        exists(DataFlowCall call |
-          fwdFlowOutFromArg(call, node) and
-          fwdFlowIsEntered(call, cc)
+        exists(DataFlowCall call, ReturnKindExtOption kind, ReturnKindExtOption disallowReturnKind |
+          fwdFlowOutFromArg(call, kind, node) and
+          fwdFlowIsEntered(call, disallowReturnKind, cc) and
+          kind != disallowReturnKind
         )
       }
 
@@ -593,11 +594,30 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
       }
 
+      pragma[nomagic]
+      private predicate fwdFlowInParam(DataFlowCall call, ParamNodeEx p, Cc cc) {
+        fwdFlowIn(call, _, cc, p)
+      }
+
+      pragma[nomagic]
+      private ReturnKindExtOption getDisallowedReturnKind(ParamNodeEx p) {
+        if allowParameterReturnInSelfEx(p)
+        then result.isNone()
+        else p.isParameterOf(_, result.asSome().(ParamUpdateReturnKind).getPosition())
+      }
+
       /**
        * Holds if an argument to `call` is reached in the flow covered by `fwdFlow`.
        */
       pragma[nomagic]
-      private predicate fwdFlowIsEntered(DataFlowCall call, Cc cc) { fwdFlowIn(call, _, cc, _) }
+      private predicate fwdFlowIsEntered(
+        DataFlowCall call, ReturnKindExtOption disallowReturnKind, Cc cc
+      ) {
+        exists(ParamNodeEx p |
+          fwdFlowInParam(call, p, cc) and
+          disallowReturnKind = getDisallowedReturnKind(p)
+        )
+      }
 
       pragma[nomagic]
       private predicate fwdFlowInReducedViableImplInSomeCallContext(
@@ -618,7 +638,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       pragma[nomagic]
       private DataFlowCallable viableImplInSomeFwdFlowCallContextExt(DataFlowCall call) {
         exists(DataFlowCall ctx |
-          fwdFlowIsEntered(ctx, _) and
+          fwdFlowIsEntered(ctx, _, _) and
           result = viableImplInCallContextExt(call, ctx)
         )
       }
@@ -666,17 +686,18 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       // inline to reduce the number of iterations
       pragma[inline]
-      private predicate fwdFlowOut(DataFlowCall call, NodeEx out, Cc cc) {
+      private predicate fwdFlowOut(DataFlowCall call, ReturnKindExt kind, NodeEx out, Cc cc) {
         exists(ReturnPosition pos |
           fwdFlowReturnPosition(pos, cc) and
           viableReturnPosOutEx(call, pos, out) and
-          not fullBarrier(out)
+          not fullBarrier(out) and
+          kind = pos.getKind()
         )
       }
 
       pragma[nomagic]
-      private predicate fwdFlowOutFromArg(DataFlowCall call, NodeEx out) {
-        fwdFlowOut(call, out, true)
+      private predicate fwdFlowOutFromArg(DataFlowCall call, ReturnKindExtOption kind, NodeEx out) {
+        fwdFlowOut(call, kind.asSome(), out, true)
       }
 
       private predicate stateStepFwd(FlowState state1, FlowState state2) {
@@ -750,7 +771,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
         or
         // flow into a callable
-        revFlowIn(_, node, false) and
+        revFlowIn(_, _, node, false) and
         toReturn = false
         or
         // flow out of a callable
@@ -761,9 +782,10 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         )
         or
         // flow through a callable
-        exists(DataFlowCall call |
-          revFlowInToReturn(call, node) and
-          revFlowIsReturned(call, toReturn)
+        exists(DataFlowCall call, ReturnKindExtOption kind, ReturnKindExtOption disallowReturnKind |
+          revFlowIsReturned(call, kind, toReturn) and
+          revFlowInToReturn(call, disallowReturnKind, node) and
+          kind != disallowReturnKind
         )
       }
 
@@ -824,16 +846,19 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       // inline to reduce the number of iterations
       pragma[inline]
-      private predicate revFlowIn(DataFlowCall call, ArgNodeEx arg, boolean toReturn) {
-        exists(ParamNodeEx p |
-          revFlow(p, toReturn) and
-          viableParamArgNodeCandFwd1(call, p, arg)
-        )
+      private predicate revFlowIn(DataFlowCall call, ParamNodeEx p, ArgNodeEx arg, boolean toReturn) {
+        revFlow(p, toReturn) and
+        viableParamArgNodeCandFwd1(call, p, arg)
       }
 
       pragma[nomagic]
-      private predicate revFlowInToReturn(DataFlowCall call, ArgNodeEx arg) {
-        revFlowIn(call, arg, true)
+      private predicate revFlowInToReturn(
+        DataFlowCall call, ReturnKindExtOption disallowReturnKind, ArgNodeEx arg
+      ) {
+        exists(ParamNodeEx p |
+          revFlowIn(call, p, arg, true) and
+          disallowReturnKind = getDisallowedReturnKind(p)
+        )
       }
 
       /**
@@ -842,10 +867,12 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
        * reaching an argument of `call`.
        */
       pragma[nomagic]
-      private predicate revFlowIsReturned(DataFlowCall call, boolean toReturn) {
+      private predicate revFlowIsReturned(
+        DataFlowCall call, ReturnKindExtOption kind, boolean toReturn
+      ) {
         exists(NodeEx out |
           revFlow(out, toReturn) and
-          fwdFlowOutFromArg(call, out)
+          fwdFlowOutFromArg(call, kind, out)
         )
       }
 
@@ -947,10 +974,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
       pragma[nomagic]
       predicate callMayFlowThroughRev(DataFlowCall call) {
-        exists(ArgNodeEx arg, boolean toReturn |
-          revFlow(arg, toReturn) and
-          revFlowInToReturn(call, arg) and
-          revFlowIsReturned(call, toReturn)
+        exists(
+          ArgNodeEx arg, ReturnKindExtOption kind, ReturnKindExtOption disallowReturnKind,
+          boolean toReturn
+        |
+          revFlow(arg, pragma[only_bind_into](toReturn)) and
+          revFlowIsReturned(call, kind, pragma[only_bind_into](toReturn)) and
+          revFlowInToReturn(call, disallowReturnKind, arg) and
+          kind != disallowReturnKind
         )
       }
 

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -2417,6 +2417,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     override string toString() { result = "param update " + pos }
   }
 
+  class ReturnKindExtOption = Option<ReturnKindExt>::Option;
+
   /** A callable tagged with a relevant return kind. */
   class ReturnPosition extends TReturnPosition0 {
     private DataFlowCallable c;


### PR DESCRIPTION
Example tuple counts (~10 % reduction in stage 1):

### Before
\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 3,530,293 | 37,778 | -1 | 1 | 5,111,856 | -1 | -1 | -1
2 | 15 | 1 Rev | 2,195,396 | 29,094 | -1 | 1 | 3,366,038 | 2,078,437 | -1 | -1
3 | 20 | 2 Fwd | 668,068 | 5,322 | 6,521 | 1 | 1,291,454 | 516,310 | 0 | 0
4 | 25 | 2 Rev | 351,997 | 3,170 | 3,673 | 1 | 526,910 | 125,603 | 0 | 0
5 | 30 | 3 Fwd | 19,865 | 75 | 89 | 1 | 27,492 | 6,212 | 1,108 | 2,127

### After

\# | n | stage | nodes | fields | conscand | states | tuples | calledges | tfnodes | tftuples
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | 10 | 1 Fwd | 3,460,957 | 37,591 | -1 | 1 | 4,764,986 | -1 | -1 | -1
2 | 15 | 1 Rev | 2,135,520 | 28,847 | -1 | 1 | 2,992,383 | 2,042,022 | -1 | -1
3 | 20 | 2 Fwd | 654,633 | 5,189 | 6,316 | 1 | 1,274,172 | 509,370 | 0 | 0
4 | 25 | 2 Rev | 349,487 | 3,144 | 3,641 | 1 | 522,787 | 124,824 | 0 | 0
5 | 30 | 3 Fwd | 19,803 | 74 | 88 | 1 | 27,397 | 6,194 | 1,103 | 2,122

