### PR TITLE
C# 13: Allows ref struct.

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
@@ -40,6 +40,9 @@ namespace Semmle.Extraction.CSharp.Entities
             if (Symbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated)
                 trapFile.general_type_parameter_constraints(this, 5);
 
+            if (Symbol.HasNotNullConstraint)
+                trapFile.general_type_parameter_constraints(this, 6);
+
             foreach (var abase in Symbol.GetAnnotatedTypeConstraints())
             {
                 var t = Type.Create(Context, abase.Symbol);

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameterConstraints.cs
@@ -43,6 +43,9 @@ namespace Semmle.Extraction.CSharp.Entities
             if (Symbol.HasNotNullConstraint)
                 trapFile.general_type_parameter_constraints(this, 6);
 
+            if (Symbol.AllowsRefLikeType)
+                trapFile.general_type_parameter_constraints(this, 7);
+
             foreach (var abase in Symbol.GetAnnotatedTypeConstraints())
             {
                 var t = Type.Create(Context, abase.Symbol);

--- a/csharp/ql/lib/change-notes/2025-01-03-allow-ref-struct.md
+++ b/csharp/ql/lib/change-notes/2025-01-03-allow-ref-struct.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* C# 13: Added extractor support and call dispatch logic (data flow) for the (negative) type parameter constraint `allows ref struct`. Added extractor support for the type parameter constraint `notnull`.

--- a/csharp/ql/lib/semmle/code/csharp/Conversion.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Conversion.qll
@@ -656,7 +656,7 @@ private predicate convBoxingValueType(ValueType fromType, Type toType) {
     or
     toType instanceof SystemValueTypeClass
   ) and
-  not fromType.(Struct).isRef()
+  not fromType.isRefLikeType()
   or
   toType = fromType.getABaseInterface+()
 }

--- a/csharp/ql/lib/semmle/code/csharp/Conversion.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Conversion.qll
@@ -649,11 +649,14 @@ predicate convBoxing(Type fromType, Type toType) {
 }
 
 private predicate convBoxingValueType(ValueType fromType, Type toType) {
-  toType instanceof ObjectType
-  or
-  toType instanceof DynamicType
-  or
-  toType instanceof SystemValueTypeClass
+  (
+    toType instanceof ObjectType
+    or
+    toType instanceof DynamicType
+    or
+    toType instanceof SystemValueTypeClass
+  ) and
+  not fromType.(Struct).isRef()
   or
   toType = fromType.getABaseInterface+()
 }

--- a/csharp/ql/lib/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Generics.qll
@@ -287,6 +287,9 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
   /** Holds if these constraints include a nullable reference type constraint. */
   predicate hasNullableRefTypeConstraint() { general_type_parameter_constraints(this, 5) }
 
+  /** Holds if these constraints include a not-null type constraint. */
+  predicate hasNotNullTypeConstraint() { general_type_parameter_constraints(this, 6) }
+
   /** Gets a textual representation of these constraints. */
   override string toString() { result = "where " + this.getTypeParameter().getName() + ": ..." }
 

--- a/csharp/ql/lib/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Generics.qll
@@ -290,6 +290,9 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
   /** Holds if these constraints include a notnull type constraint. */
   predicate hasNotNullTypeConstraint() { general_type_parameter_constraints(this, 6) }
 
+  /** Holds if these constraints include a `allows ref struct` constraint. */
+  predicate hasAllowRefLikeTypeConstraint() { general_type_parameter_constraints(this, 7) }
+
   /** Gets a textual representation of these constraints. */
   override string toString() { result = "where " + this.getTypeParameter().getName() + ": ..." }
 

--- a/csharp/ql/lib/semmle/code/csharp/Generics.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Generics.qll
@@ -287,7 +287,7 @@ class TypeParameterConstraints extends Element, @type_parameter_constraints {
   /** Holds if these constraints include a nullable reference type constraint. */
   predicate hasNullableRefTypeConstraint() { general_type_parameter_constraints(this, 5) }
 
-  /** Holds if these constraints include a not-null type constraint. */
+  /** Holds if these constraints include a notnull type constraint. */
   predicate hasNotNullTypeConstraint() { general_type_parameter_constraints(this, 6) }
 
   /** Gets a textual representation of these constraints. */

--- a/csharp/ql/lib/semmle/code/csharp/Type.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Type.qll
@@ -51,6 +51,8 @@ class Type extends Member, TypeContainer, @type {
 
   /**
    * Holds if this type is a ref like type.
+   *
+   * Only `ref struct` types are considered ref like types.
    */
   predicate isRefLikeType() { none() }
 }

--- a/csharp/ql/lib/semmle/code/csharp/Type.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Type.qll
@@ -48,6 +48,11 @@ class Type extends Member, TypeContainer, @type {
 
   /** Holds if this type is a value type, or a type parameter that is a value type. */
   predicate isValueType() { none() }
+
+  /**
+   * Holds if this type is a ref like type.
+   */
+  predicate isRefLikeType() { none() }
 }
 
 pragma[nomagic]
@@ -704,13 +709,36 @@ class Enum extends ValueType, @enum_type {
  * ```
  */
 class Struct extends ValueType, @struct_type {
-  /** Holds if this `struct` has a `ref` modifier. */
-  predicate isRef() { this.hasModifier("ref") }
+  /**
+   * DEPRECATED: Use `instanceof RefStruct` instead.
+   *
+   * Holds if this `struct` has a `ref` modifier.
+   */
+  deprecated predicate isRef() { this.hasModifier("ref") }
 
   /** Holds if this `struct` has a `readonly` modifier. */
   predicate isReadonly() { this.hasModifier("readonly") }
 
   override string getAPrimaryQlClass() { result = "Struct" }
+}
+
+/**
+ * A `ref struct`, for example
+ *
+ * ```csharp
+ * ref struct S {
+ *  ...
+ * }
+ * ```
+ */
+class RefStruct extends Struct {
+  RefStruct() { this.hasModifier("ref") }
+
+  override string getAPrimaryQlClass() { result = "RefStruct" }
+
+  override predicate isValueType() { none() }
+
+  override predicate isRefLikeType() { any() }
 }
 
 /**

--- a/csharp/ql/lib/semmle/code/csharp/Type.qll
+++ b/csharp/ql/lib/semmle/code/csharp/Type.qll
@@ -736,8 +736,6 @@ class RefStruct extends Struct {
 
   override string getAPrimaryQlClass() { result = "RefStruct" }
 
-  override predicate isValueType() { none() }
-
   override predicate isRefLikeType() { any() }
 }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -703,7 +703,7 @@ module LocalFlow {
       or
       t = any(TypeParameter tp | not tp.isValueType())
       or
-      t.(Struct).isRef()
+      t.isRefLikeType()
     ) and
     not exists(getALastEvalNode(result))
   }

--- a/csharp/ql/test/library-tests/conversion/boxing/Boxing.cs
+++ b/csharp/ql/test/library-tests/conversion/boxing/Boxing.cs
@@ -45,3 +45,6 @@ class C<T1, T2, T3, T4, T5, T6>
         x1 = x15; // not a boxing conversion
     }
 }
+
+// Ref structs can't be converted to a dynamic, object or valuetype.
+ref struct S { }

--- a/csharp/ql/test/library-tests/conversion/boxing/Boxing.expected
+++ b/csharp/ql/test/library-tests/conversion/boxing/Boxing.expected
@@ -117,6 +117,9 @@
 | Nullable<Int32> | Object |
 | Nullable<Int32> | ValueType |
 | Nullable<Int32> | dynamic |
+| S | Object |
+| S | ValueType |
+| S | dynamic |
 | T1 | Object |
 | T1 | dynamic |
 | T3 | Object |

--- a/csharp/ql/test/library-tests/conversion/boxing/Boxing.expected
+++ b/csharp/ql/test/library-tests/conversion/boxing/Boxing.expected
@@ -117,9 +117,6 @@
 | Nullable<Int32> | Object |
 | Nullable<Int32> | ValueType |
 | Nullable<Int32> | dynamic |
-| S | Object |
-| S | ValueType |
-| S | dynamic |
 | T1 | Object |
 | T1 | dynamic |
 | T3 | Object |

--- a/csharp/ql/test/library-tests/csharp11/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp11/PrintAst.expected
@@ -847,7 +847,7 @@ RequiredMembers.cs:
 #   40|         0: [Parameter] value
 Scoped.cs:
 #    1| [Struct] S1
-#    2| [Struct] S2
+#    2| [RefStruct] S2
 #    7| [Class] ScopedModifierTest
 #    9|   5: [Method] M1
 #    9|     -1: [TypeMention] int
@@ -1402,7 +1402,7 @@ Strings.cs:
 Struct.cs:
 #    1| [NamespaceDeclaration] namespace ... { ... }
 #    3|   1: [Class] MyEmptyClass
-#    5|   2: [Struct] RefStruct
+#    5|   2: [RefStruct] RefStruct
 #    7|     5: [Field] MyInt
 #    7|       -1: [TypeMention] int
 #    8|     6: [Field] MyByte

--- a/csharp/ql/test/library-tests/csharp7.2/PrintAst.expected
+++ b/csharp/ql/test/library-tests/csharp7.2/PrintAst.expected
@@ -30,8 +30,8 @@ csharp72.cs:
 #   26|           0: [FieldAccess] access to field s
 #   29|   7: [DelegateType] Del
 #   32| [Struct] ReadonlyStruct
-#   36| [Struct] RefStruct
-#   40| [Struct] ReadonlyRefStruct
+#   36| [RefStruct] RefStruct
+#   40| [RefStruct] ReadonlyRefStruct
 #   44| [Class] NumericLiterals
 #   46|   5: [Field] binaryValue
 #   46|     -1: [TypeMention] int

--- a/csharp/ql/test/library-tests/csharp7.2/RefStructs.ql
+++ b/csharp/ql/test/library-tests/csharp7.2/RefStructs.ql
@@ -1,7 +1,5 @@
 import csharp
 
-from Struct s
-where
-  s.fromSource() and
-  s.isRef()
+from RefStruct s
+where s.fromSource()
 select s

--- a/csharp/ql/test/library-tests/dispatch/CallContext.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.expected
@@ -26,5 +26,4 @@ mayBenefitFromCallContext
 | ViableCallable.cs:576:18:576:22 | call to operator / |
 | ViableCallable.cs:579:26:579:30 | call to operator checked / |
 | ViableCallable.cs:585:9:585:15 | call to method M12 |
-| ViableCallable.cs:612:9:612:13 | call to method M |
 | ViableCallable.cs:618:9:618:13 | call to method M |

--- a/csharp/ql/test/library-tests/dispatch/CallContext.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallContext.expected
@@ -26,3 +26,5 @@ mayBenefitFromCallContext
 | ViableCallable.cs:576:18:576:22 | call to operator / |
 | ViableCallable.cs:579:26:579:30 | call to operator checked / |
 | ViableCallable.cs:585:9:585:15 | call to method M12 |
+| ViableCallable.cs:612:9:612:13 | call to method M |
+| ViableCallable.cs:618:9:618:13 | call to method M |

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -260,6 +260,5 @@
 | ViableCallable.cs:555:10:555:15 | Run`1 | ViableCallable.cs:552:17:552:19 | M11 |
 | ViableCallable.cs:555:10:555:15 | Run`1 | ViableCallable.cs:553:17:553:19 | M12 |
 | ViableCallable.cs:609:17:609:23 | Run1`1 | ViableCallable.cs:601:21:601:21 | M |
-| ViableCallable.cs:609:17:609:23 | Run1`1 | ViableCallable.cs:606:21:606:21 | M |
 | ViableCallable.cs:615:17:615:23 | Run2`1 | ViableCallable.cs:601:21:601:21 | M |
 | ViableCallable.cs:615:17:615:23 | Run2`1 | ViableCallable.cs:606:21:606:21 | M |

--- a/csharp/ql/test/library-tests/dispatch/CallGraph.expected
+++ b/csharp/ql/test/library-tests/dispatch/CallGraph.expected
@@ -259,3 +259,7 @@
 | ViableCallable.cs:555:10:555:15 | Run`1 | ViableCallable.cs:550:40:550:40 | checked / |
 | ViableCallable.cs:555:10:555:15 | Run`1 | ViableCallable.cs:552:17:552:19 | M11 |
 | ViableCallable.cs:555:10:555:15 | Run`1 | ViableCallable.cs:553:17:553:19 | M12 |
+| ViableCallable.cs:609:17:609:23 | Run1`1 | ViableCallable.cs:601:21:601:21 | M |
+| ViableCallable.cs:609:17:609:23 | Run1`1 | ViableCallable.cs:606:21:606:21 | M |
+| ViableCallable.cs:615:17:615:23 | Run2`1 | ViableCallable.cs:601:21:601:21 | M |
+| ViableCallable.cs:615:17:615:23 | Run2`1 | ViableCallable.cs:606:21:606:21 | M |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -506,6 +506,5 @@
 | ViableCallable.cs:585:9:585:15 | call to method M12 | I3<T>.M12() |
 | ViableCallable.cs:588:9:588:15 | call to method M13 | I3<T>.M13() |
 | ViableCallable.cs:612:9:612:13 | call to method M | C21+A1.M() |
-| ViableCallable.cs:612:9:612:13 | call to method M | C21+A2.M() |
 | ViableCallable.cs:618:9:618:13 | call to method M | C21+A1.M() |
 | ViableCallable.cs:618:9:618:13 | call to method M | C21+A2.M() |

--- a/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
+++ b/csharp/ql/test/library-tests/dispatch/GetADynamicTarget.expected
@@ -505,3 +505,7 @@
 | ViableCallable.cs:585:9:585:15 | call to method M12 | C20.M12() |
 | ViableCallable.cs:585:9:585:15 | call to method M12 | I3<T>.M12() |
 | ViableCallable.cs:588:9:588:15 | call to method M13 | I3<T>.M13() |
+| ViableCallable.cs:612:9:612:13 | call to method M | C21+A1.M() |
+| ViableCallable.cs:612:9:612:13 | call to method M | C21+A2.M() |
+| ViableCallable.cs:618:9:618:13 | call to method M | C21+A1.M() |
+| ViableCallable.cs:618:9:618:13 | call to method M | C21+A2.M() |

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -608,7 +608,7 @@ public class C21
 
     public void Run1<T>(T t) where T : I
     {
-        // Viable callable: A1.M() [also reports A2.M(); false positive]
+        // Viable callable: A1.M()
         t.M();
     }
 

--- a/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
+++ b/csharp/ql/test/library-tests/dispatch/ViableCallable.cs
@@ -588,3 +588,33 @@ public class C20 : I3<C20>
         c.M13();
     }
 }
+
+public class C21
+{
+    public interface I
+    {
+        void M();
+    }
+
+    public class A1 : I
+    {
+        public void M() { }
+    }
+
+    public ref struct A2 : I
+    {
+        public void M() { }
+    }
+
+    public void Run1<T>(T t) where T : I
+    {
+        // Viable callable: A1.M() [also reports A2.M(); false positive]
+        t.M();
+    }
+
+    public void Run2<T>(T t) where T : I, allows ref struct
+    {
+        // Viable callable: {A1, A2}.M()
+        t.M();
+    }
+}

--- a/csharp/ql/test/library-tests/typeparameterconstraints/TypeParameterConstraints.cs
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/TypeParameterConstraints.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+public class TestClass
+{
+    public void M1<T1>(T1 x) where T1 : class { }
+
+    public void M2<T2>(T2 x) where T2 : struct { }
+
+    public void M3<T3>(T3 x) where T3 : unmanaged { }
+
+    public void M4<T4>(T4 x) where T4 : new() { }
+
+    public void M5<T5>(T5 x) where T5 : notnull { }
+
+    public void M6<T6>(T6 x) where T6 : IList<object> { }
+
+    public void M7<T7>(T7 x) where T7 : allows ref struct { }
+}

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
@@ -20,3 +20,5 @@ hasUnmanagedTypeConstraint
 hasNullableRefTypeConstraint
 hasNotNullConstraint
 | TypeParameterConstraints.cs:14:20:14:21 | T5 | file://:0:0:0:0 | where T5: ... |
+hasAllowRefLikeTypeConstraint
+| TypeParameterConstraints.cs:18:20:18:21 | T7 | file://:0:0:0:0 | where T7: ... |

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
@@ -18,3 +18,5 @@ hasValueTypeConstraint
 hasUnmanagedTypeConstraint
 | TypeParameterConstraints.cs:10:20:10:21 | T3 | file://:0:0:0:0 | where T3: ... |
 hasNullableRefTypeConstraint
+hasNotNullConstraint
+| TypeParameterConstraints.cs:14:20:14:21 | T5 | file://:0:0:0:0 | where T5: ... |

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.expected
@@ -1,0 +1,20 @@
+typeParameterContraints
+| TypeParameterConstraints.cs:6:20:6:21 | T1 | file://:0:0:0:0 | where T1: ... |
+| TypeParameterConstraints.cs:8:20:8:21 | T2 | file://:0:0:0:0 | where T2: ... |
+| TypeParameterConstraints.cs:10:20:10:21 | T3 | file://:0:0:0:0 | where T3: ... |
+| TypeParameterConstraints.cs:12:20:12:21 | T4 | file://:0:0:0:0 | where T4: ... |
+| TypeParameterConstraints.cs:14:20:14:21 | T5 | file://:0:0:0:0 | where T5: ... |
+| TypeParameterConstraints.cs:16:20:16:21 | T6 | file://:0:0:0:0 | where T6: ... |
+| TypeParameterConstraints.cs:18:20:18:21 | T7 | file://:0:0:0:0 | where T7: ... |
+specificParameterConstraints
+| TypeParameterConstraints.cs:16:20:16:21 | T6 | IList<object> |
+hasConstructorConstraint
+| TypeParameterConstraints.cs:12:20:12:21 | T4 | file://:0:0:0:0 | where T4: ... |
+hasRefTypeConstraint
+| TypeParameterConstraints.cs:6:20:6:21 | T1 | file://:0:0:0:0 | where T1: ... |
+hasValueTypeConstraint
+| TypeParameterConstraints.cs:8:20:8:21 | T2 | file://:0:0:0:0 | where T2: ... |
+| TypeParameterConstraints.cs:10:20:10:21 | T3 | file://:0:0:0:0 | where T3: ... |
+hasUnmanagedTypeConstraint
+| TypeParameterConstraints.cs:10:20:10:21 | T3 | file://:0:0:0:0 | where T3: ... |
+hasNullableRefTypeConstraint

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
@@ -1,0 +1,31 @@
+import csharp
+
+query predicate typeParameterContraints(TypeParameter tp, TypeParameterConstraints tpc) {
+  tp.fromSource() and tp.getConstraints() = tpc
+}
+
+query predicate specificParameterConstraints(TypeParameter tp, string type) {
+  exists(TypeParameterConstraints tpc |
+    typeParameterContraints(tp, tpc) and type = tpc.getATypeConstraint().toStringWithTypes()
+  )
+}
+
+query predicate hasConstructorConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasConstructorConstraint()
+}
+
+query predicate hasRefTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasRefTypeConstraint()
+}
+
+query predicate hasValueTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasValueTypeConstraint()
+}
+
+query predicate hasUnmanagedTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasUnmanagedTypeConstraint()
+}
+
+query predicate hasNullableRefTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasNullableRefTypeConstraint()
+}

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
@@ -33,3 +33,7 @@ query predicate hasNullableRefTypeConstraint(TypeParameter tp, TypeParameterCons
 query predicate hasNotNullConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
   typeParameterContraints(tp, tpc) and tpc.hasNotNullTypeConstraint()
 }
