### PR TITLE
JS: Add Angular2 DOM sources

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/HTMLExtractor.java
@@ -186,7 +186,7 @@ public class HTMLExtractor implements IExtractor {
 
   /** Attribute names that look valid in HTML or in one of the template languages we support, like Vue and Angular. */
   private static final Pattern VALID_ATTRIBUTE_NAME =
-      Pattern.compile("[*:@]?\\[?\\(?[\\w:_\\-.]+\\]?\\)?");
+      Pattern.compile("[*:@]?\\[?\\(?[\\w:_\\-.]+\\)?\\]?");
 
   /** List of HTML attributes whose value is interpreted as JavaScript. */
   private static final Pattern JS_ATTRIBUTE =

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -41,7 +41,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2024-10-29";
+  public static final String EXTRACTOR_VERSION = "2025-01-09";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/Angular2.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/Angular2.qll
@@ -554,4 +554,25 @@ module Angular2 {
       this = API::Node::ofType("@angular/core", "ElementRef").getMember("nativeElement").asSource()
     }
   }
+
+  /**
+   * A source of DOM events originating from the `$event` variable in an event handler installed in an Angular template.
+   */
+  private class DomEventSources extends DOM::DomEventSource::Range {
+    DomEventSources() {
+      exists(HTML::Element elm, string attributeName |
+        elm = any(ComponentClass cls).getATemplateElement() and
+        // Ignore instantiations of known element (mainly focus on native DOM elements)
+        not elm = any(ComponentClass cls).getATemplateInstantiation() and
+        not elm.getName().matches("ng-%") and
+        this =
+          elm.getAttributeByName(attributeName)
+              .getCodeInAttribute()
+              .(TemplateTopLevel)
+              .getAVariableUse("$event") and
+        attributeName.matches("(%)") and // event handler attribute
+        not attributeName.matches("(ng%)") // exclude NG events which aren't necessarily DOM events
+      )
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -270,4 +270,16 @@ module XssThroughDom {
       this = getSelectionCall(DataFlow::TypeTracker::end()).getAMethodCall("toString")
     }
   }
+
+  /**
+   * A source of DOM input originating from an Angular two-way data binding.
+   */
+  private class AngularNgModelSource extends Source {
+    AngularNgModelSource() {
+      exists(Angular2::ComponentClass component, string fieldName |
+        fieldName = component.getATemplateElement().getAttributeByName("[(ngModel)]").getValue() and
+        this = component.getFieldInputNode(fieldName)
+      )
+    }
+  }
 }

--- a/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
+++ b/javascript/ql/lib/semmle/javascript/security/dataflow/XssThroughDomCustomizations.qll
@@ -232,6 +232,15 @@ module XssThroughDom {
         )
       }
     }
