### PR TITLE
Go: Fix stub that is making test fail

### DIFF
--- a/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/database/vendor/github.com/jmoiron/sqlx/rows.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/flowsources/local/database/vendor/github.com/jmoiron/sqlx/rows.go
@@ -20,7 +20,3 @@ func (r *Rows) StructScan(dest interface{}) error {
 func (r *Rows) SliceScan(dest []interface{}) error {
 	return nil
 }
-
-func (r *Rows) Scan(dest ...interface{}) error {
-	return nil
-}


### PR DESCRIPTION
This method is not defined on `sqlx.Rows`, but is inherited from the embedded field of type `*sql.Rows`.