### PR TITLE
C# 13: [TEST ONLY] ref structs are allowed to implement interfaces.

### DIFF
--- a/csharp/ql/test/library-tests/implements/Implements.cs
+++ b/csharp/ql/test/library-tests/implements/Implements.cs
@@ -1,0 +1,39 @@
+using System;
+
+public interface I1
+{
+    object Prop { get; set; }
+    void M1();
+}
+
+public interface I2
+{
+    object M2();
+}
+
+public class C : I1
+{
+    public object Prop { get; set; }
+    public void M1() { }
+}
+
+public struct S : I1
+{
+    public object Prop { get; set; }
+    public void M1() { }
+    public object M2() { throw null; }
+}
+
+public ref struct RS1 : I1
+{
+    public object Prop { get; set; }
+    public void M1() { }
+    public object M2() { throw null; }
+}
+
+public ref struct RS2 : I1, I2
+{
+    public object Prop { get; set; }
+    public void M1() { }
+    public object M2() { throw null; }
+}

--- a/csharp/ql/test/library-tests/implements/Implements.expected
+++ b/csharp/ql/test/library-tests/implements/Implements.expected
@@ -1,0 +1,17 @@
+| Implements.cs:16:19:16:22 | Prop | Implements.cs:14:14:14:14 | C | Implements.cs:5:12:5:15 | Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:16:26:16:28 | get_Prop | Implements.cs:14:14:14:14 | C | Implements.cs:5:19:5:21 | get_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:16:31:16:33 | set_Prop | Implements.cs:14:14:14:14 | C | Implements.cs:5:24:5:26 | set_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:17:17:17:18 | M1 | Implements.cs:14:14:14:14 | C | Implements.cs:6:10:6:11 | M1 | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:22:19:22:22 | Prop | Implements.cs:20:15:20:15 | S | Implements.cs:5:12:5:15 | Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:22:26:22:28 | get_Prop | Implements.cs:20:15:20:15 | S | Implements.cs:5:19:5:21 | get_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:22:31:22:33 | set_Prop | Implements.cs:20:15:20:15 | S | Implements.cs:5:24:5:26 | set_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:23:17:23:18 | M1 | Implements.cs:20:15:20:15 | S | Implements.cs:6:10:6:11 | M1 | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:29:19:29:22 | Prop | Implements.cs:27:19:27:21 | RS1 | Implements.cs:5:12:5:15 | Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:29:26:29:28 | get_Prop | Implements.cs:27:19:27:21 | RS1 | Implements.cs:5:19:5:21 | get_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:29:31:29:33 | set_Prop | Implements.cs:27:19:27:21 | RS1 | Implements.cs:5:24:5:26 | set_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:30:17:30:18 | M1 | Implements.cs:27:19:27:21 | RS1 | Implements.cs:6:10:6:11 | M1 | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:36:19:36:22 | Prop | Implements.cs:34:19:34:21 | RS2 | Implements.cs:5:12:5:15 | Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:36:26:36:28 | get_Prop | Implements.cs:34:19:34:21 | RS2 | Implements.cs:5:19:5:21 | get_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:36:31:36:33 | set_Prop | Implements.cs:34:19:34:21 | RS2 | Implements.cs:5:24:5:26 | set_Prop | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:37:17:37:18 | M1 | Implements.cs:34:19:34:21 | RS2 | Implements.cs:6:10:6:11 | M1 | Implements.cs:3:18:3:19 | I1 |
+| Implements.cs:38:19:38:20 | M2 | Implements.cs:34:19:34:21 | RS2 | Implements.cs:11:12:11:13 | M2 | Implements.cs:9:18:9:19 | I2 |

--- a/csharp/ql/test/library-tests/implements/Implements.ql
+++ b/csharp/ql/test/library-tests/implements/Implements.ql
@@ -1,0 +1,8 @@
+import csharp
+
+from Overridable o1, Overridable o2
+where
+  o1.overridesOrImplements(o2) and
+  o1.fromSource() and
+  o2.fromSource()
+select o1, o1.getDeclaringType(), o2, o2.getDeclaringType()


### PR DESCRIPTION
`ref struct` types are now allowed to implement interfaces as described [here](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#ref-struct-interfaces).
In this PR we add some tests for this. Some testing of data flow and viable callable was already made in https://github.com/github/codeql/pull/18385