### PR TITLE
Dataflow: Simplify the call-edge join in reverse through-flow.

### DIFF
--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImpl.qll
@@ -2187,11 +2187,11 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate flowThroughIntoCall(
-          DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, Ap argAp, Ap ap
+          DataFlowCall call, ArgNodeEx arg, ParamNodeEx p, Ap argAp
         ) {
           exists(Typ argT, TypOption argStored |
             returnFlowsThrough(_, _, _, _, pragma[only_bind_into](p), pragma[only_bind_into](argT),
-              pragma[only_bind_into](argAp), pragma[only_bind_into](argStored), ap) and
+              pragma[only_bind_into](argAp), pragma[only_bind_into](argStored), _) and
             flowIntoCallTaken(call, _, pragma[only_bind_into](arg), p, isNil(argAp)) and
             fwdFlow(arg, _, _, _, pragma[only_bind_into](argT), pragma[only_bind_into](argAp),
               pragma[only_bind_into](argStored))
@@ -2285,9 +2285,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           returnAp = apNone()
           or
           // flow through a callable
-          exists(DataFlowCall call, ParamNodeEx p, Ap innerReturnAp |
-            revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp) and
-            flowThroughIntoCall(call, node, p, ap, innerReturnAp)
+          exists(DataFlowCall call, ParamNodeEx p |
+            revFlowThrough(call, returnCtx, p, state, returnAp, ap) and
+            flowThroughIntoCall(call, node, p, ap)
           )
           or
           // flow out of a callable
@@ -2437,11 +2437,13 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate revFlowThrough(
-          DataFlowCall call, ReturnCtx returnCtx, ParamNodeEx p, FlowState state,
-          ReturnPosition pos, ApOption returnAp, Ap ap, Ap innerReturnAp
+          DataFlowCall call, ReturnCtx returnCtx, ParamNodeEx p, FlowState state, ApOption returnAp,
+          Ap ap
         ) {
-          revFlowParamToReturn(p, state, pos, innerReturnAp, ap) and
-          revFlowIsReturned(call, returnCtx, returnAp, pos, innerReturnAp)
+          exists(ReturnPosition pos, Ap innerReturnAp |
+            revFlowParamToReturn(p, state, pos, innerReturnAp, ap) and
+            revFlowIsReturned(call, returnCtx, returnAp, pos, innerReturnAp)
+          )
         }
 
         /**
@@ -2567,9 +2569,9 @@ module MakeImpl<LocationSig Location, InputSig<Location> Lang> {
           DataFlowCall call, ArgNodeEx arg, FlowState state, ReturnCtx returnCtx, ApOption returnAp,
           Ap ap
         ) {
-          exists(ParamNodeEx p, Ap innerReturnAp |
-            revFlowThrough(call, returnCtx, p, state, _, returnAp, ap, innerReturnAp) and
-            flowThroughIntoCall(call, arg, p, ap, innerReturnAp)
+          exists(ParamNodeEx p |
+            revFlowThrough(call, returnCtx, p, state, returnAp, ap) and
+            flowThroughIntoCall(call, arg, p, ap)
           )
         }
 


### PR DESCRIPTION
Alternative to https://github.com/github/codeql/pull/18355.

For a summary edge `arg->par->ret->out` found in reverse flow with access paths `ap` at `arg`/`par` and `innerReturnAp` at `ret`/`out` it seems superfluous to include `innerReturnAp` in the call-edge `arg`-`par` join. The added constraint is that a path exists between `par` and `ret` with those access paths, but when we join `flowThroughIntoCall` in reverse flow, then that exactly what we just established, so I don't think it adds much (if anything). Dropping the column avoids the need to materialize a combination of 3 access paths (`ap`, `innerReturnAp`, and `returnAp`) that can vary independently in degenerate cases.