### PR TITLE
Go: Fix "Parameter" in models-as-data

### DIFF
--- a/go/ql/lib/change-notes/2025-01-22-fix-parameter-in-models.md
+++ b/go/ql/lib/change-notes/2025-01-22-fix-parameter-in-models.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Models-as-data models using "Parameter", "Parameter[n]" or "Parameter[n1..n2]" as the output now work correctly.

--- a/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/FlowSummaryImpl.qll
@@ -252,7 +252,9 @@ module SourceSinkInterpretationInput implements
 
     /** Gets the callable that this node corresponds to, if any. */
     DataFlowCallable asCallable() {
-      result.asSummarizedCallable().asFunction() = this.asElement().asEntity()
+      this.asElement().asEntity() = result.asSummarizedCallable().asFunction() or
+      this.asElement().asEntity() = result.asCallable().asFunction() or
+      this.asElement().asAstNode() = result.asCallable().asFuncLit()
     }
 
     /** Gets the target of this call, if any. */

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/completetest.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/completetest.ext.yml
@@ -37,6 +37,7 @@ extensions:
     data:
       - ["github.com/nonexistent/test", "", False, "SourceVariable", "", "", "", "qltest", "manual"]
       - ["github.com/nonexistent/test", "A", False, "Src1", "", "", "ReturnValue", "qltest", "manual"]
+      - ["semmle.go.Packages", "", True, "srcParam", "", "", "Parameter[0]", "qltest", "manual"]
   - addsTo:
       pack: codeql/go-all
       extensible: sinkModel

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/sinks.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/sinks.expected
@@ -44,3 +44,4 @@ invalidModelRow
 | test.go:199:23:199:26 | arg2 | qltest |
 | test.go:199:29:199:32 | arg3 | qltest |
 | test.go:202:22:202:25 | temp | qltest |
+| test.go:206:10:206:12 | src | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/srcs.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/srcs.expected
@@ -22,3 +22,4 @@ invalidModelRow
 | test.go:187:24:187:31 | call to Src1 | qltest |
 | test.go:191:24:191:31 | call to Src1 | qltest |
 | test.go:201:10:201:28 | selection of SourceVariable | qltest |
+| test.go:205:15:205:17 | definition of src | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/srcs.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/srcs.ext.yml
@@ -10,3 +10,4 @@ extensions:
       - ["github.com/nonexistent/test", "A", False, "SrcArg", "", "", "Argument[0]", "qltest-arg", "manual"]
       - ["github.com/nonexistent/test", "A", False, "Src3", "", "", "ReturnValue[0]", "qltest", "manual"]
       - ["github.com/nonexistent/test", "A", True, "Src3", "", "", "ReturnValue[1]", "qltest-w-subtypes", "manual"]
+      - ["semmle.go.Packages", "", True, "srcParam", "", "", "Parameter[0]", "qltest", "manual"]

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/test.go
@@ -203,7 +203,7 @@ func simpleflow() {
 }
 
 func srcParam(src string, b test.B) {
-	b.Sink1(src) // $ MISSING: hasTaintFlow="src"
+	b.Sink1(src) // $ hasTaintFlow="src"
 }
 
 type mapstringstringtype map[string]string

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalTaintFlow/test.go
@@ -202,6 +202,10 @@ func simpleflow() {
 	test.SinkVariable = temp // $ hasTaintFlow="temp"
 }
 
+func srcParam(src string, b test.B) {
+	b.Sink1(src) // $ MISSING: hasTaintFlow="src"
+}
+
 type mapstringstringtype map[string]string
 type arraytype []interface{}
 type channeltype chan interface{}

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/completetest.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/completetest.ext.yml
@@ -37,6 +37,7 @@ extensions:
     data:
       - ["github.com/nonexistent/test", "", False, "SourceVariable", "", "", "", "qltest", "manual"]
       - ["github.com/nonexistent/test", "A", False, "Src1", "", "", "ReturnValue", "qltest", "manual"]
+      - ["semmle.go.Packages", "", True, "srcParam", "", "", "Parameter[0]", "qltest", "manual"]
   - addsTo:
       pack: codeql/go-all
       extensible: sinkModel

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/sinks.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/sinks.expected
@@ -50,3 +50,4 @@ invalidModelRow
 | test.go:206:10:206:26 | call to min | qltest |
 | test.go:207:10:207:26 | call to min | qltest |
 | test.go:210:22:210:25 | temp | qltest |
+| test.go:214:10:214:12 | src | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/srcs.expected
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/srcs.expected
@@ -22,3 +22,4 @@ invalidModelRow
 | test.go:187:24:187:31 | call to Src1 | qltest |
 | test.go:191:24:191:31 | call to Src1 | qltest |
 | test.go:209:10:209:28 | selection of SourceVariable | qltest |
+| test.go:213:15:213:17 | definition of src | qltest |

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/srcs.ext.yml
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/srcs.ext.yml
@@ -10,3 +10,4 @@ extensions:
       - ["github.com/nonexistent/test", "A", False, "SrcArg", "", "", "Argument[0]", "qltest-arg", "manual"]
       - ["github.com/nonexistent/test", "A", False, "Src3", "", "", "ReturnValue[0]", "qltest", "manual"]
       - ["github.com/nonexistent/test", "A", True, "Src3", "", "", "ReturnValue[1]", "qltest-w-subtypes", "manual"]
+      - ["semmle.go.Packages", "", True, "srcParam", "", "", "Parameter[0]", "qltest", "manual"]

--- a/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/test.go
+++ b/go/ql/test/library-tests/semmle/go/dataflow/ExternalValueFlow/test.go
@@ -210,6 +210,10 @@ func simpleflow() {
 	test.SinkVariable = temp // $ hasValueFlow="temp"
 }
 
+func srcParam(src string, b test.B) {
+	b.Sink1(src) // $ hasValueFlow="src"
+}
+
 type mapstringstringtype map[string]string
 type arraytype []interface{}
 type channeltype chan interface{}


### PR DESCRIPTION
It was silently failing because `InterpretNode.asCallable()` was only working correctly for summarized callables. This is fine for other input and output kinds, but "Parameter" is used for parameters of functions with bodies.