### PR TITLE
C++: Harden `checkedForEof`

### DIFF
--- a/cpp/ql/src/Critical/ScanfChecks.qll
+++ b/cpp/ql/src/Critical/ScanfChecks.qll
@@ -37,7 +37,7 @@ private string getEofValue() {
  */
 private predicate checkedForEof(ScanfFunctionCall call) {
   exists(IRGuardCondition gc |
-    exists(Instruction i | i.getUnconvertedResultExpression() = call |
+    exists(CallInstruction i | i.getUnconvertedResultExpression() = call |
       exists(int val | gc.comparesEq(valueNumber(i).getAUse(), val, _, _) |
         // call == EOF
         val = getEofValue().toInt()


### PR DESCRIPTION
This is a no-op for now since the `Instruction` for which `Instruction.getUnconvertedResultExpression()` is a `Call` is obviously the `CallInstruction`, but once we add the instructions which compute the implicit `!= 0` the `CompareNE` instruction will also have the `Call` as the result of `Instruction.getUnconvertedResultExpression()`.

So to fix this we can restrict the type of `i` to be a `CallInstruction`