### PR TITLE
C++: Add a `BarrierGuard` module for indirect instruction/operand nodes.

### DIFF
--- a/cpp/ql/lib/change-notes/2025-01-13-indirect-instruction-barrier-guard.md
+++ b/cpp/ql/lib/change-notes/2025-01-13-indirect-instruction-barrier-guard.md
@@ -1,0 +1,4 @@
+---
+category: feature
+---
+* Add a new predicate `getAnIndirectBarrier` to the parameterized module `InstructionBarrierGuard` in `semmle.code.cpp.dataflow.new.DataFlow` for computing indirect dataflow nodes that are guarded by a given instruction. This predicate is similar to the `getAnIndirectBarrier` predicate on the parameterized module `BarrierGuard`.

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -2494,6 +2494,12 @@ module InstructionBarrierGuard<instructionGuardChecksSig/3 instructionGuardCheck
       result = TSsaPhiInputNode(phi, input)
     )
   }
+
+  /**
+   * Gets an indirect node with indirection index `indirectionIndex` that is
+   * safely guarded by the given guard check.
+   */
+  Node getAnIndirectBarrierNode(int indirectionIndex) { none() }
 }
 
 /**

--- a/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.cpp
@@ -1,0 +1,9 @@
+bool checkArgument(int* x);
+
+void sink(int);
+
+void testCheckArgument(int* p) {
+  if (checkArgument(p)) {
+    sink(*p); // $ barrier MISSING:barrier=1
+  }
+}

--- a/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.cpp
+++ b/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.cpp
@@ -4,6 +4,6 @@ void sink(int);
 
 void testCheckArgument(int* p) {
   if (checkArgument(p)) {
-    sink(*p); // $ barrier MISSING:barrier=1
+    sink(*p); // $ barrier barrier=1
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.ql
+++ b/cpp/ql/test/library-tests/dataflow/ir-barrier-guards/test.ql
@@ -1,0 +1,42 @@
+import cpp
+import semmle.code.cpp.dataflow.new.DataFlow
+import semmle.code.cpp.controlflow.IRGuards
+import utils.test.InlineExpectationsTest
+
+predicate instructionGuardChecks(IRGuardCondition gc, Instruction checked, boolean branch) {
+  exists(CallInstruction call |
+    call.getStaticCallTarget().hasName("checkArgument") and
+    checked = call.getAnArgument() and
+    gc.comparesEq(call.getAUse(), 0, false, any(BooleanValue bv | bv.getValue() = branch))
+  )
+}
+
+module BarrierGuard = DataFlow::InstructionBarrierGuard<instructionGuardChecks/3>;
+
+predicate indirectBarrierGuard(DataFlow::Node node, int indirectionIndex) {
+  node = BarrierGuard::getAnIndirectBarrierNode(indirectionIndex)
+}
+
+predicate barrierGuard(DataFlow::Node node) { node = BarrierGuard::getABarrierNode() }
+
+module Test implements TestSig {
+  string getARelevantTag() { result = "barrier" }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(DataFlow::Node node |
+      barrierGuard(node) and
+      value = ""
+      or
+      exists(int indirectionIndex |
+        indirectBarrierGuard(node, indirectionIndex) and
+        value = indirectionIndex.toString()
+      )
+    |
+      tag = "barrier" and
+      element = node.toString() and
+      location = node.getLocation()
+    )
+  }
+}
+
+import MakeTest<Test>


### PR DESCRIPTION
On `main` we have `BarrierGuards` for:
- `Operand`/`Instruction` nodes for reasoning about barriers at the instruction level (using `DataFlow::InstructionBarrierGuard<myPredicate/3>::getABarrierNode()`)
- `Expr` nodes for reasoning about barriers at the expression level (using DataFlow::BarrierGuard<myPredicate/3>::getABarrierNode()`)
- Indirect `Expr` nodes for reasoning about barriers on the pointed-to value of an expression (using `DataFlow::BarrierGuard<myPredicate/3>::getAnIndirectBarrierNode()`)

Spot an obvious missing one? We never added a `BarrierGuard` for reasoning about indirect instruction/operand nodes.

Barriers on indirections are nice when working with functions that validate the data pointed to by an argument to a function call. For example:
```cpp
bool isValidData(char* data);
// ...
data = getInput();
if(isValidData(data)) {
 // process data
}
```

currently, if you want to reason about `*data` (that is, the indirection of `data`) you need to use an `Expr`-based `BarrierGuard` as there is no module for indirect instruction/operand nodes.

This PR adds `DataFlow::InstructionBarrierGuard<myPredicate/3>::getAnIndirectBarrierNode()` to complete the missing API. We plan on using this predicate internally at Microsoft.

Commit-by-commit review recommended:
- d63b73406caa1f1158236ca1da66ce8b296d742c adds a skeleton predicate that's necessary to compile the test in the next commit.
- 4e3b27e920b1002e66019df0347c70d28d73e2c0 adds a testcase that needs indirect barrier guards for instruction/operand nodes.
- 6f3a2c41b3d31f8bc5482b1458d4a9058e528b8a fills in the skeleton. This is pretty much a copy/paste of the direct case, but with `node.asOperand` replaced with `node.asIndirectOperand`. So nothing interesting going on there.
- 91992e2f3f42085ae3d060f0fd9545853aa9a519 accepts the test changes

I have not started a DCA run as this code isn't used by any queries yet.