### PR TITLE
Kotlin: Add support for 2.1.20-Beta1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -218,6 +218,7 @@ use_repo(
     "kotlin-compiler-2.0.0-RC1",
     "kotlin-compiler-2.0.20-Beta2",
     "kotlin-compiler-2.1.0-Beta1",
+    "kotlin-compiler-2.1.20-Beta1",
     "kotlin-compiler-embeddable-1.5.0",
     "kotlin-compiler-embeddable-1.5.10",
     "kotlin-compiler-embeddable-1.5.20",
@@ -232,6 +233,7 @@ use_repo(
     "kotlin-compiler-embeddable-2.0.0-RC1",
     "kotlin-compiler-embeddable-2.0.20-Beta2",
     "kotlin-compiler-embeddable-2.1.0-Beta1",
+    "kotlin-compiler-embeddable-2.1.20-Beta1",
     "kotlin-stdlib-1.5.0",
     "kotlin-stdlib-1.5.10",
     "kotlin-stdlib-1.5.20",
@@ -246,6 +248,7 @@ use_repo(
     "kotlin-stdlib-2.0.0-RC1",
     "kotlin-stdlib-2.0.20-Beta2",
     "kotlin-stdlib-2.1.0-Beta1",
+    "kotlin-stdlib-2.1.20-Beta1",
 )
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")

--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -20,7 +20,7 @@
    Java,"Java 7 to 22 [5]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [6]_",``.java``
-   Kotlin,"Kotlin 1.5.0 to 2.1.0\ *x*","kotlinc",``.kt``
+   Kotlin,"Kotlin 1.5.0 to 2.1.2\ *x*","kotlinc",``.kt``
    JavaScript,ECMAScript 2022 or lower,Not applicable,"``.js``, ``.jsx``, ``.mjs``, ``.es``, ``.es6``, ``.htm``, ``.html``, ``.xhtm``, ``.xhtml``, ``.vue``, ``.hbs``, ``.ejs``, ``.njk``, ``.json``, ``.yaml``, ``.yml``, ``.raml``, ``.xml`` [7]_"
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13",Not applicable,``.py``
    Ruby [9]_,"up to 3.3",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"

--- a/java/kotlin-extractor/deps/kotlin-compiler-2.1.20-Beta1.jar
+++ b/java/kotlin-extractor/deps/kotlin-compiler-2.1.20-Beta1.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bc01138d15bc1b7657480ce9fabbbb704626f92287edc05745341b11d8795b4
+size 57815398

--- a/java/kotlin-extractor/deps/kotlin-compiler-embeddable-2.1.20-Beta1.jar
+++ b/java/kotlin-extractor/deps/kotlin-compiler-embeddable-2.1.20-Beta1.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bba10897b31a9e2b6b436bfc9e36ddfda3320f7306f32ccf896339fda3e5c64c
+size 56337688

--- a/java/kotlin-extractor/deps/kotlin-stdlib-2.1.20-Beta1.jar
+++ b/java/kotlin-extractor/deps/kotlin-stdlib-2.1.20-Beta1.jar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ec0d983b549c7296535e0fc4e1b1af38eda7c1e25c7b0f8421c133ce50e3f01
+size 1688617

--- a/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinFileExtractor.kt
@@ -25,7 +25,19 @@ import org.jetbrains.kotlin.ir.declarations.lazy.IrLazyFunction
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.expressions.impl.*
 import org.jetbrains.kotlin.ir.symbols.*
-import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.classifierOrFail
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.isAny
+import org.jetbrains.kotlin.ir.types.isNullableAny
+import org.jetbrains.kotlin.ir.types.typeOrNull
+import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.types.typeWithArguments
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrStarProjection
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.impl.makeTypeProjection
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.load.java.JvmAnnotationNames
@@ -2293,7 +2305,7 @@ open class KotlinFileExtractor(
             // synthesised and inherit the annotation from the delegate (which given it has
             // @NotNull, is likely written in Java)
             JvmAnnotationNames.JETBRAINS_NOT_NULL_ANNOTATION.takeUnless {
-                t.isNullable() ||
+                t.isNullableCodeQL() ||
                     primitiveTypeMapping.getPrimitiveInfo(t) != null ||
                     hasExistingAnnotation(it)
             }
@@ -3975,7 +3987,7 @@ open class KotlinFileExtractor(
                 target.parent
             } else {
                 val st = extensionReceiverParameter.type as? IrSimpleType
-                if (isNullable != null && st?.isNullable() != isNullable) {
+                if (isNullable != null && st?.isNullableCodeQL() != isNullable) {
                     verboseln("Nullablility of type didn't match")
                     return false
                 }
@@ -4621,9 +4633,9 @@ open class KotlinFileExtractor(
                     val isPrimitiveArrayCreation = !isBuiltinCallKotlin(c, "arrayOf")
                     val elementType =
                         if (isPrimitiveArrayCreation) {
-                            c.type.getArrayElementType(pluginContext.irBuiltIns)
+                            c.type.getArrayElementTypeCodeQL(pluginContext.irBuiltIns)
                         } else {
-                            // TODO: is there any reason not to always use getArrayElementType?
+                            // TODO: is there any reason not to always use getArrayElementTypeCodeQL?
                             if (c.typeArgumentsCount == 1) {
                                 c.getTypeArgument(0).also {
                                     if (it == null) {

--- a/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
+++ b/java/kotlin-extractor/src/main/kotlin/KotlinUsesExtractor.kt
@@ -12,7 +12,24 @@ import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.expressions.*
 import org.jetbrains.kotlin.ir.symbols.*
-import org.jetbrains.kotlin.ir.types.*
+import org.jetbrains.kotlin.ir.types.addAnnotations
+import org.jetbrains.kotlin.ir.types.classFqName
+import org.jetbrains.kotlin.ir.types.classifierOrNull
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.types.isAny
+import org.jetbrains.kotlin.ir.types.isNullableAny
+import org.jetbrains.kotlin.ir.types.isPrimitiveType
+import org.jetbrains.kotlin.ir.types.makeNullable
+import org.jetbrains.kotlin.ir.types.typeOrNull
+import org.jetbrains.kotlin.ir.types.typeWith
+import org.jetbrains.kotlin.ir.types.typeWithArguments
+import org.jetbrains.kotlin.ir.types.IrDynamicType
+import org.jetbrains.kotlin.ir.types.IrErrorType
+import org.jetbrains.kotlin.ir.types.IrSimpleType
+import org.jetbrains.kotlin.ir.types.IrStarProjection
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.impl.*
 import org.jetbrains.kotlin.ir.util.*
 import org.jetbrains.kotlin.load.java.BuiltinMethodsWithSpecialGenericSignature
@@ -679,7 +696,7 @@ open class KotlinUsesExtractor(
     private fun getInvariantNullableArrayType(arrayType: IrSimpleType): IrSimpleType =
         if (arrayType.isPrimitiveArray()) arrayType
         else {
-            val componentType = arrayType.getArrayElementType(pluginContext.irBuiltIns)
+            val componentType = arrayType.getArrayElementTypeCodeQL(pluginContext.irBuiltIns)
             val componentTypeBroadened =
                 when (componentType) {
                     is IrSimpleType ->
@@ -690,7 +707,7 @@ open class KotlinUsesExtractor(
             val unchanged =
                 componentType == componentTypeBroadened &&
                     (arrayType.arguments[0] as? IrTypeProjection)?.variance == Variance.INVARIANT &&
-                    componentType.isNullable()
+                    componentType.isNullableCodeQL()
             if (unchanged) arrayType
             else
                 IrSimpleTypeImpl(
@@ -705,7 +722,7 @@ open class KotlinUsesExtractor(
     Kotlin arrays can be broken down as:
 
     isArray(t)
-    |- t.isBoxedArray
+    |- t.isBoxedArrayCodeQL
     |  |- t.isArray()         e.g. Array<Boolean>, Array<Boolean?>
     |  |- t.isNullableArray() e.g. Array<Boolean>?, Array<Boolean?>?
     |- t.isPrimitiveArray()   e.g. BooleanArray
@@ -715,7 +732,7 @@ open class KotlinUsesExtractor(
     Primitive arrays are represented as e.g. boolean[].
     */
 
-    private fun isArray(t: IrType) = t.isBoxedArray || t.isPrimitiveArray()
+    private fun isArray(t: IrType) = t.isBoxedArrayCodeQL || t.isPrimitiveArray()
 
     data class ArrayInfo(
         val elementTypeResults: TypeResults,
@@ -756,7 +773,7 @@ open class KotlinUsesExtractor(
             ) {
                 pluginContext.irBuiltIns.anyType
             } else {
-                t.getArrayElementType(pluginContext.irBuiltIns)
+                t.getArrayElementTypeCodeQL(pluginContext.irBuiltIns)
             }
 
         val recInfo = useArrayType(elementType, t.isPrimitiveArray())
@@ -844,7 +861,7 @@ open class KotlinUsesExtractor(
                 if (
                     (context == TypeContext.RETURN ||
                         (context == TypeContext.OTHER && otherIsPrimitive)) &&
-                        !s.isNullable() &&
+                        !s.isNullableCodeQL() &&
                         getKotlinType(s)?.hasEnhancedNullability() != true &&
                         primitiveName != null
                 ) {
@@ -860,7 +877,7 @@ open class KotlinUsesExtractor(
             val kotlinClassId = useClassInstance(kotlinClass, listOf()).typeResult.id
             val kotlinResult =
                 if (true) TypeResult(fakeKotlinType(), "TODO", "TODO")
-                else if (s.isNullable()) {
+                else if (s.isNullableCodeQL()) {
                     val kotlinSignature =
                         "$kotlinPackageName.$kotlinClassName?" // TODO: Is this right?
                     val kotlinLabel = "@\"kt_type;nullable;$kotlinPackageName.$kotlinClassName\""
@@ -902,21 +919,21 @@ open class KotlinUsesExtractor(
                     return extractErrorType()
                 }
             }
-            (s.isBoxedArray && s.arguments.isNotEmpty()) || s.isPrimitiveArray() -> {
+            (s.isBoxedArrayCodeQL && s.arguments.isNotEmpty()) || s.isPrimitiveArray() -> {
                 val arrayInfo = useArrayType(s, false)
                 return arrayInfo.componentTypeResults
             }
             owner is IrClass -> {
                 val args = if (s.codeQlIsRawType()) null else s.arguments
 
-                return useSimpleTypeClass(owner, args, s.isNullable())
+                return useSimpleTypeClass(owner, args, s.isNullableCodeQL())
             }
             owner is IrTypeParameter -> {
                 val javaResult = useTypeParameter(owner)
                 val aClassId = makeClass("kotlin", "TypeParam") // TODO: Wrong
                 val kotlinResult =
                     if (true) TypeResult(fakeKotlinType(), "TODO", "TODO")
-                    else if (s.isNullable()) {
+                    else if (s.isNullableCodeQL()) {
                         val kotlinSignature = "${javaResult.signature}?" // TODO: Wrong
                         val kotlinLabel = "@\"kt_type;nullable;type_param\"" // TODO: Wrong
                         val kotlinId: Label<DbKt_nullable_type> =
@@ -1200,7 +1217,7 @@ open class KotlinUsesExtractor(
         }
 
     private fun extendsAdditionAllowed(t: IrType) =
-        if (t.isBoxedArray) {
+        if (t.isBoxedArrayCodeQL) {
             if (t is IrSimpleType) {
                 arrayExtendsAdditionAllowed(t)
             } else {
@@ -1493,7 +1510,7 @@ open class KotlinUsesExtractor(
                     }
                 } else {
                     t.classOrNull?.let { tCls ->
-                        if (t.isBoxedArray) {
+                        if (t.isBoxedArrayCodeQL) {
                             (t.arguments.singleOrNull() as? IrTypeProjection)?.let { elementTypeArg
                                 ->
                                 val elementType = elementTypeArg.type
@@ -1506,7 +1523,7 @@ open class KotlinUsesExtractor(
                                         )
                                     return tCls
                                         .typeWithArguments(listOf(newArg))
-                                        .codeQlWithHasQuestionMark(t.isNullable())
+                                        .codeQlWithHasQuestionMark(t.isNullableCodeQL())
                                 }
                             }
                         }
@@ -2086,12 +2103,12 @@ open class KotlinUsesExtractor(
             }
 
             if (owner is IrClass) {
-                if (t.isBoxedArray) {
-                    val elementType = t.getArrayElementType(pluginContext.irBuiltIns)
+                if (t.isBoxedArrayCodeQL) {
+                    val elementType = t.getArrayElementTypeCodeQL(pluginContext.irBuiltIns)
                     val erasedElementType = erase(elementType)
                     return owner
                         .typeWith(erasedElementType)
-                        .codeQlWithHasQuestionMark(t.isNullable())
+                        .codeQlWithHasQuestionMark(t.isNullableCodeQL())
                 }
 
                 return if (t.arguments.isNotEmpty())

--- a/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/ClassNames.kt
@@ -5,7 +5,7 @@ import com.github.codeql.utils.versions.*
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
-import org.jetbrains.kotlin.fir.java.JavaBinarySourceElement
+import org.jetbrains.kotlin.fir.java.VirtualFileBasedSourceElement
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.util.fqNameWhenAvailable
@@ -89,8 +89,8 @@ fun getIrClassVirtualFile(irClass: IrClass): VirtualFile? {
                 is BinaryJavaClass -> return element.virtualFile
             }
         }
-        is JavaBinarySourceElement -> {
-            return cSource.javaClass.virtualFile
+        is VirtualFileBasedSourceElement -> {
+            return cSource.virtualFile
         }
         is KotlinJvmBinarySourceElement -> {
             val binaryClass = cSource.binaryClass

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/IrBuiltIns.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/IrBuiltIns.kt
@@ -1,0 +1,5 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.descriptors.IrBuiltIns
+
+typealias IrBuiltIns = IrBuiltIns

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/VirtualFileBasedSourceElement.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/VirtualFileBasedSourceElement.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlin.fir.java
 
+import com.intellij.openapi.vfs.VirtualFile
 import org.jetbrains.kotlin.descriptors.SourceElement
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
 
@@ -7,5 +8,6 @@ import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
 We need this class to exist, but the compiler will never give us an
 instance of it.
 */
-abstract class JavaBinarySourceElement private constructor(val javaClass: BinaryJavaClass) :
-    SourceElement {}
+abstract class VirtualFileBasedSourceElement private constructor(val javaClass: BinaryJavaClass) : SourceElement {
+    abstract val virtualFile: VirtualFile
+}

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/typeUtils.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_5_0/typeUtils.kt
@@ -1,0 +1,11 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.types.*
+
+fun IrType.isNullableCodeQL(): Boolean =
+    this.isNullable()
+
+val IrType.isBoxedArrayCodeQL: Boolean by IrType::isBoxedArray
+
+fun IrType.getArrayElementTypeCodeQL(irBuiltIns: IrBuiltIns): IrType =
+   this.getArrayElementType(irBuiltIns)

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_6_0/IrBuiltIns.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_1_6_0/IrBuiltIns.kt
@@ -1,0 +1,5 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.IrBuiltIns
+
+typealias IrBuiltIns = org.jetbrains.kotlin.ir.IrBuiltIns

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_0-RC1/JavaBinarySourceElement.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_0-RC1/JavaBinarySourceElement.kt
@@ -1,3 +1,0 @@
-/*
-The compiler provides this class, so we don't have to do anything.
-*/

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_0-RC1/VirtualFileBasedSourceElement.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_0_0-RC1/VirtualFileBasedSourceElement.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.kotlin.fir.java
+
+typealias VirtualFileBasedSourceElement = JavaBinarySourceElement

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_1_20-Beta1/VirtualFileBasedSourceElement.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_1_20-Beta1/VirtualFileBasedSourceElement.kt
@@ -1,0 +1,1 @@
+// Nothing to do

--- a/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_1_20-Beta1/typeUtils.kt
+++ b/java/kotlin-extractor/src/main/kotlin/utils/versions/v_2_1_20-Beta1/typeUtils.kt
@@ -1,0 +1,12 @@
+package com.github.codeql.utils.versions
+
+import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.util.*
+
+fun IrType.isNullableCodeQL(): Boolean =
+    this.isNullable()
+
+val IrType.isBoxedArrayCodeQL: Boolean by IrType::isBoxedArray
+
+fun IrType.getArrayElementTypeCodeQL(irBuiltIns: IrBuiltIns): IrType =
+   this.getArrayElementType(irBuiltIns)

--- a/java/kotlin-extractor/versions.bzl
+++ b/java/kotlin-extractor/versions.bzl
@@ -14,6 +14,7 @@ VERSIONS = [
     "2.0.0-RC1",
     "2.0.20-Beta2",
     "2.1.0-Beta1",
+    "2.1.20-Beta1",
 ]
 
 def _version_to_tuple(v):

--- a/java/ql/integration-tests/kotlin/all-platforms/diagnostics/kotlin-version-too-new/diagnostics.expected
+++ b/java/ql/integration-tests/kotlin/all-platforms/diagnostics/kotlin-version-too-new/diagnostics.expected
@@ -1,5 +1,5 @@
 {
-  "markdownMessage": "The Kotlin version installed (`999.999.999`) is too recent for this version of CodeQL. Install a version lower than 2.1.10.",
+  "markdownMessage": "The Kotlin version installed (`999.999.999`) is too recent for this version of CodeQL. Install a version lower than 2.1.30.",
   "severity": "error",
   "source": {
     "extractorName": "java",


### PR DESCRIPTION
I had to make the `org.jetbrains.kotlin.ir.types.*` imports more explicit to avoid importing deprecated methods that clashed with their replacements.