### PR TITLE
C#: Verify that downloaded .NET CLIs are executable

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
+++ b/csharp/autobuilder/Semmle.Autobuild.CSharp/DotNetRule.cs
@@ -46,7 +46,9 @@ namespace Semmle.Autobuild.CSharp
 
             return WithDotNet(builder, ensureDotNetAvailable: false, (dotNetPath, environment) =>
                 {
-                    var ret = GetInfoCommand(builder.Actions, dotNetPath, environment);
+                    // When a custom .NET CLI has been installed, `dotnet --info` has already been executed
+                    // to verify the installation.
+                    var ret = dotNetPath is null ? GetInfoCommand(builder.Actions, dotNetPath, environment) : BuildScript.Success;
                     foreach (var projectOrSolution in builder.ProjectsOrSolutionsToBuild)
                     {
                         var cleanCommand = GetCleanCommand(builder.Actions, dotNetPath, environment);

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DependencyManager.cs
@@ -41,7 +41,6 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private int conflictedReferences = 0;
         private readonly DirectoryInfo sourceDir;
         private string? dotnetPath;
-
         private readonly TemporaryDirectory tempWorkingDirectory;
         private readonly bool cleanupTempWorkingDirectory;
 

--- a/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp.DependencyFetching/DotNet.cs
@@ -19,17 +19,20 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
         private readonly ILogger logger;
         private readonly TemporaryDirectory? tempWorkingDirectory;
 
-        private DotNet(IDotNetCliInvoker dotnetCliInvoker, ILogger logger, TemporaryDirectory? tempWorkingDirectory = null)
+        private DotNet(IDotNetCliInvoker dotnetCliInvoker, ILogger logger, bool runDotnetInfo, TemporaryDirectory? tempWorkingDirectory = null)
         {
             this.tempWorkingDirectory = tempWorkingDirectory;
             this.dotnetCliInvoker = dotnetCliInvoker;
             this.logger = logger;
-            Info();
+            if (runDotnetInfo)
+            {
+                Info();
+            }
         }
 
-        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, tempWorkingDirectory) { }
+        private DotNet(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) : this(new DotNetCliInvoker(logger, Path.Combine(dotNetPath ?? string.Empty, "dotnet"), dependabotProxy), logger, dotNetPath is null, tempWorkingDirectory) { }
 
-        internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger) => new DotNet(dotnetCliInvoker, logger);
+        internal static IDotNet Make(IDotNetCliInvoker dotnetCliInvoker, ILogger logger, bool runDotnetInfo) => new DotNet(dotnetCliInvoker, logger, runDotnetInfo);
 
         public static IDotNet Make(ILogger logger, string? dotNetPath, TemporaryDirectory tempWorkingDirectory, DependabotProxy? dependabotProxy) => new DotNet(logger, dotNetPath, tempWorkingDirectory, dependabotProxy);
 
@@ -169,7 +172,10 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
             if (versions.Count > 0)
             {
-                return DownloadDotNetVersion(actions, logger, tempWorkingDirectory, shouldCleanUp, installDir, versions);
+                return
+                    DownloadDotNetVersion(actions, logger, tempWorkingDirectory, shouldCleanUp, installDir, versions) |
+                    // if neither of the versions succeed, try the latest version
+                    DownloadDotNetVersion(actions, logger, tempWorkingDirectory, shouldCleanUp, installDir, [LatestDotNetSdkVersion], needExactVersion: false);
             }
 
             if (ensureDotNetAvailable)
@@ -269,6 +275,14 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
                         Argument(path).Script;
                 }
 
+                var dotnetInfo = new CommandBuilder(actions).
+                    RunCommand(actions.PathCombine(path, "dotnet")).
+                    Argument("--info").Script;
+
+                Func<string, BuildScript> getInstallAndVerify = version =>
+                    // run `dotnet --info` after install, to check that it executes successfully
+                    getInstall(version) & dotnetInfo;
+
                 var installScript = prelude & BuildScript.Failure;
 
                 var attempted = new HashSet<string>();
@@ -283,7 +297,7 @@ namespace Semmle.Extraction.CSharp.DependencyFetching
 
                         // When there are multiple versions requested, we want to try to fetch them all, reporting
                         // a successful exit code when at least one of them succeeds
-                        return combinedExit != 0 ? getInstall(version) : BuildScript.Bind(getInstall(version), _ => BuildScript.Success);
+                        return combinedExit != 0 ? getInstallAndVerify(version) : BuildScript.Bind(getInstallAndVerify(version), _ => BuildScript.Success);
                     });
                 }
 

--- a/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
+++ b/csharp/extractor/Semmle.Extraction.Tests/DotNet.cs
@@ -45,7 +45,7 @@ namespace Semmle.Extraction.Tests
     public class DotNetTests
     {
         private static IDotNet MakeDotnet(IDotNetCliInvoker dotnetCliInvoker) =>
-            DotNet.Make(dotnetCliInvoker, new LoggerStub());
+            DotNet.Make(dotnetCliInvoker, new LoggerStub(), true);
 
         private static IList<string> MakeDotnetRestoreOutput() =>
             new List<string> {

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/Files.expected
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/Files.expected
@@ -1,0 +1,1 @@
+| Program.cs:0:0:0:0 | Program.cs |

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/Files.ql
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/Files.ql
@@ -1,0 +1,5 @@
+import csharp
+
+from File f
+where f.fromSource()
+select f

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/Program.cs
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace standalone_dotnet3
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/global.json
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "3.1.403",
+        "rollForward": "latestFeature"
+    }
+}

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/standalone_dotnet3.csproj
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/standalone_dotnet3.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/csharp/ql/integration-tests/linux/standalone_dotnet3/test.py
+++ b/csharp/ql/integration-tests/linux/standalone_dotnet3/test.py
@@ -1,0 +1,4 @@
+import os
+
+def test(codeql, csharp):
+    codeql.database.create(build_mode="none")


### PR DESCRIPTION
When downloading (older) versions of the .NET CLI, we can sometimes run into issues where the downloaded files are not executable. For example, attempting to run .NET 3 on Ubuntu 24.04 results in this error
```
Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.
```

The fix suggested by this PR is to extend downloading to also include a verification step, where we check that running `dotnet --info` exits cleanly.