+
+query predicate hasAllowRefLikeTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasAllowRefLikeTypeConstraint()
+}

--- a/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
+++ b/csharp/ql/test/library-tests/typeparameterconstraints/typeParameterConstraints.ql
@@ -29,3 +29,7 @@ query predicate hasUnmanagedTypeConstraint(TypeParameter tp, TypeParameterConstr
 query predicate hasNullableRefTypeConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
   typeParameterContraints(tp, tpc) and tpc.hasNullableRefTypeConstraint()
 }
+
+query predicate hasNotNullConstraint(TypeParameter tp, TypeParameterConstraints tpc) {
+  typeParameterContraints(tp, tpc) and tpc.hasNotNullTypeConstraint()
+}

--- a/csharp/ql/test/library-tests/unification/Unification.cs
+++ b/csharp/ql/test/library-tests/unification/Unification.cs
@@ -48,3 +48,11 @@ class Nested<T10>
     Nested<int>.NestedB.NestedC<bool> x5;
     Nested<string>.NestedB.NestedC<decimal> x6;
 }
+
+interface I2 { }
+struct S3 : I2 { }
+ref struct RS : I2 { }
+class C7 : I2 { }
+
+class NormalConstraint<T> where T : I2 { } // False positive: Allows T to be `RS`.
+class NegativeConstraint<T> where T : I2, allows ref struct { }

