### PR TITLE
JS: Avoid inconsistent DB when embedded TS has no associated tsconfig.json

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -42,7 +42,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2025-01-09";
+  public static final String EXTRACTOR_VERSION = "2025-01-21";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -177,6 +178,12 @@ public class Main {
       if (!extractedFiles.contains(f.getAbsoluteFile())
           && FileType.forFileExtension(f) == FileType.TYPESCRIPT) {
         remainingTypescriptFiles.add(f);
+      }
+    }
+    for (Map.Entry<Path, FileSnippet> entry : extractorState.getSnippets().entrySet()) {
+      if (!extractedFiles.contains(entry.getKey().toFile())
+          && FileType.forFileExtension(entry.getKey().toFile()) == FileType.TYPESCRIPT) {
+        remainingTypescriptFiles.add(entry.getKey().toFile());
       }
     }
     if (!remainingTypescriptFiles.isEmpty()) {

--- a/javascript/ql/src/change-notes/2025-01-21-vue-ts-notsconfig.md
+++ b/javascript/ql/src/change-notes/2025-01-21-vue-ts-notsconfig.md
@@ -1,0 +1,6 @@
+---
+category: fix
+---
+* Fixed a bug that would occur when TypeScript code was found in an HTML-like file, such as a `.vue` file,
+  but where it could not be associated with any `tsconfig.json` file. Previously the embedded code was not
+  extracted in this case, but should now be extracted properly.

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/DB-CHECK.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/DB-CHECK.expected
@@ -1,3 +1,0 @@
-[VALUE_NOT_IN_TYPE] predicate toplevel_parent_xml_node(@toplevel toplevel, @xml_node_with_code xmlnode): Value 16 of field toplevel is not in type @toplevel. Appears in tuple (16,-16777216)
-	Relevant element: toplevel=16
-		Full ID for 16: @"script;(0),4,25". The ID may expand to @"script;{@"/Users/asger/git/code/ql/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/embedded-typescript.vue;sourcefile"},4,25"

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/DB-CHECK.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/DB-CHECK.expected
@@ -1,0 +1,3 @@
+[VALUE_NOT_IN_TYPE] predicate toplevel_parent_xml_node(@toplevel toplevel, @xml_node_with_code xmlnode): Value 16 of field toplevel is not in type @toplevel. Appears in tuple (16,-16777216)
+	Relevant element: toplevel=16
+		Full ID for 16: @"script;(0),4,25". The ID may expand to @"script;{@"/Users/asger/git/code/ql/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/embedded-typescript.vue;sourcefile"},4,25"

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/embedded-typescript.vue
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/embedded-typescript.vue
@@ -1,0 +1,7 @@
+<template>
+  <p v-html="input" />
+</template>
+<script setup lang="ts">
+console.log("hello");
+</script>
+<style></style>

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.expected
@@ -1,0 +1,1 @@
+| test.js:1:1:2:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.expected
@@ -1,1 +1,2 @@
+| embedded-typescript.vue:5:1:6:0 | <toplevel> |
 | test.js:1:1:2:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.js
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/EmbeddedTypeScriptNoTSConfig/test.ql
@@ -1,0 +1,3 @@
+import javascript
+
+query predicate toplevels(TopLevel top) { any() }


### PR DESCRIPTION
When TypeScript code is embedded in a HTML-like file such as a Vue file, we write the embedded code to a separate `.ts` file, to be extracted later by the TypeScript extractor. (To avoid starting up the TypeScript extractor in a multi-threaded context). These generated files are called "snippets". The mapping between such snippet files and their original source location is stored in `ExtractorState#getSnippets()`.

We have two different code paths for scheduling TypeScript files for extraction: one for files that are part of a tsconfig file, and one for "loose" files that aren't associated with any tsconfig. The second code path however was missing a case for extracting snippets. This led to unextracted code and DB consistency errors. This PR adds the missing snippet-extracting code.