### PR TITLE
C++: Uncomment preprocessor test cases and add addition `#if` test case

### DIFF
--- a/cpp/ql/test/library-tests/preprocessor/preprocessor/pp.cpp
+++ b/cpp/ql/test/library-tests/preprocessor/preprocessor/pp.cpp
@@ -68,3 +68,10 @@ int templateClassContext<T> :: val = MACRO_TEMPLATECLASSCONTEXT_REFERENCED;
 
 #define INSTANTIATION
 templateClassContext<int> tcci;
+
+#define BAR
+
+#if defined(BAR) && \
+  defined(BAR)
+#warning BAR defined
+#endif

--- a/cpp/ql/test/library-tests/preprocessor/preprocessor/pp.h
+++ b/cpp/ql/test/library-tests/preprocessor/preprocessor/pp.h
@@ -4,15 +4,15 @@
 //#pragma byte_order(big_endian)
 #warning "Not in Kansas any more"
 
-//#define MULTILINE \
+#define MULTILINE \
   /* Hello */ \
   world \
   /* from */ \
   a long \
   /* macro */
-//#undef \
+#undef \
   MULTILINE
 
-//#include \
-  <pp.h> \
+#include \
+  "pp.h" \
   \

--- a/cpp/ql/test/library-tests/preprocessor/preprocessor/preproc.expected
+++ b/cpp/ql/test/library-tests/preprocessor/preprocessor/preproc.expected
@@ -27,6 +27,13 @@
 | pp.cpp:0:0:0:0 | pp.cpp | 60 | 3 | 60 | 21 | Macro | IN_TEMPLATE |  |
 | pp.cpp:0:0:0:0 | pp.cpp | 61 | 1 | 61 | 7 | PreprocessorEndif | N/A | N/A |
 | pp.cpp:0:0:0:0 | pp.cpp | 69 | 1 | 69 | 21 | Macro | INSTANTIATION |  |
+| pp.cpp:0:0:0:0 | pp.cpp | 72 | 1 | 72 | 11 | Macro | BAR |  |
+| pp.cpp:0:0:0:0 | pp.cpp | 74 | 1 | 74 | 21 | PreprocessorIf | defined(BAR) && \\ | N/A |
+| pp.cpp:0:0:0:0 | pp.cpp | 76 | 1 | 76 | 20 | PreprocessorWarning | BAR defined | N/A |
+| pp.cpp:0:0:0:0 | pp.cpp | 77 | 1 | 77 | 6 | PreprocessorEndif | N/A | N/A |
 | pp.h:0:0:0:0 | pp.h | 1 | 1 | 1 | 12 | PreprocessorPragma | once | N/A |
 | pp.h:0:0:0:0 | pp.h | 3 | 1 | 3 | 27 | PreprocessorLine | 33  "emerald_city.h" | N/A |
 | pp.h:0:0:0:0 | pp.h | 5 | 1 | 5 | 33 | PreprocessorWarning | "Not in Kansas any more" | N/A |
+| pp.h:0:0:0:0 | pp.h | 7 | 1 | 11 | 8 | Macro | MULTILINE | world a long |
+| pp.h:0:0:0:0 | pp.h | 13 | 1 | 14 | 11 | PreprocessorUndef | MULTILINE | N/A |
+| pp.h:0:0:0:0 | pp.h | 16 | 1 | 17 | 8 | Include | "pp.h" | N/A |


### PR DESCRIPTION
Note that the new test case shows that line splicing is not correctly handled in the case of `#if`.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
