### PR TITLE
C# 13: [TEST ONLY] Add test using the new escape char for ESCAPE.

### DIFF
--- a/csharp/ql/test/library-tests/strings/Strings.cs
+++ b/csharp/ql/test/library-tests/strings/Strings.cs
@@ -1,0 +1,12 @@
+using System;
+
+public class TestClass
+{
+    public void M()
+    {
+        var x1 = "Hello world";
+        var x2 = "\u001b";
+        var x3 = "\x1b";
+        var x4 = "\e";
+    }
+}

--- a/csharp/ql/test/library-tests/strings/stringLiterals.expected
+++ b/csharp/ql/test/library-tests/strings/stringLiterals.expected
@@ -1,0 +1,4 @@
+| Strings.cs:7:18:7:30 | "Hello world" | Hello world |
+| Strings.cs:8:18:8:25 | "\u001b" | \u001b |
+| Strings.cs:9:18:9:23 | "\u001b" | \u001b |
+| Strings.cs:10:18:10:21 | "\u001b" | \u001b |

--- a/csharp/ql/test/library-tests/strings/stringLiterals.ql
+++ b/csharp/ql/test/library-tests/strings/stringLiterals.ql
@@ -1,0 +1,5 @@
+import csharp
+
+query predicate stringLiterals(StringLiteral lit, string value) {
+  lit.fromSource() and value = lit.getValue()
+}


### PR DESCRIPTION
This is a test only PR (no extractor or library development required).
In this PR we add a test using the new escape sequence `\e` for the ESCAPE character. `\e` is syntactic sugar for `\u001b`. The new feature is described [here](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#new-escape-sequence).