### PR TITLE
Java: Improve performance of XSS regex.

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/JaxWS.qll
@@ -411,18 +411,33 @@ private class JaxRSXssSink extends XssSink {
     |
       not exists(resourceMethod.getProducesAnnotation())
       or
-      isXssVulnerableContentType(getContentTypeString(resourceMethod
-              .getProducesAnnotation()
-              .getADeclaredContentTypeExpr()))
+      isXssVulnerableContentTypeExpr(resourceMethod
+            .getProducesAnnotation()
+            .getADeclaredContentTypeExpr())
     )
   }
 }
 
-private predicate isXssVulnerableContentTypeExpr(Expr e) {
-  isXssVulnerableContentType(getContentTypeString(e))
+pragma[nomagic]
+private predicate contentTypeString(string s) { s = getContentTypeString(_) }
+
+pragma[nomagic]
+private predicate isXssVulnerableContentTypeString(string s) {
+  contentTypeString(s) and isXssVulnerableContentType(s)
 }
 
-private predicate isXssSafeContentTypeExpr(Expr e) { isXssSafeContentType(getContentTypeString(e)) }
+pragma[nomagic]
+private predicate isXssSafeContentTypeString(string s) {
+  contentTypeString(s) and isXssSafeContentType(s)
+}
+
+private predicate isXssVulnerableContentTypeExpr(Expr e) {
+  isXssVulnerableContentTypeString(getContentTypeString(e))
+}
+
+private predicate isXssSafeContentTypeExpr(Expr e) {
+  isXssSafeContentTypeString(getContentTypeString(e))
+}
 
 /**
  * Gets a builder expression or related type that is configured to use the given `contentType`.

--- a/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/spring/SpringHttp.qll
@@ -152,14 +152,30 @@ private string getSpringConstantContentType(FieldAccess e) {
   )
 }
 
+private string getContentTypeString(Expr e) {
+  result = e.(CompileTimeConstantExpr).getStringValue() or
+  result = getSpringConstantContentType(e)
+}
+
+pragma[nomagic]
+private predicate contentTypeString(string s) { s = getContentTypeString(_) }
+
+pragma[nomagic]
+private predicate isXssVulnerableContentTypeString(string s) {
+  contentTypeString(s) and XSS::isXssVulnerableContentType(s)
+}
+
+pragma[nomagic]
+private predicate isXssSafeContentTypeString(string s) {
+  contentTypeString(s) and XSS::isXssSafeContentType(s)
+}
+
 private predicate isXssVulnerableContentTypeExpr(Expr e) {
-  XSS::isXssVulnerableContentType(e.(CompileTimeConstantExpr).getStringValue()) or
-  XSS::isXssVulnerableContentType(getSpringConstantContentType(e))
+  isXssVulnerableContentTypeString(getContentTypeString(e))
 }
 
 private predicate isXssSafeContentTypeExpr(Expr e) {
-  XSS::isXssSafeContentType(e.(CompileTimeConstantExpr).getStringValue()) or
-  XSS::isXssSafeContentType(getSpringConstantContentType(e))
+  isXssSafeContentTypeString(getContentTypeString(e))
 }
 
 private DataFlow::Node getABodyBuilderWithExplicitContentType(Expr contentType) {

--- a/java/ql/lib/semmle/code/java/security/XSS.qll
+++ b/java/ql/lib/semmle/code/java/security/XSS.qll
@@ -118,10 +118,15 @@ class XssVulnerableWriterSourceNode extends ApiSourceNode {
  */
 bindingset[s]
 predicate isXssVulnerableContentType(string s) {
-  s.regexpMatch("(?i)text/(html|xml|xsl|rdf|vtt|cache-manifest).*") or
-  s.regexpMatch("(?i)application/(.*\\+)?xml.*") or
-  s.regexpMatch("(?i)cache-manifest.*") or
-  s.regexpMatch("(?i)image/svg\\+xml.*")
+  s.regexpMatch("(?i)(" +
+      //
+      "text/(html|xml|xsl|rdf|vtt|cache-manifest).*" + "|" +
+      //
+      "application/(.*\\+)?xml.*" + "|" +
+      //
+      "cache-manifest.*" + "|" +
+      //
+      "image/svg\\+xml.*" + ")")
 }
 
 /**


### PR DESCRIPTION
@jbj highlighted a case where the regex matching in `isXssVulnerableContentType` was a noticeable bottleneck - it's slow and it's evaluated multiple times.

Timing it locally, I measured one of the cases to 2.5s.
Merging the 4 regexes to 1 brought that down to about 670ms.
And testing the resulting regex on a single-column projection brought that further down to about 90ms.

This makes sense, since checking a single regex is much faster than checking 4. And projecting `CompileTimeConstantExpr.getStringValue()` to the string column easily reduces the number of regex operations by an order of magnitude when many string literals have the same value.