### PR TITLE
Update suites for Actions queries

### DIFF
--- a/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.ql
+++ b/actions/ql/src/Security/CWE-829/UnversionedImmutableAction.ql
@@ -7,6 +7,7 @@
  * @id actions/unversioned-immutable-action
  * @tags security
  *       actions
+ *       internal
  *       external/cwe/cwe-829
  */
 

--- a/actions/ql/src/codeql-suites/actions-all.qls
+++ b/actions/ql/src/codeql-suites/actions-all.qls
@@ -1,4 +1,4 @@
-- description: Standard Code Scanning queries for Actions
+- description: Standard Code Scanning queries for GitHub Actions
 - queries: .
 - include:
     kind:

--- a/actions/ql/src/codeql-suites/actions-bughalla.qls
+++ b/actions/ql/src/codeql-suites/actions-bughalla.qls
@@ -1,4 +1,4 @@
-- description: Bughalla queries for Actions
+- description: Bughalla queries for GitHub Actions
 - queries: '.'
 - exclude:
     tags contain:

--- a/actions/ql/src/codeql-suites/actions-code-scanning.qls
+++ b/actions/ql/src/codeql-suites/actions-code-scanning.qls
@@ -1,4 +1,4 @@
-- description: Standard Code Scanning queries for Actions
+- description: Standard Code Scanning queries for GitHub Actions
 - queries: '.'
 - include:
     problem.severity: 
@@ -8,4 +8,4 @@
     tags contain:
       - experimental
       - debug
-      
+      - internal

--- a/actions/ql/src/codeql-suites/actions-security-and-quality.qls
+++ b/actions/ql/src/codeql-suites/actions-security-and-quality.qls
@@ -1,11 +1,2 @@
-- description: Security-and-quality queries for Actions
-- queries: '.'
-- include:
-    problem.severity: 
-      - error
-      - recommendation
-- exclude:
-    tags contain:
-      - experimental
-      - debug
-      
+- description: Security-and-quality queries for GitHub Actions
+- import: codeql-suites/actions-security-extended.qls

--- a/actions/ql/src/codeql-suites/actions-security-extended.qls
+++ b/actions/ql/src/codeql-suites/actions-security-extended.qls
@@ -1,0 +1,2 @@
+- description: Security-extended queries for GitHub Actions
+- import: codeql-suites/actions-code-scanning.qls


### PR DESCRIPTION
This PR updates the suite files for the Actions queries:

= Added `actions-security-extended.qls`, which is needed for Default Setup.
- Made `actions-security-extended.qls` just import `actions-code-scanning.qls`, since the set of queries is the same for now.
- Made `actions-security-and-quality.qls` just import `actions-security-extended.qls`, since the set of queries is the same for now.
- Replaced "Actions" with "GitHub Actions" in the suite descriptions, to match how we display the language name in the Code Scanning UI.

I also marked the `UnversionedImmutableAction.ql` query with the `internal` tag, and added an exclusion for `internal` queries in the suite file. This query refers to a feature that is not yet generally available, so it's causing customer confusion.
