### PR TITLE
C++: Fix join order problem in TaintedAllocationSize.

### DIFF
--- a/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
+++ b/cpp/ql/src/Security/CWE/CWE-190/TaintedAllocationSize.ql
@@ -33,8 +33,9 @@ predicate allocSink(HeuristicAllocationExpr alloc, DataFlow::Node sink) {
   )
 }
 
-predicate readsVariable(LoadInstruction load, Variable var) {
-  load.getSourceAddress().(VariableAddressInstruction).getAstVariable() = var
+predicate readsVariable(LoadInstruction load, Variable var, IRBlock bb) {
+  load.getSourceAddress().(VariableAddressInstruction).getAstVariable() = var and
+  bb = load.getBlock()
 }
 
 predicate hasUpperBoundsCheck(Variable var) {
@@ -46,10 +47,18 @@ predicate hasUpperBoundsCheck(Variable var) {
   )
 }
 
-predicate nodeIsBarrierEqualityCandidate(DataFlow::Node node, Operand access, Variable checkedVar) {
-  exists(Instruction instr | instr = node.asOperand().getDef() |
-    readsVariable(instr, checkedVar) and
-    any(IRGuardCondition guard).ensuresEq(access, _, _, instr.getBlock(), true)
+predicate variableEqualityCheckedInBlock(Variable checkedVar, IRBlock bb) {
+  exists(Operand access |
+    readsVariable(access.getDef(), checkedVar, _) and
+    any(IRGuardCondition guard).ensuresEq(access, _, _, bb, true)
+  )
+}
+
+predicate nodeIsBarrierEquality(DataFlow::Node node) {
+  exists(Variable checkedVar, Instruction instr, IRBlock bb |
+    instr = node.asOperand().getDef() and
+    readsVariable(instr, checkedVar, bb) and
+    variableEqualityCheckedInBlock(checkedVar, bb)
   )
 }
 
@@ -72,14 +81,11 @@ module TaintedAllocationSizeConfig implements DataFlow::ConfigSig {
     )
     or
     exists(Variable checkedVar, Instruction instr | instr = node.asOperand().getDef() |
-      readsVariable(instr, checkedVar) and
+      readsVariable(instr, checkedVar, _) and
       hasUpperBoundsCheck(checkedVar)
     )
     or
-    exists(Variable checkedVar, Operand access |
-      readsVariable(access.getDef(), checkedVar) and
-      nodeIsBarrierEqualityCandidate(node, access, checkedVar)
-    )
+    nodeIsBarrierEquality(node)
     or
     // block flow to inside of identified allocation functions (this flow leads
     // to duplicate results)


### PR DESCRIPTION
Alternative to https://github.com/github/codeql/pull/18564. Hopefully this should be a much better join-order: This reorders the two `readsVariable` conjuncts pushing one into the offending predicate and pulling the other out. The result is `variableEqualityCheckedInBlock(Variable checkedVar, IRBlock bb)` which appears to have a good column correlation (i.e. small size), and it's simple enough to handle the inlined `ensuresEq`. This makes sense since its semantic interpretation also seems like a reasonable thing to materialise. The subsequent join is fast when it happens on both columns, which we ensure by adding the basic block as an additional column to `readsVariable` (it's functional so should be a safe addition).