### PR TITLE
Go: 1.24 support - Tolerate type parameters on alias types

### DIFF
--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -475,11 +475,11 @@ func extractObjects(tw *trap.Writer, scope *types.Scope, scopeLabel trap.Label) 
 				populateTypeParamParents(funcObj.Type().(*types.Signature).TypeParams(), obj)
 				populateTypeParamParents(funcObj.Type().(*types.Signature).RecvTypeParams(), obj)
 			}
-			// Populate type parameter parents for named types. Note that we
-			// skip type aliases as the original type should be the parent
-			// of any type parameters.
-			if typeNameObj, ok := obj.(*types.TypeName); ok && !typeNameObj.IsAlias() {
+			// Populate type parameter parents for named types.
+			if typeNameObj, ok := obj.(*types.TypeName); ok {
 				if tp, ok := typeNameObj.Type().(*types.Named); ok {
+					populateTypeParamParents(tp.TypeParams(), obj)
+				} else if tp, ok := typeNameObj.Type().(*types.Alias); ok {
 					populateTypeParamParents(tp.TypeParams(), obj)
 				}
 			}

--- a/go/extractor/extractor.go
+++ b/go/extractor/extractor.go
@@ -477,7 +477,7 @@ func extractObjects(tw *trap.Writer, scope *types.Scope, scopeLabel trap.Label) 
 			}
 			// Populate type parameter parents for named types.
 			if typeNameObj, ok := obj.(*types.TypeName); ok {
-				if tp, ok := typeNameObj.Type().(*types.Named); ok {
+				if tp, ok := typeNameObj.Type().(*types.Named); ok && !typeNameObj.IsAlias() {
 					populateTypeParamParents(tp.TypeParams(), obj)
 				} else if tp, ok := typeNameObj.Type().(*types.Alias); ok {
 					populateTypeParamParents(tp.TypeParams(), obj)


### PR DESCRIPTION
This is a small part of https://github.com/github/codeql/pull/18306 that can be merged in advance and means that the extractor won't fail on code using type paramters on type aliases, which is a new language feature in go 1.24. It is not tested in this PR as that would involve the test using 1.24, but it is tested in the original PR.