### PR TITLE
Java: Add XSS Sanitizer for `HttpServletResponse.setContentType` with safe values

### DIFF
--- a/java/ql/lib/semmle/code/java/frameworks/Servlets.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/Servlets.qll
@@ -316,6 +316,16 @@ class ResponseSetHeaderMethod extends Method {
 }
 
 /**
+ * The method `setContentType` declared in `javax.servlet.http.HttpServletResponse`.
+ */
+class ResponseSetContentTypeMethod extends Method {
+  ResponseSetContentTypeMethod() {
+    this.getDeclaringType() instanceof ServletResponse and
+    this.hasName("setContentType")
+  }
+}
+
+/**
  * A class that has `javax.servlet.Servlet` as an ancestor.
  */
 class ServletClass extends Class {

--- a/java/ql/lib/semmle/code/java/security/XSS.qll
+++ b/java/ql/lib/semmle/code/java/security/XSS.qll
@@ -92,9 +92,25 @@ private class WritingMethod extends Method {
 /** An output stream or writer that writes to a servlet, JSP or JSF response. */
 class XssVulnerableWriterSource extends MethodCall {
   XssVulnerableWriterSource() {
-    this.getMethod() instanceof ServletResponseGetWriterMethod
-    or
-    this.getMethod() instanceof ServletResponseGetOutputStreamMethod
+    (
+      this.getMethod() instanceof ServletResponseGetWriterMethod
+      or
+      this.getMethod() instanceof ServletResponseGetOutputStreamMethod
+    ) and
+    not exists(MethodCall mc, Expr contentType |
+      mc.getMethod() instanceof ResponseSetContentTypeMethod and
+      contentType = mc.getArgument(0)
+      or
+      (
+        mc.getMethod() instanceof ResponseAddHeaderMethod or
+        mc.getMethod() instanceof ResponseSetHeaderMethod
+      ) and
+      mc.getArgument(0).(CompileTimeConstantExpr).getStringValue().toLowerCase() = "content-type" and
+      contentType = mc.getArgument(1)
+    |
+      isXssSafeContentTypeString(contentType.(CompileTimeConstantExpr).getStringValue()) and
+      DataFlow::localExprFlow(mc.getQualifier(), this.getQualifier())
+    )
     or
     exists(Method m | m = this.getMethod() |
       m.hasQualifiedName("javax.servlet.jsp", "JspContext", "getOut")
@@ -104,6 +120,11 @@ class XssVulnerableWriterSource extends MethodCall {
     or
     this.getMethod() instanceof FacesGetResponseStreamMethod
   }
+}
+
+pragma[nomagic]
+private predicate isXssSafeContentTypeString(string s) {
+  s = any(CompileTimeConstantExpr cte).getStringValue() and isXssSafeContentType(s)
 }
 
 /**

--- a/java/ql/src/change-notes/2025-01-28-fix-xss-content-type-safe.md
+++ b/java/ql/src/change-notes/2025-01-28-fix-xss-content-type-safe.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Fixed false positive alerts in the java query "Cross-site scripting" (`java/xss`) when `javax.servlet.http.HttpServletResponse` is used with a content type which is not exploitable.

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/JaxXSS.java
@@ -19,18 +19,18 @@ public class JaxXSS {
     if(!safeContentType) {
       if(chainDirectly) {
         if(contentTypeFirst)
-          return builder.type(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
+          return builder.type(MediaType.TEXT_HTML).entity(userControlled).build(); // $ xss
         else
-          return builder.entity(userControlled).type(MediaType.TEXT_HTML).build(); // $xss
+          return builder.entity(userControlled).type(MediaType.TEXT_HTML).build(); // $ xss
       }
       else {
         if(contentTypeFirst) {
           Response.ResponseBuilder builder2 = builder.type(MediaType.TEXT_HTML);
-          return builder2.entity(userControlled).build(); // $xss
+          return builder2.entity(userControlled).build(); // $ xss
         }
         else {
           Response.ResponseBuilder builder2 = builder.entity(userControlled);
-          return builder2.type(MediaType.TEXT_HTML).build(); // $xss
+          return builder2.type(MediaType.TEXT_HTML).build(); // $ xss
         }
       }
     }
@@ -105,39 +105,39 @@ public class JaxXSS {
     else {
       if(route == 0) {
         // via ok, as a string literal:
-        return Response.ok("text/html").entity(userControlled).build(); // $xss
+        return Response.ok("text/html").entity(userControlled).build(); // $ xss
       }
       else if(route == 1) {
         // via ok, as a string constant:
-        return Response.ok(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
+        return Response.ok(MediaType.TEXT_HTML).entity(userControlled).build(); // $ xss
       }
       else if(route == 2) {
         // via ok, as a MediaType constant:
-        return Response.ok(MediaType.TEXT_HTML_TYPE).entity(userControlled).build(); // $xss
+        return Response.ok(MediaType.TEXT_HTML_TYPE).entity(userControlled).build(); // $ xss
       }
       else if(route == 3) {
         // via ok, as a Variant, via constructor:
-        return Response.ok(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).entity(userControlled).build(); // $xss
+        return Response.ok(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).entity(userControlled).build(); // $ xss
       }
       else if(route == 4) {
         // via ok, as a Variant, via static method:
-        return Response.ok(Variant.mediaTypes(MediaType.TEXT_HTML_TYPE).build()).entity(userControlled).build(); // $xss
+        return Response.ok(Variant.mediaTypes(MediaType.TEXT_HTML_TYPE).build()).entity(userControlled).build(); // $ xss
       }
       else if(route == 5) {
         // via ok, as a Variant, via instance method:
-        return Response.ok(Variant.languages(Locale.UK).mediaTypes(MediaType.TEXT_HTML_TYPE).build()).entity(userControlled).build(); // $xss
+        return Response.ok(Variant.languages(Locale.UK).mediaTypes(MediaType.TEXT_HTML_TYPE).build()).entity(userControlled).build(); // $ xss
       }
       else if(route == 6) {
         // via builder variant, before entity:
-        return Response.ok().variant(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).entity(userControlled).build(); // $xss
+        return Response.ok().variant(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).entity(userControlled).build(); // $ xss
       }
       else if(route == 7) {
         // via builder variant, after entity:
-        return Response.ok().entity(userControlled).variant(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).build(); // $xss
+        return Response.ok().entity(userControlled).variant(new Variant(MediaType.TEXT_HTML_TYPE, "language", "encoding")).build(); // $ xss
       }
       else if(route == 8) {
         // provide entity via ok, then content-type via builder:
-        return Response.ok(userControlled).type(MediaType.TEXT_HTML_TYPE).build(); // $xss
+        return Response.ok(userControlled).type(MediaType.TEXT_HTML_TYPE).build(); // $ xss
       }
     }
 
@@ -162,27 +162,27 @@ public class JaxXSS {
 
   @GET @Produces(MediaType.TEXT_HTML)
   public static Response methodContentTypeUnsafe(String userControlled) {
-    return Response.ok(userControlled).build(); // $xss
+    return Response.ok(userControlled).build(); // $ xss
   }
 
   @POST @Produces(MediaType.TEXT_HTML)
   public static Response methodContentTypeUnsafePost(String userControlled) {
-    return Response.ok(userControlled).build(); // $xss
+    return Response.ok(userControlled).build(); // $ xss
   }
 
   @GET @Produces("text/html")
   public static Response methodContentTypeUnsafeStringLiteral(String userControlled) {
-    return Response.ok(userControlled).build(); // $xss
+    return Response.ok(userControlled).build(); // $ xss
   }
 
   @GET @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
   public static Response methodContentTypeMaybeSafe(String userControlled) {
-    return Response.ok(userControlled).build(); // $xss
+    return Response.ok(userControlled).build(); // $ xss
   }
 
   @GET @Produces(MediaType.APPLICATION_JSON)
   public static Response methodContentTypeSafeOverriddenWithUnsafe(String userControlled) {
-    return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
+    return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $ xss
   }
 
   @GET @Produces(MediaType.TEXT_HTML)
@@ -205,12 +205,12 @@ public class JaxXSS {
 
     @GET @Produces({"text/html"})
     public Response overridesWithUnsafe(String userControlled) {
-      return Response.ok(userControlled).build(); // $xss
+      return Response.ok(userControlled).build(); // $ xss
     }
 
     @GET
     public Response overridesWithUnsafe2(String userControlled) {
-      return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $xss
+      return Response.ok().type(MediaType.TEXT_HTML).entity(userControlled).build(); // $ xss
     }
   }
 
@@ -219,12 +219,12 @@ public class JaxXSS {
   public static class ClassContentTypeUnsafe {
     @GET
     public Response test(String userControlled) {
-      return Response.ok(userControlled).build(); // $xss
+      return Response.ok(userControlled).build(); // $ xss
     }
 
     @GET
     public String testDirectReturn(String userControlled) {
-      return userControlled; // $xss
+      return userControlled; // $ xss
     }
 
     @GET @Produces({"application/json"})
@@ -240,12 +240,12 @@ public class JaxXSS {
 
   @GET
   public static Response entityWithNoMediaType(String userControlled) {
-    return Response.ok(userControlled).build(); // $xss
+    return Response.ok(userControlled).build(); // $ xss
   }
 
   @GET
   public static String stringWithNoMediaType(String userControlled) {
-    return userControlled; // $xss
+    return userControlled; // $ xss
   }
 
 }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/JsfXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/JsfXSS.java
@@ -26,7 +26,7 @@ public class JsfXSS extends Renderer
         writer.write("(function(){");
         writer.write("dswh.init('" + windowId + "','"
                 + "......" + "',"
-                + -1 + ",{"); // $xss
+                + -1 + ",{"); // $ xss
         writer.write("});");
         writer.write("})();");
         writer.write("</script>");
@@ -57,13 +57,13 @@ public class JsfXSS extends Renderer
     {
         ExternalContext ec = facesContext.getExternalContext();
         ResponseWriter writer = facesContext.getResponseWriter();
-        writer.write(ec.getRequestParameterMap().keySet().iterator().next()); // $xss
-        writer.write(ec.getRequestParameterNames().next()); // $xss
-        writer.write(ec.getRequestParameterValuesMap().get("someKey")[0]); // $xss
-        writer.write(ec.getRequestParameterValuesMap().keySet().iterator().next()); // $xss
-        writer.write(ec.getRequestPathInfo()); // $xss
-        writer.write(((Cookie)ec.getRequestCookieMap().get("someKey")).getName()); // $xss
-        writer.write(ec.getRequestHeaderMap().get("someKey")); // $xss
-        writer.write(ec.getRequestHeaderValuesMap().get("someKey")[0]); // $xss
+        writer.write(ec.getRequestParameterMap().keySet().iterator().next()); // $ xss
+        writer.write(ec.getRequestParameterNames().next()); // $ xss
+        writer.write(ec.getRequestParameterValuesMap().get("someKey")[0]); // $ xss
+        writer.write(ec.getRequestParameterValuesMap().keySet().iterator().next()); // $ xss
+        writer.write(ec.getRequestPathInfo()); // $ xss
+        writer.write(((Cookie)ec.getRequestCookieMap().get("someKey")).getName()); // $ xss
+        writer.write(ec.getRequestHeaderMap().get("someKey")); // $ xss
+        writer.write(ec.getRequestHeaderValuesMap().get("someKey")[0]); // $ xss
     }
 }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SetJavascriptEnabled.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SetJavascriptEnabled.java
@@ -6,7 +6,7 @@ import android.webkit.WebSettings;
 public class SetJavascriptEnabled {
     public static void configureWebViewUnsafe(WebView view) {
         WebSettings settings = view.getSettings();
-        settings.setJavaScriptEnabled(true); // $javascriptEnabled
+        settings.setJavaScriptEnabled(true); // $ javascriptEnabled
     }
 
     public static void configureWebViewSafe(WebView view) {

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -19,11 +19,11 @@ public class SpringXSS {
 
     if(!safeContentType) {
       if(chainDirectly) {
-        return builder.contentType(MediaType.TEXT_HTML).body(userControlled); // $xss
+        return builder.contentType(MediaType.TEXT_HTML).body(userControlled); // $ xss
       }
       else {
         ResponseEntity.BodyBuilder builder2 = builder.contentType(MediaType.TEXT_HTML);
-        return builder2.body(userControlled); // $xss
+        return builder2.body(userControlled); // $ xss
       }
     }
     else {
@@ -60,22 +60,22 @@ public class SpringXSS {
 
   @GetMapping(value = "/xyz", produces = MediaType.TEXT_HTML_VALUE)
   public static ResponseEntity<String> methodContentTypeUnsafe(String userControlled) {
-    return ResponseEntity.ok(userControlled); // $xss
+    return ResponseEntity.ok(userControlled); // $ xss
   }
 
   @GetMapping(value = "/xyz", produces = "text/html")
   public static ResponseEntity<String> methodContentTypeUnsafeStringLiteral(String userControlled) {
-    return ResponseEntity.ok(userControlled); // $xss
+    return ResponseEntity.ok(userControlled); // $ xss
   }
 
   @GetMapping(value = "/xyz", produces = {MediaType.TEXT_HTML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public static ResponseEntity<String> methodContentTypeMaybeSafe(String userControlled) {
-    return ResponseEntity.ok(userControlled); // $xss
+    return ResponseEntity.ok(userControlled); // $ xss
   }
 
   @GetMapping(value = "/xyz", produces = MediaType.APPLICATION_JSON_VALUE)
   public static ResponseEntity<String> methodContentTypeSafeOverriddenWithUnsafe(String userControlled) {
-    return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $xss
+    return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $ xss
   }
 
   @GetMapping(value = "/xyz", produces = MediaType.TEXT_HTML_VALUE)
@@ -88,13 +88,13 @@ public class SpringXSS {
     // Also try out some alternative constructors for the ResponseEntity:
     switch(constructionMethod) {
       case 0:
-      return ResponseEntity.ok(userControlled); // $xss
+      return ResponseEntity.ok(userControlled); // $ xss
       case 1:
-      return ResponseEntity.of(Optional.of(userControlled)); // $xss
+      return ResponseEntity.of(Optional.of(userControlled)); // $ xss
       case 2:
-      return ResponseEntity.ok().body(userControlled); // $xss
+      return ResponseEntity.ok().body(userControlled); // $ xss
       case 3:
-      return new ResponseEntity<String>(userControlled, HttpStatus.OK); // $xss
+      return new ResponseEntity<String>(userControlled, HttpStatus.OK); // $ xss
       default:
       return null;
     }
@@ -115,12 +115,12 @@ public class SpringXSS {
 
     @GetMapping(value = "/xyz", produces = {"text/html"})
     public ResponseEntity<String> overridesWithUnsafe(String userControlled) {
-      return ResponseEntity.ok(userControlled); // $xss
+      return ResponseEntity.ok(userControlled); // $ xss
     }
 
     @GetMapping(value = "/abc")
     public ResponseEntity<String> overridesWithUnsafe2(String userControlled) {
-      return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $xss
+      return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(userControlled); // $ xss
     }
   }
 
@@ -129,12 +129,12 @@ public class SpringXSS {
   private static class ClassContentTypeUnsafe {
     @GetMapping(value = "/abc")
     public ResponseEntity<String> test(String userControlled) {
-      return ResponseEntity.ok(userControlled); // $xss
+      return ResponseEntity.ok(userControlled); // $ xss
     }
 
     @GetMapping(value = "/abc")
     public String testDirectReturn(String userControlled) {
-      return userControlled; // $xss
+      return userControlled; // $ xss
     }
 
     @GetMapping(value = "/xyz", produces = {"application/json"})
@@ -150,12 +150,12 @@ public class SpringXSS {
 
   @GetMapping(value = "/abc")
   public static ResponseEntity<String> entityWithNoMediaType(String userControlled) {
-    return ResponseEntity.ok(userControlled); // $xss
+    return ResponseEntity.ok(userControlled); // $ xss
   }
 
   @GetMapping(value = "/abc")
   public static String stringWithNoMediaType(String userControlled) {
-    return userControlled; // $xss
+    return userControlled; // $ xss
   }
 
   @GetMapping(value = "/abc")

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/SpringXSS.java
@@ -17,7 +17,7 @@ public class SpringXSS {
 
     ResponseEntity.BodyBuilder builder = ResponseEntity.ok();
 
-    if(safeContentType) {
+    if(!safeContentType) {
       if(chainDirectly) {
         return builder.contentType(MediaType.TEXT_HTML).body(userControlled); // $xss
       }

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 public class XSS extends HttpServlet {
-	protected void doGet(HttpServletRequest request, HttpServletResponse response)
+	protected void doGet(HttpServletRequest request, HttpServletResponse response, boolean safeContentType, boolean getWriter, int setContentMethod)
 			throws ServletException, IOException {
 		// BAD: a request parameter is written directly to the Servlet response stream
 		response.getWriter()
@@ -38,6 +38,79 @@ public class XSS extends HttpServlet {
 
 		// GOOD: sanitizer
 		response.getOutputStream().write(hudson.Util.escape(request.getPathInfo()).getBytes()); // safe
+
+		if(safeContentType) {
+			if(getWriter) {
+				if(setContentMethod == 0) {
+					// GOOD: set content-type to something safe
+					response.setContentType("text/plain");
+					response.getWriter().print(request.getPathInfo());
+				}
+				else if(setContentMethod == 1) {
+					// GOOD: set content-type to something safe
+					response.setHeader("Content-Type", "text/plain");
+					response.getWriter().print(request.getPathInfo());
+				}
+				else {
+					// GOOD: set content-type to something safe
+					response.addHeader("Content-Type", "text/plain");
+					response.getWriter().print(request.getPathInfo());
+				}
+			}
+			else {
+				if(setContentMethod == 0) {
+					// GOOD: set content-type to something safe
+					response.setContentType("text/plain");
+					response.getOutputStream().write(request.getPathInfo().getBytes());
+				}
+				else if(setContentMethod == 1) {
+					// GOOD: set content-type to something safe
+					response.setHeader("Content-Type", "text/plain");
+					response.getOutputStream().write(request.getPathInfo().getBytes());
+				}
+				else {
+					// GOOD: set content-type to something safe
+					response.addHeader("Content-Type", "text/plain");
+					response.getOutputStream().write(request.getPathInfo().getBytes());
+				}
+			}
+		}
+		else {
+			if(getWriter) {
+				if(setContentMethod == 0) {
+					// BAD: set content-type to something that is not safe
+					response.setContentType("text/html");
+					response.getWriter().print(request.getPathInfo()); // $ xss
+				}
+				else if(setContentMethod == 1) {
+					// BAD: set content-type to something that is not safe
+					response.setHeader("Content-Type", "text/html");
+					response.getWriter().print(request.getPathInfo()); // $ xss
+				}
+				else {
+					// BAD: set content-type to something that is not safe
+					response.addHeader("Content-Type", "text/html");
+					response.getWriter().print(request.getPathInfo()); // $ xss
+				}
+			}
+			else {
+				if(setContentMethod == 0) {
+					// BAD: set content-type to something that is not safe
+					response.setContentType("text/html");
+					response.getOutputStream().write(request.getPathInfo().getBytes()); // $ xss
+				}
+				else if(setContentMethod == 1) {
+					// BAD: set content-type to something that is not safe
+					response.setHeader("Content-Type", "text/html");
+					response.getOutputStream().write(request.getPathInfo().getBytes()); // $ xss
+				}
+				else {
+					// BAD: set content-type to something that is not safe
+					response.addHeader("Content-Type", "text/html");
+					response.getOutputStream().write(request.getPathInfo().getBytes()); // $ xss
+				}
+			}
+		}
 	}
 
 	/**

--- a/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.java
+++ b/java/ql/test/query-tests/security/CWE-079/semmle/tests/XSS.java
@@ -16,7 +16,7 @@ public class XSS extends HttpServlet {
 			throws ServletException, IOException {
 		// BAD: a request parameter is written directly to the Servlet response stream
 		response.getWriter()
-				.print("The page \"" + request.getParameter("page") + "\" was not found."); // $xss
+				.print("The page \"" + request.getParameter("page") + "\" was not found."); // $ xss
 
 		// GOOD: servlet API encodes the error message HTML for the HTML context
 		response.sendError(HttpServletResponse.SC_NOT_FOUND,
@@ -31,10 +31,10 @@ public class XSS extends HttpServlet {
 				"The page \"" + capitalizeName(request.getParameter("page")) + "\" was not found.");
 
 		// BAD: outputting the path of the resource
-		response.getWriter().print("The path section of the URL was " + request.getPathInfo()); // $xss
+		response.getWriter().print("The path section of the URL was " + request.getPathInfo()); // $ xss
 
 		// BAD: typical XSS, this time written to an OutputStream instead of a Writer
-		response.getOutputStream().write(request.getPathInfo().getBytes()); // $xss
+		response.getOutputStream().write(request.getPathInfo().getBytes()); // $ xss
 
 		// GOOD: sanitizer
 		response.getOutputStream().write(hudson.Util.escape(request.getPathInfo()).getBytes()); // safe


### PR DESCRIPTION
This already existed for Jax and Spring, but not the standard library.

### Pull Request checklist

#### All query authors

- [x] A change note is added if necessary. See [the documentation](https://github.com/github/codeql/blob/main/docs/change-notes.md) in this repository.
- ~All new queries have appropriate `.qhelp`. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-help-style-guide.md) in this repository.~
- [x] QL tests are added if necessary. See [Testing custom queries](https://docs.github.com/en/code-security/codeql-cli/using-the-advanced-functionality-of-the-codeql-cli/testing-custom-queries) in the GitHub documentation.
- ~New and changed queries have correct query metadata. See [the documentation](https://github.com/github/codeql/blob/main/docs/query-metadata-style-guide.md) in this repository.~

#### Internal query authors only

- [ ] ~Autofixes generated based on these changes are valid, only needed if this PR makes significant changes to `.ql`, `.qll`, or `.qhelp` files. See [the documentation](https://github.com/github/codeql-team/blob/main/docs/best-practices/validating-autofix-for-query-changes.md) (internal access required).~
- [x] Changes are validated [at scale](https://github.com/github/codeql-dca/) (internal access required).
- ~Adding a new query? Consider also [adding the query to autofix](https://github.com/github/codeml-autofix/blob/main/docs/updating-query-support.md#adding-a-new-query-to-the-query-suite).~
