### PR TITLE
Add BigQuery as a sink for SQLi queries.

### DIFF
--- a/go/ql/lib/semmle/go/frameworks/SQL.qll
+++ b/go/ql/lib/semmle/go/frameworks/SQL.qll
@@ -100,11 +100,27 @@ module SQL {
       }
     }
 
+    /** A string that might identify package `go/bigquery` */
+    string gobigquery() { result = "cloud.google.com/go/bigquery.Client" }
+
     /** A string that might identify package `go-pg/pg` or a specific version of it. */
     private string gopg() { result = package("github.com/go-pg/pg", "") }
 
     /** A string that might identify package `go-pg/pg/orm` or a specific version of it. */
     private string gopgorm() { result = package("github.com/go-pg/pg", "orm") }
+
+    /**
+     * A string argument to an api of `go/bigquery` that is directly interpreted as SQL
+     * without taking syntactic structure in account
+     */
+    class BigQueryString extends Range {
+      BigQueryString() {
+        exists(Function f |
+          f.hasQualifiedName(gobigquery(), "Query") and
+          this = f.getACall().getArgument(0)
+        )
+      }
+    }
 
     /**
      * A string argument to an API of `go-pg/pg` that is directly interpreted as SQL without


### PR DESCRIPTION
This PR adds bigquery's Client.Query to the SQL framework module for Go. This allows it to be used as a sink in SQL injection queries.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
