### PR TITLE
Language reference: mention BigInt.bitLength()

### DIFF
--- a/docs/codeql/ql-language-reference/modules.rst
+++ b/docs/codeql/ql-language-reference/modules.rst
@@ -443,7 +443,7 @@ The other built-in operations are:
 *   ``BigInt`` arithmetic: binary ``+``, ``-``, ``*``, ``/``, ``%``, unary ``-``,
 *   bitwise operations: ``.bitAnd(BigInt)``, ``.bitOr(BigInt)``,
     ``.bitXor(BigInt)``, ``.bitShiftLeft(int)``, ``.bitShiftRightSigned(int)``,
-    ``.bitNot()``,
+    ``.bitNot()``, ``.bitLength()``,
 *   aggregates: ``min``, ``max``, (``strict``)\ ``sum``, (``strict``)\ ``count``, ``avg``,
     ``rank``, ``unique``, ``any``.
 *   other: ``.pow(int)``, ``.abs()``, ``.gcd(BigInt)``, ``.minimum(BigInt)``,


### PR DESCRIPTION
AFAIUI this will be merged as part of the next release, when the .bitLength() primitive will be available, so should probably be merged alongside/before that.