### PR TITLE
Ruby: enable diff-informed data flow queries

### DIFF
--- a/ruby/ql/lib/codeql/ruby/experimental/UnicodeBypassValidationQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/experimental/UnicodeBypassValidationQuery.qll
@@ -158,6 +158,8 @@ private module UnicodeBypassValidationConfig implements DataFlow::StateConfigSig
     ) and
     state = PostValidationState()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/experimental/ZipSlipQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/experimental/ZipSlipQuery.qll
@@ -29,6 +29,8 @@ private module ZipSlipConfig implements DataFlow::ConfigSig {
   }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof ZipSlip::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -120,9 +120,7 @@ private module ExconDisablesCertificateValidationConfig implements DataFlow::Con
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/Excon.qll:74: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Excon.qll
@@ -118,6 +118,12 @@ private module ExconDisablesCertificateValidationConfig implements DataFlow::Con
   predicate isSink(DataFlow::Node sink) {
     sink = any(ExconHttpRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/Excon.qll:74: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module ExconDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -99,6 +99,12 @@ private module FaradayDisablesCertificateValidationConfig implements DataFlow::S
   predicate isSink(DataFlow::Node sink, FlowState state) {
     sink = any(FaradayHttpRequest req).getCertificateValidationControllingValue(state)
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/Faraday.qll:80: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module FaradayDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Faraday.qll
@@ -101,9 +101,7 @@ private module FaradayDisablesCertificateValidationConfig implements DataFlow::S
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/Faraday.qll:80: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
@@ -82,9 +82,7 @@ private module HttpClientDisablesCertificateValidationConfig implements DataFlow
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/HttpClient.qll:67: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/HttpClient.qll
@@ -80,6 +80,12 @@ private module HttpClientDisablesCertificateValidationConfig implements DataFlow
   predicate isSink(DataFlow::Node sink) {
     sink = any(HttpClientRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/HttpClient.qll:67: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module HttpClientDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -72,9 +72,7 @@ private module HttpartyDisablesCertificateValidationConfig implements DataFlow::
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/Httparty.qll:59: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Httparty.qll
@@ -70,6 +70,12 @@ private module HttpartyDisablesCertificateValidationConfig implements DataFlow::
   predicate isSink(DataFlow::Node sink) {
     sink = any(HttpartyRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/Httparty.qll:59: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module HttpartyDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -105,9 +105,7 @@ private module NetHttpDisablesCertificateValidationConfig implements DataFlow::C
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/NetHttp.qll:90: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -103,6 +103,12 @@ private module NetHttpDisablesCertificateValidationConfig implements DataFlow::C
   predicate isSink(DataFlow::Node sink) {
     sink = any(NetHttpRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/NetHttp.qll:90: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module NetHttpDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -112,10 +112,7 @@ private module OpenUriDisablesCertificateValidationConfig implements DataFlow::C
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/OpenURI.qll:48: Flow call outside 'select' clause
-    // lib/codeql/ruby/frameworks/http_clients/OpenURI.qll:95: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/OpenURI.qll
@@ -110,6 +110,13 @@ private module OpenUriDisablesCertificateValidationConfig implements DataFlow::C
     or
     sink = any(OpenUriKernelOpenRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/OpenURI.qll:48: Flow call outside 'select' clause
+    // lib/codeql/ruby/frameworks/http_clients/OpenURI.qll:95: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module OpenUriDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -75,9 +75,7 @@ private module RestClientDisablesCertificateValidationConfig implements DataFlow
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/RestClient.qll:60: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/RestClient.qll
@@ -73,6 +73,12 @@ private module RestClientDisablesCertificateValidationConfig implements DataFlow
   predicate isSink(DataFlow::Node sink) {
     sink = any(RestClientHttpRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/RestClient.qll:60: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module RestClientDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -66,9 +66,7 @@ private module TyphoeusDisablesCertificateValidationConfig implements DataFlow::
   }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll:53: Flow call outside 'select' clause
-    none()
+    none() // Used for a library model
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll
@@ -64,6 +64,12 @@ private module TyphoeusDisablesCertificateValidationConfig implements DataFlow::
   predicate isSink(DataFlow::Node sink) {
     sink = any(TyphoeusHttpRequest req).getCertificateValidationControllingValue()
   }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // lib/codeql/ruby/frameworks/http_clients/Typhoeus.qll:53: Flow call outside 'select' clause
+    none()
+  }
 }
 
 private module TyphoeusDisablesCertificateValidationFlow =

--- a/ruby/ql/lib/codeql/ruby/frameworks/stdlib/Pathname.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/stdlib/Pathname.qll
@@ -54,9 +54,7 @@ module Pathname {
     }
 
     predicate observeDiffInformedIncrementalMode() {
-      // TODO(diff-informed): Manually verify if config can be diff-informed.
-      // lib/codeql/ruby/frameworks/stdlib/Pathname.qll:30: Flow call outside 'select' clause
-      none()
+      none() // Used for a library model
     }
   }
 

--- a/ruby/ql/lib/codeql/ruby/frameworks/stdlib/Pathname.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/stdlib/Pathname.qll
@@ -52,6 +52,12 @@ module Pathname {
             ]
         )
     }
+
+    predicate observeDiffInformedIncrementalMode() {
+      // TODO(diff-informed): Manually verify if config can be diff-informed.
+      // lib/codeql/ruby/frameworks/stdlib/Pathname.qll:30: Flow call outside 'select' clause
+      none()
+    }
   }
 
   private module PathnameFlow = DataFlow::Global<PathnameConfig>;

--- a/ruby/ql/lib/codeql/ruby/security/CleartextLoggingQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CleartextLoggingQuery.qll
@@ -27,6 +27,8 @@ private module Config implements DataFlow::ConfigSig {
     cs.isAny() and
     isSink(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/CleartextStorageQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CleartextStorageQuery.qll
@@ -26,6 +26,8 @@ private module Config implements DataFlow::ConfigSig {
     cs.isAny() and
     isSink(node)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/CodeInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CodeInjectionQuery.qll
@@ -31,6 +31,8 @@ private module Config implements DataFlow::StateConfigSig {
   predicate isBarrierIn(DataFlow::Node node) { node instanceof Source }
 
   int fieldFlowBranchLimit() { result = 10 }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/CommandInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/CommandInjectionQuery.qll
@@ -23,6 +23,8 @@ private module Config implements DataFlow::ConfigSig {
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/ConditionalBypassQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ConditionalBypassQuery.qll
@@ -18,11 +18,7 @@ private module Config implements DataFlow::ConfigSig {
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-  predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // src/experimental/cwe-807/ConditionalBypass.ql:78: Flow call outside 'select' clause
-    none()
-  }
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/ConditionalBypassQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ConditionalBypassQuery.qll
@@ -17,6 +17,12 @@ private module Config implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // src/experimental/cwe-807/ConditionalBypass.ql:78: Flow call outside 'select' clause
+    none()
+  }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/HardcodedDataInterpretedAsCodeQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HardcodedDataInterpretedAsCodeQuery.qll
@@ -33,6 +33,8 @@ private module Config implements DataFlow::StateConfigSig {
     ) and
     stateTo = FlowState::Taint()
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/HttpToFileAccessQuery.qll
@@ -17,6 +17,8 @@ module HttpToFileAccessConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/ImproperLdapAuthQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ImproperLdapAuthQuery.qll
@@ -13,6 +13,8 @@ private module ImproperLdapAuthConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/InsecureDownloadQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/InsecureDownloadQuery.qll
@@ -20,6 +20,8 @@ private module InsecureDownloadConfig implements DataFlow::StateConfigSig {
   predicate isSink(DataFlow::Node sink, FlowState label) { sink.(Sink).getAFlowLabel() = label }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/InsecureRandomnessQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/InsecureRandomnessQuery.qll
@@ -13,6 +13,8 @@ private module InsecureRandomnessConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/KernelOpenQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/KernelOpenQuery.qll
@@ -85,6 +85,8 @@ private module KernelOpenConfig implements DataFlow::ConfigSig {
     node instanceof StringConstArrayInclusionCallBarrier or
     node instanceof Sanitizer
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/LdapInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/LdapInjectionQuery.qll
@@ -26,6 +26,8 @@ private module LdapInjectionConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     LI::isAdditionalFlowStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/LogInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/LogInjectionQuery.qll
@@ -73,6 +73,8 @@ private module LogInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/MassAssignmentQuery.qll
@@ -59,6 +59,8 @@ private module Config implements DataFlow::StateConfigSig {
       state2 instanceof FlowState::Permitted
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /** Taint tracking for reasoning about user input used for mass assignment. */

--- a/ruby/ql/lib/codeql/ruby/security/PathInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/PathInjectionQuery.qll
@@ -20,6 +20,8 @@ private module PathInjectionConfig implements DataFlow::ConfigSig {
   predicate isBarrier(DataFlow::Node node) {
     node instanceof Path::PathSanitization or node instanceof PathInjection::Sanitizer
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/ReflectedXSSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ReflectedXSSQuery.qll
@@ -22,6 +22,8 @@ private module ReflectedXssConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     RX::isAdditionalXssTaintStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/SensitiveGetQueryQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/SensitiveGetQueryQuery.qll
@@ -16,6 +16,12 @@ private module SensitiveGetQueryConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node source) { source instanceof Source }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
+
+  predicate observeDiffInformedIncrementalMode() {
+    // TODO(diff-informed): Manually verify if config can be diff-informed.
+    // src/queries/security/cwe-598/SensitiveGetQuery.ql:21: Column 3 does not select a source or sink originating from the flow call on line 20
+    none()
+  }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/SensitiveGetQueryQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/SensitiveGetQueryQuery.qll
@@ -18,9 +18,7 @@ private module SensitiveGetQueryConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate observeDiffInformedIncrementalMode() {
-    // TODO(diff-informed): Manually verify if config can be diff-informed.
-    // src/queries/security/cwe-598/SensitiveGetQuery.ql:21: Column 3 does not select a source or sink originating from the flow call on line 20
-    none()
+    none() // Disabled since the alert references `Source.getHandler()`
   }
 }
 

--- a/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/ServerSideRequestForgeryQuery.qll
@@ -22,6 +22,8 @@ private module ServerSideRequestForgeryConfig implements DataFlow::ConfigSig {
     node instanceof StringConstCompareBarrier or
     node instanceof StringConstArrayInclusionCallBarrier
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/SqlInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/SqlInjectionQuery.qll
@@ -13,6 +13,8 @@ private module SqlInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/StackTraceExposureQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/StackTraceExposureQuery.qll
@@ -17,6 +17,8 @@ private module StackTraceExposureConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/StoredXSSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/StoredXSSQuery.qll
@@ -32,6 +32,8 @@ private module StoredXssConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     isAdditionalXssTaintStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/TaintedFormatStringQuery.qll
@@ -19,6 +19,8 @@ module TaintedFormatStringConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/TemplateInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/TemplateInjectionQuery.qll
@@ -13,6 +13,8 @@ private module TemplateInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeCodeConstructionQuery.qll
@@ -24,6 +24,8 @@ private module UnsafeCodeConstructionConfig implements DataFlow::ConfigSig {
 
   // override to require the path doesn't have unmatched return steps
   DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeDeserializationQuery.qll
@@ -17,6 +17,8 @@ private module UnsafeDeserializationConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeDeserialization::Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof UnsafeDeserialization::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeHtmlConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeHtmlConstructionQuery.qll
@@ -21,6 +21,8 @@ private module UnsafeHtmlConstructionConfig implements DataFlow::ConfigSig {
 
   // override to require the path doesn't have unmatched return steps
   DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UnsafeShellCommandConstructionQuery.qll
@@ -26,6 +26,8 @@ private module UnsafeShellCommandConstructionConfig implements DataFlow::ConfigS
 
   // override to require the path doesn't have unmatched return steps
   DataFlow::FlowFeature getAFeature() { result instanceof DataFlow::FeatureHasSourceCallContext }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/UrlRedirectQuery.qll
@@ -22,6 +22,8 @@ private module UrlRedirectConfig implements DataFlow::ConfigSig {
   predicate isAdditionalFlowStep(DataFlow::Node node1, DataFlow::Node node2) {
     UrlRedirect::isAdditionalTaintStep(node1, node2)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll
@@ -28,6 +28,12 @@ module NormalHashFunction {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() {
+      // TODO(diff-informed): Manually verify if config can be diff-informed.
+      // lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll:79: Flow call outside 'select' clause
+      none()
+    }
   }
 
   /** Global taint-tracking for detecting "use of a broken or weak cryptographic hashing algorithm on sensitive data" vulnerabilities. */
@@ -54,6 +60,12 @@ module ComputationallyExpensiveHashFunction {
     predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+    predicate observeDiffInformedIncrementalMode() {
+      // TODO(diff-informed): Manually verify if config can be diff-informed.
+      // lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll:86: Flow call outside 'select' clause
+      none()
+    }
   }
 
   /** Global taint-tracking for detecting "use of a broken or weak cryptographic hashing algorithm on passwords" vulnerabilities. */

--- a/ruby/ql/lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll
@@ -29,11 +29,7 @@ module NormalHashFunction {
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-    predicate observeDiffInformedIncrementalMode() {
-      // TODO(diff-informed): Manually verify if config can be diff-informed.
-      // lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll:79: Flow call outside 'select' clause
-      none()
-    }
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Global taint-tracking for detecting "use of a broken or weak cryptographic hashing algorithm on sensitive data" vulnerabilities. */
@@ -61,11 +57,7 @@ module ComputationallyExpensiveHashFunction {
 
     predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
 
-    predicate observeDiffInformedIncrementalMode() {
-      // TODO(diff-informed): Manually verify if config can be diff-informed.
-      // lib/codeql/ruby/security/WeakSensitiveDataHashingQuery.qll:86: Flow call outside 'select' clause
-      none()
-    }
+    predicate observeDiffInformedIncrementalMode() { any() }
   }
 
   /** Global taint-tracking for detecting "use of a broken or weak cryptographic hashing algorithm on passwords" vulnerabilities. */

--- a/ruby/ql/lib/codeql/ruby/security/XpathInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/XpathInjectionQuery.qll
@@ -24,6 +24,8 @@ private module XpathInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/MissingFullAnchorQuery.qll
@@ -17,6 +17,8 @@ private module MissingFullAnchorConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/PolynomialReDoSQuery.qll
@@ -18,6 +18,8 @@ private module PolynomialReDoSConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/codeql/ruby/security/regexp/RegExpInjectionQuery.qll
+++ b/ruby/ql/lib/codeql/ruby/security/regexp/RegExpInjectionQuery.qll
@@ -17,6 +17,8 @@ private module RegExpInjectionConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) { sink instanceof RegExpInjection::Sink }
 
   predicate isBarrier(DataFlow::Node node) { node instanceof RegExpInjection::Sanitizer }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 /**

--- a/ruby/ql/lib/emptydiff.model.yml
+++ b/ruby/ql/lib/emptydiff.model.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/util
+      extensible: restrictAlertsTo
+    data:
+      - ["dummy", 1, 1]

--- a/ruby/ql/lib/emptydiff.model.yml
+++ b/ruby/ql/lib/emptydiff.model.yml
@@ -1,6 +1,0 @@
-extensions:
-  - addsTo:
-      pack: codeql/util
-      extensible: restrictAlertsTo
-    data:
-      - ["dummy", 1, 1]

--- a/ruby/ql/lib/qlpack.yml
+++ b/ruby/ql/lib/qlpack.yml
@@ -16,5 +16,4 @@ dependencies:
 dataExtensions:
   - codeql/ruby/frameworks/**/model.yml
   - codeql/ruby/frameworks/**/*.model.yml
-  - '*.model.yml'
 warnOnImplicitThis: true

--- a/ruby/ql/lib/qlpack.yml
+++ b/ruby/ql/lib/qlpack.yml
@@ -16,4 +16,5 @@ dependencies:
 dataExtensions:
   - codeql/ruby/frameworks/**/model.yml
   - codeql/ruby/frameworks/**/*.model.yml
+  - '*.model.yml'
 warnOnImplicitThis: true

--- a/ruby/ql/src/experimental/CWE-522-DecompressionBombs/DecompressionBombs.ql
+++ b/ruby/ql/src/experimental/CWE-522-DecompressionBombs/DecompressionBombs.ql
@@ -57,6 +57,8 @@ module BombsConfig implements DataFlow::ConfigSig {
       nodeTo = cn
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 module Bombs = TaintTracking::Global<BombsConfig>;

--- a/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
+++ b/ruby/ql/src/experimental/decompression-api/DecompressionApi.ql
@@ -39,6 +39,8 @@ private module DecompressionApiConfig implements DataFlow::ConfigSig {
 
   // our Decompression APIs defined above will be the sinks we use for this query
   predicate isSink(DataFlow::Node sink) { sink instanceof DecompressionApiUse }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module DecompressionApiFlow = TaintTracking::Global<DecompressionApiConfig>;

--- a/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
+++ b/ruby/ql/src/experimental/manually-check-http-verb/ManuallyCheckHttpVerb.ql
@@ -86,6 +86,8 @@ private module HttpVerbConfig implements DataFlow::ConfigSig {
     exists(ExprNodes::ConditionalExprCfgNode c | c.getCondition() = sink.asExpr()) or
     exists(ExprNodes::CaseExprCfgNode c | c.getValue() = sink.asExpr())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module HttpVerbFlow = TaintTracking::Global<HttpVerbConfig>;

--- a/ruby/ql/src/experimental/weak-params/WeakParams.ql
+++ b/ruby/ql/src/experimental/weak-params/WeakParams.ql
@@ -46,6 +46,8 @@ private module WeakParamsConfig implements DataFlow::ConfigSig {
 
   // the sink is an instance of a Model class that receives a method call
   predicate isSink(DataFlow::Node node) { node = any(PersistentWriteAccess a).getValue() }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module WeakParamsFlow = TaintTracking::Global<WeakParamsConfig>;

--- a/ruby/ql/src/queries/meta/TaintedNodes.ql
+++ b/ruby/ql/src/queries/meta/TaintedNodes.ql
@@ -19,6 +19,8 @@ private module BasicTaintConfig implements DataFlow::ConfigSig {
     // To reduce noise from synthetic nodes, only count nodes that have an associated expression.
     exists(node.asExpr().getExpr())
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module BasicTaintFlow = TaintTracking::Global<BasicTaintConfig>;

--- a/ruby/ql/src/queries/security/cwe-611/Xxe.ql
+++ b/ruby/ql/src/queries/security/cwe-611/Xxe.ql
@@ -31,6 +31,8 @@ private module XxeConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node src) { src instanceof RemoteFlowSource }
 
   predicate isSink(DataFlow::Node sink) { sink instanceof UnsafeXxeSink }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module XxeFlow = TaintTracking::Global<XxeConfig>;

--- a/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
+++ b/ruby/ql/src/queries/security/cwe-732/WeakFilePermissions.ql
@@ -54,6 +54,8 @@ private module PermissivePermissionsConfig implements DataFlow::ConfigSig {
   predicate isSink(DataFlow::Node sink) {
     exists(FileSystemPermissionModification mod | mod.getAPermissionNode() = sink)
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module PermissivePermissionsFlow = DataFlow::Global<PermissivePermissionsConfig>;

--- a/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
+++ b/ruby/ql/src/queries/security/cwe-798/HardcodedCredentials.ql
@@ -147,6 +147,8 @@ private module HardcodedCredentialsConfig implements DataFlow::ConfigSig {
       binop.getExpr() instanceof AddExpr
     )
   }
+
+  predicate observeDiffInformedIncrementalMode() { any() }
 }
 
 private module HardcodedCredentialsFlow = DataFlow::Global<HardcodedCredentialsConfig>;


### PR DESCRIPTION
The first commit is an auto-generated patch that enables diff-informed data flow in the obvious cases, and inserts a TODO comment in the non-obvious cases.

Those TODOs are then fixed up in the second commit.

[Evaluation](https://github.com/github/codeql-dca-main/issues/26114) shows up to 63% speedup, with a median of 18% speedup.