### PR TITLE
Change includes paths in autobuild.sh

### DIFF
--- a/actions/extractor/tools/autobuild-impl.ps1
+++ b/actions/extractor/tools/autobuild-impl.ps1
@@ -2,10 +2,16 @@ if (($null -ne $env:LGTM_INDEX_INCLUDE) -or ($null -ne $env:LGTM_INDEX_EXCLUDE) 
     Write-Output 'Path filters set. Passing them through to the JavaScript extractor.' 
 } else {
     Write-Output 'No path filters set. Using the default filters.'
+    # Note: We're adding the `reusable_workflows` subdirectories to proactively
+    # record workflows that were called cross-repo, check them out locally,
+    # and enable an interprocedural analysis across the workflow files.
+    # These workflows follow the convention `.github/reusable_workflows/<nwo>/*.ya?ml`
     $DefaultPathFilters = @(
         'exclude:**/*',
-        'include:.github/workflows/**/*.yml',
-        'include:.github/workflows/**/*.yaml',
+        'include:.github/workflows/*.yml',
+        'include:.github/workflows/*.yaml',
+        'include:.github/reusable_workflows/**/*.yml',
+        'include:.github/reusable_workflows/**/*.yaml',
         'include:**/action.yml',
         'include:**/action.yaml'
     )

--- a/actions/extractor/tools/autobuild.sh
+++ b/actions/extractor/tools/autobuild.sh
@@ -6,6 +6,8 @@ DEFAULT_PATH_FILTERS=$(cat << END
 exclude:**/*
 include:.github/workflows/*.yml
 include:.github/workflows/*.yaml
+include:.github/reusable_workflows/**/*.yml
+include:.github/reusable_workflows/**/*.yaml
 include:**/action.yml
 include:**/action.yaml
 END

--- a/actions/extractor/tools/autobuild.sh
+++ b/actions/extractor/tools/autobuild.sh
@@ -2,6 +2,10 @@
 
 set -eu
 
+# Note: We're adding the `reusable_workflows` subdirectories to proactively
+# record workflows that were called cross-repo, check them out locally,
+# and enable an interprocedural analysis across the workflow files.
+# These workflows follow the convention `.github/reusable_workflows/<nwo>/*.ya?ml`
 DEFAULT_PATH_FILTERS=$(cat << END
 exclude:**/*
 include:.github/workflows/*.yml

--- a/actions/extractor/tools/autobuild.sh
+++ b/actions/extractor/tools/autobuild.sh
@@ -4,8 +4,8 @@ set -eu
 
 DEFAULT_PATH_FILTERS=$(cat << END
 exclude:**/*
-include:.github/workflows/**/*.yml
-include:.github/workflows/**/*.yaml
+include:.github/workflows/*.yml
+include:.github/workflows/*.yaml
 include:**/action.yml
 include:**/action.yaml
 END


### PR DESCRIPTION
This PR changes the includes paths to only look at `.github/workflows/*.yml` and `.github/workflows/*.yaml` because workflows cannot be nested under subdirectories in `.github/workflows`.

After further discussion, we've decided to add

```
include:.github/reusable_workflows/**/*.yml
include:.github/reusable_workflows/**/*.yaml
```

to support reusable workflows.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
