### PR TITLE
Improve shared sensitive data library handling of snake_case variable names

### DIFF
--- a/javascript/ql/lib/change-notes/2025-01-10-sensitive-data.md
+++ b/javascript/ql/lib/change-notes/2025-01-10-sensitive-data.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sensitive data library has been improved so that `snake_case` style variable names are recognized more reliably. This may result in more sensitive data being identified, and more results from queries that use the sensitive data library.

--- a/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
+++ b/javascript/ql/lib/semmle/javascript/security/internal/SensitiveDataHeuristics.qll
@@ -62,7 +62,7 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?is).*(puid|user.?name|user.?id|session.?(id|key)).*" or
     result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
@@ -71,8 +71,8 @@ module HeuristicNames {
    * a password or an authorization key.
    */
   string maybePassword() {
-    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
-    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+    result = "(?is).*pass(wd|word|code|.?phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?).?key.*"
   }
 
   /**

--- a/python/ql/lib/change-notes/2025-01-10-sensitive-data.md
+++ b/python/ql/lib/change-notes/2025-01-10-sensitive-data.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sensitive data library has been improved so that `snake_case` style variable names are recognized more reliably. This may result in more sensitive data being identified, and more results from queries that use the sensitive data library.

--- a/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
+++ b/python/ql/lib/semmle/python/security/internal/SensitiveDataHeuristics.qll
@@ -62,7 +62,7 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?is).*(puid|user.?name|user.?id|session.?(id|key)).*" or
     result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
@@ -71,8 +71,8 @@ module HeuristicNames {
    * a password or an authorization key.
    */
   string maybePassword() {
-    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
-    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+    result = "(?is).*pass(wd|word|code|.?phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?).?key.*"
   }
 
   /**

--- a/ruby/ql/lib/change-notes/2025-01-10-sensitive-data.md
+++ b/ruby/ql/lib/change-notes/2025-01-10-sensitive-data.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sensitive data library has been improved so that `snake_case` style variable names are recognized more reliably. This may result in more sensitive data being identified, and more results from queries that use the sensitive data library.

--- a/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
+++ b/ruby/ql/lib/codeql/ruby/security/internal/SensitiveDataHeuristics.qll
@@ -62,7 +62,7 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?is).*(puid|user.?name|user.?id|session.?(id|key)).*" or
     result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
@@ -71,8 +71,8 @@ module HeuristicNames {
    * a password or an authorization key.
    */
   string maybePassword() {
-    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
-    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+    result = "(?is).*pass(wd|word|code|.?phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?).?key.*"
   }
 
   /**

--- a/rust/ql/lib/codeql/rust/security/internal/SensitiveDataHeuristics.qll
+++ b/rust/ql/lib/codeql/rust/security/internal/SensitiveDataHeuristics.qll
@@ -62,7 +62,7 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?is).*(puid|user.?name|user.?id|session.?(id|key)).*" or
     result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
@@ -71,8 +71,8 @@ module HeuristicNames {
    * a password or an authorization key.
    */
   string maybePassword() {
-    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
-    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+    result = "(?is).*pass(wd|word|code|.?phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?).?key.*"
   }
 
   /**

--- a/rust/ql/test/library-tests/sensitivedata/test.rs
+++ b/rust/ql/test/library-tests/sensitivedata/test.rs
@@ -33,14 +33,14 @@ fn test_passwords(
 	sink(passwd); // $ sensitive=password
 	sink(my_password); // $ sensitive=password
 	sink(password_str); // $ sensitive=password
-	sink(pass_phrase); // $ MISSING: sensitive=password
+	sink(pass_phrase); // $ sensitive=password
 	sink(passphrase); // $ sensitive=password
 	sink(passPhrase); // $ sensitive=password
 
-	sink(auth_key); // $ MISSING: sensitive=password
+	sink(auth_key); // $ sensitive=password
 	sink(authkey); // $ sensitive=password
 	sink(authKey); // $ sensitive=password
-	sink(authentication_key); // $ MISSING: sensitive=password
+	sink(authentication_key); // $ sensitive=password
 	sink(authenticationkey); // $ sensitive=password
 	sink(authenticationKey); // $ sensitive=password
 
@@ -85,13 +85,13 @@ fn test_credentials(
 	sink(secret_key); // $ sensitive=secret
 
 	sink(username); // $ sensitive=id
-	sink(user_name); // $ MISSING: sensitive=id
+	sink(user_name); // $ sensitive=id
 	sink(userid); // $ sensitive=id
-	sink(user_id); // $ MISSING: sensitive=id
-	sink(my_user_id_64); // $ MISSING: sensitive=id
+	sink(user_id); // $ sensitive=id
+	sink(my_user_id_64); // $ sensitive=id
 
 	sink(sessionkey); // $ sensitive=id
-	sink(session_key); // $ MISSING: sensitive=id
+	sink(session_key); // $ sensitive=id
 
 	sink(ms.get_certificate()); // $ sensitive=certificate
 

--- a/rust/ql/test/library-tests/sensitivedata/test.rs
+++ b/rust/ql/test/library-tests/sensitivedata/test.rs
@@ -21,20 +21,28 @@ impl MyStruct {
 fn get_password() -> String { get_string() }
 
 fn test_passwords(
-	password: &str, passwd: &str, my_password: &str, password_str: &str, pass_phrase: &str,
-	auth_key: &str, authenticationkey: &str, authKey: &str,
+	password: &str, pass_word: &str, passwd: &str, my_password: &str, password_str: &str,
+	pass_phrase: &str, passphrase: &str, passPhrase: &str,
+	auth_key: &str, authkey: &str, authKey: &str, authentication_key: &str, authenticationkey: &str, authenticationKey: &str,
 	harmless: &str, encrypted_password: &str, password_hash: &str,
 	ms: &MyStruct
 ) {
 	// passwords
 	sink(password); // $ sensitive=password
+	sink(pass_word); // $ MISSING: sensitive=password
 	sink(passwd); // $ sensitive=password
 	sink(my_password); // $ sensitive=password
 	sink(password_str); // $ sensitive=password
 	sink(pass_phrase); // $ MISSING: sensitive=password
+	sink(passphrase); // $ sensitive=password
+	sink(passPhrase); // $ sensitive=password
+
 	sink(auth_key); // $ MISSING: sensitive=password
-	sink(authenticationkey); // $ sensitive=password
+	sink(authkey); // $ sensitive=password
 	sink(authKey); // $ sensitive=password
+	sink(authentication_key); // $ MISSING: sensitive=password
+	sink(authenticationkey); // $ sensitive=password
+	sink(authenticationKey); // $ sensitive=password
 
 	sink(ms); // $ MISSING: sensitive=password
 	sink(ms.password.as_str()); // $ MISSING: sensitive=password
@@ -65,7 +73,9 @@ fn get_secret_token() -> String { get_string() }
 fn get_next_token() -> String { get_string() }
 
 fn test_credentials(
-	account_key: &str, accnt_key: &str, license_key: &str, secret_key: &str, is_secret: bool, num_accounts: i64, uid: i64,
+	account_key: &str, accnt_key: &str, license_key: &str, secret_key: &str, is_secret: bool, num_accounts: i64,
+	username: String, user_name: String, userid: i64, user_id: i64, my_user_id_64: i64, unique_id: i64, uid: i64,
+	sessionkey: &[u64; 4], session_key: &[u64; 4], hashkey: &[u64; 4], hash_key: &[u64; 4],
 	ms: &MyStruct
 ) {
 	// credentials
@@ -74,6 +84,15 @@ fn test_credentials(
 	sink(license_key); // $ MISSING: sensitive=secret
 	sink(secret_key); // $ sensitive=secret
 
+	sink(username); // $ sensitive=id
+	sink(user_name); // $ MISSING: sensitive=id
+	sink(userid); // $ sensitive=id
+	sink(user_id); // $ MISSING: sensitive=id
+	sink(my_user_id_64); // $ MISSING: sensitive=id
+
+	sink(sessionkey); // $ sensitive=id
+	sink(session_key); // $ MISSING: sensitive=id
+
 	sink(ms.get_certificate()); // $ sensitive=certificate
 
 	sink(generate_secret_key()); // $ sensitive=secret
@@ -81,10 +100,13 @@ fn test_credentials(
 	sink(get_private_key()); // $ MISSING: sensitive=secret
 	sink(get_secret_token()); // $ sensitive=secret
 
-	// not credentials
+	// not (necessarily) credentials
 	sink(is_secret);
 	sink(num_accounts); // $ SPURIOUS: sensitive=id
+	sink(unique_id);
 	sink(uid); // $ SPURIOUS: sensitive=id
+	sink(hashkey);
+	sink(hash_key);
 
 	sink(ms.get_certificate_url()); // $ SPURIOUS: sensitive=certificate
 	sink(ms.get_certificate_file()); // $ SPURIOUS: sensitive=certificate

--- a/swift/ql/lib/change-notes/2025-01-10-sensitive-data.md
+++ b/swift/ql/lib/change-notes/2025-01-10-sensitive-data.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* The sensitive data library has been improved so that `snake_case` style variable names are recognized more reliably. This may result in more sensitive data being identified, and more results from queries that use the sensitive data library.

--- a/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
+++ b/swift/ql/lib/codeql/swift/security/SensitiveExprs.qll
@@ -34,8 +34,6 @@ class SensitivePassword extends SensitiveDataType, TPassword {
 
   override string getRegexp() {
     result = HeuristicNames::maybeSensitiveRegexp(SensitiveDataClassification::password())
-    or
-    result = "(?is).*pass.?phrase.*"
   }
 }
 

--- a/swift/ql/lib/codeql/swift/security/internal/SensitiveDataHeuristics.qll
+++ b/swift/ql/lib/codeql/swift/security/internal/SensitiveDataHeuristics.qll
@@ -62,7 +62,7 @@ module HeuristicNames {
    */
   string maybeAccountInfo() {
     result = "(?is).*acc(ou)?nt.*" or
-    result = "(?is).*(puid|username|userid|session(id|key)).*" or
+    result = "(?is).*(puid|user.?name|user.?id|session.?(id|key)).*" or
     result = "(?s).*([uU]|^|_|[a-z](?=U))([uU][iI][dD]).*"
   }
 
@@ -71,8 +71,8 @@ module HeuristicNames {
    * a password or an authorization key.
    */
   string maybePassword() {
-    result = "(?is).*pass(wd|word|code|phrase)(?!.*question).*" or
-    result = "(?is).*(auth(entication|ori[sz]ation)?)key.*"
+    result = "(?is).*pass(wd|word|code|.?phrase)(?!.*question).*" or
+    result = "(?is).*(auth(entication|ori[sz]ation)?).?key.*"
   }
 
   /**


### PR DESCRIPTION
Improve the share sensitive data library handling of `snake_case` variable names.  This is especially relevant for Rust, where snake case is encouraged and widely used, but the main change is in the shared `SensitiveDataHeuristics.qll` file and will affect (hopefully benefit) other languages as well.  It's a simple change, but we need a fairly high level of confidence / agreement before merging this.

Testing:
- [x] CI / tests passing (if you add up the sensitive data tests across all languages, coverage is really quite good)
- [x] review differences in sensitive data identified
	- [x] Rust, all DCA projects (by running `rust/summary/sensitive-data`) --- [experiment](https://github.com/github/codeql-dca-main/issues/25913), 389 new sensitive expressions, LGTM
	- [x] Swift, MRVA top-100 projects (by running `swift/summary/sensitive-expressions`) --- no differences
- [x] review differences in query results (DCA) --- all new results look at least as good as existing results
	- [x] Javascript --- no new results
	- [x] Python --- 1 new result; I believe this is logging "Updating pool config for auth key: {auth_key}" with a key (that might only be a public key), as part of some blockchain logic.
	- [x] Ruby -- 8 new results; the first is hashing a secure random number `session_id` with MD5.  The second is a `user_id` with SHA1.  The rest appear to be variations on this theme.
	- [x] Rust --- no new results (we haven't yet merged our first query that uses sensitive data!)
	- [x] Swift --- no new results
- [x] check performance
	- [x] `swift/summary/sensitive-expressions` (locally) --- no significant differences
	- [x] `swift/cleartext-logging` (locally) --- no significant differences
	- [x] DCA analysis times, all languages --- 3% overall slowdown for Swift, which is well within normal wobble; negligible wobble for other languages.