### PR TITLE
Java: fix stats for databaseMetadata relation

### DIFF
--- a/java/ql/lib/config/semmlecode.dbscheme.stats
+++ b/java/ql/lib/config/semmlecode.dbscheme.stats
@@ -3981,7 +3981,28 @@
                     <v>1</v>
                 </e>
             </columnsizes>
-            <dependencies/>
+            <dependencies>
+                <dep>
+                    <src>metadataKey</src>
+                    <trg>value</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs/>
+                        </hist>
+                    </val>
+                </dep>
+                <dep>
+                    <src>value</src>
+                    <trg>metadataKey</trg>
+                    <val>
+                        <hist>
+                            <budget>12</budget>
+                            <bs/>
+                        </hist>
+                    </val>
+                </dep>
+            </dependencies>
         </relation>
         <relation>
             <name>smap_header</name>


### PR DESCRIPTION
https://github.com/github/codeql/pull/18529 passed all its CI checks, but caused an internal stats-checking unit test to fail. This should fix it.