### PR TITLE
Rust: reinstate extraction of test code

### DIFF
--- a/rust/autobuild/src/main.rs
+++ b/rust/autobuild/src/main.rs
@@ -1,5 +1,5 @@
-use std::path::PathBuf;
 use codeql_extractor::autobuilder;
+use std::path::PathBuf;
 
 fn main() -> std::io::Result<()> {
     let database = std::env::var("CODEQL_EXTRACTOR_RUST_WIP_DATABASE")
@@ -7,7 +7,7 @@ fn main() -> std::io::Result<()> {
 
     autobuilder::Autobuilder::new("rust", PathBuf::from(database))
         .include_extensions(&[".rs"])
-        .exclude_globs(&["**/.git", "**/tests/**"])
+        .exclude_globs(&["**/.git"])
         .size_limit("5m")
         .run()
 }

--- a/rust/ql/integration-tests/file-exclusions/codeql-config.yml
+++ b/rust/ql/integration-tests/file-exclusions/codeql-config.yml
@@ -1,2 +1,3 @@
 paths-ignore:
   - '/src/maybe_ignore'
+  - '**/tests'

--- a/rust/ql/integration-tests/file-exclusions/source_archive.default.expected
+++ b/rust/ql/integration-tests/file-exclusions/source_archive.default.expected
@@ -1,3 +1,4 @@
 src/lib.rs
 src/maybe_ignore/a_source.rs
 src/maybe_ignore/mod.rs
+tests/integration.rs

--- a/rust/ql/integration-tests/options/cfg/functions.expected
+++ b/rust/ql/integration-tests/options/cfg/functions.expected
@@ -1,3 +1,4 @@
 | src/lib.rs:7:1:8:19 | fn cfg_no_flag |
 | src/lib.rs:10:1:11:18 | fn cfg_no_key |
-| src/lib.rs:16:1:17:24 | fn pointer_width_64 |
+| src/lib.rs:15:5:16:16 | fn test |
+| src/lib.rs:19:1:20:24 | fn pointer_width_64 |

--- a/rust/ql/integration-tests/options/cfg/functions.override.expected
+++ b/rust/ql/integration-tests/options/cfg/functions.override.expected
@@ -1,4 +1,3 @@
 | src/lib.rs:1:1:2:16 | fn cfg_flag |
 | src/lib.rs:4:1:5:15 | fn cfg_key |
-| src/lib.rs:13:1:14:12 | fn test |
-| src/lib.rs:19:1:20:24 | fn pointer_width_32 |
+| src/lib.rs:22:1:23:24 | fn pointer_width_32 |

--- a/rust/ql/integration-tests/options/cfg/src/lib.rs
+++ b/rust/ql/integration-tests/options/cfg/src/lib.rs
@@ -11,7 +11,10 @@ fn cfg_no_flag() {}
 fn cfg_no_key() {}
 
 #[cfg(test)]
-fn test() {}
+mod tests {
+    #[test]
+    fn test() {}
+}
 
 #[cfg(target_pointer_width = "64")]
 fn pointer_width_64() {}

--- a/rust/ql/integration-tests/options/cfg/test_cfg_overrides_option.py
+++ b/rust/ql/integration-tests/options/cfg/test_cfg_overrides_option.py
@@ -14,6 +14,24 @@ def test_cfg_overrides(codeql, rust):
         "cfg_key=value",
         "-target_pointer_width=64",
         "target_pointer_width=32",
+        "-test",
+    ))
+    codeql.database.create(extractor_option=f"cargo_cfg_overrides={overrides}")
+
+@pytest.mark.ql_test(expected=".override.expected")
+def test_ducplicate_cfg_overrides(codeql, rust):
+    overrides = ",".join((
+        "cfg_flag",
+        "cfg_key=value",
+        "-cfg_flag",
+        "target_pointer_width=32",
+        "-target_pointer_width=64",
+        "cfg_flag",
+        "cfg_flag",
+        "target_pointer_width=32",
+        "-test",
+        "-test",
         "test",
+        "-test",
     ))
     codeql.database.create(extractor_option=f"cargo_cfg_overrides={overrides}")

--- a/rust/ql/integration-tests/options/cfg/test_cfg_overrides_option.py
+++ b/rust/ql/integration-tests/options/cfg/test_cfg_overrides_option.py
@@ -19,7 +19,7 @@ def test_cfg_overrides(codeql, rust):
     codeql.database.create(extractor_option=f"cargo_cfg_overrides={overrides}")
 
 @pytest.mark.ql_test(expected=".override.expected")
-def test_ducplicate_cfg_overrides(codeql, rust):
+def test_duplicate_cfg_overrides(codeql, rust):
     overrides = ",".join((
         "cfg_flag",
         "cfg_key=value",


### PR DESCRIPTION
Users will still be able to opt out:
* for unit tests, by providing the `cargo_cfg_overrides=-test` extractor option
* for integration tests, by excluding the test files from the analysis using `paths-ignore` in the codescanning configuration file

We may want to revisit whether we want a single option for both. Also further work will be needed to restrict our security queries to non-test code on the QL side.