--- a/csharp/ql/test/library-tests/unification/Unification.cs
+++ b/csharp/ql/test/library-tests/unification/Unification.cs
@@ -54,5 +54,5 @@ struct S3 : I2 { }
 ref struct RS : I2 { }
 class C7 : I2 { }
 
-class NormalConstraint<T> where T : I2 { } // False positive: Allows T to be `RS`.
+class NormalConstraint<T> where T : I2 { }
 class NegativeConstraint<T> where T : I2, allows ref struct { }

--- a/csharp/ql/test/library-tests/unification/Unification.expected
+++ b/csharp/ql/test/library-tests/unification/Unification.expected
@@ -7,6 +7,8 @@ constrainedTypeParameterSubsumes
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:30:12:30:24 | (string, int) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:32:12:32:19 | (T8, T9) |
+| Unification.cs:8:10:8:11 | T2 | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:8:10:8:11 | T2 | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:1:11:1:12 | I1 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:6:7:6:8 | C0 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:7:7:7:12 | C1<C0> |
@@ -57,6 +59,10 @@ constrainedTypeParameterSubsumes
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<T12> |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<decimal> |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:57:7:57:25 | NormalConstraint<T> |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:58:7:58:27 | NegativeConstraint<T> |
 | Unification.cs:10:10:10:11 | T4 | Unification.cs:7:7:7:12 | C1<C0> |
 | Unification.cs:10:10:10:11 | T4 | Unification.cs:10:10:10:11 | T4 |
 | Unification.cs:11:10:11:11 | T5 | Unification.cs:8:7:8:12 | C2<S1> |
