### PR TITLE
feat(rust:) Add initial RuSQLite support

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/rusqlite.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/rusqlite.model.yml
@@ -1,0 +1,11 @@
+extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: sinkModel
+    data:
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::execute", "Argument[0]", "sql-injection", "manual"]
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::execute_batch", "Argument[0]", "sql-injection", "manual"]
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::prepare", "Argument[0]", "sql-injection", "manual"]
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::prepare_with_flags", "Argument[0]", "sql-injection", "manual"]
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::query_row", "Argument[0]", "sql-injection", "manual"]
+      - ["repo:https://github.com/rusqlite/rusqlite:rusqlite", "<crate::Connection>::query_row_and_then", "Argument[0]", "sql-injection", "manual"]

--- a/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/taint/TaintFlowStep.expected
@@ -1,5 +1,5 @@
-| file://:0:0:0:0 | [summary param] 0 in lang:alloc::_::crate::fmt::format | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::crate::fmt::format | MaD:24 |
-| file://:0:0:0:0 | [summary param] self in lang:alloc::_::<crate::string::String>::as_str | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::<crate::string::String>::as_str | MaD:22 |
+| file://:0:0:0:0 | [summary param] 0 in lang:alloc::_::crate::fmt::format | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::crate::fmt::format | MaD:34 |
+| file://:0:0:0:0 | [summary param] self in lang:alloc::_::<crate::string::String>::as_str | file://:0:0:0:0 | [summary] to write: ReturnValue in lang:alloc::_::<crate::string::String>::as_str | MaD:32 |
 | file://:0:0:0:0 | [summary param] self in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | file://:0:0:0:0 | [summary] to write: ReturnValue.Variant[crate::result::Result::Ok(0)] in repo:https://github.com/seanmonstar/reqwest:reqwest::_::<crate::blocking::response::Response>::text | MaD:10 |
 | main.rs:4:5:4:8 | 1000 | main.rs:4:5:4:12 | ... + ... |  |
 | main.rs:4:12:4:12 | i | main.rs:4:5:4:12 | ... + ... |  |

--- a/rust/ql/test/library-tests/frameworks/rusqlite/Rusqlite.ql
+++ b/rust/ql/test/library-tests/frameworks/rusqlite/Rusqlite.ql
@@ -1,0 +1,20 @@
+import rust
+import codeql.rust.security.SqlInjectionExtensions
+import codeql.rust.Concepts
+import utils.test.InlineExpectationsTest
+
+module RusqliteTest implements TestSig {
+  string getARelevantTag() { result = ["sql-sink"] }
+
+  predicate hasActualResult(Location location, string element, string tag, string value) {
+    exists(SqlInjection::Sink sink |
+      location = sink.getLocation() and
+      location.getFile().getBaseName() != "" and
+      element = sink.toString() and
+      tag = "sql-sink" and
+      value = ""
+    )
+  }
+}
+
+import MakeTest<RusqliteTest>

--- a/rust/ql/test/library-tests/frameworks/rusqlite/cargo.toml.manual
+++ b/rust/ql/test/library-tests/frameworks/rusqlite/cargo.toml.manual
@@ -1,0 +1,13 @@
+[workspace]
+
+[package]
+name = "rusqlite-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rusqlite = { version = "0.33", features = ["bundled"] }
+
+[[bin]]
+name = "rusqlite"
+path = "./main.rs"

--- a/rust/ql/test/library-tests/frameworks/rusqlite/main.rs
+++ b/rust/ql/test/library-tests/frameworks/rusqlite/main.rs
@@ -1,0 +1,50 @@
+
+use rusqlite::Connection;
+
+#[derive(Debug)]
+struct Person {
+    id: i32,
+    name: String,
+    age: i32,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get input from CLI
+    let args: Vec<String> = std::env::args().collect();
+    let name = &args[1];
+    let age = &args[2];
+
+    let connection = Connection::open_in_memory()?;
+
+    connection.execute(       // $ sql-sink
+        "CREATE TABLE person (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR NOT NULL,
+            age INT NOT NULL
+        )",
+        (),
+    )?;
+    
+    let query = format!("INSERT INTO person (name, age) VALUES ('{}', '{}')", name, age);
+
+    connection.execute(&query, ())?;    // $ sql-sink
+
+    let person = connection.query_row(&query, (), |row| {    // $ sql-sink
+        Ok(Person {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            age: row.get(2)?,
+        })
+    })?;
+
+    let mut stmt = connection.prepare("SELECT id, name, age FROM person")?;      // $ sql-sink
+    let people = stmt.query_map([], |row| {
+        Ok(Person {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            age: row.get(2)?,
+        })
+    })?;
+
+    Ok(())
+}

--- a/rust/ql/test/library-tests/frameworks/rusqlite/options.yml
+++ b/rust/ql/test/library-tests/frameworks/rusqlite/options.yml
@@ -1,0 +1,3 @@
+qltest_cargo_check: true
+qltest_dependencies:
+    - rusqlite = { version = "0.33", features = ["bundled"] }


### PR DESCRIPTION
This PR adds support for RuSQLite driver support.

### Pull Request checklist

#### All query authors

- [ ] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- [ ] All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.
- [ ] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- [ ] New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.

#### Internal query authors only

- [ ] Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).
- [ ] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- [ ] Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).
