### PR TITLE
Rust: Sensitive data library

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -247,7 +247,8 @@
     "javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll",
     "python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll",
     "ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll",
-    "swift/ql/lib/codeql/swift/security/internal/SensitiveDataHeuristics.qll"
+    "swift/ql/lib/codeql/swift/security/internal/SensitiveDataHeuristics.qll",
+    "rust/ql/lib/codeql/rust/security/internal/SensitiveDataHeuristics.qll"
   ],
   "IncompleteUrlSubstringSanitization": [
     "javascript/ql/src/Security/CWE-020/IncompleteUrlSubstringSanitization.qll",

--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -14,5 +14,6 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
+| Sensitive data | 0 |
 | Taint sources - active | 0 |
 | Taint sources - total | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -14,5 +14,6 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
+| Sensitive data | 0 |
 | Taint sources - active | 0 |
 | Taint sources - total | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -14,5 +14,6 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
+| Sensitive data | 0 |
 | Taint sources - active | 0 |
 | Taint sources - total | 0 |

--- a/rust/ql/lib/codeql/rust/security/SensitiveData.qll
+++ b/rust/ql/lib/codeql/rust/security/SensitiveData.qll
@@ -15,7 +15,7 @@ private import codeql.rust.dataflow.DataFlow
 cached
 abstract class SensitiveData extends DataFlow::Node {
   /**
-   * Gets a classification of the kind of sensitive data this expression might contain.
+   * Gets the classification of sensitive data this expression might contain.
    */
   cached
   abstract SensitiveDataClassification getClassification();
@@ -35,7 +35,7 @@ private class SensitiveDataFunction extends Function {
 }
 
 /**
- * A function call that might produce sensitive data.
+ * A function call data flow node that might produce sensitive data.
  */
 private class SensitiveDataCall extends SensitiveData {
   SensitiveDataClassification classification;
@@ -67,7 +67,7 @@ private class SensitiveDataVariable extends Variable {
 }
 
 /**
- * A variable access that might produce sensitive data.
+ * A variable access data flow node that might produce sensitive data.
  */
 private class SensitiveVariableAccess extends SensitiveData {
   SensitiveDataClassification classification;

--- a/rust/ql/lib/codeql/rust/security/SensitiveData.qll
+++ b/rust/ql/lib/codeql/rust/security/SensitiveData.qll
@@ -1,0 +1,86 @@
+/**
+ * Provides classes and predicates for identifying sensitive data.
+ *
+ * 'Sensitive' data is anything that should not be sent in unencrypted form. This library tries to
+ * guess where sensitive data may either be stored in a variable or produced by a method.
+ */
+
+import rust
+private import internal.SensitiveDataHeuristics
+private import codeql.rust.dataflow.DataFlow
+
+/**
+ * A data flow node that might contain sensitive data.
+ */
+cached
+abstract class SensitiveData extends DataFlow::Node {
+  /**
+   * Gets a classification of the kind of sensitive data this expression might contain.
+   */
+  cached
+  abstract SensitiveDataClassification getClassification();
+}
+
+/**
+ * A function that might produce sensitive data.
+ */
+private class SensitiveDataFunction extends Function {
+  SensitiveDataClassification classification;
+
+  SensitiveDataFunction() {
+    HeuristicNames::nameIndicatesSensitiveData(this.getName().getText(), classification)
+  }
+
+  SensitiveDataClassification getClassification() { result = classification }
+}
+
+/**
+ * A function call that might produce sensitive data.
+ */
+private class SensitiveDataCall extends SensitiveData {
+  SensitiveDataClassification classification;
+
+  SensitiveDataCall() {
+    classification =
+      this.asExpr()
+          .getAstNode()
+          .(CallExprBase)
+          .getStaticTarget()
+          .(SensitiveDataFunction)
+          .getClassification()
+  }
+
+  override SensitiveDataClassification getClassification() { result = classification }
+}
+
+/**
+ * A variable that might contain sensitive data.
+ */
+private class SensitiveDataVariable extends Variable {
+  SensitiveDataClassification classification;
+
+  SensitiveDataVariable() {
+    HeuristicNames::nameIndicatesSensitiveData(this.getName(), classification)
+  }
+
+  SensitiveDataClassification getClassification() { result = classification }
+}
+
+/**
+ * A variable access that might produce sensitive data.
+ */
+private class SensitiveVariableAccess extends SensitiveData {
+  SensitiveDataClassification classification;
+
+  SensitiveVariableAccess() {
+    classification =
+      this.asExpr()
+          .getAstNode()
+          .(VariableAccess)
+          .getVariable()
+          .(SensitiveDataVariable)
+          .getClassification()
+  }
+
+  override SensitiveDataClassification getClassification() { result = classification }
+}

--- a/rust/ql/lib/codeql/rust/security/internal/SensitiveDataHeuristics.qll
+++ b/rust/ql/lib/codeql/rust/security/internal/SensitiveDataHeuristics.qll
@@ -1,0 +1,188 @@
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides classes and predicates for identifying strings that may indicate the presence of sensitive data.
+ * Such that we can share this logic across our CodeQL analysis of different languages.
+ *
+ * 'Sensitive' data in general is anything that should not be sent around in unencrypted form.
+ */
+
+/**
+ * A classification of different kinds of sensitive data:
+ *
+ *   - secret: generic secret or trusted data;
+ *   - id: a user name or other account information;
+ *   - password: a password or authorization key;
+ *   - certificate: a certificate.
+ *   - private: private data such as credit card numbers
+ *
+ * While classifications are represented as strings, this should not be relied upon.
+ * Instead, use the predicates in `SensitiveDataClassification::` to work with
+ * classifications.
+ */
+class SensitiveDataClassification extends string {
+  SensitiveDataClassification() { this in ["secret", "id", "password", "certificate", "private"] }
+}
+
+/**
+ * Provides predicates to select the different kinds of sensitive data we support.
+ */
+module SensitiveDataClassification {
+  /** Gets the classification for secret or trusted data. */
+  SensitiveDataClassification secret() { result = "secret" }
+
+  /** Gets the classification for user names or other account information. */
+  SensitiveDataClassification id() { result = "id" }
+
+  /** Gets the classification for passwords or authorization keys. */
+  SensitiveDataClassification password() { result = "password" }
+
+  /** Gets the classification for certificates. */
+  SensitiveDataClassification certificate() { result = "certificate" }
+
+  /** Gets the classification for private data. */
+  SensitiveDataClassification private() { result = "private" }
+}
+
+/**
+ * INTERNAL: Do not use.
+ *
+ * Provides heuristics for identifying names related to sensitive information.
+ */
+module HeuristicNames {
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of secret
+   * or trusted data.
+   */
+  string maybeSecret() { result = "(?is).*((?<!is|is_)secret|(?<!un|un_|is|is_)trusted).*" }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of
+   * user names or other account information.
+   */
+  string maybeAccountInfo() {
+    result = "(?is).*acc(ou)?nt.*" or
+    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
+  }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of
+   * a password or an authorization key.
+   */
+  string maybePassword() {
+    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+  }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of
+   * a certificate.
+   */
+  string maybeCertificate() { result = "(?is).*(cert)(?!.*(format|name|ification)).*" }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of
+   * private data.
+   */
+  string maybePrivate() {
+    result =
+      "(?is).*(" +
+        // Inspired by the list on https://cwe.mitre.org/data/definitions/359.html
+        // Government identifiers, such as Social Security Numbers
+        "social.?security|employer.?identification|national.?insurance|resident.?id|" +
+        "passport.?(num|no)|([_-]|\\b)ssn([_-]|\\b)|" +
+        // Contact information, such as home addresses
+        "post.?code|zip.?code|home.?addr|" +
+        // and telephone numbers
+        "(mob(ile)?|home).?(num|no|tel|phone)|(tel|fax|phone).?(num|no)|telephone|" +
+        "emergency.?contact|" +
+        // Geographic location - where the user is (or was)
+        "latitude|longitude|nationality|" +
+        // Financial data - such as credit card numbers, salary, bank accounts, and debts
+        "(credit|debit|bank|visa).?(card|num|no|acc(ou)?nt)|acc(ou)?nt.?(no|num|credit)|" +
+        "salary|billing|credit.?(rating|score)|([_-]|\\b)ccn([_-]|\\b)|" +
+        // Communications - e-mail addresses, private e-mail messages, SMS text messages, chat logs, etc.
+        // "e(mail|_mail)|" + // this seems too noisy
+        // Health - medical conditions, insurance status, prescription records
+        "birth.?da(te|y)|da(te|y).?(of.?)?birth|" +
+        "medical|(health|care).?plan|healthkit|appointment|prescription|" +
+        "blood.?(type|alcohol|glucose|pressure)|heart.?(rate|rhythm)|body.?(mass|fat)|" +
+        "menstrua|pregnan|insulin|inhaler|" +
+        // Relationships - work and family
+        "employ(er|ee)|spouse|maiden.?name" +
+        // ---
+        ").*"
+  }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence
+   * of sensitive data, with `classification` describing the kind of sensitive data involved.
+   */
+  string maybeSensitiveRegexp(SensitiveDataClassification classification) {
+    result = maybeSecret() and classification = SensitiveDataClassification::secret()
+    or
+    result = maybeAccountInfo() and classification = SensitiveDataClassification::id()
+    or
+    result = maybePassword() and classification = SensitiveDataClassification::password()
+    or
+    result = maybeCertificate() and
+    classification = SensitiveDataClassification::certificate()
+    or
+    result = maybePrivate() and
+    classification = SensitiveDataClassification::private()
+  }
+
+  /**
+   * Gets a regular expression that identifies strings that may indicate the presence of data
+   * that is hashed or encrypted, and hence rendered non-sensitive, or contains special characters
+   * suggesting nouns within the string do not represent the meaning of the whole string (e.g. a URL or a SQL query).
+   *
+   * We also filter out common words like `certain` and `concert`, since otherwise these could
+   * be matched by the certificate regular expressions. Same for `accountable` (account), or
+   * `secretarial` (secret).
+   */
+  string notSensitiveRegexp() {
+    result =
+      "(?is).*([^\\w$.-]|redact|censor|obfuscate|hash|md5|sha|random|((?<!un)(en))?(crypt|(?<!pass)code)|certain|concert|secretar|accountant|accountab).*"
+  }
+
+  /**
+   * Holds if `name` may indicate the presence of sensitive data, and `name` does not indicate that
+   * the data is in fact non-sensitive (for example since it is hashed or encrypted).
+   *
+   * That is, one of the regexps from `maybeSensitiveRegexp` matches `name` (with the given
+   * classification), and none of the regexps from `notSensitiveRegexp` matches `name`.
+   */
+  bindingset[name]
+  predicate nameIndicatesSensitiveData(string name) {
+    exists(string combinedRegexp |
+      // Combine all the maybe-sensitive regexps into one using non-capturing groups and |.
+      combinedRegexp =
+        "(?:" + strictconcat(string r | r = maybeSensitiveRegexp(_) | r, ")|(?:") + ")"
+    |
+      name.regexpMatch(combinedRegexp)
+    ) and
+    not name.regexpMatch(notSensitiveRegexp())
+  }
+
+  /**
+   * Holds if `name` may indicate the presence of sensitive data, and
+   * `name` does not indicate that the data is in fact non-sensitive (for example since
+   * it is hashed or encrypted). `classification` describes the kind of sensitive data
+   * involved.
+   *
+   * That is, one of the regexps from `maybeSensitiveRegexp` matches `name` (with the
+   * given classification), and none of the regexps from `notSensitiveRegexp` matches
+   * `name`.
+   *
+   * When the set of names is large, it's worth using `nameIndicatesSensitiveData/1` as a first
+   * pass, since that combines all the regexps into one, and should be faster. Then call this
+   * predicate to get the classification(s).
+   */
+  bindingset[name]
+  predicate nameIndicatesSensitiveData(string name, SensitiveDataClassification classification) {
+    name.regexpMatch(maybeSensitiveRegexp(classification)) and
+    not name.regexpMatch(notSensitiveRegexp())
+  }
+}

--- a/rust/ql/src/queries/summary/SensitiveData.ql
+++ b/rust/ql/src/queries/summary/SensitiveData.ql
@@ -1,0 +1,15 @@
+/**
+ * @name Sensitive Data
+ * @description List all sensitive data found in the database. Sensitive data is anything that
+ *              should not be sent in unencrypted form.
+ * @kind problem
+ * @problem.severity info
+ * @id rust/summary/sensitive-data
+ * @tags summary
+ */
+
+import rust
+import codeql.rust.security.SensitiveData
+
+from SensitiveData d
+select d, "Sensitive data (" + d.getClassification() + "): " + d.toString()

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -8,6 +8,7 @@
 
 import rust
 import codeql.rust.Concepts
+import codeql.rust.security.SensitiveData
 import codeql.rust.Diagnostics
 import Stats
 
@@ -56,4 +57,6 @@ where
   key = "Taint sources - total" and value = count(ThreatModelSource s)
   or
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
+  or
+  key = "Sensitive data" and value = count(SensitiveData d)
 select key, value order by key

--- a/rust/ql/test/library-tests/sensitivedata/SensitiveData.ql
+++ b/rust/ql/test/library-tests/sensitivedata/SensitiveData.ql
@@ -1,0 +1,36 @@
+import rust
+import codeql.rust.dataflow.DataFlow
+import codeql.rust.dataflow.TaintTracking
+import codeql.rust.security.SensitiveData
+import utils.test.InlineExpectationsTest
+
+/**
+ * Configuration for flow from any sensitive data source to an argument of the function `sink`.
+ */
+module SensitiveDataConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof SensitiveData }
+
+  predicate isSink(DataFlow::Node sink) {
+    any(CallExpr call | call.getFunction().(PathExpr).getResolvedPath() = "crate::test::sink")
+        .getArgList()
+        .getAnArg() = sink.asExpr().getExpr()
+  }
+}
+
+module SensitiveDataFlow = TaintTracking::Global<SensitiveDataConfig>;
+
+module SensitiveDataTest implements TestSig {
+  string getARelevantTag() { result = "sensitive" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(DataFlow::Node source, DataFlow::Node sink |
+      SensitiveDataFlow::flow(source, sink) and
+      location = sink.getLocation() and
+      element = sink.toString() and
+      tag = "sensitive" and
+      value = source.(SensitiveData).getClassification()
+    )
+  }
+}
+
+import MakeTest<SensitiveDataTest>

--- a/rust/ql/test/library-tests/sensitivedata/test.rs
+++ b/rust/ql/test/library-tests/sensitivedata/test.rs
@@ -27,21 +27,21 @@ fn test_passwords(
 	ms: &MyStruct
 ) {
 	// passwords
-	sink(password); // $ MISSING: sensitive=password
-	sink(passwd); // $ MISSING: sensitive=password
-	sink(my_password); // $ MISSING: sensitive=password
-	sink(password_str); // $ MISSING: sensitive=password
+	sink(password); // $ sensitive=password
+	sink(passwd); // $ sensitive=password
+	sink(my_password); // $ sensitive=password
+	sink(password_str); // $ sensitive=password
 	sink(pass_phrase); // $ MISSING: sensitive=password
 	sink(auth_key); // $ MISSING: sensitive=password
-	sink(authenticationkey); // $ MISSING: sensitive=password
-	sink(authKey); // $ MISSING: sensitive=password
+	sink(authenticationkey); // $ sensitive=password
+	sink(authKey); // $ sensitive=password
 
 	sink(ms); // $ MISSING: sensitive=password
 	sink(ms.password.as_str()); // $ MISSING: sensitive=password
 
-	sink(get_password()); // $ MISSING: sensitive=password
+	sink(get_password()); // $ sensitive=password
 	let password2 = get_string();
-	sink(password2); // $ MISSING: sensitive=password
+	sink(password2); // $ sensitive=password
 
 	// not passwords
 	sink(harmless);
@@ -69,25 +69,25 @@ fn test_credentials(
 	ms: &MyStruct
 ) {
 	// credentials
-	sink(account_key); // $ MISSING: sensitive=secret
-	sink(accnt_key); // $ MISSING: sensitive=secret
+	sink(account_key); // $ sensitive=id
+	sink(accnt_key); // $ sensitive=id
 	sink(license_key); // $ MISSING: sensitive=secret
-	sink(secret_key); // $ MISSING: sensitive=secret
+	sink(secret_key); // $ sensitive=secret
 
-	sink(ms.get_certificate()); // $ MISSING: sensitive=certificate
+	sink(ms.get_certificate()); // $ sensitive=certificate
 
-	sink(generate_secret_key()); // $ MISSING: sensitive=secret
+	sink(generate_secret_key()); // $ sensitive=secret
 	sink(get_secure_key()); // $ MISSING: sensitive=secret
 	sink(get_private_key()); // $ MISSING: sensitive=secret
-	sink(get_secret_token()); // $ MISSING: sensitive=secret
+	sink(get_secret_token()); // $ sensitive=secret
 
 	// not credentials
 	sink(is_secret);
-	sink(num_accounts);
-	sink(uid);
+	sink(num_accounts); // $ SPURIOUS: sensitive=id
+	sink(uid); // $ SPURIOUS: sensitive=id
 
-	sink(ms.get_certificate_url());
-	sink(ms.get_certificate_file());
+	sink(ms.get_certificate_url()); // $ SPURIOUS: sensitive=certificate
+	sink(ms.get_certificate_file()); // $ SPURIOUS: sensitive=certificate
 
 	sink(get_public_key());
 	sink(get_next_token());

--- a/rust/ql/test/library-tests/sensitivedata/test.rs
+++ b/rust/ql/test/library-tests/sensitivedata/test.rs
@@ -1,0 +1,150 @@
+
+fn get_string() -> String { "string".to_string() }
+
+fn sink<T>(_: T) { }
+
+// --- tests ---
+
+struct MyStruct {
+	harmless: String,
+	password: String,
+	password_file_path: String,
+	password_enabled: String,
+}
+
+impl MyStruct {
+	fn get_certificate(&self) -> String { return get_string() }
+	fn get_certificate_url(&self) -> String { return get_string() }
+	fn get_certificate_file(&self) -> String { return get_string() }
+}
+
+fn get_password() -> String { get_string() }
+
+fn test_passwords(
+	password: &str, passwd: &str, my_password: &str, password_str: &str, pass_phrase: &str,
+	auth_key: &str, authenticationkey: &str, authKey: &str,
+	harmless: &str, encrypted_password: &str, password_hash: &str,
+	ms: &MyStruct
+) {
+	// passwords
+	sink(password); // $ MISSING: sensitive=password
+	sink(passwd); // $ MISSING: sensitive=password
+	sink(my_password); // $ MISSING: sensitive=password
+	sink(password_str); // $ MISSING: sensitive=password
+	sink(pass_phrase); // $ MISSING: sensitive=password
+	sink(auth_key); // $ MISSING: sensitive=password
+	sink(authenticationkey); // $ MISSING: sensitive=password
+	sink(authKey); // $ MISSING: sensitive=password
+
+	sink(ms); // $ MISSING: sensitive=password
+	sink(ms.password.as_str()); // $ MISSING: sensitive=password
+
+	sink(get_password()); // $ MISSING: sensitive=password
+	let password2 = get_string();
+	sink(password2); // $ MISSING: sensitive=password
+
+	// not passwords
+	sink(harmless);
+	sink(encrypted_password);
+	sink(password_hash);
+
+	sink(ms.harmless.as_str());
+	sink(ms.password_file_path.as_str());
+	sink(ms.password_enabled.as_str());
+
+	sink(get_string());
+	let harmless2 = get_string();
+	sink(harmless2);
+}
+
+fn generate_secret_key() -> String { get_string() }
+fn get_secure_key() -> String { get_string() }
+fn get_private_key() -> String { get_string() }
+fn get_public_key() -> String { get_string() }
+fn get_secret_token() -> String { get_string() }
+fn get_next_token() -> String { get_string() }
+
+fn test_credentials(
+	account_key: &str, accnt_key: &str, license_key: &str, secret_key: &str, is_secret: bool, num_accounts: i64, uid: i64,
+	ms: &MyStruct
+) {
+	// credentials
+	sink(account_key); // $ MISSING: sensitive=secret
+	sink(accnt_key); // $ MISSING: sensitive=secret
+	sink(license_key); // $ MISSING: sensitive=secret
+	sink(secret_key); // $ MISSING: sensitive=secret
+
+	sink(ms.get_certificate()); // $ MISSING: sensitive=certificate
+
+	sink(generate_secret_key()); // $ MISSING: sensitive=secret
+	sink(get_secure_key()); // $ MISSING: sensitive=secret
+	sink(get_private_key()); // $ MISSING: sensitive=secret
+	sink(get_secret_token()); // $ MISSING: sensitive=secret
+
+	// not credentials
+	sink(is_secret);
+	sink(num_accounts);
+	sink(uid);
+
+	sink(ms.get_certificate_url());
+	sink(ms.get_certificate_file());
+
+	sink(get_public_key());
+	sink(get_next_token());
+}
+
+struct Financials {
+	harmless: String,
+	my_bank_account_number: String,
+	credit_card_no: String,
+	credit_rating: i32,
+	user_ccn: String
+}
+
+struct MyPrivateInfo {
+	mobile_phone_num: String,
+	contact_email: String,
+	contact_e_mail_2: String,
+	my_ssn: String,
+	birthday: String,
+	emergency_contact: String,
+	name_of_employer: String,
+
+	medical_notes: Vec<String>,
+	latitude: f64,
+	longitude: Option<f64>,
+
+	financials: Financials
+}
+
+fn test_private_info(
+	info: &MyPrivateInfo
+) {
+	// private info
+	sink(info.mobile_phone_num.as_str()); // $ MISSING: sensitive=private
+	sink(info.mobile_phone_num.to_string()); // $ MISSING: sensitive=private
+	sink(info.contact_email.as_str()); // $ MISSING: sensitive=private
+	sink(info.contact_e_mail_2.as_str()); // $ MISSING: sensitive=private
+	sink(info.my_ssn.as_str()); // $ MISSING: sensitive=private
+	sink(info.birthday.as_str()); // $ MISSING: sensitive=private
+	sink(info.emergency_contact.as_str()); // $ MISSING: sensitive=private
+	sink(info.name_of_employer.as_str()); // $ MISSING: sensitive=private
+
+	sink(&info.medical_notes); // $ MISSING: sensitive=private
+	sink(info.medical_notes[0].as_str()); // $ MISSING: sensitive=private
+	for n in info.medical_notes.iter() {
+		sink(n.as_str()); // $ MISSING: sensitive=private
+	}
+
+	sink(info.latitude); // $ MISSING: sensitive=private
+	let x = info.longitude.unwrap();
+	sink(x); // $ MISSING: sensitive=private
+
+	sink(info.financials.my_bank_account_number.as_str()); // $ MISSING: sensitive=private
+	sink(info.financials.credit_card_no.as_str()); // $ MISSING: sensitive=private
+	sink(info.financials.credit_rating); // $ MISSING: sensitive=private
+	sink(info.financials.user_ccn.as_str()); // $ MISSING: sensitive=private
+
+	// not private info
+	sink(info.financials.harmless.as_str());
+}

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -14,5 +14,6 @@
 | Macro calls - resolved | 8 |
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
+| Sensitive data | 0 |
 | Taint sources - active | 0 |
 | Taint sources - total | 0 |


### PR DESCRIPTION
Add a library for recognising sensitive data in Rust.  The core logic in `SensitiveDataHeuristics.qll` is shared between languages, the integration in `SensitiveData.qll` is Rust specific (so are the tests and summary queries).

The implementation here is a bit minimal, there's a lot I want to improve both in the integration and in the shared library.  However I'm keen to get something in place and working so that I can start building queries on top of this alongside making improvements to it.