### PR TITLE
C# 13: [TEST ONLY] Test example with ref local, unsafe context and ref struct in async- and iterator methods.

### DIFF
--- a/csharp/ql/test/library-tests/async/Async.expected
+++ b/csharp/ql/test/library-tests/async/Async.expected
@@ -12,3 +12,6 @@
 | async.cs:50:49:50:57 | OpenAsync | file://:0:0:0:0 | async |
 | async.cs:50:49:50:57 | OpenAsync | file://:0:0:0:0 | private |
 | async.cs:50:49:50:57 | OpenAsync | file://:0:0:0:0 | static |
+| async.cs:64:40:64:53 | GetObjectAsync | file://:0:0:0:0 | async |
+| async.cs:64:40:64:53 | GetObjectAsync | file://:0:0:0:0 | private |
+| async.cs:64:40:64:53 | GetObjectAsync | file://:0:0:0:0 | static |

--- a/csharp/ql/test/library-tests/async/Await.expected
+++ b/csharp/ql/test/library-tests/async/Await.expected
@@ -3,3 +3,4 @@
 | 42 | async.cs:42:46:42:70 | await ... | async.cs:42:52:42:70 | call to method OpenAsync |
 | 44 | async.cs:44:38:44:66 | await ... | async.cs:44:44:44:66 | call to method ReadToEndAsync |
 | 52 | async.cs:52:13:52:51 | await ... | async.cs:52:19:52:51 | call to method PrintContentLengthAsync |
+| 73 | async.cs:73:13:73:31 | await ... | async.cs:73:19:73:31 | call to method Delay |

--- a/csharp/ql/test/library-tests/async/async.cs
+++ b/csharp/ql/test/library-tests/async/async.cs
@@ -52,5 +52,26 @@ namespace Semmle
             await PrintContentLengthAsync(filename);
             return File.OpenText(filename);
         }
+
+        private ref struct RS
+        {
+            public int GetZero() { return 0; }
+        }
+
+        private static int one = 1;
+
+        // Test that we can use ref locals, ref structs and unsafe blocks in async methods.
+        private static async Task<int> GetObjectAsync()
+        {
+            unsafe
+            {
+                // Do pointer stuff
+            }
+            RS rs;
+            ref int i = ref one;
+            var zero = rs.GetZero();
+            await Task.Delay(i);
+            return zero;
+        }
     }
 }

--- a/csharp/ql/test/library-tests/iterators/iterators.cs
+++ b/csharp/ql/test/library-tests/iterators/iterators.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+public ref struct RS
+{
+    public int GetZero() { return 0; }
+}
+
+public class C
+{
+    private int one = 1;
+
+    // Test that we can use unsafe context, ref locals and ref structs in iterators.
+    public IEnumerable<int> GetObjects()
+    {
+        unsafe
+        {
+            // Do pointer stuff
+        }
+        ref int i = ref one;
+        RS rs;
+        var zero = rs.GetZero();
+        yield return zero;
+    }
+}

--- a/csharp/ql/test/library-tests/iterators/iterators.expected
+++ b/csharp/ql/test/library-tests/iterators/iterators.expected
@@ -1,0 +1,1 @@
+| iterators.cs:14:29:14:38 | GetObjects | iterators.cs:23:22:23:25 | access to local variable zero |

--- a/csharp/ql/test/library-tests/iterators/iterators.ql
+++ b/csharp/ql/test/library-tests/iterators/iterators.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from Callable c, Expr return
+where c.canYieldReturn(return)
+select c, return


### PR DESCRIPTION
For C# 13 we are now allowed to use ref locals, ref structs and unsafe context in iterators and async methods as described [here](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-13#ref-and-unsafe-in-iterators-and-async-methods).
In this PR we just add some code examples to check that this compiles and doesn't fail during extraction.