### PR TITLE
Dataflow: Minor join-order fix

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3879,11 +3879,6 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       bindingset[node, state, t0, ap]
       predicate filter(NodeEx node, FlowState state, Typ t0, Ap ap, Typ t) {
         exists(state) and
-        // We can get away with not using type strengthening here, since we aren't
-        // going to use the tracked types in the construction of Stage 4 access
-        // paths. For Stage 4 and onwards, the tracked types must be consistent as
-        // the cons candidates including types are used to construct subsequent
-        // access path approximations.
         t0 = t and
         (
           notExpectsContent(node)

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -3127,6 +3127,14 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             override predicate isSource() { sourceNode(node, state) }
           }
 
+          bindingset[p, state, t, ap, stored]
+          pragma[inline_late]
+          private SummaryCtxSome mkSummaryCtxSome(
+            ParamNodeEx p, FlowState state, Typ t, Ap ap, TypOption stored
+          ) {
+            result = TSummaryCtxSome(p, state, t, ap, stored)
+          }
+
           pragma[nomagic]
           private predicate fwdFlowInStep(
             ArgNodeEx arg, ParamNodeEx p, FlowState state, Cc outercc, CcCall innercc,
@@ -3138,7 +3146,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
             or
             FwdFlowInThrough::fwdFlowIn(_, arg, _, p, state, outercc, innercc, outerSummaryCtx, t,
               ap, stored, _) and
-            innerSummaryCtx = TSummaryCtxSome(p, state, t, ap, stored)
+            innerSummaryCtx = mkSummaryCtxSome(p, state, t, ap, stored)
           }
 
           pragma[nomagic]


### PR DESCRIPTION
This was identified by the join-order metric. It's not recursive, so it didn't hurt us too much, but it's an easy fix.

Before:
```
[2025-01-16 10:32:29] Evaluated non-recursive predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::fwdFlowInStep/10#316df909@3f9c0ft4 in 13ms (size: 38324).
Evaluated relational algebra for predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::fwdFlowInStep/10#316df909@3f9c0ft4 with tuple counts:
          15972   ~0%    {7} r1 = JOIN `num#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::TSummaryCtxNone#7d1df047` WITH `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::FwdFlowInNoThrough::fwdFlowInValidEdgeTypeFlowEnabled/8#ed2cbed3` CARTESIAN PRODUCT OUTPUT Rhs.0, Rhs.1, Rhs.4, Rhs.5, Lhs.0, Rhs.2, Rhs.3
          26378   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowIntoArg/9#973fa733#reorder_0_2_6_8_1_3_4_5_7` ON FIRST 4 OUTPUT Lhs.0, Lhs.5, Rhs.4, Lhs.1, Lhs.6, Rhs.5, Lhs.4, Rhs.6, Rhs.7, Rhs.8
                     
           4063   ~0%    {6} r2 = SCAN `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::TSummaryCtxSome#abb16013` OUTPUT In.1, In.2, In.3, In.4, In.0, In.5
        3282287   ~0%    {11}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowIntoArg/9#973fa733#reorder_0_2_6_8_1_3_4_5_7_467801523#join_rhs` ON FIRST 4 OUTPUT Rhs.4, Rhs.5, Lhs.4, Rhs.7, Rhs.8, Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.5, Rhs.6
          11946   ~1%    {10}    | JOIN WITH `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::FwdFlowInThrough::fwdFlowInValidEdgeTypeFlowEnabled/8#5803fd18_012453#join_rhs` ON FIRST 5 OUTPUT Lhs.0, Lhs.2, Lhs.5, Lhs.1, Rhs.5, Lhs.10, Lhs.9, Lhs.6, Lhs.7, Lhs.8
                     
          38324   ~0%    {10} r3 = r1 UNION r2
                         return r3
```
After:
```
[2025-01-16 10:31:51] Evaluated non-recursive predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::fwdFlowInStep/10#316df909@d5c761bm in 5ms (size: 38324).
Evaluated relational algebra for predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::fwdFlowInStep/10#316df909@d5c761bm with tuple counts:
        15972   ~0%    {7} r1 = JOIN `num#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::TSummaryCtxNone#7d1df047` WITH `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::FwdFlowInNoThrough::fwdFlowInValidEdgeTypeFlowEnabled/8#ed2cbed3` CARTESIAN PRODUCT OUTPUT Rhs.0, Rhs.1, Rhs.4, Rhs.5, Lhs.0, Rhs.2, Rhs.3
        26378   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowIntoArg/9#973fa733#reorder_0_2_6_8_1_3_4_5_7` ON FIRST 4 OUTPUT Lhs.0, Lhs.5, Rhs.4, Lhs.1, Lhs.6, Rhs.5, Lhs.4, Rhs.6, Rhs.7, Rhs.8
                   
         6214   ~5%    {6} r2 = SCAN `project#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::FwdFlowInThrough::fwdFlowInValidEdgeTypeFlowEnabled/8#5803fd18` OUTPUT In.0, In.1, In.4, In.5, In.2, In.3
        11946   ~0%    {9}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowIntoArg/9#973fa733#reorder_0_2_6_8_1_3_4_5_7` ON FIRST 4 OUTPUT Lhs.4, Rhs.4, Rhs.6, Rhs.7, Rhs.8, Lhs.0, Lhs.1, Lhs.5, Rhs.5
        11946   ~1%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::TSummaryCtxSome#abb16013` ON FIRST 5 OUTPUT Lhs.5, Lhs.0, Lhs.1, Lhs.6, Lhs.7, Lhs.8, Rhs.5, Lhs.2, Lhs.3, Lhs.4
                   
        38324   ~0%    {10} r3 = r1 UNION r2
                       return r3
```
(I've also piggy-backed a commit that deletes an outdated comment)