### PR TITLE
C++: Fix join-order problem found on `IncorrectCheckScanf.ql`

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
+++ b/cpp/ql/lib/semmle/code/cpp/controlflow/IRGuards.qll
@@ -981,7 +981,8 @@ private module Cached {
     or
     exists(CompareValueNumber cmp, Operand left, Operand right, AbstractValue v |
       test = cmp and
-      cmp.hasOperands(left, right) and
+      pragma[only_bind_into](cmp)
+          .hasOperands(pragma[only_bind_into](left), pragma[only_bind_into](right)) and
       isConvertedBool(left.getDef()) and
       int_value(right.getDef()) = 0 and
       unary_compares_eq(valueNumberOfOperand(left), op, k, areEqual, v)


### PR DESCRIPTION
Before on `silentearth/curl2`:

```
Evaluated recursive predicate IRGuards::Cached::unary_compares_eq/5#7aa979d8@e3b01fca in 26109ms on iteration 2 (delta size: 4020).
Evaluated relational algebra for predicate IRGuards::Cached::unary_compares_eq/5#7aa979d8@e3b01fca on iteration 2 running pipeline standard with tuple counts:
                 0   ~0%    {5} r1 = JOIN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` WITH `IRGuards::Cached::BuiltinExpectCallValueNumber.getCondition/0#dispred#9b2b5da2_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

           1835651   ~2%    {5} r2 = SCAN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` OUTPUT In.4, In.0, In.1, In.2, In.3
           1832833   ~0%    {5}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              3996   ~0%    {5}    | JOIN WITH `IRGuards::Cached::LogicalNotValueNumber.getUnary/0#dispred#b2251f1f_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

           1835651   ~7%    {5} r3 = SCAN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` OUTPUT In.1, In.0, In.2, In.3, In.4
           1835651   ~1%    {5}    | JOIN WITH `Operand::Operand.getAnyDef/0#dispred#8dbe2fb8` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

                 0   ~0%    {5} r4 = JOIN r3 WITH project#Instruction::PointerSubInstruction#0d109780 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
                 0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                 0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 + In.6) KEEPING 5

                23  ~76%    {5} r5 = JOIN r3 WITH Instruction::SubInstruction#fc619901 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
                22  ~56%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                22  ~56%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 + In.6) KEEPING 5

                 0   ~0%    {5} r6 = JOIN r3 WITH project#Instruction::PointerAddInstruction#5233892c ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4

                 0   ~0%    {6} r7 = JOIN r6 WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                 0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

                 0   ~0%    {6} r8 = JOIN r6 WITH `Instruction::BinaryInstruction.getRightOperand/0#dispred#9ca710da` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                 0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeft/0#dispred#5cf78406` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

                12  ~49%    {5} r9 = JOIN r3 WITH Instruction::AddInstruction#7f8fb455 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4

                12  ~49%    {6} r10 = JOIN r9 WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                12  ~71%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

                12  ~49%    {6} r11 = JOIN r9 WITH `Instruction::BinaryInstruction.getRightOperand/0#dispred#9ca710da` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
                12  ~49%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeft/0#dispred#5cf78406` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
                 0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

                 0   ~0%    {5} r12 = JOIN r1 WITH `IRGuards::Cached::BuiltinExpectCallValueNumber.getAUse/0#dispred#23233591` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
                 0   ~0%    {6}    | JOIN WITH `IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.2

                 0   ~0%    {6} r13 = JOIN r12 WITH project#IRGuards::Cached::CompareNEValueNumber#1aeec1bd ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.4

                 0   ~0%    {6} r14 = JOIN r12 WITH project#IRGuards::Cached::CompareEQValueNumber#994b6833 ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.5
                 0   ~0%    {6}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d_10#join_rhs` ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1

                 0   ~0%    {6} r15 = r13 UNION r14
                 0   ~0%    {7}    | JOIN WITH `Operand::Operand.getAnyDef/0#dispred#8dbe2fb8` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                 0   ~0%    {7}    | REWRITE WITH Out.1 := 0
                 0   ~0%    {5}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.4, Lhs.6

        1901910478   ~1%    {5} r16 = JOIN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
        1902015678   ~4%    {5}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
        1902015678   ~3%    {6}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.0
        1901976207   ~4%    {5}    | JOIN WITH `IRGuards::Cached::isConvertedBool/1#9a130da2` ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.4
                74  ~10%    {6}    | JOIN WITH `IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.2

                54  ~10%    {6} r17 = JOIN r16 WITH project#IRGuards::Cached::CompareNEValueNumber#1aeec1bd ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.4

                20   ~0%    {6} r18 = JOIN r16 WITH project#IRGuards::Cached::CompareEQValueNumber#994b6833 ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.5
                20   ~0%    {6}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d` ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1

                74   ~5%    {6} r19 = r17 UNION r18
                74   ~5%    {7}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
                74   ~4%    {7}    | REWRITE WITH Out.1 := 0
                66   ~0%    {5}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.4, Lhs.6

              4062   ~0%    {5} r20 = r1 UNION r2 UNION r4 UNION r5 UNION r7 UNION r8 UNION r10 UNION r11 UNION r15 UNION r19
              4020   ~0%    {5}    | AND NOT `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev`(FIRST 5)
                            return r20
```

After:
```
[2025-01-22 14:50:44] Evaluated non-recursive predicate _IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs_IRGuards::Cached::__#join_rhs@25668753 in 36ms (size: 47).
Evaluated relational algebra for predicate _IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs_IRGuards::Cached::__#join_rhs@25668753 with tuple counts:
        285951  ~0%    {4} r1 = JOIN `IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs` WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Lhs.2
            47  ~2%    {3}    | JOIN WITH `IRGuards::Cached::isConvertedBool/1#9a130da2` ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3
            47  ~0%    {3}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
            47  ~0%    {3}    | JOIN WITH `ValueNumberingInternal::tvalueNumber/1#f03b58f9` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
                       return r1
                       Evaluated recursive predicate IRGuards::Cached::unary_compares_eq/5#7aa979d8@a808bbfb in 63ms on iteration 2 (delta size: 4020).
