### PR TITLE
Rust: Translate more MaD IDs in tests

### DIFF
--- a/rust/ql/lib/utils/test/TranslateModels.qll
+++ b/rust/ql/lib/utils/test/TranslateModels.qll
@@ -1,0 +1,9 @@
+private import codeql.dataflow.test.ProvenancePathGraph as Graph
+private import codeql.rust.dataflow.internal.ModelsAsData as MaD
+
+private signature predicate provenanceSig(string model);
+
+/** Translates models-as-data provenance information into a format that can be used in tests. */
+module TranslateModels<provenanceSig/1 provenance> {
+  import Graph::TranslateModels<MaD::interpretModelForTest/2, provenance/1>
+}

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -1,468 +1,480 @@
 localStep
-| main.rs:3:11:3:11 | [SSA] i | main.rs:4:12:4:12 | i |
-| main.rs:3:11:3:11 | i | main.rs:3:11:3:11 | [SSA] i |
-| main.rs:3:11:3:16 | ...: i64 | main.rs:3:11:3:11 | i |
-| main.rs:4:5:4:12 | ... + ... | main.rs:3:26:5:1 | { ... } |
-| main.rs:7:9:7:9 | [SSA] s | main.rs:8:20:8:20 | s |
-| main.rs:7:9:7:9 | s | main.rs:7:9:7:9 | [SSA] s |
-| main.rs:7:9:7:14 | ...: i64 | main.rs:7:9:7:9 | s |
-| main.rs:8:14:8:20 | FormatArgsExpr | main.rs:8:14:8:20 | MacroExpr |
-| main.rs:19:9:19:9 | [SSA] s | main.rs:20:10:20:10 | s |
-| main.rs:19:9:19:9 | s | main.rs:19:9:19:9 | [SSA] s |
-| main.rs:19:13:19:21 | source(...) | main.rs:19:9:19:9 | s |
-| main.rs:23:18:23:21 | [SSA] cond | main.rs:26:16:26:19 | cond |
-| main.rs:23:18:23:21 | cond | main.rs:23:18:23:21 | [SSA] cond |
-| main.rs:23:18:23:27 | ...: bool | main.rs:23:18:23:21 | cond |
-| main.rs:24:9:24:9 | [SSA] a | main.rs:26:23:26:23 | a |
-| main.rs:24:9:24:9 | a | main.rs:24:9:24:9 | [SSA] a |
-| main.rs:24:13:24:21 | source(...) | main.rs:24:9:24:9 | a |
-| main.rs:25:9:25:9 | [SSA] b | main.rs:26:34:26:34 | b |
-| main.rs:25:9:25:9 | b | main.rs:25:9:25:9 | [SSA] b |
-| main.rs:25:13:25:13 | 2 | main.rs:25:9:25:9 | b |
-| main.rs:26:9:26:9 | [SSA] c | main.rs:27:10:27:10 | c |
-| main.rs:26:9:26:9 | c | main.rs:26:9:26:9 | [SSA] c |
-| main.rs:26:13:26:36 | if cond {...} else {...} | main.rs:26:9:26:9 | c |
-| main.rs:26:21:26:25 | { ... } | main.rs:26:13:26:36 | if cond {...} else {...} |
-| main.rs:26:23:26:23 | a | main.rs:26:21:26:25 | { ... } |
-| main.rs:26:32:26:36 | { ... } | main.rs:26:13:26:36 | if cond {...} else {...} |
-| main.rs:26:34:26:34 | b | main.rs:26:32:26:36 | { ... } |
-| main.rs:30:21:30:21 | [SSA] m | main.rs:32:19:32:19 | m |
-| main.rs:30:21:30:21 | m | main.rs:30:21:30:21 | [SSA] m |
-| main.rs:30:21:30:34 | ...: Option::<...> | main.rs:30:21:30:21 | m |
-| main.rs:31:9:31:9 | [SSA] a | main.rs:33:20:33:20 | a |
-| main.rs:31:9:31:9 | a | main.rs:31:9:31:9 | [SSA] a |
-| main.rs:31:13:31:21 | source(...) | main.rs:31:9:31:9 | a |
-| main.rs:32:9:32:9 | [SSA] b | main.rs:36:10:36:10 | b |
-| main.rs:32:9:32:9 | b | main.rs:32:9:32:9 | [SSA] b |
-| main.rs:32:13:35:5 | match m { ... } | main.rs:32:9:32:9 | b |
-| main.rs:32:19:32:19 | m | main.rs:33:9:33:15 | Some(...) |
-| main.rs:32:19:32:19 | m | main.rs:34:9:34:12 | None |
-| main.rs:33:20:33:20 | a | main.rs:32:13:35:5 | match m { ... } |
-| main.rs:34:17:34:17 | 0 | main.rs:32:13:35:5 | match m { ... } |
-| main.rs:40:9:40:9 | [SSA] a | main.rs:43:10:43:10 | a |
-| main.rs:40:9:40:9 | a | main.rs:40:9:40:9 | [SSA] a |
-| main.rs:40:13:42:5 | loop { ... } | main.rs:40:9:40:9 | a |
-| main.rs:41:9:41:15 | break 1 | main.rs:40:13:42:5 | loop { ... } |
-| main.rs:41:15:41:15 | 1 | main.rs:41:9:41:15 | break 1 |
-| main.rs:44:9:44:9 | [SSA] b | main.rs:47:10:47:10 | b |
-| main.rs:44:9:44:9 | b | main.rs:44:9:44:9 | [SSA] b |
-| main.rs:44:13:46:5 | loop { ... } | main.rs:44:9:44:9 | b |
-| main.rs:45:9:45:23 | break ... | main.rs:44:13:46:5 | loop { ... } |
-| main.rs:45:15:45:23 | source(...) | main.rs:45:9:45:23 | break ... |
-| main.rs:51:9:51:13 | [SSA] i | main.rs:52:10:52:10 | i |
-| main.rs:51:9:51:13 | i | main.rs:51:9:51:13 | [SSA] i |
-| main.rs:51:17:51:17 | 1 | main.rs:51:9:51:13 | i |
-| main.rs:53:5:53:5 | [SSA] i | main.rs:54:10:54:10 | i |
-| main.rs:53:5:53:5 | i | main.rs:53:5:53:5 | [SSA] i |
-| main.rs:53:9:53:17 | source(...) | main.rs:53:5:53:5 | i |
-| main.rs:58:9:58:9 | [SSA] a | main.rs:59:5:59:5 | a |
-| main.rs:58:9:58:9 | a | main.rs:58:9:58:9 | [SSA] a |
-| main.rs:58:13:58:17 | { ... } | main.rs:58:9:58:9 | a |
-| main.rs:58:15:58:15 | 0 | main.rs:58:13:58:17 | { ... } |
-| main.rs:59:5:59:5 | a | main.rs:57:31:60:1 | { ... } |
-| main.rs:62:22:62:22 | [SSA] b | main.rs:64:12:64:12 | b |
-| main.rs:62:22:62:22 | b | main.rs:62:22:62:22 | [SSA] b |
-| main.rs:62:22:62:28 | ...: bool | main.rs:62:22:62:22 | b |
-| main.rs:63:9:63:9 | [SSA] a | main.rs:69:5:69:5 | a |
-| main.rs:63:9:63:9 | a | main.rs:63:9:63:9 | [SSA] a |
-| main.rs:63:13:68:5 | 'block: { ... } | main.rs:63:9:63:9 | a |
-| main.rs:65:13:65:26 | break ''block 1 | main.rs:63:13:68:5 | 'block: { ... } |
-| main.rs:65:26:65:26 | 1 | main.rs:65:13:65:26 | break ''block 1 |
-| main.rs:67:9:67:9 | 2 | main.rs:63:13:68:5 | 'block: { ... } |
-| main.rs:69:5:69:5 | a | main.rs:62:38:70:1 | { ... } |
-| main.rs:72:22:72:22 | [SSA] b | main.rs:74:12:74:12 | b |
-| main.rs:72:22:72:22 | b | main.rs:72:22:72:22 | [SSA] b |
-| main.rs:72:22:72:28 | ...: bool | main.rs:72:22:72:22 | b |
-| main.rs:73:9:73:9 | [SSA] a | main.rs:79:5:79:5 | a |
-| main.rs:73:9:73:9 | a | main.rs:73:9:73:9 | [SSA] a |
-| main.rs:73:13:78:5 | 'block: { ... } | main.rs:73:9:73:9 | a |
-| main.rs:75:13:75:26 | break ''block 1 | main.rs:73:13:78:5 | 'block: { ... } |
-| main.rs:75:26:75:26 | 1 | main.rs:75:13:75:26 | break ''block 1 |
-| main.rs:77:9:77:22 | break ''block 2 | main.rs:73:13:78:5 | 'block: { ... } |
-| main.rs:77:22:77:22 | 2 | main.rs:77:9:77:22 | break ''block 2 |
-| main.rs:79:5:79:5 | a | main.rs:72:38:80:1 | { ... } |
-| main.rs:86:9:86:9 | [SSA] i | main.rs:87:11:87:11 | i |
-| main.rs:86:9:86:9 | i | main.rs:86:9:86:9 | [SSA] i |
-| main.rs:86:13:86:31 | ...::new(...) | main.rs:86:9:86:9 | i |
-| main.rs:94:9:94:9 | [SSA] a | main.rs:95:10:95:10 | a |
-| main.rs:94:9:94:9 | a | main.rs:94:9:94:9 | [SSA] a |
-| main.rs:94:13:94:26 | TupleExpr | main.rs:94:9:94:9 | a |
-| main.rs:95:10:95:10 | [post] a | main.rs:96:10:96:10 | a |
-| main.rs:95:10:95:10 | a | main.rs:96:10:96:10 | a |
-| main.rs:100:9:100:9 | [SSA] a | main.rs:101:24:101:24 | a |
-| main.rs:100:9:100:9 | a | main.rs:100:9:100:9 | [SSA] a |
-| main.rs:100:13:100:30 | TupleExpr | main.rs:100:9:100:9 | a |
-| main.rs:101:10:101:11 | [SSA] a0 | main.rs:102:10:102:11 | a0 |
-| main.rs:101:10:101:11 | a0 | main.rs:101:10:101:11 | [SSA] a0 |
-| main.rs:101:14:101:15 | [SSA] a1 | main.rs:103:10:103:11 | a1 |
-| main.rs:101:14:101:15 | a1 | main.rs:101:14:101:15 | [SSA] a1 |
-| main.rs:101:18:101:19 | [SSA] a2 | main.rs:104:10:104:11 | a2 |
-| main.rs:101:18:101:19 | a2 | main.rs:101:18:101:19 | [SSA] a2 |
-| main.rs:101:24:101:24 | a | main.rs:101:9:101:20 | TuplePat |
-| main.rs:108:9:108:13 | [SSA] a | main.rs:109:10:109:10 | a |
-| main.rs:108:9:108:13 | a | main.rs:108:9:108:13 | [SSA] a |
-| main.rs:108:17:108:31 | TupleExpr | main.rs:108:9:108:13 | a |
-| main.rs:109:10:109:10 | [post] a | main.rs:110:10:110:10 | a |
-| main.rs:109:10:109:10 | a | main.rs:110:10:110:10 | a |
-| main.rs:110:10:110:10 | [post] a | main.rs:111:5:111:5 | a |
-| main.rs:110:10:110:10 | a | main.rs:111:5:111:5 | a |
-| main.rs:111:5:111:5 | [post] a | main.rs:112:5:112:5 | a |
-| main.rs:111:5:111:5 | a | main.rs:112:5:112:5 | a |
-| main.rs:111:11:111:20 | source(...) | main.rs:111:5:111:7 | a.0 |
-| main.rs:112:5:112:5 | [post] a | main.rs:113:10:113:10 | a |
-| main.rs:112:5:112:5 | a | main.rs:113:10:113:10 | a |
-| main.rs:112:11:112:11 | 2 | main.rs:112:5:112:7 | a.1 |
-| main.rs:113:10:113:10 | [post] a | main.rs:114:10:114:10 | a |
-| main.rs:113:10:113:10 | a | main.rs:114:10:114:10 | a |
-| main.rs:118:9:118:9 | [SSA] a | main.rs:119:14:119:14 | a |
-| main.rs:118:9:118:9 | a | main.rs:118:9:118:9 | [SSA] a |
-| main.rs:118:13:118:27 | TupleExpr | main.rs:118:9:118:9 | a |
-| main.rs:119:9:119:9 | [SSA] b | main.rs:120:10:120:10 | b |
-| main.rs:119:9:119:9 | b | main.rs:119:9:119:9 | [SSA] b |
-| main.rs:119:13:119:18 | TupleExpr | main.rs:119:9:119:9 | b |
-| main.rs:120:10:120:10 | [post] b | main.rs:121:10:121:10 | b |
-| main.rs:120:10:120:10 | b | main.rs:121:10:121:10 | b |
-| main.rs:121:10:121:10 | [post] b | main.rs:122:10:122:10 | b |
-| main.rs:121:10:121:10 | b | main.rs:122:10:122:10 | b |
-| main.rs:134:9:134:9 | [SSA] p | main.rs:135:10:135:10 | p |
-| main.rs:134:9:134:9 | p | main.rs:134:9:134:9 | [SSA] p |
-| main.rs:134:13:134:40 | Point {...} | main.rs:134:9:134:9 | p |
-| main.rs:135:10:135:10 | [post] p | main.rs:136:10:136:10 | p |
-| main.rs:135:10:135:10 | p | main.rs:136:10:136:10 | p |
-| main.rs:140:9:140:13 | [SSA] p | main.rs:141:10:141:10 | p |
-| main.rs:140:9:140:13 | p | main.rs:140:9:140:13 | [SSA] p |
-| main.rs:140:17:140:44 | Point {...} | main.rs:140:9:140:13 | p |
-| main.rs:141:10:141:10 | [post] p | main.rs:142:5:142:5 | p |
-| main.rs:141:10:141:10 | p | main.rs:142:5:142:5 | p |
-| main.rs:142:5:142:5 | [post] p | main.rs:143:10:143:10 | p |
-| main.rs:142:5:142:5 | p | main.rs:143:10:143:10 | p |
-| main.rs:142:11:142:20 | source(...) | main.rs:142:5:142:7 | p.y |
-| main.rs:147:9:147:9 | [SSA] p | main.rs:151:32:151:32 | p |
-| main.rs:147:9:147:9 | p | main.rs:147:9:147:9 | [SSA] p |
-| main.rs:147:13:150:5 | Point {...} | main.rs:147:9:147:9 | p |
-| main.rs:151:20:151:20 | [SSA] a | main.rs:152:10:152:10 | a |
-| main.rs:151:20:151:20 | a | main.rs:151:20:151:20 | [SSA] a |
-| main.rs:151:26:151:26 | [SSA] b | main.rs:153:10:153:10 | b |
-| main.rs:151:26:151:26 | b | main.rs:151:26:151:26 | [SSA] b |
-| main.rs:151:32:151:32 | p | main.rs:151:9:151:28 | Point {...} |
-| main.rs:162:9:162:9 | [SSA] p | main.rs:169:10:169:10 | p |
-| main.rs:162:9:162:9 | p | main.rs:162:9:162:9 | [SSA] p |
-| main.rs:162:13:168:5 | Point3D {...} | main.rs:162:9:162:9 | p |
-| main.rs:169:10:169:10 | [post] p | main.rs:170:10:170:10 | p |
-| main.rs:169:10:169:10 | p | main.rs:170:10:170:10 | p |
-| main.rs:170:10:170:10 | [post] p | main.rs:171:10:171:10 | p |
-| main.rs:170:10:170:10 | p | main.rs:171:10:171:10 | p |
-| main.rs:175:9:175:9 | [SSA] p | main.rs:182:11:182:11 | p |
-| main.rs:175:9:175:9 | p | main.rs:175:9:175:9 | [SSA] p |
-| main.rs:175:13:181:5 | Point3D {...} | main.rs:175:9:175:9 | p |
-| main.rs:182:5:191:5 | match p { ... } | main.rs:174:26:192:1 | { ... } |
-| main.rs:182:11:182:11 | p | main.rs:183:9:186:9 | Point3D {...} |
-| main.rs:184:28:184:28 | [SSA] x | main.rs:187:18:187:18 | x |
-| main.rs:184:28:184:28 | x | main.rs:184:28:184:28 | [SSA] x |
-| main.rs:184:31:184:31 | [SSA] y | main.rs:188:18:188:18 | y |
-| main.rs:184:31:184:31 | y | main.rs:184:31:184:31 | [SSA] y |
-| main.rs:185:13:185:13 | [SSA] z | main.rs:189:18:189:18 | z |
-| main.rs:185:13:185:13 | z | main.rs:185:13:185:13 | [SSA] z |
-| main.rs:186:14:190:9 | { ... } | main.rs:182:5:191:5 | match p { ... } |
-| main.rs:198:9:198:10 | [SSA] s1 | main.rs:200:11:200:12 | s1 |
-| main.rs:198:9:198:10 | s1 | main.rs:198:9:198:10 | [SSA] s1 |
-| main.rs:198:14:198:37 | ...::Some(...) | main.rs:198:9:198:10 | s1 |
-| main.rs:199:9:199:10 | [SSA] s2 | main.rs:204:11:204:12 | s2 |
-| main.rs:199:9:199:10 | s2 | main.rs:199:9:199:10 | [SSA] s2 |
-| main.rs:199:14:199:28 | ...::Some(...) | main.rs:199:9:199:10 | s2 |
-| main.rs:200:11:200:12 | s1 | main.rs:201:9:201:23 | ...::Some(...) |
-| main.rs:200:11:200:12 | s1 | main.rs:202:9:202:20 | ...::None |
-| main.rs:201:22:201:22 | [SSA] n | main.rs:201:33:201:33 | n |
-| main.rs:201:22:201:22 | n | main.rs:201:22:201:22 | [SSA] n |
-| main.rs:201:28:201:34 | sink(...) | main.rs:200:5:203:5 | match s1 { ... } |
-| main.rs:202:25:202:31 | sink(...) | main.rs:200:5:203:5 | match s1 { ... } |
-| main.rs:204:5:207:5 | match s2 { ... } | main.rs:197:37:208:1 | { ... } |
-| main.rs:204:11:204:12 | s2 | main.rs:205:9:205:23 | ...::Some(...) |
-| main.rs:204:11:204:12 | s2 | main.rs:206:9:206:20 | ...::None |
-| main.rs:205:22:205:22 | [SSA] n | main.rs:205:33:205:33 | n |
-| main.rs:205:22:205:22 | n | main.rs:205:22:205:22 | [SSA] n |
-| main.rs:205:28:205:34 | sink(...) | main.rs:204:5:207:5 | match s2 { ... } |
-| main.rs:206:25:206:31 | sink(...) | main.rs:204:5:207:5 | match s2 { ... } |
-| main.rs:211:9:211:10 | [SSA] s1 | main.rs:213:11:213:12 | s1 |
-| main.rs:211:9:211:10 | s1 | main.rs:211:9:211:10 | [SSA] s1 |
-| main.rs:211:14:211:29 | Some(...) | main.rs:211:9:211:10 | s1 |
-| main.rs:212:9:212:10 | [SSA] s2 | main.rs:217:11:217:12 | s2 |
-| main.rs:212:9:212:10 | s2 | main.rs:212:9:212:10 | [SSA] s2 |
-| main.rs:212:14:212:20 | Some(...) | main.rs:212:9:212:10 | s2 |
-| main.rs:213:11:213:12 | s1 | main.rs:214:9:214:15 | Some(...) |
-| main.rs:213:11:213:12 | s1 | main.rs:215:9:215:12 | None |
-| main.rs:214:14:214:14 | [SSA] n | main.rs:214:25:214:25 | n |
-| main.rs:214:14:214:14 | n | main.rs:214:14:214:14 | [SSA] n |
-| main.rs:214:20:214:26 | sink(...) | main.rs:213:5:216:5 | match s1 { ... } |
-| main.rs:215:17:215:23 | sink(...) | main.rs:213:5:216:5 | match s1 { ... } |
-| main.rs:217:5:220:5 | match s2 { ... } | main.rs:210:39:221:1 | { ... } |
-| main.rs:217:11:217:12 | s2 | main.rs:218:9:218:15 | Some(...) |
-| main.rs:217:11:217:12 | s2 | main.rs:219:9:219:12 | None |
-| main.rs:218:14:218:14 | [SSA] n | main.rs:218:25:218:25 | n |
-| main.rs:218:14:218:14 | n | main.rs:218:14:218:14 | [SSA] n |
-| main.rs:218:20:218:26 | sink(...) | main.rs:217:5:220:5 | match s2 { ... } |
-| main.rs:219:17:219:23 | sink(...) | main.rs:217:5:220:5 | match s2 { ... } |
-| main.rs:224:9:224:10 | [SSA] s1 | main.rs:225:10:225:11 | s1 |
-| main.rs:224:9:224:10 | s1 | main.rs:224:9:224:10 | [SSA] s1 |
-| main.rs:224:14:224:29 | Some(...) | main.rs:224:9:224:10 | s1 |
-| main.rs:229:9:229:10 | [SSA] s1 | main.rs:230:10:230:11 | s1 |
-| main.rs:229:9:229:10 | s1 | main.rs:229:9:229:10 | [SSA] s1 |
-| main.rs:229:14:229:29 | Some(...) | main.rs:229:9:229:10 | s1 |
-| main.rs:230:23:230:23 | 0 | main.rs:230:10:230:24 | s1.unwrap_or(...) |
-| main.rs:232:9:232:10 | [SSA] s2 | main.rs:233:10:233:11 | s2 |
-| main.rs:232:9:232:10 | s2 | main.rs:232:9:232:10 | [SSA] s2 |
-| main.rs:232:14:232:20 | Some(...) | main.rs:232:9:232:10 | s2 |
-| main.rs:233:23:233:32 | source(...) | main.rs:233:10:233:33 | s2.unwrap_or(...) |
-| main.rs:237:9:237:10 | [SSA] s1 | main.rs:239:14:239:15 | s1 |
-| main.rs:237:9:237:10 | s1 | main.rs:237:9:237:10 | [SSA] s1 |
-| main.rs:237:14:237:29 | Some(...) | main.rs:237:9:237:10 | s1 |
-| main.rs:238:9:238:10 | [SSA] s2 | main.rs:241:10:241:11 | s2 |
-| main.rs:238:9:238:10 | s2 | main.rs:238:9:238:10 | [SSA] s2 |
-| main.rs:238:14:238:20 | Some(...) | main.rs:238:9:238:10 | s2 |
-| main.rs:239:9:239:10 | [SSA] i1 | main.rs:240:10:240:11 | i1 |
-| main.rs:239:9:239:10 | i1 | main.rs:239:9:239:10 | [SSA] i1 |
-| main.rs:239:14:239:16 | TryExpr | main.rs:239:9:239:10 | i1 |
-| main.rs:242:5:242:11 | Some(...) | main.rs:236:41:243:1 | { ... } |
-| main.rs:246:9:246:10 | [SSA] s1 | main.rs:249:14:249:15 | s1 |
-| main.rs:246:9:246:10 | s1 | main.rs:246:9:246:10 | [SSA] s1 |
-| main.rs:246:32:246:45 | Ok(...) | main.rs:246:9:246:10 | s1 |
-| main.rs:247:9:247:10 | [SSA] s2 | main.rs:250:14:250:15 | s2 |
-| main.rs:247:9:247:10 | s2 | main.rs:247:9:247:10 | [SSA] s2 |
-| main.rs:247:32:247:36 | Ok(...) | main.rs:247:9:247:10 | s2 |
-| main.rs:248:9:248:10 | [SSA] s3 | main.rs:253:14:253:15 | s3 |
-| main.rs:248:9:248:10 | s3 | main.rs:248:9:248:10 | [SSA] s3 |
-| main.rs:248:32:248:46 | Err(...) | main.rs:248:9:248:10 | s3 |
-| main.rs:249:9:249:10 | [SSA] i1 | main.rs:251:10:251:11 | i1 |
-| main.rs:249:9:249:10 | i1 | main.rs:249:9:249:10 | [SSA] i1 |
-| main.rs:249:14:249:16 | TryExpr | main.rs:249:9:249:10 | i1 |
-| main.rs:250:9:250:10 | [SSA] i2 | main.rs:252:10:252:11 | i2 |
-| main.rs:250:9:250:10 | i2 | main.rs:250:9:250:10 | [SSA] i2 |
-| main.rs:250:14:250:16 | TryExpr | main.rs:250:9:250:10 | i2 |
-| main.rs:253:9:253:10 | [SSA] i3 | main.rs:254:10:254:11 | i3 |
-| main.rs:253:9:253:10 | i3 | main.rs:253:9:253:10 | [SSA] i3 |
-| main.rs:253:14:253:16 | TryExpr | main.rs:253:9:253:10 | i3 |
-| main.rs:255:5:255:9 | Ok(...) | main.rs:245:46:256:1 | { ... } |
-| main.rs:264:9:264:10 | [SSA] s1 | main.rs:266:11:266:12 | s1 |
-| main.rs:264:9:264:10 | s1 | main.rs:264:9:264:10 | [SSA] s1 |
-| main.rs:264:14:264:39 | ...::A(...) | main.rs:264:9:264:10 | s1 |
-| main.rs:265:9:265:10 | [SSA] s2 | main.rs:273:11:273:12 | s2 |
-| main.rs:265:9:265:10 | s2 | main.rs:265:9:265:10 | [SSA] s2 |
-| main.rs:265:14:265:30 | ...::B(...) | main.rs:265:9:265:10 | s2 |
-| main.rs:266:11:266:12 | s1 | main.rs:267:9:267:25 | ...::A(...) |
-| main.rs:266:11:266:12 | s1 | main.rs:268:9:268:25 | ...::B(...) |
-| main.rs:266:11:266:12 | s1 | main.rs:270:11:270:12 | s1 |
-| main.rs:267:24:267:24 | [SSA] n | main.rs:267:35:267:35 | n |
-| main.rs:267:24:267:24 | n | main.rs:267:24:267:24 | [SSA] n |
-| main.rs:267:30:267:36 | sink(...) | main.rs:266:5:269:5 | match s1 { ... } |
-| main.rs:268:24:268:24 | [SSA] n | main.rs:268:35:268:35 | n |
-| main.rs:268:24:268:24 | n | main.rs:268:24:268:24 | [SSA] n |
-| main.rs:268:30:268:36 | sink(...) | main.rs:266:5:269:5 | match s1 { ... } |
-| main.rs:270:11:270:12 | s1 | main.rs:271:9:271:45 | ... \| ... |
-| main.rs:271:9:271:45 | ... \| ... | main.rs:271:9:271:25 | ...::A(...) |
-| main.rs:271:9:271:45 | ... \| ... | main.rs:271:29:271:45 | ...::B(...) |
-| main.rs:271:9:271:45 | [SSA] [match(true)] phi | main.rs:271:55:271:55 | n |
-| main.rs:271:24:271:24 | [SSA] [input] [match(true)] phi | main.rs:271:9:271:45 | [SSA] [match(true)] phi |
-| main.rs:271:24:271:24 | [SSA] n | main.rs:271:24:271:24 | [SSA] [input] [match(true)] phi |
-| main.rs:271:24:271:24 | n | main.rs:271:24:271:24 | [SSA] n |
-| main.rs:271:44:271:44 | [SSA] [input] [match(true)] phi | main.rs:271:9:271:45 | [SSA] [match(true)] phi |
-| main.rs:271:44:271:44 | [SSA] n | main.rs:271:44:271:44 | [SSA] [input] [match(true)] phi |
-| main.rs:271:44:271:44 | n | main.rs:271:44:271:44 | [SSA] n |
-| main.rs:271:50:271:56 | sink(...) | main.rs:270:5:272:5 | match s1 { ... } |
-| main.rs:273:5:276:5 | match s2 { ... } | main.rs:263:48:277:1 | { ... } |
-| main.rs:273:11:273:12 | s2 | main.rs:274:9:274:25 | ...::A(...) |
-| main.rs:273:11:273:12 | s2 | main.rs:275:9:275:25 | ...::B(...) |
-| main.rs:274:24:274:24 | [SSA] n | main.rs:274:35:274:35 | n |
-| main.rs:274:24:274:24 | n | main.rs:274:24:274:24 | [SSA] n |
-| main.rs:274:30:274:36 | sink(...) | main.rs:273:5:276:5 | match s2 { ... } |
-| main.rs:275:24:275:24 | [SSA] n | main.rs:275:35:275:35 | n |
-| main.rs:275:24:275:24 | n | main.rs:275:24:275:24 | [SSA] n |
-| main.rs:275:30:275:36 | sink(...) | main.rs:273:5:276:5 | match s2 { ... } |
-| main.rs:282:9:282:10 | [SSA] s1 | main.rs:284:11:284:12 | s1 |
-| main.rs:282:9:282:10 | s1 | main.rs:282:9:282:10 | [SSA] s1 |
-| main.rs:282:14:282:26 | A(...) | main.rs:282:9:282:10 | s1 |
-| main.rs:283:9:283:10 | [SSA] s2 | main.rs:291:11:291:12 | s2 |
-| main.rs:283:9:283:10 | s2 | main.rs:283:9:283:10 | [SSA] s2 |
-| main.rs:283:14:283:17 | B(...) | main.rs:283:9:283:10 | s2 |
-| main.rs:284:11:284:12 | s1 | main.rs:285:9:285:12 | A(...) |
-| main.rs:284:11:284:12 | s1 | main.rs:286:9:286:12 | B(...) |
-| main.rs:284:11:284:12 | s1 | main.rs:288:11:288:12 | s1 |
-| main.rs:285:11:285:11 | [SSA] n | main.rs:285:22:285:22 | n |
-| main.rs:285:11:285:11 | n | main.rs:285:11:285:11 | [SSA] n |
-| main.rs:285:17:285:23 | sink(...) | main.rs:284:5:287:5 | match s1 { ... } |
-| main.rs:286:11:286:11 | [SSA] n | main.rs:286:22:286:22 | n |
-| main.rs:286:11:286:11 | n | main.rs:286:11:286:11 | [SSA] n |
-| main.rs:286:17:286:23 | sink(...) | main.rs:284:5:287:5 | match s1 { ... } |
-| main.rs:288:11:288:12 | s1 | main.rs:289:9:289:19 | ... \| ... |
-| main.rs:289:9:289:19 | ... \| ... | main.rs:289:9:289:12 | A(...) |
-| main.rs:289:9:289:19 | ... \| ... | main.rs:289:16:289:19 | B(...) |
-| main.rs:289:9:289:19 | [SSA] [match(true)] phi | main.rs:289:29:289:29 | n |
-| main.rs:289:11:289:11 | [SSA] [input] [match(true)] phi | main.rs:289:9:289:19 | [SSA] [match(true)] phi |
-| main.rs:289:11:289:11 | [SSA] n | main.rs:289:11:289:11 | [SSA] [input] [match(true)] phi |
-| main.rs:289:11:289:11 | n | main.rs:289:11:289:11 | [SSA] n |
-| main.rs:289:18:289:18 | [SSA] [input] [match(true)] phi | main.rs:289:9:289:19 | [SSA] [match(true)] phi |
-| main.rs:289:18:289:18 | [SSA] n | main.rs:289:18:289:18 | [SSA] [input] [match(true)] phi |
-| main.rs:289:18:289:18 | n | main.rs:289:18:289:18 | [SSA] n |
-| main.rs:289:24:289:30 | sink(...) | main.rs:288:5:290:5 | match s1 { ... } |
-| main.rs:291:5:294:5 | match s2 { ... } | main.rs:281:50:295:1 | { ... } |
-| main.rs:291:11:291:12 | s2 | main.rs:292:9:292:12 | A(...) |
-| main.rs:291:11:291:12 | s2 | main.rs:293:9:293:12 | B(...) |
-| main.rs:292:11:292:11 | [SSA] n | main.rs:292:22:292:22 | n |
-| main.rs:292:11:292:11 | n | main.rs:292:11:292:11 | [SSA] n |
-| main.rs:292:17:292:23 | sink(...) | main.rs:291:5:294:5 | match s2 { ... } |
-| main.rs:293:11:293:11 | [SSA] n | main.rs:293:22:293:22 | n |
-| main.rs:293:11:293:11 | n | main.rs:293:11:293:11 | [SSA] n |
-| main.rs:293:17:293:23 | sink(...) | main.rs:291:5:294:5 | match s2 { ... } |
-| main.rs:303:9:303:10 | [SSA] s1 | main.rs:307:11:307:12 | s1 |
-| main.rs:303:9:303:10 | s1 | main.rs:303:9:303:10 | [SSA] s1 |
-| main.rs:303:14:305:5 | ...::C {...} | main.rs:303:9:303:10 | s1 |
-| main.rs:306:9:306:10 | [SSA] s2 | main.rs:314:11:314:12 | s2 |
-| main.rs:306:9:306:10 | s2 | main.rs:306:9:306:10 | [SSA] s2 |
-| main.rs:306:14:306:43 | ...::D {...} | main.rs:306:9:306:10 | s2 |
-| main.rs:307:11:307:12 | s1 | main.rs:308:9:308:38 | ...::C {...} |
-| main.rs:307:11:307:12 | s1 | main.rs:309:9:309:38 | ...::D {...} |
-| main.rs:307:11:307:12 | s1 | main.rs:311:11:311:12 | s1 |
-| main.rs:308:36:308:36 | [SSA] n | main.rs:308:48:308:48 | n |
-| main.rs:308:36:308:36 | n | main.rs:308:36:308:36 | [SSA] n |
-| main.rs:308:43:308:49 | sink(...) | main.rs:307:5:310:5 | match s1 { ... } |
-| main.rs:309:36:309:36 | [SSA] n | main.rs:309:48:309:48 | n |
-| main.rs:309:36:309:36 | n | main.rs:309:36:309:36 | [SSA] n |
-| main.rs:309:43:309:49 | sink(...) | main.rs:307:5:310:5 | match s1 { ... } |
-| main.rs:311:11:311:12 | s1 | main.rs:312:9:312:71 | ... \| ... |
-| main.rs:312:9:312:71 | ... \| ... | main.rs:312:9:312:38 | ...::C {...} |
-| main.rs:312:9:312:71 | ... \| ... | main.rs:312:42:312:71 | ...::D {...} |
-| main.rs:312:9:312:71 | [SSA] [match(true)] phi | main.rs:312:81:312:81 | n |
-| main.rs:312:36:312:36 | [SSA] [input] [match(true)] phi | main.rs:312:9:312:71 | [SSA] [match(true)] phi |
-| main.rs:312:36:312:36 | [SSA] n | main.rs:312:36:312:36 | [SSA] [input] [match(true)] phi |
-| main.rs:312:36:312:36 | n | main.rs:312:36:312:36 | [SSA] n |
-| main.rs:312:69:312:69 | [SSA] [input] [match(true)] phi | main.rs:312:9:312:71 | [SSA] [match(true)] phi |
-| main.rs:312:69:312:69 | [SSA] n | main.rs:312:69:312:69 | [SSA] [input] [match(true)] phi |
-| main.rs:312:69:312:69 | n | main.rs:312:69:312:69 | [SSA] n |
-| main.rs:312:76:312:82 | sink(...) | main.rs:311:5:313:5 | match s1 { ... } |
-| main.rs:314:5:317:5 | match s2 { ... } | main.rs:302:49:318:1 | { ... } |
-| main.rs:314:11:314:12 | s2 | main.rs:315:9:315:38 | ...::C {...} |
-| main.rs:314:11:314:12 | s2 | main.rs:316:9:316:38 | ...::D {...} |
-| main.rs:315:36:315:36 | [SSA] n | main.rs:315:48:315:48 | n |
-| main.rs:315:36:315:36 | n | main.rs:315:36:315:36 | [SSA] n |
-| main.rs:315:43:315:49 | sink(...) | main.rs:314:5:317:5 | match s2 { ... } |
-| main.rs:316:36:316:36 | [SSA] n | main.rs:316:48:316:48 | n |
-| main.rs:316:36:316:36 | n | main.rs:316:36:316:36 | [SSA] n |
-| main.rs:316:43:316:49 | sink(...) | main.rs:314:5:317:5 | match s2 { ... } |
-| main.rs:323:9:323:10 | [SSA] s1 | main.rs:327:11:327:12 | s1 |
-| main.rs:323:9:323:10 | s1 | main.rs:323:9:323:10 | [SSA] s1 |
-| main.rs:323:14:325:5 | C {...} | main.rs:323:9:323:10 | s1 |
-| main.rs:326:9:326:10 | [SSA] s2 | main.rs:334:11:334:12 | s2 |
-| main.rs:326:9:326:10 | s2 | main.rs:326:9:326:10 | [SSA] s2 |
-| main.rs:326:14:326:29 | D {...} | main.rs:326:9:326:10 | s2 |
-| main.rs:327:11:327:12 | s1 | main.rs:328:9:328:24 | C {...} |
-| main.rs:327:11:327:12 | s1 | main.rs:329:9:329:24 | D {...} |
-| main.rs:327:11:327:12 | s1 | main.rs:331:11:331:12 | s1 |
-| main.rs:328:22:328:22 | [SSA] n | main.rs:328:34:328:34 | n |
-| main.rs:328:22:328:22 | n | main.rs:328:22:328:22 | [SSA] n |
-| main.rs:328:29:328:35 | sink(...) | main.rs:327:5:330:5 | match s1 { ... } |
-| main.rs:329:22:329:22 | [SSA] n | main.rs:329:34:329:34 | n |
-| main.rs:329:22:329:22 | n | main.rs:329:22:329:22 | [SSA] n |
-| main.rs:329:29:329:35 | sink(...) | main.rs:327:5:330:5 | match s1 { ... } |
-| main.rs:331:11:331:12 | s1 | main.rs:332:9:332:43 | ... \| ... |
-| main.rs:332:9:332:43 | ... \| ... | main.rs:332:9:332:24 | C {...} |
-| main.rs:332:9:332:43 | ... \| ... | main.rs:332:28:332:43 | D {...} |
-| main.rs:332:9:332:43 | [SSA] [match(true)] phi | main.rs:332:53:332:53 | n |
-| main.rs:332:22:332:22 | [SSA] [input] [match(true)] phi | main.rs:332:9:332:43 | [SSA] [match(true)] phi |
-| main.rs:332:22:332:22 | [SSA] n | main.rs:332:22:332:22 | [SSA] [input] [match(true)] phi |
-| main.rs:332:22:332:22 | n | main.rs:332:22:332:22 | [SSA] n |
-| main.rs:332:41:332:41 | [SSA] [input] [match(true)] phi | main.rs:332:9:332:43 | [SSA] [match(true)] phi |
-| main.rs:332:41:332:41 | [SSA] n | main.rs:332:41:332:41 | [SSA] [input] [match(true)] phi |
-| main.rs:332:41:332:41 | n | main.rs:332:41:332:41 | [SSA] n |
-| main.rs:332:48:332:54 | sink(...) | main.rs:331:5:333:5 | match s1 { ... } |
-| main.rs:334:5:337:5 | match s2 { ... } | main.rs:322:51:338:1 | { ... } |
-| main.rs:334:11:334:12 | s2 | main.rs:335:9:335:24 | C {...} |
-| main.rs:334:11:334:12 | s2 | main.rs:336:9:336:24 | D {...} |
-| main.rs:335:22:335:22 | [SSA] n | main.rs:335:34:335:34 | n |
-| main.rs:335:22:335:22 | n | main.rs:335:22:335:22 | [SSA] n |
-| main.rs:335:29:335:35 | sink(...) | main.rs:334:5:337:5 | match s2 { ... } |
-| main.rs:336:22:336:22 | [SSA] n | main.rs:336:34:336:34 | n |
-| main.rs:336:22:336:22 | n | main.rs:336:22:336:22 | [SSA] n |
-| main.rs:336:29:336:35 | sink(...) | main.rs:334:5:337:5 | match s2 { ... } |
-| main.rs:344:9:344:12 | [SSA] arr1 | main.rs:345:14:345:17 | arr1 |
-| main.rs:344:9:344:12 | arr1 | main.rs:344:9:344:12 | [SSA] arr1 |
-| main.rs:344:16:344:33 | [...] | main.rs:344:9:344:12 | arr1 |
-| main.rs:345:9:345:10 | [SSA] n1 | main.rs:346:10:346:11 | n1 |
-| main.rs:345:9:345:10 | n1 | main.rs:345:9:345:10 | [SSA] n1 |
-| main.rs:345:14:345:20 | arr1[2] | main.rs:345:9:345:10 | n1 |
-| main.rs:348:9:348:12 | [SSA] arr2 | main.rs:349:14:349:17 | arr2 |
-| main.rs:348:9:348:12 | arr2 | main.rs:348:9:348:12 | [SSA] arr2 |
-| main.rs:348:16:348:31 | [...; 10] | main.rs:348:9:348:12 | arr2 |
-| main.rs:349:9:349:10 | [SSA] n2 | main.rs:350:10:350:11 | n2 |
-| main.rs:349:9:349:10 | n2 | main.rs:349:9:349:10 | [SSA] n2 |
-| main.rs:349:14:349:20 | arr2[4] | main.rs:349:9:349:10 | n2 |
-| main.rs:352:9:352:12 | [SSA] arr3 | main.rs:353:14:353:17 | arr3 |
-| main.rs:352:9:352:12 | arr3 | main.rs:352:9:352:12 | [SSA] arr3 |
-| main.rs:352:16:352:24 | [...] | main.rs:352:9:352:12 | arr3 |
-| main.rs:353:9:353:10 | [SSA] n3 | main.rs:354:10:354:11 | n3 |
-| main.rs:353:9:353:10 | n3 | main.rs:353:9:353:10 | [SSA] n3 |
-| main.rs:353:14:353:20 | arr3[2] | main.rs:353:9:353:10 | n3 |
-| main.rs:358:9:358:12 | [SSA] arr1 | main.rs:359:15:359:18 | arr1 |
-| main.rs:358:9:358:12 | arr1 | main.rs:358:9:358:12 | [SSA] arr1 |
-| main.rs:358:16:358:33 | [...] | main.rs:358:9:358:12 | arr1 |
-| main.rs:359:9:359:10 | [SSA] n1 | main.rs:360:14:360:15 | n1 |
-| main.rs:359:9:359:10 | n1 | main.rs:359:9:359:10 | [SSA] n1 |
-| main.rs:363:9:363:12 | [SSA] arr2 | main.rs:364:15:364:18 | arr2 |
-| main.rs:363:9:363:12 | arr2 | main.rs:363:9:363:12 | [SSA] arr2 |
-| main.rs:363:16:363:24 | [...] | main.rs:363:9:363:12 | arr2 |
-| main.rs:364:5:366:5 | for ... in ... { ... } | main.rs:357:21:367:1 | { ... } |
-| main.rs:364:9:364:10 | [SSA] n2 | main.rs:365:14:365:15 | n2 |
-| main.rs:364:9:364:10 | n2 | main.rs:364:9:364:10 | [SSA] n2 |
-| main.rs:370:9:370:12 | [SSA] arr1 | main.rs:371:11:371:14 | arr1 |
-| main.rs:370:9:370:12 | arr1 | main.rs:370:9:370:12 | [SSA] arr1 |
-| main.rs:370:16:370:33 | [...] | main.rs:370:9:370:12 | arr1 |
-| main.rs:371:5:377:5 | match arr1 { ... } | main.rs:369:26:378:1 | { ... } |
-| main.rs:371:11:371:14 | arr1 | main.rs:372:9:372:17 | SlicePat |
-| main.rs:372:10:372:10 | [SSA] a | main.rs:373:18:373:18 | a |
-| main.rs:372:10:372:10 | a | main.rs:372:10:372:10 | [SSA] a |
-| main.rs:372:13:372:13 | [SSA] b | main.rs:374:18:374:18 | b |
-| main.rs:372:13:372:13 | b | main.rs:372:13:372:13 | [SSA] b |
-| main.rs:372:16:372:16 | [SSA] c | main.rs:375:18:375:18 | c |
-| main.rs:372:16:372:16 | c | main.rs:372:16:372:16 | [SSA] c |
-| main.rs:372:22:376:9 | { ... } | main.rs:371:5:377:5 | match arr1 { ... } |
-| main.rs:381:9:381:19 | [SSA] mut_arr | main.rs:382:10:382:16 | mut_arr |
-| main.rs:381:9:381:19 | mut_arr | main.rs:381:9:381:19 | [SSA] mut_arr |
-| main.rs:381:23:381:31 | [...] | main.rs:381:9:381:19 | mut_arr |
-| main.rs:382:10:382:16 | [post] mut_arr | main.rs:384:5:384:11 | mut_arr |
-| main.rs:382:10:382:16 | mut_arr | main.rs:384:5:384:11 | mut_arr |
-| main.rs:384:5:384:11 | [post] mut_arr | main.rs:385:13:385:19 | mut_arr |
-| main.rs:384:5:384:11 | mut_arr | main.rs:385:13:385:19 | mut_arr |
-| main.rs:384:18:384:27 | source(...) | main.rs:384:5:384:14 | mut_arr[1] |
-| main.rs:385:9:385:9 | [SSA] d | main.rs:386:10:386:10 | d |
-| main.rs:385:9:385:9 | d | main.rs:385:9:385:9 | [SSA] d |
-| main.rs:385:13:385:19 | [post] mut_arr | main.rs:387:10:387:16 | mut_arr |
-| main.rs:385:13:385:19 | mut_arr | main.rs:387:10:387:16 | mut_arr |
-| main.rs:385:13:385:22 | mut_arr[1] | main.rs:385:9:385:9 | d |
-| main.rs:392:39:392:43 | [SSA] names | main.rs:394:23:394:27 | names |
-| main.rs:392:39:392:43 | names | main.rs:392:39:392:43 | [SSA] names |
-| main.rs:392:39:392:72 | ...: Vec::<...> | main.rs:392:39:392:43 | names |
-| main.rs:393:7:393:18 | [SSA] default_name | main.rs:394:23:394:27 | [SSA] [input] SSA phi read(default_name) |
-| main.rs:393:7:393:18 | default_name | main.rs:393:7:393:18 | [SSA] default_name |
-| main.rs:393:22:393:43 | ... .to_string(...) | main.rs:393:7:393:18 | default_name |
-| main.rs:394:3:400:3 | for ... in ... { ... } | main.rs:392:75:401:1 | { ... } |
-| main.rs:394:7:394:18 | [SSA] SSA phi read(default_name) | main.rs:394:29:400:3 | [SSA] [input] SSA phi read(default_name) |
-| main.rs:394:7:394:18 | [SSA] SSA phi read(default_name) | main.rs:398:7:398:14 | [SSA] [input] SSA phi read(default_name) |
-| main.rs:394:8:394:11 | [SSA] cond | main.rs:395:8:395:11 | cond |
-| main.rs:394:8:394:11 | cond | main.rs:394:8:394:11 | [SSA] cond |
-| main.rs:394:14:394:17 | [SSA] name | main.rs:396:15:396:18 | name |
-| main.rs:394:14:394:17 | name | main.rs:394:14:394:17 | [SSA] name |
-| main.rs:394:23:394:27 | [SSA] [input] SSA phi read(default_name) | main.rs:394:7:394:18 | [SSA] SSA phi read(default_name) |
-| main.rs:394:29:400:3 | [SSA] [input] SSA phi read(default_name) | main.rs:394:7:394:18 | [SSA] SSA phi read(default_name) |
-| main.rs:395:5:399:5 | if cond {...} | main.rs:394:29:400:3 | { ... } |
-| main.rs:396:11:396:11 | [SSA] n | main.rs:397:12:397:12 | n |
-| main.rs:396:11:396:11 | n | main.rs:396:11:396:11 | [SSA] n |
-| main.rs:396:15:396:62 | name.unwrap_or_else(...) | main.rs:396:11:396:11 | n |
-| main.rs:396:35:396:61 | [SSA] <captured entry> default_name | main.rs:396:38:396:49 | default_name |
-| main.rs:398:7:398:14 | [SSA] [input] SSA phi read(default_name) | main.rs:394:7:394:18 | [SSA] SSA phi read(default_name) |
-| main.rs:410:9:410:9 | [SSA] s | main.rs:411:10:411:10 | s |
-| main.rs:410:9:410:9 | s | main.rs:410:9:410:9 | [SSA] s |
-| main.rs:410:13:410:27 | MacroExpr | main.rs:410:9:410:9 | s |
-| main.rs:410:25:410:26 | source(...) | main.rs:410:13:410:27 | MacroExpr |
-| main.rs:436:13:436:33 | result_questionmark(...) | main.rs:436:9:436:9 | _ |
-| main.rs:448:36:448:41 | ...::new(...) | main.rs:448:36:448:41 | MacroExpr |
+| file://:0:0:0:0 | [summary param] 0 in lang:core::_::<crate::option::Option>::unwrap_or | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::option::Option>::unwrap_or | MaD:2 |
+| file://:0:0:0:0 | [summary param] 0 in lang:core::_::<crate::result::Result>::unwrap_or | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::result::Result>::unwrap_or | MaD:5 |
+| file://:0:0:0:0 | [summary param] 0 in lang:core::_::crate::hint::must_use | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::crate::hint::must_use | MaD:7 |
+| file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::option::Option::Some(0)] in lang:core::_::<crate::option::Option>::unwrap | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::option::Option>::unwrap | MaD:1 |
+| file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::option::Option::Some(0)] in lang:core::_::<crate::option::Option>::unwrap_or | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::option::Option>::unwrap_or | MaD:3 |
+| file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::result::Result::Ok(0)] in lang:core::_::<crate::result::Result>::unwrap | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::result::Result>::unwrap | MaD:4 |
+| file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::result::Result::Ok(0)] in lang:core::_::<crate::result::Result>::unwrap_or | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:core::_::<crate::result::Result>::unwrap_or | MaD:6 |
+| main.rs:3:11:3:11 | [SSA] i | main.rs:4:12:4:12 | i |  |
+| main.rs:3:11:3:11 | i | main.rs:3:11:3:11 | [SSA] i |  |
+| main.rs:3:11:3:16 | ...: i64 | main.rs:3:11:3:11 | i |  |
+| main.rs:4:5:4:12 | ... + ... | main.rs:3:26:5:1 | { ... } |  |
+| main.rs:7:9:7:9 | [SSA] s | main.rs:8:20:8:20 | s |  |
+| main.rs:7:9:7:9 | s | main.rs:7:9:7:9 | [SSA] s |  |
+| main.rs:7:9:7:14 | ...: i64 | main.rs:7:9:7:9 | s |  |
+| main.rs:8:14:8:20 | FormatArgsExpr | main.rs:8:14:8:20 | MacroExpr |  |
+| main.rs:19:9:19:9 | [SSA] s | main.rs:20:10:20:10 | s |  |
+| main.rs:19:9:19:9 | s | main.rs:19:9:19:9 | [SSA] s |  |
+| main.rs:19:13:19:21 | source(...) | main.rs:19:9:19:9 | s |  |
+| main.rs:23:18:23:21 | [SSA] cond | main.rs:26:16:26:19 | cond |  |
+| main.rs:23:18:23:21 | cond | main.rs:23:18:23:21 | [SSA] cond |  |
+| main.rs:23:18:23:27 | ...: bool | main.rs:23:18:23:21 | cond |  |
+| main.rs:24:9:24:9 | [SSA] a | main.rs:26:23:26:23 | a |  |
+| main.rs:24:9:24:9 | a | main.rs:24:9:24:9 | [SSA] a |  |
+| main.rs:24:13:24:21 | source(...) | main.rs:24:9:24:9 | a |  |
+| main.rs:25:9:25:9 | [SSA] b | main.rs:26:34:26:34 | b |  |
+| main.rs:25:9:25:9 | b | main.rs:25:9:25:9 | [SSA] b |  |
+| main.rs:25:13:25:13 | 2 | main.rs:25:9:25:9 | b |  |
+| main.rs:26:9:26:9 | [SSA] c | main.rs:27:10:27:10 | c |  |
+| main.rs:26:9:26:9 | c | main.rs:26:9:26:9 | [SSA] c |  |
+| main.rs:26:13:26:36 | if cond {...} else {...} | main.rs:26:9:26:9 | c |  |
+| main.rs:26:21:26:25 | { ... } | main.rs:26:13:26:36 | if cond {...} else {...} |  |
+| main.rs:26:23:26:23 | a | main.rs:26:21:26:25 | { ... } |  |
+| main.rs:26:32:26:36 | { ... } | main.rs:26:13:26:36 | if cond {...} else {...} |  |
+| main.rs:26:34:26:34 | b | main.rs:26:32:26:36 | { ... } |  |
+| main.rs:30:21:30:21 | [SSA] m | main.rs:32:19:32:19 | m |  |
+| main.rs:30:21:30:21 | m | main.rs:30:21:30:21 | [SSA] m |  |
+| main.rs:30:21:30:34 | ...: Option::<...> | main.rs:30:21:30:21 | m |  |
+| main.rs:31:9:31:9 | [SSA] a | main.rs:33:20:33:20 | a |  |
+| main.rs:31:9:31:9 | a | main.rs:31:9:31:9 | [SSA] a |  |
+| main.rs:31:13:31:21 | source(...) | main.rs:31:9:31:9 | a |  |
+| main.rs:32:9:32:9 | [SSA] b | main.rs:36:10:36:10 | b |  |
+| main.rs:32:9:32:9 | b | main.rs:32:9:32:9 | [SSA] b |  |
+| main.rs:32:13:35:5 | match m { ... } | main.rs:32:9:32:9 | b |  |
+| main.rs:32:19:32:19 | m | main.rs:33:9:33:15 | Some(...) |  |
+| main.rs:32:19:32:19 | m | main.rs:34:9:34:12 | None |  |
+| main.rs:33:20:33:20 | a | main.rs:32:13:35:5 | match m { ... } |  |
+| main.rs:34:17:34:17 | 0 | main.rs:32:13:35:5 | match m { ... } |  |
+| main.rs:40:9:40:9 | [SSA] a | main.rs:43:10:43:10 | a |  |
+| main.rs:40:9:40:9 | a | main.rs:40:9:40:9 | [SSA] a |  |
+| main.rs:40:13:42:5 | loop { ... } | main.rs:40:9:40:9 | a |  |
+| main.rs:41:9:41:15 | break 1 | main.rs:40:13:42:5 | loop { ... } |  |
+| main.rs:41:15:41:15 | 1 | main.rs:41:9:41:15 | break 1 |  |
+| main.rs:44:9:44:9 | [SSA] b | main.rs:47:10:47:10 | b |  |
+| main.rs:44:9:44:9 | b | main.rs:44:9:44:9 | [SSA] b |  |
+| main.rs:44:13:46:5 | loop { ... } | main.rs:44:9:44:9 | b |  |
+| main.rs:45:9:45:23 | break ... | main.rs:44:13:46:5 | loop { ... } |  |
+| main.rs:45:15:45:23 | source(...) | main.rs:45:9:45:23 | break ... |  |
+| main.rs:51:9:51:13 | [SSA] i | main.rs:52:10:52:10 | i |  |
+| main.rs:51:9:51:13 | i | main.rs:51:9:51:13 | [SSA] i |  |
+| main.rs:51:17:51:17 | 1 | main.rs:51:9:51:13 | i |  |
+| main.rs:53:5:53:5 | [SSA] i | main.rs:54:10:54:10 | i |  |
+| main.rs:53:5:53:5 | i | main.rs:53:5:53:5 | [SSA] i |  |
+| main.rs:53:9:53:17 | source(...) | main.rs:53:5:53:5 | i |  |
+| main.rs:58:9:58:9 | [SSA] a | main.rs:59:5:59:5 | a |  |
+| main.rs:58:9:58:9 | a | main.rs:58:9:58:9 | [SSA] a |  |
+| main.rs:58:13:58:17 | { ... } | main.rs:58:9:58:9 | a |  |
+| main.rs:58:15:58:15 | 0 | main.rs:58:13:58:17 | { ... } |  |
+| main.rs:59:5:59:5 | a | main.rs:57:31:60:1 | { ... } |  |
+| main.rs:62:22:62:22 | [SSA] b | main.rs:64:12:64:12 | b |  |
+| main.rs:62:22:62:22 | b | main.rs:62:22:62:22 | [SSA] b |  |
+| main.rs:62:22:62:28 | ...: bool | main.rs:62:22:62:22 | b |  |
+| main.rs:63:9:63:9 | [SSA] a | main.rs:69:5:69:5 | a |  |
+| main.rs:63:9:63:9 | a | main.rs:63:9:63:9 | [SSA] a |  |
+| main.rs:63:13:68:5 | 'block: { ... } | main.rs:63:9:63:9 | a |  |
+| main.rs:65:13:65:26 | break ''block 1 | main.rs:63:13:68:5 | 'block: { ... } |  |
+| main.rs:65:26:65:26 | 1 | main.rs:65:13:65:26 | break ''block 1 |  |
+| main.rs:67:9:67:9 | 2 | main.rs:63:13:68:5 | 'block: { ... } |  |
+| main.rs:69:5:69:5 | a | main.rs:62:38:70:1 | { ... } |  |
+| main.rs:72:22:72:22 | [SSA] b | main.rs:74:12:74:12 | b |  |
+| main.rs:72:22:72:22 | b | main.rs:72:22:72:22 | [SSA] b |  |
+| main.rs:72:22:72:28 | ...: bool | main.rs:72:22:72:22 | b |  |
+| main.rs:73:9:73:9 | [SSA] a | main.rs:79:5:79:5 | a |  |
+| main.rs:73:9:73:9 | a | main.rs:73:9:73:9 | [SSA] a |  |
+| main.rs:73:13:78:5 | 'block: { ... } | main.rs:73:9:73:9 | a |  |
+| main.rs:75:13:75:26 | break ''block 1 | main.rs:73:13:78:5 | 'block: { ... } |  |
+| main.rs:75:26:75:26 | 1 | main.rs:75:13:75:26 | break ''block 1 |  |
+| main.rs:77:9:77:22 | break ''block 2 | main.rs:73:13:78:5 | 'block: { ... } |  |
+| main.rs:77:22:77:22 | 2 | main.rs:77:9:77:22 | break ''block 2 |  |
+| main.rs:79:5:79:5 | a | main.rs:72:38:80:1 | { ... } |  |
+| main.rs:86:9:86:9 | [SSA] i | main.rs:87:11:87:11 | i |  |
+| main.rs:86:9:86:9 | i | main.rs:86:9:86:9 | [SSA] i |  |
+| main.rs:86:13:86:31 | ...::new(...) | main.rs:86:9:86:9 | i |  |
+| main.rs:94:9:94:9 | [SSA] a | main.rs:95:10:95:10 | a |  |
+| main.rs:94:9:94:9 | a | main.rs:94:9:94:9 | [SSA] a |  |
+| main.rs:94:13:94:26 | TupleExpr | main.rs:94:9:94:9 | a |  |
+| main.rs:95:10:95:10 | [post] a | main.rs:96:10:96:10 | a |  |
+| main.rs:95:10:95:10 | a | main.rs:96:10:96:10 | a |  |
+| main.rs:100:9:100:9 | [SSA] a | main.rs:101:24:101:24 | a |  |
+| main.rs:100:9:100:9 | a | main.rs:100:9:100:9 | [SSA] a |  |
+| main.rs:100:13:100:30 | TupleExpr | main.rs:100:9:100:9 | a |  |
+| main.rs:101:10:101:11 | [SSA] a0 | main.rs:102:10:102:11 | a0 |  |
+| main.rs:101:10:101:11 | a0 | main.rs:101:10:101:11 | [SSA] a0 |  |
+| main.rs:101:14:101:15 | [SSA] a1 | main.rs:103:10:103:11 | a1 |  |
+| main.rs:101:14:101:15 | a1 | main.rs:101:14:101:15 | [SSA] a1 |  |
+| main.rs:101:18:101:19 | [SSA] a2 | main.rs:104:10:104:11 | a2 |  |
+| main.rs:101:18:101:19 | a2 | main.rs:101:18:101:19 | [SSA] a2 |  |
+| main.rs:101:24:101:24 | a | main.rs:101:9:101:20 | TuplePat |  |
+| main.rs:108:9:108:13 | [SSA] a | main.rs:109:10:109:10 | a |  |
+| main.rs:108:9:108:13 | a | main.rs:108:9:108:13 | [SSA] a |  |
+| main.rs:108:17:108:31 | TupleExpr | main.rs:108:9:108:13 | a |  |
+| main.rs:109:10:109:10 | [post] a | main.rs:110:10:110:10 | a |  |
+| main.rs:109:10:109:10 | a | main.rs:110:10:110:10 | a |  |
+| main.rs:110:10:110:10 | [post] a | main.rs:111:5:111:5 | a |  |
+| main.rs:110:10:110:10 | a | main.rs:111:5:111:5 | a |  |
+| main.rs:111:5:111:5 | [post] a | main.rs:112:5:112:5 | a |  |
+| main.rs:111:5:111:5 | a | main.rs:112:5:112:5 | a |  |
+| main.rs:111:11:111:20 | source(...) | main.rs:111:5:111:7 | a.0 |  |
+| main.rs:112:5:112:5 | [post] a | main.rs:113:10:113:10 | a |  |
+| main.rs:112:5:112:5 | a | main.rs:113:10:113:10 | a |  |
+| main.rs:112:11:112:11 | 2 | main.rs:112:5:112:7 | a.1 |  |
+| main.rs:113:10:113:10 | [post] a | main.rs:114:10:114:10 | a |  |
+| main.rs:113:10:113:10 | a | main.rs:114:10:114:10 | a |  |
+| main.rs:118:9:118:9 | [SSA] a | main.rs:119:14:119:14 | a |  |
+| main.rs:118:9:118:9 | a | main.rs:118:9:118:9 | [SSA] a |  |
+| main.rs:118:13:118:27 | TupleExpr | main.rs:118:9:118:9 | a |  |
+| main.rs:119:9:119:9 | [SSA] b | main.rs:120:10:120:10 | b |  |
+| main.rs:119:9:119:9 | b | main.rs:119:9:119:9 | [SSA] b |  |
+| main.rs:119:13:119:18 | TupleExpr | main.rs:119:9:119:9 | b |  |
+| main.rs:120:10:120:10 | [post] b | main.rs:121:10:121:10 | b |  |
+| main.rs:120:10:120:10 | b | main.rs:121:10:121:10 | b |  |
+| main.rs:121:10:121:10 | [post] b | main.rs:122:10:122:10 | b |  |
+| main.rs:121:10:121:10 | b | main.rs:122:10:122:10 | b |  |
+| main.rs:134:9:134:9 | [SSA] p | main.rs:135:10:135:10 | p |  |
+| main.rs:134:9:134:9 | p | main.rs:134:9:134:9 | [SSA] p |  |
+| main.rs:134:13:134:40 | Point {...} | main.rs:134:9:134:9 | p |  |
+| main.rs:135:10:135:10 | [post] p | main.rs:136:10:136:10 | p |  |
+| main.rs:135:10:135:10 | p | main.rs:136:10:136:10 | p |  |
+| main.rs:140:9:140:13 | [SSA] p | main.rs:141:10:141:10 | p |  |
+| main.rs:140:9:140:13 | p | main.rs:140:9:140:13 | [SSA] p |  |
+| main.rs:140:17:140:44 | Point {...} | main.rs:140:9:140:13 | p |  |
+| main.rs:141:10:141:10 | [post] p | main.rs:142:5:142:5 | p |  |
+| main.rs:141:10:141:10 | p | main.rs:142:5:142:5 | p |  |
+| main.rs:142:5:142:5 | [post] p | main.rs:143:10:143:10 | p |  |
+| main.rs:142:5:142:5 | p | main.rs:143:10:143:10 | p |  |
+| main.rs:142:11:142:20 | source(...) | main.rs:142:5:142:7 | p.y |  |
+| main.rs:147:9:147:9 | [SSA] p | main.rs:151:32:151:32 | p |  |
+| main.rs:147:9:147:9 | p | main.rs:147:9:147:9 | [SSA] p |  |
+| main.rs:147:13:150:5 | Point {...} | main.rs:147:9:147:9 | p |  |
+| main.rs:151:20:151:20 | [SSA] a | main.rs:152:10:152:10 | a |  |
+| main.rs:151:20:151:20 | a | main.rs:151:20:151:20 | [SSA] a |  |
+| main.rs:151:26:151:26 | [SSA] b | main.rs:153:10:153:10 | b |  |
+| main.rs:151:26:151:26 | b | main.rs:151:26:151:26 | [SSA] b |  |
+| main.rs:151:32:151:32 | p | main.rs:151:9:151:28 | Point {...} |  |
+| main.rs:162:9:162:9 | [SSA] p | main.rs:169:10:169:10 | p |  |
+| main.rs:162:9:162:9 | p | main.rs:162:9:162:9 | [SSA] p |  |
+| main.rs:162:13:168:5 | Point3D {...} | main.rs:162:9:162:9 | p |  |
+| main.rs:169:10:169:10 | [post] p | main.rs:170:10:170:10 | p |  |
+| main.rs:169:10:169:10 | p | main.rs:170:10:170:10 | p |  |
+| main.rs:170:10:170:10 | [post] p | main.rs:171:10:171:10 | p |  |
+| main.rs:170:10:170:10 | p | main.rs:171:10:171:10 | p |  |
+| main.rs:175:9:175:9 | [SSA] p | main.rs:182:11:182:11 | p |  |
+| main.rs:175:9:175:9 | p | main.rs:175:9:175:9 | [SSA] p |  |
+| main.rs:175:13:181:5 | Point3D {...} | main.rs:175:9:175:9 | p |  |
+| main.rs:182:5:191:5 | match p { ... } | main.rs:174:26:192:1 | { ... } |  |
+| main.rs:182:11:182:11 | p | main.rs:183:9:186:9 | Point3D {...} |  |
+| main.rs:184:28:184:28 | [SSA] x | main.rs:187:18:187:18 | x |  |
+| main.rs:184:28:184:28 | x | main.rs:184:28:184:28 | [SSA] x |  |
+| main.rs:184:31:184:31 | [SSA] y | main.rs:188:18:188:18 | y |  |
+| main.rs:184:31:184:31 | y | main.rs:184:31:184:31 | [SSA] y |  |
+| main.rs:185:13:185:13 | [SSA] z | main.rs:189:18:189:18 | z |  |
+| main.rs:185:13:185:13 | z | main.rs:185:13:185:13 | [SSA] z |  |
+| main.rs:186:14:190:9 | { ... } | main.rs:182:5:191:5 | match p { ... } |  |
+| main.rs:198:9:198:10 | [SSA] s1 | main.rs:200:11:200:12 | s1 |  |
+| main.rs:198:9:198:10 | s1 | main.rs:198:9:198:10 | [SSA] s1 |  |
+| main.rs:198:14:198:37 | ...::Some(...) | main.rs:198:9:198:10 | s1 |  |
+| main.rs:199:9:199:10 | [SSA] s2 | main.rs:204:11:204:12 | s2 |  |
+| main.rs:199:9:199:10 | s2 | main.rs:199:9:199:10 | [SSA] s2 |  |
+| main.rs:199:14:199:28 | ...::Some(...) | main.rs:199:9:199:10 | s2 |  |
+| main.rs:200:11:200:12 | s1 | main.rs:201:9:201:23 | ...::Some(...) |  |
+| main.rs:200:11:200:12 | s1 | main.rs:202:9:202:20 | ...::None |  |
+| main.rs:201:22:201:22 | [SSA] n | main.rs:201:33:201:33 | n |  |
+| main.rs:201:22:201:22 | n | main.rs:201:22:201:22 | [SSA] n |  |
+| main.rs:201:28:201:34 | sink(...) | main.rs:200:5:203:5 | match s1 { ... } |  |
+| main.rs:202:25:202:31 | sink(...) | main.rs:200:5:203:5 | match s1 { ... } |  |
+| main.rs:204:5:207:5 | match s2 { ... } | main.rs:197:37:208:1 | { ... } |  |
+| main.rs:204:11:204:12 | s2 | main.rs:205:9:205:23 | ...::Some(...) |  |
+| main.rs:204:11:204:12 | s2 | main.rs:206:9:206:20 | ...::None |  |
+| main.rs:205:22:205:22 | [SSA] n | main.rs:205:33:205:33 | n |  |
+| main.rs:205:22:205:22 | n | main.rs:205:22:205:22 | [SSA] n |  |
+| main.rs:205:28:205:34 | sink(...) | main.rs:204:5:207:5 | match s2 { ... } |  |
+| main.rs:206:25:206:31 | sink(...) | main.rs:204:5:207:5 | match s2 { ... } |  |
+| main.rs:211:9:211:10 | [SSA] s1 | main.rs:213:11:213:12 | s1 |  |
+| main.rs:211:9:211:10 | s1 | main.rs:211:9:211:10 | [SSA] s1 |  |
+| main.rs:211:14:211:29 | Some(...) | main.rs:211:9:211:10 | s1 |  |
+| main.rs:212:9:212:10 | [SSA] s2 | main.rs:217:11:217:12 | s2 |  |
+| main.rs:212:9:212:10 | s2 | main.rs:212:9:212:10 | [SSA] s2 |  |
+| main.rs:212:14:212:20 | Some(...) | main.rs:212:9:212:10 | s2 |  |
+| main.rs:213:11:213:12 | s1 | main.rs:214:9:214:15 | Some(...) |  |
+| main.rs:213:11:213:12 | s1 | main.rs:215:9:215:12 | None |  |
+| main.rs:214:14:214:14 | [SSA] n | main.rs:214:25:214:25 | n |  |
+| main.rs:214:14:214:14 | n | main.rs:214:14:214:14 | [SSA] n |  |
+| main.rs:214:20:214:26 | sink(...) | main.rs:213:5:216:5 | match s1 { ... } |  |
+| main.rs:215:17:215:23 | sink(...) | main.rs:213:5:216:5 | match s1 { ... } |  |
+| main.rs:217:5:220:5 | match s2 { ... } | main.rs:210:39:221:1 | { ... } |  |
+| main.rs:217:11:217:12 | s2 | main.rs:218:9:218:15 | Some(...) |  |
+| main.rs:217:11:217:12 | s2 | main.rs:219:9:219:12 | None |  |
+| main.rs:218:14:218:14 | [SSA] n | main.rs:218:25:218:25 | n |  |
+| main.rs:218:14:218:14 | n | main.rs:218:14:218:14 | [SSA] n |  |
+| main.rs:218:20:218:26 | sink(...) | main.rs:217:5:220:5 | match s2 { ... } |  |
+| main.rs:219:17:219:23 | sink(...) | main.rs:217:5:220:5 | match s2 { ... } |  |
+| main.rs:224:9:224:10 | [SSA] s1 | main.rs:225:10:225:11 | s1 |  |
+| main.rs:224:9:224:10 | s1 | main.rs:224:9:224:10 | [SSA] s1 |  |
+| main.rs:224:14:224:29 | Some(...) | main.rs:224:9:224:10 | s1 |  |
+| main.rs:229:9:229:10 | [SSA] s1 | main.rs:230:10:230:11 | s1 |  |
+| main.rs:229:9:229:10 | s1 | main.rs:229:9:229:10 | [SSA] s1 |  |
+| main.rs:229:14:229:29 | Some(...) | main.rs:229:9:229:10 | s1 |  |
+| main.rs:232:9:232:10 | [SSA] s2 | main.rs:233:10:233:11 | s2 |  |
+| main.rs:232:9:232:10 | s2 | main.rs:232:9:232:10 | [SSA] s2 |  |
+| main.rs:232:14:232:20 | Some(...) | main.rs:232:9:232:10 | s2 |  |
+| main.rs:237:9:237:10 | [SSA] s1 | main.rs:239:14:239:15 | s1 |  |
+| main.rs:237:9:237:10 | s1 | main.rs:237:9:237:10 | [SSA] s1 |  |
+| main.rs:237:14:237:29 | Some(...) | main.rs:237:9:237:10 | s1 |  |
+| main.rs:238:9:238:10 | [SSA] s2 | main.rs:241:10:241:11 | s2 |  |
+| main.rs:238:9:238:10 | s2 | main.rs:238:9:238:10 | [SSA] s2 |  |
+| main.rs:238:14:238:20 | Some(...) | main.rs:238:9:238:10 | s2 |  |
+| main.rs:239:9:239:10 | [SSA] i1 | main.rs:240:10:240:11 | i1 |  |
+| main.rs:239:9:239:10 | i1 | main.rs:239:9:239:10 | [SSA] i1 |  |
+| main.rs:239:14:239:16 | TryExpr | main.rs:239:9:239:10 | i1 |  |
+| main.rs:242:5:242:11 | Some(...) | main.rs:236:41:243:1 | { ... } |  |
+| main.rs:246:9:246:10 | [SSA] s1 | main.rs:249:14:249:15 | s1 |  |
+| main.rs:246:9:246:10 | s1 | main.rs:246:9:246:10 | [SSA] s1 |  |
+| main.rs:246:32:246:45 | Ok(...) | main.rs:246:9:246:10 | s1 |  |
+| main.rs:247:9:247:10 | [SSA] s2 | main.rs:250:14:250:15 | s2 |  |
+| main.rs:247:9:247:10 | s2 | main.rs:247:9:247:10 | [SSA] s2 |  |
+| main.rs:247:32:247:36 | Ok(...) | main.rs:247:9:247:10 | s2 |  |
+| main.rs:248:9:248:10 | [SSA] s3 | main.rs:253:14:253:15 | s3 |  |
+| main.rs:248:9:248:10 | s3 | main.rs:248:9:248:10 | [SSA] s3 |  |
+| main.rs:248:32:248:46 | Err(...) | main.rs:248:9:248:10 | s3 |  |
+| main.rs:249:9:249:10 | [SSA] i1 | main.rs:251:10:251:11 | i1 |  |
+| main.rs:249:9:249:10 | i1 | main.rs:249:9:249:10 | [SSA] i1 |  |
+| main.rs:249:14:249:16 | TryExpr | main.rs:249:9:249:10 | i1 |  |
+| main.rs:250:9:250:10 | [SSA] i2 | main.rs:252:10:252:11 | i2 |  |
+| main.rs:250:9:250:10 | i2 | main.rs:250:9:250:10 | [SSA] i2 |  |
+| main.rs:250:14:250:16 | TryExpr | main.rs:250:9:250:10 | i2 |  |
+| main.rs:253:9:253:10 | [SSA] i3 | main.rs:254:10:254:11 | i3 |  |
+| main.rs:253:9:253:10 | i3 | main.rs:253:9:253:10 | [SSA] i3 |  |
+| main.rs:253:14:253:16 | TryExpr | main.rs:253:9:253:10 | i3 |  |
+| main.rs:255:5:255:9 | Ok(...) | main.rs:245:46:256:1 | { ... } |  |
+| main.rs:264:9:264:10 | [SSA] s1 | main.rs:266:11:266:12 | s1 |  |
+| main.rs:264:9:264:10 | s1 | main.rs:264:9:264:10 | [SSA] s1 |  |
+| main.rs:264:14:264:39 | ...::A(...) | main.rs:264:9:264:10 | s1 |  |
+| main.rs:265:9:265:10 | [SSA] s2 | main.rs:273:11:273:12 | s2 |  |
+| main.rs:265:9:265:10 | s2 | main.rs:265:9:265:10 | [SSA] s2 |  |
+| main.rs:265:14:265:30 | ...::B(...) | main.rs:265:9:265:10 | s2 |  |
+| main.rs:266:11:266:12 | s1 | main.rs:267:9:267:25 | ...::A(...) |  |
+| main.rs:266:11:266:12 | s1 | main.rs:268:9:268:25 | ...::B(...) |  |
+| main.rs:266:11:266:12 | s1 | main.rs:270:11:270:12 | s1 |  |
+| main.rs:267:24:267:24 | [SSA] n | main.rs:267:35:267:35 | n |  |
+| main.rs:267:24:267:24 | n | main.rs:267:24:267:24 | [SSA] n |  |
+| main.rs:267:30:267:36 | sink(...) | main.rs:266:5:269:5 | match s1 { ... } |  |
+| main.rs:268:24:268:24 | [SSA] n | main.rs:268:35:268:35 | n |  |
+| main.rs:268:24:268:24 | n | main.rs:268:24:268:24 | [SSA] n |  |
+| main.rs:268:30:268:36 | sink(...) | main.rs:266:5:269:5 | match s1 { ... } |  |
+| main.rs:270:11:270:12 | s1 | main.rs:271:9:271:45 | ... \| ... |  |
+| main.rs:271:9:271:45 | ... \| ... | main.rs:271:9:271:25 | ...::A(...) |  |
+| main.rs:271:9:271:45 | ... \| ... | main.rs:271:29:271:45 | ...::B(...) |  |
+| main.rs:271:9:271:45 | [SSA] [match(true)] phi | main.rs:271:55:271:55 | n |  |
+| main.rs:271:24:271:24 | [SSA] [input] [match(true)] phi | main.rs:271:9:271:45 | [SSA] [match(true)] phi |  |
+| main.rs:271:24:271:24 | [SSA] n | main.rs:271:24:271:24 | [SSA] [input] [match(true)] phi |  |
+| main.rs:271:24:271:24 | n | main.rs:271:24:271:24 | [SSA] n |  |
+| main.rs:271:44:271:44 | [SSA] [input] [match(true)] phi | main.rs:271:9:271:45 | [SSA] [match(true)] phi |  |
+| main.rs:271:44:271:44 | [SSA] n | main.rs:271:44:271:44 | [SSA] [input] [match(true)] phi |  |
+| main.rs:271:44:271:44 | n | main.rs:271:44:271:44 | [SSA] n |  |
+| main.rs:271:50:271:56 | sink(...) | main.rs:270:5:272:5 | match s1 { ... } |  |
+| main.rs:273:5:276:5 | match s2 { ... } | main.rs:263:48:277:1 | { ... } |  |
+| main.rs:273:11:273:12 | s2 | main.rs:274:9:274:25 | ...::A(...) |  |
+| main.rs:273:11:273:12 | s2 | main.rs:275:9:275:25 | ...::B(...) |  |
+| main.rs:274:24:274:24 | [SSA] n | main.rs:274:35:274:35 | n |  |
+| main.rs:274:24:274:24 | n | main.rs:274:24:274:24 | [SSA] n |  |
+| main.rs:274:30:274:36 | sink(...) | main.rs:273:5:276:5 | match s2 { ... } |  |
+| main.rs:275:24:275:24 | [SSA] n | main.rs:275:35:275:35 | n |  |
+| main.rs:275:24:275:24 | n | main.rs:275:24:275:24 | [SSA] n |  |
+| main.rs:275:30:275:36 | sink(...) | main.rs:273:5:276:5 | match s2 { ... } |  |
+| main.rs:282:9:282:10 | [SSA] s1 | main.rs:284:11:284:12 | s1 |  |
+| main.rs:282:9:282:10 | s1 | main.rs:282:9:282:10 | [SSA] s1 |  |
+| main.rs:282:14:282:26 | A(...) | main.rs:282:9:282:10 | s1 |  |
+| main.rs:283:9:283:10 | [SSA] s2 | main.rs:291:11:291:12 | s2 |  |
+| main.rs:283:9:283:10 | s2 | main.rs:283:9:283:10 | [SSA] s2 |  |
+| main.rs:283:14:283:17 | B(...) | main.rs:283:9:283:10 | s2 |  |
+| main.rs:284:11:284:12 | s1 | main.rs:285:9:285:12 | A(...) |  |
+| main.rs:284:11:284:12 | s1 | main.rs:286:9:286:12 | B(...) |  |
+| main.rs:284:11:284:12 | s1 | main.rs:288:11:288:12 | s1 |  |
+| main.rs:285:11:285:11 | [SSA] n | main.rs:285:22:285:22 | n |  |
+| main.rs:285:11:285:11 | n | main.rs:285:11:285:11 | [SSA] n |  |
+| main.rs:285:17:285:23 | sink(...) | main.rs:284:5:287:5 | match s1 { ... } |  |
+| main.rs:286:11:286:11 | [SSA] n | main.rs:286:22:286:22 | n |  |
+| main.rs:286:11:286:11 | n | main.rs:286:11:286:11 | [SSA] n |  |
+| main.rs:286:17:286:23 | sink(...) | main.rs:284:5:287:5 | match s1 { ... } |  |
+| main.rs:288:11:288:12 | s1 | main.rs:289:9:289:19 | ... \| ... |  |
+| main.rs:289:9:289:19 | ... \| ... | main.rs:289:9:289:12 | A(...) |  |
+| main.rs:289:9:289:19 | ... \| ... | main.rs:289:16:289:19 | B(...) |  |
+| main.rs:289:9:289:19 | [SSA] [match(true)] phi | main.rs:289:29:289:29 | n |  |
+| main.rs:289:11:289:11 | [SSA] [input] [match(true)] phi | main.rs:289:9:289:19 | [SSA] [match(true)] phi |  |
+| main.rs:289:11:289:11 | [SSA] n | main.rs:289:11:289:11 | [SSA] [input] [match(true)] phi |  |
+| main.rs:289:11:289:11 | n | main.rs:289:11:289:11 | [SSA] n |  |
+| main.rs:289:18:289:18 | [SSA] [input] [match(true)] phi | main.rs:289:9:289:19 | [SSA] [match(true)] phi |  |
+| main.rs:289:18:289:18 | [SSA] n | main.rs:289:18:289:18 | [SSA] [input] [match(true)] phi |  |
+| main.rs:289:18:289:18 | n | main.rs:289:18:289:18 | [SSA] n |  |
+| main.rs:289:24:289:30 | sink(...) | main.rs:288:5:290:5 | match s1 { ... } |  |
+| main.rs:291:5:294:5 | match s2 { ... } | main.rs:281:50:295:1 | { ... } |  |
+| main.rs:291:11:291:12 | s2 | main.rs:292:9:292:12 | A(...) |  |
+| main.rs:291:11:291:12 | s2 | main.rs:293:9:293:12 | B(...) |  |
+| main.rs:292:11:292:11 | [SSA] n | main.rs:292:22:292:22 | n |  |
+| main.rs:292:11:292:11 | n | main.rs:292:11:292:11 | [SSA] n |  |
+| main.rs:292:17:292:23 | sink(...) | main.rs:291:5:294:5 | match s2 { ... } |  |
+| main.rs:293:11:293:11 | [SSA] n | main.rs:293:22:293:22 | n |  |
+| main.rs:293:11:293:11 | n | main.rs:293:11:293:11 | [SSA] n |  |
+| main.rs:293:17:293:23 | sink(...) | main.rs:291:5:294:5 | match s2 { ... } |  |
+| main.rs:303:9:303:10 | [SSA] s1 | main.rs:307:11:307:12 | s1 |  |
+| main.rs:303:9:303:10 | s1 | main.rs:303:9:303:10 | [SSA] s1 |  |
+| main.rs:303:14:305:5 | ...::C {...} | main.rs:303:9:303:10 | s1 |  |
+| main.rs:306:9:306:10 | [SSA] s2 | main.rs:314:11:314:12 | s2 |  |
+| main.rs:306:9:306:10 | s2 | main.rs:306:9:306:10 | [SSA] s2 |  |
+| main.rs:306:14:306:43 | ...::D {...} | main.rs:306:9:306:10 | s2 |  |
+| main.rs:307:11:307:12 | s1 | main.rs:308:9:308:38 | ...::C {...} |  |
+| main.rs:307:11:307:12 | s1 | main.rs:309:9:309:38 | ...::D {...} |  |
+| main.rs:307:11:307:12 | s1 | main.rs:311:11:311:12 | s1 |  |
+| main.rs:308:36:308:36 | [SSA] n | main.rs:308:48:308:48 | n |  |
+| main.rs:308:36:308:36 | n | main.rs:308:36:308:36 | [SSA] n |  |
+| main.rs:308:43:308:49 | sink(...) | main.rs:307:5:310:5 | match s1 { ... } |  |
+| main.rs:309:36:309:36 | [SSA] n | main.rs:309:48:309:48 | n |  |
+| main.rs:309:36:309:36 | n | main.rs:309:36:309:36 | [SSA] n |  |
+| main.rs:309:43:309:49 | sink(...) | main.rs:307:5:310:5 | match s1 { ... } |  |
+| main.rs:311:11:311:12 | s1 | main.rs:312:9:312:71 | ... \| ... |  |
+| main.rs:312:9:312:71 | ... \| ... | main.rs:312:9:312:38 | ...::C {...} |  |
+| main.rs:312:9:312:71 | ... \| ... | main.rs:312:42:312:71 | ...::D {...} |  |
+| main.rs:312:9:312:71 | [SSA] [match(true)] phi | main.rs:312:81:312:81 | n |  |
+| main.rs:312:36:312:36 | [SSA] [input] [match(true)] phi | main.rs:312:9:312:71 | [SSA] [match(true)] phi |  |
+| main.rs:312:36:312:36 | [SSA] n | main.rs:312:36:312:36 | [SSA] [input] [match(true)] phi |  |
+| main.rs:312:36:312:36 | n | main.rs:312:36:312:36 | [SSA] n |  |
+| main.rs:312:69:312:69 | [SSA] [input] [match(true)] phi | main.rs:312:9:312:71 | [SSA] [match(true)] phi |  |
+| main.rs:312:69:312:69 | [SSA] n | main.rs:312:69:312:69 | [SSA] [input] [match(true)] phi |  |
+| main.rs:312:69:312:69 | n | main.rs:312:69:312:69 | [SSA] n |  |
+| main.rs:312:76:312:82 | sink(...) | main.rs:311:5:313:5 | match s1 { ... } |  |
+| main.rs:314:5:317:5 | match s2 { ... } | main.rs:302:49:318:1 | { ... } |  |
+| main.rs:314:11:314:12 | s2 | main.rs:315:9:315:38 | ...::C {...} |  |
+| main.rs:314:11:314:12 | s2 | main.rs:316:9:316:38 | ...::D {...} |  |
+| main.rs:315:36:315:36 | [SSA] n | main.rs:315:48:315:48 | n |  |
+| main.rs:315:36:315:36 | n | main.rs:315:36:315:36 | [SSA] n |  |
+| main.rs:315:43:315:49 | sink(...) | main.rs:314:5:317:5 | match s2 { ... } |  |
+| main.rs:316:36:316:36 | [SSA] n | main.rs:316:48:316:48 | n |  |
+| main.rs:316:36:316:36 | n | main.rs:316:36:316:36 | [SSA] n |  |
+| main.rs:316:43:316:49 | sink(...) | main.rs:314:5:317:5 | match s2 { ... } |  |
+| main.rs:323:9:323:10 | [SSA] s1 | main.rs:327:11:327:12 | s1 |  |
+| main.rs:323:9:323:10 | s1 | main.rs:323:9:323:10 | [SSA] s1 |  |
+| main.rs:323:14:325:5 | C {...} | main.rs:323:9:323:10 | s1 |  |
+| main.rs:326:9:326:10 | [SSA] s2 | main.rs:334:11:334:12 | s2 |  |
+| main.rs:326:9:326:10 | s2 | main.rs:326:9:326:10 | [SSA] s2 |  |
+| main.rs:326:14:326:29 | D {...} | main.rs:326:9:326:10 | s2 |  |
+| main.rs:327:11:327:12 | s1 | main.rs:328:9:328:24 | C {...} |  |
+| main.rs:327:11:327:12 | s1 | main.rs:329:9:329:24 | D {...} |  |
+| main.rs:327:11:327:12 | s1 | main.rs:331:11:331:12 | s1 |  |
+| main.rs:328:22:328:22 | [SSA] n | main.rs:328:34:328:34 | n |  |
+| main.rs:328:22:328:22 | n | main.rs:328:22:328:22 | [SSA] n |  |
+| main.rs:328:29:328:35 | sink(...) | main.rs:327:5:330:5 | match s1 { ... } |  |
+| main.rs:329:22:329:22 | [SSA] n | main.rs:329:34:329:34 | n |  |
+| main.rs:329:22:329:22 | n | main.rs:329:22:329:22 | [SSA] n |  |
+| main.rs:329:29:329:35 | sink(...) | main.rs:327:5:330:5 | match s1 { ... } |  |
+| main.rs:331:11:331:12 | s1 | main.rs:332:9:332:43 | ... \| ... |  |
+| main.rs:332:9:332:43 | ... \| ... | main.rs:332:9:332:24 | C {...} |  |
+| main.rs:332:9:332:43 | ... \| ... | main.rs:332:28:332:43 | D {...} |  |
+| main.rs:332:9:332:43 | [SSA] [match(true)] phi | main.rs:332:53:332:53 | n |  |
+| main.rs:332:22:332:22 | [SSA] [input] [match(true)] phi | main.rs:332:9:332:43 | [SSA] [match(true)] phi |  |
+| main.rs:332:22:332:22 | [SSA] n | main.rs:332:22:332:22 | [SSA] [input] [match(true)] phi |  |
+| main.rs:332:22:332:22 | n | main.rs:332:22:332:22 | [SSA] n |  |
+| main.rs:332:41:332:41 | [SSA] [input] [match(true)] phi | main.rs:332:9:332:43 | [SSA] [match(true)] phi |  |
+| main.rs:332:41:332:41 | [SSA] n | main.rs:332:41:332:41 | [SSA] [input] [match(true)] phi |  |
+| main.rs:332:41:332:41 | n | main.rs:332:41:332:41 | [SSA] n |  |
+| main.rs:332:48:332:54 | sink(...) | main.rs:331:5:333:5 | match s1 { ... } |  |
+| main.rs:334:5:337:5 | match s2 { ... } | main.rs:322:51:338:1 | { ... } |  |
+| main.rs:334:11:334:12 | s2 | main.rs:335:9:335:24 | C {...} |  |
+| main.rs:334:11:334:12 | s2 | main.rs:336:9:336:24 | D {...} |  |
+| main.rs:335:22:335:22 | [SSA] n | main.rs:335:34:335:34 | n |  |
+| main.rs:335:22:335:22 | n | main.rs:335:22:335:22 | [SSA] n |  |
+| main.rs:335:29:335:35 | sink(...) | main.rs:334:5:337:5 | match s2 { ... } |  |
+| main.rs:336:22:336:22 | [SSA] n | main.rs:336:34:336:34 | n |  |
+| main.rs:336:22:336:22 | n | main.rs:336:22:336:22 | [SSA] n |  |
+| main.rs:336:29:336:35 | sink(...) | main.rs:334:5:337:5 | match s2 { ... } |  |
+| main.rs:344:9:344:12 | [SSA] arr1 | main.rs:345:14:345:17 | arr1 |  |
+| main.rs:344:9:344:12 | arr1 | main.rs:344:9:344:12 | [SSA] arr1 |  |
+| main.rs:344:16:344:33 | [...] | main.rs:344:9:344:12 | arr1 |  |
+| main.rs:345:9:345:10 | [SSA] n1 | main.rs:346:10:346:11 | n1 |  |
+| main.rs:345:9:345:10 | n1 | main.rs:345:9:345:10 | [SSA] n1 |  |
+| main.rs:345:14:345:20 | arr1[2] | main.rs:345:9:345:10 | n1 |  |
+| main.rs:348:9:348:12 | [SSA] arr2 | main.rs:349:14:349:17 | arr2 |  |
+| main.rs:348:9:348:12 | arr2 | main.rs:348:9:348:12 | [SSA] arr2 |  |
+| main.rs:348:16:348:31 | [...; 10] | main.rs:348:9:348:12 | arr2 |  |
+| main.rs:349:9:349:10 | [SSA] n2 | main.rs:350:10:350:11 | n2 |  |
+| main.rs:349:9:349:10 | n2 | main.rs:349:9:349:10 | [SSA] n2 |  |
+| main.rs:349:14:349:20 | arr2[4] | main.rs:349:9:349:10 | n2 |  |
+| main.rs:352:9:352:12 | [SSA] arr3 | main.rs:353:14:353:17 | arr3 |  |
+| main.rs:352:9:352:12 | arr3 | main.rs:352:9:352:12 | [SSA] arr3 |  |
+| main.rs:352:16:352:24 | [...] | main.rs:352:9:352:12 | arr3 |  |
+| main.rs:353:9:353:10 | [SSA] n3 | main.rs:354:10:354:11 | n3 |  |
+| main.rs:353:9:353:10 | n3 | main.rs:353:9:353:10 | [SSA] n3 |  |
+| main.rs:353:14:353:20 | arr3[2] | main.rs:353:9:353:10 | n3 |  |
+| main.rs:358:9:358:12 | [SSA] arr1 | main.rs:359:15:359:18 | arr1 |  |
+| main.rs:358:9:358:12 | arr1 | main.rs:358:9:358:12 | [SSA] arr1 |  |
+| main.rs:358:16:358:33 | [...] | main.rs:358:9:358:12 | arr1 |  |
+| main.rs:359:9:359:10 | [SSA] n1 | main.rs:360:14:360:15 | n1 |  |
+| main.rs:359:9:359:10 | n1 | main.rs:359:9:359:10 | [SSA] n1 |  |
+| main.rs:363:9:363:12 | [SSA] arr2 | main.rs:364:15:364:18 | arr2 |  |
+| main.rs:363:9:363:12 | arr2 | main.rs:363:9:363:12 | [SSA] arr2 |  |
+| main.rs:363:16:363:24 | [...] | main.rs:363:9:363:12 | arr2 |  |
+| main.rs:364:5:366:5 | for ... in ... { ... } | main.rs:357:21:367:1 | { ... } |  |
+| main.rs:364:9:364:10 | [SSA] n2 | main.rs:365:14:365:15 | n2 |  |
+| main.rs:364:9:364:10 | n2 | main.rs:364:9:364:10 | [SSA] n2 |  |
+| main.rs:370:9:370:12 | [SSA] arr1 | main.rs:371:11:371:14 | arr1 |  |
+| main.rs:370:9:370:12 | arr1 | main.rs:370:9:370:12 | [SSA] arr1 |  |
+| main.rs:370:16:370:33 | [...] | main.rs:370:9:370:12 | arr1 |  |
+| main.rs:371:5:377:5 | match arr1 { ... } | main.rs:369:26:378:1 | { ... } |  |
+| main.rs:371:11:371:14 | arr1 | main.rs:372:9:372:17 | SlicePat |  |
+| main.rs:372:10:372:10 | [SSA] a | main.rs:373:18:373:18 | a |  |
+| main.rs:372:10:372:10 | a | main.rs:372:10:372:10 | [SSA] a |  |
+| main.rs:372:13:372:13 | [SSA] b | main.rs:374:18:374:18 | b |  |
+| main.rs:372:13:372:13 | b | main.rs:372:13:372:13 | [SSA] b |  |
+| main.rs:372:16:372:16 | [SSA] c | main.rs:375:18:375:18 | c |  |
+| main.rs:372:16:372:16 | c | main.rs:372:16:372:16 | [SSA] c |  |
+| main.rs:372:22:376:9 | { ... } | main.rs:371:5:377:5 | match arr1 { ... } |  |
+| main.rs:381:9:381:19 | [SSA] mut_arr | main.rs:382:10:382:16 | mut_arr |  |
+| main.rs:381:9:381:19 | mut_arr | main.rs:381:9:381:19 | [SSA] mut_arr |  |
+| main.rs:381:23:381:31 | [...] | main.rs:381:9:381:19 | mut_arr |  |
+| main.rs:382:10:382:16 | [post] mut_arr | main.rs:384:5:384:11 | mut_arr |  |
+| main.rs:382:10:382:16 | mut_arr | main.rs:384:5:384:11 | mut_arr |  |
+| main.rs:384:5:384:11 | [post] mut_arr | main.rs:385:13:385:19 | mut_arr |  |
+| main.rs:384:5:384:11 | mut_arr | main.rs:385:13:385:19 | mut_arr |  |
+| main.rs:384:18:384:27 | source(...) | main.rs:384:5:384:14 | mut_arr[1] |  |
+| main.rs:385:9:385:9 | [SSA] d | main.rs:386:10:386:10 | d |  |
+| main.rs:385:9:385:9 | d | main.rs:385:9:385:9 | [SSA] d |  |
+| main.rs:385:13:385:19 | [post] mut_arr | main.rs:387:10:387:16 | mut_arr |  |
+| main.rs:385:13:385:19 | mut_arr | main.rs:387:10:387:16 | mut_arr |  |
+| main.rs:385:13:385:22 | mut_arr[1] | main.rs:385:9:385:9 | d |  |
+| main.rs:392:39:392:43 | [SSA] names | main.rs:394:23:394:27 | names |  |
+| main.rs:392:39:392:43 | names | main.rs:392:39:392:43 | [SSA] names |  |
+| main.rs:392:39:392:72 | ...: Vec::<...> | main.rs:392:39:392:43 | names |  |
+| main.rs:393:7:393:18 | default_name | main.rs:393:7:393:18 | [SSA] default_name |  |
+| main.rs:393:22:393:43 | ... .to_string(...) | main.rs:393:7:393:18 | default_name |  |
+| main.rs:393:22:393:43 | ... .to_string(...) | main.rs:394:7:394:18 | phi(default_name) |  |
+| main.rs:394:3:400:3 | for ... in ... { ... } | main.rs:392:75:401:1 | { ... } |  |
+| main.rs:394:7:394:18 | phi(default_name) | main.rs:394:7:394:18 | phi(default_name) |  |
+| main.rs:394:7:394:18 | phi(default_name) | main.rs:396:35:396:61 | default_name |  |
+| main.rs:394:8:394:11 | [SSA] cond | main.rs:395:8:395:11 | cond |  |
+| main.rs:394:8:394:11 | cond | main.rs:394:8:394:11 | [SSA] cond |  |
+| main.rs:394:14:394:17 | [SSA] name | main.rs:396:15:396:18 | name |  |
+| main.rs:394:14:394:17 | name | main.rs:394:14:394:17 | [SSA] name |  |
+| main.rs:395:5:399:5 | if cond {...} | main.rs:394:29:400:3 | { ... } |  |
+| main.rs:396:11:396:11 | [SSA] n | main.rs:397:12:397:12 | n |  |
+| main.rs:396:11:396:11 | n | main.rs:396:11:396:11 | [SSA] n |  |
+| main.rs:396:15:396:62 | name.unwrap_or_else(...) | main.rs:396:11:396:11 | n |  |
+| main.rs:396:35:396:61 | [post] default_name | main.rs:394:7:394:18 | phi(default_name) |  |
+| main.rs:396:35:396:61 | closure self in \|...\| ... | main.rs:396:38:396:49 | this |  |
+| main.rs:396:35:396:61 | default_name | main.rs:394:7:394:18 | phi(default_name) |  |
+| main.rs:410:9:410:9 | [SSA] s | main.rs:411:10:411:10 | s |  |
+| main.rs:410:9:410:9 | s | main.rs:410:9:410:9 | [SSA] s |  |
+| main.rs:410:13:410:27 | MacroExpr | main.rs:410:9:410:9 | s |  |
+| main.rs:410:25:410:26 | source(...) | main.rs:410:13:410:27 | MacroExpr |  |
+| main.rs:436:13:436:33 | result_questionmark(...) | main.rs:436:9:436:9 | _ |  |
+| main.rs:448:36:448:41 | ...::new(...) | main.rs:448:36:448:41 | MacroExpr |  |
+models
+| 1 | Summary: lang:core; <crate::option::Option>::unwrap; Argument[self].Variant[crate::option::Option::Some(0)]; ReturnValue; value |
+| 2 | Summary: lang:core; <crate::option::Option>::unwrap_or; Argument[0]; ReturnValue; value |
+| 3 | Summary: lang:core; <crate::option::Option>::unwrap_or; Argument[self].Variant[crate::option::Option::Some(0)]; ReturnValue; value |
+| 4 | Summary: lang:core; <crate::result::Result>::unwrap; Argument[self].Variant[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 5 | Summary: lang:core; <crate::result::Result>::unwrap_or; Argument[0]; ReturnValue; value |
+| 6 | Summary: lang:core; <crate::result::Result>::unwrap_or; Argument[self].Variant[crate::result::Result::Ok(0)]; ReturnValue; value |
+| 7 | Summary: lang:core; crate::hint::must_use; Argument[0]; ReturnValue; value |
 storeStep
 | file://:0:0:0:0 | [summary] to write: ReturnValue.Variant[crate::result::Result::Ok(0)] in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | Ok | file://:0:0:0:0 | [summary] to write: ReturnValue in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text |
 | main.rs:94:14:94:22 | source(...) | tuple.0 | main.rs:94:13:94:26 | TupleExpr |

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.ql
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.ql
@@ -1,7 +1,19 @@
 import codeql.rust.dataflow.DataFlow
 import codeql.rust.dataflow.internal.DataFlowImpl
+import utils.test.TranslateModels
 
-query predicate localStep = DataFlow::localFlowStep/2;
+private predicate provenance(string model) { RustDataFlow::simpleLocalFlowStep(_, _, model) }
+
+private module Tm = TranslateModels<provenance/1>;
+
+query predicate models = Tm::models/2;
+
+query predicate localStep(Node nodeFrom, Node nodeTo, string model) {
+  exists(string madId |
+    RustDataFlow::simpleLocalFlowStep(nodeFrom, nodeTo, madId) and
+    Tm::translateModels(madId, model)
+  )
+}
 
 query predicate storeStep = RustDataFlow::storeStep/3;
 

--- a/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.expected
@@ -1,6 +1,7 @@
-| file://:0:0:0:0 | [summary param] 0 in lang:alloc::_::crate::fmt::format | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::crate::fmt::format | MaD:35 |
-| file://:0:0:0:0 | [summary param] self in lang:alloc::_::<crate::string::String>::as_str | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::<crate::string::String>::as_str | MaD:33 |
-| file://:0:0:0:0 | [summary param] self in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | file://:0:0:0:0 | [summary] to write: ReturnValue.Variant[crate::result::Result::Ok(0)] in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | MaD:12 |
+additionalTaintStep
+| file://:0:0:0:0 | [summary param] 0 in lang:alloc::_::crate::fmt::format | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::crate::fmt::format | MaD:2 |
+| file://:0:0:0:0 | [summary param] self in lang:alloc::_::<crate::string::String>::as_str | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::<crate::string::String>::as_str | MaD:1 |
+| file://:0:0:0:0 | [summary param] self in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | file://:0:0:0:0 | [summary] to write: ReturnValue.Variant[crate::result::Result::Ok(0)] in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | MaD:3 |
 | main.rs:4:5:4:8 | 1000 | main.rs:4:5:4:12 | ... + ... |  |
 | main.rs:4:12:4:12 | i | main.rs:4:5:4:12 | ... + ... |  |
 | main.rs:8:20:8:20 | s | main.rs:8:14:8:20 | FormatArgsExpr |  |
@@ -17,3 +18,7 @@
 | main.rs:64:24:64:24 | s | main.rs:64:24:64:27 | s[1] |  |
 | main.rs:64:24:64:27 | s[1] | main.rs:64:18:64:27 | FormatArgsExpr |  |
 | main.rs:69:9:69:12 | arr2 | main.rs:69:9:69:15 | arr2[1] |  |
+models
+| 1 | Summary: lang:alloc; <crate::string::String>::as_str; Argument[self]; ReturnValue; taint |
+| 2 | Summary: lang:alloc; crate::fmt::format; Argument[0]; ReturnValue; taint |
+| 3 | Summary: repo:https://github.com/seanmonstar/reqwest:reqwest; <crate::blocking::response::Response>::text; Argument[self]; ReturnValue.Variant[crate::result::Result::Ok(0)]; taint |

--- a/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.ql
+++ b/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.ql
@@ -1,4 +1,18 @@
 import codeql.rust.dataflow.DataFlow
 import codeql.rust.dataflow.internal.TaintTrackingImpl
+import utils.test.TranslateModels
 
-query predicate additionalTaintStep = RustTaintTracking::defaultAdditionalTaintStep/3;
+private predicate provenance(string model) {
+  RustTaintTracking::defaultAdditionalTaintStep(_, _, model)
+}
+
+private module Tm = TranslateModels<provenance/1>;
+
+query predicate models = Tm::models/2;
+
+query predicate additionalTaintStep(DataFlow::Node pred, DataFlow::Node succ, string model) {
+  exists(string madId |
+    RustTaintTracking::defaultAdditionalTaintStep(pred, succ, madId) and
+    Tm::translateModels(madId, model)
+  )
+}

--- a/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
+++ b/shared/dataflow/codeql/dataflow/test/ProvenancePathGraph.qll
@@ -16,7 +16,8 @@ signature class PathNodeSig {
 
 private signature predicate provenanceSig(string model);
 
-private module TranslateModels<
+/** Translates models-as-data provenance information into a format that can be used in tests. */
+module TranslateModels<
   interpretModelForTestSig/2 interpretModelForTest0, provenanceSig/1 provenance>
 {
   private predicate madIds(string madId) {
@@ -79,6 +80,7 @@ private module TranslateModels<
     )
   }
 
+  /** Holds if the model `model1` should be translated to `model2`. */
   predicate translateModels(string model1, string model2) {
     exists(int i |
       translateModelsPart(model1, model2, i) and


### PR DESCRIPTION
I also updated `rust/ql/test/library-tests/dataflow/local/DataFlowStep.ql` to test the local flow step relation used by global data flow instead of the exposed local step relation.