### PR TITLE
Go: Add post-processing to StoredXss.qlref test

### DIFF
--- a/go/ql/test/query-tests/Security/CWE-079/StoredXss.qlref
+++ b/go/ql/test/query-tests/Security/CWE-079/StoredXss.qlref
@@ -1,1 +1,2 @@
-Security/CWE-079/StoredXss.ql
+query: Security/CWE-079/StoredXss.ql
+postprocess: utils/test/PrettyPrintModels.ql


### PR DESCRIPTION
Updates the `StoredXss.qlref` test to use test post-processing. 

Merging this separately will make the `database` source model PRs easier.