### PR TITLE
Rust: Add two additional control flow tests

### DIFF
--- a/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
+++ b/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
@@ -160,500 +160,519 @@ dominates
 | test.rs:130:9:134:9 | if ... {...} else {...} | test.rs:130:9:134:9 | if ... {...} else {...} |
 | test.rs:131:13:131:13 | 0 | test.rs:131:13:131:13 | 0 |
 | test.rs:133:13:133:13 | n | test.rs:133:13:133:13 | n |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:138:9:142:9 | if ... {...} else {...} |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:138:21:138:21 | n |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:141:13:141:13 | 0 |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:138:9:142:9 | if ... {...} else {...} |
-| test.rs:138:21:138:21 | n | test.rs:138:21:138:21 | n |
-| test.rs:141:13:141:13 | 0 | test.rs:141:13:141:13 | 0 |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:145:5:150:5 | exit fn test_if_let (normal) |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:146:9:148:9 | if ... {...} |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:146:21:146:21 | n |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:145:5:150:5 | exit fn test_if_let (normal) |
-| test.rs:146:9:148:9 | if ... {...} | test.rs:146:9:148:9 | if ... {...} |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:137:5:143:5 | enter fn test_if_without_else |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:139:9:141:9 | if b {...} |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:140:13:140:19 | ExprStmt |
+| test.rs:139:9:141:9 | if b {...} | test.rs:139:9:141:9 | if b {...} |
+| test.rs:140:13:140:19 | ExprStmt | test.rs:140:13:140:19 | ExprStmt |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:146:9:150:9 | if ... {...} else {...} |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:146:21:146:21 | n |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:149:13:149:13 | 0 |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:146:9:150:9 | if ... {...} else {...} |
 | test.rs:146:21:146:21 | n | test.rs:146:21:146:21 | n |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:9:157:9 | if ... {...} else {...} |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:24:153:24 | a |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:41:153:41 | a |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:154:13:154:13 | 1 |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:156:13:156:13 | 0 |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:9:157:9 | if ... {...} else {...} |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:156:13:156:13 | 0 |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:154:13:154:13 | 1 |
-| test.rs:153:22:153:32 | [boolean(false)] { ... } | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:153:22:153:32 | [boolean(true)] { ... } | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:153:24:153:24 | a | test.rs:153:24:153:24 | a |
-| test.rs:153:39:153:48 | [boolean(false)] { ... } | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:153:39:153:48 | [boolean(true)] { ... } | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:153:41:153:41 | a | test.rs:153:41:153:41 | a |
-| test.rs:154:13:154:13 | 1 | test.rs:154:13:154:13 | 1 |
-| test.rs:156:13:156:13 | 0 | test.rs:156:13:156:13 | 0 |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:161:9:168:9 | if ... {...} else {...} |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:162:18:162:21 | true |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:163:13:163:13 | _ |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:165:13:165:13 | 1 |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:167:13:167:13 | 0 |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:161:9:168:9 | if ... {...} else {...} |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:167:13:167:13 | 0 |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:165:13:165:13 | 1 |
-| test.rs:162:18:162:21 | true | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:162:18:162:21 | true | test.rs:162:18:162:21 | true |
-| test.rs:162:18:162:21 | true | test.rs:165:13:165:13 | 1 |
-| test.rs:163:13:163:13 | _ | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:163:13:163:13 | _ | test.rs:163:13:163:13 | _ |
-| test.rs:163:13:163:13 | _ | test.rs:167:13:167:13 | 0 |
-| test.rs:165:13:165:13 | 1 | test.rs:165:13:165:13 | 1 |
-| test.rs:167:13:167:13 | 0 | test.rs:167:13:167:13 | 0 |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:9:179:9 | if ... {...} else {...} |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:176:13:176:13 | 1 |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:178:13:178:13 | 0 |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:172:9:179:9 | if ... {...} else {...} |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:178:13:178:13 | 0 |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:176:13:176:13 | 1 |
-| test.rs:176:13:176:13 | 1 | test.rs:176:13:176:13 | 1 |
-| test.rs:178:13:178:13 | 0 | test.rs:178:13:178:13 | 0 |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:9:191:9 | if ... {...} else {...} |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:188:13:188:13 | 1 |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:190:13:190:13 | 0 |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:184:9:191:9 | if ... {...} else {...} |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:190:13:190:13 | 0 |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:188:13:188:13 | 1 |
-| test.rs:188:13:188:13 | 1 | test.rs:188:13:188:13 | 1 |
-| test.rs:190:13:190:13 | 0 | test.rs:190:13:190:13 | 0 |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:195:9:204:9 | if ... {...} else {...} |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:201:13:201:13 | 1 |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:203:13:203:13 | 0 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:195:9:204:9 | if ... {...} else {...} |
-| test.rs:196:13:198:13 | if ... {...} | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:195:9:204:9 | if ... {...} else {...} |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:201:13:201:13 | 1 |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:203:13:203:13 | 0 |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:203:13:203:13 | 0 |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:201:13:201:13 | 1 |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:195:9:204:9 | if ... {...} else {...} |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:201:13:201:13 | 1 |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:203:13:203:13 | 0 |
-| test.rs:201:13:201:13 | 1 | test.rs:201:13:201:13 | 1 |
-| test.rs:203:13:203:13 | 0 | test.rs:203:13:203:13 | 0 |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:208:9:217:9 | if ... {...} else {...} |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:214:13:214:13 | 1 |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:216:13:216:13 | 0 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:208:9:217:9 | if ... {...} else {...} |
-| test.rs:209:13:211:13 | if ... {...} | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:208:9:217:9 | if ... {...} else {...} |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:214:13:214:13 | 1 |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:216:13:216:13 | 0 |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:216:13:216:13 | 0 |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:214:13:214:13 | 1 |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:208:9:217:9 | if ... {...} else {...} |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:214:13:214:13 | 1 |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:216:13:216:13 | 0 |
-| test.rs:214:13:214:13 | 1 | test.rs:214:13:214:13 | 1 |
-| test.rs:216:13:216:13 | 0 | test.rs:216:13:216:13 | 0 |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:221:9:227:9 | if ... {...} else {...} |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:224:13:224:13 | 1 |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:226:13:226:13 | 0 |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:221:9:227:9 | if ... {...} else {...} |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:226:13:226:13 | 0 |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:224:13:224:13 | 1 |
-| test.rs:224:13:224:13 | 1 | test.rs:224:13:224:13 | 1 |
-| test.rs:226:13:226:13 | 0 | test.rs:226:13:226:13 | 0 |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:17:234:22 | [boolean(false)] ... && ... |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:17:234:27 | ... && ... |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:22:234:22 | b |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:27:234:27 | c |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:234:17:234:22 | [boolean(false)] ... && ... |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:27:234:27 | c |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:17:234:27 | ... && ... |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:234:22:234:22 | b | test.rs:234:22:234:22 | b |
-| test.rs:234:22:234:22 | b | test.rs:234:27:234:27 | c |
-| test.rs:234:27:234:27 | c | test.rs:234:27:234:27 | c |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:17:239:27 | ... \|\| ... |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:22:239:22 | b |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:27:239:27 | c |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:27:239:27 | c |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:17:239:27 | ... \|\| ... |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:239:22:239:22 | b | test.rs:239:22:239:22 | b |
-| test.rs:239:22:239:22 | b | test.rs:239:27:239:27 | c |
-| test.rs:239:27:239:27 | c | test.rs:239:27:239:27 | c |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:17:244:35 | ... \|\| ... |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:23:244:23 | b |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:35:244:35 | c |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:35:244:35 | c |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:17:244:35 | ... \|\| ... |
-| test.rs:244:23:244:23 | b | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:244:23:244:23 | b | test.rs:244:23:244:23 | b |
-| test.rs:244:23:244:23 | b | test.rs:244:35:244:35 | c |
-| test.rs:244:35:244:35 | c | test.rs:244:35:244:35 | c |
-| test.rs:248:5:251:5 | enter fn test_not_operator | test.rs:248:5:251:5 | enter fn test_not_operator |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:9:258:9 | if ... {...} else {...} |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:17:254:17 | b |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:22:254:22 | c |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:255:13:255:16 | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:257:13:257:17 | false |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:9:258:9 | if ... {...} else {...} |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:22:254:22 | c |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:257:13:257:17 | false |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:17:254:17 | b | test.rs:254:17:254:17 | b |
-| test.rs:254:17:254:17 | b | test.rs:254:22:254:22 | c |
-| test.rs:254:17:254:17 | b | test.rs:255:13:255:16 | true |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:22:254:22 | c | test.rs:254:22:254:22 | c |
-| test.rs:254:22:254:22 | c | test.rs:255:13:255:16 | true |
-| test.rs:255:13:255:16 | true | test.rs:255:13:255:16 | true |
-| test.rs:257:13:257:17 | false | test.rs:257:13:257:17 | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:9:266:9 | if ... {...} else {...} |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:17:262:17 | b |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:22:262:22 | c |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:263:13:263:16 | true |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:265:13:265:17 | false |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:9:266:9 | if ... {...} else {...} |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:22:262:22 | c |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:263:13:263:16 | true |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:17:262:17 | b | test.rs:262:17:262:17 | b |
-| test.rs:262:17:262:17 | b | test.rs:262:22:262:22 | c |
-| test.rs:262:17:262:17 | b | test.rs:265:13:265:17 | false |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:22:262:22 | c | test.rs:262:22:262:22 | c |
-| test.rs:262:22:262:22 | c | test.rs:265:13:265:17 | false |
-| test.rs:263:13:263:16 | true | test.rs:263:13:263:16 | true |
-| test.rs:265:13:265:17 | false | test.rs:265:13:265:17 | false |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:9:274:9 | if ... {...} else {...} |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:271:13:271:16 | true |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:273:13:273:17 | false |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:270:9:274:9 | if ... {...} else {...} |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:273:13:273:17 | false |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:271:13:271:16 | true |
-| test.rs:271:13:271:16 | true | test.rs:271:13:271:16 | true |
-| test.rs:273:13:273:17 | false | test.rs:273:13:273:17 | false |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:277:5:279:5 | exit fn test_and_return (normal) |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:9:278:19 | ... && ... |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:14:278:19 | return |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:277:5:279:5 | exit fn test_and_return (normal) |
-| test.rs:278:9:278:19 | ... && ... | test.rs:278:9:278:19 | ... && ... |
-| test.rs:278:14:278:19 | return | test.rs:278:14:278:19 | return |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:281:5:286:5 | exit fn test_and_true (normal) |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:9:284:9 | if ... {...} |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:18:282:21 | true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:281:5:286:5 | exit fn test_and_true (normal) |
-| test.rs:282:9:284:9 | if ... {...} | test.rs:282:9:284:9 | if ... {...} |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:9:284:9 | if ... {...} |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:282:18:282:21 | true | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:282:18:282:21 | true | test.rs:282:18:282:21 | true |
-| test.rs:282:18:282:21 | true | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 |
-| test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) |
-| test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | test.rs:293:32:293:32 | 4 |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) |
-| test.rs:293:32:293:32 | 4 | test.rs:293:32:293:32 | 4 |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:297:9:300:9 | match ... { ... } |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:298:13:298:16 | true |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:298:21:298:24 | Some |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:299:13:299:17 | false |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:297:9:300:9 | match ... { ... } |
-| test.rs:298:13:298:16 | true | test.rs:297:9:300:9 | match ... { ... } |
-| test.rs:298:13:298:16 | true | test.rs:298:13:298:16 | true |
-| test.rs:298:13:298:16 | true | test.rs:298:21:298:24 | Some |
-| test.rs:298:13:298:16 | true | test.rs:299:13:299:17 | false |
-| test.rs:298:21:298:24 | Some | test.rs:298:21:298:24 | Some |
-| test.rs:299:13:299:17 | false | test.rs:299:13:299:17 | false |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:308:9:312:9 | match maybe_digit { ... } |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:309:26:309:26 | x |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:309:42:309:42 | x |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:310:26:310:26 | x |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:311:13:311:24 | ...::None |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:308:9:312:9 | match maybe_digit { ... } |
-| test.rs:309:26:309:26 | x | test.rs:309:26:309:26 | x |
-| test.rs:309:26:309:26 | x | test.rs:309:42:309:42 | x |
-| test.rs:309:42:309:42 | x | test.rs:309:42:309:42 | x |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:310:26:310:26 | x |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:311:13:311:24 | ...::None |
-| test.rs:310:26:310:26 | x | test.rs:310:26:310:26 | x |
-| test.rs:311:13:311:24 | ...::None | test.rs:311:13:311:24 | ...::None |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:316:9:323:9 | match ... { ... } |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:317:13:317:21 | ExprStmt |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:321:26:321:26 | x |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:322:13:322:24 | ...::None |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:316:9:323:9 | match ... { ... } |
-| test.rs:317:13:317:21 | ExprStmt | test.rs:317:13:317:21 | ExprStmt |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:316:9:323:9 | match ... { ... } |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:321:26:321:26 | x |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:322:13:322:24 | ...::None |
-| test.rs:321:26:321:26 | x | test.rs:321:26:321:26 | x |
-| test.rs:322:13:322:24 | ...::None | test.rs:322:13:322:24 | ...::None |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:327:9:330:18 | ... && ... |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:327:10:330:9 | [boolean(false)] match r { ... } |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:328:18:328:18 | a |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:329:13:329:13 | _ |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:330:15:330:18 | cond |
-| test.rs:327:9:330:18 | ... && ... | test.rs:327:9:330:18 | ... && ... |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:327:10:330:9 | [boolean(false)] match r { ... } |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:330:15:330:18 | cond |
-| test.rs:328:18:328:18 | a | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:328:18:328:18 | a | test.rs:328:18:328:18 | a |
-| test.rs:328:18:328:18 | a | test.rs:330:15:330:18 | cond |
-| test.rs:329:13:329:13 | _ | test.rs:329:13:329:13 | _ |
-| test.rs:330:15:330:18 | cond | test.rs:330:15:330:18 | cond |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:334:9:337:9 | match r { ... } |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:335:16:335:20 | value |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:336:13:336:22 | Err(...) |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:334:9:337:9 | match r { ... } |
-| test.rs:335:16:335:20 | value | test.rs:335:16:335:20 | value |
-| test.rs:336:13:336:22 | Err(...) | test.rs:336:13:336:22 | Err(...) |
-| test.rs:343:5:346:5 | enter fn test_let_match | test.rs:343:5:346:5 | enter fn test_let_match |
-| test.rs:343:5:346:5 | enter fn test_let_match | test.rs:344:18:344:18 | n |
-| test.rs:343:5:346:5 | enter fn test_let_match | test.rs:344:39:344:53 | MacroStmts |
-| test.rs:344:18:344:18 | n | test.rs:344:18:344:18 | n |
-| test.rs:344:39:344:53 | MacroStmts | test.rs:344:39:344:53 | MacroStmts |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:348:5:354:5 | exit fn test_let_with_return (normal) |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:350:18:350:20 | ret |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:351:13:351:16 | None |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:348:5:354:5 | exit fn test_let_with_return (normal) |
-| test.rs:350:18:350:20 | ret | test.rs:350:18:350:20 | ret |
-| test.rs:351:13:351:16 | None | test.rs:351:13:351:16 | None |
-| test.rs:359:5:362:5 | enter fn empty_tuple_pattern | test.rs:359:5:362:5 | enter fn empty_tuple_pattern |
-| test.rs:366:5:370:5 | enter fn empty_struct_pattern | test.rs:366:5:370:5 | enter fn empty_struct_pattern |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:373:9:378:9 | match 42 { ... } |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:374:15:374:15 | 0 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:374:20:374:20 | 1 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:375:13:375:13 | 1 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:375:13:375:16 | RangePat |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:375:16:375:16 | 2 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:375:21:375:21 | 2 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:376:13:376:13 | 5 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:376:13:376:15 | RangePat |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:376:20:376:20 | 3 |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:377:13:377:13 | _ |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:373:9:378:9 | match 42 { ... } |
-| test.rs:374:15:374:15 | 0 | test.rs:374:15:374:15 | 0 |
-| test.rs:374:15:374:15 | 0 | test.rs:374:20:374:20 | 1 |
-| test.rs:374:20:374:20 | 1 | test.rs:374:20:374:20 | 1 |
-| test.rs:375:13:375:13 | 1 | test.rs:375:13:375:13 | 1 |
-| test.rs:375:13:375:13 | 1 | test.rs:375:16:375:16 | 2 |
-| test.rs:375:13:375:13 | 1 | test.rs:375:21:375:21 | 2 |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:13:375:13 | 1 |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:13:375:16 | RangePat |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:16:375:16 | 2 |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:21:375:21 | 2 |
-| test.rs:375:13:375:16 | RangePat | test.rs:376:13:376:13 | 5 |
-| test.rs:375:13:375:16 | RangePat | test.rs:376:13:376:15 | RangePat |
-| test.rs:375:13:375:16 | RangePat | test.rs:376:20:376:20 | 3 |
-| test.rs:375:13:375:16 | RangePat | test.rs:377:13:377:13 | _ |
-| test.rs:375:16:375:16 | 2 | test.rs:375:16:375:16 | 2 |
-| test.rs:375:16:375:16 | 2 | test.rs:375:21:375:21 | 2 |
-| test.rs:375:21:375:21 | 2 | test.rs:375:21:375:21 | 2 |
-| test.rs:376:13:376:13 | 5 | test.rs:376:13:376:13 | 5 |
-| test.rs:376:13:376:13 | 5 | test.rs:376:20:376:20 | 3 |
-| test.rs:376:13:376:15 | RangePat | test.rs:376:13:376:13 | 5 |
-| test.rs:376:13:376:15 | RangePat | test.rs:376:13:376:15 | RangePat |
-| test.rs:376:13:376:15 | RangePat | test.rs:376:20:376:20 | 3 |
-| test.rs:376:13:376:15 | RangePat | test.rs:377:13:377:13 | _ |
-| test.rs:376:20:376:20 | 3 | test.rs:376:20:376:20 | 3 |
-| test.rs:377:13:377:13 | _ | test.rs:377:13:377:13 | _ |
-| test.rs:383:5:388:5 | enter fn test_infinite_loop | test.rs:383:5:388:5 | enter fn test_infinite_loop |
-| test.rs:383:5:388:5 | enter fn test_infinite_loop | test.rs:385:13:385:14 | TupleExpr |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:385:13:385:14 | TupleExpr |
-| test.rs:392:5:394:5 | enter fn say_hello | test.rs:392:5:394:5 | enter fn say_hello |
-| test.rs:396:5:415:5 | enter fn async_block | test.rs:396:5:415:5 | enter fn async_block |
-| test.rs:397:26:399:9 | enter { ... } | test.rs:397:26:399:9 | enter { ... } |
-| test.rs:400:31:402:9 | enter { ... } | test.rs:400:31:402:9 | enter { ... } |
-| test.rs:409:22:414:9 | enter \|...\| ... | test.rs:409:22:414:9 | enter \|...\| ... |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:409:28:414:9 | exit { ... } (normal) |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:410:13:412:13 | if b {...} |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:411:17:411:41 | ExprStmt |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:409:28:414:9 | exit { ... } (normal) |
-| test.rs:410:13:412:13 | if b {...} | test.rs:410:13:412:13 | if b {...} |
-| test.rs:411:17:411:41 | ExprStmt | test.rs:411:17:411:41 | ExprStmt |
-| test.rs:421:5:423:5 | enter fn add_two | test.rs:421:5:423:5 | enter fn add_two |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:13:431:49 | ExprStmt |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(false)] ! ... |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | if ... {...} |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:13:431:49 | ExprStmt |
-| test.rs:431:13:431:49 | enter fn panic_cold_explicit | test.rs:431:13:431:49 | enter fn panic_cold_explicit |
-| test.rs:431:21:431:48 | [boolean(false)] ! ... | test.rs:431:21:431:48 | [boolean(false)] ! ... |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:13:431:49 | ExprStmt |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | if ... {...} |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:437:5:446:5 | enter fn const_block_panic |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:439:9:444:9 | if false {...} |
-| test.rs:439:9:444:9 | if false {...} | test.rs:439:9:444:9 | if false {...} |
-| test.rs:442:17:442:24 | enter fn panic_cold_explicit | test.rs:442:17:442:24 | enter fn panic_cold_explicit |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:449:1:454:1 | enter fn dead_code |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:451:9:451:17 | ExprStmt |
-| test.rs:451:9:451:17 | ExprStmt | test.rs:451:9:451:17 | ExprStmt |
-| test.rs:456:1:456:16 | enter fn do_thing | test.rs:456:1:456:16 | enter fn do_thing |
-| test.rs:458:1:460:1 | enter fn condition_not_met | test.rs:458:1:460:1 | enter fn condition_not_met |
-| test.rs:462:1:462:21 | enter fn do_next_thing | test.rs:462:1:462:21 | enter fn do_next_thing |
-| test.rs:464:1:464:21 | enter fn do_last_thing | test.rs:464:1:464:21 | enter fn do_last_thing |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:467:18:478:5 | 'block: { ... } |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:470:13:470:27 | ExprStmt |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:473:9:475:9 | if ... {...} |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:474:13:474:27 | ExprStmt |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:467:18:478:5 | 'block: { ... } |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:473:9:475:9 | if ... {...} |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:474:13:474:27 | ExprStmt |
-| test.rs:470:13:470:27 | ExprStmt | test.rs:470:13:470:27 | ExprStmt |
-| test.rs:473:9:475:9 | if ... {...} | test.rs:473:9:475:9 | if ... {...} |
-| test.rs:474:13:474:27 | ExprStmt | test.rs:474:13:474:27 | ExprStmt |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:482:1:490:1 | enter fn labelled_block2 |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:483:18:489:5 | 'block: { ... } |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:485:18:485:18 | y |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:486:13:486:27 | ExprStmt |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:483:18:489:5 | 'block: { ... } |
-| test.rs:485:18:485:18 | y | test.rs:485:18:485:18 | y |
-| test.rs:486:13:486:27 | ExprStmt | test.rs:486:13:486:27 | ExprStmt |
-| test.rs:492:1:498:1 | enter fn test_nested_function2 | test.rs:492:1:498:1 | enter fn test_nested_function2 |
-| test.rs:494:5:496:5 | enter fn nested | test.rs:494:5:496:5 | enter fn nested |
-| test.rs:509:5:511:5 | enter fn new | test.rs:509:5:511:5 | enter fn new |
-| test.rs:513:5:515:5 | enter fn negated | test.rs:513:5:515:5 | enter fn negated |
-| test.rs:517:5:519:5 | enter fn multifly_add | test.rs:517:5:519:5 | enter fn multifly_add |
+| test.rs:149:13:149:13 | 0 | test.rs:149:13:149:13 | 0 |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:153:5:158:5 | exit fn test_if_let (normal) |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:154:9:156:9 | if ... {...} |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:154:21:154:21 | n |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:153:5:158:5 | exit fn test_if_let (normal) |
+| test.rs:154:9:156:9 | if ... {...} | test.rs:154:9:156:9 | if ... {...} |
+| test.rs:154:21:154:21 | n | test.rs:154:21:154:21 | n |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:9:165:9 | if ... {...} else {...} |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:24:161:24 | a |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:41:161:41 | a |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:162:13:162:13 | 1 |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:164:13:164:13 | 0 |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:9:165:9 | if ... {...} else {...} |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:164:13:164:13 | 0 |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:162:13:162:13 | 1 |
+| test.rs:161:22:161:32 | [boolean(false)] { ... } | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:161:22:161:32 | [boolean(true)] { ... } | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:161:24:161:24 | a | test.rs:161:24:161:24 | a |
+| test.rs:161:39:161:48 | [boolean(false)] { ... } | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:161:39:161:48 | [boolean(true)] { ... } | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:161:41:161:41 | a | test.rs:161:41:161:41 | a |
+| test.rs:162:13:162:13 | 1 | test.rs:162:13:162:13 | 1 |
+| test.rs:164:13:164:13 | 0 | test.rs:164:13:164:13 | 0 |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:168:5:177:5 | enter fn test_nested_if_2 |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:169:9:176:9 | if cond1 {...} |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:170:13:174:13 | if cond2 {...} else {...} |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:169:9:176:9 | if cond1 {...} |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:170:13:174:13 | if cond2 {...} else {...} |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:170:13:174:13 | if cond2 {...} else {...} |
+| test.rs:171:17:171:30 | ExprStmt | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:173:17:173:30 | ExprStmt | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:180:9:187:9 | if ... {...} else {...} |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:181:18:181:21 | true |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:182:13:182:13 | _ |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:184:13:184:13 | 1 |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:186:13:186:13 | 0 |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:180:9:187:9 | if ... {...} else {...} |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:186:13:186:13 | 0 |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:184:13:184:13 | 1 |
+| test.rs:181:18:181:21 | true | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:181:18:181:21 | true | test.rs:181:18:181:21 | true |
+| test.rs:181:18:181:21 | true | test.rs:184:13:184:13 | 1 |
+| test.rs:182:13:182:13 | _ | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:182:13:182:13 | _ | test.rs:182:13:182:13 | _ |
+| test.rs:182:13:182:13 | _ | test.rs:186:13:186:13 | 0 |
+| test.rs:184:13:184:13 | 1 | test.rs:184:13:184:13 | 1 |
+| test.rs:186:13:186:13 | 0 | test.rs:186:13:186:13 | 0 |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:9:198:9 | if ... {...} else {...} |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:195:13:195:13 | 1 |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:197:13:197:13 | 0 |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:191:9:198:9 | if ... {...} else {...} |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:197:13:197:13 | 0 |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:195:13:195:13 | 1 |
+| test.rs:195:13:195:13 | 1 | test.rs:195:13:195:13 | 1 |
+| test.rs:197:13:197:13 | 0 | test.rs:197:13:197:13 | 0 |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:9:210:9 | if ... {...} else {...} |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:207:13:207:13 | 1 |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:209:13:209:13 | 0 |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:203:9:210:9 | if ... {...} else {...} |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:209:13:209:13 | 0 |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:207:13:207:13 | 1 |
+| test.rs:207:13:207:13 | 1 | test.rs:207:13:207:13 | 1 |
+| test.rs:209:13:209:13 | 0 | test.rs:209:13:209:13 | 0 |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:214:9:223:9 | if ... {...} else {...} |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:220:13:220:13 | 1 |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:222:13:222:13 | 0 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:214:9:223:9 | if ... {...} else {...} |
+| test.rs:215:13:217:13 | if ... {...} | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:214:9:223:9 | if ... {...} else {...} |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:220:13:220:13 | 1 |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:222:13:222:13 | 0 |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:222:13:222:13 | 0 |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:220:13:220:13 | 1 |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:214:9:223:9 | if ... {...} else {...} |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:220:13:220:13 | 1 |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:222:13:222:13 | 0 |
+| test.rs:220:13:220:13 | 1 | test.rs:220:13:220:13 | 1 |
+| test.rs:222:13:222:13 | 0 | test.rs:222:13:222:13 | 0 |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:227:9:236:9 | if ... {...} else {...} |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:233:13:233:13 | 1 |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:235:13:235:13 | 0 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:227:9:236:9 | if ... {...} else {...} |
+| test.rs:228:13:230:13 | if ... {...} | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:227:9:236:9 | if ... {...} else {...} |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:233:13:233:13 | 1 |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:235:13:235:13 | 0 |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:235:13:235:13 | 0 |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:233:13:233:13 | 1 |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:227:9:236:9 | if ... {...} else {...} |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:233:13:233:13 | 1 |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:235:13:235:13 | 0 |
+| test.rs:233:13:233:13 | 1 | test.rs:233:13:233:13 | 1 |
+| test.rs:235:13:235:13 | 0 | test.rs:235:13:235:13 | 0 |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:240:9:246:9 | if ... {...} else {...} |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:243:13:243:13 | 1 |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:245:13:245:13 | 0 |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:240:9:246:9 | if ... {...} else {...} |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:245:13:245:13 | 0 |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:243:13:243:13 | 1 |
+| test.rs:243:13:243:13 | 1 | test.rs:243:13:243:13 | 1 |
+| test.rs:245:13:245:13 | 0 | test.rs:245:13:245:13 | 0 |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:17:253:22 | [boolean(false)] ... && ... |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:17:253:27 | ... && ... |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:22:253:22 | b |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:27:253:27 | c |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:253:17:253:22 | [boolean(false)] ... && ... |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:27:253:27 | c |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:17:253:27 | ... && ... |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:253:22:253:22 | b | test.rs:253:22:253:22 | b |
+| test.rs:253:22:253:22 | b | test.rs:253:27:253:27 | c |
+| test.rs:253:27:253:27 | c | test.rs:253:27:253:27 | c |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:17:258:27 | ... \|\| ... |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:22:258:22 | b |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:27:258:27 | c |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:27:258:27 | c |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:17:258:27 | ... \|\| ... |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:258:22:258:22 | b | test.rs:258:22:258:22 | b |
+| test.rs:258:22:258:22 | b | test.rs:258:27:258:27 | c |
+| test.rs:258:27:258:27 | c | test.rs:258:27:258:27 | c |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:17:263:35 | ... \|\| ... |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:23:263:23 | b |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:35:263:35 | c |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:35:263:35 | c |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:17:263:35 | ... \|\| ... |
+| test.rs:263:23:263:23 | b | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:263:23:263:23 | b | test.rs:263:23:263:23 | b |
+| test.rs:263:23:263:23 | b | test.rs:263:35:263:35 | c |
+| test.rs:263:35:263:35 | c | test.rs:263:35:263:35 | c |
+| test.rs:267:5:270:5 | enter fn test_not_operator | test.rs:267:5:270:5 | enter fn test_not_operator |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:9:277:9 | if ... {...} else {...} |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:17:273:17 | b |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:22:273:22 | c |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:274:13:274:16 | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:276:13:276:17 | false |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:9:277:9 | if ... {...} else {...} |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:22:273:22 | c |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:276:13:276:17 | false |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:17:273:17 | b | test.rs:273:17:273:17 | b |
+| test.rs:273:17:273:17 | b | test.rs:273:22:273:22 | c |
+| test.rs:273:17:273:17 | b | test.rs:274:13:274:16 | true |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:22:273:22 | c | test.rs:273:22:273:22 | c |
+| test.rs:273:22:273:22 | c | test.rs:274:13:274:16 | true |
+| test.rs:274:13:274:16 | true | test.rs:274:13:274:16 | true |
+| test.rs:276:13:276:17 | false | test.rs:276:13:276:17 | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:9:285:9 | if ... {...} else {...} |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:17:281:17 | b |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:22:281:22 | c |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:282:13:282:16 | true |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:284:13:284:17 | false |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:9:285:9 | if ... {...} else {...} |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:22:281:22 | c |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:282:13:282:16 | true |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:17:281:17 | b | test.rs:281:17:281:17 | b |
+| test.rs:281:17:281:17 | b | test.rs:281:22:281:22 | c |
+| test.rs:281:17:281:17 | b | test.rs:284:13:284:17 | false |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:22:281:22 | c | test.rs:281:22:281:22 | c |
+| test.rs:281:22:281:22 | c | test.rs:284:13:284:17 | false |
+| test.rs:282:13:282:16 | true | test.rs:282:13:282:16 | true |
+| test.rs:284:13:284:17 | false | test.rs:284:13:284:17 | false |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:9:293:9 | if ... {...} else {...} |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:290:13:290:16 | true |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:292:13:292:17 | false |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:289:9:293:9 | if ... {...} else {...} |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:292:13:292:17 | false |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:290:13:290:16 | true |
+| test.rs:290:13:290:16 | true | test.rs:290:13:290:16 | true |
+| test.rs:292:13:292:17 | false | test.rs:292:13:292:17 | false |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:296:5:298:5 | exit fn test_and_return (normal) |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:9:297:19 | ... && ... |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:14:297:19 | return |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:296:5:298:5 | exit fn test_and_return (normal) |
+| test.rs:297:9:297:19 | ... && ... | test.rs:297:9:297:19 | ... && ... |
+| test.rs:297:14:297:19 | return | test.rs:297:14:297:19 | return |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:300:5:305:5 | exit fn test_and_true (normal) |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:9:303:9 | if ... {...} |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:18:301:21 | true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:300:5:305:5 | exit fn test_and_true (normal) |
+| test.rs:301:9:303:9 | if ... {...} | test.rs:301:9:303:9 | if ... {...} |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:9:303:9 | if ... {...} |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:301:18:301:21 | true | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:301:18:301:21 | true | test.rs:301:18:301:21 | true |
+| test.rs:301:18:301:21 | true | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 |
+| test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) |
+| test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | test.rs:312:32:312:32 | 4 |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) |
+| test.rs:312:32:312:32 | 4 | test.rs:312:32:312:32 | 4 |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:316:9:319:9 | match ... { ... } |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:317:13:317:16 | true |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:317:21:317:24 | Some |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:318:13:318:17 | false |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:316:9:319:9 | match ... { ... } |
+| test.rs:317:13:317:16 | true | test.rs:316:9:319:9 | match ... { ... } |
+| test.rs:317:13:317:16 | true | test.rs:317:13:317:16 | true |
+| test.rs:317:13:317:16 | true | test.rs:317:21:317:24 | Some |
+| test.rs:317:13:317:16 | true | test.rs:318:13:318:17 | false |
+| test.rs:317:21:317:24 | Some | test.rs:317:21:317:24 | Some |
+| test.rs:318:13:318:17 | false | test.rs:318:13:318:17 | false |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:327:9:331:9 | match maybe_digit { ... } |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:328:26:328:26 | x |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:328:42:328:42 | x |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:329:26:329:26 | x |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:330:13:330:24 | ...::None |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:327:9:331:9 | match maybe_digit { ... } |
+| test.rs:328:26:328:26 | x | test.rs:328:26:328:26 | x |
+| test.rs:328:26:328:26 | x | test.rs:328:42:328:42 | x |
+| test.rs:328:42:328:42 | x | test.rs:328:42:328:42 | x |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:329:26:329:26 | x |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:330:13:330:24 | ...::None |
+| test.rs:329:26:329:26 | x | test.rs:329:26:329:26 | x |
+| test.rs:330:13:330:24 | ...::None | test.rs:330:13:330:24 | ...::None |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:335:9:342:9 | match ... { ... } |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:336:13:336:21 | ExprStmt |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:340:26:340:26 | x |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:341:13:341:24 | ...::None |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:335:9:342:9 | match ... { ... } |
+| test.rs:336:13:336:21 | ExprStmt | test.rs:336:13:336:21 | ExprStmt |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:335:9:342:9 | match ... { ... } |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:340:26:340:26 | x |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:341:13:341:24 | ...::None |
+| test.rs:340:26:340:26 | x | test.rs:340:26:340:26 | x |
+| test.rs:341:13:341:24 | ...::None | test.rs:341:13:341:24 | ...::None |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:346:9:349:18 | ... && ... |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:346:10:349:9 | [boolean(false)] match r { ... } |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:347:18:347:18 | a |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:348:13:348:13 | _ |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:349:15:349:18 | cond |
+| test.rs:346:9:349:18 | ... && ... | test.rs:346:9:349:18 | ... && ... |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:346:10:349:9 | [boolean(false)] match r { ... } |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:349:15:349:18 | cond |
+| test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:347:18:347:18 | a | test.rs:347:18:347:18 | a |
+| test.rs:347:18:347:18 | a | test.rs:349:15:349:18 | cond |
+| test.rs:348:13:348:13 | _ | test.rs:348:13:348:13 | _ |
+| test.rs:349:15:349:18 | cond | test.rs:349:15:349:18 | cond |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:353:9:356:9 | match r { ... } |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:354:16:354:20 | value |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:355:13:355:22 | Err(...) |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:353:9:356:9 | match r { ... } |
+| test.rs:354:16:354:20 | value | test.rs:354:16:354:20 | value |
+| test.rs:355:13:355:22 | Err(...) | test.rs:355:13:355:22 | Err(...) |
+| test.rs:362:5:365:5 | enter fn test_let_match | test.rs:362:5:365:5 | enter fn test_let_match |
+| test.rs:362:5:365:5 | enter fn test_let_match | test.rs:363:18:363:18 | n |
+| test.rs:362:5:365:5 | enter fn test_let_match | test.rs:363:39:363:53 | MacroStmts |
+| test.rs:363:18:363:18 | n | test.rs:363:18:363:18 | n |
+| test.rs:363:39:363:53 | MacroStmts | test.rs:363:39:363:53 | MacroStmts |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:367:5:373:5 | exit fn test_let_with_return (normal) |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:369:18:369:20 | ret |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:370:13:370:16 | None |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:367:5:373:5 | exit fn test_let_with_return (normal) |
+| test.rs:369:18:369:20 | ret | test.rs:369:18:369:20 | ret |
+| test.rs:370:13:370:16 | None | test.rs:370:13:370:16 | None |
+| test.rs:378:5:381:5 | enter fn empty_tuple_pattern | test.rs:378:5:381:5 | enter fn empty_tuple_pattern |
+| test.rs:385:5:389:5 | enter fn empty_struct_pattern | test.rs:385:5:389:5 | enter fn empty_struct_pattern |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:392:9:397:9 | match 42 { ... } |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:393:15:393:15 | 0 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:393:20:393:20 | 1 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:394:13:394:13 | 1 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:394:13:394:16 | RangePat |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:394:16:394:16 | 2 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:394:21:394:21 | 2 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:395:13:395:13 | 5 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:395:13:395:15 | RangePat |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:395:20:395:20 | 3 |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:396:13:396:13 | _ |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:392:9:397:9 | match 42 { ... } |
+| test.rs:393:15:393:15 | 0 | test.rs:393:15:393:15 | 0 |
+| test.rs:393:15:393:15 | 0 | test.rs:393:20:393:20 | 1 |
+| test.rs:393:20:393:20 | 1 | test.rs:393:20:393:20 | 1 |
+| test.rs:394:13:394:13 | 1 | test.rs:394:13:394:13 | 1 |
+| test.rs:394:13:394:13 | 1 | test.rs:394:16:394:16 | 2 |
+| test.rs:394:13:394:13 | 1 | test.rs:394:21:394:21 | 2 |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:13:394:13 | 1 |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:13:394:16 | RangePat |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:16:394:16 | 2 |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:21:394:21 | 2 |
+| test.rs:394:13:394:16 | RangePat | test.rs:395:13:395:13 | 5 |
+| test.rs:394:13:394:16 | RangePat | test.rs:395:13:395:15 | RangePat |
+| test.rs:394:13:394:16 | RangePat | test.rs:395:20:395:20 | 3 |
+| test.rs:394:13:394:16 | RangePat | test.rs:396:13:396:13 | _ |
+| test.rs:394:16:394:16 | 2 | test.rs:394:16:394:16 | 2 |
+| test.rs:394:16:394:16 | 2 | test.rs:394:21:394:21 | 2 |
+| test.rs:394:21:394:21 | 2 | test.rs:394:21:394:21 | 2 |
+| test.rs:395:13:395:13 | 5 | test.rs:395:13:395:13 | 5 |
+| test.rs:395:13:395:13 | 5 | test.rs:395:20:395:20 | 3 |
+| test.rs:395:13:395:15 | RangePat | test.rs:395:13:395:13 | 5 |
+| test.rs:395:13:395:15 | RangePat | test.rs:395:13:395:15 | RangePat |
+| test.rs:395:13:395:15 | RangePat | test.rs:395:20:395:20 | 3 |
+| test.rs:395:13:395:15 | RangePat | test.rs:396:13:396:13 | _ |
+| test.rs:395:20:395:20 | 3 | test.rs:395:20:395:20 | 3 |
+| test.rs:396:13:396:13 | _ | test.rs:396:13:396:13 | _ |
+| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:402:5:407:5 | enter fn test_infinite_loop |
+| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:404:13:404:14 | TupleExpr |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr |
+| test.rs:411:5:413:5 | enter fn say_hello | test.rs:411:5:413:5 | enter fn say_hello |
+| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:5:434:5 | enter fn async_block |
+| test.rs:416:26:418:9 | enter { ... } | test.rs:416:26:418:9 | enter { ... } |
+| test.rs:419:31:421:9 | enter { ... } | test.rs:419:31:421:9 | enter { ... } |
+| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:22:433:9 | enter \|...\| ... |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | exit { ... } (normal) |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } (normal) |
+| test.rs:429:13:431:13 | if b {...} | test.rs:429:13:431:13 | if b {...} |
+| test.rs:430:17:430:41 | ExprStmt | test.rs:430:17:430:41 | ExprStmt |
+| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:5:442:5 | enter fn add_two |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:13:450:49 | ExprStmt |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | if ... {...} |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | ExprStmt |
+| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | enter fn panic_cold_explicit |
+| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | [boolean(false)] ! ... |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | if ... {...} |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:456:5:465:5 | enter fn const_block_panic |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} |
+| test.rs:458:9:463:9 | if false {...} | test.rs:458:9:463:9 | if false {...} |
+| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | enter fn panic_cold_explicit |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:468:1:473:1 | enter fn dead_code |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt |
+| test.rs:470:9:470:17 | ExprStmt | test.rs:470:9:470:17 | ExprStmt |
+| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:1:475:16 | enter fn do_thing |
+| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:477:1:479:1 | enter fn condition_not_met |
+| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:1:481:21 | enter fn do_next_thing |
+| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:1:483:21 | enter fn do_last_thing |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:486:18:497:5 | 'block: { ... } |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:492:9:494:9 | if ... {...} |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:493:13:493:27 | ExprStmt |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:18:497:5 | 'block: { ... } |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt |
+| test.rs:489:13:489:27 | ExprStmt | test.rs:489:13:489:27 | ExprStmt |
+| test.rs:492:9:494:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
+| test.rs:493:13:493:27 | ExprStmt | test.rs:493:13:493:27 | ExprStmt |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:502:18:508:5 | 'block: { ... } |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:504:18:504:18 | y |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:18:508:5 | 'block: { ... } |
+| test.rs:504:18:504:18 | y | test.rs:504:18:504:18 | y |
+| test.rs:505:13:505:27 | ExprStmt | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:511:1:517:1 | enter fn test_nested_function2 |
+| test.rs:513:5:515:5 | enter fn nested | test.rs:513:5:515:5 | enter fn nested |
+| test.rs:528:5:530:5 | enter fn new | test.rs:528:5:530:5 | enter fn new |
+| test.rs:532:5:534:5 | enter fn negated | test.rs:532:5:534:5 | enter fn negated |
+| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:5:538:5 | enter fn multifly_add |
 postDominance
 | test.rs:5:5:8:5 | enter fn function_call | test.rs:5:5:8:5 | enter fn function_call |
 | test.rs:10:5:13:5 | enter fn method_call | test.rs:10:5:13:5 | enter fn method_call |
@@ -771,449 +790,468 @@ postDominance
 | test.rs:130:9:134:9 | if ... {...} else {...} | test.rs:133:13:133:13 | n |
 | test.rs:131:13:131:13 | 0 | test.rs:131:13:131:13 | 0 |
 | test.rs:133:13:133:13 | n | test.rs:133:13:133:13 | n |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:138:9:142:9 | if ... {...} else {...} |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:138:21:138:21 | n |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:141:13:141:13 | 0 |
-| test.rs:138:21:138:21 | n | test.rs:138:21:138:21 | n |
-| test.rs:141:13:141:13 | 0 | test.rs:141:13:141:13 | 0 |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:145:5:150:5 | exit fn test_if_let (normal) |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:146:9:148:9 | if ... {...} |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:146:21:146:21 | n |
-| test.rs:146:9:148:9 | if ... {...} | test.rs:146:9:148:9 | if ... {...} |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:137:5:143:5 | enter fn test_if_without_else |
+| test.rs:139:9:141:9 | if b {...} | test.rs:137:5:143:5 | enter fn test_if_without_else |
+| test.rs:139:9:141:9 | if b {...} | test.rs:139:9:141:9 | if b {...} |
+| test.rs:139:9:141:9 | if b {...} | test.rs:140:13:140:19 | ExprStmt |
+| test.rs:140:13:140:19 | ExprStmt | test.rs:140:13:140:19 | ExprStmt |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:146:9:150:9 | if ... {...} else {...} |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:146:21:146:21 | n |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:149:13:149:13 | 0 |
 | test.rs:146:21:146:21 | n | test.rs:146:21:146:21 | n |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:9:157:9 | if ... {...} else {...} |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:24:153:24 | a |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:153:41:153:41 | a |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:154:13:154:13 | 1 |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:156:13:156:13 | 0 |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:153:22:153:32 | [boolean(false)] { ... } | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:153:22:153:32 | [boolean(true)] { ... } | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:153:24:153:24 | a | test.rs:153:24:153:24 | a |
-| test.rs:153:39:153:48 | [boolean(false)] { ... } | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:153:39:153:48 | [boolean(true)] { ... } | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:153:41:153:41 | a | test.rs:153:41:153:41 | a |
-| test.rs:154:13:154:13 | 1 | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:154:13:154:13 | 1 | test.rs:153:22:153:32 | [boolean(true)] { ... } |
-| test.rs:154:13:154:13 | 1 | test.rs:153:39:153:48 | [boolean(true)] { ... } |
-| test.rs:154:13:154:13 | 1 | test.rs:154:13:154:13 | 1 |
-| test.rs:156:13:156:13 | 0 | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:156:13:156:13 | 0 | test.rs:153:22:153:32 | [boolean(false)] { ... } |
-| test.rs:156:13:156:13 | 0 | test.rs:153:39:153:48 | [boolean(false)] { ... } |
-| test.rs:156:13:156:13 | 0 | test.rs:156:13:156:13 | 0 |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:161:9:168:9 | if ... {...} else {...} |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:162:18:162:21 | true |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:163:13:163:13 | _ |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:165:13:165:13 | 1 |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:167:13:167:13 | 0 |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:163:13:163:13 | _ |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:162:18:162:21 | true |
-| test.rs:162:18:162:21 | true | test.rs:162:18:162:21 | true |
-| test.rs:163:13:163:13 | _ | test.rs:163:13:163:13 | _ |
-| test.rs:165:13:165:13 | 1 | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:165:13:165:13 | 1 | test.rs:162:18:162:21 | true |
-| test.rs:165:13:165:13 | 1 | test.rs:165:13:165:13 | 1 |
-| test.rs:167:13:167:13 | 0 | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:167:13:167:13 | 0 | test.rs:163:13:163:13 | _ |
-| test.rs:167:13:167:13 | 0 | test.rs:167:13:167:13 | 0 |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:172:9:179:9 | if ... {...} else {...} |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:176:13:176:13 | 1 |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:178:13:178:13 | 0 |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:176:13:176:13 | 1 | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:176:13:176:13 | 1 | test.rs:176:13:176:13 | 1 |
-| test.rs:178:13:178:13 | 0 | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:178:13:178:13 | 0 | test.rs:178:13:178:13 | 0 |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:184:9:191:9 | if ... {...} else {...} |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:188:13:188:13 | 1 |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:190:13:190:13 | 0 |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:188:13:188:13 | 1 | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:188:13:188:13 | 1 | test.rs:188:13:188:13 | 1 |
-| test.rs:190:13:190:13 | 0 | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:190:13:190:13 | 0 | test.rs:190:13:190:13 | 0 |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:195:9:204:9 | if ... {...} else {...} |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:201:13:201:13 | 1 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:203:13:203:13 | 0 |
-| test.rs:196:13:198:13 | if ... {...} | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:196:13:198:13 | if ... {...} |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:201:13:201:13 | 1 | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:201:13:201:13 | 1 | test.rs:201:13:201:13 | 1 |
-| test.rs:203:13:203:13 | 0 | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:203:13:203:13 | 0 | test.rs:203:13:203:13 | 0 |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:208:9:217:9 | if ... {...} else {...} |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:214:13:214:13 | 1 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:216:13:216:13 | 0 |
-| test.rs:209:13:211:13 | if ... {...} | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:209:13:211:13 | if ... {...} |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:214:13:214:13 | 1 | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:214:13:214:13 | 1 | test.rs:214:13:214:13 | 1 |
-| test.rs:216:13:216:13 | 0 | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:216:13:216:13 | 0 | test.rs:216:13:216:13 | 0 |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:221:9:227:9 | if ... {...} else {...} |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:224:13:224:13 | 1 |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:226:13:226:13 | 0 |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:224:13:224:13 | 1 | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:224:13:224:13 | 1 | test.rs:224:13:224:13 | 1 |
-| test.rs:226:13:226:13 | 0 | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:226:13:226:13 | 0 | test.rs:226:13:226:13 | 0 |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:234:17:234:22 | [boolean(false)] ... && ... |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:234:17:234:27 | ... && ... | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:17:234:22 | [boolean(false)] ... && ... |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:17:234:27 | ... && ... |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:22:234:22 | b |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:27:234:27 | c |
-| test.rs:234:22:234:22 | b | test.rs:234:22:234:22 | b |
-| test.rs:234:27:234:27 | c | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:234:27:234:27 | c | test.rs:234:27:234:27 | c |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:17:239:27 | ... \|\| ... |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:22:239:22 | b |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:27:239:27 | c |
-| test.rs:239:22:239:22 | b | test.rs:239:22:239:22 | b |
-| test.rs:239:27:239:27 | c | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:239:27:239:27 | c | test.rs:239:27:239:27 | c |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:17:244:35 | ... \|\| ... |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:23:244:23 | b |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:35:244:35 | c |
-| test.rs:244:23:244:23 | b | test.rs:244:23:244:23 | b |
-| test.rs:244:35:244:35 | c | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:244:35:244:35 | c | test.rs:244:35:244:35 | c |
-| test.rs:248:5:251:5 | enter fn test_not_operator | test.rs:248:5:251:5 | enter fn test_not_operator |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:9:258:9 | if ... {...} else {...} |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:17:254:17 | b |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:254:22:254:22 | c |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:255:13:255:16 | true |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:257:13:257:17 | false |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:254:17:254:17 | b | test.rs:254:17:254:17 | b |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:254:22:254:22 | c | test.rs:254:22:254:22 | c |
-| test.rs:255:13:255:16 | true | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:255:13:255:16 | true | test.rs:255:13:255:16 | true |
-| test.rs:257:13:257:17 | false | test.rs:254:12:254:17 | [boolean(false)] ... && ... |
-| test.rs:257:13:257:17 | false | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:257:13:257:17 | false | test.rs:257:13:257:17 | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:9:266:9 | if ... {...} else {...} |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:17:262:17 | b |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:262:22:262:22 | c |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:263:13:263:16 | true |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:265:13:265:17 | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:262:17:262:17 | b | test.rs:262:17:262:17 | b |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:262:22:262:22 | c | test.rs:262:22:262:22 | c |
-| test.rs:263:13:263:16 | true | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... |
-| test.rs:263:13:263:16 | true | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:263:13:263:16 | true | test.rs:263:13:263:16 | true |
-| test.rs:265:13:265:17 | false | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:265:13:265:17 | false | test.rs:265:13:265:17 | false |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:270:9:274:9 | if ... {...} else {...} |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:271:13:271:16 | true |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:273:13:273:17 | false |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:271:13:271:16 | true | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:271:13:271:16 | true | test.rs:271:13:271:16 | true |
-| test.rs:273:13:273:17 | false | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:273:13:273:17 | false | test.rs:273:13:273:17 | false |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:277:5:279:5 | exit fn test_and_return (normal) |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:278:9:278:19 | ... && ... |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:278:14:278:19 | return |
-| test.rs:278:9:278:19 | ... && ... | test.rs:278:9:278:19 | ... && ... |
-| test.rs:278:14:278:19 | return | test.rs:278:14:278:19 | return |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:281:5:286:5 | exit fn test_and_true (normal) |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:282:9:284:9 | if ... {...} |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:282:18:282:21 | true |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:282:9:284:9 | if ... {...} | test.rs:282:9:284:9 | if ... {...} |
-| test.rs:282:9:284:9 | if ... {...} | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:282:18:282:21 | true |
-| test.rs:282:18:282:21 | true | test.rs:282:18:282:21 | true |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:282:18:282:21 | true |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:283:13:283:21 | ExprStmt |
-| test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:293:32:293:32 | 4 |
-| test.rs:293:32:293:32 | 4 | test.rs:293:32:293:32 | 4 |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:297:9:300:9 | match ... { ... } |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:298:13:298:16 | true |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:298:21:298:24 | Some |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:299:13:299:17 | false |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:297:9:300:9 | match ... { ... } |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:298:13:298:16 | true |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:298:21:298:24 | Some |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:299:13:299:17 | false |
-| test.rs:298:13:298:16 | true | test.rs:298:13:298:16 | true |
-| test.rs:298:21:298:24 | Some | test.rs:298:21:298:24 | Some |
-| test.rs:299:13:299:17 | false | test.rs:299:13:299:17 | false |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:308:9:312:9 | match maybe_digit { ... } |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:309:26:309:26 | x |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:309:42:309:42 | x |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:310:26:310:26 | x |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:311:13:311:24 | ...::None |
-| test.rs:309:26:309:26 | x | test.rs:309:26:309:26 | x |
-| test.rs:309:42:309:42 | x | test.rs:309:42:309:42 | x |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:310:26:310:26 | x | test.rs:310:26:310:26 | x |
-| test.rs:311:13:311:24 | ...::None | test.rs:311:13:311:24 | ...::None |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:316:9:323:9 | match ... { ... } |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:317:13:317:21 | ExprStmt |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:321:26:321:26 | x |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:322:13:322:24 | ...::None |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:316:9:323:9 | match ... { ... } |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:321:26:321:26 | x |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:322:13:322:24 | ...::None |
-| test.rs:317:13:317:21 | ExprStmt | test.rs:317:13:317:21 | ExprStmt |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:321:26:321:26 | x | test.rs:321:26:321:26 | x |
-| test.rs:322:13:322:24 | ...::None | test.rs:322:13:322:24 | ...::None |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:327:9:330:18 | ... && ... | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:327:9:330:18 | ... && ... | test.rs:327:9:330:18 | ... && ... |
-| test.rs:327:9:330:18 | ... && ... | test.rs:327:10:330:9 | [boolean(false)] match r { ... } |
-| test.rs:327:9:330:18 | ... && ... | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:327:9:330:18 | ... && ... | test.rs:328:18:328:18 | a |
-| test.rs:327:9:330:18 | ... && ... | test.rs:329:13:329:13 | _ |
-| test.rs:327:9:330:18 | ... && ... | test.rs:330:15:330:18 | cond |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:327:10:330:9 | [boolean(false)] match r { ... } |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:329:13:329:13 | _ |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:328:18:328:18 | a | test.rs:328:18:328:18 | a |
-| test.rs:329:13:329:13 | _ | test.rs:329:13:329:13 | _ |
-| test.rs:330:15:330:18 | cond | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:330:15:330:18 | cond | test.rs:330:15:330:18 | cond |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:334:9:337:9 | match r { ... } |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:335:16:335:20 | value |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:336:13:336:22 | Err(...) |
-| test.rs:335:16:335:20 | value | test.rs:335:16:335:20 | value |
-| test.rs:336:13:336:22 | Err(...) | test.rs:336:13:336:22 | Err(...) |
-| test.rs:343:5:346:5 | enter fn test_let_match | test.rs:343:5:346:5 | enter fn test_let_match |
-| test.rs:344:18:344:18 | n | test.rs:343:5:346:5 | enter fn test_let_match |
-| test.rs:344:18:344:18 | n | test.rs:344:18:344:18 | n |
-| test.rs:344:39:344:53 | MacroStmts | test.rs:344:39:344:53 | MacroStmts |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:348:5:354:5 | exit fn test_let_with_return (normal) |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:350:18:350:20 | ret |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:351:13:351:16 | None |
-| test.rs:350:18:350:20 | ret | test.rs:350:18:350:20 | ret |
-| test.rs:351:13:351:16 | None | test.rs:351:13:351:16 | None |
-| test.rs:359:5:362:5 | enter fn empty_tuple_pattern | test.rs:359:5:362:5 | enter fn empty_tuple_pattern |
-| test.rs:366:5:370:5 | enter fn empty_struct_pattern | test.rs:366:5:370:5 | enter fn empty_struct_pattern |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:373:9:378:9 | match 42 { ... } |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:374:15:374:15 | 0 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:374:20:374:20 | 1 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:375:13:375:13 | 1 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:375:13:375:16 | RangePat |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:375:16:375:16 | 2 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:375:21:375:21 | 2 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:376:13:376:13 | 5 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:376:13:376:15 | RangePat |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:376:20:376:20 | 3 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:377:13:377:13 | _ |
-| test.rs:374:15:374:15 | 0 | test.rs:374:15:374:15 | 0 |
-| test.rs:374:20:374:20 | 1 | test.rs:374:20:374:20 | 1 |
-| test.rs:375:13:375:13 | 1 | test.rs:375:13:375:13 | 1 |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:13:375:16 | RangePat |
-| test.rs:375:16:375:16 | 2 | test.rs:375:16:375:16 | 2 |
-| test.rs:375:21:375:21 | 2 | test.rs:375:21:375:21 | 2 |
-| test.rs:376:13:376:13 | 5 | test.rs:376:13:376:13 | 5 |
-| test.rs:376:13:376:15 | RangePat | test.rs:376:13:376:15 | RangePat |
-| test.rs:376:20:376:20 | 3 | test.rs:376:20:376:20 | 3 |
-| test.rs:377:13:377:13 | _ | test.rs:377:13:377:13 | _ |
-| test.rs:383:5:388:5 | enter fn test_infinite_loop | test.rs:383:5:388:5 | enter fn test_infinite_loop |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:385:13:385:14 | TupleExpr |
-| test.rs:392:5:394:5 | enter fn say_hello | test.rs:392:5:394:5 | enter fn say_hello |
-| test.rs:396:5:415:5 | enter fn async_block | test.rs:396:5:415:5 | enter fn async_block |
-| test.rs:397:26:399:9 | enter { ... } | test.rs:397:26:399:9 | enter { ... } |
-| test.rs:400:31:402:9 | enter { ... } | test.rs:400:31:402:9 | enter { ... } |
-| test.rs:409:22:414:9 | enter \|...\| ... | test.rs:409:22:414:9 | enter \|...\| ... |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:409:28:414:9 | exit { ... } (normal) |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:410:13:412:13 | if b {...} |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:411:17:411:41 | ExprStmt |
-| test.rs:410:13:412:13 | if b {...} | test.rs:410:13:412:13 | if b {...} |
-| test.rs:411:17:411:41 | ExprStmt | test.rs:411:17:411:41 | ExprStmt |
-| test.rs:421:5:423:5 | enter fn add_two | test.rs:421:5:423:5 | enter fn add_two |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:13:431:49 | ExprStmt |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:431:13:431:49 | enter fn panic_cold_explicit | test.rs:431:13:431:49 | enter fn panic_cold_explicit |
-| test.rs:431:21:431:48 | [boolean(false)] ! ... | test.rs:431:21:431:48 | [boolean(false)] ! ... |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:13:431:49 | ExprStmt |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | [boolean(false)] ! ... |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | if ... {...} |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:437:5:446:5 | enter fn const_block_panic |
-| test.rs:439:9:444:9 | if false {...} | test.rs:437:5:446:5 | enter fn const_block_panic |
-| test.rs:439:9:444:9 | if false {...} | test.rs:439:9:444:9 | if false {...} |
-| test.rs:442:17:442:24 | enter fn panic_cold_explicit | test.rs:442:17:442:24 | enter fn panic_cold_explicit |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:449:1:454:1 | enter fn dead_code |
-| test.rs:451:9:451:17 | ExprStmt | test.rs:449:1:454:1 | enter fn dead_code |
-| test.rs:451:9:451:17 | ExprStmt | test.rs:451:9:451:17 | ExprStmt |
-| test.rs:456:1:456:16 | enter fn do_thing | test.rs:456:1:456:16 | enter fn do_thing |
-| test.rs:458:1:460:1 | enter fn condition_not_met | test.rs:458:1:460:1 | enter fn condition_not_met |
-| test.rs:462:1:462:21 | enter fn do_next_thing | test.rs:462:1:462:21 | enter fn do_next_thing |
-| test.rs:464:1:464:21 | enter fn do_last_thing | test.rs:464:1:464:21 | enter fn do_last_thing |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:467:18:478:5 | 'block: { ... } |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:470:13:470:27 | ExprStmt |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:473:9:475:9 | if ... {...} |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:474:13:474:27 | ExprStmt |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:470:13:470:27 | ExprStmt | test.rs:470:13:470:27 | ExprStmt |
-| test.rs:473:9:475:9 | if ... {...} | test.rs:473:9:475:9 | if ... {...} |
-| test.rs:474:13:474:27 | ExprStmt | test.rs:474:13:474:27 | ExprStmt |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:482:1:490:1 | enter fn labelled_block2 |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:482:1:490:1 | enter fn labelled_block2 |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:483:18:489:5 | 'block: { ... } |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:485:18:485:18 | y |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:486:13:486:27 | ExprStmt |
-| test.rs:485:18:485:18 | y | test.rs:485:18:485:18 | y |
-| test.rs:486:13:486:27 | ExprStmt | test.rs:486:13:486:27 | ExprStmt |
-| test.rs:492:1:498:1 | enter fn test_nested_function2 | test.rs:492:1:498:1 | enter fn test_nested_function2 |
-| test.rs:494:5:496:5 | enter fn nested | test.rs:494:5:496:5 | enter fn nested |
-| test.rs:509:5:511:5 | enter fn new | test.rs:509:5:511:5 | enter fn new |
-| test.rs:513:5:515:5 | enter fn negated | test.rs:513:5:515:5 | enter fn negated |
-| test.rs:517:5:519:5 | enter fn multifly_add | test.rs:517:5:519:5 | enter fn multifly_add |
+| test.rs:149:13:149:13 | 0 | test.rs:149:13:149:13 | 0 |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:153:5:158:5 | exit fn test_if_let (normal) |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:154:9:156:9 | if ... {...} |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:154:21:154:21 | n |
+| test.rs:154:9:156:9 | if ... {...} | test.rs:154:9:156:9 | if ... {...} |
+| test.rs:154:21:154:21 | n | test.rs:154:21:154:21 | n |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:9:165:9 | if ... {...} else {...} |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:24:161:24 | a |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:161:41:161:41 | a |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:162:13:162:13 | 1 |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:164:13:164:13 | 0 |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:161:22:161:32 | [boolean(false)] { ... } | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:161:22:161:32 | [boolean(true)] { ... } | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:161:24:161:24 | a | test.rs:161:24:161:24 | a |
+| test.rs:161:39:161:48 | [boolean(false)] { ... } | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:161:39:161:48 | [boolean(true)] { ... } | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:161:41:161:41 | a | test.rs:161:41:161:41 | a |
+| test.rs:162:13:162:13 | 1 | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:162:13:162:13 | 1 | test.rs:161:22:161:32 | [boolean(true)] { ... } |
+| test.rs:162:13:162:13 | 1 | test.rs:161:39:161:48 | [boolean(true)] { ... } |
+| test.rs:162:13:162:13 | 1 | test.rs:162:13:162:13 | 1 |
+| test.rs:164:13:164:13 | 0 | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:164:13:164:13 | 0 | test.rs:161:22:161:32 | [boolean(false)] { ... } |
+| test.rs:164:13:164:13 | 0 | test.rs:161:39:161:48 | [boolean(false)] { ... } |
+| test.rs:164:13:164:13 | 0 | test.rs:164:13:164:13 | 0 |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:168:5:177:5 | enter fn test_nested_if_2 |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:168:5:177:5 | enter fn test_nested_if_2 |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:169:9:176:9 | if cond1 {...} |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:170:13:174:13 | if cond2 {...} else {...} |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:170:13:174:13 | if cond2 {...} else {...} |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:171:17:171:30 | ExprStmt | test.rs:171:17:171:30 | ExprStmt |
+| test.rs:173:17:173:30 | ExprStmt | test.rs:173:17:173:30 | ExprStmt |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:180:9:187:9 | if ... {...} else {...} |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:181:18:181:21 | true |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:182:13:182:13 | _ |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:184:13:184:13 | 1 |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:186:13:186:13 | 0 |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:182:13:182:13 | _ |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:181:18:181:21 | true |
+| test.rs:181:18:181:21 | true | test.rs:181:18:181:21 | true |
+| test.rs:182:13:182:13 | _ | test.rs:182:13:182:13 | _ |
+| test.rs:184:13:184:13 | 1 | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:184:13:184:13 | 1 | test.rs:181:18:181:21 | true |
+| test.rs:184:13:184:13 | 1 | test.rs:184:13:184:13 | 1 |
+| test.rs:186:13:186:13 | 0 | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:186:13:186:13 | 0 | test.rs:182:13:182:13 | _ |
+| test.rs:186:13:186:13 | 0 | test.rs:186:13:186:13 | 0 |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:191:9:198:9 | if ... {...} else {...} |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:195:13:195:13 | 1 |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:197:13:197:13 | 0 |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:195:13:195:13 | 1 | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:195:13:195:13 | 1 | test.rs:195:13:195:13 | 1 |
+| test.rs:197:13:197:13 | 0 | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:197:13:197:13 | 0 | test.rs:197:13:197:13 | 0 |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:203:9:210:9 | if ... {...} else {...} |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:207:13:207:13 | 1 |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:209:13:209:13 | 0 |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:207:13:207:13 | 1 | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:207:13:207:13 | 1 | test.rs:207:13:207:13 | 1 |
+| test.rs:209:13:209:13 | 0 | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:209:13:209:13 | 0 | test.rs:209:13:209:13 | 0 |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:214:9:223:9 | if ... {...} else {...} |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:220:13:220:13 | 1 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:222:13:222:13 | 0 |
+| test.rs:215:13:217:13 | if ... {...} | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:215:13:217:13 | if ... {...} |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:220:13:220:13 | 1 | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:220:13:220:13 | 1 | test.rs:220:13:220:13 | 1 |
+| test.rs:222:13:222:13 | 0 | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:222:13:222:13 | 0 | test.rs:222:13:222:13 | 0 |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:227:9:236:9 | if ... {...} else {...} |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:233:13:233:13 | 1 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:235:13:235:13 | 0 |
+| test.rs:228:13:230:13 | if ... {...} | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:228:13:230:13 | if ... {...} |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:233:13:233:13 | 1 | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:233:13:233:13 | 1 | test.rs:233:13:233:13 | 1 |
+| test.rs:235:13:235:13 | 0 | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:235:13:235:13 | 0 | test.rs:235:13:235:13 | 0 |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:240:9:246:9 | if ... {...} else {...} |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:243:13:243:13 | 1 |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:245:13:245:13 | 0 |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:243:13:243:13 | 1 | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:243:13:243:13 | 1 | test.rs:243:13:243:13 | 1 |
+| test.rs:245:13:245:13 | 0 | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:245:13:245:13 | 0 | test.rs:245:13:245:13 | 0 |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:253:17:253:22 | [boolean(false)] ... && ... |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:253:17:253:27 | ... && ... | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:17:253:22 | [boolean(false)] ... && ... |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:17:253:27 | ... && ... |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:22:253:22 | b |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:27:253:27 | c |
+| test.rs:253:22:253:22 | b | test.rs:253:22:253:22 | b |
+| test.rs:253:27:253:27 | c | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:253:27:253:27 | c | test.rs:253:27:253:27 | c |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:17:258:27 | ... \|\| ... |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:22:258:22 | b |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:27:258:27 | c |
+| test.rs:258:22:258:22 | b | test.rs:258:22:258:22 | b |
+| test.rs:258:27:258:27 | c | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:258:27:258:27 | c | test.rs:258:27:258:27 | c |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:17:263:35 | ... \|\| ... |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:23:263:23 | b |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:35:263:35 | c |
+| test.rs:263:23:263:23 | b | test.rs:263:23:263:23 | b |
+| test.rs:263:35:263:35 | c | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:263:35:263:35 | c | test.rs:263:35:263:35 | c |
+| test.rs:267:5:270:5 | enter fn test_not_operator | test.rs:267:5:270:5 | enter fn test_not_operator |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:9:277:9 | if ... {...} else {...} |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:17:273:17 | b |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:273:22:273:22 | c |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:274:13:274:16 | true |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:276:13:276:17 | false |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:273:17:273:17 | b | test.rs:273:17:273:17 | b |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:273:22:273:22 | c | test.rs:273:22:273:22 | c |
+| test.rs:274:13:274:16 | true | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:274:13:274:16 | true | test.rs:274:13:274:16 | true |
+| test.rs:276:13:276:17 | false | test.rs:273:12:273:17 | [boolean(false)] ... && ... |
+| test.rs:276:13:276:17 | false | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:276:13:276:17 | false | test.rs:276:13:276:17 | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:9:285:9 | if ... {...} else {...} |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:17:281:17 | b |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:281:22:281:22 | c |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:282:13:282:16 | true |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:284:13:284:17 | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:281:17:281:17 | b | test.rs:281:17:281:17 | b |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:281:22:281:22 | c | test.rs:281:22:281:22 | c |
+| test.rs:282:13:282:16 | true | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... |
+| test.rs:282:13:282:16 | true | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:282:13:282:16 | true | test.rs:282:13:282:16 | true |
+| test.rs:284:13:284:17 | false | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:284:13:284:17 | false | test.rs:284:13:284:17 | false |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:289:9:293:9 | if ... {...} else {...} |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:290:13:290:16 | true |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:292:13:292:17 | false |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:290:13:290:16 | true | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:290:13:290:16 | true | test.rs:290:13:290:16 | true |
+| test.rs:292:13:292:17 | false | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:292:13:292:17 | false | test.rs:292:13:292:17 | false |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:296:5:298:5 | exit fn test_and_return (normal) |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:297:9:297:19 | ... && ... |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:297:14:297:19 | return |
+| test.rs:297:9:297:19 | ... && ... | test.rs:297:9:297:19 | ... && ... |
+| test.rs:297:14:297:19 | return | test.rs:297:14:297:19 | return |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:300:5:305:5 | exit fn test_and_true (normal) |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:301:9:303:9 | if ... {...} |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:301:18:301:21 | true |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:301:9:303:9 | if ... {...} | test.rs:301:9:303:9 | if ... {...} |
+| test.rs:301:9:303:9 | if ... {...} | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:301:18:301:21 | true |
+| test.rs:301:18:301:21 | true | test.rs:301:18:301:21 | true |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:301:18:301:21 | true |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:302:13:302:21 | ExprStmt |
+| test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:312:32:312:32 | 4 |
+| test.rs:312:32:312:32 | 4 | test.rs:312:32:312:32 | 4 |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:316:9:319:9 | match ... { ... } |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:317:13:317:16 | true |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:317:21:317:24 | Some |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:318:13:318:17 | false |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:316:9:319:9 | match ... { ... } |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:317:13:317:16 | true |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:317:21:317:24 | Some |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:318:13:318:17 | false |
+| test.rs:317:13:317:16 | true | test.rs:317:13:317:16 | true |
+| test.rs:317:21:317:24 | Some | test.rs:317:21:317:24 | Some |
+| test.rs:318:13:318:17 | false | test.rs:318:13:318:17 | false |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:327:9:331:9 | match maybe_digit { ... } |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:328:26:328:26 | x |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:328:42:328:42 | x |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:329:26:329:26 | x |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:330:13:330:24 | ...::None |
+| test.rs:328:26:328:26 | x | test.rs:328:26:328:26 | x |
+| test.rs:328:42:328:42 | x | test.rs:328:42:328:42 | x |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:329:26:329:26 | x | test.rs:329:26:329:26 | x |
+| test.rs:330:13:330:24 | ...::None | test.rs:330:13:330:24 | ...::None |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:335:9:342:9 | match ... { ... } |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:336:13:336:21 | ExprStmt |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:340:26:340:26 | x |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:341:13:341:24 | ...::None |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:335:9:342:9 | match ... { ... } |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:340:26:340:26 | x |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:341:13:341:24 | ...::None |
+| test.rs:336:13:336:21 | ExprStmt | test.rs:336:13:336:21 | ExprStmt |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:340:26:340:26 | x | test.rs:340:26:340:26 | x |
+| test.rs:341:13:341:24 | ...::None | test.rs:341:13:341:24 | ...::None |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:346:9:349:18 | ... && ... | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:346:9:349:18 | ... && ... | test.rs:346:9:349:18 | ... && ... |
+| test.rs:346:9:349:18 | ... && ... | test.rs:346:10:349:9 | [boolean(false)] match r { ... } |
+| test.rs:346:9:349:18 | ... && ... | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:346:9:349:18 | ... && ... | test.rs:347:18:347:18 | a |
+| test.rs:346:9:349:18 | ... && ... | test.rs:348:13:348:13 | _ |
+| test.rs:346:9:349:18 | ... && ... | test.rs:349:15:349:18 | cond |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:346:10:349:9 | [boolean(false)] match r { ... } |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:348:13:348:13 | _ |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:347:18:347:18 | a | test.rs:347:18:347:18 | a |
+| test.rs:348:13:348:13 | _ | test.rs:348:13:348:13 | _ |
+| test.rs:349:15:349:18 | cond | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:349:15:349:18 | cond | test.rs:349:15:349:18 | cond |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:353:9:356:9 | match r { ... } |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:354:16:354:20 | value |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:355:13:355:22 | Err(...) |
+| test.rs:354:16:354:20 | value | test.rs:354:16:354:20 | value |
+| test.rs:355:13:355:22 | Err(...) | test.rs:355:13:355:22 | Err(...) |
+| test.rs:362:5:365:5 | enter fn test_let_match | test.rs:362:5:365:5 | enter fn test_let_match |
+| test.rs:363:18:363:18 | n | test.rs:362:5:365:5 | enter fn test_let_match |
+| test.rs:363:18:363:18 | n | test.rs:363:18:363:18 | n |
+| test.rs:363:39:363:53 | MacroStmts | test.rs:363:39:363:53 | MacroStmts |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:367:5:373:5 | exit fn test_let_with_return (normal) |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:369:18:369:20 | ret |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:370:13:370:16 | None |
+| test.rs:369:18:369:20 | ret | test.rs:369:18:369:20 | ret |
+| test.rs:370:13:370:16 | None | test.rs:370:13:370:16 | None |
+| test.rs:378:5:381:5 | enter fn empty_tuple_pattern | test.rs:378:5:381:5 | enter fn empty_tuple_pattern |
+| test.rs:385:5:389:5 | enter fn empty_struct_pattern | test.rs:385:5:389:5 | enter fn empty_struct_pattern |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:392:9:397:9 | match 42 { ... } |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:393:15:393:15 | 0 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:393:20:393:20 | 1 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:394:13:394:13 | 1 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:394:13:394:16 | RangePat |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:394:16:394:16 | 2 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:394:21:394:21 | 2 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:395:13:395:13 | 5 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:395:13:395:15 | RangePat |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:395:20:395:20 | 3 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:396:13:396:13 | _ |
+| test.rs:393:15:393:15 | 0 | test.rs:393:15:393:15 | 0 |
+| test.rs:393:20:393:20 | 1 | test.rs:393:20:393:20 | 1 |
+| test.rs:394:13:394:13 | 1 | test.rs:394:13:394:13 | 1 |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:13:394:16 | RangePat |
+| test.rs:394:16:394:16 | 2 | test.rs:394:16:394:16 | 2 |
+| test.rs:394:21:394:21 | 2 | test.rs:394:21:394:21 | 2 |
+| test.rs:395:13:395:13 | 5 | test.rs:395:13:395:13 | 5 |
+| test.rs:395:13:395:15 | RangePat | test.rs:395:13:395:15 | RangePat |
+| test.rs:395:20:395:20 | 3 | test.rs:395:20:395:20 | 3 |
+| test.rs:396:13:396:13 | _ | test.rs:396:13:396:13 | _ |
+| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:402:5:407:5 | enter fn test_infinite_loop |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr |
+| test.rs:411:5:413:5 | enter fn say_hello | test.rs:411:5:413:5 | enter fn say_hello |
+| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:5:434:5 | enter fn async_block |
+| test.rs:416:26:418:9 | enter { ... } | test.rs:416:26:418:9 | enter { ... } |
+| test.rs:419:31:421:9 | enter { ... } | test.rs:419:31:421:9 | enter { ... } |
+| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:22:433:9 | enter \|...\| ... |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } (normal) |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:429:13:431:13 | if b {...} |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:430:17:430:41 | ExprStmt |
+| test.rs:429:13:431:13 | if b {...} | test.rs:429:13:431:13 | if b {...} |
+| test.rs:430:17:430:41 | ExprStmt | test.rs:430:17:430:41 | ExprStmt |
+| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:5:442:5 | enter fn add_two |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | ExprStmt |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | enter fn panic_cold_explicit |
+| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | [boolean(false)] ! ... |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:13:450:49 | ExprStmt |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(false)] ! ... |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | if ... {...} |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:456:5:465:5 | enter fn const_block_panic |
+| test.rs:458:9:463:9 | if false {...} | test.rs:456:5:465:5 | enter fn const_block_panic |
+| test.rs:458:9:463:9 | if false {...} | test.rs:458:9:463:9 | if false {...} |
+| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | enter fn panic_cold_explicit |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:468:1:473:1 | enter fn dead_code |
+| test.rs:470:9:470:17 | ExprStmt | test.rs:468:1:473:1 | enter fn dead_code |
+| test.rs:470:9:470:17 | ExprStmt | test.rs:470:9:470:17 | ExprStmt |
+| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:1:475:16 | enter fn do_thing |
+| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:477:1:479:1 | enter fn condition_not_met |
+| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:1:481:21 | enter fn do_next_thing |
+| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:1:483:21 | enter fn do_last_thing |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:18:497:5 | 'block: { ... } |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:489:13:489:27 | ExprStmt |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:492:9:494:9 | if ... {...} |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:493:13:493:27 | ExprStmt |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:489:13:489:27 | ExprStmt | test.rs:489:13:489:27 | ExprStmt |
+| test.rs:492:9:494:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
+| test.rs:493:13:493:27 | ExprStmt | test.rs:493:13:493:27 | ExprStmt |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:18:508:5 | 'block: { ... } |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:504:18:504:18 | y |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:504:18:504:18 | y | test.rs:504:18:504:18 | y |
+| test.rs:505:13:505:27 | ExprStmt | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:511:1:517:1 | enter fn test_nested_function2 |
+| test.rs:513:5:515:5 | enter fn nested | test.rs:513:5:515:5 | enter fn nested |
+| test.rs:528:5:530:5 | enter fn new | test.rs:528:5:530:5 | enter fn new |
+| test.rs:532:5:534:5 | enter fn negated | test.rs:532:5:534:5 | enter fn negated |
+| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:5:538:5 | enter fn multifly_add |
 immediateDominator
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:18:5:24:5 | enter fn next |
 | test.rs:20:13:20:13 | n | test.rs:18:5:24:5 | enter fn next |
@@ -1261,170 +1299,177 @@ immediateDominator
 | test.rs:130:9:134:9 | if ... {...} else {...} | test.rs:129:5:135:5 | enter fn test_if_else |
 | test.rs:131:13:131:13 | 0 | test.rs:129:5:135:5 | enter fn test_if_else |
 | test.rs:133:13:133:13 | n | test.rs:129:5:135:5 | enter fn test_if_else |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:138:21:138:21 | n | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:141:13:141:13 | 0 | test.rs:137:5:143:5 | enter fn test_if_let_else |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:146:9:148:9 | if ... {...} | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:146:21:146:21 | n | test.rs:145:5:150:5 | enter fn test_if_let |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:22:153:32 | [boolean(false)] { ... } | test.rs:153:24:153:24 | a |
-| test.rs:153:22:153:32 | [boolean(true)] { ... } | test.rs:153:24:153:24 | a |
-| test.rs:153:24:153:24 | a | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:153:39:153:48 | [boolean(false)] { ... } | test.rs:153:41:153:41 | a |
-| test.rs:153:39:153:48 | [boolean(true)] { ... } | test.rs:153:41:153:41 | a |
-| test.rs:153:41:153:41 | a | test.rs:152:5:158:5 | enter fn test_nested_if |
-| test.rs:154:13:154:13 | 1 | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} |
-| test.rs:156:13:156:13 | 0 | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:163:13:163:13 | _ |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:162:18:162:21 | true |
-| test.rs:162:18:162:21 | true | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:163:13:163:13 | _ | test.rs:160:5:169:5 | enter fn test_nested_if_match |
-| test.rs:165:13:165:13 | 1 | test.rs:161:13:164:9 | [boolean(true)] match a { ... } |
-| test.rs:167:13:167:13 | 0 | test.rs:161:13:164:9 | [boolean(false)] match a { ... } |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:171:5:180:5 | enter fn test_nested_if_block |
-| test.rs:176:13:176:13 | 1 | test.rs:172:12:175:9 | [boolean(true)] { ... } |
-| test.rs:178:13:178:13 | 0 | test.rs:172:12:175:9 | [boolean(false)] { ... } |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:182:5:192:5 | enter fn test_if_assignment |
-| test.rs:188:13:188:13 | 1 | test.rs:184:12:187:9 | [boolean(true)] { ... } |
-| test.rs:190:13:190:13 | 0 | test.rs:184:12:187:9 | [boolean(false)] { ... } |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:196:13:198:13 | if ... {...} | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:194:5:205:5 | enter fn test_if_loop1 |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:197:17:197:29 | ExprStmt |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:196:13:198:14 | ExprStmt |
-| test.rs:201:13:201:13 | 1 | test.rs:197:17:197:28 | [boolean(true)] break ... |
-| test.rs:203:13:203:13 | 0 | test.rs:197:17:197:28 | [boolean(false)] break ... |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:209:13:211:13 | if ... {...} | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:207:5:218:5 | enter fn test_if_loop2 |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:210:17:210:36 | ExprStmt |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:209:13:211:14 | ExprStmt |
-| test.rs:214:13:214:13 | 1 | test.rs:210:17:210:35 | [boolean(true)] break ''label ... |
-| test.rs:216:13:216:13 | 0 | test.rs:210:17:210:35 | [boolean(false)] break ''label ... |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:220:5:228:5 | enter fn test_labelled_block |
-| test.rs:224:13:224:13 | 1 | test.rs:222:13:222:30 | [boolean(true)] break ''block ... |
-| test.rs:226:13:226:13 | 0 | test.rs:222:13:222:30 | [boolean(false)] break ''block ... |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:22:234:22 | b |
-| test.rs:234:17:234:27 | ... && ... | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:234:22:234:22 | b | test.rs:233:5:236:5 | enter fn test_and_operator |
-| test.rs:234:27:234:27 | c | test.rs:234:17:234:22 | [boolean(true)] ... && ... |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:22:239:22 | b |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:239:22:239:22 | b | test.rs:238:5:241:5 | enter fn test_or_operator |
-| test.rs:239:27:239:27 | c | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:23:244:23 | b |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:244:23:244:23 | b | test.rs:243:5:246:5 | enter fn test_or_operator_2 |
-| test.rs:244:35:244:35 | c | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:17:254:17 | b |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:254:22:254:22 | c |
-| test.rs:254:17:254:17 | b | test.rs:253:5:259:5 | enter fn test_if_and_operator |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:17 | [boolean(true)] ... && ... |
-| test.rs:255:13:255:16 | true | test.rs:254:12:254:22 | [boolean(true)] ... && ... |
-| test.rs:257:13:257:17 | false | test.rs:254:12:254:22 | [boolean(false)] ... && ... |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:17:262:17 | b |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:262:22:262:22 | c |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:17:262:17 | b | test.rs:261:5:267:5 | enter fn test_if_or_operator |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... |
-| test.rs:263:13:263:16 | true | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... |
-| test.rs:265:13:265:17 | false | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:269:5:275:5 | enter fn test_if_not_operator |
-| test.rs:271:13:271:16 | true | test.rs:270:12:270:13 | [boolean(true)] ! ... |
-| test.rs:273:13:273:17 | false | test.rs:270:12:270:13 | [boolean(false)] ! ... |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:278:9:278:19 | ... && ... | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:278:14:278:19 | return | test.rs:277:5:279:5 | enter fn test_and_return |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:282:9:284:9 | if ... {...} | test.rs:282:13:282:21 | [boolean(false)] ... && ... |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:282:18:282:21 | true |
-| test.rs:282:18:282:21 | true | test.rs:281:5:286:5 | enter fn test_and_true |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:282:13:282:21 | [boolean(true)] ... && ... |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 |
-| test.rs:293:32:293:32 | 4 | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:298:13:298:16 | true |
-| test.rs:298:13:298:16 | true | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 |
-| test.rs:298:21:298:24 | Some | test.rs:298:13:298:16 | true |
-| test.rs:299:13:299:17 | false | test.rs:298:13:298:16 | true |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:309:26:309:26 | x | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:309:42:309:42 | x | test.rs:309:26:309:26 | x |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:307:5:313:5 | enter fn test_match |
-| test.rs:310:26:310:26 | x | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:311:13:311:24 | ...::None | test.rs:310:13:310:27 | ...::Some(...) |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:317:13:317:21 | ExprStmt | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee |
-| test.rs:321:26:321:26 | x | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:322:13:322:24 | ...::None | test.rs:319:13:319:23 | maybe_digit |
-| test.rs:327:9:330:18 | ... && ... | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:328:18:328:18 | a |
-| test.rs:328:18:328:18 | a | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:329:13:329:13 | _ | test.rs:326:5:331:5 | enter fn test_match_and |
-| test.rs:330:15:330:18 | cond | test.rs:327:10:330:9 | [boolean(true)] match r { ... } |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:335:16:335:20 | value | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:336:13:336:22 | Err(...) | test.rs:333:5:338:5 | enter fn test_match_with_no_arms |
-| test.rs:344:18:344:18 | n | test.rs:343:5:346:5 | enter fn test_let_match |
-| test.rs:344:39:344:53 | MacroStmts | test.rs:343:5:346:5 | enter fn test_let_match |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:350:18:350:20 | ret | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:351:13:351:16 | None | test.rs:348:5:354:5 | enter fn test_let_with_return |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:374:15:374:15 | 0 | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:374:20:374:20 | 1 | test.rs:374:15:374:15 | 0 |
-| test.rs:375:13:375:13 | 1 | test.rs:375:13:375:16 | RangePat |
-| test.rs:375:13:375:16 | RangePat | test.rs:372:5:379:5 | enter fn range_pattern |
-| test.rs:375:16:375:16 | 2 | test.rs:375:13:375:13 | 1 |
-| test.rs:375:21:375:21 | 2 | test.rs:375:16:375:16 | 2 |
-| test.rs:376:13:376:13 | 5 | test.rs:376:13:376:15 | RangePat |
-| test.rs:376:13:376:15 | RangePat | test.rs:375:13:375:16 | RangePat |
-| test.rs:376:20:376:20 | 3 | test.rs:376:13:376:13 | 5 |
-| test.rs:377:13:377:13 | _ | test.rs:376:13:376:15 | RangePat |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:383:5:388:5 | enter fn test_infinite_loop |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:410:13:412:13 | if b {...} | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:411:17:411:41 | ExprStmt | test.rs:409:28:414:9 | enter { ... } |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:21:431:48 | [boolean(true)] ! ... |
-| test.rs:431:21:431:48 | [boolean(false)] ! ... | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:427:5:435:5 | enter fn const_block_assert |
-| test.rs:439:9:444:9 | if false {...} | test.rs:437:5:446:5 | enter fn const_block_panic |
-| test.rs:451:9:451:17 | ExprStmt | test.rs:449:1:454:1 | enter fn dead_code |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:470:13:470:27 | ExprStmt | test.rs:466:1:480:1 | enter fn labelled_block1 |
-| test.rs:473:9:475:9 | if ... {...} | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:474:13:474:27 | ExprStmt | test.rs:469:9:471:9 | if ... {...} |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:482:1:490:1 | enter fn labelled_block2 |
-| test.rs:485:18:485:18 | y | test.rs:482:1:490:1 | enter fn labelled_block2 |
-| test.rs:486:13:486:27 | ExprStmt | test.rs:482:1:490:1 | enter fn labelled_block2 |
+| test.rs:139:9:141:9 | if b {...} | test.rs:137:5:143:5 | enter fn test_if_without_else |
+| test.rs:140:13:140:19 | ExprStmt | test.rs:137:5:143:5 | enter fn test_if_without_else |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:146:21:146:21 | n | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:149:13:149:13 | 0 | test.rs:145:5:151:5 | enter fn test_if_let_else |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:154:9:156:9 | if ... {...} | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:154:21:154:21 | n | test.rs:153:5:158:5 | enter fn test_if_let |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:22:161:32 | [boolean(false)] { ... } | test.rs:161:24:161:24 | a |
+| test.rs:161:22:161:32 | [boolean(true)] { ... } | test.rs:161:24:161:24 | a |
+| test.rs:161:24:161:24 | a | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:161:39:161:48 | [boolean(false)] { ... } | test.rs:161:41:161:41 | a |
+| test.rs:161:39:161:48 | [boolean(true)] { ... } | test.rs:161:41:161:41 | a |
+| test.rs:161:41:161:41 | a | test.rs:160:5:166:5 | enter fn test_nested_if |
+| test.rs:162:13:162:13 | 1 | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} |
+| test.rs:164:13:164:13 | 0 | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:168:5:177:5 | enter fn test_nested_if_2 |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:168:5:177:5 | enter fn test_nested_if_2 |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:171:17:171:30 | ExprStmt | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:173:17:173:30 | ExprStmt | test.rs:170:13:174:13 | ExprStmt |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:182:13:182:13 | _ |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:181:18:181:21 | true |
+| test.rs:181:18:181:21 | true | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:182:13:182:13 | _ | test.rs:179:5:188:5 | enter fn test_nested_if_match |
+| test.rs:184:13:184:13 | 1 | test.rs:180:13:183:9 | [boolean(true)] match a { ... } |
+| test.rs:186:13:186:13 | 0 | test.rs:180:13:183:9 | [boolean(false)] match a { ... } |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:190:5:199:5 | enter fn test_nested_if_block |
+| test.rs:195:13:195:13 | 1 | test.rs:191:12:194:9 | [boolean(true)] { ... } |
+| test.rs:197:13:197:13 | 0 | test.rs:191:12:194:9 | [boolean(false)] { ... } |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:201:5:211:5 | enter fn test_if_assignment |
+| test.rs:207:13:207:13 | 1 | test.rs:203:12:206:9 | [boolean(true)] { ... } |
+| test.rs:209:13:209:13 | 0 | test.rs:203:12:206:9 | [boolean(false)] { ... } |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:215:13:217:13 | if ... {...} | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:213:5:224:5 | enter fn test_if_loop1 |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:216:17:216:29 | ExprStmt |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:215:13:217:14 | ExprStmt |
+| test.rs:220:13:220:13 | 1 | test.rs:216:17:216:28 | [boolean(true)] break ... |
+| test.rs:222:13:222:13 | 0 | test.rs:216:17:216:28 | [boolean(false)] break ... |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:228:13:230:13 | if ... {...} | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:226:5:237:5 | enter fn test_if_loop2 |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:229:17:229:36 | ExprStmt |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:228:13:230:14 | ExprStmt |
+| test.rs:233:13:233:13 | 1 | test.rs:229:17:229:35 | [boolean(true)] break ''label ... |
+| test.rs:235:13:235:13 | 0 | test.rs:229:17:229:35 | [boolean(false)] break ''label ... |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:239:5:247:5 | enter fn test_labelled_block |
+| test.rs:243:13:243:13 | 1 | test.rs:241:13:241:30 | [boolean(true)] break ''block ... |
+| test.rs:245:13:245:13 | 0 | test.rs:241:13:241:30 | [boolean(false)] break ''block ... |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:22:253:22 | b |
+| test.rs:253:17:253:27 | ... && ... | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:253:22:253:22 | b | test.rs:252:5:255:5 | enter fn test_and_operator |
+| test.rs:253:27:253:27 | c | test.rs:253:17:253:22 | [boolean(true)] ... && ... |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:22:258:22 | b |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:258:22:258:22 | b | test.rs:257:5:260:5 | enter fn test_or_operator |
+| test.rs:258:27:258:27 | c | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:23:263:23 | b |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:263:23:263:23 | b | test.rs:262:5:265:5 | enter fn test_or_operator_2 |
+| test.rs:263:35:263:35 | c | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:17:273:17 | b |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:273:22:273:22 | c |
+| test.rs:273:17:273:17 | b | test.rs:272:5:278:5 | enter fn test_if_and_operator |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:17 | [boolean(true)] ... && ... |
+| test.rs:274:13:274:16 | true | test.rs:273:12:273:22 | [boolean(true)] ... && ... |
+| test.rs:276:13:276:17 | false | test.rs:273:12:273:22 | [boolean(false)] ... && ... |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:17:281:17 | b |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:281:22:281:22 | c |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:17:281:17 | b | test.rs:280:5:286:5 | enter fn test_if_or_operator |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... |
+| test.rs:282:13:282:16 | true | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... |
+| test.rs:284:13:284:17 | false | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:288:5:294:5 | enter fn test_if_not_operator |
+| test.rs:290:13:290:16 | true | test.rs:289:12:289:13 | [boolean(true)] ! ... |
+| test.rs:292:13:292:17 | false | test.rs:289:12:289:13 | [boolean(false)] ! ... |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:297:9:297:19 | ... && ... | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:297:14:297:19 | return | test.rs:296:5:298:5 | enter fn test_and_return |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:301:9:303:9 | if ... {...} | test.rs:301:13:301:21 | [boolean(false)] ... && ... |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:301:18:301:21 | true |
+| test.rs:301:18:301:21 | true | test.rs:300:5:305:5 | enter fn test_and_true |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:301:13:301:21 | [boolean(true)] ... && ... |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 |
+| test.rs:312:32:312:32 | 4 | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:317:13:317:16 | true |
+| test.rs:317:13:317:16 | true | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 |
+| test.rs:317:21:317:24 | Some | test.rs:317:13:317:16 | true |
+| test.rs:318:13:318:17 | false | test.rs:317:13:317:16 | true |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:328:26:328:26 | x | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:328:42:328:42 | x | test.rs:328:26:328:26 | x |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:326:5:332:5 | enter fn test_match |
+| test.rs:329:26:329:26 | x | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:330:13:330:24 | ...::None | test.rs:329:13:329:27 | ...::Some(...) |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:336:13:336:21 | ExprStmt | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee |
+| test.rs:340:26:340:26 | x | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:341:13:341:24 | ...::None | test.rs:338:13:338:23 | maybe_digit |
+| test.rs:346:9:349:18 | ... && ... | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:347:18:347:18 | a |
+| test.rs:347:18:347:18 | a | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:348:13:348:13 | _ | test.rs:345:5:350:5 | enter fn test_match_and |
+| test.rs:349:15:349:18 | cond | test.rs:346:10:349:9 | [boolean(true)] match r { ... } |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:354:16:354:20 | value | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:355:13:355:22 | Err(...) | test.rs:352:5:357:5 | enter fn test_match_with_no_arms |
+| test.rs:363:18:363:18 | n | test.rs:362:5:365:5 | enter fn test_let_match |
+| test.rs:363:39:363:53 | MacroStmts | test.rs:362:5:365:5 | enter fn test_let_match |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:369:18:369:20 | ret | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:370:13:370:16 | None | test.rs:367:5:373:5 | enter fn test_let_with_return |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:393:15:393:15 | 0 | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:393:20:393:20 | 1 | test.rs:393:15:393:15 | 0 |
+| test.rs:394:13:394:13 | 1 | test.rs:394:13:394:16 | RangePat |
+| test.rs:394:13:394:16 | RangePat | test.rs:391:5:398:5 | enter fn range_pattern |
+| test.rs:394:16:394:16 | 2 | test.rs:394:13:394:13 | 1 |
+| test.rs:394:21:394:21 | 2 | test.rs:394:16:394:16 | 2 |
+| test.rs:395:13:395:13 | 5 | test.rs:395:13:395:15 | RangePat |
+| test.rs:395:13:395:15 | RangePat | test.rs:394:13:394:16 | RangePat |
+| test.rs:395:20:395:20 | 3 | test.rs:395:13:395:13 | 5 |
+| test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:402:5:407:5 | enter fn test_infinite_loop |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:429:13:431:13 | if b {...} | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:430:17:430:41 | ExprStmt | test.rs:428:28:433:9 | enter { ... } |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:21:450:48 | [boolean(true)] ! ... |
+| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:446:5:454:5 | enter fn const_block_assert |
+| test.rs:458:9:463:9 | if false {...} | test.rs:456:5:465:5 | enter fn const_block_panic |
+| test.rs:470:9:470:17 | ExprStmt | test.rs:468:1:473:1 | enter fn dead_code |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:489:13:489:27 | ExprStmt | test.rs:485:1:499:1 | enter fn labelled_block1 |
+| test.rs:492:9:494:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:493:13:493:27 | ExprStmt | test.rs:488:9:490:9 | if ... {...} |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:504:18:504:18 | y | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:505:13:505:27 | ExprStmt | test.rs:501:1:509:1 | enter fn labelled_block2 |
 controls
 | test.rs:18:5:24:5 | enter fn next | test.rs:20:13:20:13 | n | true |
 | test.rs:18:5:24:5 | enter fn next | test.rs:22:13:22:13 | 3 | false |
@@ -1469,158 +1514,165 @@ controls
 | test.rs:108:13:110:13 | ExprStmt | test.rs:109:17:109:22 | ExprStmt | true |
 | test.rs:129:5:135:5 | enter fn test_if_else | test.rs:131:13:131:13 | 0 | true |
 | test.rs:129:5:135:5 | enter fn test_if_else | test.rs:133:13:133:13 | n | false |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:22:153:32 | [boolean(false)] { ... } | true |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:22:153:32 | [boolean(true)] { ... } | true |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:24:153:24 | a | true |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:39:153:48 | [boolean(false)] { ... } | false |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:39:153:48 | [boolean(true)] { ... } | false |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:41:153:41 | a | false |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:156:13:156:13 | 0 | false |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:154:13:154:13 | 1 | true |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(false)] { ... } | false |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(true)] { ... } | true |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(false)] { ... } | false |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(true)] { ... } | true |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:167:13:167:13 | 0 | false |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:165:13:165:13 | 1 | true |
-| test.rs:162:18:162:21 | true | test.rs:161:13:164:9 | [boolean(true)] match a { ... } | true |
-| test.rs:162:18:162:21 | true | test.rs:165:13:165:13 | 1 | true |
-| test.rs:163:13:163:13 | _ | test.rs:161:13:164:9 | [boolean(false)] match a { ... } | false |
-| test.rs:163:13:163:13 | _ | test.rs:167:13:167:13 | 0 | false |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(false)] { ... } | false |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(true)] { ... } | true |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:176:13:176:13 | 1 | true |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:178:13:178:13 | 0 | false |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:178:13:178:13 | 0 | false |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:176:13:176:13 | 1 | true |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(false)] { ... } | false |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(true)] { ... } | true |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:188:13:188:13 | 1 | true |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:190:13:190:13 | 0 | false |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:190:13:190:13 | 0 | false |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:188:13:188:13 | 1 | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:195:9:204:9 | if ... {...} else {...} | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:13 | if ... {...} | false |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:28 | [boolean(false)] break ... | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:28 | [boolean(true)] break ... | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:29 | ExprStmt | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:201:13:201:13 | 1 | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:203:13:203:13 | 0 | true |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:203:13:203:13 | 0 | false |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:201:13:201:13 | 1 | true |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(false)] break ... | false |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(true)] break ... | true |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:201:13:201:13 | 1 | true |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:203:13:203:13 | 0 | false |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:208:9:217:9 | if ... {...} else {...} | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:13 | if ... {...} | false |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:35 | [boolean(false)] break ''label ... | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:35 | [boolean(true)] break ''label ... | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:36 | ExprStmt | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:214:13:214:13 | 1 | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:216:13:216:13 | 0 | true |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:216:13:216:13 | 0 | false |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:214:13:214:13 | 1 | true |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(false)] break ''label ... | false |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(true)] break ''label ... | true |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:214:13:214:13 | 1 | true |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:216:13:216:13 | 0 | false |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(false)] break ''block ... | false |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(true)] break ''block ... | true |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:224:13:224:13 | 1 | true |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:226:13:226:13 | 0 | false |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:226:13:226:13 | 0 | false |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:224:13:224:13 | 1 | true |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:17:234:22 | [boolean(true)] ... && ... | true |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:22:234:22 | b | true |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:27:234:27 | c | true |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:27:234:27 | c | true |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(true)] ... && ... | true |
-| test.rs:234:22:234:22 | b | test.rs:234:27:234:27 | c | true |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:22:239:22 | b | false |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:27:239:27 | c | false |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:27:239:27 | c | false |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:239:22:239:22 | b | test.rs:239:27:239:27 | c | false |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | false |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:23:244:23 | b | false |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:35:244:35 | c | false |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:35:244:35 | c | false |
-| test.rs:244:23:244:23 | b | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | false |
-| test.rs:244:23:244:23 | b | test.rs:244:35:244:35 | c | false |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:17 | [boolean(true)] ... && ... | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:17:254:17 | b | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:22:254:22 | c | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:255:13:255:16 | true | true |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:22:254:22 | c | true |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true | true |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:257:13:257:17 | false | false |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true | true |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(true)] ... && ... | true |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:254:17:254:17 | b | test.rs:254:22:254:22 | c | true |
-| test.rs:254:17:254:17 | b | test.rs:255:13:255:16 | true | true |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:254:22:254:22 | c | test.rs:255:13:255:16 | true | true |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:17:262:17 | b | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:22:262:22 | c | false |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:265:13:265:17 | false | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:22:262:22 | c | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false | false |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false | false |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:263:13:263:16 | true | true |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:17:262:17 | b | test.rs:262:22:262:22 | c | false |
-| test.rs:262:17:262:17 | b | test.rs:265:13:265:17 | false | false |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:22:262:22 | c | test.rs:265:13:265:17 | false | false |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(false)] ! ... | true |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(true)] ! ... | false |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:271:13:271:16 | true | false |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:273:13:273:17 | false | true |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:273:13:273:17 | false | false |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:271:13:271:16 | true | true |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:9:278:19 | ... && ... | false |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:14:278:19 | return | true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:9:284:9 | if ... {...} | false |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:13:282:21 | [boolean(false)] ... && ... | false |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:13:282:21 | [boolean(true)] ... && ... | true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:18:282:21 | true | true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:283:13:283:21 | ExprStmt | true |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:9:284:9 | if ... {...} | false |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:283:13:283:21 | ExprStmt | true |
-| test.rs:282:18:282:21 | true | test.rs:282:13:282:21 | [boolean(true)] ... && ... | true |
-| test.rs:282:18:282:21 | true | test.rs:283:13:283:21 | ExprStmt | true |
-| test.rs:309:26:309:26 | x | test.rs:309:42:309:42 | x | true |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:316:9:323:9 | match ... { ... } | false |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:317:13:317:21 | ExprStmt | true |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:319:13:319:23 | maybe_digit | false |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:321:26:321:26 | x | false |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:322:13:322:24 | ...::None | false |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:330:15:330:18 | cond | true |
-| test.rs:328:18:328:18 | a | test.rs:327:10:330:9 | [boolean(true)] match r { ... } | true |
-| test.rs:328:18:328:18 | a | test.rs:330:15:330:18 | cond | true |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:410:13:412:13 | if b {...} | false |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:411:17:411:41 | ExprStmt | true |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:13:431:49 | ExprStmt | false |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(false)] ! ... | true |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(true)] ! ... | false |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:13:431:49 | ExprStmt | true |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:439:9:444:9 | if false {...} | false |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:451:9:451:17 | ExprStmt | true |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:469:9:471:9 | if ... {...} | false |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:470:13:470:27 | ExprStmt | true |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:473:9:475:9 | if ... {...} | false |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:474:13:474:27 | ExprStmt | false |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:473:9:475:9 | if ... {...} | false |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:474:13:474:27 | ExprStmt | true |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:140:13:140:19 | ExprStmt | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:22:161:32 | [boolean(false)] { ... } | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:22:161:32 | [boolean(true)] { ... } | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:24:161:24 | a | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:39:161:48 | [boolean(false)] { ... } | false |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:39:161:48 | [boolean(true)] { ... } | false |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:41:161:41 | a | false |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:164:13:164:13 | 0 | false |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:162:13:162:13 | 1 | true |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(false)] { ... } | false |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(true)] { ... } | true |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(false)] { ... } | false |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(true)] { ... } | true |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:170:13:174:13 | ExprStmt | true |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:170:13:174:13 | if cond2 {...} else {...} | true |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:171:17:171:30 | ExprStmt | true |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:173:17:173:30 | ExprStmt | true |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:171:17:171:30 | ExprStmt | true |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:173:17:173:30 | ExprStmt | false |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:186:13:186:13 | 0 | false |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:184:13:184:13 | 1 | true |
+| test.rs:181:18:181:21 | true | test.rs:180:13:183:9 | [boolean(true)] match a { ... } | true |
+| test.rs:181:18:181:21 | true | test.rs:184:13:184:13 | 1 | true |
+| test.rs:182:13:182:13 | _ | test.rs:180:13:183:9 | [boolean(false)] match a { ... } | false |
+| test.rs:182:13:182:13 | _ | test.rs:186:13:186:13 | 0 | false |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(false)] { ... } | false |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(true)] { ... } | true |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:195:13:195:13 | 1 | true |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:197:13:197:13 | 0 | false |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:197:13:197:13 | 0 | false |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:195:13:195:13 | 1 | true |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(false)] { ... } | false |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(true)] { ... } | true |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:207:13:207:13 | 1 | true |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:209:13:209:13 | 0 | false |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:209:13:209:13 | 0 | false |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:207:13:207:13 | 1 | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:214:9:223:9 | if ... {...} else {...} | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:13 | if ... {...} | false |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:28 | [boolean(false)] break ... | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:28 | [boolean(true)] break ... | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:29 | ExprStmt | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:220:13:220:13 | 1 | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:222:13:222:13 | 0 | true |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:222:13:222:13 | 0 | false |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:220:13:220:13 | 1 | true |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(false)] break ... | false |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(true)] break ... | true |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:220:13:220:13 | 1 | true |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:222:13:222:13 | 0 | false |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:227:9:236:9 | if ... {...} else {...} | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:13 | if ... {...} | false |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:35 | [boolean(false)] break ''label ... | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:35 | [boolean(true)] break ''label ... | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:36 | ExprStmt | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:233:13:233:13 | 1 | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:235:13:235:13 | 0 | true |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:235:13:235:13 | 0 | false |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:233:13:233:13 | 1 | true |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(false)] break ''label ... | false |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(true)] break ''label ... | true |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:233:13:233:13 | 1 | true |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:235:13:235:13 | 0 | false |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(false)] break ''block ... | false |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(true)] break ''block ... | true |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:243:13:243:13 | 1 | true |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:245:13:245:13 | 0 | false |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:245:13:245:13 | 0 | false |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:243:13:243:13 | 1 | true |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:17:253:22 | [boolean(true)] ... && ... | true |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:22:253:22 | b | true |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:27:253:27 | c | true |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:27:253:27 | c | true |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(true)] ... && ... | true |
+| test.rs:253:22:253:22 | b | test.rs:253:27:253:27 | c | true |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:22:258:22 | b | false |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:27:258:27 | c | false |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:27:258:27 | c | false |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:258:22:258:22 | b | test.rs:258:27:258:27 | c | false |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | false |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:23:263:23 | b | false |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:35:263:35 | c | false |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:35:263:35 | c | false |
+| test.rs:263:23:263:23 | b | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | false |
+| test.rs:263:23:263:23 | b | test.rs:263:35:263:35 | c | false |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:17 | [boolean(true)] ... && ... | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:17:273:17 | b | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:22:273:22 | c | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:274:13:274:16 | true | true |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:22:273:22 | c | true |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true | true |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:276:13:276:17 | false | false |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true | true |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(true)] ... && ... | true |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:273:17:273:17 | b | test.rs:273:22:273:22 | c | true |
+| test.rs:273:17:273:17 | b | test.rs:274:13:274:16 | true | true |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:273:22:273:22 | c | test.rs:274:13:274:16 | true | true |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:17:281:17 | b | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:22:281:22 | c | false |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:284:13:284:17 | false | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:22:281:22 | c | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false | false |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false | false |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:282:13:282:16 | true | true |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:17:281:17 | b | test.rs:281:22:281:22 | c | false |
+| test.rs:281:17:281:17 | b | test.rs:284:13:284:17 | false | false |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:22:281:22 | c | test.rs:284:13:284:17 | false | false |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(false)] ! ... | true |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(true)] ! ... | false |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:290:13:290:16 | true | false |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:292:13:292:17 | false | true |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:292:13:292:17 | false | false |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:290:13:290:16 | true | true |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:9:297:19 | ... && ... | false |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:14:297:19 | return | true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:9:303:9 | if ... {...} | false |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:13:301:21 | [boolean(false)] ... && ... | false |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:13:301:21 | [boolean(true)] ... && ... | true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:18:301:21 | true | true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:302:13:302:21 | ExprStmt | true |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:9:303:9 | if ... {...} | false |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:302:13:302:21 | ExprStmt | true |
+| test.rs:301:18:301:21 | true | test.rs:301:13:301:21 | [boolean(true)] ... && ... | true |
+| test.rs:301:18:301:21 | true | test.rs:302:13:302:21 | ExprStmt | true |
+| test.rs:328:26:328:26 | x | test.rs:328:42:328:42 | x | true |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:335:9:342:9 | match ... { ... } | false |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:336:13:336:21 | ExprStmt | true |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:338:13:338:23 | maybe_digit | false |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:340:26:340:26 | x | false |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:341:13:341:24 | ...::None | false |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:349:15:349:18 | cond | true |
+| test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | true |
+| test.rs:347:18:347:18 | a | test.rs:349:15:349:18 | cond | true |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} | false |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt | true |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:13:450:49 | ExprStmt | false |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} | false |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt | true |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} | false |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt | true |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:492:9:494:9 | if ... {...} | false |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:493:13:493:27 | ExprStmt | false |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} | false |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt | true |
 successor
 | test.rs:18:5:24:5 | enter fn next | test.rs:20:13:20:13 | n | true |
 | test.rs:18:5:24:5 | enter fn next | test.rs:22:13:22:13 | 3 | false |
@@ -1652,116 +1704,122 @@ successor
 | test.rs:108:13:110:13 | ExprStmt | test.rs:109:17:109:22 | ExprStmt | true |
 | test.rs:129:5:135:5 | enter fn test_if_else | test.rs:131:13:131:13 | 0 | true |
 | test.rs:129:5:135:5 | enter fn test_if_else | test.rs:133:13:133:13 | n | false |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:24:153:24 | a | true |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:153:41:153:41 | a | false |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:156:13:156:13 | 0 | false |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:154:13:154:13 | 1 | true |
-| test.rs:153:22:153:32 | [boolean(false)] { ... } | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | false |
-| test.rs:153:22:153:32 | [boolean(true)] { ... } | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | true |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(false)] { ... } | false |
-| test.rs:153:24:153:24 | a | test.rs:153:22:153:32 | [boolean(true)] { ... } | true |
-| test.rs:153:39:153:48 | [boolean(false)] { ... } | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | false |
-| test.rs:153:39:153:48 | [boolean(true)] { ... } | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | true |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(false)] { ... } | false |
-| test.rs:153:41:153:41 | a | test.rs:153:39:153:48 | [boolean(true)] { ... } | true |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:167:13:167:13 | 0 | false |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:165:13:165:13 | 1 | true |
-| test.rs:162:18:162:21 | true | test.rs:161:13:164:9 | [boolean(true)] match a { ... } | true |
-| test.rs:163:13:163:13 | _ | test.rs:161:13:164:9 | [boolean(false)] match a { ... } | false |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(false)] { ... } | false |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:172:12:175:9 | [boolean(true)] { ... } | true |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:178:13:178:13 | 0 | false |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:176:13:176:13 | 1 | true |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(false)] { ... } | false |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:184:12:187:9 | [boolean(true)] { ... } | true |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:190:13:190:13 | 0 | false |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:188:13:188:13 | 1 | true |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:13 | if ... {...} | false |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:197:17:197:29 | ExprStmt | true |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:203:13:203:13 | 0 | false |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:201:13:201:13 | 1 | true |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(false)] break ... | false |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:17:197:28 | [boolean(true)] break ... | true |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:13 | if ... {...} | false |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:210:17:210:36 | ExprStmt | true |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:216:13:216:13 | 0 | false |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:214:13:214:13 | 1 | true |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(false)] break ''label ... | false |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:17:210:35 | [boolean(true)] break ''label ... | true |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(false)] break ''block ... | false |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:222:13:222:30 | [boolean(true)] break ''block ... | true |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:226:13:226:13 | 0 | false |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:224:13:224:13 | 1 | true |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:17:234:22 | [boolean(false)] ... && ... | false |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:234:22:234:22 | b | true |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:234:17:234:27 | ... && ... | false |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:27:234:27 | c | true |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(false)] ... && ... | false |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(true)] ... && ... | true |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:239:22:239:22 | b | false |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:27:239:27 | c | false |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:239:17:239:27 | ... \|\| ... | true |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | true |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:244:23:244:23 | b | false |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:35:244:35 | c | false |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:244:17:244:35 | ... \|\| ... | true |
-| test.rs:244:23:244:23 | b | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | false |
-| test.rs:244:23:244:23 | b | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | true |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:12:254:17 | [boolean(false)] ... && ... | false |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:254:17:254:17 | b | true |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:254:12:254:22 | [boolean(false)] ... && ... | false |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:22:254:22 | c | true |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:257:13:257:17 | false | false |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true | true |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(false)] ... && ... | false |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(true)] ... && ... | true |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(false)] ... && ... | false |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | true |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:262:17:262:17 | b | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:22:262:22 | c | false |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false | false |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:263:13:263:16 | true | true |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(false)] ! ... | true |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:270:12:270:13 | [boolean(true)] ! ... | false |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:273:13:273:17 | false | false |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:271:13:271:16 | true | true |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:9:278:19 | ... && ... | false |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:278:14:278:19 | return | true |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:13:282:21 | [boolean(false)] ... && ... | false |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:282:18:282:21 | true | true |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:9:284:9 | if ... {...} | false |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:283:13:283:21 | ExprStmt | true |
-| test.rs:282:18:282:21 | true | test.rs:282:13:282:21 | [boolean(true)] ... && ... | true |
-| test.rs:309:26:309:26 | x | test.rs:309:42:309:42 | x | true |
-| test.rs:309:26:309:26 | x | test.rs:310:13:310:27 | ...::Some(...) | false |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:317:13:317:21 | ExprStmt | true |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:319:13:319:23 | maybe_digit | false |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:327:9:330:18 | ... && ... | false |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:330:15:330:18 | cond | true |
-| test.rs:328:18:328:18 | a | test.rs:327:10:330:9 | [boolean(false)] match r { ... } | false |
-| test.rs:328:18:328:18 | a | test.rs:327:10:330:9 | [boolean(true)] match r { ... } | true |
-| test.rs:329:13:329:13 | _ | test.rs:327:10:330:9 | [boolean(false)] match r { ... } | false |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:410:13:412:13 | if b {...} | false |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:411:17:411:41 | ExprStmt | true |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(false)] ! ... | true |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:431:21:431:48 | [boolean(true)] ! ... | false |
-| test.rs:431:21:431:48 | [boolean(false)] ! ... | test.rs:431:21:431:48 | if ... {...} | false |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:13:431:49 | ExprStmt | true |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:439:9:444:9 | if false {...} | false |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:451:9:451:17 | ExprStmt | true |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:469:9:471:9 | if ... {...} | false |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:470:13:470:27 | ExprStmt | true |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:473:9:475:9 | if ... {...} | false |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:474:13:474:27 | ExprStmt | true |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:139:9:141:9 | if b {...} | false |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:140:13:140:19 | ExprStmt | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:24:161:24 | a | true |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:161:41:161:41 | a | false |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:164:13:164:13 | 0 | false |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:162:13:162:13 | 1 | true |
+| test.rs:161:22:161:32 | [boolean(false)] { ... } | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | false |
+| test.rs:161:22:161:32 | [boolean(true)] { ... } | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | true |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(false)] { ... } | false |
+| test.rs:161:24:161:24 | a | test.rs:161:22:161:32 | [boolean(true)] { ... } | true |
+| test.rs:161:39:161:48 | [boolean(false)] { ... } | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | false |
+| test.rs:161:39:161:48 | [boolean(true)] { ... } | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | true |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(false)] { ... } | false |
+| test.rs:161:41:161:41 | a | test.rs:161:39:161:48 | [boolean(true)] { ... } | true |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:169:9:176:9 | if cond1 {...} | false |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:170:13:174:13 | ExprStmt | true |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:171:17:171:30 | ExprStmt | true |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:173:17:173:30 | ExprStmt | false |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:186:13:186:13 | 0 | false |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:184:13:184:13 | 1 | true |
+| test.rs:181:18:181:21 | true | test.rs:180:13:183:9 | [boolean(true)] match a { ... } | true |
+| test.rs:182:13:182:13 | _ | test.rs:180:13:183:9 | [boolean(false)] match a { ... } | false |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(false)] { ... } | false |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:191:12:194:9 | [boolean(true)] { ... } | true |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:197:13:197:13 | 0 | false |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:195:13:195:13 | 1 | true |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(false)] { ... } | false |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:203:12:206:9 | [boolean(true)] { ... } | true |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:209:13:209:13 | 0 | false |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:207:13:207:13 | 1 | true |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:13 | if ... {...} | false |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:216:17:216:29 | ExprStmt | true |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:222:13:222:13 | 0 | false |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:220:13:220:13 | 1 | true |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(false)] break ... | false |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:17:216:28 | [boolean(true)] break ... | true |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:13 | if ... {...} | false |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:229:17:229:36 | ExprStmt | true |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:235:13:235:13 | 0 | false |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:233:13:233:13 | 1 | true |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(false)] break ''label ... | false |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:17:229:35 | [boolean(true)] break ''label ... | true |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(false)] break ''block ... | false |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:241:13:241:30 | [boolean(true)] break ''block ... | true |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:245:13:245:13 | 0 | false |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:243:13:243:13 | 1 | true |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:17:253:22 | [boolean(false)] ... && ... | false |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:253:22:253:22 | b | true |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:253:17:253:27 | ... && ... | false |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:27:253:27 | c | true |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(false)] ... && ... | false |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(true)] ... && ... | true |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:258:22:258:22 | b | false |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:27:258:27 | c | false |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:258:17:258:27 | ... \|\| ... | true |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | true |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:263:23:263:23 | b | false |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:35:263:35 | c | false |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:263:17:263:35 | ... \|\| ... | true |
+| test.rs:263:23:263:23 | b | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | false |
+| test.rs:263:23:263:23 | b | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | true |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:12:273:17 | [boolean(false)] ... && ... | false |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:273:17:273:17 | b | true |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:273:12:273:22 | [boolean(false)] ... && ... | false |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:22:273:22 | c | true |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:276:13:276:17 | false | false |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true | true |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(false)] ... && ... | false |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(true)] ... && ... | true |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(false)] ... && ... | false |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | true |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:281:17:281:17 | b | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:22:281:22 | c | false |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false | false |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:282:13:282:16 | true | true |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(false)] ! ... | true |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:289:12:289:13 | [boolean(true)] ! ... | false |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:292:13:292:17 | false | false |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:290:13:290:16 | true | true |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:9:297:19 | ... && ... | false |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:297:14:297:19 | return | true |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:13:301:21 | [boolean(false)] ... && ... | false |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:301:18:301:21 | true | true |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:9:303:9 | if ... {...} | false |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:302:13:302:21 | ExprStmt | true |
+| test.rs:301:18:301:21 | true | test.rs:301:13:301:21 | [boolean(true)] ... && ... | true |
+| test.rs:328:26:328:26 | x | test.rs:328:42:328:42 | x | true |
+| test.rs:328:26:328:26 | x | test.rs:329:13:329:27 | ...::Some(...) | false |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:336:13:336:21 | ExprStmt | true |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:338:13:338:23 | maybe_digit | false |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:346:9:349:18 | ... && ... | false |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:349:15:349:18 | cond | true |
+| test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
+| test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | true |
+| test.rs:348:13:348:13 | _ | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} | false |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt | true |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
+| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | if ... {...} | false |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} | false |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt | true |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} | false |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt | true |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} | false |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt | true |
 joinBlockPredecessor
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:20:13:20:13 | n | 1 |
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:22:13:22:13 | 3 | 0 |
@@ -1797,104 +1855,110 @@ joinBlockPredecessor
 | test.rs:107:13:107:13 | i | test.rs:108:13:110:13 | if ... {...} | 0 |
 | test.rs:130:9:134:9 | if ... {...} else {...} | test.rs:131:13:131:13 | 0 | 1 |
 | test.rs:130:9:134:9 | if ... {...} else {...} | test.rs:133:13:133:13 | n | 0 |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:138:21:138:21 | n | 0 |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:141:13:141:13 | 0 | 1 |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:146:9:148:9 | if ... {...} | 1 |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:146:21:146:21 | n | 0 |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:154:13:154:13 | 1 | 1 |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:156:13:156:13 | 0 | 0 |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(false)] { ... } | 1 |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(false)] { ... } | 0 |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:22:153:32 | [boolean(true)] { ... } | 1 |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:153:39:153:48 | [boolean(true)] { ... } | 0 |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:165:13:165:13 | 1 | 1 |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:167:13:167:13 | 0 | 0 |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:176:13:176:13 | 1 | 1 |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:178:13:178:13 | 0 | 0 |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:188:13:188:13 | 1 | 1 |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:190:13:190:13 | 0 | 0 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:201:13:201:13 | 1 | 1 |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:203:13:203:13 | 0 | 0 |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:194:5:205:5 | enter fn test_if_loop1 | 1 |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:13:198:13 | if ... {...} | 0 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:214:13:214:13 | 1 | 1 |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:216:13:216:13 | 0 | 0 |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:207:5:218:5 | enter fn test_if_loop2 | 1 |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:13:211:13 | if ... {...} | 0 |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:224:13:224:13 | 1 | 1 |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:226:13:226:13 | 0 | 0 |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:233:5:236:5 | enter fn test_and_operator | 1 |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:234:22:234:22 | b | 0 |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:17:234:22 | [boolean(false)] ... && ... | 0 |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:27:234:27 | c | 1 |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:238:5:241:5 | enter fn test_or_operator | 1 |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:239:22:239:22 | b | 0 |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | 0 |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:27:239:27 | c | 1 |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:243:5:246:5 | enter fn test_or_operator_2 | 1 |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:244:23:244:23 | b | 0 |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | 0 |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:35:244:35 | c | 1 |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:255:13:255:16 | true | 1 |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:257:13:257:17 | false | 0 |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:253:5:259:5 | enter fn test_if_and_operator | 1 |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:254:17:254:17 | b | 0 |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:254:12:254:17 | [boolean(false)] ... && ... | 0 |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:254:22:254:22 | c | 1 |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:263:13:263:16 | true | 1 |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:265:13:265:17 | false | 0 |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:261:5:267:5 | enter fn test_if_or_operator | 1 |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:262:17:262:17 | b | 0 |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | 0 |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:262:22:262:22 | c | 1 |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:271:13:271:16 | true | 1 |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:273:13:273:17 | false | 0 |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:278:9:278:19 | ... && ... | 1 |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:278:14:278:19 | return | 0 |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:282:9:284:9 | if ... {...} | 1 |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:283:13:283:21 | ExprStmt | 0 |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | 1 |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:293:32:293:32 | 4 | 0 |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | 1 |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:297:9:300:9 | match ... { ... } | 0 |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:298:21:298:24 | Some | 0 |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:299:13:299:17 | false | 1 |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:309:42:309:42 | x | 0 |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:310:26:310:26 | x | 1 |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:311:13:311:24 | ...::None | 2 |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:307:5:313:5 | enter fn test_match | 1 |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:309:26:309:26 | x | 0 |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:316:9:323:9 | match ... { ... } | 1 |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:317:13:317:21 | ExprStmt | 0 |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:321:26:321:26 | x | 0 |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:322:13:322:24 | ...::None | 1 |
-| test.rs:327:9:330:18 | ... && ... | test.rs:327:10:330:9 | [boolean(false)] match r { ... } | 0 |
-| test.rs:327:9:330:18 | ... && ... | test.rs:330:15:330:18 | cond | 1 |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:328:18:328:18 | a | 0 |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:329:13:329:13 | _ | 1 |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:335:16:335:20 | value | 0 |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:336:13:336:22 | Err(...) | 1 |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:350:18:350:20 | ret | 0 |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:351:13:351:16 | None | 1 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:374:20:374:20 | 1 | 0 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:375:21:375:21 | 2 | 1 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:376:20:376:20 | 3 | 2 |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:377:13:377:13 | _ | 3 |
-| test.rs:375:13:375:16 | RangePat | test.rs:372:5:379:5 | enter fn range_pattern | 1 |
-| test.rs:375:13:375:16 | RangePat | test.rs:374:15:374:15 | 0 | 0 |
-| test.rs:376:13:376:15 | RangePat | test.rs:375:13:375:13 | 1 | 1 |
-| test.rs:376:13:376:15 | RangePat | test.rs:375:13:375:16 | RangePat | 2 |
-| test.rs:376:13:376:15 | RangePat | test.rs:375:16:375:16 | 2 | 0 |
-| test.rs:377:13:377:13 | _ | test.rs:376:13:376:13 | 5 | 0 |
-| test.rs:377:13:377:13 | _ | test.rs:376:13:376:15 | RangePat | 1 |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:383:5:388:5 | enter fn test_infinite_loop | 1 |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:385:13:385:14 | TupleExpr | 0 |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:410:13:412:13 | if b {...} | 1 |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:411:17:411:41 | ExprStmt | 0 |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:13:431:49 | ExprStmt | 1 |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | [boolean(false)] ! ... | 0 |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:470:13:470:27 | ExprStmt | 0 |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:473:9:475:9 | if ... {...} | 2 |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:474:13:474:27 | ExprStmt | 1 |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:485:18:485:18 | y | 1 |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:486:13:486:27 | ExprStmt | 0 |
+| test.rs:139:9:141:9 | if b {...} | test.rs:137:5:143:5 | enter fn test_if_without_else | 1 |
+| test.rs:139:9:141:9 | if b {...} | test.rs:140:13:140:19 | ExprStmt | 0 |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:146:21:146:21 | n | 0 |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:149:13:149:13 | 0 | 1 |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:154:9:156:9 | if ... {...} | 1 |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:154:21:154:21 | n | 0 |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:162:13:162:13 | 1 | 1 |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:164:13:164:13 | 0 | 0 |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(false)] { ... } | 1 |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(false)] { ... } | 0 |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:22:161:32 | [boolean(true)] { ... } | 1 |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:161:39:161:48 | [boolean(true)] { ... } | 0 |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:168:5:177:5 | enter fn test_nested_if_2 | 1 |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:170:13:174:13 | if cond2 {...} else {...} | 0 |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:171:17:171:30 | ExprStmt | 1 |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:173:17:173:30 | ExprStmt | 0 |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:184:13:184:13 | 1 | 1 |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:186:13:186:13 | 0 | 0 |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:195:13:195:13 | 1 | 1 |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:197:13:197:13 | 0 | 0 |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:207:13:207:13 | 1 | 1 |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:209:13:209:13 | 0 | 0 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:220:13:220:13 | 1 | 1 |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:222:13:222:13 | 0 | 0 |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:213:5:224:5 | enter fn test_if_loop1 | 1 |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:13:217:13 | if ... {...} | 0 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:233:13:233:13 | 1 | 1 |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:235:13:235:13 | 0 | 0 |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:226:5:237:5 | enter fn test_if_loop2 | 1 |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:13:230:13 | if ... {...} | 0 |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:243:13:243:13 | 1 | 1 |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:245:13:245:13 | 0 | 0 |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:252:5:255:5 | enter fn test_and_operator | 1 |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:253:22:253:22 | b | 0 |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:17:253:22 | [boolean(false)] ... && ... | 0 |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:27:253:27 | c | 1 |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:257:5:260:5 | enter fn test_or_operator | 1 |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:258:22:258:22 | b | 0 |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | 0 |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:27:258:27 | c | 1 |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:262:5:265:5 | enter fn test_or_operator_2 | 1 |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:263:23:263:23 | b | 0 |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | 0 |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:35:263:35 | c | 1 |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:274:13:274:16 | true | 1 |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:276:13:276:17 | false | 0 |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:272:5:278:5 | enter fn test_if_and_operator | 1 |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:273:17:273:17 | b | 0 |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:273:12:273:17 | [boolean(false)] ... && ... | 0 |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:273:22:273:22 | c | 1 |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:282:13:282:16 | true | 1 |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:284:13:284:17 | false | 0 |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:280:5:286:5 | enter fn test_if_or_operator | 1 |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:281:17:281:17 | b | 0 |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | 0 |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:281:22:281:22 | c | 1 |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:290:13:290:16 | true | 1 |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:292:13:292:17 | false | 0 |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:297:9:297:19 | ... && ... | 1 |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:297:14:297:19 | return | 0 |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:301:9:303:9 | if ... {...} | 1 |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:302:13:302:21 | ExprStmt | 0 |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | 1 |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:312:32:312:32 | 4 | 0 |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | 1 |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:316:9:319:9 | match ... { ... } | 0 |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:317:21:317:24 | Some | 0 |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:318:13:318:17 | false | 1 |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:328:42:328:42 | x | 0 |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:329:26:329:26 | x | 1 |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:330:13:330:24 | ...::None | 2 |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:326:5:332:5 | enter fn test_match | 1 |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:328:26:328:26 | x | 0 |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:335:9:342:9 | match ... { ... } | 1 |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:336:13:336:21 | ExprStmt | 0 |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:340:26:340:26 | x | 0 |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:341:13:341:24 | ...::None | 1 |
+| test.rs:346:9:349:18 | ... && ... | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | 0 |
+| test.rs:346:9:349:18 | ... && ... | test.rs:349:15:349:18 | cond | 1 |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:347:18:347:18 | a | 0 |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:348:13:348:13 | _ | 1 |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:354:16:354:20 | value | 0 |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:355:13:355:22 | Err(...) | 1 |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:369:18:369:20 | ret | 0 |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:370:13:370:16 | None | 1 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:393:20:393:20 | 1 | 0 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:394:21:394:21 | 2 | 1 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:395:20:395:20 | 3 | 2 |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:396:13:396:13 | _ | 3 |
+| test.rs:394:13:394:16 | RangePat | test.rs:391:5:398:5 | enter fn range_pattern | 1 |
+| test.rs:394:13:394:16 | RangePat | test.rs:393:15:393:15 | 0 | 0 |
+| test.rs:395:13:395:15 | RangePat | test.rs:394:13:394:13 | 1 | 1 |
+| test.rs:395:13:395:15 | RangePat | test.rs:394:13:394:16 | RangePat | 2 |
+| test.rs:395:13:395:15 | RangePat | test.rs:394:16:394:16 | 2 | 0 |
+| test.rs:396:13:396:13 | _ | test.rs:395:13:395:13 | 5 | 0 |
+| test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat | 1 |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:402:5:407:5 | enter fn test_infinite_loop | 1 |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr | 0 |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:429:13:431:13 | if b {...} | 1 |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:430:17:430:41 | ExprStmt | 0 |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:13:450:49 | ExprStmt | 1 |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(false)] ! ... | 0 |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:489:13:489:27 | ExprStmt | 0 |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:492:9:494:9 | if ... {...} | 2 |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:493:13:493:27 | ExprStmt | 1 |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:504:18:504:18 | y | 1 |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt | 0 |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -267,844 +267,916 @@ edges
 | test.rs:133:13:133:13 | n | test.rs:133:17:133:17 | 1 |  |
 | test.rs:133:13:133:17 | ... - ... | test.rs:132:16:134:9 | { ... } |  |
 | test.rs:133:17:133:17 | 1 | test.rs:133:13:133:17 | ... - ... |  |
-| test.rs:137:5:143:5 | enter fn test_if_let_else | test.rs:137:25:137:25 | a |  |
-| test.rs:137:5:143:5 | exit fn test_if_let_else (normal) | test.rs:137:5:143:5 | exit fn test_if_let_else |  |
-| test.rs:137:25:137:25 | a | test.rs:137:25:137:38 | ...: Option::<...> | match |
-| test.rs:137:25:137:38 | ...: Option::<...> | test.rs:138:12:138:26 | let ... = a |  |
-| test.rs:137:48:143:5 | { ... } | test.rs:137:5:143:5 | exit fn test_if_let_else (normal) |  |
-| test.rs:138:9:142:9 | if ... {...} else {...} | test.rs:137:48:143:5 | { ... } |  |
-| test.rs:138:12:138:26 | let ... = a | test.rs:138:26:138:26 | a |  |
-| test.rs:138:16:138:22 | Some(...) | test.rs:138:21:138:21 | n | match |
-| test.rs:138:16:138:22 | Some(...) | test.rs:141:13:141:13 | 0 | no-match |
-| test.rs:138:21:138:21 | n | test.rs:139:13:139:13 | n | match |
-| test.rs:138:26:138:26 | a | test.rs:138:16:138:22 | Some(...) |  |
-| test.rs:138:28:140:9 | { ... } | test.rs:138:9:142:9 | if ... {...} else {...} |  |
-| test.rs:139:13:139:13 | n | test.rs:138:28:140:9 | { ... } |  |
-| test.rs:140:16:142:9 | { ... } | test.rs:138:9:142:9 | if ... {...} else {...} |  |
-| test.rs:141:13:141:13 | 0 | test.rs:140:16:142:9 | { ... } |  |
-| test.rs:145:5:150:5 | enter fn test_if_let | test.rs:145:20:145:20 | a |  |
-| test.rs:145:5:150:5 | exit fn test_if_let (normal) | test.rs:145:5:150:5 | exit fn test_if_let |  |
-| test.rs:145:20:145:20 | a | test.rs:145:20:145:33 | ...: Option::<...> | match |
-| test.rs:145:20:145:33 | ...: Option::<...> | test.rs:146:9:148:9 | ExprStmt |  |
-| test.rs:145:43:150:5 | { ... } | test.rs:145:5:150:5 | exit fn test_if_let (normal) |  |
-| test.rs:146:9:148:9 | ExprStmt | test.rs:146:12:146:26 | let ... = a |  |
-| test.rs:146:9:148:9 | if ... {...} | test.rs:149:9:149:9 | 0 |  |
+| test.rs:137:5:143:5 | enter fn test_if_without_else | test.rs:137:29:137:29 | b |  |
+| test.rs:137:5:143:5 | exit fn test_if_without_else (normal) | test.rs:137:5:143:5 | exit fn test_if_without_else |  |
+| test.rs:137:29:137:29 | b | test.rs:137:29:137:35 | ...: bool | match |
+| test.rs:137:29:137:35 | ...: bool | test.rs:138:9:138:22 | let ... = 3 |  |
+| test.rs:137:45:143:5 | { ... } | test.rs:137:5:143:5 | exit fn test_if_without_else (normal) |  |
+| test.rs:138:9:138:22 | let ... = 3 | test.rs:138:21:138:21 | 3 |  |
+| test.rs:138:13:138:17 | i | test.rs:139:9:141:9 | ExprStmt | match |
+| test.rs:138:21:138:21 | 3 | test.rs:138:13:138:17 | i |  |
+| test.rs:139:9:141:9 | ExprStmt | test.rs:139:12:139:12 | b |  |
+| test.rs:139:9:141:9 | if b {...} | test.rs:142:9:142:9 | i |  |
+| test.rs:139:12:139:12 | b | test.rs:139:9:141:9 | if b {...} | false |
+| test.rs:139:12:139:12 | b | test.rs:140:13:140:19 | ExprStmt | true |
+| test.rs:139:14:141:9 | { ... } | test.rs:139:9:141:9 | if b {...} |  |
+| test.rs:140:13:140:13 | i | test.rs:140:18:140:18 | 1 |  |
+| test.rs:140:13:140:18 | ... += ... | test.rs:139:14:141:9 | { ... } |  |
+| test.rs:140:13:140:19 | ExprStmt | test.rs:140:13:140:13 | i |  |
+| test.rs:140:18:140:18 | 1 | test.rs:140:13:140:18 | ... += ... |  |
+| test.rs:142:9:142:9 | i | test.rs:137:45:143:5 | { ... } |  |
+| test.rs:145:5:151:5 | enter fn test_if_let_else | test.rs:145:25:145:25 | a |  |
+| test.rs:145:5:151:5 | exit fn test_if_let_else (normal) | test.rs:145:5:151:5 | exit fn test_if_let_else |  |
+| test.rs:145:25:145:25 | a | test.rs:145:25:145:38 | ...: Option::<...> | match |
+| test.rs:145:25:145:38 | ...: Option::<...> | test.rs:146:12:146:26 | let ... = a |  |
+| test.rs:145:48:151:5 | { ... } | test.rs:145:5:151:5 | exit fn test_if_let_else (normal) |  |
+| test.rs:146:9:150:9 | if ... {...} else {...} | test.rs:145:48:151:5 | { ... } |  |
 | test.rs:146:12:146:26 | let ... = a | test.rs:146:26:146:26 | a |  |
-| test.rs:146:16:146:22 | Some(...) | test.rs:146:9:148:9 | if ... {...} | no-match |
 | test.rs:146:16:146:22 | Some(...) | test.rs:146:21:146:21 | n | match |
-| test.rs:146:21:146:21 | n | test.rs:147:13:147:21 | ExprStmt | match |
+| test.rs:146:16:146:22 | Some(...) | test.rs:149:13:149:13 | 0 | no-match |
+| test.rs:146:21:146:21 | n | test.rs:147:13:147:13 | n | match |
 | test.rs:146:26:146:26 | a | test.rs:146:16:146:22 | Some(...) |  |
-| test.rs:147:13:147:20 | return n | test.rs:145:5:150:5 | exit fn test_if_let (normal) | return |
-| test.rs:147:13:147:21 | ExprStmt | test.rs:147:20:147:20 | n |  |
-| test.rs:147:20:147:20 | n | test.rs:147:13:147:20 | return n |  |
-| test.rs:149:9:149:9 | 0 | test.rs:145:43:150:5 | { ... } |  |
-| test.rs:152:5:158:5 | enter fn test_nested_if | test.rs:152:23:152:23 | a |  |
-| test.rs:152:5:158:5 | exit fn test_nested_if (normal) | test.rs:152:5:158:5 | exit fn test_nested_if |  |
-| test.rs:152:23:152:23 | a | test.rs:152:23:152:28 | ...: i64 | match |
-| test.rs:152:23:152:28 | ...: i64 | test.rs:153:16:153:16 | a |  |
-| test.rs:152:38:158:5 | { ... } | test.rs:152:5:158:5 | exit fn test_nested_if (normal) |  |
-| test.rs:153:9:157:9 | if ... {...} else {...} | test.rs:152:38:158:5 | { ... } |  |
-| test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | test.rs:156:13:156:13 | 0 | false |
-| test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | test.rs:154:13:154:13 | 1 | true |
-| test.rs:153:16:153:16 | a | test.rs:153:20:153:20 | 0 |  |
-| test.rs:153:16:153:20 | ... < ... | test.rs:153:24:153:24 | a | true |
-| test.rs:153:16:153:20 | ... < ... | test.rs:153:41:153:41 | a | false |
-| test.rs:153:20:153:20 | 0 | test.rs:153:16:153:20 | ... < ... |  |
-| test.rs:153:22:153:32 | [boolean(false)] { ... } | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | false |
-| test.rs:153:22:153:32 | [boolean(true)] { ... } | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | true |
-| test.rs:153:24:153:24 | a | test.rs:153:29:153:30 | 10 |  |
-| test.rs:153:24:153:30 | ... < ... | test.rs:153:22:153:32 | [boolean(false)] { ... } | false |
-| test.rs:153:24:153:30 | ... < ... | test.rs:153:22:153:32 | [boolean(true)] { ... } | true |
-| test.rs:153:28:153:30 | - ... | test.rs:153:24:153:30 | ... < ... |  |
-| test.rs:153:29:153:30 | 10 | test.rs:153:28:153:30 | - ... |  |
-| test.rs:153:39:153:48 | [boolean(false)] { ... } | test.rs:153:13:153:48 | [boolean(false)] if ... {...} else {...} | false |
-| test.rs:153:39:153:48 | [boolean(true)] { ... } | test.rs:153:13:153:48 | [boolean(true)] if ... {...} else {...} | true |
-| test.rs:153:41:153:41 | a | test.rs:153:45:153:46 | 10 |  |
-| test.rs:153:41:153:46 | ... > ... | test.rs:153:39:153:48 | [boolean(false)] { ... } | false |
-| test.rs:153:41:153:46 | ... > ... | test.rs:153:39:153:48 | [boolean(true)] { ... } | true |
-| test.rs:153:45:153:46 | 10 | test.rs:153:41:153:46 | ... > ... |  |
-| test.rs:153:51:155:9 | { ... } | test.rs:153:9:157:9 | if ... {...} else {...} |  |
-| test.rs:154:13:154:13 | 1 | test.rs:153:51:155:9 | { ... } |  |
-| test.rs:155:16:157:9 | { ... } | test.rs:153:9:157:9 | if ... {...} else {...} |  |
-| test.rs:156:13:156:13 | 0 | test.rs:155:16:157:9 | { ... } |  |
-| test.rs:160:5:169:5 | enter fn test_nested_if_match | test.rs:160:29:160:29 | a |  |
-| test.rs:160:5:169:5 | exit fn test_nested_if_match (normal) | test.rs:160:5:169:5 | exit fn test_nested_if_match |  |
-| test.rs:160:29:160:29 | a | test.rs:160:29:160:34 | ...: i64 | match |
-| test.rs:160:29:160:34 | ...: i64 | test.rs:161:19:161:19 | a |  |
-| test.rs:160:44:169:5 | { ... } | test.rs:160:5:169:5 | exit fn test_nested_if_match (normal) |  |
-| test.rs:161:9:168:9 | if ... {...} else {...} | test.rs:160:44:169:5 | { ... } |  |
-| test.rs:161:13:164:9 | [boolean(false)] match a { ... } | test.rs:167:13:167:13 | 0 | false |
-| test.rs:161:13:164:9 | [boolean(true)] match a { ... } | test.rs:165:13:165:13 | 1 | true |
-| test.rs:161:19:161:19 | a | test.rs:162:13:162:13 | 0 |  |
-| test.rs:162:13:162:13 | 0 | test.rs:162:13:162:13 | 0 |  |
-| test.rs:162:13:162:13 | 0 | test.rs:162:18:162:21 | true | match |
-| test.rs:162:13:162:13 | 0 | test.rs:163:13:163:13 | _ | no-match |
-| test.rs:162:18:162:21 | true | test.rs:161:13:164:9 | [boolean(true)] match a { ... } | true |
-| test.rs:163:13:163:13 | _ | test.rs:163:18:163:22 | false | match |
-| test.rs:163:18:163:22 | false | test.rs:161:13:164:9 | [boolean(false)] match a { ... } | false |
-| test.rs:164:12:166:9 | { ... } | test.rs:161:9:168:9 | if ... {...} else {...} |  |
-| test.rs:165:13:165:13 | 1 | test.rs:164:12:166:9 | { ... } |  |
-| test.rs:166:16:168:9 | { ... } | test.rs:161:9:168:9 | if ... {...} else {...} |  |
-| test.rs:167:13:167:13 | 0 | test.rs:166:16:168:9 | { ... } |  |
-| test.rs:171:5:180:5 | enter fn test_nested_if_block | test.rs:171:29:171:29 | a |  |
-| test.rs:171:5:180:5 | exit fn test_nested_if_block (normal) | test.rs:171:5:180:5 | exit fn test_nested_if_block |  |
-| test.rs:171:29:171:29 | a | test.rs:171:29:171:34 | ...: i64 | match |
-| test.rs:171:29:171:34 | ...: i64 | test.rs:173:13:173:15 | ExprStmt |  |
-| test.rs:171:44:180:5 | { ... } | test.rs:171:5:180:5 | exit fn test_nested_if_block (normal) |  |
-| test.rs:172:9:179:9 | if ... {...} else {...} | test.rs:171:44:180:5 | { ... } |  |
-| test.rs:172:12:175:9 | [boolean(false)] { ... } | test.rs:178:13:178:13 | 0 | false |
-| test.rs:172:12:175:9 | [boolean(true)] { ... } | test.rs:176:13:176:13 | 1 | true |
-| test.rs:173:13:173:14 | TupleExpr | test.rs:174:13:174:13 | a |  |
-| test.rs:173:13:173:15 | ExprStmt | test.rs:173:13:173:14 | TupleExpr |  |
-| test.rs:174:13:174:13 | a | test.rs:174:17:174:17 | 0 |  |
-| test.rs:174:13:174:17 | ... > ... | test.rs:172:12:175:9 | [boolean(false)] { ... } | false |
-| test.rs:174:13:174:17 | ... > ... | test.rs:172:12:175:9 | [boolean(true)] { ... } | true |
-| test.rs:174:17:174:17 | 0 | test.rs:174:13:174:17 | ... > ... |  |
-| test.rs:175:11:177:9 | { ... } | test.rs:172:9:179:9 | if ... {...} else {...} |  |
-| test.rs:176:13:176:13 | 1 | test.rs:175:11:177:9 | { ... } |  |
-| test.rs:177:16:179:9 | { ... } | test.rs:172:9:179:9 | if ... {...} else {...} |  |
-| test.rs:178:13:178:13 | 0 | test.rs:177:16:179:9 | { ... } |  |
-| test.rs:182:5:192:5 | enter fn test_if_assignment | test.rs:182:27:182:27 | a |  |
-| test.rs:182:5:192:5 | exit fn test_if_assignment (normal) | test.rs:182:5:192:5 | exit fn test_if_assignment |  |
-| test.rs:182:27:182:27 | a | test.rs:182:27:182:32 | ...: i64 | match |
-| test.rs:182:27:182:32 | ...: i64 | test.rs:183:9:183:26 | let ... = false |  |
-| test.rs:182:42:192:5 | { ... } | test.rs:182:5:192:5 | exit fn test_if_assignment (normal) |  |
-| test.rs:183:9:183:26 | let ... = false | test.rs:183:21:183:25 | false |  |
-| test.rs:183:13:183:17 | x | test.rs:185:13:185:21 | ExprStmt | match |
-| test.rs:183:21:183:25 | false | test.rs:183:13:183:17 | x |  |
-| test.rs:184:9:191:9 | if ... {...} else {...} | test.rs:182:42:192:5 | { ... } |  |
-| test.rs:184:12:187:9 | [boolean(false)] { ... } | test.rs:190:13:190:13 | 0 | false |
-| test.rs:184:12:187:9 | [boolean(true)] { ... } | test.rs:188:13:188:13 | 1 | true |
-| test.rs:185:13:185:13 | x | test.rs:185:17:185:20 | true |  |
-| test.rs:185:13:185:20 | ... = ... | test.rs:186:13:186:13 | x |  |
-| test.rs:185:13:185:21 | ExprStmt | test.rs:185:13:185:13 | x |  |
-| test.rs:185:17:185:20 | true | test.rs:185:13:185:20 | ... = ... |  |
-| test.rs:186:13:186:13 | x | test.rs:184:12:187:9 | [boolean(false)] { ... } | false |
-| test.rs:186:13:186:13 | x | test.rs:184:12:187:9 | [boolean(true)] { ... } | true |
-| test.rs:187:11:189:9 | { ... } | test.rs:184:9:191:9 | if ... {...} else {...} |  |
-| test.rs:188:13:188:13 | 1 | test.rs:187:11:189:9 | { ... } |  |
-| test.rs:189:16:191:9 | { ... } | test.rs:184:9:191:9 | if ... {...} else {...} |  |
-| test.rs:190:13:190:13 | 0 | test.rs:189:16:191:9 | { ... } |  |
-| test.rs:194:5:205:5 | enter fn test_if_loop1 | test.rs:194:22:194:22 | a |  |
-| test.rs:194:5:205:5 | exit fn test_if_loop1 (normal) | test.rs:194:5:205:5 | exit fn test_if_loop1 |  |
-| test.rs:194:22:194:22 | a | test.rs:194:22:194:27 | ...: i64 | match |
-| test.rs:194:22:194:27 | ...: i64 | test.rs:196:13:198:14 | ExprStmt |  |
-| test.rs:194:37:205:5 | { ... } | test.rs:194:5:205:5 | exit fn test_if_loop1 (normal) |  |
-| test.rs:195:9:204:9 | if ... {...} else {...} | test.rs:194:37:205:5 | { ... } |  |
-| test.rs:195:13:200:9 | [boolean(false)] loop { ... } | test.rs:203:13:203:13 | 0 | false |
-| test.rs:195:13:200:9 | [boolean(true)] loop { ... } | test.rs:201:13:201:13 | 1 | true |
-| test.rs:195:18:200:9 | { ... } | test.rs:196:13:198:14 | ExprStmt |  |
-| test.rs:196:13:198:13 | if ... {...} | test.rs:199:13:199:19 | ExprStmt |  |
-| test.rs:196:13:198:14 | ExprStmt | test.rs:196:16:196:16 | a |  |
-| test.rs:196:16:196:16 | a | test.rs:196:20:196:20 | 0 |  |
-| test.rs:196:16:196:20 | ... > ... | test.rs:196:13:198:13 | if ... {...} | false |
-| test.rs:196:16:196:20 | ... > ... | test.rs:197:17:197:29 | ExprStmt | true |
-| test.rs:196:20:196:20 | 0 | test.rs:196:16:196:20 | ... > ... |  |
-| test.rs:197:17:197:28 | [boolean(false)] break ... | test.rs:195:13:200:9 | [boolean(false)] loop { ... } | break |
-| test.rs:197:17:197:28 | [boolean(true)] break ... | test.rs:195:13:200:9 | [boolean(true)] loop { ... } | break |
-| test.rs:197:17:197:29 | ExprStmt | test.rs:197:23:197:23 | a |  |
-| test.rs:197:23:197:23 | a | test.rs:197:27:197:28 | 10 |  |
-| test.rs:197:23:197:28 | ... > ... | test.rs:197:17:197:28 | [boolean(false)] break ... | false |
-| test.rs:197:23:197:28 | ... > ... | test.rs:197:17:197:28 | [boolean(true)] break ... | true |
-| test.rs:197:27:197:28 | 10 | test.rs:197:23:197:28 | ... > ... |  |
-| test.rs:199:13:199:13 | a | test.rs:199:17:199:18 | 10 |  |
-| test.rs:199:13:199:18 | ... < ... | test.rs:195:18:200:9 | { ... } |  |
-| test.rs:199:13:199:19 | ExprStmt | test.rs:199:13:199:13 | a |  |
-| test.rs:199:17:199:18 | 10 | test.rs:199:13:199:18 | ... < ... |  |
-| test.rs:200:12:202:9 | { ... } | test.rs:195:9:204:9 | if ... {...} else {...} |  |
-| test.rs:201:13:201:13 | 1 | test.rs:200:12:202:9 | { ... } |  |
-| test.rs:202:16:204:9 | { ... } | test.rs:195:9:204:9 | if ... {...} else {...} |  |
-| test.rs:203:13:203:13 | 0 | test.rs:202:16:204:9 | { ... } |  |
-| test.rs:207:5:218:5 | enter fn test_if_loop2 | test.rs:207:22:207:22 | a |  |
-| test.rs:207:5:218:5 | exit fn test_if_loop2 (normal) | test.rs:207:5:218:5 | exit fn test_if_loop2 |  |
-| test.rs:207:22:207:22 | a | test.rs:207:22:207:27 | ...: i64 | match |
-| test.rs:207:22:207:27 | ...: i64 | test.rs:209:13:211:14 | ExprStmt |  |
-| test.rs:207:37:218:5 | { ... } | test.rs:207:5:218:5 | exit fn test_if_loop2 (normal) |  |
-| test.rs:208:9:217:9 | if ... {...} else {...} | test.rs:207:37:218:5 | { ... } |  |
-| test.rs:208:13:213:9 | [boolean(false)] 'label: loop { ... } | test.rs:216:13:216:13 | 0 | false |
-| test.rs:208:13:213:9 | [boolean(true)] 'label: loop { ... } | test.rs:214:13:214:13 | 1 | true |
-| test.rs:208:26:213:9 | { ... } | test.rs:209:13:211:14 | ExprStmt |  |
-| test.rs:209:13:211:13 | if ... {...} | test.rs:212:13:212:19 | ExprStmt |  |
-| test.rs:209:13:211:14 | ExprStmt | test.rs:209:16:209:16 | a |  |
-| test.rs:209:16:209:16 | a | test.rs:209:20:209:20 | 0 |  |
-| test.rs:209:16:209:20 | ... > ... | test.rs:209:13:211:13 | if ... {...} | false |
-| test.rs:209:16:209:20 | ... > ... | test.rs:210:17:210:36 | ExprStmt | true |
-| test.rs:209:20:209:20 | 0 | test.rs:209:16:209:20 | ... > ... |  |
-| test.rs:210:17:210:35 | [boolean(false)] break ''label ... | test.rs:208:13:213:9 | [boolean(false)] 'label: loop { ... } | break |
-| test.rs:210:17:210:35 | [boolean(true)] break ''label ... | test.rs:208:13:213:9 | [boolean(true)] 'label: loop { ... } | break |
-| test.rs:210:17:210:36 | ExprStmt | test.rs:210:30:210:30 | a |  |
-| test.rs:210:30:210:30 | a | test.rs:210:34:210:35 | 10 |  |
-| test.rs:210:30:210:35 | ... > ... | test.rs:210:17:210:35 | [boolean(false)] break ''label ... | false |
-| test.rs:210:30:210:35 | ... > ... | test.rs:210:17:210:35 | [boolean(true)] break ''label ... | true |
-| test.rs:210:34:210:35 | 10 | test.rs:210:30:210:35 | ... > ... |  |
-| test.rs:212:13:212:13 | a | test.rs:212:17:212:18 | 10 |  |
-| test.rs:212:13:212:18 | ... < ... | test.rs:208:26:213:9 | { ... } |  |
-| test.rs:212:13:212:19 | ExprStmt | test.rs:212:13:212:13 | a |  |
-| test.rs:212:17:212:18 | 10 | test.rs:212:13:212:18 | ... < ... |  |
-| test.rs:213:12:215:9 | { ... } | test.rs:208:9:217:9 | if ... {...} else {...} |  |
-| test.rs:214:13:214:13 | 1 | test.rs:213:12:215:9 | { ... } |  |
-| test.rs:215:16:217:9 | { ... } | test.rs:208:9:217:9 | if ... {...} else {...} |  |
-| test.rs:216:13:216:13 | 0 | test.rs:215:16:217:9 | { ... } |  |
-| test.rs:220:5:228:5 | enter fn test_labelled_block | test.rs:220:28:220:28 | a |  |
-| test.rs:220:5:228:5 | exit fn test_labelled_block (normal) | test.rs:220:5:228:5 | exit fn test_labelled_block |  |
-| test.rs:220:28:220:28 | a | test.rs:220:28:220:33 | ...: i64 | match |
-| test.rs:220:28:220:33 | ...: i64 | test.rs:222:13:222:31 | ExprStmt |  |
-| test.rs:220:43:228:5 | { ... } | test.rs:220:5:228:5 | exit fn test_labelled_block (normal) |  |
-| test.rs:221:9:227:9 | if ... {...} else {...} | test.rs:220:43:228:5 | { ... } |  |
-| test.rs:221:13:223:9 | [boolean(false)] 'block: { ... } | test.rs:226:13:226:13 | 0 | false |
-| test.rs:221:13:223:9 | [boolean(true)] 'block: { ... } | test.rs:224:13:224:13 | 1 | true |
-| test.rs:222:13:222:30 | [boolean(false)] break ''block ... | test.rs:221:13:223:9 | [boolean(false)] 'block: { ... } | break |
-| test.rs:222:13:222:30 | [boolean(true)] break ''block ... | test.rs:221:13:223:9 | [boolean(true)] 'block: { ... } | break |
-| test.rs:222:13:222:31 | ExprStmt | test.rs:222:26:222:26 | a |  |
-| test.rs:222:26:222:26 | a | test.rs:222:30:222:30 | 0 |  |
-| test.rs:222:26:222:30 | ... > ... | test.rs:222:13:222:30 | [boolean(false)] break ''block ... | false |
-| test.rs:222:26:222:30 | ... > ... | test.rs:222:13:222:30 | [boolean(true)] break ''block ... | true |
-| test.rs:222:30:222:30 | 0 | test.rs:222:26:222:30 | ... > ... |  |
-| test.rs:223:12:225:9 | { ... } | test.rs:221:9:227:9 | if ... {...} else {...} |  |
-| test.rs:224:13:224:13 | 1 | test.rs:223:12:225:9 | { ... } |  |
-| test.rs:225:16:227:9 | { ... } | test.rs:221:9:227:9 | if ... {...} else {...} |  |
-| test.rs:226:13:226:13 | 0 | test.rs:225:16:227:9 | { ... } |  |
-| test.rs:233:5:236:5 | enter fn test_and_operator | test.rs:233:30:233:30 | a |  |
-| test.rs:233:5:236:5 | exit fn test_and_operator (normal) | test.rs:233:5:236:5 | exit fn test_and_operator |  |
-| test.rs:233:30:233:30 | a | test.rs:233:30:233:36 | ...: bool | match |
-| test.rs:233:30:233:36 | ...: bool | test.rs:233:39:233:39 | b |  |
-| test.rs:233:39:233:39 | b | test.rs:233:39:233:45 | ...: bool | match |
-| test.rs:233:39:233:45 | ...: bool | test.rs:233:48:233:48 | c |  |
-| test.rs:233:48:233:48 | c | test.rs:233:48:233:54 | ...: bool | match |
-| test.rs:233:48:233:54 | ...: bool | test.rs:234:9:234:28 | let ... = ... |  |
-| test.rs:233:65:236:5 | { ... } | test.rs:233:5:236:5 | exit fn test_and_operator (normal) |  |
-| test.rs:234:9:234:28 | let ... = ... | test.rs:234:17:234:17 | a |  |
-| test.rs:234:13:234:13 | d | test.rs:235:9:235:9 | d | match |
-| test.rs:234:17:234:17 | a | test.rs:234:17:234:22 | [boolean(false)] ... && ... | false |
-| test.rs:234:17:234:17 | a | test.rs:234:22:234:22 | b | true |
-| test.rs:234:17:234:22 | [boolean(false)] ... && ... | test.rs:234:17:234:27 | ... && ... | false |
-| test.rs:234:17:234:22 | [boolean(true)] ... && ... | test.rs:234:27:234:27 | c | true |
-| test.rs:234:17:234:27 | ... && ... | test.rs:234:13:234:13 | d |  |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(false)] ... && ... | false |
-| test.rs:234:22:234:22 | b | test.rs:234:17:234:22 | [boolean(true)] ... && ... | true |
-| test.rs:234:27:234:27 | c | test.rs:234:17:234:27 | ... && ... |  |
-| test.rs:235:9:235:9 | d | test.rs:233:65:236:5 | { ... } |  |
-| test.rs:238:5:241:5 | enter fn test_or_operator | test.rs:238:25:238:25 | a |  |
-| test.rs:238:5:241:5 | exit fn test_or_operator (normal) | test.rs:238:5:241:5 | exit fn test_or_operator |  |
-| test.rs:238:25:238:25 | a | test.rs:238:25:238:31 | ...: bool | match |
-| test.rs:238:25:238:31 | ...: bool | test.rs:238:34:238:34 | b |  |
-| test.rs:238:34:238:34 | b | test.rs:238:34:238:40 | ...: bool | match |
-| test.rs:238:34:238:40 | ...: bool | test.rs:238:43:238:43 | c |  |
-| test.rs:238:43:238:43 | c | test.rs:238:43:238:49 | ...: bool | match |
-| test.rs:238:43:238:49 | ...: bool | test.rs:239:9:239:28 | let ... = ... |  |
-| test.rs:238:60:241:5 | { ... } | test.rs:238:5:241:5 | exit fn test_or_operator (normal) |  |
-| test.rs:239:9:239:28 | let ... = ... | test.rs:239:17:239:17 | a |  |
-| test.rs:239:13:239:13 | d | test.rs:240:9:240:9 | d | match |
-| test.rs:239:17:239:17 | a | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:239:17:239:17 | a | test.rs:239:22:239:22 | b | false |
-| test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | test.rs:239:27:239:27 | c | false |
-| test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | test.rs:239:17:239:27 | ... \|\| ... | true |
-| test.rs:239:17:239:27 | ... \|\| ... | test.rs:239:13:239:13 | d |  |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:239:22:239:22 | b | test.rs:239:17:239:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:239:27:239:27 | c | test.rs:239:17:239:27 | ... \|\| ... |  |
-| test.rs:240:9:240:9 | d | test.rs:238:60:241:5 | { ... } |  |
-| test.rs:243:5:246:5 | enter fn test_or_operator_2 | test.rs:243:27:243:27 | a |  |
-| test.rs:243:5:246:5 | exit fn test_or_operator_2 (normal) | test.rs:243:5:246:5 | exit fn test_or_operator_2 |  |
-| test.rs:243:27:243:27 | a | test.rs:243:27:243:33 | ...: bool | match |
-| test.rs:243:27:243:33 | ...: bool | test.rs:243:36:243:36 | b |  |
-| test.rs:243:36:243:36 | b | test.rs:243:36:243:41 | ...: i64 | match |
-| test.rs:243:36:243:41 | ...: i64 | test.rs:243:44:243:44 | c |  |
-| test.rs:243:44:243:44 | c | test.rs:243:44:243:50 | ...: bool | match |
-| test.rs:243:44:243:50 | ...: bool | test.rs:244:9:244:36 | let ... = ... |  |
-| test.rs:243:61:246:5 | { ... } | test.rs:243:5:246:5 | exit fn test_or_operator_2 (normal) |  |
-| test.rs:244:9:244:36 | let ... = ... | test.rs:244:17:244:17 | a |  |
-| test.rs:244:13:244:13 | d | test.rs:245:9:245:9 | d | match |
-| test.rs:244:17:244:17 | a | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | true |
-| test.rs:244:17:244:17 | a | test.rs:244:23:244:23 | b | false |
-| test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | test.rs:244:35:244:35 | c | false |
-| test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | test.rs:244:17:244:35 | ... \|\| ... | true |
-| test.rs:244:17:244:35 | ... \|\| ... | test.rs:244:13:244:13 | d |  |
-| test.rs:244:23:244:23 | b | test.rs:244:28:244:29 | 28 |  |
-| test.rs:244:23:244:29 | ... == ... | test.rs:244:17:244:30 | [boolean(false)] ... \|\| ... | false |
-| test.rs:244:23:244:29 | ... == ... | test.rs:244:17:244:30 | [boolean(true)] ... \|\| ... | true |
-| test.rs:244:28:244:29 | 28 | test.rs:244:23:244:29 | ... == ... |  |
-| test.rs:244:35:244:35 | c | test.rs:244:17:244:35 | ... \|\| ... |  |
-| test.rs:245:9:245:9 | d | test.rs:243:61:246:5 | { ... } |  |
-| test.rs:248:5:251:5 | enter fn test_not_operator | test.rs:248:26:248:26 | a |  |
-| test.rs:248:5:251:5 | exit fn test_not_operator (normal) | test.rs:248:5:251:5 | exit fn test_not_operator |  |
-| test.rs:248:26:248:26 | a | test.rs:248:26:248:32 | ...: bool | match |
-| test.rs:248:26:248:32 | ...: bool | test.rs:249:9:249:19 | let ... = ... |  |
-| test.rs:248:43:251:5 | { ... } | test.rs:248:5:251:5 | exit fn test_not_operator (normal) |  |
-| test.rs:249:9:249:19 | let ... = ... | test.rs:249:18:249:18 | a |  |
-| test.rs:249:13:249:13 | d | test.rs:250:9:250:9 | d | match |
-| test.rs:249:17:249:18 | ! ... | test.rs:249:13:249:13 | d |  |
-| test.rs:249:18:249:18 | a | test.rs:249:17:249:18 | ! ... |  |
-| test.rs:250:9:250:9 | d | test.rs:248:43:251:5 | { ... } |  |
-| test.rs:253:5:259:5 | enter fn test_if_and_operator | test.rs:253:29:253:29 | a |  |
-| test.rs:253:5:259:5 | exit fn test_if_and_operator (normal) | test.rs:253:5:259:5 | exit fn test_if_and_operator |  |
-| test.rs:253:29:253:29 | a | test.rs:253:29:253:35 | ...: bool | match |
-| test.rs:253:29:253:35 | ...: bool | test.rs:253:38:253:38 | b |  |
-| test.rs:253:38:253:38 | b | test.rs:253:38:253:44 | ...: bool | match |
-| test.rs:253:38:253:44 | ...: bool | test.rs:253:47:253:47 | c |  |
-| test.rs:253:47:253:47 | c | test.rs:253:47:253:53 | ...: bool | match |
-| test.rs:253:47:253:53 | ...: bool | test.rs:254:12:254:12 | a |  |
-| test.rs:253:64:259:5 | { ... } | test.rs:253:5:259:5 | exit fn test_if_and_operator (normal) |  |
-| test.rs:254:9:258:9 | if ... {...} else {...} | test.rs:253:64:259:5 | { ... } |  |
-| test.rs:254:12:254:12 | a | test.rs:254:12:254:17 | [boolean(false)] ... && ... | false |
-| test.rs:254:12:254:12 | a | test.rs:254:17:254:17 | b | true |
-| test.rs:254:12:254:17 | [boolean(false)] ... && ... | test.rs:254:12:254:22 | [boolean(false)] ... && ... | false |
-| test.rs:254:12:254:17 | [boolean(true)] ... && ... | test.rs:254:22:254:22 | c | true |
-| test.rs:254:12:254:22 | [boolean(false)] ... && ... | test.rs:257:13:257:17 | false | false |
-| test.rs:254:12:254:22 | [boolean(true)] ... && ... | test.rs:255:13:255:16 | true | true |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(false)] ... && ... | false |
-| test.rs:254:17:254:17 | b | test.rs:254:12:254:17 | [boolean(true)] ... && ... | true |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(false)] ... && ... | false |
-| test.rs:254:22:254:22 | c | test.rs:254:12:254:22 | [boolean(true)] ... && ... | true |
-| test.rs:254:24:256:9 | { ... } | test.rs:254:9:258:9 | if ... {...} else {...} |  |
-| test.rs:255:13:255:16 | true | test.rs:254:24:256:9 | { ... } |  |
-| test.rs:256:16:258:9 | { ... } | test.rs:254:9:258:9 | if ... {...} else {...} |  |
-| test.rs:257:13:257:17 | false | test.rs:256:16:258:9 | { ... } |  |
-| test.rs:261:5:267:5 | enter fn test_if_or_operator | test.rs:261:28:261:28 | a |  |
-| test.rs:261:5:267:5 | exit fn test_if_or_operator (normal) | test.rs:261:5:267:5 | exit fn test_if_or_operator |  |
-| test.rs:261:28:261:28 | a | test.rs:261:28:261:34 | ...: bool | match |
-| test.rs:261:28:261:34 | ...: bool | test.rs:261:37:261:37 | b |  |
-| test.rs:261:37:261:37 | b | test.rs:261:37:261:43 | ...: bool | match |
-| test.rs:261:37:261:43 | ...: bool | test.rs:261:46:261:46 | c |  |
-| test.rs:261:46:261:46 | c | test.rs:261:46:261:52 | ...: bool | match |
-| test.rs:261:46:261:52 | ...: bool | test.rs:262:12:262:12 | a |  |
-| test.rs:261:63:267:5 | { ... } | test.rs:261:5:267:5 | exit fn test_if_or_operator (normal) |  |
-| test.rs:262:9:266:9 | if ... {...} else {...} | test.rs:261:63:267:5 | { ... } |  |
-| test.rs:262:12:262:12 | a | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:12:262:12 | a | test.rs:262:17:262:17 | b | false |
-| test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | test.rs:262:22:262:22 | c | false |
-| test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | test.rs:265:13:265:17 | false | false |
-| test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | test.rs:263:13:263:16 | true | true |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:17:262:17 | b | test.rs:262:12:262:17 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(false)] ... \|\| ... | false |
-| test.rs:262:22:262:22 | c | test.rs:262:12:262:22 | [boolean(true)] ... \|\| ... | true |
-| test.rs:262:24:264:9 | { ... } | test.rs:262:9:266:9 | if ... {...} else {...} |  |
-| test.rs:263:13:263:16 | true | test.rs:262:24:264:9 | { ... } |  |
-| test.rs:264:16:266:9 | { ... } | test.rs:262:9:266:9 | if ... {...} else {...} |  |
-| test.rs:265:13:265:17 | false | test.rs:264:16:266:9 | { ... } |  |
-| test.rs:269:5:275:5 | enter fn test_if_not_operator | test.rs:269:29:269:29 | a |  |
-| test.rs:269:5:275:5 | exit fn test_if_not_operator (normal) | test.rs:269:5:275:5 | exit fn test_if_not_operator |  |
-| test.rs:269:29:269:29 | a | test.rs:269:29:269:35 | ...: bool | match |
-| test.rs:269:29:269:35 | ...: bool | test.rs:270:13:270:13 | a |  |
-| test.rs:269:46:275:5 | { ... } | test.rs:269:5:275:5 | exit fn test_if_not_operator (normal) |  |
-| test.rs:270:9:274:9 | if ... {...} else {...} | test.rs:269:46:275:5 | { ... } |  |
-| test.rs:270:12:270:13 | [boolean(false)] ! ... | test.rs:273:13:273:17 | false | false |
-| test.rs:270:12:270:13 | [boolean(true)] ! ... | test.rs:271:13:271:16 | true | true |
-| test.rs:270:13:270:13 | a | test.rs:270:12:270:13 | [boolean(false)] ! ... | true |
-| test.rs:270:13:270:13 | a | test.rs:270:12:270:13 | [boolean(true)] ! ... | false |
-| test.rs:270:15:272:9 | { ... } | test.rs:270:9:274:9 | if ... {...} else {...} |  |
-| test.rs:271:13:271:16 | true | test.rs:270:15:272:9 | { ... } |  |
-| test.rs:272:16:274:9 | { ... } | test.rs:270:9:274:9 | if ... {...} else {...} |  |
-| test.rs:273:13:273:17 | false | test.rs:272:16:274:9 | { ... } |  |
-| test.rs:277:5:279:5 | enter fn test_and_return | test.rs:277:24:277:24 | a |  |
-| test.rs:277:5:279:5 | exit fn test_and_return (normal) | test.rs:277:5:279:5 | exit fn test_and_return |  |
-| test.rs:277:24:277:24 | a | test.rs:277:24:277:30 | ...: bool | match |
-| test.rs:277:24:277:30 | ...: bool | test.rs:278:9:278:20 | ExprStmt |  |
-| test.rs:277:33:279:5 | { ... } | test.rs:277:5:279:5 | exit fn test_and_return (normal) |  |
-| test.rs:278:9:278:9 | a | test.rs:278:9:278:19 | ... && ... | false |
-| test.rs:278:9:278:9 | a | test.rs:278:14:278:19 | return | true |
-| test.rs:278:9:278:19 | ... && ... | test.rs:277:33:279:5 | { ... } |  |
-| test.rs:278:9:278:20 | ExprStmt | test.rs:278:9:278:9 | a |  |
-| test.rs:278:14:278:19 | return | test.rs:277:5:279:5 | exit fn test_and_return (normal) | return |
-| test.rs:281:5:286:5 | enter fn test_and_true | test.rs:281:22:281:22 | a |  |
-| test.rs:281:5:286:5 | exit fn test_and_true (normal) | test.rs:281:5:286:5 | exit fn test_and_true |  |
-| test.rs:281:22:281:22 | a | test.rs:281:22:281:28 | ...: bool | match |
-| test.rs:281:22:281:28 | ...: bool | test.rs:282:9:284:9 | ExprStmt |  |
-| test.rs:281:38:286:5 | { ... } | test.rs:281:5:286:5 | exit fn test_and_true (normal) |  |
-| test.rs:282:9:284:9 | ExprStmt | test.rs:282:13:282:13 | a |  |
-| test.rs:282:9:284:9 | if ... {...} | test.rs:285:9:285:9 | 0 |  |
-| test.rs:282:13:282:13 | a | test.rs:282:13:282:21 | [boolean(false)] ... && ... | false |
-| test.rs:282:13:282:13 | a | test.rs:282:18:282:21 | true | true |
-| test.rs:282:13:282:21 | [boolean(false)] ... && ... | test.rs:282:9:284:9 | if ... {...} | false |
-| test.rs:282:13:282:21 | [boolean(true)] ... && ... | test.rs:283:13:283:21 | ExprStmt | true |
-| test.rs:282:18:282:21 | true | test.rs:282:13:282:21 | [boolean(true)] ... && ... | true |
-| test.rs:283:13:283:20 | return 1 | test.rs:281:5:286:5 | exit fn test_and_true (normal) | return |
-| test.rs:283:13:283:21 | ExprStmt | test.rs:283:20:283:20 | 1 |  |
-| test.rs:283:20:283:20 | 1 | test.rs:283:13:283:20 | return 1 |  |
-| test.rs:285:9:285:9 | 0 | test.rs:281:38:286:5 | { ... } |  |
-| test.rs:292:5:294:5 | enter fn test_question_mark_operator_1 | test.rs:292:38:292:38 | s |  |
-| test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 |  |
-| test.rs:292:38:292:38 | s | test.rs:292:38:292:44 | ...: ... | match |
-| test.rs:292:38:292:44 | ...: ... | test.rs:293:9:293:10 | Ok |  |
-| test.rs:292:87:294:5 | { ... } | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) |  |
-| test.rs:293:9:293:10 | Ok | test.rs:293:12:293:12 | s |  |
-| test.rs:293:9:293:33 | Ok(...) | test.rs:292:87:294:5 | { ... } |  |
-| test.rs:293:12:293:12 | s | test.rs:293:12:293:27 | s.parse(...) |  |
-| test.rs:293:12:293:27 | s.parse(...) | test.rs:293:12:293:28 | TryExpr |  |
-| test.rs:293:12:293:28 | TryExpr | test.rs:292:5:294:5 | exit fn test_question_mark_operator_1 (normal) | return |
-| test.rs:293:12:293:28 | TryExpr | test.rs:293:32:293:32 | 4 | match |
-| test.rs:293:12:293:32 | ... + ... | test.rs:293:9:293:33 | Ok(...) |  |
-| test.rs:293:32:293:32 | 4 | test.rs:293:12:293:32 | ... + ... |  |
-| test.rs:296:5:301:5 | enter fn test_question_mark_operator_2 | test.rs:296:38:296:38 | b |  |
-| test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 |  |
-| test.rs:296:38:296:38 | b | test.rs:296:38:296:52 | ...: Option::<...> | match |
-| test.rs:296:38:296:52 | ...: Option::<...> | test.rs:297:15:297:15 | b |  |
-| test.rs:296:71:301:5 | { ... } | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) |  |
-| test.rs:297:9:300:9 | match ... { ... } | test.rs:296:71:301:5 | { ... } |  |
-| test.rs:297:15:297:15 | b | test.rs:297:15:297:16 | TryExpr |  |
-| test.rs:297:15:297:16 | TryExpr | test.rs:296:5:301:5 | exit fn test_question_mark_operator_2 (normal) | return |
-| test.rs:297:15:297:16 | TryExpr | test.rs:298:13:298:16 | true | match |
-| test.rs:298:13:298:16 | true | test.rs:298:13:298:16 | true |  |
-| test.rs:298:13:298:16 | true | test.rs:298:21:298:24 | Some | match |
-| test.rs:298:13:298:16 | true | test.rs:299:13:299:17 | false | no-match |
-| test.rs:298:21:298:24 | Some | test.rs:298:26:298:30 | false |  |
-| test.rs:298:21:298:31 | Some(...) | test.rs:297:9:300:9 | match ... { ... } |  |
-| test.rs:298:26:298:30 | false | test.rs:298:21:298:31 | Some(...) |  |
-| test.rs:299:13:299:17 | false | test.rs:299:13:299:17 | false |  |
-| test.rs:299:13:299:17 | false | test.rs:299:22:299:25 | Some | match |
-| test.rs:299:22:299:25 | Some | test.rs:299:27:299:30 | true |  |
-| test.rs:299:22:299:31 | Some(...) | test.rs:297:9:300:9 | match ... { ... } |  |
-| test.rs:299:27:299:30 | true | test.rs:299:22:299:31 | Some(...) |  |
-| test.rs:307:5:313:5 | enter fn test_match | test.rs:307:19:307:29 | maybe_digit |  |
-| test.rs:307:5:313:5 | exit fn test_match (normal) | test.rs:307:5:313:5 | exit fn test_match |  |
-| test.rs:307:19:307:29 | maybe_digit | test.rs:307:19:307:42 | ...: Option::<...> | match |
-| test.rs:307:19:307:42 | ...: Option::<...> | test.rs:308:15:308:25 | maybe_digit |  |
-| test.rs:307:52:313:5 | { ... } | test.rs:307:5:313:5 | exit fn test_match (normal) |  |
-| test.rs:308:9:312:9 | match maybe_digit { ... } | test.rs:307:52:313:5 | { ... } |  |
-| test.rs:308:15:308:25 | maybe_digit | test.rs:309:13:309:27 | ...::Some(...) |  |
-| test.rs:309:13:309:27 | ...::Some(...) | test.rs:309:26:309:26 | x | match |
-| test.rs:309:13:309:27 | ...::Some(...) | test.rs:310:13:310:27 | ...::Some(...) | no-match |
-| test.rs:309:26:309:26 | x | test.rs:309:32:309:32 | x | match |
-| test.rs:309:32:309:32 | x | test.rs:309:36:309:37 | 10 |  |
-| test.rs:309:32:309:37 | ... < ... | test.rs:309:42:309:42 | x | true |
-| test.rs:309:32:309:37 | ... < ... | test.rs:310:13:310:27 | ...::Some(...) | false |
-| test.rs:309:36:309:37 | 10 | test.rs:309:32:309:37 | ... < ... |  |
-| test.rs:309:42:309:42 | x | test.rs:309:46:309:46 | 5 |  |
-| test.rs:309:42:309:46 | ... + ... | test.rs:308:9:312:9 | match maybe_digit { ... } |  |
-| test.rs:309:46:309:46 | 5 | test.rs:309:42:309:46 | ... + ... |  |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:310:26:310:26 | x | match |
-| test.rs:310:13:310:27 | ...::Some(...) | test.rs:311:13:311:24 | ...::None | no-match |
-| test.rs:310:26:310:26 | x | test.rs:310:32:310:32 | x | match |
-| test.rs:310:32:310:32 | x | test.rs:308:9:312:9 | match maybe_digit { ... } |  |
-| test.rs:311:13:311:24 | ...::None | test.rs:311:29:311:29 | 5 | match |
-| test.rs:311:29:311:29 | 5 | test.rs:308:9:312:9 | match maybe_digit { ... } |  |
-| test.rs:315:5:324:5 | enter fn test_match_with_return_in_scrutinee | test.rs:315:44:315:54 | maybe_digit |  |
-| test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee |  |
-| test.rs:315:44:315:54 | maybe_digit | test.rs:315:44:315:67 | ...: Option::<...> | match |
-| test.rs:315:44:315:67 | ...: Option::<...> | test.rs:316:19:316:29 | maybe_digit |  |
-| test.rs:315:77:324:5 | { ... } | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) |  |
-| test.rs:316:9:323:9 | match ... { ... } | test.rs:315:77:324:5 | { ... } |  |
-| test.rs:316:16:320:9 | if ... {...} else {...} | test.rs:321:13:321:27 | ...::Some(...) |  |
-| test.rs:316:19:316:29 | maybe_digit | test.rs:316:34:316:37 | Some |  |
-| test.rs:316:19:316:40 | ... == ... | test.rs:317:13:317:21 | ExprStmt | true |
-| test.rs:316:19:316:40 | ... == ... | test.rs:319:13:319:23 | maybe_digit | false |
-| test.rs:316:34:316:37 | Some | test.rs:316:39:316:39 | 3 |  |
-| test.rs:316:34:316:40 | Some(...) | test.rs:316:19:316:40 | ... == ... |  |
-| test.rs:316:39:316:39 | 3 | test.rs:316:34:316:40 | Some(...) |  |
-| test.rs:317:13:317:20 | return 3 | test.rs:315:5:324:5 | exit fn test_match_with_return_in_scrutinee (normal) | return |
-| test.rs:317:13:317:21 | ExprStmt | test.rs:317:20:317:20 | 3 |  |
-| test.rs:317:20:317:20 | 3 | test.rs:317:13:317:20 | return 3 |  |
-| test.rs:318:16:320:9 | { ... } | test.rs:316:16:320:9 | if ... {...} else {...} |  |
-| test.rs:319:13:319:23 | maybe_digit | test.rs:318:16:320:9 | { ... } |  |
-| test.rs:321:13:321:27 | ...::Some(...) | test.rs:321:26:321:26 | x | match |
-| test.rs:321:13:321:27 | ...::Some(...) | test.rs:322:13:322:24 | ...::None | no-match |
-| test.rs:321:26:321:26 | x | test.rs:321:32:321:32 | x | match |
-| test.rs:321:32:321:32 | x | test.rs:321:36:321:36 | 5 |  |
-| test.rs:321:32:321:36 | ... + ... | test.rs:316:9:323:9 | match ... { ... } |  |
-| test.rs:321:36:321:36 | 5 | test.rs:321:32:321:36 | ... + ... |  |
-| test.rs:322:13:322:24 | ...::None | test.rs:322:29:322:29 | 5 | match |
-| test.rs:322:29:322:29 | 5 | test.rs:316:9:323:9 | match ... { ... } |  |
-| test.rs:326:5:331:5 | enter fn test_match_and | test.rs:326:23:326:26 | cond |  |
-| test.rs:326:5:331:5 | exit fn test_match_and (normal) | test.rs:326:5:331:5 | exit fn test_match_and |  |
-| test.rs:326:23:326:26 | cond | test.rs:326:23:326:32 | ...: bool | match |
-| test.rs:326:23:326:32 | ...: bool | test.rs:326:35:326:35 | r |  |
-| test.rs:326:35:326:35 | r | test.rs:326:35:326:49 | ...: Option::<...> | match |
-| test.rs:326:35:326:49 | ...: Option::<...> | test.rs:327:16:327:16 | r |  |
-| test.rs:326:60:331:5 | { ... } | test.rs:326:5:331:5 | exit fn test_match_and (normal) |  |
-| test.rs:327:9:330:18 | ... && ... | test.rs:326:60:331:5 | { ... } |  |
-| test.rs:327:10:330:9 | [boolean(false)] match r { ... } | test.rs:327:9:330:18 | ... && ... | false |
-| test.rs:327:10:330:9 | [boolean(true)] match r { ... } | test.rs:330:15:330:18 | cond | true |
-| test.rs:327:16:327:16 | r | test.rs:328:13:328:19 | Some(...) |  |
-| test.rs:328:13:328:19 | Some(...) | test.rs:328:18:328:18 | a | match |
-| test.rs:328:13:328:19 | Some(...) | test.rs:329:13:329:13 | _ | no-match |
-| test.rs:328:18:328:18 | a | test.rs:328:24:328:24 | a | match |
-| test.rs:328:24:328:24 | a | test.rs:327:10:330:9 | [boolean(false)] match r { ... } | false |
-| test.rs:328:24:328:24 | a | test.rs:327:10:330:9 | [boolean(true)] match r { ... } | true |
-| test.rs:329:13:329:13 | _ | test.rs:329:18:329:22 | false | match |
-| test.rs:329:18:329:22 | false | test.rs:327:10:330:9 | [boolean(false)] match r { ... } | false |
-| test.rs:330:15:330:18 | cond | test.rs:327:9:330:18 | ... && ... |  |
-| test.rs:333:5:338:5 | enter fn test_match_with_no_arms | test.rs:333:35:333:35 | r |  |
-| test.rs:333:5:338:5 | exit fn test_match_with_no_arms (normal) | test.rs:333:5:338:5 | exit fn test_match_with_no_arms |  |
-| test.rs:333:35:333:35 | r | test.rs:333:35:333:58 | ...: Result::<...> | match |
-| test.rs:333:35:333:58 | ...: Result::<...> | test.rs:334:15:334:15 | r |  |
-| test.rs:333:66:338:5 | { ... } | test.rs:333:5:338:5 | exit fn test_match_with_no_arms (normal) |  |
-| test.rs:334:9:337:9 | match r { ... } | test.rs:333:66:338:5 | { ... } |  |
-| test.rs:334:15:334:15 | r | test.rs:335:13:335:21 | Ok(...) |  |
-| test.rs:335:13:335:21 | Ok(...) | test.rs:335:16:335:20 | value | match |
-| test.rs:335:13:335:21 | Ok(...) | test.rs:336:13:336:22 | Err(...) | no-match |
-| test.rs:335:16:335:20 | value | test.rs:335:26:335:30 | value | match |
-| test.rs:335:26:335:30 | value | test.rs:334:9:337:9 | match r { ... } |  |
-| test.rs:336:13:336:22 | Err(...) | test.rs:336:17:336:21 | never | match |
-| test.rs:336:17:336:21 | never | test.rs:336:33:336:37 | never | match |
-| test.rs:336:27:336:40 | match never { ... } | test.rs:334:9:337:9 | match r { ... } |  |
-| test.rs:336:33:336:37 | never | test.rs:336:27:336:40 | match never { ... } |  |
-| test.rs:343:5:346:5 | enter fn test_let_match | test.rs:343:23:343:23 | a |  |
-| test.rs:343:5:346:5 | exit fn test_let_match (normal) | test.rs:343:5:346:5 | exit fn test_let_match |  |
-| test.rs:343:23:343:23 | a | test.rs:343:23:343:36 | ...: Option::<...> | match |
-| test.rs:343:23:343:36 | ...: Option::<...> | test.rs:344:9:344:57 | let ... = a else {...} |  |
-| test.rs:343:46:346:5 | { ... } | test.rs:343:5:346:5 | exit fn test_let_match (normal) |  |
-| test.rs:344:9:344:57 | let ... = a else {...} | test.rs:344:23:344:23 | a |  |
-| test.rs:344:13:344:19 | Some(...) | test.rs:344:18:344:18 | n | match |
-| test.rs:344:13:344:19 | Some(...) | test.rs:344:39:344:53 | MacroStmts | no-match |
-| test.rs:344:18:344:18 | n | test.rs:345:9:345:9 | n | match |
-| test.rs:344:23:344:23 | a | test.rs:344:13:344:19 | Some(...) |  |
-| test.rs:344:32:344:54 | ...::panic_fmt | test.rs:344:39:344:53 | "Expected some" |  |
-| test.rs:344:32:344:54 | MacroExpr | test.rs:344:30:344:56 | { ... } |  |
-| test.rs:344:32:344:54 | panic!... | test.rs:344:32:344:54 | MacroExpr |  |
-| test.rs:344:39:344:53 | "Expected some" | test.rs:344:39:344:53 | FormatArgsExpr |  |
-| test.rs:344:39:344:53 | ...::const_format_args!... | test.rs:344:39:344:53 | MacroExpr |  |
-| test.rs:344:39:344:53 | ...::panic_2021!... | test.rs:344:39:344:53 | MacroExpr |  |
-| test.rs:344:39:344:53 | ...::panic_fmt(...) | test.rs:344:39:344:53 | { ... } |  |
-| test.rs:344:39:344:53 | ExprStmt | test.rs:344:32:344:54 | ...::panic_fmt |  |
-| test.rs:344:39:344:53 | FormatArgsExpr | test.rs:344:39:344:53 | ...::const_format_args!... |  |
-| test.rs:344:39:344:53 | MacroExpr | test.rs:344:32:344:54 | panic!... |  |
-| test.rs:344:39:344:53 | MacroExpr | test.rs:344:39:344:53 | ...::panic_fmt(...) |  |
-| test.rs:344:39:344:53 | MacroStmts | test.rs:344:39:344:53 | ExprStmt |  |
-| test.rs:344:39:344:53 | MacroStmts | test.rs:344:39:344:53 | MacroStmts |  |
-| test.rs:344:39:344:53 | { ... } | test.rs:344:39:344:53 | ...::panic_2021!... |  |
-| test.rs:345:9:345:9 | n | test.rs:343:46:346:5 | { ... } |  |
-| test.rs:348:5:354:5 | enter fn test_let_with_return | test.rs:348:29:348:29 | m |  |
-| test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | test.rs:348:5:354:5 | exit fn test_let_with_return |  |
-| test.rs:348:29:348:29 | m | test.rs:348:29:348:42 | ...: Option::<...> | match |
-| test.rs:348:29:348:42 | ...: Option::<...> | test.rs:349:9:352:10 | let ... = ... |  |
-| test.rs:348:53:354:5 | { ... } | test.rs:348:5:354:5 | exit fn test_let_with_return (normal) |  |
-| test.rs:349:9:352:10 | let ... = ... | test.rs:349:25:349:25 | m |  |
-| test.rs:349:13:349:15 | ret | test.rs:353:9:353:12 | true | match |
-| test.rs:349:19:352:9 | match m { ... } | test.rs:349:13:349:15 | ret |  |
-| test.rs:349:25:349:25 | m | test.rs:350:13:350:21 | Some(...) |  |
-| test.rs:350:13:350:21 | Some(...) | test.rs:350:18:350:20 | ret | match |
-| test.rs:350:13:350:21 | Some(...) | test.rs:351:13:351:16 | None | no-match |
-| test.rs:350:18:350:20 | ret | test.rs:350:26:350:28 | ret | match |
-| test.rs:350:26:350:28 | ret | test.rs:349:19:352:9 | match m { ... } |  |
-| test.rs:351:13:351:16 | None | test.rs:351:28:351:32 | false | match |
-| test.rs:351:21:351:32 | return false | test.rs:348:5:354:5 | exit fn test_let_with_return (normal) | return |
-| test.rs:351:28:351:32 | false | test.rs:351:21:351:32 | return false |  |
-| test.rs:353:9:353:12 | true | test.rs:348:53:354:5 | { ... } |  |
-| test.rs:359:5:362:5 | enter fn empty_tuple_pattern | test.rs:359:28:359:31 | unit |  |
-| test.rs:359:5:362:5 | exit fn empty_tuple_pattern (normal) | test.rs:359:5:362:5 | exit fn empty_tuple_pattern |  |
-| test.rs:359:28:359:31 | unit | test.rs:359:28:359:35 | ...: ... | match |
-| test.rs:359:28:359:35 | ...: ... | test.rs:360:9:360:22 | let ... = unit |  |
-| test.rs:360:9:360:22 | let ... = unit | test.rs:360:18:360:21 | unit |  |
-| test.rs:360:13:360:14 | TuplePat | test.rs:361:9:361:15 | ExprStmt | match |
-| test.rs:360:18:360:21 | unit | test.rs:360:13:360:14 | TuplePat |  |
-| test.rs:361:9:361:14 | return | test.rs:359:5:362:5 | exit fn empty_tuple_pattern (normal) | return |
-| test.rs:361:9:361:15 | ExprStmt | test.rs:361:9:361:14 | return |  |
-| test.rs:366:5:370:5 | enter fn empty_struct_pattern | test.rs:366:29:366:30 | st |  |
-| test.rs:366:5:370:5 | exit fn empty_struct_pattern (normal) | test.rs:366:5:370:5 | exit fn empty_struct_pattern |  |
-| test.rs:366:29:366:30 | st | test.rs:366:29:366:40 | ...: MyStruct | match |
-| test.rs:366:29:366:40 | ...: MyStruct | test.rs:367:15:367:16 | st |  |
-| test.rs:366:50:370:5 | { ... } | test.rs:366:5:370:5 | exit fn empty_struct_pattern (normal) |  |
-| test.rs:367:9:369:9 | match st { ... } | test.rs:366:50:370:5 | { ... } |  |
-| test.rs:367:15:367:16 | st | test.rs:368:13:368:27 | MyStruct {...} |  |
-| test.rs:368:13:368:27 | MyStruct {...} | test.rs:368:24:368:25 | .. | match |
-| test.rs:368:24:368:25 | .. | test.rs:368:32:368:32 | 1 | match |
-| test.rs:368:32:368:32 | 1 | test.rs:367:9:369:9 | match st { ... } |  |
-| test.rs:372:5:379:5 | enter fn range_pattern | test.rs:373:15:373:16 | 42 |  |
-| test.rs:372:5:379:5 | exit fn range_pattern (normal) | test.rs:372:5:379:5 | exit fn range_pattern |  |
-| test.rs:372:31:379:5 | { ... } | test.rs:372:5:379:5 | exit fn range_pattern (normal) |  |
-| test.rs:373:9:378:9 | match 42 { ... } | test.rs:372:31:379:5 | { ... } |  |
-| test.rs:373:15:373:16 | 42 | test.rs:374:13:374:15 | RangePat |  |
-| test.rs:374:13:374:15 | RangePat | test.rs:374:15:374:15 | 0 | match |
-| test.rs:374:13:374:15 | RangePat | test.rs:375:13:375:16 | RangePat | no-match |
-| test.rs:374:15:374:15 | 0 | test.rs:374:15:374:15 | 0 |  |
-| test.rs:374:15:374:15 | 0 | test.rs:374:20:374:20 | 1 | match |
-| test.rs:374:15:374:15 | 0 | test.rs:375:13:375:16 | RangePat | no-match |
-| test.rs:374:20:374:20 | 1 | test.rs:373:9:378:9 | match 42 { ... } |  |
-| test.rs:375:13:375:13 | 1 | test.rs:375:13:375:13 | 1 |  |
-| test.rs:375:13:375:13 | 1 | test.rs:375:16:375:16 | 2 | match |
-| test.rs:375:13:375:13 | 1 | test.rs:376:13:376:15 | RangePat | no-match |
-| test.rs:375:13:375:16 | RangePat | test.rs:375:13:375:13 | 1 | match |
-| test.rs:375:13:375:16 | RangePat | test.rs:376:13:376:15 | RangePat | no-match |
-| test.rs:375:16:375:16 | 2 | test.rs:375:16:375:16 | 2 |  |
-| test.rs:375:16:375:16 | 2 | test.rs:375:21:375:21 | 2 | match |
-| test.rs:375:16:375:16 | 2 | test.rs:376:13:376:15 | RangePat | no-match |
-| test.rs:375:21:375:21 | 2 | test.rs:373:9:378:9 | match 42 { ... } |  |
-| test.rs:376:13:376:13 | 5 | test.rs:376:13:376:13 | 5 |  |
-| test.rs:376:13:376:13 | 5 | test.rs:376:20:376:20 | 3 | match |
-| test.rs:376:13:376:13 | 5 | test.rs:377:13:377:13 | _ | no-match |
-| test.rs:376:13:376:15 | RangePat | test.rs:376:13:376:13 | 5 | match |
-| test.rs:376:13:376:15 | RangePat | test.rs:377:13:377:13 | _ | no-match |
-| test.rs:376:20:376:20 | 3 | test.rs:373:9:378:9 | match 42 { ... } |  |
-| test.rs:377:13:377:13 | _ | test.rs:377:18:377:18 | 4 | match |
-| test.rs:377:18:377:18 | 4 | test.rs:373:9:378:9 | match 42 { ... } |  |
-| test.rs:383:5:388:5 | enter fn test_infinite_loop | test.rs:384:9:386:9 | ExprStmt |  |
-| test.rs:384:9:386:9 | ExprStmt | test.rs:385:13:385:14 | TupleExpr |  |
-| test.rs:384:14:386:9 | { ... } | test.rs:385:13:385:14 | TupleExpr |  |
-| test.rs:385:13:385:14 | TupleExpr | test.rs:384:14:386:9 | { ... } |  |
-| test.rs:392:5:394:5 | enter fn say_hello | test.rs:393:9:393:34 | ExprStmt |  |
-| test.rs:392:5:394:5 | exit fn say_hello (normal) | test.rs:392:5:394:5 | exit fn say_hello |  |
-| test.rs:392:26:394:5 | { ... } | test.rs:392:5:394:5 | exit fn say_hello (normal) |  |
-| test.rs:393:9:393:33 | ...::_print | test.rs:393:18:393:32 | "hello, world!\\n" |  |
-| test.rs:393:9:393:33 | MacroExpr | test.rs:392:26:394:5 | { ... } |  |
-| test.rs:393:9:393:33 | println!... | test.rs:393:9:393:33 | MacroExpr |  |
-| test.rs:393:9:393:34 | ExprStmt | test.rs:393:18:393:32 | MacroStmts |  |
-| test.rs:393:18:393:32 | "hello, world!\\n" | test.rs:393:18:393:32 | FormatArgsExpr |  |
-| test.rs:393:18:393:32 | ...::_print(...) | test.rs:393:18:393:32 | { ... } |  |
-| test.rs:393:18:393:32 | ...::format_args_nl!... | test.rs:393:18:393:32 | MacroExpr |  |
-| test.rs:393:18:393:32 | ExprStmt | test.rs:393:9:393:33 | ...::_print |  |
-| test.rs:393:18:393:32 | FormatArgsExpr | test.rs:393:18:393:32 | ...::format_args_nl!... |  |
-| test.rs:393:18:393:32 | MacroExpr | test.rs:393:18:393:32 | ...::_print(...) |  |
-| test.rs:393:18:393:32 | MacroStmts | test.rs:393:18:393:32 | ExprStmt |  |
-| test.rs:393:18:393:32 | { ... } | test.rs:393:9:393:33 | println!... |  |
-| test.rs:396:5:415:5 | enter fn async_block | test.rs:396:26:396:26 | b |  |
-| test.rs:396:5:415:5 | exit fn async_block (normal) | test.rs:396:5:415:5 | exit fn async_block |  |
-| test.rs:396:26:396:26 | b | test.rs:396:26:396:32 | ...: bool | match |
-| test.rs:396:26:396:32 | ...: bool | test.rs:397:9:399:10 | let ... = ... |  |
-| test.rs:396:35:415:5 | { ... } | test.rs:396:5:415:5 | exit fn async_block (normal) |  |
-| test.rs:397:9:399:10 | let ... = ... | test.rs:397:26:399:9 | { ... } |  |
-| test.rs:397:13:397:22 | say_godbye | test.rs:400:9:402:10 | let ... = ... | match |
-| test.rs:397:26:399:9 | enter { ... } | test.rs:398:13:398:42 | ExprStmt |  |
-| test.rs:397:26:399:9 | exit { ... } (normal) | test.rs:397:26:399:9 | exit { ... } |  |
-| test.rs:397:26:399:9 | { ... } | test.rs:397:13:397:22 | say_godbye |  |
-| test.rs:398:13:398:41 | ...::_print | test.rs:398:22:398:40 | "godbye, everyone!\\n" |  |
-| test.rs:398:13:398:41 | MacroExpr | test.rs:397:26:399:9 | exit { ... } (normal) |  |
-| test.rs:398:13:398:41 | println!... | test.rs:398:13:398:41 | MacroExpr |  |
-| test.rs:398:13:398:42 | ExprStmt | test.rs:398:22:398:40 | MacroStmts |  |
-| test.rs:398:22:398:40 | "godbye, everyone!\\n" | test.rs:398:22:398:40 | FormatArgsExpr |  |
-| test.rs:398:22:398:40 | ...::_print(...) | test.rs:398:22:398:40 | { ... } |  |
-| test.rs:398:22:398:40 | ...::format_args_nl!... | test.rs:398:22:398:40 | MacroExpr |  |
-| test.rs:398:22:398:40 | ExprStmt | test.rs:398:13:398:41 | ...::_print |  |
-| test.rs:398:22:398:40 | FormatArgsExpr | test.rs:398:22:398:40 | ...::format_args_nl!... |  |
-| test.rs:398:22:398:40 | MacroExpr | test.rs:398:22:398:40 | ...::_print(...) |  |
-| test.rs:398:22:398:40 | MacroStmts | test.rs:398:22:398:40 | ExprStmt |  |
-| test.rs:398:22:398:40 | { ... } | test.rs:398:13:398:41 | println!... |  |
-| test.rs:400:9:402:10 | let ... = ... | test.rs:400:31:402:9 | { ... } |  |
-| test.rs:400:13:400:27 | say_how_are_you | test.rs:403:9:403:28 | let ... = ... | match |
-| test.rs:400:31:402:9 | enter { ... } | test.rs:401:13:401:37 | ExprStmt |  |
-| test.rs:400:31:402:9 | exit { ... } (normal) | test.rs:400:31:402:9 | exit { ... } |  |
-| test.rs:400:31:402:9 | { ... } | test.rs:400:13:400:27 | say_how_are_you |  |
-| test.rs:401:13:401:36 | ...::_print | test.rs:401:22:401:35 | "how are you?\\n" |  |
-| test.rs:401:13:401:36 | MacroExpr | test.rs:400:31:402:9 | exit { ... } (normal) |  |
-| test.rs:401:13:401:36 | println!... | test.rs:401:13:401:36 | MacroExpr |  |
-| test.rs:401:13:401:37 | ExprStmt | test.rs:401:22:401:35 | MacroStmts |  |
-| test.rs:401:22:401:35 | "how are you?\\n" | test.rs:401:22:401:35 | FormatArgsExpr |  |
-| test.rs:401:22:401:35 | ...::_print(...) | test.rs:401:22:401:35 | { ... } |  |
-| test.rs:401:22:401:35 | ...::format_args_nl!... | test.rs:401:22:401:35 | MacroExpr |  |
-| test.rs:401:22:401:35 | ExprStmt | test.rs:401:13:401:36 | ...::_print |  |
-| test.rs:401:22:401:35 | FormatArgsExpr | test.rs:401:22:401:35 | ...::format_args_nl!... |  |
-| test.rs:401:22:401:35 | MacroExpr | test.rs:401:22:401:35 | ...::_print(...) |  |
-| test.rs:401:22:401:35 | MacroStmts | test.rs:401:22:401:35 | ExprStmt |  |
-| test.rs:401:22:401:35 | { ... } | test.rs:401:13:401:36 | println!... |  |
-| test.rs:403:9:403:28 | let ... = ... | test.rs:403:20:403:27 | { ... } |  |
-| test.rs:403:13:403:16 | noop | test.rs:404:9:404:26 | ExprStmt | match |
-| test.rs:403:20:403:27 | { ... } | test.rs:403:13:403:16 | noop |  |
-| test.rs:404:9:404:17 | say_hello | test.rs:404:9:404:19 | say_hello(...) |  |
-| test.rs:404:9:404:19 | say_hello(...) | test.rs:404:9:404:25 | await ... |  |
-| test.rs:404:9:404:25 | await ... | test.rs:405:9:405:30 | ExprStmt |  |
-| test.rs:404:9:404:26 | ExprStmt | test.rs:404:9:404:17 | say_hello |  |
-| test.rs:405:9:405:23 | say_how_are_you | test.rs:405:9:405:29 | await say_how_are_you |  |
-| test.rs:405:9:405:29 | await say_how_are_you | test.rs:406:9:406:25 | ExprStmt |  |
-| test.rs:405:9:405:30 | ExprStmt | test.rs:405:9:405:23 | say_how_are_you |  |
-| test.rs:406:9:406:18 | say_godbye | test.rs:406:9:406:24 | await say_godbye |  |
-| test.rs:406:9:406:24 | await say_godbye | test.rs:407:9:407:19 | ExprStmt |  |
-| test.rs:406:9:406:25 | ExprStmt | test.rs:406:9:406:18 | say_godbye |  |
-| test.rs:407:9:407:12 | noop | test.rs:407:9:407:18 | await noop |  |
-| test.rs:407:9:407:18 | await noop | test.rs:409:9:414:10 | let ... = ... |  |
-| test.rs:407:9:407:19 | ExprStmt | test.rs:407:9:407:12 | noop |  |
-| test.rs:409:9:414:10 | let ... = ... | test.rs:409:22:414:9 | \|...\| ... |  |
-| test.rs:409:13:409:18 | lambda | test.rs:396:35:415:5 | { ... } | match |
-| test.rs:409:22:414:9 | \|...\| ... | test.rs:409:13:409:18 | lambda |  |
-| test.rs:409:22:414:9 | enter \|...\| ... | test.rs:409:23:409:25 | foo |  |
-| test.rs:409:22:414:9 | exit \|...\| ... (normal) | test.rs:409:22:414:9 | exit \|...\| ... |  |
-| test.rs:409:23:409:25 | ... | test.rs:409:28:414:9 | { ... } |  |
-| test.rs:409:23:409:25 | foo | test.rs:409:23:409:25 | ... | match |
-| test.rs:409:28:414:9 | enter { ... } | test.rs:410:13:412:14 | ExprStmt |  |
-| test.rs:409:28:414:9 | exit { ... } (normal) | test.rs:409:28:414:9 | exit { ... } |  |
-| test.rs:409:28:414:9 | { ... } | test.rs:409:22:414:9 | exit \|...\| ... (normal) |  |
-| test.rs:410:13:412:13 | if b {...} | test.rs:413:13:413:15 | foo |  |
-| test.rs:410:13:412:14 | ExprStmt | test.rs:410:16:410:16 | b |  |
-| test.rs:410:16:410:16 | b | test.rs:410:13:412:13 | if b {...} | false |
-| test.rs:410:16:410:16 | b | test.rs:411:17:411:41 | ExprStmt | true |
-| test.rs:411:17:411:40 | return ... | test.rs:409:28:414:9 | exit { ... } (normal) | return |
-| test.rs:411:17:411:41 | ExprStmt | test.rs:411:24:411:34 | async_block |  |
-| test.rs:411:24:411:34 | async_block | test.rs:411:36:411:39 | true |  |
-| test.rs:411:24:411:40 | async_block(...) | test.rs:411:17:411:40 | return ... |  |
-| test.rs:411:36:411:39 | true | test.rs:411:24:411:40 | async_block(...) |  |
-| test.rs:413:13:413:15 | foo | test.rs:409:28:414:9 | exit { ... } (normal) |  |
-| test.rs:421:5:423:5 | enter fn add_two | test.rs:421:22:421:22 | n |  |
-| test.rs:421:5:423:5 | exit fn add_two (normal) | test.rs:421:5:423:5 | exit fn add_two |  |
-| test.rs:421:22:421:22 | n | test.rs:421:22:421:27 | ...: i64 | match |
-| test.rs:421:22:421:27 | ...: i64 | test.rs:422:9:422:9 | n |  |
-| test.rs:421:37:423:5 | { ... } | test.rs:421:5:423:5 | exit fn add_two (normal) |  |
-| test.rs:422:9:422:9 | n | test.rs:422:13:422:13 | 2 |  |
-| test.rs:422:9:422:13 | ... + ... | test.rs:421:37:423:5 | { ... } |  |
-| test.rs:422:13:422:13 | 2 | test.rs:422:9:422:13 | ... + ... |  |
-| test.rs:427:5:435:5 | enter fn const_block_assert | test.rs:430:9:432:9 | ExprStmt |  |
-| test.rs:427:5:435:5 | exit fn const_block_assert (normal) | test.rs:427:5:435:5 | exit fn const_block_assert |  |
-| test.rs:427:41:435:5 | { ... } | test.rs:427:5:435:5 | exit fn const_block_assert (normal) |  |
-| test.rs:430:9:432:9 | ExprStmt | test.rs:431:13:431:50 | ExprStmt |  |
-| test.rs:430:9:432:9 | { ... } | test.rs:434:9:434:10 | 42 |  |
-| test.rs:431:13:431:49 | ...::panic_2021!... | test.rs:431:13:431:49 | MacroExpr |  |
-| test.rs:431:13:431:49 | ...::panic_explicit | test.rs:431:13:431:49 | ...::panic_explicit(...) |  |
-| test.rs:431:13:431:49 | ...::panic_explicit(...) | test.rs:431:13:431:49 | { ... } |  |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:13:431:49 | MacroStmts |  |
-| test.rs:431:13:431:49 | ExprStmt | test.rs:431:13:431:49 | panic_cold_explicit |  |
-| test.rs:431:13:431:49 | MacroExpr | test.rs:430:9:432:9 | { ... } |  |
-| test.rs:431:13:431:49 | MacroExpr | test.rs:431:13:431:49 | { ... } |  |
-| test.rs:431:13:431:49 | MacroStmts | test.rs:431:13:431:49 | fn panic_cold_explicit |  |
-| test.rs:431:13:431:49 | assert!... | test.rs:431:13:431:49 | MacroExpr |  |
-| test.rs:431:13:431:49 | enter fn panic_cold_explicit | test.rs:431:13:431:49 | ...::panic_explicit |  |
-| test.rs:431:13:431:49 | exit fn panic_cold_explicit (normal) | test.rs:431:13:431:49 | exit fn panic_cold_explicit |  |
-| test.rs:431:13:431:49 | fn panic_cold_explicit | test.rs:431:13:431:49 | ExprStmt |  |
-| test.rs:431:13:431:49 | panic_cold_explicit | test.rs:431:13:431:49 | panic_cold_explicit(...) |  |
-| test.rs:431:13:431:49 | panic_cold_explicit(...) | test.rs:431:13:431:49 | { ... } |  |
-| test.rs:431:13:431:49 | { ... } | test.rs:431:13:431:49 | ...::panic_2021!... |  |
-| test.rs:431:13:431:49 | { ... } | test.rs:431:13:431:49 | exit fn panic_cold_explicit (normal) |  |
-| test.rs:431:13:431:49 | { ... } | test.rs:431:21:431:48 | if ... {...} |  |
-| test.rs:431:13:431:50 | ExprStmt | test.rs:431:21:431:48 | MacroStmts |  |
-| test.rs:431:21:431:42 | ...::size_of::<...> | test.rs:431:21:431:44 | ...::size_of::<...>(...) |  |
-| test.rs:431:21:431:44 | ...::size_of::<...>(...) | test.rs:431:48:431:48 | 0 |  |
-| test.rs:431:21:431:48 | ... > ... | test.rs:431:21:431:48 | [boolean(false)] ! ... | true |
-| test.rs:431:21:431:48 | ... > ... | test.rs:431:21:431:48 | [boolean(true)] ! ... | false |
-| test.rs:431:21:431:48 | MacroStmts | test.rs:431:21:431:42 | ...::size_of::<...> |  |
-| test.rs:431:21:431:48 | [boolean(false)] ! ... | test.rs:431:21:431:48 | if ... {...} | false |
-| test.rs:431:21:431:48 | [boolean(true)] ! ... | test.rs:431:13:431:49 | ExprStmt | true |
-| test.rs:431:21:431:48 | if ... {...} | test.rs:431:21:431:48 | { ... } |  |
-| test.rs:431:21:431:48 | { ... } | test.rs:431:13:431:49 | assert!... |  |
-| test.rs:431:48:431:48 | 0 | test.rs:431:21:431:48 | ... > ... |  |
-| test.rs:434:9:434:10 | 42 | test.rs:427:41:435:5 | { ... } |  |
-| test.rs:437:5:446:5 | enter fn const_block_panic | test.rs:438:9:438:30 | Const |  |
-| test.rs:437:5:446:5 | exit fn const_block_panic (normal) | test.rs:437:5:446:5 | exit fn const_block_panic |  |
-| test.rs:437:35:446:5 | { ... } | test.rs:437:5:446:5 | exit fn const_block_panic (normal) |  |
-| test.rs:438:9:438:30 | Const | test.rs:439:9:444:9 | ExprStmt |  |
-| test.rs:439:9:444:9 | ExprStmt | test.rs:439:12:439:16 | false |  |
-| test.rs:439:9:444:9 | if false {...} | test.rs:445:9:445:9 | N |  |
-| test.rs:439:12:439:16 | false | test.rs:439:9:444:9 | if false {...} | false |
-| test.rs:442:17:442:24 | ...::panic_explicit | test.rs:442:17:442:24 | ...::panic_explicit(...) |  |
-| test.rs:442:17:442:24 | ...::panic_explicit(...) | test.rs:442:17:442:24 | { ... } |  |
-| test.rs:442:17:442:24 | enter fn panic_cold_explicit | test.rs:442:17:442:24 | ...::panic_explicit |  |
-| test.rs:442:17:442:24 | exit fn panic_cold_explicit (normal) | test.rs:442:17:442:24 | exit fn panic_cold_explicit |  |
-| test.rs:442:17:442:24 | { ... } | test.rs:442:17:442:24 | exit fn panic_cold_explicit (normal) |  |
-| test.rs:445:9:445:9 | N | test.rs:437:35:446:5 | { ... } |  |
-| test.rs:449:1:454:1 | enter fn dead_code | test.rs:450:5:452:5 | ExprStmt |  |
-| test.rs:449:1:454:1 | exit fn dead_code (normal) | test.rs:449:1:454:1 | exit fn dead_code |  |
-| test.rs:450:5:452:5 | ExprStmt | test.rs:450:9:450:12 | true |  |
-| test.rs:450:9:450:12 | true | test.rs:451:9:451:17 | ExprStmt | true |
-| test.rs:451:9:451:16 | return 0 | test.rs:449:1:454:1 | exit fn dead_code (normal) | return |
-| test.rs:451:9:451:17 | ExprStmt | test.rs:451:16:451:16 | 0 |  |
-| test.rs:451:16:451:16 | 0 | test.rs:451:9:451:16 | return 0 |  |
-| test.rs:456:1:456:16 | enter fn do_thing | test.rs:456:15:456:16 | { ... } |  |
-| test.rs:456:1:456:16 | exit fn do_thing (normal) | test.rs:456:1:456:16 | exit fn do_thing |  |
-| test.rs:456:15:456:16 | { ... } | test.rs:456:1:456:16 | exit fn do_thing (normal) |  |
-| test.rs:458:1:460:1 | enter fn condition_not_met | test.rs:459:5:459:9 | false |  |
-| test.rs:458:1:460:1 | exit fn condition_not_met (normal) | test.rs:458:1:460:1 | exit fn condition_not_met |  |
-| test.rs:458:32:460:1 | { ... } | test.rs:458:1:460:1 | exit fn condition_not_met (normal) |  |
-| test.rs:459:5:459:9 | false | test.rs:458:32:460:1 | { ... } |  |
-| test.rs:462:1:462:21 | enter fn do_next_thing | test.rs:462:20:462:21 | { ... } |  |
-| test.rs:462:1:462:21 | exit fn do_next_thing (normal) | test.rs:462:1:462:21 | exit fn do_next_thing |  |
-| test.rs:462:20:462:21 | { ... } | test.rs:462:1:462:21 | exit fn do_next_thing (normal) |  |
-| test.rs:464:1:464:21 | enter fn do_last_thing | test.rs:464:20:464:21 | { ... } |  |
-| test.rs:464:1:464:21 | exit fn do_last_thing (normal) | test.rs:464:1:464:21 | exit fn do_last_thing |  |
-| test.rs:464:20:464:21 | { ... } | test.rs:464:1:464:21 | exit fn do_last_thing (normal) |  |
-| test.rs:466:1:480:1 | enter fn labelled_block1 | test.rs:467:5:478:6 | let ... = ... |  |
-| test.rs:466:1:480:1 | exit fn labelled_block1 (normal) | test.rs:466:1:480:1 | exit fn labelled_block1 |  |
-| test.rs:466:29:480:1 | { ... } | test.rs:466:1:480:1 | exit fn labelled_block1 (normal) |  |
-| test.rs:467:5:478:6 | let ... = ... | test.rs:468:9:468:19 | ExprStmt |  |
-| test.rs:467:9:467:14 | result | test.rs:479:5:479:10 | result | match |
-| test.rs:467:18:478:5 | 'block: { ... } | test.rs:467:9:467:14 | result |  |
-| test.rs:468:9:468:16 | do_thing | test.rs:468:9:468:18 | do_thing(...) |  |
-| test.rs:468:9:468:18 | do_thing(...) | test.rs:469:9:471:9 | ExprStmt |  |
-| test.rs:468:9:468:19 | ExprStmt | test.rs:468:9:468:16 | do_thing |  |
-| test.rs:469:9:471:9 | ExprStmt | test.rs:469:12:469:28 | condition_not_met |  |
-| test.rs:469:9:471:9 | if ... {...} | test.rs:472:9:472:24 | ExprStmt |  |
-| test.rs:469:12:469:28 | condition_not_met | test.rs:469:12:469:30 | condition_not_met(...) |  |
-| test.rs:469:12:469:30 | condition_not_met(...) | test.rs:469:9:471:9 | if ... {...} | false |
-| test.rs:469:12:469:30 | condition_not_met(...) | test.rs:470:13:470:27 | ExprStmt | true |
-| test.rs:470:13:470:26 | break ''block 1 | test.rs:467:18:478:5 | 'block: { ... } | break |
-| test.rs:470:13:470:27 | ExprStmt | test.rs:470:26:470:26 | 1 |  |
-| test.rs:470:26:470:26 | 1 | test.rs:470:13:470:26 | break ''block 1 |  |
-| test.rs:472:9:472:21 | do_next_thing | test.rs:472:9:472:23 | do_next_thing(...) |  |
-| test.rs:472:9:472:23 | do_next_thing(...) | test.rs:473:9:475:9 | ExprStmt |  |
-| test.rs:472:9:472:24 | ExprStmt | test.rs:472:9:472:21 | do_next_thing |  |
-| test.rs:473:9:475:9 | ExprStmt | test.rs:473:12:473:28 | condition_not_met |  |
-| test.rs:473:9:475:9 | if ... {...} | test.rs:476:9:476:24 | ExprStmt |  |
-| test.rs:473:12:473:28 | condition_not_met | test.rs:473:12:473:30 | condition_not_met(...) |  |
-| test.rs:473:12:473:30 | condition_not_met(...) | test.rs:473:9:475:9 | if ... {...} | false |
-| test.rs:473:12:473:30 | condition_not_met(...) | test.rs:474:13:474:27 | ExprStmt | true |
-| test.rs:474:13:474:26 | break ''block 2 | test.rs:467:18:478:5 | 'block: { ... } | break |
-| test.rs:474:13:474:27 | ExprStmt | test.rs:474:26:474:26 | 2 |  |
-| test.rs:474:26:474:26 | 2 | test.rs:474:13:474:26 | break ''block 2 |  |
-| test.rs:476:9:476:21 | do_last_thing | test.rs:476:9:476:23 | do_last_thing(...) |  |
-| test.rs:476:9:476:23 | do_last_thing(...) | test.rs:477:9:477:9 | 3 |  |
-| test.rs:476:9:476:24 | ExprStmt | test.rs:476:9:476:21 | do_last_thing |  |
-| test.rs:477:9:477:9 | 3 | test.rs:467:18:478:5 | 'block: { ... } |  |
-| test.rs:479:5:479:10 | result | test.rs:466:29:480:1 | { ... } |  |
-| test.rs:482:1:490:1 | enter fn labelled_block2 | test.rs:483:5:489:6 | let ... = ... |  |
-| test.rs:482:1:490:1 | exit fn labelled_block2 (normal) | test.rs:482:1:490:1 | exit fn labelled_block2 |  |
-| test.rs:482:22:490:1 | { ... } | test.rs:482:1:490:1 | exit fn labelled_block2 (normal) |  |
-| test.rs:483:5:489:6 | let ... = ... | test.rs:484:9:484:34 | let ... = None |  |
-| test.rs:483:9:483:14 | result | test.rs:482:22:490:1 | { ... } | match |
-| test.rs:483:18:489:5 | 'block: { ... } | test.rs:483:9:483:14 | result |  |
-| test.rs:484:9:484:34 | let ... = None | test.rs:484:30:484:33 | None |  |
-| test.rs:484:13:484:13 | x | test.rs:485:9:487:10 | let ... = x else {...} | match |
-| test.rs:484:30:484:33 | None | test.rs:484:13:484:13 | x |  |
-| test.rs:485:9:487:10 | let ... = x else {...} | test.rs:485:23:485:23 | x |  |
-| test.rs:485:13:485:19 | Some(...) | test.rs:485:18:485:18 | y | match |
-| test.rs:485:13:485:19 | Some(...) | test.rs:486:13:486:27 | ExprStmt | no-match |
-| test.rs:485:18:485:18 | y | test.rs:488:9:488:9 | 0 | match |
-| test.rs:485:23:485:23 | x | test.rs:485:13:485:19 | Some(...) |  |
-| test.rs:486:13:486:26 | break ''block 1 | test.rs:483:18:489:5 | 'block: { ... } | break |
-| test.rs:486:13:486:27 | ExprStmt | test.rs:486:26:486:26 | 1 |  |
-| test.rs:486:26:486:26 | 1 | test.rs:486:13:486:26 | break ''block 1 |  |
-| test.rs:488:9:488:9 | 0 | test.rs:483:18:489:5 | 'block: { ... } |  |
-| test.rs:492:1:498:1 | enter fn test_nested_function2 | test.rs:493:5:493:18 | let ... = 0 |  |
-| test.rs:492:1:498:1 | exit fn test_nested_function2 (normal) | test.rs:492:1:498:1 | exit fn test_nested_function2 |  |
-| test.rs:492:28:498:1 | { ... } | test.rs:492:1:498:1 | exit fn test_nested_function2 (normal) |  |
-| test.rs:493:5:493:18 | let ... = 0 | test.rs:493:17:493:17 | 0 |  |
-| test.rs:493:9:493:13 | x | test.rs:494:5:496:5 | fn nested | match |
-| test.rs:493:17:493:17 | 0 | test.rs:493:9:493:13 | x |  |
-| test.rs:494:5:496:5 | enter fn nested | test.rs:494:15:494:15 | x |  |
-| test.rs:494:5:496:5 | exit fn nested (normal) | test.rs:494:5:496:5 | exit fn nested |  |
-| test.rs:494:5:496:5 | fn nested | test.rs:497:5:497:19 | ExprStmt |  |
-| test.rs:494:15:494:15 | x | test.rs:494:15:494:25 | ...: ... | match |
-| test.rs:494:15:494:25 | ...: ... | test.rs:495:9:495:16 | ExprStmt |  |
-| test.rs:494:28:496:5 | { ... } | test.rs:494:5:496:5 | exit fn nested (normal) |  |
-| test.rs:495:9:495:10 | * ... | test.rs:495:15:495:15 | 1 |  |
-| test.rs:495:9:495:15 | ... += ... | test.rs:494:28:496:5 | { ... } |  |
-| test.rs:495:9:495:16 | ExprStmt | test.rs:495:10:495:10 | x |  |
-| test.rs:495:10:495:10 | x | test.rs:495:9:495:10 | * ... |  |
-| test.rs:495:15:495:15 | 1 | test.rs:495:9:495:15 | ... += ... |  |
-| test.rs:497:5:497:10 | nested | test.rs:497:17:497:17 | x |  |
-| test.rs:497:5:497:18 | nested(...) | test.rs:492:28:498:1 | { ... } |  |
-| test.rs:497:5:497:19 | ExprStmt | test.rs:497:5:497:10 | nested |  |
-| test.rs:497:12:497:17 | &mut x | test.rs:497:5:497:18 | nested(...) |  |
-| test.rs:497:17:497:17 | x | test.rs:497:12:497:17 | &mut x |  |
-| test.rs:509:5:511:5 | enter fn new | test.rs:509:12:509:12 | a |  |
-| test.rs:509:5:511:5 | exit fn new (normal) | test.rs:509:5:511:5 | exit fn new |  |
-| test.rs:509:12:509:12 | a | test.rs:509:12:509:17 | ...: i64 | match |
-| test.rs:509:12:509:17 | ...: i64 | test.rs:510:23:510:23 | a |  |
-| test.rs:509:28:511:5 | { ... } | test.rs:509:5:511:5 | exit fn new (normal) |  |
-| test.rs:510:9:510:25 | MyNumber {...} | test.rs:509:28:511:5 | { ... } |  |
-| test.rs:510:23:510:23 | a | test.rs:510:9:510:25 | MyNumber {...} |  |
-| test.rs:513:5:515:5 | enter fn negated | test.rs:513:16:513:19 | self |  |
-| test.rs:513:5:515:5 | exit fn negated (normal) | test.rs:513:5:515:5 | exit fn negated |  |
-| test.rs:513:16:513:19 | SelfParam | test.rs:514:23:514:26 | self |  |
-| test.rs:513:16:513:19 | self | test.rs:513:16:513:19 | SelfParam |  |
-| test.rs:513:30:515:5 | { ... } | test.rs:513:5:515:5 | exit fn negated (normal) |  |
-| test.rs:514:9:514:30 | MyNumber {...} | test.rs:513:30:515:5 | { ... } |  |
-| test.rs:514:23:514:26 | self | test.rs:514:23:514:28 | self.n |  |
-| test.rs:514:23:514:28 | self.n | test.rs:514:9:514:30 | MyNumber {...} |  |
-| test.rs:517:5:519:5 | enter fn multifly_add | test.rs:517:26:517:29 | self |  |
-| test.rs:517:5:519:5 | exit fn multifly_add (normal) | test.rs:517:5:519:5 | exit fn multifly_add |  |
-| test.rs:517:21:517:29 | SelfParam | test.rs:517:32:517:32 | a |  |
-| test.rs:517:26:517:29 | self | test.rs:517:21:517:29 | SelfParam |  |
-| test.rs:517:32:517:32 | a | test.rs:517:32:517:37 | ...: i64 | match |
-| test.rs:517:32:517:37 | ...: i64 | test.rs:517:40:517:40 | b |  |
-| test.rs:517:40:517:40 | b | test.rs:517:40:517:45 | ...: i64 | match |
-| test.rs:517:40:517:45 | ...: i64 | test.rs:518:9:518:34 | ExprStmt |  |
-| test.rs:517:48:519:5 | { ... } | test.rs:517:5:519:5 | exit fn multifly_add (normal) |  |
-| test.rs:518:9:518:12 | self | test.rs:518:9:518:14 | self.n |  |
-| test.rs:518:9:518:14 | self.n | test.rs:518:19:518:22 | self |  |
-| test.rs:518:9:518:33 | ... = ... | test.rs:517:48:519:5 | { ... } |  |
-| test.rs:518:9:518:34 | ExprStmt | test.rs:518:9:518:12 | self |  |
-| test.rs:518:18:518:33 | ... + ... | test.rs:518:9:518:33 | ... = ... |  |
-| test.rs:518:19:518:22 | self | test.rs:518:19:518:24 | self.n |  |
-| test.rs:518:19:518:24 | self.n | test.rs:518:28:518:28 | a |  |
-| test.rs:518:19:518:28 | ... * ... | test.rs:518:33:518:33 | b |  |
-| test.rs:518:28:518:28 | a | test.rs:518:19:518:28 | ... * ... |  |
-| test.rs:518:33:518:33 | b | test.rs:518:18:518:33 | ... + ... |  |
+| test.rs:146:28:148:9 | { ... } | test.rs:146:9:150:9 | if ... {...} else {...} |  |
+| test.rs:147:13:147:13 | n | test.rs:146:28:148:9 | { ... } |  |
+| test.rs:148:16:150:9 | { ... } | test.rs:146:9:150:9 | if ... {...} else {...} |  |
+| test.rs:149:13:149:13 | 0 | test.rs:148:16:150:9 | { ... } |  |
+| test.rs:153:5:158:5 | enter fn test_if_let | test.rs:153:20:153:20 | a |  |
+| test.rs:153:5:158:5 | exit fn test_if_let (normal) | test.rs:153:5:158:5 | exit fn test_if_let |  |
+| test.rs:153:20:153:20 | a | test.rs:153:20:153:33 | ...: Option::<...> | match |
+| test.rs:153:20:153:33 | ...: Option::<...> | test.rs:154:9:156:9 | ExprStmt |  |
+| test.rs:153:43:158:5 | { ... } | test.rs:153:5:158:5 | exit fn test_if_let (normal) |  |
+| test.rs:154:9:156:9 | ExprStmt | test.rs:154:12:154:26 | let ... = a |  |
+| test.rs:154:9:156:9 | if ... {...} | test.rs:157:9:157:9 | 0 |  |
+| test.rs:154:12:154:26 | let ... = a | test.rs:154:26:154:26 | a |  |
+| test.rs:154:16:154:22 | Some(...) | test.rs:154:9:156:9 | if ... {...} | no-match |
+| test.rs:154:16:154:22 | Some(...) | test.rs:154:21:154:21 | n | match |
+| test.rs:154:21:154:21 | n | test.rs:155:13:155:21 | ExprStmt | match |
+| test.rs:154:26:154:26 | a | test.rs:154:16:154:22 | Some(...) |  |
+| test.rs:155:13:155:20 | return n | test.rs:153:5:158:5 | exit fn test_if_let (normal) | return |
+| test.rs:155:13:155:21 | ExprStmt | test.rs:155:20:155:20 | n |  |
+| test.rs:155:20:155:20 | n | test.rs:155:13:155:20 | return n |  |
+| test.rs:157:9:157:9 | 0 | test.rs:153:43:158:5 | { ... } |  |
+| test.rs:160:5:166:5 | enter fn test_nested_if | test.rs:160:23:160:23 | a |  |
+| test.rs:160:5:166:5 | exit fn test_nested_if (normal) | test.rs:160:5:166:5 | exit fn test_nested_if |  |
+| test.rs:160:23:160:23 | a | test.rs:160:23:160:28 | ...: i64 | match |
+| test.rs:160:23:160:28 | ...: i64 | test.rs:161:16:161:16 | a |  |
+| test.rs:160:38:166:5 | { ... } | test.rs:160:5:166:5 | exit fn test_nested_if (normal) |  |
+| test.rs:161:9:165:9 | if ... {...} else {...} | test.rs:160:38:166:5 | { ... } |  |
+| test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | test.rs:164:13:164:13 | 0 | false |
+| test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | test.rs:162:13:162:13 | 1 | true |
+| test.rs:161:16:161:16 | a | test.rs:161:20:161:20 | 0 |  |
+| test.rs:161:16:161:20 | ... < ... | test.rs:161:24:161:24 | a | true |
+| test.rs:161:16:161:20 | ... < ... | test.rs:161:41:161:41 | a | false |
+| test.rs:161:20:161:20 | 0 | test.rs:161:16:161:20 | ... < ... |  |
+| test.rs:161:22:161:32 | [boolean(false)] { ... } | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | false |
+| test.rs:161:22:161:32 | [boolean(true)] { ... } | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | true |
+| test.rs:161:24:161:24 | a | test.rs:161:29:161:30 | 10 |  |
+| test.rs:161:24:161:30 | ... < ... | test.rs:161:22:161:32 | [boolean(false)] { ... } | false |
+| test.rs:161:24:161:30 | ... < ... | test.rs:161:22:161:32 | [boolean(true)] { ... } | true |
+| test.rs:161:28:161:30 | - ... | test.rs:161:24:161:30 | ... < ... |  |
+| test.rs:161:29:161:30 | 10 | test.rs:161:28:161:30 | - ... |  |
+| test.rs:161:39:161:48 | [boolean(false)] { ... } | test.rs:161:13:161:48 | [boolean(false)] if ... {...} else {...} | false |
+| test.rs:161:39:161:48 | [boolean(true)] { ... } | test.rs:161:13:161:48 | [boolean(true)] if ... {...} else {...} | true |
+| test.rs:161:41:161:41 | a | test.rs:161:45:161:46 | 10 |  |
+| test.rs:161:41:161:46 | ... > ... | test.rs:161:39:161:48 | [boolean(false)] { ... } | false |
+| test.rs:161:41:161:46 | ... > ... | test.rs:161:39:161:48 | [boolean(true)] { ... } | true |
+| test.rs:161:45:161:46 | 10 | test.rs:161:41:161:46 | ... > ... |  |
+| test.rs:161:51:163:9 | { ... } | test.rs:161:9:165:9 | if ... {...} else {...} |  |
+| test.rs:162:13:162:13 | 1 | test.rs:161:51:163:9 | { ... } |  |
+| test.rs:163:16:165:9 | { ... } | test.rs:161:9:165:9 | if ... {...} else {...} |  |
+| test.rs:164:13:164:13 | 0 | test.rs:163:16:165:9 | { ... } |  |
+| test.rs:168:5:177:5 | enter fn test_nested_if_2 | test.rs:168:25:168:29 | cond1 |  |
+| test.rs:168:5:177:5 | exit fn test_nested_if_2 (normal) | test.rs:168:5:177:5 | exit fn test_nested_if_2 |  |
+| test.rs:168:25:168:29 | cond1 | test.rs:168:25:168:35 | ...: bool | match |
+| test.rs:168:25:168:35 | ...: bool | test.rs:168:38:168:42 | cond2 |  |
+| test.rs:168:38:168:42 | cond2 | test.rs:168:38:168:48 | ...: bool | match |
+| test.rs:168:38:168:48 | ...: bool | test.rs:169:9:176:10 | ExprStmt |  |
+| test.rs:168:57:177:5 | { ... } | test.rs:168:5:177:5 | exit fn test_nested_if_2 (normal) |  |
+| test.rs:169:9:176:9 | if cond1 {...} | test.rs:168:57:177:5 | { ... } |  |
+| test.rs:169:9:176:10 | ExprStmt | test.rs:169:12:169:16 | cond1 |  |
+| test.rs:169:12:169:16 | cond1 | test.rs:169:9:176:9 | if cond1 {...} | false |
+| test.rs:169:12:169:16 | cond1 | test.rs:170:13:174:13 | ExprStmt | true |
+| test.rs:169:18:176:9 | { ... } | test.rs:169:9:176:9 | if cond1 {...} |  |
+| test.rs:170:13:174:13 | ExprStmt | test.rs:170:16:170:20 | cond2 |  |
+| test.rs:170:13:174:13 | if cond2 {...} else {...} | test.rs:175:13:175:26 | ExprStmt |  |
+| test.rs:170:16:170:20 | cond2 | test.rs:171:17:171:30 | ExprStmt | true |
+| test.rs:170:16:170:20 | cond2 | test.rs:173:17:173:30 | ExprStmt | false |
+| test.rs:170:22:172:13 | { ... } | test.rs:170:13:174:13 | if cond2 {...} else {...} |  |
+| test.rs:171:17:171:29 | ...::_print | test.rs:171:26:171:28 | "1\\n" |  |
+| test.rs:171:17:171:29 | MacroExpr | test.rs:170:22:172:13 | { ... } |  |
+| test.rs:171:17:171:29 | println!... | test.rs:171:17:171:29 | MacroExpr |  |
+| test.rs:171:17:171:30 | ExprStmt | test.rs:171:26:171:28 | MacroStmts |  |
+| test.rs:171:26:171:28 | "1\\n" | test.rs:171:26:171:28 | FormatArgsExpr |  |
+| test.rs:171:26:171:28 | ...::_print(...) | test.rs:171:26:171:28 | { ... } |  |
+| test.rs:171:26:171:28 | ...::format_args_nl!... | test.rs:171:26:171:28 | MacroExpr |  |
+| test.rs:171:26:171:28 | ExprStmt | test.rs:171:17:171:29 | ...::_print |  |
+| test.rs:171:26:171:28 | FormatArgsExpr | test.rs:171:26:171:28 | ...::format_args_nl!... |  |
+| test.rs:171:26:171:28 | MacroExpr | test.rs:171:26:171:28 | ...::_print(...) |  |
+| test.rs:171:26:171:28 | MacroStmts | test.rs:171:26:171:28 | ExprStmt |  |
+| test.rs:171:26:171:28 | { ... } | test.rs:171:17:171:29 | println!... |  |
+| test.rs:172:20:174:13 | { ... } | test.rs:170:13:174:13 | if cond2 {...} else {...} |  |
+| test.rs:173:17:173:29 | ...::_print | test.rs:173:26:173:28 | "2\\n" |  |
+| test.rs:173:17:173:29 | MacroExpr | test.rs:172:20:174:13 | { ... } |  |
+| test.rs:173:17:173:29 | println!... | test.rs:173:17:173:29 | MacroExpr |  |
+| test.rs:173:17:173:30 | ExprStmt | test.rs:173:26:173:28 | MacroStmts |  |
+| test.rs:173:26:173:28 | "2\\n" | test.rs:173:26:173:28 | FormatArgsExpr |  |
+| test.rs:173:26:173:28 | ...::_print(...) | test.rs:173:26:173:28 | { ... } |  |
+| test.rs:173:26:173:28 | ...::format_args_nl!... | test.rs:173:26:173:28 | MacroExpr |  |
+| test.rs:173:26:173:28 | ExprStmt | test.rs:173:17:173:29 | ...::_print |  |
+| test.rs:173:26:173:28 | FormatArgsExpr | test.rs:173:26:173:28 | ...::format_args_nl!... |  |
+| test.rs:173:26:173:28 | MacroExpr | test.rs:173:26:173:28 | ...::_print(...) |  |
+| test.rs:173:26:173:28 | MacroStmts | test.rs:173:26:173:28 | ExprStmt |  |
+| test.rs:173:26:173:28 | { ... } | test.rs:173:17:173:29 | println!... |  |
+| test.rs:175:13:175:25 | ...::_print | test.rs:175:22:175:24 | "3\\n" |  |
+| test.rs:175:13:175:25 | MacroExpr | test.rs:169:18:176:9 | { ... } |  |
+| test.rs:175:13:175:25 | println!... | test.rs:175:13:175:25 | MacroExpr |  |
+| test.rs:175:13:175:26 | ExprStmt | test.rs:175:22:175:24 | MacroStmts |  |
+| test.rs:175:22:175:24 | "3\\n" | test.rs:175:22:175:24 | FormatArgsExpr |  |
+| test.rs:175:22:175:24 | ...::_print(...) | test.rs:175:22:175:24 | { ... } |  |
+| test.rs:175:22:175:24 | ...::format_args_nl!... | test.rs:175:22:175:24 | MacroExpr |  |
+| test.rs:175:22:175:24 | ExprStmt | test.rs:175:13:175:25 | ...::_print |  |
+| test.rs:175:22:175:24 | FormatArgsExpr | test.rs:175:22:175:24 | ...::format_args_nl!... |  |
+| test.rs:175:22:175:24 | MacroExpr | test.rs:175:22:175:24 | ...::_print(...) |  |
+| test.rs:175:22:175:24 | MacroStmts | test.rs:175:22:175:24 | ExprStmt |  |
+| test.rs:175:22:175:24 | { ... } | test.rs:175:13:175:25 | println!... |  |
+| test.rs:179:5:188:5 | enter fn test_nested_if_match | test.rs:179:29:179:29 | a |  |
+| test.rs:179:5:188:5 | exit fn test_nested_if_match (normal) | test.rs:179:5:188:5 | exit fn test_nested_if_match |  |
+| test.rs:179:29:179:29 | a | test.rs:179:29:179:34 | ...: i64 | match |
+| test.rs:179:29:179:34 | ...: i64 | test.rs:180:19:180:19 | a |  |
+| test.rs:179:44:188:5 | { ... } | test.rs:179:5:188:5 | exit fn test_nested_if_match (normal) |  |
+| test.rs:180:9:187:9 | if ... {...} else {...} | test.rs:179:44:188:5 | { ... } |  |
+| test.rs:180:13:183:9 | [boolean(false)] match a { ... } | test.rs:186:13:186:13 | 0 | false |
+| test.rs:180:13:183:9 | [boolean(true)] match a { ... } | test.rs:184:13:184:13 | 1 | true |
+| test.rs:180:19:180:19 | a | test.rs:181:13:181:13 | 0 |  |
+| test.rs:181:13:181:13 | 0 | test.rs:181:13:181:13 | 0 |  |
+| test.rs:181:13:181:13 | 0 | test.rs:181:18:181:21 | true | match |
+| test.rs:181:13:181:13 | 0 | test.rs:182:13:182:13 | _ | no-match |
+| test.rs:181:18:181:21 | true | test.rs:180:13:183:9 | [boolean(true)] match a { ... } | true |
+| test.rs:182:13:182:13 | _ | test.rs:182:18:182:22 | false | match |
+| test.rs:182:18:182:22 | false | test.rs:180:13:183:9 | [boolean(false)] match a { ... } | false |
+| test.rs:183:12:185:9 | { ... } | test.rs:180:9:187:9 | if ... {...} else {...} |  |
+| test.rs:184:13:184:13 | 1 | test.rs:183:12:185:9 | { ... } |  |
+| test.rs:185:16:187:9 | { ... } | test.rs:180:9:187:9 | if ... {...} else {...} |  |
+| test.rs:186:13:186:13 | 0 | test.rs:185:16:187:9 | { ... } |  |
+| test.rs:190:5:199:5 | enter fn test_nested_if_block | test.rs:190:29:190:29 | a |  |
+| test.rs:190:5:199:5 | exit fn test_nested_if_block (normal) | test.rs:190:5:199:5 | exit fn test_nested_if_block |  |
+| test.rs:190:29:190:29 | a | test.rs:190:29:190:34 | ...: i64 | match |
+| test.rs:190:29:190:34 | ...: i64 | test.rs:192:13:192:15 | ExprStmt |  |
+| test.rs:190:44:199:5 | { ... } | test.rs:190:5:199:5 | exit fn test_nested_if_block (normal) |  |
+| test.rs:191:9:198:9 | if ... {...} else {...} | test.rs:190:44:199:5 | { ... } |  |
+| test.rs:191:12:194:9 | [boolean(false)] { ... } | test.rs:197:13:197:13 | 0 | false |
+| test.rs:191:12:194:9 | [boolean(true)] { ... } | test.rs:195:13:195:13 | 1 | true |
+| test.rs:192:13:192:14 | TupleExpr | test.rs:193:13:193:13 | a |  |
+| test.rs:192:13:192:15 | ExprStmt | test.rs:192:13:192:14 | TupleExpr |  |
+| test.rs:193:13:193:13 | a | test.rs:193:17:193:17 | 0 |  |
+| test.rs:193:13:193:17 | ... > ... | test.rs:191:12:194:9 | [boolean(false)] { ... } | false |
+| test.rs:193:13:193:17 | ... > ... | test.rs:191:12:194:9 | [boolean(true)] { ... } | true |
+| test.rs:193:17:193:17 | 0 | test.rs:193:13:193:17 | ... > ... |  |
+| test.rs:194:11:196:9 | { ... } | test.rs:191:9:198:9 | if ... {...} else {...} |  |
+| test.rs:195:13:195:13 | 1 | test.rs:194:11:196:9 | { ... } |  |
+| test.rs:196:16:198:9 | { ... } | test.rs:191:9:198:9 | if ... {...} else {...} |  |
+| test.rs:197:13:197:13 | 0 | test.rs:196:16:198:9 | { ... } |  |
+| test.rs:201:5:211:5 | enter fn test_if_assignment | test.rs:201:27:201:27 | a |  |
+| test.rs:201:5:211:5 | exit fn test_if_assignment (normal) | test.rs:201:5:211:5 | exit fn test_if_assignment |  |
+| test.rs:201:27:201:27 | a | test.rs:201:27:201:32 | ...: i64 | match |
+| test.rs:201:27:201:32 | ...: i64 | test.rs:202:9:202:26 | let ... = false |  |
+| test.rs:201:42:211:5 | { ... } | test.rs:201:5:211:5 | exit fn test_if_assignment (normal) |  |
+| test.rs:202:9:202:26 | let ... = false | test.rs:202:21:202:25 | false |  |
+| test.rs:202:13:202:17 | x | test.rs:204:13:204:21 | ExprStmt | match |
+| test.rs:202:21:202:25 | false | test.rs:202:13:202:17 | x |  |
+| test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:201:42:211:5 | { ... } |  |
+| test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:209:13:209:13 | 0 | false |
+| test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:207:13:207:13 | 1 | true |
+| test.rs:204:13:204:13 | x | test.rs:204:17:204:20 | true |  |
+| test.rs:204:13:204:20 | ... = ... | test.rs:205:13:205:13 | x |  |
+| test.rs:204:13:204:21 | ExprStmt | test.rs:204:13:204:13 | x |  |
+| test.rs:204:17:204:20 | true | test.rs:204:13:204:20 | ... = ... |  |
+| test.rs:205:13:205:13 | x | test.rs:203:12:206:9 | [boolean(false)] { ... } | false |
+| test.rs:205:13:205:13 | x | test.rs:203:12:206:9 | [boolean(true)] { ... } | true |
+| test.rs:206:11:208:9 | { ... } | test.rs:203:9:210:9 | if ... {...} else {...} |  |
+| test.rs:207:13:207:13 | 1 | test.rs:206:11:208:9 | { ... } |  |
+| test.rs:208:16:210:9 | { ... } | test.rs:203:9:210:9 | if ... {...} else {...} |  |
+| test.rs:209:13:209:13 | 0 | test.rs:208:16:210:9 | { ... } |  |
+| test.rs:213:5:224:5 | enter fn test_if_loop1 | test.rs:213:22:213:22 | a |  |
+| test.rs:213:5:224:5 | exit fn test_if_loop1 (normal) | test.rs:213:5:224:5 | exit fn test_if_loop1 |  |
+| test.rs:213:22:213:22 | a | test.rs:213:22:213:27 | ...: i64 | match |
+| test.rs:213:22:213:27 | ...: i64 | test.rs:215:13:217:14 | ExprStmt |  |
+| test.rs:213:37:224:5 | { ... } | test.rs:213:5:224:5 | exit fn test_if_loop1 (normal) |  |
+| test.rs:214:9:223:9 | if ... {...} else {...} | test.rs:213:37:224:5 | { ... } |  |
+| test.rs:214:13:219:9 | [boolean(false)] loop { ... } | test.rs:222:13:222:13 | 0 | false |
+| test.rs:214:13:219:9 | [boolean(true)] loop { ... } | test.rs:220:13:220:13 | 1 | true |
+| test.rs:214:18:219:9 | { ... } | test.rs:215:13:217:14 | ExprStmt |  |
+| test.rs:215:13:217:13 | if ... {...} | test.rs:218:13:218:19 | ExprStmt |  |
+| test.rs:215:13:217:14 | ExprStmt | test.rs:215:16:215:16 | a |  |
+| test.rs:215:16:215:16 | a | test.rs:215:20:215:20 | 0 |  |
+| test.rs:215:16:215:20 | ... > ... | test.rs:215:13:217:13 | if ... {...} | false |
+| test.rs:215:16:215:20 | ... > ... | test.rs:216:17:216:29 | ExprStmt | true |
+| test.rs:215:20:215:20 | 0 | test.rs:215:16:215:20 | ... > ... |  |
+| test.rs:216:17:216:28 | [boolean(false)] break ... | test.rs:214:13:219:9 | [boolean(false)] loop { ... } | break |
+| test.rs:216:17:216:28 | [boolean(true)] break ... | test.rs:214:13:219:9 | [boolean(true)] loop { ... } | break |
+| test.rs:216:17:216:29 | ExprStmt | test.rs:216:23:216:23 | a |  |
+| test.rs:216:23:216:23 | a | test.rs:216:27:216:28 | 10 |  |
+| test.rs:216:23:216:28 | ... > ... | test.rs:216:17:216:28 | [boolean(false)] break ... | false |
+| test.rs:216:23:216:28 | ... > ... | test.rs:216:17:216:28 | [boolean(true)] break ... | true |
+| test.rs:216:27:216:28 | 10 | test.rs:216:23:216:28 | ... > ... |  |
+| test.rs:218:13:218:13 | a | test.rs:218:17:218:18 | 10 |  |
+| test.rs:218:13:218:18 | ... < ... | test.rs:214:18:219:9 | { ... } |  |
+| test.rs:218:13:218:19 | ExprStmt | test.rs:218:13:218:13 | a |  |
+| test.rs:218:17:218:18 | 10 | test.rs:218:13:218:18 | ... < ... |  |
+| test.rs:219:12:221:9 | { ... } | test.rs:214:9:223:9 | if ... {...} else {...} |  |
+| test.rs:220:13:220:13 | 1 | test.rs:219:12:221:9 | { ... } |  |
+| test.rs:221:16:223:9 | { ... } | test.rs:214:9:223:9 | if ... {...} else {...} |  |
+| test.rs:222:13:222:13 | 0 | test.rs:221:16:223:9 | { ... } |  |
+| test.rs:226:5:237:5 | enter fn test_if_loop2 | test.rs:226:22:226:22 | a |  |
+| test.rs:226:5:237:5 | exit fn test_if_loop2 (normal) | test.rs:226:5:237:5 | exit fn test_if_loop2 |  |
+| test.rs:226:22:226:22 | a | test.rs:226:22:226:27 | ...: i64 | match |
+| test.rs:226:22:226:27 | ...: i64 | test.rs:228:13:230:14 | ExprStmt |  |
+| test.rs:226:37:237:5 | { ... } | test.rs:226:5:237:5 | exit fn test_if_loop2 (normal) |  |
+| test.rs:227:9:236:9 | if ... {...} else {...} | test.rs:226:37:237:5 | { ... } |  |
+| test.rs:227:13:232:9 | [boolean(false)] 'label: loop { ... } | test.rs:235:13:235:13 | 0 | false |
+| test.rs:227:13:232:9 | [boolean(true)] 'label: loop { ... } | test.rs:233:13:233:13 | 1 | true |
+| test.rs:227:26:232:9 | { ... } | test.rs:228:13:230:14 | ExprStmt |  |
+| test.rs:228:13:230:13 | if ... {...} | test.rs:231:13:231:19 | ExprStmt |  |
+| test.rs:228:13:230:14 | ExprStmt | test.rs:228:16:228:16 | a |  |
+| test.rs:228:16:228:16 | a | test.rs:228:20:228:20 | 0 |  |
+| test.rs:228:16:228:20 | ... > ... | test.rs:228:13:230:13 | if ... {...} | false |
+| test.rs:228:16:228:20 | ... > ... | test.rs:229:17:229:36 | ExprStmt | true |
+| test.rs:228:20:228:20 | 0 | test.rs:228:16:228:20 | ... > ... |  |
+| test.rs:229:17:229:35 | [boolean(false)] break ''label ... | test.rs:227:13:232:9 | [boolean(false)] 'label: loop { ... } | break |
+| test.rs:229:17:229:35 | [boolean(true)] break ''label ... | test.rs:227:13:232:9 | [boolean(true)] 'label: loop { ... } | break |
+| test.rs:229:17:229:36 | ExprStmt | test.rs:229:30:229:30 | a |  |
+| test.rs:229:30:229:30 | a | test.rs:229:34:229:35 | 10 |  |
+| test.rs:229:30:229:35 | ... > ... | test.rs:229:17:229:35 | [boolean(false)] break ''label ... | false |
+| test.rs:229:30:229:35 | ... > ... | test.rs:229:17:229:35 | [boolean(true)] break ''label ... | true |
+| test.rs:229:34:229:35 | 10 | test.rs:229:30:229:35 | ... > ... |  |
+| test.rs:231:13:231:13 | a | test.rs:231:17:231:18 | 10 |  |
+| test.rs:231:13:231:18 | ... < ... | test.rs:227:26:232:9 | { ... } |  |
+| test.rs:231:13:231:19 | ExprStmt | test.rs:231:13:231:13 | a |  |
+| test.rs:231:17:231:18 | 10 | test.rs:231:13:231:18 | ... < ... |  |
+| test.rs:232:12:234:9 | { ... } | test.rs:227:9:236:9 | if ... {...} else {...} |  |
+| test.rs:233:13:233:13 | 1 | test.rs:232:12:234:9 | { ... } |  |
+| test.rs:234:16:236:9 | { ... } | test.rs:227:9:236:9 | if ... {...} else {...} |  |
+| test.rs:235:13:235:13 | 0 | test.rs:234:16:236:9 | { ... } |  |
+| test.rs:239:5:247:5 | enter fn test_labelled_block | test.rs:239:28:239:28 | a |  |
+| test.rs:239:5:247:5 | exit fn test_labelled_block (normal) | test.rs:239:5:247:5 | exit fn test_labelled_block |  |
+| test.rs:239:28:239:28 | a | test.rs:239:28:239:33 | ...: i64 | match |
+| test.rs:239:28:239:33 | ...: i64 | test.rs:241:13:241:31 | ExprStmt |  |
+| test.rs:239:43:247:5 | { ... } | test.rs:239:5:247:5 | exit fn test_labelled_block (normal) |  |
+| test.rs:240:9:246:9 | if ... {...} else {...} | test.rs:239:43:247:5 | { ... } |  |
+| test.rs:240:13:242:9 | [boolean(false)] 'block: { ... } | test.rs:245:13:245:13 | 0 | false |
+| test.rs:240:13:242:9 | [boolean(true)] 'block: { ... } | test.rs:243:13:243:13 | 1 | true |
+| test.rs:241:13:241:30 | [boolean(false)] break ''block ... | test.rs:240:13:242:9 | [boolean(false)] 'block: { ... } | break |
+| test.rs:241:13:241:30 | [boolean(true)] break ''block ... | test.rs:240:13:242:9 | [boolean(true)] 'block: { ... } | break |
+| test.rs:241:13:241:31 | ExprStmt | test.rs:241:26:241:26 | a |  |
+| test.rs:241:26:241:26 | a | test.rs:241:30:241:30 | 0 |  |
+| test.rs:241:26:241:30 | ... > ... | test.rs:241:13:241:30 | [boolean(false)] break ''block ... | false |
+| test.rs:241:26:241:30 | ... > ... | test.rs:241:13:241:30 | [boolean(true)] break ''block ... | true |
+| test.rs:241:30:241:30 | 0 | test.rs:241:26:241:30 | ... > ... |  |
+| test.rs:242:12:244:9 | { ... } | test.rs:240:9:246:9 | if ... {...} else {...} |  |
+| test.rs:243:13:243:13 | 1 | test.rs:242:12:244:9 | { ... } |  |
+| test.rs:244:16:246:9 | { ... } | test.rs:240:9:246:9 | if ... {...} else {...} |  |
+| test.rs:245:13:245:13 | 0 | test.rs:244:16:246:9 | { ... } |  |
+| test.rs:252:5:255:5 | enter fn test_and_operator | test.rs:252:30:252:30 | a |  |
+| test.rs:252:5:255:5 | exit fn test_and_operator (normal) | test.rs:252:5:255:5 | exit fn test_and_operator |  |
+| test.rs:252:30:252:30 | a | test.rs:252:30:252:36 | ...: bool | match |
+| test.rs:252:30:252:36 | ...: bool | test.rs:252:39:252:39 | b |  |
+| test.rs:252:39:252:39 | b | test.rs:252:39:252:45 | ...: bool | match |
+| test.rs:252:39:252:45 | ...: bool | test.rs:252:48:252:48 | c |  |
+| test.rs:252:48:252:48 | c | test.rs:252:48:252:54 | ...: bool | match |
+| test.rs:252:48:252:54 | ...: bool | test.rs:253:9:253:28 | let ... = ... |  |
+| test.rs:252:65:255:5 | { ... } | test.rs:252:5:255:5 | exit fn test_and_operator (normal) |  |
+| test.rs:253:9:253:28 | let ... = ... | test.rs:253:17:253:17 | a |  |
+| test.rs:253:13:253:13 | d | test.rs:254:9:254:9 | d | match |
+| test.rs:253:17:253:17 | a | test.rs:253:17:253:22 | [boolean(false)] ... && ... | false |
+| test.rs:253:17:253:17 | a | test.rs:253:22:253:22 | b | true |
+| test.rs:253:17:253:22 | [boolean(false)] ... && ... | test.rs:253:17:253:27 | ... && ... | false |
+| test.rs:253:17:253:22 | [boolean(true)] ... && ... | test.rs:253:27:253:27 | c | true |
+| test.rs:253:17:253:27 | ... && ... | test.rs:253:13:253:13 | d |  |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(false)] ... && ... | false |
+| test.rs:253:22:253:22 | b | test.rs:253:17:253:22 | [boolean(true)] ... && ... | true |
+| test.rs:253:27:253:27 | c | test.rs:253:17:253:27 | ... && ... |  |
+| test.rs:254:9:254:9 | d | test.rs:252:65:255:5 | { ... } |  |
+| test.rs:257:5:260:5 | enter fn test_or_operator | test.rs:257:25:257:25 | a |  |
+| test.rs:257:5:260:5 | exit fn test_or_operator (normal) | test.rs:257:5:260:5 | exit fn test_or_operator |  |
+| test.rs:257:25:257:25 | a | test.rs:257:25:257:31 | ...: bool | match |
+| test.rs:257:25:257:31 | ...: bool | test.rs:257:34:257:34 | b |  |
+| test.rs:257:34:257:34 | b | test.rs:257:34:257:40 | ...: bool | match |
+| test.rs:257:34:257:40 | ...: bool | test.rs:257:43:257:43 | c |  |
+| test.rs:257:43:257:43 | c | test.rs:257:43:257:49 | ...: bool | match |
+| test.rs:257:43:257:49 | ...: bool | test.rs:258:9:258:28 | let ... = ... |  |
+| test.rs:257:60:260:5 | { ... } | test.rs:257:5:260:5 | exit fn test_or_operator (normal) |  |
+| test.rs:258:9:258:28 | let ... = ... | test.rs:258:17:258:17 | a |  |
+| test.rs:258:13:258:13 | d | test.rs:259:9:259:9 | d | match |
+| test.rs:258:17:258:17 | a | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:258:17:258:17 | a | test.rs:258:22:258:22 | b | false |
+| test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | test.rs:258:27:258:27 | c | false |
+| test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | test.rs:258:17:258:27 | ... \|\| ... | true |
+| test.rs:258:17:258:27 | ... \|\| ... | test.rs:258:13:258:13 | d |  |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:258:22:258:22 | b | test.rs:258:17:258:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:258:27:258:27 | c | test.rs:258:17:258:27 | ... \|\| ... |  |
+| test.rs:259:9:259:9 | d | test.rs:257:60:260:5 | { ... } |  |
+| test.rs:262:5:265:5 | enter fn test_or_operator_2 | test.rs:262:27:262:27 | a |  |
+| test.rs:262:5:265:5 | exit fn test_or_operator_2 (normal) | test.rs:262:5:265:5 | exit fn test_or_operator_2 |  |
+| test.rs:262:27:262:27 | a | test.rs:262:27:262:33 | ...: bool | match |
+| test.rs:262:27:262:33 | ...: bool | test.rs:262:36:262:36 | b |  |
+| test.rs:262:36:262:36 | b | test.rs:262:36:262:41 | ...: i64 | match |
+| test.rs:262:36:262:41 | ...: i64 | test.rs:262:44:262:44 | c |  |
+| test.rs:262:44:262:44 | c | test.rs:262:44:262:50 | ...: bool | match |
+| test.rs:262:44:262:50 | ...: bool | test.rs:263:9:263:36 | let ... = ... |  |
+| test.rs:262:61:265:5 | { ... } | test.rs:262:5:265:5 | exit fn test_or_operator_2 (normal) |  |
+| test.rs:263:9:263:36 | let ... = ... | test.rs:263:17:263:17 | a |  |
+| test.rs:263:13:263:13 | d | test.rs:264:9:264:9 | d | match |
+| test.rs:263:17:263:17 | a | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | true |
+| test.rs:263:17:263:17 | a | test.rs:263:23:263:23 | b | false |
+| test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | test.rs:263:35:263:35 | c | false |
+| test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | test.rs:263:17:263:35 | ... \|\| ... | true |
+| test.rs:263:17:263:35 | ... \|\| ... | test.rs:263:13:263:13 | d |  |
+| test.rs:263:23:263:23 | b | test.rs:263:28:263:29 | 28 |  |
+| test.rs:263:23:263:29 | ... == ... | test.rs:263:17:263:30 | [boolean(false)] ... \|\| ... | false |
+| test.rs:263:23:263:29 | ... == ... | test.rs:263:17:263:30 | [boolean(true)] ... \|\| ... | true |
+| test.rs:263:28:263:29 | 28 | test.rs:263:23:263:29 | ... == ... |  |
+| test.rs:263:35:263:35 | c | test.rs:263:17:263:35 | ... \|\| ... |  |
+| test.rs:264:9:264:9 | d | test.rs:262:61:265:5 | { ... } |  |
+| test.rs:267:5:270:5 | enter fn test_not_operator | test.rs:267:26:267:26 | a |  |
+| test.rs:267:5:270:5 | exit fn test_not_operator (normal) | test.rs:267:5:270:5 | exit fn test_not_operator |  |
+| test.rs:267:26:267:26 | a | test.rs:267:26:267:32 | ...: bool | match |
+| test.rs:267:26:267:32 | ...: bool | test.rs:268:9:268:19 | let ... = ... |  |
+| test.rs:267:43:270:5 | { ... } | test.rs:267:5:270:5 | exit fn test_not_operator (normal) |  |
+| test.rs:268:9:268:19 | let ... = ... | test.rs:268:18:268:18 | a |  |
+| test.rs:268:13:268:13 | d | test.rs:269:9:269:9 | d | match |
+| test.rs:268:17:268:18 | ! ... | test.rs:268:13:268:13 | d |  |
+| test.rs:268:18:268:18 | a | test.rs:268:17:268:18 | ! ... |  |
+| test.rs:269:9:269:9 | d | test.rs:267:43:270:5 | { ... } |  |
+| test.rs:272:5:278:5 | enter fn test_if_and_operator | test.rs:272:29:272:29 | a |  |
+| test.rs:272:5:278:5 | exit fn test_if_and_operator (normal) | test.rs:272:5:278:5 | exit fn test_if_and_operator |  |
+| test.rs:272:29:272:29 | a | test.rs:272:29:272:35 | ...: bool | match |
+| test.rs:272:29:272:35 | ...: bool | test.rs:272:38:272:38 | b |  |
+| test.rs:272:38:272:38 | b | test.rs:272:38:272:44 | ...: bool | match |
+| test.rs:272:38:272:44 | ...: bool | test.rs:272:47:272:47 | c |  |
+| test.rs:272:47:272:47 | c | test.rs:272:47:272:53 | ...: bool | match |
+| test.rs:272:47:272:53 | ...: bool | test.rs:273:12:273:12 | a |  |
+| test.rs:272:64:278:5 | { ... } | test.rs:272:5:278:5 | exit fn test_if_and_operator (normal) |  |
+| test.rs:273:9:277:9 | if ... {...} else {...} | test.rs:272:64:278:5 | { ... } |  |
+| test.rs:273:12:273:12 | a | test.rs:273:12:273:17 | [boolean(false)] ... && ... | false |
+| test.rs:273:12:273:12 | a | test.rs:273:17:273:17 | b | true |
+| test.rs:273:12:273:17 | [boolean(false)] ... && ... | test.rs:273:12:273:22 | [boolean(false)] ... && ... | false |
+| test.rs:273:12:273:17 | [boolean(true)] ... && ... | test.rs:273:22:273:22 | c | true |
+| test.rs:273:12:273:22 | [boolean(false)] ... && ... | test.rs:276:13:276:17 | false | false |
+| test.rs:273:12:273:22 | [boolean(true)] ... && ... | test.rs:274:13:274:16 | true | true |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(false)] ... && ... | false |
+| test.rs:273:17:273:17 | b | test.rs:273:12:273:17 | [boolean(true)] ... && ... | true |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(false)] ... && ... | false |
+| test.rs:273:22:273:22 | c | test.rs:273:12:273:22 | [boolean(true)] ... && ... | true |
+| test.rs:273:24:275:9 | { ... } | test.rs:273:9:277:9 | if ... {...} else {...} |  |
+| test.rs:274:13:274:16 | true | test.rs:273:24:275:9 | { ... } |  |
+| test.rs:275:16:277:9 | { ... } | test.rs:273:9:277:9 | if ... {...} else {...} |  |
+| test.rs:276:13:276:17 | false | test.rs:275:16:277:9 | { ... } |  |
+| test.rs:280:5:286:5 | enter fn test_if_or_operator | test.rs:280:28:280:28 | a |  |
+| test.rs:280:5:286:5 | exit fn test_if_or_operator (normal) | test.rs:280:5:286:5 | exit fn test_if_or_operator |  |
+| test.rs:280:28:280:28 | a | test.rs:280:28:280:34 | ...: bool | match |
+| test.rs:280:28:280:34 | ...: bool | test.rs:280:37:280:37 | b |  |
+| test.rs:280:37:280:37 | b | test.rs:280:37:280:43 | ...: bool | match |
+| test.rs:280:37:280:43 | ...: bool | test.rs:280:46:280:46 | c |  |
+| test.rs:280:46:280:46 | c | test.rs:280:46:280:52 | ...: bool | match |
+| test.rs:280:46:280:52 | ...: bool | test.rs:281:12:281:12 | a |  |
+| test.rs:280:63:286:5 | { ... } | test.rs:280:5:286:5 | exit fn test_if_or_operator (normal) |  |
+| test.rs:281:9:285:9 | if ... {...} else {...} | test.rs:280:63:286:5 | { ... } |  |
+| test.rs:281:12:281:12 | a | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:12:281:12 | a | test.rs:281:17:281:17 | b | false |
+| test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | test.rs:281:22:281:22 | c | false |
+| test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | test.rs:284:13:284:17 | false | false |
+| test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | test.rs:282:13:282:16 | true | true |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:17:281:17 | b | test.rs:281:12:281:17 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(false)] ... \|\| ... | false |
+| test.rs:281:22:281:22 | c | test.rs:281:12:281:22 | [boolean(true)] ... \|\| ... | true |
+| test.rs:281:24:283:9 | { ... } | test.rs:281:9:285:9 | if ... {...} else {...} |  |
+| test.rs:282:13:282:16 | true | test.rs:281:24:283:9 | { ... } |  |
+| test.rs:283:16:285:9 | { ... } | test.rs:281:9:285:9 | if ... {...} else {...} |  |
+| test.rs:284:13:284:17 | false | test.rs:283:16:285:9 | { ... } |  |
+| test.rs:288:5:294:5 | enter fn test_if_not_operator | test.rs:288:29:288:29 | a |  |
+| test.rs:288:5:294:5 | exit fn test_if_not_operator (normal) | test.rs:288:5:294:5 | exit fn test_if_not_operator |  |
+| test.rs:288:29:288:29 | a | test.rs:288:29:288:35 | ...: bool | match |
+| test.rs:288:29:288:35 | ...: bool | test.rs:289:13:289:13 | a |  |
+| test.rs:288:46:294:5 | { ... } | test.rs:288:5:294:5 | exit fn test_if_not_operator (normal) |  |
+| test.rs:289:9:293:9 | if ... {...} else {...} | test.rs:288:46:294:5 | { ... } |  |
+| test.rs:289:12:289:13 | [boolean(false)] ! ... | test.rs:292:13:292:17 | false | false |
+| test.rs:289:12:289:13 | [boolean(true)] ! ... | test.rs:290:13:290:16 | true | true |
+| test.rs:289:13:289:13 | a | test.rs:289:12:289:13 | [boolean(false)] ! ... | true |
+| test.rs:289:13:289:13 | a | test.rs:289:12:289:13 | [boolean(true)] ! ... | false |
+| test.rs:289:15:291:9 | { ... } | test.rs:289:9:293:9 | if ... {...} else {...} |  |
+| test.rs:290:13:290:16 | true | test.rs:289:15:291:9 | { ... } |  |
+| test.rs:291:16:293:9 | { ... } | test.rs:289:9:293:9 | if ... {...} else {...} |  |
+| test.rs:292:13:292:17 | false | test.rs:291:16:293:9 | { ... } |  |
+| test.rs:296:5:298:5 | enter fn test_and_return | test.rs:296:24:296:24 | a |  |
+| test.rs:296:5:298:5 | exit fn test_and_return (normal) | test.rs:296:5:298:5 | exit fn test_and_return |  |
+| test.rs:296:24:296:24 | a | test.rs:296:24:296:30 | ...: bool | match |
+| test.rs:296:24:296:30 | ...: bool | test.rs:297:9:297:20 | ExprStmt |  |
+| test.rs:296:33:298:5 | { ... } | test.rs:296:5:298:5 | exit fn test_and_return (normal) |  |
+| test.rs:297:9:297:9 | a | test.rs:297:9:297:19 | ... && ... | false |
+| test.rs:297:9:297:9 | a | test.rs:297:14:297:19 | return | true |
+| test.rs:297:9:297:19 | ... && ... | test.rs:296:33:298:5 | { ... } |  |
+| test.rs:297:9:297:20 | ExprStmt | test.rs:297:9:297:9 | a |  |
+| test.rs:297:14:297:19 | return | test.rs:296:5:298:5 | exit fn test_and_return (normal) | return |
+| test.rs:300:5:305:5 | enter fn test_and_true | test.rs:300:22:300:22 | a |  |
+| test.rs:300:5:305:5 | exit fn test_and_true (normal) | test.rs:300:5:305:5 | exit fn test_and_true |  |
+| test.rs:300:22:300:22 | a | test.rs:300:22:300:28 | ...: bool | match |
+| test.rs:300:22:300:28 | ...: bool | test.rs:301:9:303:9 | ExprStmt |  |
+| test.rs:300:38:305:5 | { ... } | test.rs:300:5:305:5 | exit fn test_and_true (normal) |  |
+| test.rs:301:9:303:9 | ExprStmt | test.rs:301:13:301:13 | a |  |
+| test.rs:301:9:303:9 | if ... {...} | test.rs:304:9:304:9 | 0 |  |
+| test.rs:301:13:301:13 | a | test.rs:301:13:301:21 | [boolean(false)] ... && ... | false |
+| test.rs:301:13:301:13 | a | test.rs:301:18:301:21 | true | true |
+| test.rs:301:13:301:21 | [boolean(false)] ... && ... | test.rs:301:9:303:9 | if ... {...} | false |
+| test.rs:301:13:301:21 | [boolean(true)] ... && ... | test.rs:302:13:302:21 | ExprStmt | true |
+| test.rs:301:18:301:21 | true | test.rs:301:13:301:21 | [boolean(true)] ... && ... | true |
+| test.rs:302:13:302:20 | return 1 | test.rs:300:5:305:5 | exit fn test_and_true (normal) | return |
+| test.rs:302:13:302:21 | ExprStmt | test.rs:302:20:302:20 | 1 |  |
+| test.rs:302:20:302:20 | 1 | test.rs:302:13:302:20 | return 1 |  |
+| test.rs:304:9:304:9 | 0 | test.rs:300:38:305:5 | { ... } |  |
+| test.rs:311:5:313:5 | enter fn test_question_mark_operator_1 | test.rs:311:38:311:38 | s |  |
+| test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 |  |
+| test.rs:311:38:311:38 | s | test.rs:311:38:311:44 | ...: ... | match |
+| test.rs:311:38:311:44 | ...: ... | test.rs:312:9:312:10 | Ok |  |
+| test.rs:311:87:313:5 | { ... } | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) |  |
+| test.rs:312:9:312:10 | Ok | test.rs:312:12:312:12 | s |  |
+| test.rs:312:9:312:33 | Ok(...) | test.rs:311:87:313:5 | { ... } |  |
+| test.rs:312:12:312:12 | s | test.rs:312:12:312:27 | s.parse(...) |  |
+| test.rs:312:12:312:27 | s.parse(...) | test.rs:312:12:312:28 | TryExpr |  |
+| test.rs:312:12:312:28 | TryExpr | test.rs:311:5:313:5 | exit fn test_question_mark_operator_1 (normal) | return |
+| test.rs:312:12:312:28 | TryExpr | test.rs:312:32:312:32 | 4 | match |
+| test.rs:312:12:312:32 | ... + ... | test.rs:312:9:312:33 | Ok(...) |  |
+| test.rs:312:32:312:32 | 4 | test.rs:312:12:312:32 | ... + ... |  |
+| test.rs:315:5:320:5 | enter fn test_question_mark_operator_2 | test.rs:315:38:315:38 | b |  |
+| test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 |  |
+| test.rs:315:38:315:38 | b | test.rs:315:38:315:52 | ...: Option::<...> | match |
+| test.rs:315:38:315:52 | ...: Option::<...> | test.rs:316:15:316:15 | b |  |
+| test.rs:315:71:320:5 | { ... } | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) |  |
+| test.rs:316:9:319:9 | match ... { ... } | test.rs:315:71:320:5 | { ... } |  |
+| test.rs:316:15:316:15 | b | test.rs:316:15:316:16 | TryExpr |  |
+| test.rs:316:15:316:16 | TryExpr | test.rs:315:5:320:5 | exit fn test_question_mark_operator_2 (normal) | return |
+| test.rs:316:15:316:16 | TryExpr | test.rs:317:13:317:16 | true | match |
+| test.rs:317:13:317:16 | true | test.rs:317:13:317:16 | true |  |
+| test.rs:317:13:317:16 | true | test.rs:317:21:317:24 | Some | match |
+| test.rs:317:13:317:16 | true | test.rs:318:13:318:17 | false | no-match |
+| test.rs:317:21:317:24 | Some | test.rs:317:26:317:30 | false |  |
+| test.rs:317:21:317:31 | Some(...) | test.rs:316:9:319:9 | match ... { ... } |  |
+| test.rs:317:26:317:30 | false | test.rs:317:21:317:31 | Some(...) |  |
+| test.rs:318:13:318:17 | false | test.rs:318:13:318:17 | false |  |
+| test.rs:318:13:318:17 | false | test.rs:318:22:318:25 | Some | match |
+| test.rs:318:22:318:25 | Some | test.rs:318:27:318:30 | true |  |
+| test.rs:318:22:318:31 | Some(...) | test.rs:316:9:319:9 | match ... { ... } |  |
+| test.rs:318:27:318:30 | true | test.rs:318:22:318:31 | Some(...) |  |
+| test.rs:326:5:332:5 | enter fn test_match | test.rs:326:19:326:29 | maybe_digit |  |
+| test.rs:326:5:332:5 | exit fn test_match (normal) | test.rs:326:5:332:5 | exit fn test_match |  |
+| test.rs:326:19:326:29 | maybe_digit | test.rs:326:19:326:42 | ...: Option::<...> | match |
+| test.rs:326:19:326:42 | ...: Option::<...> | test.rs:327:15:327:25 | maybe_digit |  |
+| test.rs:326:52:332:5 | { ... } | test.rs:326:5:332:5 | exit fn test_match (normal) |  |
+| test.rs:327:9:331:9 | match maybe_digit { ... } | test.rs:326:52:332:5 | { ... } |  |
+| test.rs:327:15:327:25 | maybe_digit | test.rs:328:13:328:27 | ...::Some(...) |  |
+| test.rs:328:13:328:27 | ...::Some(...) | test.rs:328:26:328:26 | x | match |
+| test.rs:328:13:328:27 | ...::Some(...) | test.rs:329:13:329:27 | ...::Some(...) | no-match |
+| test.rs:328:26:328:26 | x | test.rs:328:32:328:32 | x | match |
+| test.rs:328:32:328:32 | x | test.rs:328:36:328:37 | 10 |  |
+| test.rs:328:32:328:37 | ... < ... | test.rs:328:42:328:42 | x | true |
+| test.rs:328:32:328:37 | ... < ... | test.rs:329:13:329:27 | ...::Some(...) | false |
+| test.rs:328:36:328:37 | 10 | test.rs:328:32:328:37 | ... < ... |  |
+| test.rs:328:42:328:42 | x | test.rs:328:46:328:46 | 5 |  |
+| test.rs:328:42:328:46 | ... + ... | test.rs:327:9:331:9 | match maybe_digit { ... } |  |
+| test.rs:328:46:328:46 | 5 | test.rs:328:42:328:46 | ... + ... |  |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:329:26:329:26 | x | match |
+| test.rs:329:13:329:27 | ...::Some(...) | test.rs:330:13:330:24 | ...::None | no-match |
+| test.rs:329:26:329:26 | x | test.rs:329:32:329:32 | x | match |
+| test.rs:329:32:329:32 | x | test.rs:327:9:331:9 | match maybe_digit { ... } |  |
+| test.rs:330:13:330:24 | ...::None | test.rs:330:29:330:29 | 5 | match |
+| test.rs:330:29:330:29 | 5 | test.rs:327:9:331:9 | match maybe_digit { ... } |  |
+| test.rs:334:5:343:5 | enter fn test_match_with_return_in_scrutinee | test.rs:334:44:334:54 | maybe_digit |  |
+| test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee |  |
+| test.rs:334:44:334:54 | maybe_digit | test.rs:334:44:334:67 | ...: Option::<...> | match |
+| test.rs:334:44:334:67 | ...: Option::<...> | test.rs:335:19:335:29 | maybe_digit |  |
+| test.rs:334:77:343:5 | { ... } | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) |  |
+| test.rs:335:9:342:9 | match ... { ... } | test.rs:334:77:343:5 | { ... } |  |
+| test.rs:335:16:339:9 | if ... {...} else {...} | test.rs:340:13:340:27 | ...::Some(...) |  |
+| test.rs:335:19:335:29 | maybe_digit | test.rs:335:34:335:37 | Some |  |
+| test.rs:335:19:335:40 | ... == ... | test.rs:336:13:336:21 | ExprStmt | true |
+| test.rs:335:19:335:40 | ... == ... | test.rs:338:13:338:23 | maybe_digit | false |
+| test.rs:335:34:335:37 | Some | test.rs:335:39:335:39 | 3 |  |
+| test.rs:335:34:335:40 | Some(...) | test.rs:335:19:335:40 | ... == ... |  |
+| test.rs:335:39:335:39 | 3 | test.rs:335:34:335:40 | Some(...) |  |
+| test.rs:336:13:336:20 | return 3 | test.rs:334:5:343:5 | exit fn test_match_with_return_in_scrutinee (normal) | return |
+| test.rs:336:13:336:21 | ExprStmt | test.rs:336:20:336:20 | 3 |  |
+| test.rs:336:20:336:20 | 3 | test.rs:336:13:336:20 | return 3 |  |
+| test.rs:337:16:339:9 | { ... } | test.rs:335:16:339:9 | if ... {...} else {...} |  |
+| test.rs:338:13:338:23 | maybe_digit | test.rs:337:16:339:9 | { ... } |  |
+| test.rs:340:13:340:27 | ...::Some(...) | test.rs:340:26:340:26 | x | match |
+| test.rs:340:13:340:27 | ...::Some(...) | test.rs:341:13:341:24 | ...::None | no-match |
+| test.rs:340:26:340:26 | x | test.rs:340:32:340:32 | x | match |
+| test.rs:340:32:340:32 | x | test.rs:340:36:340:36 | 5 |  |
+| test.rs:340:32:340:36 | ... + ... | test.rs:335:9:342:9 | match ... { ... } |  |
+| test.rs:340:36:340:36 | 5 | test.rs:340:32:340:36 | ... + ... |  |
+| test.rs:341:13:341:24 | ...::None | test.rs:341:29:341:29 | 5 | match |
+| test.rs:341:29:341:29 | 5 | test.rs:335:9:342:9 | match ... { ... } |  |
+| test.rs:345:5:350:5 | enter fn test_match_and | test.rs:345:23:345:26 | cond |  |
+| test.rs:345:5:350:5 | exit fn test_match_and (normal) | test.rs:345:5:350:5 | exit fn test_match_and |  |
+| test.rs:345:23:345:26 | cond | test.rs:345:23:345:32 | ...: bool | match |
+| test.rs:345:23:345:32 | ...: bool | test.rs:345:35:345:35 | r |  |
+| test.rs:345:35:345:35 | r | test.rs:345:35:345:49 | ...: Option::<...> | match |
+| test.rs:345:35:345:49 | ...: Option::<...> | test.rs:346:16:346:16 | r |  |
+| test.rs:345:60:350:5 | { ... } | test.rs:345:5:350:5 | exit fn test_match_and (normal) |  |
+| test.rs:346:9:349:18 | ... && ... | test.rs:345:60:350:5 | { ... } |  |
+| test.rs:346:10:349:9 | [boolean(false)] match r { ... } | test.rs:346:9:349:18 | ... && ... | false |
+| test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:349:15:349:18 | cond | true |
+| test.rs:346:16:346:16 | r | test.rs:347:13:347:19 | Some(...) |  |
+| test.rs:347:13:347:19 | Some(...) | test.rs:347:18:347:18 | a | match |
+| test.rs:347:13:347:19 | Some(...) | test.rs:348:13:348:13 | _ | no-match |
+| test.rs:347:18:347:18 | a | test.rs:347:24:347:24 | a | match |
+| test.rs:347:24:347:24 | a | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
+| test.rs:347:24:347:24 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | true |
+| test.rs:348:13:348:13 | _ | test.rs:348:18:348:22 | false | match |
+| test.rs:348:18:348:22 | false | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
+| test.rs:349:15:349:18 | cond | test.rs:346:9:349:18 | ... && ... |  |
+| test.rs:352:5:357:5 | enter fn test_match_with_no_arms | test.rs:352:35:352:35 | r |  |
+| test.rs:352:5:357:5 | exit fn test_match_with_no_arms (normal) | test.rs:352:5:357:5 | exit fn test_match_with_no_arms |  |
+| test.rs:352:35:352:35 | r | test.rs:352:35:352:58 | ...: Result::<...> | match |
+| test.rs:352:35:352:58 | ...: Result::<...> | test.rs:353:15:353:15 | r |  |
+| test.rs:352:66:357:5 | { ... } | test.rs:352:5:357:5 | exit fn test_match_with_no_arms (normal) |  |
+| test.rs:353:9:356:9 | match r { ... } | test.rs:352:66:357:5 | { ... } |  |
+| test.rs:353:15:353:15 | r | test.rs:354:13:354:21 | Ok(...) |  |
+| test.rs:354:13:354:21 | Ok(...) | test.rs:354:16:354:20 | value | match |
+| test.rs:354:13:354:21 | Ok(...) | test.rs:355:13:355:22 | Err(...) | no-match |
+| test.rs:354:16:354:20 | value | test.rs:354:26:354:30 | value | match |
+| test.rs:354:26:354:30 | value | test.rs:353:9:356:9 | match r { ... } |  |
+| test.rs:355:13:355:22 | Err(...) | test.rs:355:17:355:21 | never | match |
+| test.rs:355:17:355:21 | never | test.rs:355:33:355:37 | never | match |
+| test.rs:355:27:355:40 | match never { ... } | test.rs:353:9:356:9 | match r { ... } |  |
+| test.rs:355:33:355:37 | never | test.rs:355:27:355:40 | match never { ... } |  |
+| test.rs:362:5:365:5 | enter fn test_let_match | test.rs:362:23:362:23 | a |  |
+| test.rs:362:5:365:5 | exit fn test_let_match (normal) | test.rs:362:5:365:5 | exit fn test_let_match |  |
+| test.rs:362:23:362:23 | a | test.rs:362:23:362:36 | ...: Option::<...> | match |
+| test.rs:362:23:362:36 | ...: Option::<...> | test.rs:363:9:363:57 | let ... = a else {...} |  |
+| test.rs:362:46:365:5 | { ... } | test.rs:362:5:365:5 | exit fn test_let_match (normal) |  |
+| test.rs:363:9:363:57 | let ... = a else {...} | test.rs:363:23:363:23 | a |  |
+| test.rs:363:13:363:19 | Some(...) | test.rs:363:18:363:18 | n | match |
+| test.rs:363:13:363:19 | Some(...) | test.rs:363:39:363:53 | MacroStmts | no-match |
+| test.rs:363:18:363:18 | n | test.rs:364:9:364:9 | n | match |
+| test.rs:363:23:363:23 | a | test.rs:363:13:363:19 | Some(...) |  |
+| test.rs:363:32:363:54 | ...::panic_fmt | test.rs:363:39:363:53 | "Expected some" |  |
+| test.rs:363:32:363:54 | MacroExpr | test.rs:363:30:363:56 | { ... } |  |
+| test.rs:363:32:363:54 | panic!... | test.rs:363:32:363:54 | MacroExpr |  |
+| test.rs:363:39:363:53 | "Expected some" | test.rs:363:39:363:53 | FormatArgsExpr |  |
+| test.rs:363:39:363:53 | ...::const_format_args!... | test.rs:363:39:363:53 | MacroExpr |  |
+| test.rs:363:39:363:53 | ...::panic_2021!... | test.rs:363:39:363:53 | MacroExpr |  |
+| test.rs:363:39:363:53 | ...::panic_fmt(...) | test.rs:363:39:363:53 | { ... } |  |
+| test.rs:363:39:363:53 | ExprStmt | test.rs:363:32:363:54 | ...::panic_fmt |  |
+| test.rs:363:39:363:53 | FormatArgsExpr | test.rs:363:39:363:53 | ...::const_format_args!... |  |
+| test.rs:363:39:363:53 | MacroExpr | test.rs:363:32:363:54 | panic!... |  |
+| test.rs:363:39:363:53 | MacroExpr | test.rs:363:39:363:53 | ...::panic_fmt(...) |  |
+| test.rs:363:39:363:53 | MacroStmts | test.rs:363:39:363:53 | ExprStmt |  |
+| test.rs:363:39:363:53 | MacroStmts | test.rs:363:39:363:53 | MacroStmts |  |
+| test.rs:363:39:363:53 | { ... } | test.rs:363:39:363:53 | ...::panic_2021!... |  |
+| test.rs:364:9:364:9 | n | test.rs:362:46:365:5 | { ... } |  |
+| test.rs:367:5:373:5 | enter fn test_let_with_return | test.rs:367:29:367:29 | m |  |
+| test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | test.rs:367:5:373:5 | exit fn test_let_with_return |  |
+| test.rs:367:29:367:29 | m | test.rs:367:29:367:42 | ...: Option::<...> | match |
+| test.rs:367:29:367:42 | ...: Option::<...> | test.rs:368:9:371:10 | let ... = ... |  |
+| test.rs:367:53:373:5 | { ... } | test.rs:367:5:373:5 | exit fn test_let_with_return (normal) |  |
+| test.rs:368:9:371:10 | let ... = ... | test.rs:368:25:368:25 | m |  |
+| test.rs:368:13:368:15 | ret | test.rs:372:9:372:12 | true | match |
+| test.rs:368:19:371:9 | match m { ... } | test.rs:368:13:368:15 | ret |  |
+| test.rs:368:25:368:25 | m | test.rs:369:13:369:21 | Some(...) |  |
+| test.rs:369:13:369:21 | Some(...) | test.rs:369:18:369:20 | ret | match |
+| test.rs:369:13:369:21 | Some(...) | test.rs:370:13:370:16 | None | no-match |
+| test.rs:369:18:369:20 | ret | test.rs:369:26:369:28 | ret | match |
+| test.rs:369:26:369:28 | ret | test.rs:368:19:371:9 | match m { ... } |  |
+| test.rs:370:13:370:16 | None | test.rs:370:28:370:32 | false | match |
+| test.rs:370:21:370:32 | return false | test.rs:367:5:373:5 | exit fn test_let_with_return (normal) | return |
+| test.rs:370:28:370:32 | false | test.rs:370:21:370:32 | return false |  |
+| test.rs:372:9:372:12 | true | test.rs:367:53:373:5 | { ... } |  |
+| test.rs:378:5:381:5 | enter fn empty_tuple_pattern | test.rs:378:28:378:31 | unit |  |
+| test.rs:378:5:381:5 | exit fn empty_tuple_pattern (normal) | test.rs:378:5:381:5 | exit fn empty_tuple_pattern |  |
+| test.rs:378:28:378:31 | unit | test.rs:378:28:378:35 | ...: ... | match |
+| test.rs:378:28:378:35 | ...: ... | test.rs:379:9:379:22 | let ... = unit |  |
+| test.rs:379:9:379:22 | let ... = unit | test.rs:379:18:379:21 | unit |  |
+| test.rs:379:13:379:14 | TuplePat | test.rs:380:9:380:15 | ExprStmt | match |
+| test.rs:379:18:379:21 | unit | test.rs:379:13:379:14 | TuplePat |  |
+| test.rs:380:9:380:14 | return | test.rs:378:5:381:5 | exit fn empty_tuple_pattern (normal) | return |
+| test.rs:380:9:380:15 | ExprStmt | test.rs:380:9:380:14 | return |  |
+| test.rs:385:5:389:5 | enter fn empty_struct_pattern | test.rs:385:29:385:30 | st |  |
+| test.rs:385:5:389:5 | exit fn empty_struct_pattern (normal) | test.rs:385:5:389:5 | exit fn empty_struct_pattern |  |
+| test.rs:385:29:385:30 | st | test.rs:385:29:385:40 | ...: MyStruct | match |
+| test.rs:385:29:385:40 | ...: MyStruct | test.rs:386:15:386:16 | st |  |
+| test.rs:385:50:389:5 | { ... } | test.rs:385:5:389:5 | exit fn empty_struct_pattern (normal) |  |
+| test.rs:386:9:388:9 | match st { ... } | test.rs:385:50:389:5 | { ... } |  |
+| test.rs:386:15:386:16 | st | test.rs:387:13:387:27 | MyStruct {...} |  |
+| test.rs:387:13:387:27 | MyStruct {...} | test.rs:387:24:387:25 | .. | match |
+| test.rs:387:24:387:25 | .. | test.rs:387:32:387:32 | 1 | match |
+| test.rs:387:32:387:32 | 1 | test.rs:386:9:388:9 | match st { ... } |  |
+| test.rs:391:5:398:5 | enter fn range_pattern | test.rs:392:15:392:16 | 42 |  |
+| test.rs:391:5:398:5 | exit fn range_pattern (normal) | test.rs:391:5:398:5 | exit fn range_pattern |  |
+| test.rs:391:31:398:5 | { ... } | test.rs:391:5:398:5 | exit fn range_pattern (normal) |  |
+| test.rs:392:9:397:9 | match 42 { ... } | test.rs:391:31:398:5 | { ... } |  |
+| test.rs:392:15:392:16 | 42 | test.rs:393:13:393:15 | RangePat |  |
+| test.rs:393:13:393:15 | RangePat | test.rs:393:15:393:15 | 0 | match |
+| test.rs:393:13:393:15 | RangePat | test.rs:394:13:394:16 | RangePat | no-match |
+| test.rs:393:15:393:15 | 0 | test.rs:393:15:393:15 | 0 |  |
+| test.rs:393:15:393:15 | 0 | test.rs:393:20:393:20 | 1 | match |
+| test.rs:393:15:393:15 | 0 | test.rs:394:13:394:16 | RangePat | no-match |
+| test.rs:393:20:393:20 | 1 | test.rs:392:9:397:9 | match 42 { ... } |  |
+| test.rs:394:13:394:13 | 1 | test.rs:394:13:394:13 | 1 |  |
+| test.rs:394:13:394:13 | 1 | test.rs:394:16:394:16 | 2 | match |
+| test.rs:394:13:394:13 | 1 | test.rs:395:13:395:15 | RangePat | no-match |
+| test.rs:394:13:394:16 | RangePat | test.rs:394:13:394:13 | 1 | match |
+| test.rs:394:13:394:16 | RangePat | test.rs:395:13:395:15 | RangePat | no-match |
+| test.rs:394:16:394:16 | 2 | test.rs:394:16:394:16 | 2 |  |
+| test.rs:394:16:394:16 | 2 | test.rs:394:21:394:21 | 2 | match |
+| test.rs:394:16:394:16 | 2 | test.rs:395:13:395:15 | RangePat | no-match |
+| test.rs:394:21:394:21 | 2 | test.rs:392:9:397:9 | match 42 { ... } |  |
+| test.rs:395:13:395:13 | 5 | test.rs:395:13:395:13 | 5 |  |
+| test.rs:395:13:395:13 | 5 | test.rs:395:20:395:20 | 3 | match |
+| test.rs:395:13:395:13 | 5 | test.rs:396:13:396:13 | _ | no-match |
+| test.rs:395:13:395:15 | RangePat | test.rs:395:13:395:13 | 5 | match |
+| test.rs:395:13:395:15 | RangePat | test.rs:396:13:396:13 | _ | no-match |
+| test.rs:395:20:395:20 | 3 | test.rs:392:9:397:9 | match 42 { ... } |  |
+| test.rs:396:13:396:13 | _ | test.rs:396:18:396:18 | 4 | match |
+| test.rs:396:18:396:18 | 4 | test.rs:392:9:397:9 | match 42 { ... } |  |
+| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:403:9:405:9 | ExprStmt |  |
+| test.rs:403:9:405:9 | ExprStmt | test.rs:404:13:404:14 | TupleExpr |  |
+| test.rs:403:14:405:9 | { ... } | test.rs:404:13:404:14 | TupleExpr |  |
+| test.rs:404:13:404:14 | TupleExpr | test.rs:403:14:405:9 | { ... } |  |
+| test.rs:411:5:413:5 | enter fn say_hello | test.rs:412:9:412:34 | ExprStmt |  |
+| test.rs:411:5:413:5 | exit fn say_hello (normal) | test.rs:411:5:413:5 | exit fn say_hello |  |
+| test.rs:411:26:413:5 | { ... } | test.rs:411:5:413:5 | exit fn say_hello (normal) |  |
+| test.rs:412:9:412:33 | ...::_print | test.rs:412:18:412:32 | "hello, world!\\n" |  |
+| test.rs:412:9:412:33 | MacroExpr | test.rs:411:26:413:5 | { ... } |  |
+| test.rs:412:9:412:33 | println!... | test.rs:412:9:412:33 | MacroExpr |  |
+| test.rs:412:9:412:34 | ExprStmt | test.rs:412:18:412:32 | MacroStmts |  |
+| test.rs:412:18:412:32 | "hello, world!\\n" | test.rs:412:18:412:32 | FormatArgsExpr |  |
+| test.rs:412:18:412:32 | ...::_print(...) | test.rs:412:18:412:32 | { ... } |  |
+| test.rs:412:18:412:32 | ...::format_args_nl!... | test.rs:412:18:412:32 | MacroExpr |  |
+| test.rs:412:18:412:32 | ExprStmt | test.rs:412:9:412:33 | ...::_print |  |
+| test.rs:412:18:412:32 | FormatArgsExpr | test.rs:412:18:412:32 | ...::format_args_nl!... |  |
+| test.rs:412:18:412:32 | MacroExpr | test.rs:412:18:412:32 | ...::_print(...) |  |
+| test.rs:412:18:412:32 | MacroStmts | test.rs:412:18:412:32 | ExprStmt |  |
+| test.rs:412:18:412:32 | { ... } | test.rs:412:9:412:33 | println!... |  |
+| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:26:415:26 | b |  |
+| test.rs:415:5:434:5 | exit fn async_block (normal) | test.rs:415:5:434:5 | exit fn async_block |  |
+| test.rs:415:26:415:26 | b | test.rs:415:26:415:32 | ...: bool | match |
+| test.rs:415:26:415:32 | ...: bool | test.rs:416:9:418:10 | let ... = ... |  |
+| test.rs:415:35:434:5 | { ... } | test.rs:415:5:434:5 | exit fn async_block (normal) |  |
+| test.rs:416:9:418:10 | let ... = ... | test.rs:416:26:418:9 | { ... } |  |
+| test.rs:416:13:416:22 | say_godbye | test.rs:419:9:421:10 | let ... = ... | match |
+| test.rs:416:26:418:9 | enter { ... } | test.rs:417:13:417:42 | ExprStmt |  |
+| test.rs:416:26:418:9 | exit { ... } (normal) | test.rs:416:26:418:9 | exit { ... } |  |
+| test.rs:416:26:418:9 | { ... } | test.rs:416:13:416:22 | say_godbye |  |
+| test.rs:417:13:417:41 | ...::_print | test.rs:417:22:417:40 | "godbye, everyone!\\n" |  |
+| test.rs:417:13:417:41 | MacroExpr | test.rs:416:26:418:9 | exit { ... } (normal) |  |
+| test.rs:417:13:417:41 | println!... | test.rs:417:13:417:41 | MacroExpr |  |
+| test.rs:417:13:417:42 | ExprStmt | test.rs:417:22:417:40 | MacroStmts |  |
+| test.rs:417:22:417:40 | "godbye, everyone!\\n" | test.rs:417:22:417:40 | FormatArgsExpr |  |
+| test.rs:417:22:417:40 | ...::_print(...) | test.rs:417:22:417:40 | { ... } |  |
+| test.rs:417:22:417:40 | ...::format_args_nl!... | test.rs:417:22:417:40 | MacroExpr |  |
+| test.rs:417:22:417:40 | ExprStmt | test.rs:417:13:417:41 | ...::_print |  |
+| test.rs:417:22:417:40 | FormatArgsExpr | test.rs:417:22:417:40 | ...::format_args_nl!... |  |
+| test.rs:417:22:417:40 | MacroExpr | test.rs:417:22:417:40 | ...::_print(...) |  |
+| test.rs:417:22:417:40 | MacroStmts | test.rs:417:22:417:40 | ExprStmt |  |
+| test.rs:417:22:417:40 | { ... } | test.rs:417:13:417:41 | println!... |  |
+| test.rs:419:9:421:10 | let ... = ... | test.rs:419:31:421:9 | { ... } |  |
+| test.rs:419:13:419:27 | say_how_are_you | test.rs:422:9:422:28 | let ... = ... | match |
+| test.rs:419:31:421:9 | enter { ... } | test.rs:420:13:420:37 | ExprStmt |  |
+| test.rs:419:31:421:9 | exit { ... } (normal) | test.rs:419:31:421:9 | exit { ... } |  |
+| test.rs:419:31:421:9 | { ... } | test.rs:419:13:419:27 | say_how_are_you |  |
+| test.rs:420:13:420:36 | ...::_print | test.rs:420:22:420:35 | "how are you?\\n" |  |
+| test.rs:420:13:420:36 | MacroExpr | test.rs:419:31:421:9 | exit { ... } (normal) |  |
+| test.rs:420:13:420:36 | println!... | test.rs:420:13:420:36 | MacroExpr |  |
+| test.rs:420:13:420:37 | ExprStmt | test.rs:420:22:420:35 | MacroStmts |  |
+| test.rs:420:22:420:35 | "how are you?\\n" | test.rs:420:22:420:35 | FormatArgsExpr |  |
+| test.rs:420:22:420:35 | ...::_print(...) | test.rs:420:22:420:35 | { ... } |  |
+| test.rs:420:22:420:35 | ...::format_args_nl!... | test.rs:420:22:420:35 | MacroExpr |  |
+| test.rs:420:22:420:35 | ExprStmt | test.rs:420:13:420:36 | ...::_print |  |
+| test.rs:420:22:420:35 | FormatArgsExpr | test.rs:420:22:420:35 | ...::format_args_nl!... |  |
+| test.rs:420:22:420:35 | MacroExpr | test.rs:420:22:420:35 | ...::_print(...) |  |
+| test.rs:420:22:420:35 | MacroStmts | test.rs:420:22:420:35 | ExprStmt |  |
+| test.rs:420:22:420:35 | { ... } | test.rs:420:13:420:36 | println!... |  |
+| test.rs:422:9:422:28 | let ... = ... | test.rs:422:20:422:27 | { ... } |  |
+| test.rs:422:13:422:16 | noop | test.rs:423:9:423:26 | ExprStmt | match |
+| test.rs:422:20:422:27 | { ... } | test.rs:422:13:422:16 | noop |  |
+| test.rs:423:9:423:17 | say_hello | test.rs:423:9:423:19 | say_hello(...) |  |
+| test.rs:423:9:423:19 | say_hello(...) | test.rs:423:9:423:25 | await ... |  |
+| test.rs:423:9:423:25 | await ... | test.rs:424:9:424:30 | ExprStmt |  |
+| test.rs:423:9:423:26 | ExprStmt | test.rs:423:9:423:17 | say_hello |  |
+| test.rs:424:9:424:23 | say_how_are_you | test.rs:424:9:424:29 | await say_how_are_you |  |
+| test.rs:424:9:424:29 | await say_how_are_you | test.rs:425:9:425:25 | ExprStmt |  |
+| test.rs:424:9:424:30 | ExprStmt | test.rs:424:9:424:23 | say_how_are_you |  |
+| test.rs:425:9:425:18 | say_godbye | test.rs:425:9:425:24 | await say_godbye |  |
+| test.rs:425:9:425:24 | await say_godbye | test.rs:426:9:426:19 | ExprStmt |  |
+| test.rs:425:9:425:25 | ExprStmt | test.rs:425:9:425:18 | say_godbye |  |
+| test.rs:426:9:426:12 | noop | test.rs:426:9:426:18 | await noop |  |
+| test.rs:426:9:426:18 | await noop | test.rs:428:9:433:10 | let ... = ... |  |
+| test.rs:426:9:426:19 | ExprStmt | test.rs:426:9:426:12 | noop |  |
+| test.rs:428:9:433:10 | let ... = ... | test.rs:428:22:433:9 | \|...\| ... |  |
+| test.rs:428:13:428:18 | lambda | test.rs:415:35:434:5 | { ... } | match |
+| test.rs:428:22:433:9 | \|...\| ... | test.rs:428:13:428:18 | lambda |  |
+| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:23:428:25 | foo |  |
+| test.rs:428:22:433:9 | exit \|...\| ... (normal) | test.rs:428:22:433:9 | exit \|...\| ... |  |
+| test.rs:428:23:428:25 | ... | test.rs:428:28:433:9 | { ... } |  |
+| test.rs:428:23:428:25 | foo | test.rs:428:23:428:25 | ... | match |
+| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:14 | ExprStmt |  |
+| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } |  |
+| test.rs:428:28:433:9 | { ... } | test.rs:428:22:433:9 | exit \|...\| ... (normal) |  |
+| test.rs:429:13:431:13 | if b {...} | test.rs:432:13:432:15 | foo |  |
+| test.rs:429:13:431:14 | ExprStmt | test.rs:429:16:429:16 | b |  |
+| test.rs:429:16:429:16 | b | test.rs:429:13:431:13 | if b {...} | false |
+| test.rs:429:16:429:16 | b | test.rs:430:17:430:41 | ExprStmt | true |
+| test.rs:430:17:430:40 | return ... | test.rs:428:28:433:9 | exit { ... } (normal) | return |
+| test.rs:430:17:430:41 | ExprStmt | test.rs:430:24:430:34 | async_block |  |
+| test.rs:430:24:430:34 | async_block | test.rs:430:36:430:39 | true |  |
+| test.rs:430:24:430:40 | async_block(...) | test.rs:430:17:430:40 | return ... |  |
+| test.rs:430:36:430:39 | true | test.rs:430:24:430:40 | async_block(...) |  |
+| test.rs:432:13:432:15 | foo | test.rs:428:28:433:9 | exit { ... } (normal) |  |
+| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:22:440:22 | n |  |
+| test.rs:440:5:442:5 | exit fn add_two (normal) | test.rs:440:5:442:5 | exit fn add_two |  |
+| test.rs:440:22:440:22 | n | test.rs:440:22:440:27 | ...: i64 | match |
+| test.rs:440:22:440:27 | ...: i64 | test.rs:441:9:441:9 | n |  |
+| test.rs:440:37:442:5 | { ... } | test.rs:440:5:442:5 | exit fn add_two (normal) |  |
+| test.rs:441:9:441:9 | n | test.rs:441:13:441:13 | 2 |  |
+| test.rs:441:9:441:13 | ... + ... | test.rs:440:37:442:5 | { ... } |  |
+| test.rs:441:13:441:13 | 2 | test.rs:441:9:441:13 | ... + ... |  |
+| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:449:9:451:9 | ExprStmt |  |
+| test.rs:446:5:454:5 | exit fn const_block_assert (normal) | test.rs:446:5:454:5 | exit fn const_block_assert |  |
+| test.rs:446:41:454:5 | { ... } | test.rs:446:5:454:5 | exit fn const_block_assert (normal) |  |
+| test.rs:449:9:451:9 | ExprStmt | test.rs:450:13:450:50 | ExprStmt |  |
+| test.rs:449:9:451:9 | { ... } | test.rs:453:9:453:10 | 42 |  |
+| test.rs:450:13:450:49 | ...::panic_2021!... | test.rs:450:13:450:49 | MacroExpr |  |
+| test.rs:450:13:450:49 | ...::panic_explicit | test.rs:450:13:450:49 | ...::panic_explicit(...) |  |
+| test.rs:450:13:450:49 | ...::panic_explicit(...) | test.rs:450:13:450:49 | { ... } |  |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | MacroStmts |  |
+| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | panic_cold_explicit |  |
+| test.rs:450:13:450:49 | MacroExpr | test.rs:449:9:451:9 | { ... } |  |
+| test.rs:450:13:450:49 | MacroExpr | test.rs:450:13:450:49 | { ... } |  |
+| test.rs:450:13:450:49 | MacroStmts | test.rs:450:13:450:49 | fn panic_cold_explicit |  |
+| test.rs:450:13:450:49 | assert!... | test.rs:450:13:450:49 | MacroExpr |  |
+| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | ...::panic_explicit |  |
+| test.rs:450:13:450:49 | exit fn panic_cold_explicit (normal) | test.rs:450:13:450:49 | exit fn panic_cold_explicit |  |
+| test.rs:450:13:450:49 | fn panic_cold_explicit | test.rs:450:13:450:49 | ExprStmt |  |
+| test.rs:450:13:450:49 | panic_cold_explicit | test.rs:450:13:450:49 | panic_cold_explicit(...) |  |
+| test.rs:450:13:450:49 | panic_cold_explicit(...) | test.rs:450:13:450:49 | { ... } |  |
+| test.rs:450:13:450:49 | { ... } | test.rs:450:13:450:49 | ...::panic_2021!... |  |
+| test.rs:450:13:450:49 | { ... } | test.rs:450:13:450:49 | exit fn panic_cold_explicit (normal) |  |
+| test.rs:450:13:450:49 | { ... } | test.rs:450:21:450:48 | if ... {...} |  |
+| test.rs:450:13:450:50 | ExprStmt | test.rs:450:21:450:48 | MacroStmts |  |
+| test.rs:450:21:450:42 | ...::size_of::<...> | test.rs:450:21:450:44 | ...::size_of::<...>(...) |  |
+| test.rs:450:21:450:44 | ...::size_of::<...>(...) | test.rs:450:48:450:48 | 0 |  |
+| test.rs:450:21:450:48 | ... > ... | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
+| test.rs:450:21:450:48 | ... > ... | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
+| test.rs:450:21:450:48 | MacroStmts | test.rs:450:21:450:42 | ...::size_of::<...> |  |
+| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | if ... {...} | false |
+| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
+| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | { ... } |  |
+| test.rs:450:21:450:48 | { ... } | test.rs:450:13:450:49 | assert!... |  |
+| test.rs:450:48:450:48 | 0 | test.rs:450:21:450:48 | ... > ... |  |
+| test.rs:453:9:453:10 | 42 | test.rs:446:41:454:5 | { ... } |  |
+| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:457:9:457:30 | Const |  |
+| test.rs:456:5:465:5 | exit fn const_block_panic (normal) | test.rs:456:5:465:5 | exit fn const_block_panic |  |
+| test.rs:456:35:465:5 | { ... } | test.rs:456:5:465:5 | exit fn const_block_panic (normal) |  |
+| test.rs:457:9:457:30 | Const | test.rs:458:9:463:9 | ExprStmt |  |
+| test.rs:458:9:463:9 | ExprStmt | test.rs:458:12:458:16 | false |  |
+| test.rs:458:9:463:9 | if false {...} | test.rs:464:9:464:9 | N |  |
+| test.rs:458:12:458:16 | false | test.rs:458:9:463:9 | if false {...} | false |
+| test.rs:461:17:461:24 | ...::panic_explicit | test.rs:461:17:461:24 | ...::panic_explicit(...) |  |
+| test.rs:461:17:461:24 | ...::panic_explicit(...) | test.rs:461:17:461:24 | { ... } |  |
+| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | ...::panic_explicit |  |
+| test.rs:461:17:461:24 | exit fn panic_cold_explicit (normal) | test.rs:461:17:461:24 | exit fn panic_cold_explicit |  |
+| test.rs:461:17:461:24 | { ... } | test.rs:461:17:461:24 | exit fn panic_cold_explicit (normal) |  |
+| test.rs:464:9:464:9 | N | test.rs:456:35:465:5 | { ... } |  |
+| test.rs:468:1:473:1 | enter fn dead_code | test.rs:469:5:471:5 | ExprStmt |  |
+| test.rs:468:1:473:1 | exit fn dead_code (normal) | test.rs:468:1:473:1 | exit fn dead_code |  |
+| test.rs:469:5:471:5 | ExprStmt | test.rs:469:9:469:12 | true |  |
+| test.rs:469:9:469:12 | true | test.rs:470:9:470:17 | ExprStmt | true |
+| test.rs:470:9:470:16 | return 0 | test.rs:468:1:473:1 | exit fn dead_code (normal) | return |
+| test.rs:470:9:470:17 | ExprStmt | test.rs:470:16:470:16 | 0 |  |
+| test.rs:470:16:470:16 | 0 | test.rs:470:9:470:16 | return 0 |  |
+| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:15:475:16 | { ... } |  |
+| test.rs:475:1:475:16 | exit fn do_thing (normal) | test.rs:475:1:475:16 | exit fn do_thing |  |
+| test.rs:475:15:475:16 | { ... } | test.rs:475:1:475:16 | exit fn do_thing (normal) |  |
+| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:478:5:478:9 | false |  |
+| test.rs:477:1:479:1 | exit fn condition_not_met (normal) | test.rs:477:1:479:1 | exit fn condition_not_met |  |
+| test.rs:477:32:479:1 | { ... } | test.rs:477:1:479:1 | exit fn condition_not_met (normal) |  |
+| test.rs:478:5:478:9 | false | test.rs:477:32:479:1 | { ... } |  |
+| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:20:481:21 | { ... } |  |
+| test.rs:481:1:481:21 | exit fn do_next_thing (normal) | test.rs:481:1:481:21 | exit fn do_next_thing |  |
+| test.rs:481:20:481:21 | { ... } | test.rs:481:1:481:21 | exit fn do_next_thing (normal) |  |
+| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:20:483:21 | { ... } |  |
+| test.rs:483:1:483:21 | exit fn do_last_thing (normal) | test.rs:483:1:483:21 | exit fn do_last_thing |  |
+| test.rs:483:20:483:21 | { ... } | test.rs:483:1:483:21 | exit fn do_last_thing (normal) |  |
+| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:486:5:497:6 | let ... = ... |  |
+| test.rs:485:1:499:1 | exit fn labelled_block1 (normal) | test.rs:485:1:499:1 | exit fn labelled_block1 |  |
+| test.rs:485:29:499:1 | { ... } | test.rs:485:1:499:1 | exit fn labelled_block1 (normal) |  |
+| test.rs:486:5:497:6 | let ... = ... | test.rs:487:9:487:19 | ExprStmt |  |
+| test.rs:486:9:486:14 | result | test.rs:498:5:498:10 | result | match |
+| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:9:486:14 | result |  |
+| test.rs:487:9:487:16 | do_thing | test.rs:487:9:487:18 | do_thing(...) |  |
+| test.rs:487:9:487:18 | do_thing(...) | test.rs:488:9:490:9 | ExprStmt |  |
+| test.rs:487:9:487:19 | ExprStmt | test.rs:487:9:487:16 | do_thing |  |
+| test.rs:488:9:490:9 | ExprStmt | test.rs:488:12:488:28 | condition_not_met |  |
+| test.rs:488:9:490:9 | if ... {...} | test.rs:491:9:491:24 | ExprStmt |  |
+| test.rs:488:12:488:28 | condition_not_met | test.rs:488:12:488:30 | condition_not_met(...) |  |
+| test.rs:488:12:488:30 | condition_not_met(...) | test.rs:488:9:490:9 | if ... {...} | false |
+| test.rs:488:12:488:30 | condition_not_met(...) | test.rs:489:13:489:27 | ExprStmt | true |
+| test.rs:489:13:489:26 | break ''block 1 | test.rs:486:18:497:5 | 'block: { ... } | break |
+| test.rs:489:13:489:27 | ExprStmt | test.rs:489:26:489:26 | 1 |  |
+| test.rs:489:26:489:26 | 1 | test.rs:489:13:489:26 | break ''block 1 |  |
+| test.rs:491:9:491:21 | do_next_thing | test.rs:491:9:491:23 | do_next_thing(...) |  |
+| test.rs:491:9:491:23 | do_next_thing(...) | test.rs:492:9:494:9 | ExprStmt |  |
+| test.rs:491:9:491:24 | ExprStmt | test.rs:491:9:491:21 | do_next_thing |  |
+| test.rs:492:9:494:9 | ExprStmt | test.rs:492:12:492:28 | condition_not_met |  |
+| test.rs:492:9:494:9 | if ... {...} | test.rs:495:9:495:24 | ExprStmt |  |
+| test.rs:492:12:492:28 | condition_not_met | test.rs:492:12:492:30 | condition_not_met(...) |  |
+| test.rs:492:12:492:30 | condition_not_met(...) | test.rs:492:9:494:9 | if ... {...} | false |
+| test.rs:492:12:492:30 | condition_not_met(...) | test.rs:493:13:493:27 | ExprStmt | true |
+| test.rs:493:13:493:26 | break ''block 2 | test.rs:486:18:497:5 | 'block: { ... } | break |
+| test.rs:493:13:493:27 | ExprStmt | test.rs:493:26:493:26 | 2 |  |
+| test.rs:493:26:493:26 | 2 | test.rs:493:13:493:26 | break ''block 2 |  |
+| test.rs:495:9:495:21 | do_last_thing | test.rs:495:9:495:23 | do_last_thing(...) |  |
+| test.rs:495:9:495:23 | do_last_thing(...) | test.rs:496:9:496:9 | 3 |  |
+| test.rs:495:9:495:24 | ExprStmt | test.rs:495:9:495:21 | do_last_thing |  |
+| test.rs:496:9:496:9 | 3 | test.rs:486:18:497:5 | 'block: { ... } |  |
+| test.rs:498:5:498:10 | result | test.rs:485:29:499:1 | { ... } |  |
+| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:502:5:508:6 | let ... = ... |  |
+| test.rs:501:1:509:1 | exit fn labelled_block2 (normal) | test.rs:501:1:509:1 | exit fn labelled_block2 |  |
+| test.rs:501:22:509:1 | { ... } | test.rs:501:1:509:1 | exit fn labelled_block2 (normal) |  |
+| test.rs:502:5:508:6 | let ... = ... | test.rs:503:9:503:34 | let ... = None |  |
+| test.rs:502:9:502:14 | result | test.rs:501:22:509:1 | { ... } | match |
+| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:9:502:14 | result |  |
+| test.rs:503:9:503:34 | let ... = None | test.rs:503:30:503:33 | None |  |
+| test.rs:503:13:503:13 | x | test.rs:504:9:506:10 | let ... = x else {...} | match |
+| test.rs:503:30:503:33 | None | test.rs:503:13:503:13 | x |  |
+| test.rs:504:9:506:10 | let ... = x else {...} | test.rs:504:23:504:23 | x |  |
+| test.rs:504:13:504:19 | Some(...) | test.rs:504:18:504:18 | y | match |
+| test.rs:504:13:504:19 | Some(...) | test.rs:505:13:505:27 | ExprStmt | no-match |
+| test.rs:504:18:504:18 | y | test.rs:507:9:507:9 | 0 | match |
+| test.rs:504:23:504:23 | x | test.rs:504:13:504:19 | Some(...) |  |
+| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:508:5 | 'block: { ... } | break |
+| test.rs:505:13:505:27 | ExprStmt | test.rs:505:26:505:26 | 1 |  |
+| test.rs:505:26:505:26 | 1 | test.rs:505:13:505:26 | break ''block 1 |  |
+| test.rs:507:9:507:9 | 0 | test.rs:502:18:508:5 | 'block: { ... } |  |
+| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:512:5:512:18 | let ... = 0 |  |
+| test.rs:511:1:517:1 | exit fn test_nested_function2 (normal) | test.rs:511:1:517:1 | exit fn test_nested_function2 |  |
+| test.rs:511:28:517:1 | { ... } | test.rs:511:1:517:1 | exit fn test_nested_function2 (normal) |  |
+| test.rs:512:5:512:18 | let ... = 0 | test.rs:512:17:512:17 | 0 |  |
+| test.rs:512:9:512:13 | x | test.rs:513:5:515:5 | fn nested | match |
+| test.rs:512:17:512:17 | 0 | test.rs:512:9:512:13 | x |  |
+| test.rs:513:5:515:5 | enter fn nested | test.rs:513:15:513:15 | x |  |
+| test.rs:513:5:515:5 | exit fn nested (normal) | test.rs:513:5:515:5 | exit fn nested |  |
+| test.rs:513:5:515:5 | fn nested | test.rs:516:5:516:19 | ExprStmt |  |
+| test.rs:513:15:513:15 | x | test.rs:513:15:513:25 | ...: ... | match |
+| test.rs:513:15:513:25 | ...: ... | test.rs:514:9:514:16 | ExprStmt |  |
+| test.rs:513:28:515:5 | { ... } | test.rs:513:5:515:5 | exit fn nested (normal) |  |
+| test.rs:514:9:514:10 | * ... | test.rs:514:15:514:15 | 1 |  |
+| test.rs:514:9:514:15 | ... += ... | test.rs:513:28:515:5 | { ... } |  |
+| test.rs:514:9:514:16 | ExprStmt | test.rs:514:10:514:10 | x |  |
+| test.rs:514:10:514:10 | x | test.rs:514:9:514:10 | * ... |  |
+| test.rs:514:15:514:15 | 1 | test.rs:514:9:514:15 | ... += ... |  |
+| test.rs:516:5:516:10 | nested | test.rs:516:17:516:17 | x |  |
+| test.rs:516:5:516:18 | nested(...) | test.rs:511:28:517:1 | { ... } |  |
+| test.rs:516:5:516:19 | ExprStmt | test.rs:516:5:516:10 | nested |  |
+| test.rs:516:12:516:17 | &mut x | test.rs:516:5:516:18 | nested(...) |  |
+| test.rs:516:17:516:17 | x | test.rs:516:12:516:17 | &mut x |  |
+| test.rs:528:5:530:5 | enter fn new | test.rs:528:12:528:12 | a |  |
+| test.rs:528:5:530:5 | exit fn new (normal) | test.rs:528:5:530:5 | exit fn new |  |
+| test.rs:528:12:528:12 | a | test.rs:528:12:528:17 | ...: i64 | match |
+| test.rs:528:12:528:17 | ...: i64 | test.rs:529:23:529:23 | a |  |
+| test.rs:528:28:530:5 | { ... } | test.rs:528:5:530:5 | exit fn new (normal) |  |
+| test.rs:529:9:529:25 | MyNumber {...} | test.rs:528:28:530:5 | { ... } |  |
+| test.rs:529:23:529:23 | a | test.rs:529:9:529:25 | MyNumber {...} |  |
+| test.rs:532:5:534:5 | enter fn negated | test.rs:532:16:532:19 | self |  |
+| test.rs:532:5:534:5 | exit fn negated (normal) | test.rs:532:5:534:5 | exit fn negated |  |
+| test.rs:532:16:532:19 | SelfParam | test.rs:533:23:533:26 | self |  |
+| test.rs:532:16:532:19 | self | test.rs:532:16:532:19 | SelfParam |  |
+| test.rs:532:30:534:5 | { ... } | test.rs:532:5:534:5 | exit fn negated (normal) |  |
+| test.rs:533:9:533:30 | MyNumber {...} | test.rs:532:30:534:5 | { ... } |  |
+| test.rs:533:23:533:26 | self | test.rs:533:23:533:28 | self.n |  |
+| test.rs:533:23:533:28 | self.n | test.rs:533:9:533:30 | MyNumber {...} |  |
+| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:26:536:29 | self |  |
+| test.rs:536:5:538:5 | exit fn multifly_add (normal) | test.rs:536:5:538:5 | exit fn multifly_add |  |
+| test.rs:536:21:536:29 | SelfParam | test.rs:536:32:536:32 | a |  |
+| test.rs:536:26:536:29 | self | test.rs:536:21:536:29 | SelfParam |  |
+| test.rs:536:32:536:32 | a | test.rs:536:32:536:37 | ...: i64 | match |
+| test.rs:536:32:536:37 | ...: i64 | test.rs:536:40:536:40 | b |  |
+| test.rs:536:40:536:40 | b | test.rs:536:40:536:45 | ...: i64 | match |
+| test.rs:536:40:536:45 | ...: i64 | test.rs:537:9:537:34 | ExprStmt |  |
+| test.rs:536:48:538:5 | { ... } | test.rs:536:5:538:5 | exit fn multifly_add (normal) |  |
+| test.rs:537:9:537:12 | self | test.rs:537:9:537:14 | self.n |  |
+| test.rs:537:9:537:14 | self.n | test.rs:537:19:537:22 | self |  |
+| test.rs:537:9:537:33 | ... = ... | test.rs:536:48:538:5 | { ... } |  |
+| test.rs:537:9:537:34 | ExprStmt | test.rs:537:9:537:12 | self |  |
+| test.rs:537:18:537:33 | ... + ... | test.rs:537:9:537:33 | ... = ... |  |
+| test.rs:537:19:537:22 | self | test.rs:537:19:537:24 | self.n |  |
+| test.rs:537:19:537:24 | self.n | test.rs:537:28:537:28 | a |  |
+| test.rs:537:19:537:28 | ... * ... | test.rs:537:33:537:33 | b |  |
+| test.rs:537:28:537:28 | a | test.rs:537:19:537:28 | ... * ... |  |
+| test.rs:537:33:537:33 | b | test.rs:537:18:537:33 | ... + ... |  |
 breakTarget
 | test.rs:34:17:34:21 | break | test.rs:28:9:40:9 | loop { ... } |
 | test.rs:48:21:48:25 | break | test.rs:46:13:53:13 | 'inner: loop { ... } |
@@ -1114,12 +1186,12 @@ breakTarget
 | test.rs:101:17:101:21 | break | test.rs:99:9:103:9 | while ... { ... } |
 | test.rs:109:17:109:21 | break | test.rs:107:9:112:9 | for ... in ... { ... } |
 | test.rs:117:13:117:26 | break ... | test.rs:116:9:118:9 | loop { ... } |
-| test.rs:197:17:197:28 | break ... | test.rs:195:13:200:9 | loop { ... } |
-| test.rs:210:17:210:35 | break ''label ... | test.rs:208:13:213:9 | 'label: loop { ... } |
-| test.rs:222:13:222:30 | break ''block ... | test.rs:221:13:223:9 | 'block: { ... } |
-| test.rs:470:13:470:26 | break ''block 1 | test.rs:467:18:478:5 | 'block: { ... } |
-| test.rs:474:13:474:26 | break ''block 2 | test.rs:467:18:478:5 | 'block: { ... } |
-| test.rs:486:13:486:26 | break ''block 1 | test.rs:483:18:489:5 | 'block: { ... } |
+| test.rs:216:17:216:28 | break ... | test.rs:214:13:219:9 | loop { ... } |
+| test.rs:229:17:229:35 | break ''label ... | test.rs:227:13:232:9 | 'label: loop { ... } |
+| test.rs:241:13:241:30 | break ''block ... | test.rs:240:13:242:9 | 'block: { ... } |
+| test.rs:489:13:489:26 | break ''block 1 | test.rs:486:18:497:5 | 'block: { ... } |
+| test.rs:493:13:493:26 | break ''block 2 | test.rs:486:18:497:5 | 'block: { ... } |
+| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:508:5 | 'block: { ... } |
 continueTarget
 | test.rs:37:17:37:24 | continue | test.rs:28:9:40:9 | loop { ... } |
 | test.rs:63:21:63:28 | continue | test.rs:61:13:68:13 | 'inner: loop { ... } |

--- a/rust/ql/test/library-tests/controlflow/test.rs
+++ b/rust/ql/test/library-tests/controlflow/test.rs
@@ -134,6 +134,14 @@ mod if_expression {
         }
     }
 
+    fn test_if_without_else(b: bool) -> i64 {
+        let mut i = 3;
+        if b {
+            i += 1;
+        }
+        i
+    }
+
     fn test_if_let_else(a: Option<i64>) -> i64 {
         if let Some(n) = a {
             n
@@ -155,6 +163,17 @@ mod if_expression {
         } else {
             0
         }
+    }
+
+    fn test_nested_if_2(cond1: bool, cond2: bool) -> () {
+        if cond1 {
+            if cond2 {
+                println!("1");
+            } else {
+                println!("2");
+            }
+            println!("3");
+        };
     }
 
     fn test_nested_if_match(a: i64) -> i64 {


### PR DESCRIPTION
Just two additional control flow tests for two patterns that weren't covered before.