+
+    /**
+     * An object containing input values from an Angular form, accessed through an `NgForm` object.
+     */
+    class AngularFormSource extends Source {
+      AngularFormSource() {
+        this = API::Node::ofType("@angular/forms", "NgForm").getMember("value").asSource()
+      }
+    }
   }
 
   /**

--- a/javascript/ql/src/change-notes/2025-01-09-angular2-xss-through-dom.md
+++ b/javascript/ql/src/change-notes/2025-01-09-angular2-xss-through-dom.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The `js/xss-through-dom` query now recognises sources of DOM input originating from Angular templates.

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,6 +1,6 @@
 edges
-| angular.ts:12:5:12:23 | field: string = ""; | angular.ts:28:24:28:33 | this.field | provenance |  |
-| angular.ts:24:24:24:33 | form.value | angular.ts:24:24:24:37 | form.value.foo | provenance |  |
+| angular.ts:12:5:12:23 | field: string = ""; | angular.ts:33:24:33:33 | this.field | provenance |  |
+| angular.ts:29:24:29:33 | form.value | angular.ts:29:24:29:37 | form.value.foo | provenance |  |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values | provenance |  |
 | forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo | provenance |  |
 | forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values | provenance |  |
@@ -47,9 +47,9 @@ nodes
 | angular.ts:12:5:12:23 | field: string = ""; | semmle.label | field: string = ""; |
 | angular.ts:16:24:16:41 | event.target.value | semmle.label | event.target.value |
 | angular.ts:20:24:20:35 | target.value | semmle.label | target.value |
-| angular.ts:24:24:24:33 | form.value | semmle.label | form.value |
-| angular.ts:24:24:24:37 | form.value.foo | semmle.label | form.value.foo |
-| angular.ts:28:24:28:33 | this.field | semmle.label | this.field |
+| angular.ts:29:24:29:33 | form.value | semmle.label | form.value |
+| angular.ts:29:24:29:37 | form.value.foo | semmle.label | form.value.foo |
+| angular.ts:33:24:33:33 | this.field | semmle.label | this.field |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -134,8 +134,8 @@ subpaths
 #select
 | angular.ts:16:24:16:41 | event.target.value | angular.ts:16:24:16:41 | event.target.value | angular.ts:16:24:16:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:16:24:16:41 | event.target.value | DOM text |
 | angular.ts:20:24:20:35 | target.value | angular.ts:20:24:20:35 | target.value | angular.ts:20:24:20:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:20:24:20:35 | target.value | DOM text |
-| angular.ts:24:24:24:37 | form.value.foo | angular.ts:24:24:24:33 | form.value | angular.ts:24:24:24:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:24:24:24:33 | form.value | DOM text |
-| angular.ts:28:24:28:33 | this.field | angular.ts:12:5:12:23 | field: string = ""; | angular.ts:28:24:28:33 | this.field | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:5:12:23 | field: string = ""; | DOM text |
+| angular.ts:29:24:29:37 | form.value.foo | angular.ts:29:24:29:33 | form.value | angular.ts:29:24:29:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:29:24:29:33 | form.value | DOM text |
+| angular.ts:33:24:33:33 | this.field | angular.ts:12:5:12:23 | field: string = ""; | angular.ts:33:24:33:33 | this.field | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:5:12:23 | field: string = ""; | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,4 +1,5 @@
 edges
+| angular.ts:20:24:20:33 | form.value | angular.ts:20:24:20:37 | form.value.foo | provenance |  |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values | provenance |  |
 | forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo | provenance |  |
 | forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values | provenance |  |
@@ -44,6 +45,8 @@ edges
 nodes
 | angular.ts:12:24:12:41 | event.target.value | semmle.label | event.target.value |
 | angular.ts:16:24:16:35 | target.value | semmle.label | target.value |
+| angular.ts:20:24:20:33 | form.value | semmle.label | form.value |
+| angular.ts:20:24:20:37 | form.value.foo | semmle.label | form.value.foo |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -128,6 +131,7 @@ subpaths
 #select
 | angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:24:12:41 | event.target.value | DOM text |
 | angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:16:24:16:35 | target.value | DOM text |
+| angular.ts:20:24:20:37 | form.value.foo | angular.ts:20:24:20:33 | form.value | angular.ts:20:24:20:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:20:24:20:33 | form.value | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,6 +1,6 @@
 edges
-| angular.ts:12:5:12:23 | field: string = ""; | angular.ts:27:24:27:33 | this.field | provenance |  |
-| angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | provenance |  |
+| angular.ts:12:5:12:23 | field: string = ""; | angular.ts:28:24:28:33 | this.field | provenance |  |
+| angular.ts:24:24:24:33 | form.value | angular.ts:24:24:24:37 | form.value.foo | provenance |  |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values | provenance |  |
 | forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo | provenance |  |
 | forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values | provenance |  |
@@ -45,11 +45,11 @@ edges
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg | provenance |  |
 nodes
 | angular.ts:12:5:12:23 | field: string = ""; | semmle.label | field: string = ""; |
-| angular.ts:15:24:15:41 | event.target.value | semmle.label | event.target.value |
-| angular.ts:19:24:19:35 | target.value | semmle.label | target.value |
-| angular.ts:23:24:23:33 | form.value | semmle.label | form.value |
-| angular.ts:23:24:23:37 | form.value.foo | semmle.label | form.value.foo |
-| angular.ts:27:24:27:33 | this.field | semmle.label | this.field |
+| angular.ts:16:24:16:41 | event.target.value | semmle.label | event.target.value |
+| angular.ts:20:24:20:35 | target.value | semmle.label | target.value |
+| angular.ts:24:24:24:33 | form.value | semmle.label | form.value |
+| angular.ts:24:24:24:37 | form.value.foo | semmle.label | form.value.foo |
+| angular.ts:28:24:28:33 | this.field | semmle.label | this.field |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -132,10 +132,10 @@ nodes
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | semmle.label | $("textarea").val() |
 subpaths
 #select
-| angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:15:24:15:41 | event.target.value | DOM text |
-| angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:19:24:19:35 | target.value | DOM text |
-| angular.ts:23:24:23:37 | form.value.foo | angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:23:24:23:33 | form.value | DOM text |
-| angular.ts:27:24:27:33 | this.field | angular.ts:12:5:12:23 | field: string = ""; | angular.ts:27:24:27:33 | this.field | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:5:12:23 | field: string = ""; | DOM text |
+| angular.ts:16:24:16:41 | event.target.value | angular.ts:16:24:16:41 | event.target.value | angular.ts:16:24:16:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:16:24:16:41 | event.target.value | DOM text |
+| angular.ts:20:24:20:35 | target.value | angular.ts:20:24:20:35 | target.value | angular.ts:20:24:20:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:20:24:20:35 | target.value | DOM text |
+| angular.ts:24:24:24:37 | form.value.foo | angular.ts:24:24:24:33 | form.value | angular.ts:24:24:24:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:24:24:24:33 | form.value | DOM text |
+| angular.ts:28:24:28:33 | this.field | angular.ts:12:5:12:23 | field: string = ""; | angular.ts:28:24:28:33 | this.field | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:5:12:23 | field: string = ""; | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -42,6 +42,8 @@ edges
 | xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg | provenance |  |
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg | provenance |  |
 nodes
+| angular.ts:11:24:11:41 | event.target.value | semmle.label | event.target.value |
+| angular.ts:15:24:15:35 | target.value | semmle.label | target.value |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -124,6 +126,8 @@ nodes
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | semmle.label | $("textarea").val() |
 subpaths
 #select
+| angular.ts:11:24:11:41 | event.target.value | angular.ts:11:24:11:41 | event.target.value | angular.ts:11:24:11:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:11:24:11:41 | event.target.value | DOM text |
+| angular.ts:15:24:15:35 | target.value | angular.ts:15:24:15:35 | target.value | angular.ts:15:24:15:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:15:24:15:35 | target.value | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,5 +1,5 @@
 edges
-| angular.ts:20:24:20:33 | form.value | angular.ts:20:24:20:37 | form.value.foo | provenance |  |
+| angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | provenance |  |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values | provenance |  |
 | forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo | provenance |  |
 | forms.js:11:24:11:29 | values | forms.js:12:31:12:36 | values | provenance |  |
@@ -43,10 +43,10 @@ edges
 | xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg | provenance |  |
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg | provenance |  |
 nodes
-| angular.ts:12:24:12:41 | event.target.value | semmle.label | event.target.value |
-| angular.ts:16:24:16:35 | target.value | semmle.label | target.value |
-| angular.ts:20:24:20:33 | form.value | semmle.label | form.value |
-| angular.ts:20:24:20:37 | form.value.foo | semmle.label | form.value.foo |
+| angular.ts:15:24:15:41 | event.target.value | semmle.label | event.target.value |
+| angular.ts:19:24:19:35 | target.value | semmle.label | target.value |
+| angular.ts:23:24:23:33 | form.value | semmle.label | form.value |
+| angular.ts:23:24:23:37 | form.value.foo | semmle.label | form.value.foo |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -129,9 +129,9 @@ nodes
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | semmle.label | $("textarea").val() |
 subpaths
 #select
-| angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:24:12:41 | event.target.value | DOM text |
-| angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:16:24:16:35 | target.value | DOM text |
-| angular.ts:20:24:20:37 | form.value.foo | angular.ts:20:24:20:33 | form.value | angular.ts:20:24:20:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:20:24:20:33 | form.value | DOM text |
+| angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:15:24:15:41 | event.target.value | DOM text |
+| angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:19:24:19:35 | target.value | DOM text |
+| angular.ts:23:24:23:37 | form.value.foo | angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:23:24:23:33 | form.value | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -42,8 +42,8 @@ edges
 | xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg | provenance |  |
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg | provenance |  |
 nodes
-| angular.ts:11:24:11:41 | event.target.value | semmle.label | event.target.value |
-| angular.ts:15:24:15:35 | target.value | semmle.label | target.value |
+| angular.ts:12:24:12:41 | event.target.value | semmle.label | event.target.value |
+| angular.ts:16:24:16:35 | target.value | semmle.label | target.value |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -126,8 +126,8 @@ nodes
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | semmle.label | $("textarea").val() |
 subpaths
 #select
-| angular.ts:11:24:11:41 | event.target.value | angular.ts:11:24:11:41 | event.target.value | angular.ts:11:24:11:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:11:24:11:41 | event.target.value | DOM text |
-| angular.ts:15:24:15:35 | target.value | angular.ts:15:24:15:35 | target.value | angular.ts:15:24:15:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:15:24:15:35 | target.value | DOM text |
+| angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | angular.ts:12:24:12:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:24:12:41 | event.target.value | DOM text |
+| angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | angular.ts:16:24:16:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:16:24:16:35 | target.value | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/XssThroughDom.expected
@@ -1,4 +1,5 @@
 edges
+| angular.ts:12:5:12:23 | field: string = ""; | angular.ts:27:24:27:33 | this.field | provenance |  |
 | angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | provenance |  |
 | forms.js:8:23:8:28 | values | forms.js:9:31:9:36 | values | provenance |  |
 | forms.js:9:31:9:36 | values | forms.js:9:31:9:40 | values.foo | provenance |  |
@@ -43,10 +44,12 @@ edges
 | xss-through-dom.js:154:25:154:27 | msg | xss-through-dom.js:155:27:155:29 | msg | provenance |  |
 | xss-through-dom.js:159:34:159:52 | $("textarea").val() | xss-through-dom.js:154:25:154:27 | msg | provenance |  |
 nodes
+| angular.ts:12:5:12:23 | field: string = ""; | semmle.label | field: string = ""; |
 | angular.ts:15:24:15:41 | event.target.value | semmle.label | event.target.value |
 | angular.ts:19:24:19:35 | target.value | semmle.label | target.value |
 | angular.ts:23:24:23:33 | form.value | semmle.label | form.value |
 | angular.ts:23:24:23:37 | form.value.foo | semmle.label | form.value.foo |
+| angular.ts:27:24:27:33 | this.field | semmle.label | this.field |
 | forms.js:8:23:8:28 | values | semmle.label | values |
 | forms.js:9:31:9:36 | values | semmle.label | values |
 | forms.js:9:31:9:40 | values.foo | semmle.label | values.foo |
@@ -132,6 +135,7 @@ subpaths
 | angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | angular.ts:15:24:15:41 | event.target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:15:24:15:41 | event.target.value | DOM text |
 | angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | angular.ts:19:24:19:35 | target.value | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:19:24:19:35 | target.value | DOM text |
 | angular.ts:23:24:23:37 | form.value.foo | angular.ts:23:24:23:33 | form.value | angular.ts:23:24:23:37 | form.value.foo | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:23:24:23:33 | form.value | DOM text |
+| angular.ts:27:24:27:33 | this.field | angular.ts:12:5:12:23 | field: string = ""; | angular.ts:27:24:27:33 | this.field | $@ is reinterpreted as HTML without escaping meta-characters. | angular.ts:12:5:12:23 | field: string = ""; | DOM text |
 | forms.js:9:31:9:40 | values.foo | forms.js:8:23:8:28 | values | forms.js:9:31:9:40 | values.foo | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:8:23:8:28 | values | DOM text |
 | forms.js:12:31:12:40 | values.bar | forms.js:11:24:11:29 | values | forms.js:12:31:12:40 | values.bar | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:11:24:11:29 | values | DOM text |
 | forms.js:25:23:25:34 | values.email | forms.js:24:15:24:20 | values | forms.js:25:23:25:34 | values.email | $@ is reinterpreted as HTML without escaping meta-characters. | forms.js:24:15:24:20 | values | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -24,6 +24,6 @@ export class Foo {
     }
 
     useField() {
-        document.write(this.field); // NOT OK [INCONSISTENCY]
+        document.write(this.field); // NOT OK
     }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -1,0 +1,17 @@
+import { Component } from "@angular/core";
+
+@Component({
+    template: `
+        <input type="text" (input)="setInput1($event)"></input>
+        <input type="text" (input)="setInput2($event.target)"></input>
+    `
+})
+export class Foo {
+    setInput1(event) {
+        document.write(event.target.value); // NOT OK [INCONSISTENCY]
+    }
+
+    setInput2(target) {
+        document.write(target.value); // NOT OK [INCONSISTENCY]
+    }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -5,9 +5,12 @@ import { NgForm } from "@angular/forms";
     template: `
         <input type="text" (input)="setInput1($event)"></input>
         <input type="text" (input)="setInput2($event.target)"></input>
+        <input type="text" [(ngModel)]="field"></input>
     `
 })
 export class Foo {
+    field: string = "";
+
     setInput1(event) {
         document.write(event.target.value); // NOT OK
     }
@@ -18,5 +21,9 @@ export class Foo {
 
     blah(form: NgForm) {
         document.write(form.value.foo); // NOT OK
+    }
+
+    useField() {
+        document.write(this.field); // NOT OK [INCONSISTENCY]
     }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -20,6 +20,11 @@ export class Foo {
         document.write(target.value); // NOT OK
     }
 
+    setOtherInput(e) {
+        document.write(e.target.value); // OK
+        document.write(e.value); // OK
+    }
+
     blah(form: NgForm) {
         document.write(form.value.foo); // NOT OK
     }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -17,6 +17,6 @@ export class Foo {
     }
 
     blah(form: NgForm) {
-        document.write(form.value.foo); // NOT OK [INCONSISTENCY]
+        document.write(form.value.foo); // NOT OK
     }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { NgForm } from "@angular/forms";
 
 @Component({
     template: `
@@ -13,5 +14,9 @@ export class Foo {
 
     setInput2(target) {
         document.write(target.value); // NOT OK
+    }
+
+    blah(form: NgForm) {
+        document.write(form.value.foo); // NOT OK [INCONSISTENCY]
     }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -8,10 +8,10 @@ import { Component } from "@angular/core";
 })
 export class Foo {
     setInput1(event) {
-        document.write(event.target.value); // NOT OK [INCONSISTENCY]
+        document.write(event.target.value); // NOT OK
     }
 
     setInput2(target) {
-        document.write(target.value); // NOT OK [INCONSISTENCY]
+        document.write(target.value); // NOT OK
     }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom/angular.ts
@@ -10,6 +10,7 @@ import { NgForm } from "@angular/forms";
 })
 export class Foo {
     field: string = "";
+    safeField: string = "";
 
     setInput1(event) {
         document.write(event.target.value); // NOT OK
@@ -25,5 +26,6 @@ export class Foo {
 
     useField() {
         document.write(this.field); // NOT OK
+        document.write(this.safeField); // OK
     }
 }


### PR DESCRIPTION
Adds support for a few sources of form inputs and DOM objects coming from Angular:
- Recognise `$event` inside an Angular event handler as a source of DOM events
- Recognise `NgForm.value` as a source of form input
- Recognise `[(ngModel)]` two-way data binding as a source of form input
