### PR TITLE
Rust: More metrics for tracking taint.

### DIFF
--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -14,6 +14,11 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Sensitive data | 0 |
+| Taint edges - number of edges | 2 |
+| Taint reach - nodes tainted | 0 |
+| Taint reach - per million nodes | 0 |
+| Taint sinks - cryptographic operations | 0 |
+| Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |
-| Taint sources - total | 0 |
+| Taint sources - disabled | 0 |
+| Taint sources - sensitive data | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -14,6 +14,11 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Sensitive data | 0 |
+| Taint edges - number of edges | 2 |
+| Taint reach - nodes tainted | 0 |
+| Taint reach - per million nodes | 0 |
+| Taint sinks - cryptographic operations | 0 |
+| Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |
-| Taint sources - total | 0 |
+| Taint sources - disabled | 0 |
+| Taint sources - sensitive data | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -14,6 +14,11 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Sensitive data | 0 |
+| Taint edges - number of edges | 2 |
+| Taint reach - nodes tainted | 0 |
+| Taint reach - per million nodes | 0 |
+| Taint sinks - cryptographic operations | 0 |
+| Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |
-| Taint sources - total | 0 |
+| Taint sources - disabled | 0 |
+| Taint sources - sensitive data | 0 |

--- a/rust/ql/src/queries/summary/CryptographicOperations.ql
+++ b/rust/ql/src/queries/summary/CryptographicOperations.ql
@@ -1,0 +1,59 @@
+/**
+ * @name Cryptographic Operations
+ * @description List all cryptographic operations found in the database.
+ * @kind problem
+ * @problem.severity info
+ * @id rust/summary/cryptographic-operations
+ * @tags summary
+ */
+
+import rust
+import codeql.rust.Concepts
+import codeql.rust.security.WeakSensitiveDataHashingExtensions
+
+/**
+ * Gets the type of cryptographic algorithm `alg`.
+ */
+string getAlgorithmType(Cryptography::CryptographicAlgorithm alg) {
+  alg instanceof Cryptography::EncryptionAlgorithm and result = "EncryptionAlgorithm"
+  or
+  alg instanceof Cryptography::HashingAlgorithm and result = "HashingAlgorithm"
+  or
+  alg instanceof Cryptography::PasswordHashingAlgorithm and result = "PasswordHashingAlgorithm"
+}
+
+/**
+ * Gets a feature of cryptographic algorithm `alg`.
+ */
+string getAlgorithmFeature(Cryptography::CryptographicAlgorithm alg) {
+  alg.isWeak() and result = "WEAK"
+}
+
+/**
+ * Gets a description of cryptographic algorithm `alg`.
+ */
+string describeAlgorithm(Cryptography::CryptographicAlgorithm alg) {
+  result =
+    getAlgorithmType(alg) + " " + alg.getName() + " " + concat(getAlgorithmFeature(alg), ", ")
+}
+
+/**
+ * Gets a feature of cryptographic operation `operation`.
+ */
+string getOperationFeature(Cryptography::CryptographicOperation op) {
+  result = "inputs:" + strictcount(op.getAnInput()).toString() or
+  result = "blockmodes:" + strictcount(op.getBlockMode()).toString()
+}
+
+/**
+ * Gets a description of cryptographic operation `operation`.
+ */
+string describeOperation(Cryptography::CryptographicOperation op) {
+  result = describeAlgorithm(op.getAlgorithm()) + " " + concat(getOperationFeature(op), ", ")
+  or
+  not exists(op.getAlgorithm()) and
+  result = "(unknown) " + concat(getOperationFeature(op), ", ")
+}
+
+from Cryptography::CryptographicOperation operation
+select operation, describeOperation(operation)

