### PR TITLE
Dataflow: Another minor join-order fix

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2154,8 +2154,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
         pragma[nomagic]
         private predicate storeStepFwd(NodeEx node1, Ap ap1, Content c, NodeEx node2, Ap ap2) {
           fwdFlowStore(node1, _, ap1, _, c, _, _, node2, _, _, _) and
-          ap2 = apCons(c, ap1) and
-          readStepFwd(_, ap2, c, _, _)
+          readStepFwd(_, ap2, c, _, ap1)
         }
 
         pragma[nomagic]

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -4392,6 +4392,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       Typ getTyp(DataFlowType t) { result = t }
 
       bindingset[c, tail]
+      pragma[inline_late]
       Ap apCons(Content c, Ap tail) { result.isCons(c, tail) }
 
       class ApHeadContent = Content;
@@ -4461,6 +4462,7 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
       abstract Content getHead();
 
       /** Holds if this is a representation of `head` followed by `tail`. */
+      pragma[nomagic]
       abstract predicate isCons(Content head, AccessPath tail);
 
       /** Gets the front of this access path. */


### PR DESCRIPTION
The first commit tweaks a join-order slightly: We can add the final column of `readStepFwd` to the join as a noop, but then `ap2 = apCons(c, ap1)` becomes implied and can be dropped, which simplifies things. This was mainly motivated by the second commit to get a cleaner RA diff.

The second commit fixes an actual join-order issue in `S6Graph::localStep/10`.
Before:
```
[2025-01-16 10:31:51] Evaluated non-recursive predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::localStep/10#eaf7e0b3@d7e3e562 in 46ms (size: 49487).
Evaluated relational algebra for predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::localStep/10#eaf7e0b3@d7e3e562 with tuple counts:
           63139   ~2%    {8} r1 = SCAN `num#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::TPathNodeMid#2a7e4aad` OUTPUT In.0, In.4, In.5, In.6, In.1, In.2, In.3, In.7
            3680   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowRead/12#00c1fd2f_0123910115678#join_rhs` ON FIRST 7 OUTPUT Lhs.7, Rhs.7, Lhs.4, Lhs.5, Lhs.6, Rhs.8, Rhs.9, Rhs.10, _, _
            3680   ~0%    {10}    | REWRITE WITH Out.8 := "", Out.9 := false
                      
           63139   ~5%    {8} r2 = SCAN `num#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::TPathNodeMid#2a7e4aad` OUTPUT In.5, In.0, In.1, In.2, In.3, In.4, In.6, In.7
        12371270   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::AccessPath.isCons/2#dispred#830d3217_201#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, Lhs.0, Lhs.6, Rhs.2, Lhs.2, Lhs.3, Lhs.4, Lhs.7, Rhs.1
            1915   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowStore/11#24237f6c_012348910567#join_rhs` ON FIRST 8 OUTPUT Lhs.8, Rhs.10, Lhs.5, Lhs.6, Lhs.7, Rhs.8, Lhs.9, Rhs.9, _, _
            1915   ~1%    {10}    | REWRITE WITH Out.8 := "", Out.9 := true
            ...
```
After:
```
[2025-01-16 12:10:51] Evaluated non-recursive predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::localStep/10#eaf7e0b3@93954fc8 in 6ms (size: 49487).
Evaluated relational algebra for predicate DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::localStep/10#eaf7e0b3@93954fc8 with tuple counts:
        63139   ~0%    {8} r1 = SCAN `num#DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::S6Graph::TPathNodeMid#2a7e4aad` OUTPUT In.0, In.4, In.5, In.6, In.1, In.2, In.3, In.7
                   
         3680   ~0%    {10} r2 = JOIN r1 WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowRead/12#00c1fd2f_0123910115678#join_rhs` ON FIRST 7 OUTPUT Lhs.7, Rhs.7, Lhs.4, Lhs.5, Lhs.6, Rhs.8, Rhs.9, Rhs.10, _, _
         3680   ~0%    {10}    | REWRITE WITH Out.8 := "", Out.9 := false
                   
         1920   ~0%    {9} r3 = JOIN r1 WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::Stage6::fwdFlowStore/11#24237f6c_012389104567#join_rhs` ON FIRST 7 OUTPUT Rhs.7, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Rhs.8, Rhs.9, Rhs.10
         1915   ~0%    {10}    | JOIN WITH `DataFlowImpl::MakeImpl<Location::Location,DataFlowImplSpecific::JavaDataFlow>::Impl<SensitiveLoggingQuery::SensitiveLoggerFlow::C>::AccessPath.isCons/2#dispred#830d3217_120#join_rhs` ON FIRST 2 OUTPUT Lhs.5, Lhs.8, Lhs.2, Lhs.3, Lhs.4, Lhs.6, Rhs.2, Lhs.7, _, _
         1915   ~0%    {10}    | REWRITE WITH Out.8 := "", Out.9 := true
         ...
```