@@ -96,8 +102,22 @@ constrainedTypeParameterSubsumes
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:30:12:30:24 | (string, int) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:32:12:32:19 | (T8, T9) |
+| Unification.cs:12:25:12:27 | T6d | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:12:25:12:27 | T6d | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<S2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:24:12:24:13 | Tm |
+| Unification.cs:57:24:57:24 | T | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:54:12:54:13 | RS |
+| Unification.cs:57:24:57:24 | T | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:57:24:57:24 | T |
+| Unification.cs:57:24:57:24 | T | Unification.cs:58:26:58:26 | T |
+| Unification.cs:58:26:58:26 | T | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:54:12:54:13 | RS |
+| Unification.cs:58:26:58:26 | T | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:57:24:57:24 | T |
+| Unification.cs:58:26:58:26 | T | Unification.cs:58:26:58:26 | T |
 constrainedTypeParameterSubsumptionImpliesUnification
 constrainedTypeParameterUnifiable
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:3:8:3:9 | S1 |
@@ -108,6 +128,8 @@ constrainedTypeParameterUnifiable
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:30:12:30:24 | (string, int) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:32:12:32:19 | (T8, T9) |
+| Unification.cs:8:10:8:11 | T2 | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:8:10:8:11 | T2 | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:1:11:1:12 | I1 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:6:7:6:8 | C0 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:7:7:7:12 | C1<C0> |
@@ -158,6 +180,10 @@ constrainedTypeParameterUnifiable
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<T12> |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<decimal> |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:57:7:57:25 | NormalConstraint<T> |
+| Unification.cs:9:10:9:11 | T3 | Unification.cs:58:7:58:27 | NegativeConstraint<T> |
 | Unification.cs:10:10:10:11 | T4 | Unification.cs:7:7:7:12 | C1<C0> |
 | Unification.cs:10:10:10:11 | T4 | Unification.cs:7:7:7:12 | C1<T1> |
 | Unification.cs:10:10:10:11 | T4 | Unification.cs:7:7:7:12 | C1<T2> |