--- a/rust/ql/src/queries/summary/CryptographicOperations.ql
+++ b/rust/ql/src/queries/summary/CryptographicOperations.ql
@@ -38,7 +38,7 @@ string describeAlgorithm(Cryptography::CryptographicAlgorithm alg) {
 }
 
 /**
- * Gets a feature of cryptographic operation `operation`.
+ * Gets a feature of cryptographic operation `op`.
  */
 string getOperationFeature(Cryptography::CryptographicOperation op) {
   result = "inputs:" + strictcount(op.getAnInput()).toString() or
@@ -46,7 +46,7 @@ string getOperationFeature(Cryptography::CryptographicOperation op) {
 }
 
 /**
- * Gets a description of cryptographic operation `operation`.
+ * Gets a description of cryptographic operation `op`.
  */
 string describeOperation(Cryptography::CryptographicOperation op) {
   result = describeAlgorithm(op.getAlgorithm()) + " " + concat(getOperationFeature(op), ", ")

--- a/rust/ql/src/queries/summary/QuerySinkCounts.ql
+++ b/rust/ql/src/queries/summary/QuerySinkCounts.ql
@@ -1,0 +1,17 @@
+/**
+ * @name Query Sink Counts
+ * @description Lists the number of query sinks of each type found in the database. Query sinks are
+ *              flow sinks that are used as possible locations for query results. Cryptographic
+ *              operations are excluded.
+ * @kind metric
+ * @id rust/summary/query-sink-counts
+ * @tags summary
+ */
+
+import rust
+import codeql.rust.dataflow.DataFlow
+import Stats
+
+from string kind, int num
+where num = strictcount(DataFlow::Node n | getAQuerySinkKind(n) = kind)
+select kind, num

--- a/rust/ql/src/queries/summary/QuerySinks.ql
+++ b/rust/ql/src/queries/summary/QuerySinks.ql
@@ -14,4 +14,4 @@ import codeql.rust.dataflow.DataFlow
 import Stats
 
 from DataFlow::Node n
-select n, "Sink for " + strictconcat(getAQuerySinkKind(n), ", ")
+select n, "Sink for " + strictconcat(getAQuerySinkKind(n), ", ") + "."

--- a/rust/ql/src/queries/summary/QuerySinks.ql
+++ b/rust/ql/src/queries/summary/QuerySinks.ql
@@ -1,0 +1,25 @@
+/**
+ * @name Query Sinks
+ * @description Lists query sinks that are found in the database. Query sinks are flow sinks that
+ *              are used as possible locations for query results. Cryptographic operations are
+ *              excluded (see `rust/summary/cryptographic-operations` instead).
+ * @kind problem
+ * @problem.severity info
+ * @id rust/summary/query-sinks
+ * @tags summary
+ */
+
+import rust
+import codeql.rust.dataflow.DataFlow
+import codeql.rust.security.SqlInjectionExtensions
+import Stats
+
+/**
+ * Gets a kind of query for which `n` is a sink (if any).
+ */
+string getAQuerySinkKind(DataFlow::Node n) {
+  (n instanceof SqlInjection::Sink and result = "SqlInjection")
+}
+
+from DataFlow::Node n
+select n, "sink for " + strictconcat(getAQuerySinkKind(n), ", ")

--- a/rust/ql/src/queries/summary/QuerySinks.ql
+++ b/rust/ql/src/queries/summary/QuerySinks.ql
@@ -11,15 +11,7 @@
 
 import rust
 import codeql.rust.dataflow.DataFlow
-import codeql.rust.security.SqlInjectionExtensions
 import Stats
-
-/**
- * Gets a kind of query for which `n` is a sink (if any).
- */
-string getAQuerySinkKind(DataFlow::Node n) {
-  (n instanceof SqlInjection::Sink and result = "SqlInjection")
-}
 
 from DataFlow::Node n
 select n, "sink for " + strictconcat(getAQuerySinkKind(n), ", ")

--- a/rust/ql/src/queries/summary/QuerySinks.ql
+++ b/rust/ql/src/queries/summary/QuerySinks.ql
@@ -14,4 +14,4 @@ import codeql.rust.dataflow.DataFlow
 import Stats
 
 from DataFlow::Node n
-select n, "sink for " + strictconcat(getAQuerySinkKind(n), ", ")
+select n, "Sink for " + strictconcat(getAQuerySinkKind(n), ", ")

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -64,4 +64,4 @@ string getAQuerySinkKind(DataFlow::Node n) {
 /**
  * Gets a count of the total number of query sinks in the database.
  */
-int getQuerySinksCount() { result = count(DataFlow::Node n | exists(getAQuerySinkKind(n)) | n) }
+int getQuerySinksCount() { result = count(DataFlow::Node n | exists(getAQuerySinkKind(n))) }

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -3,11 +3,13 @@
  */
 
 import rust
+private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.internal.DataFlowImpl
 private import codeql.rust.dataflow.internal.TaintTrackingImpl
 private import codeql.rust.AstConsistency as AstConsistency
 private import codeql.rust.controlflow.internal.CfgConsistency as CfgConsistency
 private import codeql.rust.dataflow.internal.DataFlowConsistency as DataFlowConsistency
+private import codeql.rust.security.SqlInjectionExtensions
 
 /**
  * Gets a count of the total number of lines of code in the database.
@@ -41,3 +43,15 @@ int getTotalCfgInconsistencies() {
 int getTotalDataFlowInconsistencies() {
   result = sum(string type | | DataFlowConsistency::getInconsistencyCounts(type))
 }
+
+/**
+ * Gets a kind of query for which `n` is a sink (if any).
+ */
+string getAQuerySinkKind(DataFlow::Node n) {
+  (n instanceof SqlInjection::Sink and result = "SqlInjection")
+}
+
+/**
+ * Gets a count of the total number of query sinks in the database.
+ */
+int getQuerySinksCount() { result = count(DataFlow::Node n | exists(getAQuerySinkKind(n)) | n) }

--- a/rust/ql/src/queries/summary/Stats.qll
+++ b/rust/ql/src/queries/summary/Stats.qll
@@ -45,6 +45,16 @@ int getTotalDataFlowInconsistencies() {
 }
 
 /**
+ * Gets the total number of taint edges in the database.
+ */
+int getTaintEdgesCount() {
+  result =
+    count(DataFlow::Node a, DataFlow::Node b |
+      RustTaintTracking::defaultAdditionalTaintStep(a, b, _)
+    )
+}
+
+/**
  * Gets a kind of query for which `n` is a sink (if any).
  */
 string getAQuerySinkKind(DataFlow::Node n) {

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -9,6 +9,7 @@
 import rust
 import codeql.rust.Concepts
 import codeql.rust.security.SensitiveData
+import codeql.rust.security.WeakSensitiveDataHashingExtensions
 import codeql.rust.Diagnostics
 import Stats
 
@@ -59,4 +60,9 @@ where
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
   or
   key = "Sensitive data" and value = count(SensitiveData d)
+  or
+  key = "Taint sinks - query sinks" and value = getQuerySinksCount()
+  or
+  key = "Taint sinks - cryptographic operations" and
+  value = count(Cryptography::CryptographicOperation o)
 select key, value order by key

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -12,6 +12,7 @@ import codeql.rust.security.SensitiveData
 import codeql.rust.security.WeakSensitiveDataHashingExtensions
 import codeql.rust.Diagnostics
 import Stats
+import TaintReach
 
 from string key, int value
 where
@@ -58,6 +59,10 @@ where
   key = "Taint sources - total" and value = count(ThreatModelSource s)
   or
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
+  or
+  key = "Taint reach - nodes tainted" and value = getTaintedNodesCount()
+  or
+  key = "Taint reach - per million nodes" and value = getTaintReach().floor()
   or
   key = "Sensitive data" and value = count(SensitiveData d)
   or

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -60,6 +60,8 @@ where
   or
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
   or
+  key = "Taint edges - number of edges" and value = getTaintEdgesCount()
+  or
   key = "Taint reach - nodes tainted" and value = getTaintedNodesCount()
   or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -58,7 +58,8 @@ where
   or
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
   or
-  key = "Taint sources - disabled" and value = count(ThreatModelSource s | not s instanceof ActiveThreatModelSource)
+  key = "Taint sources - disabled" and
+  value = count(ThreatModelSource s | not s instanceof ActiveThreatModelSource)
   or
   key = "Taint sources - sensitive data" and value = count(SensitiveData d)
   or

--- a/rust/ql/src/queries/summary/SummaryStats.ql
+++ b/rust/ql/src/queries/summary/SummaryStats.ql
@@ -56,17 +56,17 @@ where
   or
   key = "Macro calls - unresolved" and value = count(MacroCall mc | not mc.hasExpanded())
   or
-  key = "Taint sources - total" and value = count(ThreatModelSource s)
-  or
   key = "Taint sources - active" and value = count(ActiveThreatModelSource s)
+  or
+  key = "Taint sources - disabled" and value = count(ThreatModelSource s | not s instanceof ActiveThreatModelSource)
+  or
+  key = "Taint sources - sensitive data" and value = count(SensitiveData d)
   or
   key = "Taint edges - number of edges" and value = getTaintEdgesCount()
   or
   key = "Taint reach - nodes tainted" and value = getTaintedNodesCount()
   or
   key = "Taint reach - per million nodes" and value = getTaintReach().floor()
-  or
-  key = "Sensitive data" and value = count(SensitiveData d)
   or
   key = "Taint sinks - query sinks" and value = getQuerySinksCount()
   or

--- a/rust/ql/src/queries/summary/TaintReach.qll
+++ b/rust/ql/src/queries/summary/TaintReach.qll
@@ -1,0 +1,31 @@
+/**
+ * Taint reach computation. Taint reach is the proportion of all dataflow nodes that can be reached
+ * via taint flow from any active thread model source. It's usually expressed per million nodes.
+ */
+
+import rust
+private import codeql.rust.Concepts
+private import codeql.rust.dataflow.DataFlow
+private import codeql.rust.dataflow.TaintTracking
+
+/**
+ * A taint configuration for taint reach (flow to any node from any modelled source).
+ */
+private module TaintReachConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node node) { node instanceof ActiveThreatModelSource }
+
+  predicate isSink(DataFlow::Node node) { any() }
+}
+
+private module TaintReachFlow = TaintTracking::Global<TaintReachConfig>;
+
+/**
+ * Gets the total number of dataflow nodes that taint reaches (from any source).
+ */
+int getTaintedNodesCount() { result = count(DataFlow::Node n | TaintReachFlow::flowTo(n)) }
+
+/**
+ * Gets the proportion of dataflow nodes that taint reaches (from any source),
+ * expressed as a count per million nodes.
+ */
+float getTaintReach() { result = (getTaintedNodesCount() * 1000000.0) / count(DataFlow::Node n) }

--- a/rust/ql/src/queries/summary/TaintReach.qll
+++ b/rust/ql/src/queries/summary/TaintReach.qll
@@ -20,12 +20,12 @@ private module TaintReachConfig implements DataFlow::ConfigSig {
 private module TaintReachFlow = TaintTracking::Global<TaintReachConfig>;
 
 /**
- * Gets the total number of dataflow nodes that taint reaches (from any source).
+ * Gets the total number of data flow nodes that taint reaches (from any source).
  */
 int getTaintedNodesCount() { result = count(DataFlow::Node n | TaintReachFlow::flowTo(n)) }
 
 /**
- * Gets the proportion of dataflow nodes that taint reaches (from any source),
+ * Gets the proportion of data flow nodes that taint reaches (from any source),
  * expressed as a count per million nodes.
  */
 float getTaintReach() { result = (getTaintedNodesCount() * 1000000.0) / count(DataFlow::Node n) }

--- a/rust/ql/src/queries/summary/TaintReach.qll
+++ b/rust/ql/src/queries/summary/TaintReach.qll
@@ -9,7 +9,7 @@ private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.TaintTracking
 
 /**
- * A taint configuration for taint reach (flow to any node from any modelled source).
+ * A taint configuration for taint reach (flow to any node from any modeled source).
  */
 private module TaintReachConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof ActiveThreatModelSource }

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,6 +15,7 @@
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
 | Sensitive data | 0 |
+| Taint edges - number of edges | 2 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -14,11 +14,11 @@
 | Macro calls - resolved | 8 |
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
-| Sensitive data | 0 |
 | Taint edges - number of edges | 2 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |
 | Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |
-| Taint sources - total | 0 |
+| Taint sources - disabled | 0 |
+| Taint sources - sensitive data | 0 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,6 +15,8 @@
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
 | Sensitive data | 0 |
+| Taint reach - nodes tainted | 0 |
+| Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |
 | Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,5 +15,7 @@
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
 | Sensitive data | 0 |
+| Taint sinks - cryptographic operations | 0 |
+| Taint sinks - query sinks | 0 |
 | Taint sources - active | 0 |
 | Taint sources - total | 0 |


### PR DESCRIPTION
Add more metrics for tracking taint flow in Rust.  Prior to this PR we have:
- taint sources, tracked by `rust/summary/taint-sources` and `rust/summary/summary-statistics`.
- sensitive data (which are also commonly used as taint sources), tracked by `rust/summary/sensitive-data` and `rust/summary/summary-statistics`.

Which doesn't give us a very complete picture.  This PR adds:
- query sinks, tracked by `rust/summary/query-sinks`, `rust/summary/query-sink-counts` and `rust/summary/summary-statistics`.
- cryptographic operations (which are also commonly used as taint sinks), tracked by `rust/summary/cryptographic-operations` and `rust/summary/summary-statistics`.
- taint edges (raw count), tracked by `rust/summary/summary-statistics`.
- taint reach, tracked by `rust/summary/summary-statistics`.

Most of these are soon to be added to our DCA runs (for catching regressions) and our metrics tracking page (to inform future work).

In the past people have raised performance concerns about taint reach, but I've never seen a problem in practice.  DCA will confirm.