### PR TITLE
JS: Add deprecation qldoc to Configuration classes

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -76,6 +76,15 @@ private import semmle.javascript.internal.CachedStages
 private import AdditionalFlowSteps
 
 /**
+ * DEPRECATED.
+ * Subclasses of this class should be replaced by a module implementing the new `ConfigSig` or `StateConfigSig` interface.
+ * See the [data flow guide](https://codeql.github.com/docs/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript/#using-global-data-flow)
+ * for details about how to use this new interface.
+ *
+ * Data flow configurations that used the `FlowLabel` class should be translated to use the `StateConfigSig` interface.
+ * See [guide on using flow state](https://codeql.github.com/docs/codeql-language-guides/using-flow-labels-for-precise-data-flow-analysis) for more details.
+ *
+ * #### Legacy documentation
  * A data flow tracking configuration for finding inter-procedural paths from
  * sources to sinks.
  *

--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -6,10 +6,6 @@
  * Additional data flow edges can be specified, and conversely certain nodes or
  * edges can be designated as _barriers_ that block flow.
  *
- * NOTE: The API of this library is not stable yet and may change in
- *       the future.
- *
- *
  * # Technical overview
  *
  * This module implements a summarization-based inter-procedural data flow

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -27,6 +27,17 @@ module TaintTracking {
   import AdditionalTaintSteps
 
   /**
+   * DEPRECATED.
+   * Subclasses of this class should be replaced by a module implementing the new `ConfigSig` or `StateConfigSig` interface.
+   * See the [data flow guide](https://codeql.github.com/docs/codeql-language-guides/analyzing-data-flow-in-javascript-and-typescript/#using-global-taint-tracking)
+   * for details about how to use this new interface.
+   *
+   * When migrating a `TaintTracking::Configuration` to `DataFlow::ConfigSig`, use `TaintTracking::Global<...>` instead of `DataFlow::Global<...>`.
+   *
+   * Taint-tracking configurations that used the `FlowLabel` class should be translated to use the `StateConfigSig` interface.
+   * See [guide on using flow state](https://codeql.github.com/docs/codeql-language-guides/using-flow-labels-for-precise-data-flow-analysis) for more details.
+   *
+   * #### Legacy documentation
    * A data flow tracking configuration that considers taint propagation through
    * objects, arrays, promises and strings in addition to standard data flow.
    *

--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -8,9 +8,6 @@
  * substrings. As for data flow configurations, additional flow edges can be
  * specified, and conversely certain nodes or edges can be designated as taint
  * _sanitizers_ that block flow.
- *
- * NOTE: The API of this library is not stable yet and may change in
- *       the future.
  */
 
 import javascript


### PR DESCRIPTION
It would be good with a dedicated migration guide, but just adding a bare minimum of qldoc here seems like a good alternative for now.