Evaluated relational algebra for predicate IRGuards::Cached::unary_compares_eq/5#7aa979d8@a808bbfb on iteration 2 running pipeline standard with tuple counts:
              0   ~0%    {5} r1 = JOIN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` WITH `IRGuards::Cached::BuiltinExpectCallValueNumber.getCondition/0#dispred#9b2b5da2_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

        1881864  ~10%    {5} r2 = SCAN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` OUTPUT In.4, In.0, In.1, In.2, In.3
        1879046   ~4%    {5}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
           3986   ~0%    {5}    | JOIN WITH `IRGuards::Cached::LogicalNotValueNumber.getUnary/0#dispred#b2251f1f_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

        1881864  ~11%    {5} r3 = SCAN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` OUTPUT In.1, In.0, In.2, In.3, In.4
        1881864   ~2%    {5}    | JOIN WITH `Operand::Operand.getAnyDef/0#dispred#8dbe2fb8` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4

              0   ~0%    {5} r4 = JOIN r3 WITH project#Instruction::PointerSubInstruction#0d109780 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
              0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 + In.6) KEEPING 5

             16  ~14%    {5} r5 = JOIN r3 WITH Instruction::SubInstruction#fc619901 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
             16  ~14%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
             16  ~14%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 + In.6) KEEPING 5

              0   ~0%    {5} r6 = JOIN r3 WITH project#Instruction::PointerAddInstruction#5233892c ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4

              0   ~0%    {6} r7 = JOIN r6 WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

              0   ~0%    {6} r8 = JOIN r6 WITH `Instruction::BinaryInstruction.getRightOperand/0#dispred#9ca710da` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              0   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeft/0#dispred#5cf78406` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

              8   ~0%    {5} r9 = JOIN r3 WITH Instruction::AddInstruction#7f8fb455 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4

              8   ~0%    {6} r10 = JOIN r9 WITH `Instruction::BinaryInstruction.getLeftOperand/0#dispred#c8432d08` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              8   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getRight/0#dispred#1f78e436` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

              8   ~0%    {6} r11 = JOIN r9 WITH `Instruction::BinaryInstruction.getRightOperand/0#dispred#9ca710da` ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1
              8   ~0%    {6}    | JOIN WITH `Instruction::BinaryInstruction.getLeft/0#dispred#5cf78406` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 1 OUTPUT Lhs.1, Lhs.5, _, Lhs.3, Lhs.4, Lhs.2, Rhs.1
              0   ~0%    {5}    | REWRITE WITH Out.2 := (In.5 - In.6) KEEPING 5

             70   ~6%    {6} r12 = JOIN `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev_delta` WITH `_IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs_IRGuards::Cached::__#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1, Lhs.2, Lhs.3, Lhs.4

             50   ~2%    {6} r13 = JOIN r12 WITH project#IRGuards::Cached::CompareNEValueNumber#1aeec1bd ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Lhs.3, Lhs.4, Lhs.5

             20   ~0%    {6} r14 = JOIN r12 WITH project#IRGuards::Cached::CompareEQValueNumber#994b6833 ON FIRST 1 OUTPUT Lhs.5, Lhs.0, Lhs.1, Lhs.2, Lhs.3, Lhs.4
             20   ~0%    {6}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d` ON FIRST 1 OUTPUT Lhs.2, Lhs.1, Lhs.3, Lhs.4, Lhs.5, Rhs.1

             70   ~0%    {6} r15 = r13 UNION r14
             70   ~1%    {7}    | JOIN WITH `Operand::Operand.getDef/0#dispred#a70e8079` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
             70   ~0%    {7}    | REWRITE WITH Out.1 := 0
             66   ~2%    {5}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6

              0   ~0%    {5} r16 = JOIN r1 WITH `IRGuards::Cached::BuiltinExpectCallValueNumber.getAUse/0#dispred#23233591` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4
              0   ~0%    {6}    | JOIN WITH `IRGuards::Cached::CompareValueNumber.hasOperands/2#dispred#7aa36763_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.2

              0   ~0%    {6} r17 = JOIN r16 WITH project#IRGuards::Cached::CompareNEValueNumber#1aeec1bd ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.4

              0   ~0%    {6} r18 = JOIN r16 WITH project#IRGuards::Cached::CompareEQValueNumber#994b6833 ON FIRST 1 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.5
              0   ~0%    {6}    | JOIN WITH `IRGuards::AbstractValue.getDualValue/0#dispred#bfb2631d_10#join_rhs` ON FIRST 1 OUTPUT Lhs.5, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Rhs.1

              0   ~0%    {6} r19 = r17 UNION r18
              0   ~0%    {7}    | JOIN WITH `Operand::Operand.getAnyDef/0#dispred#8dbe2fb8` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5
              0   ~0%    {7}    | REWRITE WITH Out.1 := 0
              0   ~0%    {5}    | JOIN WITH `IRGuards::Cached::int_value/1#f9d7a458` ON FIRST 2 OUTPUT Lhs.5, Lhs.2, Lhs.3, Lhs.4, Lhs.6

           4052   ~1%    {5} r20 = r1 UNION r2 UNION r4 UNION r5 UNION r7 UNION r8 UNION r10 UNION r11 UNION r15 UNION r19
           4020   ~1%    {5}    | AND NOT `IRGuards::Cached::unary_compares_eq/5#7aa979d8#prev`(FIRST 5)
                         return r20
```

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