@@ -205,9 +231,23 @@ constrainedTypeParameterUnifiable
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:30:12:30:24 | (string, int) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:32:12:32:19 | (T8, T9) |
+| Unification.cs:12:25:12:27 | T6d | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:12:25:12:27 | T6d | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<S2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<T2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:24:12:24:13 | Tm |
+| Unification.cs:57:24:57:24 | T | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:54:12:54:13 | RS |
+| Unification.cs:57:24:57:24 | T | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:57:24:57:24 | T | Unification.cs:57:24:57:24 | T |
+| Unification.cs:57:24:57:24 | T | Unification.cs:58:26:58:26 | T |
+| Unification.cs:58:26:58:26 | T | Unification.cs:52:11:52:12 | I2 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:53:8:53:9 | S3 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:54:12:54:13 | RS |
+| Unification.cs:58:26:58:26 | T | Unification.cs:55:7:55:8 | C7 |
+| Unification.cs:58:26:58:26 | T | Unification.cs:57:24:57:24 | T |
+| Unification.cs:58:26:58:26 | T | Unification.cs:58:26:58:26 | T |
 subsumes
 | Unification.cs:7:7:7:12 | C1<C0> | Unification.cs:7:7:7:12 | C1<C0> |
 | Unification.cs:7:7:7:12 | C1<S1> | Unification.cs:7:7:7:12 | C1<S1> |
