### PR TITLE
C++: Silence alerts coming from CMake test compilation files

### DIFF
--- a/cpp/ql/lib/change-notes/2025-01-07-config.md
+++ b/cpp/ql/lib/change-notes/2025-01-07-config.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* A new abstract class `ConfigurationTestFile` (`semmle.code.cpp.ConfigurationTestFile.ConfigurationTestFile`) was introduced, which represents files created to test the build configuration. A subclass `CmakeTryCompileFile` of `ConfigurationTestFile` was also introduced, which represents files created by CMake to test the build configuration.

--- a/cpp/ql/lib/semmle/code/cpp/ConfigurationTestFile.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ConfigurationTestFile.qll
@@ -1,0 +1,28 @@
+/**
+ * Provides classes for identifying files that created to test the
+ * build configuration. It is often desirable to exclude these files
+ * from analysis.
+ */
+
+import File
+
+/**
+ * A file created to test the system configuration.
+ */
+abstract class ConfigurationTestFile extends File { }
+
+/**
+ * A file created by CMake to test the system configuration.
+ */
+class CmakeTryCompileFile extends ConfigurationTestFile {
+  CmakeTryCompileFile() {
+    exists(Folder folder, Folder parent |
+      folder = this.getParentContainer() and
+      parent = folder.getParentContainer()
+    |
+      folder.getBaseName().matches("TryCompile-%") and
+      parent.getBaseName() = "CMakeScratch" and
+      parent.getParentContainer().getBaseName() = "CMakeFiles"
+    )
+  }
+}

--- a/cpp/ql/src/Best Practices/SloppyGlobal.ql
+++ b/cpp/ql/src/Best Practices/SloppyGlobal.ql
@@ -9,11 +9,13 @@
  */
 
 import cpp
+import semmle.code.cpp.ConfigurationTestFile
 
 from GlobalVariable gv
 where
   gv.getName().length() <= 3 and
-  not gv.isStatic()
+  not gv.isStatic() and
+  not gv.getFile() instanceof ConfigurationTestFile // variables in files generated during configuration are likely false positives
 select gv,
   "Poor global variable name '" + gv.getName() +
     "'. Prefer longer, descriptive names for globals (eg. kMyGlobalConstant, not foo)."

