### PR TITLE
Clarify immutable actions help text

### DIFF
--- a/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
+++ b/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This action is eligible for a new GitHub feature called Immutable Actions that is currently only available for internal users but will be publicly available soon. Immutable Actions are released as packages in the GitHub package registry instead of resolved from a pinned SHA at the repository. The immutable action provides the same immutability as pinning the version to a SHA but with improved readability.
+This action is eligible for Immutable Actions, a new GitHub feature that is currently only available for internal users. Immutable Actions are released as packages in the GitHub package registry instead of resolved from a pinned SHA at the repository. The Immutable Action provides the same immutability as pinning the version to a SHA but with improved readability and additional security guarantees.
 
 ## Recommendations
 

--- a/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
+++ b/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
@@ -2,11 +2,11 @@
 
 ## Description
 
-This action is eligible for immutable actions which are released as packages in the GitHub package registry instead of resolved from a pinned SHA at the repository. The immutable action provides the same immutability as pinning the version to a SHA but with improved readability.
+This action is eligible for a new GitHub feature called Immutable Actions that is currently only available for internal users but will be publicly available soon. Immutable Actions are released as packages in the GitHub package registry instead of resolved from a pinned SHA at the repository. The immutable action provides the same immutability as pinning the version to a SHA but with improved readability.
 
 ## Recommendations
 
-When using [immutable actions](https://github.com/github/package-registry-team/blob/main/docs/immutable-actions/immutable-actions-howto.md) use the full semantic version of the action. This will ensure that the action is resolved to the exact version stored in the GitHub package registry.
+For internal users: when using [immutable actions](https://github.com/github/package-registry-team/blob/main/docs/immutable-actions/immutable-actions-howto.md) use the full semantic version of the action. This will ensure that the action is resolved to the exact version stored in the GitHub package registry.
 
 ## Examples
 

--- a/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
+++ b/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.md
@@ -2,12 +2,11 @@
 
 ## Description
 
-Using an immutable action without indicating proper semantic version will result in the version being resolved to a tag that is mutable. This means the action code can change between runs and without the user's knowledge. Using an immutable action with proper semantic versioning will resolve to the exact version
-of the action stored in the GitHub package registry. The action code will not change between runs.
+This action is eligible for immutable actions which are released as packages in the GitHub package registry instead of resolved from a pinned SHA at the repository. The immutable action provides the same immutability as pinning the version to a SHA but with improved readability.
 
 ## Recommendations
 
-When using [immutable actions](https://github.com/github/package-registry-team/blob/main/docs/immutable-actions/immutable-actions-howto.md) use the full semantic version of the action. This will ensure that the action is resolved to the exact version stored in the GitHub package registry. This will prevent the action code from changing between runs.
+When using [immutable actions](https://github.com/github/package-registry-team/blob/main/docs/immutable-actions/immutable-actions-howto.md) use the full semantic version of the action. This will ensure that the action is resolved to the exact version stored in the GitHub package registry.
 
 ## Examples
 


### PR DESCRIPTION
### Pull Request checklist

Clarify immutable actions help text to indicate that sha pinning also guarantees immutability. 

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [x] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [x] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [x] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [x] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
