### PR TITLE
Rust: extend `paths-ignore` to all `rust/ql`

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,5 +9,4 @@ paths-ignore:
   - '/python/'
   - '/javascript/ql/test'
   - '/javascript/extractor/tests'
-  - '/rust/ql/test'
-  - '/rust/ql/integration-tests'
+  - '/rust/ql'


### PR DESCRIPTION
This will also exclude code examples in `rust/ql/src/queries`.