### PR TITLE
JS: Fix FPs with js/incorrect-suffix-check

### DIFF
--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -49,9 +49,20 @@ class IndexOfCall extends DataFlow::MethodCallNode {
     exists(DataFlow::Node recv, string m |
       this.receiverAndMethodName(recv, m) and result.receiverAndMethodName(recv, m)
     |
+      // both directly reference the same value
       result.getArgument(0).getALocalSource() = this.getArgument(0).getALocalSource()
       or
+      // both use the same string literal
       result.getArgument(0).getStringValue() = this.getArgument(0).getStringValue()
+      or
+      // both use the same concatenation of a string and a value
+      exists(Expr origin, StringLiteral str, AddExpr otherAdd |
+        this.getArgument(0).asExpr().(AddExpr).hasOperands(origin, str) and
+        otherAdd = result.getArgument(0).asExpr().(AddExpr)
+      |
+        otherAdd.getAnOperand().(StringLiteral).getStringValue() = str.getStringValue() and
+        otherAdd.getAnOperand().flow().getALocalSource() = origin.flow().getALocalSource()
+      )
     )
   }
 

--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -58,7 +58,7 @@ class IndexOfCall extends DataFlow::MethodCallNode {
       // both use the same concatenation of a string and a value
       exists(Expr origin, StringLiteral str, AddExpr otherAdd |
         this.getArgument(0).asExpr().(AddExpr).hasOperands(origin, str) and
-        otherAdd = result.getArgument(0).asExpr().(AddExpr)
+        otherAdd = result.getArgument(0).asExpr()
       |
         otherAdd.getAnOperand().(StringLiteral).getStringValue() = str.getStringValue() and
         otherAdd.getAnOperand().flow().getALocalSource() = origin.flow().getALocalSource()

--- a/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
+++ b/javascript/ql/src/Security/CWE-020/IncorrectSuffixCheck.ql
@@ -44,6 +44,8 @@ class IndexOfCall extends DataFlow::MethodCallNode {
    * Gets an `indexOf` call with the same receiver, argument, and method name, including this call itself.
    */
   IndexOfCall getAnEquivalentIndexOfCall() {
+    result = this
+    or
     exists(DataFlow::Node recv, string m |
       this.receiverAndMethodName(recv, m) and result.receiverAndMethodName(recv, m)
     |

--- a/javascript/ql/src/change-notes/2025-01-22-indexof-suffix-check.md
+++ b/javascript/ql/src/change-notes/2025-01-22-indexof-suffix-check.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The `js/incorrect-suffix-check` query now recognises some good patterns of the form `origin.indexOf("." + allowedOrigin)` that were previously falsely flagged.

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
@@ -9,3 +9,5 @@
 | tst.js:67:32:67:71 | x.index ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:76:25:76:57 | index = ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:80:10:80:57 | x.index ... th + 1) | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
+| tst.js:105:23:105:80 | ind === ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
+| tst.js:110:65:110:164 | trusted ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
@@ -9,5 +9,4 @@
 | tst.js:67:32:67:71 | x.index ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:76:25:76:57 | index = ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:80:10:80:57 | x.index ... th + 1) | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
-| tst.js:105:23:105:80 | ind === ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:110:65:110:164 | trusted ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/IncorrectSuffixCheck.expected
@@ -9,4 +9,3 @@
 | tst.js:67:32:67:71 | x.index ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:76:25:76:57 | index = ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
 | tst.js:80:10:80:57 | x.index ... th + 1) | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |
-| tst.js:110:65:110:164 | trusted ... gth - 1 | This suffix check is missing a length comparison to correctly handle indexOf returning -1. |

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
@@ -97,3 +97,15 @@ function lastIndexNeqMinusOne(x) {
 function lastIndexEqMinusOne(x) {
   return x.lastIndexOf("example.com") === -1 || x.lastIndexOf("example.com") === x.length - "example.com".length; // OK
 }
+
+function sameCheck(allowedOrigin) {
+    const trustedAuthority = "example.com";
+
+    const ind = trustedAuthority.indexOf("." + allowedOrigin);
+    return ind > 0 && ind === trustedAuthority.length - allowedOrigin.length - 1; // OK - but currently failing
+}
+
+function sameConcatenation(allowedOrigin) {
+    const trustedAuthority = "example.com";
+    return trustedAuthority.indexOf("." + allowedOrigin) > 0 && trustedAuthority.indexOf("." + allowedOrigin) === trustedAuthority.length - allowedOrigin.length - 1; // OK - but currently failing
+}

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
@@ -107,5 +107,5 @@ function sameCheck(allowedOrigin) {
 
 function sameConcatenation(allowedOrigin) {
     const trustedAuthority = "example.com";
-    return trustedAuthority.indexOf("." + allowedOrigin) > 0 && trustedAuthority.indexOf("." + allowedOrigin) === trustedAuthority.length - allowedOrigin.length - 1; // OK - but currently failing
+    return trustedAuthority.indexOf("." + allowedOrigin) > 0 && trustedAuthority.indexOf("." + allowedOrigin) === trustedAuthority.length - allowedOrigin.length - 1; // OK
 }

--- a/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-020/IncorrectSuffixCheck/tst.js
@@ -102,7 +102,7 @@ function sameCheck(allowedOrigin) {
     const trustedAuthority = "example.com";
 
     const ind = trustedAuthority.indexOf("." + allowedOrigin);
-    return ind > 0 && ind === trustedAuthority.length - allowedOrigin.length - 1; // OK - but currently failing
+    return ind > 0 && ind === trustedAuthority.length - allowedOrigin.length - 1; // OK
 }
 
 function sameConcatenation(allowedOrigin) {


### PR DESCRIPTION
Fixes internal issue (see backref).   

Evaluations were uneventful. I did a rerun of the `nightly-old` due to the first one hinting slightly towards a performance regression, but that disappeared on a rerun. 