--- a/cpp/ql/src/Critical/OverflowStatic.ql
+++ b/cpp/ql/src/Critical/OverflowStatic.ql
@@ -17,6 +17,7 @@ import cpp
 import semmle.code.cpp.commons.Buffer
 import semmle.code.cpp.ir.dataflow.DataFlow
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
+import semmle.code.cpp.ConfigurationTestFile
 import LoopBounds
 
 private predicate staticBufferBase(VariableAccess access, Variable v) {
@@ -148,7 +149,10 @@ predicate outOfBounds(BufferAccess bufaccess, string msg) {
 
 from Element error, string msg
 where
-  overflowOffsetInLoop(error, msg) or
-  wrongBufferSize(error, msg) or
-  outOfBounds(error, msg)
+  (
+    overflowOffsetInLoop(error, msg) or
+    wrongBufferSize(error, msg) or
+    outOfBounds(error, msg)
+  ) and
+  not error.getFile() instanceof ConfigurationTestFile // elements in files generated during configuration are likely false positives
 select error, msg

--- a/cpp/ql/src/Likely Bugs/Arithmetic/FloatComparison.ql
+++ b/cpp/ql/src/Likely Bugs/Arithmetic/FloatComparison.ql
@@ -12,6 +12,7 @@
  */
 
 import cpp
+import semmle.code.cpp.ConfigurationTestFile
 
 from EqualityOperation ro, Expr left, Expr right
 where
@@ -20,5 +21,6 @@ where
   ro.getAnOperand().getExplicitlyConverted().getType().getUnderlyingType() instanceof
     FloatingPointType and
   not ro.getAnOperand().isConstant() and // comparisons to constants generate too many false positives
-  not left.(VariableAccess).getTarget() = right.(VariableAccess).getTarget() // skip self comparison
+  not left.(VariableAccess).getTarget() = right.(VariableAccess).getTarget() and // skip self comparison
+  not ro.getFile() instanceof ConfigurationTestFile // expressions in files generated during configuration are likely false positives
 select ro, "Equality checks on floating point values can yield unexpected results."

--- a/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
+++ b/cpp/ql/src/Likely Bugs/Likely Typos/ExprHasNoEffect.ql
@@ -12,7 +12,8 @@
  */
 
 import cpp
-private import semmle.code.cpp.commons.Exclusions
+import semmle.code.cpp.commons.Exclusions
+import semmle.code.cpp.ConfigurationTestFile
 
 class PureExprInVoidContext extends ExprInVoidContext {
   PureExprInVoidContext() { this.isPure() }
@@ -90,6 +91,7 @@ where
   not peivc.getType() instanceof UnknownType and
   not functionContainsDisabledCodeRecursive(peivc.(FunctionCall).getTarget()) and
   not functionDefinedInIfDefRecursive(peivc.(FunctionCall).getTarget()) and
+  not peivc.getFile() instanceof ConfigurationTestFile and // expressions in files generated during configuration are likely false positives
   if peivc instanceof FunctionCall
   then
     exists(Function target |

--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.ql
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/TooFewArguments.ql
@@ -19,7 +19,10 @@
 
 import cpp
 import TooFewArguments
+import semmle.code.cpp.ConfigurationTestFile
 
 from FunctionCall fc, Function f
-where tooFewArguments(fc, f)
+where
+  tooFewArguments(fc, f) and
+  not fc.getFile() instanceof ConfigurationTestFile // calls in files generated during configuration are likely false positives
 select fc, "This call has fewer arguments than required by $@.", f, f.toString()

--- a/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
+++ b/cpp/ql/src/Security/CWE/CWE-120/BadlyBoundedWrite.ql
@@ -16,6 +16,7 @@
  */
 
 import semmle.code.cpp.security.BufferWrite
+import semmle.code.cpp.ConfigurationTestFile
 
 /*
  * See CWE-120/UnboundedWrite.ql for a summary of CWE-120 alert cases.
@@ -26,7 +27,8 @@ where
   bw.hasExplicitLimit() and // has an explicit size limit
   destSize = max(getBufferSize(bw.getDest(), _)) and
   bw.getExplicitLimit() > destSize and // but it's larger than the destination
-  not bw.getDest().getType().stripType() instanceof ErroneousType // destSize may be incorrect
+  not bw.getDest().getType().stripType() instanceof ErroneousType and // destSize may be incorrect
+  not bw.getFile() instanceof ConfigurationTestFile // expressions in files generated during configuration are likely false positives
 select bw,
   "This '" + bw.getBWDesc() + "' operation is limited to " + bw.getExplicitLimit() +
     " bytes but the destination is only " + destSize + " bytes."

--- a/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
+++ b/cpp/ql/src/Security/CWE/CWE-732/DoNotCreateWorldWritable.ql
@@ -12,6 +12,7 @@
 
 import cpp
 import FilePermissions
+import semmle.code.cpp.ConfigurationTestFile
 
 predicate worldWritableCreation(FileCreationExpr fc, int mode) {
   mode = localUmask(fc).mask(fc.getMode()) and
@@ -27,6 +28,7 @@ predicate setWorldWritable(FunctionCall fc, int mode) {
 from Expr fc, int mode, string message
 where
   worldWritableCreation(fc, mode) and
+  not fc.getFile() instanceof ConfigurationTestFile and // expressions in files generated during configuration are likely false positives
   message =
     "A file may be created here with mode " + octalFileMode(mode) +
       ", which would make it world-writable."

--- a/cpp/ql/src/change-notes/2025-01-07-cmake.md
+++ b/cpp/ql/src/change-notes/2025-01-07-cmake.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The `cpp/badly-bounded-write`, `cpp/equality-on-floats`, `cpp/short-global-name`, `cpp/static-buffer-overflow`, `cpp/too-few-arguments`, `cpp/useless-expression`, `cpp/world-writable-file-creation` queries no longer produce alerts on files created by CMake to test the build configuration.

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/CheckFunctionExists.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/CheckFunctionExists.c
@@ -3,6 +3,6 @@ typedef long long size_t;
 size_t strlen(const char *s);
 
 int main() {
-  strlen("");
+  strlen(""); // GOOD: the source file occurs in a `CMakeFiles/CMakeScratch/TryCompile-...` directory
   return 0;
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/CheckFunctionExists.c
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/CheckFunctionExists.c
@@ -1,0 +1,8 @@
+typedef long long size_t;
+
+size_t strlen(const char *s);
+
+int main() {
+  strlen("");
+  return 0;
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.expected
@@ -1,1 +1,0 @@
-| CheckFunctionExists.c:6:3:6:8 | call to strlen | This expression has no effect (because $@ has no external side effects). | CheckFunctionExists.c:3:8:3:13 | strlen | strlen |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.expected
@@ -1,0 +1,1 @@
+| CheckFunctionExists.c:6:3:6:8 | call to strlen | This expression has no effect (because $@ has no external side effects). | CheckFunctionExists.c:3:8:3:13 | strlen | strlen |

--- a/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.qlref
+++ b/cpp/ql/test/query-tests/Likely Bugs/Likely Typos/ExprHasNoEffect/CMakeFiles/CMakeScratch/TryCompile-abcdef/ExprHasNoEffect.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Likely Typos/ExprHasNoEffect.ql


### PR DESCRIPTION
This silences alert wobble, as the suffix of CMake `TryCompile-` directories is random and changes each time a project is built.

There's probably other queries where this makes sense, but for now I've limited myself to queries for which I concretely observed `TryCompile-` files showing up.

DCA nightly shows that the neovim alerts on `TryCompile-` files disappears, and similarly for DCA autobuild posix and .NET diagnostics.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
