### PR TITLE
C++: Speed up the `cpp/unbounded-write` query for an upcoming change

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -1453,3 +1453,25 @@ private module Cached {
 }
 
 private import Cached
+
+/**
+ * Holds if `left < right + k` evaluates to `isLt` given that some guard
+ * evaluates to `value`.
+ *
+ * To find the specific guard that performs the comparison
+ * use `IRGuards.comparesLt`.
+ */
+predicate comparesLt(Operand left, Operand right, int k, boolean isLt, AbstractValue value) {
+  compares_lt(_, left, right, k, isLt, value)
+}
+
+/**
+ * Holds if `left = right + k` evaluates to `isLt` given that some guard
+ * evaluates to `value`.
+ *
+ * To find the specific guard that performs the comparison
+ * use `IRGuards.comparesEq`.
+ */
+predicate comparesEq(Operand left, Operand right, int k, boolean isLt, AbstractValue value) {
+  compares_eq(_, left, right, k, isLt, value)
+}


### PR DESCRIPTION
This fixes a performance problem in https://github.com/github/codeql/pull/18017 on some projects compiled as C code (where we infer many new guards on https://github.com/github/codeql/pull/18017 which causes the barrier to explode in size).

This PR adds a very cheap pruning phase to the `cpp/unbounded-write` query. The "cheapness" comes from the fact that we only evaluate the first stage of dataflow. This provides enough pruning to make the performance impact of https://github.com/github/codeql/pull/18017 negligible (compare [this run](https://github.com/github/codeql-dca-main/tree/data/MathiasVP/generate-int-to__nightly__nightly__3/reports) with [this run](https://github.com/github/codeql-dca-main/tree/data/MathiasVP/generate-int-to__nightly__nightly__2/reports)).