### PR TITLE
Rust: Use `PathResolution` module in data flow

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -631,7 +631,7 @@ private module VariantInLib {
       )
     }
 
-  /** An enum variant from library code, represented by its canonical path. */
+  /** An enum variant from library code, represented by the enum's canonical path and the variant's name. */
   class VariantInLib extends MkVariantInLib {
     CrateOriginOption crate;
     string path;

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -61,21 +61,30 @@ module Input implements InputSig<Location, RustDataFlow> {
 
   string encodeContent(ContentSet cs, string arg) {
     exists(Content c | cs = TSingletonContentSet(c) |
-      exists(VariantCanonicalPath v | result = "Variant" |
+      exists(Variant v | result = "Variant" |
         exists(int pos |
-          c = TVariantPositionContent(v, pos) and
+          c = TVariantTupleFieldContent(v, pos) and
+          // TODO: calculate in QL
           arg = v.getExtendedCanonicalPath() + "(" + pos + ")"
         )
         or
         exists(string field |
-          c = TVariantFieldContent(v, field) and
+          // TODO: calculate in QL
+          c = TVariantRecordFieldContent(v, field) and
           arg = v.getExtendedCanonicalPath() + "::" + field
         )
       )
       or
-      exists(StructCanonicalPath s, string field |
+      result = "Variant" and
+      c =
+        any(VariantLibTupleFieldContent v |
+          arg = v.getExtendedCanonicalPath() + "(" + v.getPosition() + ")"
+        )
+      or
+      exists(Struct s, string field |
         result = "Struct" and
         c = TStructFieldContent(s, field) and
+        // TODO: calculate in QL
         arg = s.getExtendedCanonicalPath() + "::" + field
       )
       or

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -77,7 +77,7 @@ module Input implements InputSig<Location, RustDataFlow> {
       or
       result = "Variant" and
       c =
-        any(VariantLibTupleFieldContent v |
+        any(VariantInLibTupleFieldContent v |
           arg = v.getExtendedCanonicalPath() + "(" + v.getPosition() + ")"
         )
       or


### PR DESCRIPTION
This PR updates our data flow library to use the [newly introduced](https://github.com/github/codeql/pull/18579) `PathResolution` library for identifying record and variant constructions. We still need a workaround for built-in types like `Option`, until we extract the relevant source code.