### PR TITLE
Java: exclude `writeReplace`-defining classes from `Serializable` check

### DIFF
--- a/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
+++ b/java/ql/src/Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql
@@ -24,6 +24,16 @@ where
     c.hasNoParameters() and
     not c.isPrivate()
   ) and
+  // Assume if an object replaces itself prior to serialization,
+  // then it is unlikely to be directly deserialized.
+  // That means it won't need to comply with default serialization rules,
+  // such as non-serializable super-classes having a no-argument constructor.
+  not exists(Method m |
+    m = serial.getAMethod() and
+    m.hasName("writeReplace") and
+    m.getReturnType() instanceof TypeObject and
+    m.hasNoParameters()
+  ) and
   serial.fromSource()
 select serial,
   "This class is serializable, but its non-serializable " +

--- a/java/ql/src/change-notes/2025-01-06-write-replace-serializable.md
+++ b/java/ql/src/change-notes/2025-01-06-write-replace-serializable.md
@@ -1,0 +1,4 @@
+---
+category: fix
+---
+* Classes that define a `writeReplace` method are no longer flagged by the `java/missing-no-arg-constructor-on-serializable` query on the assumption they are unlikely to be deserialized using the default algorithm.

--- a/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/MissingVoidConstructorsOnSerializable.expected
+++ b/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/MissingVoidConstructorsOnSerializable.expected
@@ -1,0 +1,1 @@
+| Test.java:12:7:12:7 | A | This class is serializable, but its non-serializable super-class $@ does not declare a no-argument constructor. | Test.java:4:7:4:20 | NonSerialzable | NonSerialzable |

--- a/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/MissingVoidConstructorsOnSerializable.qlref
+++ b/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/MissingVoidConstructorsOnSerializable.qlref
@@ -1,0 +1,1 @@
+Likely Bugs/Serialization/MissingVoidConstructorsOnSerializable.ql

--- a/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/Test.java
+++ b/java/ql/test/query-tests/MissingVoidConstructorsOnSerializable/Test.java
@@ -1,0 +1,24 @@
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+class NonSerialzable { 
+
+  // Has no default constructor
+  public NonSerialzable(int x) { }
+
+}
+
+// BAD: Serializable but its parent cannot be instantiated
+class A extends NonSerialzable implements Serializable { 
+  public A() { super(1); }
+}
+
+// GOOD: writeReplaces itself, so unlikely to be deserialized
+// according to default rules.
+class B extends NonSerialzable implements Serializable { 
+  public B() { super(2); }
+
+  public Object writeReplace() throws ObjectStreamException {
+    return null;
+  }
+}


### PR DESCRIPTION
https://github.com/github/codeql/issues/18371 notes that it is a common pattern to define `writeReplace` and thereby avoid needing to meet the default algorithm's requirements of `Serializable`-tagged classes.

This is imprecise since in general the defining class might show up in an object stream anyhow (old version; writeReplace that sometimes keeps the original object or another of the same type; etc), but the query is of low importance anyhow so I went for a low-effort fix. This should simply reduce noise for people using the security-and-quality suite.