### PR TITLE
Add Minimum Permissions Map

### DIFF
--- a/actions/ql/lib/codeql/actions/config/Config.qll
+++ b/actions/ql/lib/codeql/actions/config/Config.qll
@@ -127,6 +127,18 @@ predicate vulnerableActionsDataModel(
 predicate immutableActionsDataModel(string action) { Extensions::immutableActionsDataModel(action) }
 
 /**
+ * MaD models for minimum permissions for actions
+ * Fields:
+ *    - action: action name
+ *    - minimum_permissions: list of minimum permissions
+ */
+predicate minimumPermissionsDataModel(
+  string action, string minimum_permissions
+) {
+  Extensions::minimumPermissionsDataModel(action, minimum_permissions)
+}
+
+/**
  * MaD models for untrusted git commands
  * Fields:
  *    - cmd_regex: Regular expression for matching untrusted git commands

--- a/actions/ql/lib/codeql/actions/config/ConfigExtensions.qll
+++ b/actions/ql/lib/codeql/actions/config/ConfigExtensions.qll
@@ -64,6 +64,11 @@ extensible predicate vulnerableActionsDataModel(
 extensible predicate immutableActionsDataModel(string action);
 
 /**
+ * Holds for actions that have a minimum permissions definition.
+ */
+extensible predicate minimumPermissionsDataModel(string action, string minimum_permissions);
+
+/**
  * Holds for git commands that may introduce untrusted data when called on an attacker controlled branch.
  */
 extensible predicate untrustedGitCommandDataModel(string cmd_regex, string flag);

--- a/actions/ql/lib/codeql/actions/security/MinimumActionsPermissions.qll
+++ b/actions/ql/lib/codeql/actions/security/MinimumActionsPermissions.qll
@@ -1,0 +1,14 @@
+import actions
+class MinimumActionsPermissions extends UsesStep {
+  string action;
+  string minimum_permissions;
+
+  MinimumActionsPermissions() {
+    minimumPermissionsDataModel(action, minimum_permissions) and
+    this.getCallee() = action
+  }
+
+  string getMinimumPermissions() { result = minimum_permissions }
+
+  string getAction() { result = action }
+}

--- a/actions/ql/lib/ext/config/minimum_permissions_map.yml
+++ b/actions/ql/lib/ext/config/minimum_permissions_map.yml
@@ -1,0 +1,25 @@
+:
+  - addsTo:
+    pack: github/actions-all
+    extensible: minimumPermissionsDataModel
+    data:
+    - ["actions/cache", "{}"]
+    - ["actions/setup-node", "contents:read"]
+    - ["actions/upload-artifact", "{}"]
+    - ["actions/setup-python", "contents:read"]
+    - ["actions/download-artifact", "{}"]
+    - ["actions/github-script", "It depends on what the script does"]
+    - ["actions/setup-java", "contents:read"]
+    - ["actions/setup-go", "contents:read"]
+    - ["actions/setup-dotnet", "contents:read"]
+    - ["actions/labeler", "contents:read, pull-requests:write"]
+    - ["actions/attest", "id-token:write, attestations:write"]
+    - ["actions/add-to-project", "repository-projects:read, repository-projects:write, issues:read, pull-requests:read"]
+    - ["actions/dependency-review-action", "contents:read"]
+    - ["actions/attest-sbom", "id-token:write, attestations:write"]
+    - ["actions/stale", "contents:write, issues:write, pull-requests:write"]
+    - ["actions/attest-build-provenance", "id-token:write, attestations:write"]
+    - ["actions/jekyll-build-pages", "contents:read, pages:write, id-token:write"]
+    - ["actions/publish-action", "contents:write"]
+    - ["actions/version-package-tools", "contents:read, actions:read"]
+    - ["actions/reusable-workflows", "contents:read, actions:read"]

--- a/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
+++ b/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
@@ -11,15 +11,38 @@
  *       external/cwe/cwe-275
  */
 
-import actions
+ import actions
+ import codeql.actions.security.MinimumActionsPermissions
 
-from Job job
-where
-  not exists(job.getPermissions()) and
-  not exists(job.getEnclosingWorkflow().getPermissions()) and
-  // exists a trigger event that is not a workflow_call
-  exists(Event e |
-    e = job.getATriggerEvent() and
-    not e.getName() = "workflow_call"
-  )
-select job, "Actions Job or Workflow does not set permissions"
+ // Returns the minimum permissions for all of the uses steps
+ // that are children of the job separated by a comma
+ // e.g. "contents: read, packages: write".  If we cannot determine
+ // the permission we fallback to "unknown"
+ string getMinPermissions(Job job) {
+   if unknownPermissions(job) = true then result = "unknown" else
+   result = minPermissions(job)
+ }
+
+ string minPermissions(Job job) {
+   result = concat(job.getAChildNode*().(MinimumActionsPermissions).getMinimumPermissions(), ", ")
+ }
+
+ // Holds if we cannot determine the permissions for the uses step
+ // using the data extension or there are no uses steps
+ // that are children of the job
+ boolean unknownPermissions(Job job) {
+    minPermissions(job) = "" and result = true or count(job.getAChildNode*().(MinimumActionsPermissions)) = 0 and result = true
+ }
+
+ from Job job
+ where
+   not exists(job.getPermissions()) and
+   not exists(job.getEnclosingWorkflow().getPermissions()) and
+   // exists a trigger event that is not a workflow_call
+   exists(Event e |
+     e = job.getATriggerEvent() and
+     not e.getName() = "workflow_call"
+   )
+ select job,
+ "Actions Job or Workflow does not set permissions. Recommended minimum permissions are ($@)",
+ job, getMinPermissions(job)


### PR DESCRIPTION
### Pull Request checklist

Add a map to suggest the minimum permissions needed for the GITHUB_TOKEN when commonly used GitHub owned actions are detected

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