@@ -312,6 +352,8 @@ subsumes
 | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<T12> |
 | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> | Unification.cs:41:22:41:33 | Nested<System.String>+NestedB+NestedC<decimal> |
 | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> | Unification.cs:41:22:41:33 | Nested`1+NestedB+NestedC<T12> |
+| Unification.cs:57:7:57:25 | NormalConstraint<T> | Unification.cs:57:7:57:25 | NormalConstraint<T> |
+| Unification.cs:58:7:58:27 | NegativeConstraint<T> | Unification.cs:58:7:58:27 | NegativeConstraint<T> |
 subsumptionImpliesUnification
 unifiable
 | Unification.cs:7:7:7:12 | C1<C0> | Unification.cs:7:7:7:12 | C1<T1> |

--- a/csharp/ql/test/library-tests/unification/Unification.expected
+++ b/csharp/ql/test/library-tests/unification/Unification.expected
@@ -8,7 +8,6 @@ constrainedTypeParameterSubsumes
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:32:12:32:19 | (T8, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:8:10:8:11 | T2 | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:1:11:1:12 | I1 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:6:7:6:8 | C0 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:7:7:7:12 | C1<C0> |
@@ -103,12 +102,10 @@ constrainedTypeParameterSubsumes
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:32:12:32:19 | (T8, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:12:25:12:27 | T6d | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<S2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:24:12:24:13 | Tm |
 | Unification.cs:57:24:57:24 | T | Unification.cs:52:11:52:12 | I2 |
 | Unification.cs:57:24:57:24 | T | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:57:24:57:24 | T | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:57:24:57:24 | T | Unification.cs:55:7:55:8 | C7 |
 | Unification.cs:57:24:57:24 | T | Unification.cs:57:24:57:24 | T |
 | Unification.cs:57:24:57:24 | T | Unification.cs:58:26:58:26 | T |
@@ -129,7 +126,6 @@ constrainedTypeParameterUnifiable
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:32:12:32:19 | (T8, T9) |
 | Unification.cs:8:10:8:11 | T2 | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:8:10:8:11 | T2 | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:1:11:1:12 | I1 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:6:7:6:8 | C0 |
 | Unification.cs:9:10:9:11 | T3 | Unification.cs:7:7:7:12 | C1<C0> |
@@ -232,13 +228,11 @@ constrainedTypeParameterUnifiable
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:31:12:31:23 | (string, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:32:12:32:19 | (T8, T9) |
 | Unification.cs:12:25:12:27 | T6d | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:12:25:12:27 | T6d | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<S2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:8:7:8:12 | C2<T2> |
 | Unification.cs:24:12:24:13 | Tm | Unification.cs:24:12:24:13 | Tm |
 | Unification.cs:57:24:57:24 | T | Unification.cs:52:11:52:12 | I2 |
 | Unification.cs:57:24:57:24 | T | Unification.cs:53:8:53:9 | S3 |
-| Unification.cs:57:24:57:24 | T | Unification.cs:54:12:54:13 | RS |
 | Unification.cs:57:24:57:24 | T | Unification.cs:55:7:55:8 | C7 |
 | Unification.cs:57:24:57:24 | T | Unification.cs:57:24:57:24 | T |
 | Unification.cs:57:24:57:24 | T | Unification.cs:58:26:58:26 | T |


### PR DESCRIPTION
In this PR we introduce support for the `allows ref struct` type parameter constraint. The language feature is described [here](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#allows-ref-struct).

A couple of notes on the implementation.
- A `ref struct` type can not be implicitly converted to a `dynamic` type, `object` or `ValueType`.
- The `allows ref struct` is a *negative* constraint meaning that it extends the number of types that can be used as type replacement for a type parameter.

The *unification* and *dispatch* *call* logic has been adapted to take the `allows ref struct` constraint into account (relevant for dynamic dispatch) for deciding relevant dispatch targets. To make things easier a new class `RefStruct` has been introduced in the type hierarcy. One could consider whether we want to change the type hierarchy such that `RefStruct` doesn't extend `Struct` (and thereby `ValueType`). Not sure whether this is worth it.


Furthermore, we also extract the `notnull` general type parameter constraint.
