### PR TITLE
C#: Fix crash if proxy environment variables are already set

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependabotProxy.cs
@@ -52,8 +52,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             if (!string.IsNullOrWhiteSpace(cert))
             {
-                logger.LogInfo("No certificate configured for Dependabot proxy.");
-
                 var certDirPath = new DirectoryInfo(Path.Join(tempWorkingDirectory.DirInfo.FullName, ".dependabot-proxy"));
                 Directory.CreateDirectory(certDirPath.FullName);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNetCliInvoker.cs
@@ -46,9 +46,9 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
             {
                 logger.LogInfo($"Setting up Dependabot proxy at {this.proxy.Address}");
 
-                startInfo.EnvironmentVariables.Add("HTTP_PROXY", this.proxy.Address);
-                startInfo.EnvironmentVariables.Add("HTTPS_PROXY", this.proxy.Address);
-                startInfo.EnvironmentVariables.Add("SSL_CERT_FILE", this.proxy.CertificatePath);
+                startInfo.EnvironmentVariables["HTTP_PROXY"] = this.proxy.Address;
+                startInfo.EnvironmentVariables["HTTPS_PROXY"] = this.proxy.Address;
+                startInfo.EnvironmentVariables["SSL_CERT_FILE"] = this.proxy.CertificatePath;
             }
 
             return startInfo;


### PR DESCRIPTION
This fixes an extractor crash if any of the three environment variables are already set (existing values will be overridden). This problem was reported to us by a customer who already has `HTTP_PROXY` and `HTTPS_PROXY` set on their runner. Overriding the existing values should be the desired behaviour here, because the Dependabot proxy settings are only available if there is a private registry configuration and the Dependabot proxy was started.

I have also removed some incorrect log output in the first commit.