### PR TITLE
C++: Fix FPs in `cpp/overflow-buffer`

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/SAMATE/UnboundedWrite.expected
@@ -1,4 +1,4 @@
 edges
-subpaths
 nodes
+subpaths
 #select

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
@@ -49,12 +49,9 @@
 | tests.cpp:577:7:577:13 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:565:7:565:12 | buffer | array |
 | tests.cpp:637:6:637:15 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:633:7:633:12 | buffer | array |
 | tests.cpp:645:7:645:13 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:633:7:633:12 | buffer | array |
-| tests.cpp:696:3:696:8 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:691:16:691:16 | a | destination buffer |
-| tests.cpp:700:3:700:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:692:16:692:16 | b | destination buffer |
 | tests.cpp:708:3:708:8 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
 | tests.cpp:712:3:712:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
 | tests.cpp:716:3:716:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
-| tests.cpp:726:2:726:7 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:691:16:691:16 | a | destination buffer |
 | tests.cpp:727:2:727:7 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
 | tests_restrict.c:12:2:12:7 | call to memcpy | This 'memcpy' operation accesses 2 bytes but the $@ is only 1 byte. | tests_restrict.c:7:6:7:13 | smallbuf | source buffer |
 | unions.cpp:26:2:26:7 | call to memset | This 'memset' operation accesses 200 bytes but the $@ is only 100 bytes. | unions.cpp:21:10:21:11 | mu | destination buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/OverflowBuffer.expected
@@ -49,6 +49,13 @@
 | tests.cpp:577:7:577:13 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:565:7:565:12 | buffer | array |
 | tests.cpp:637:6:637:15 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:633:7:633:12 | buffer | array |
 | tests.cpp:645:7:645:13 | access to array | This array indexing operation accesses a negative index -1 on the $@. | tests.cpp:633:7:633:12 | buffer | array |
+| tests.cpp:696:3:696:8 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:691:16:691:16 | a | destination buffer |
+| tests.cpp:700:3:700:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:692:16:692:16 | b | destination buffer |
+| tests.cpp:708:3:708:8 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
+| tests.cpp:712:3:712:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
+| tests.cpp:716:3:716:8 | call to memset | This 'memset' operation accesses 16 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
+| tests.cpp:726:2:726:7 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:691:16:691:16 | a | destination buffer |
+| tests.cpp:727:2:727:7 | call to memset | This 'memset' operation accesses 24 bytes but the $@ is only 8 bytes. | tests.cpp:693:16:693:16 | c | destination buffer |
 | tests_restrict.c:12:2:12:7 | call to memcpy | This 'memcpy' operation accesses 2 bytes but the $@ is only 1 byte. | tests_restrict.c:7:6:7:13 | smallbuf | source buffer |
 | unions.cpp:26:2:26:7 | call to memset | This 'memset' operation accesses 200 bytes but the $@ is only 100 bytes. | unions.cpp:21:10:21:11 | mu | destination buffer |
 | unions.cpp:30:2:30:7 | call to memset | This 'memset' operation accesses 200 bytes but the $@ is only 100 bytes. | unions.cpp:15:7:15:11 | small | destination buffer |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/UnboundedWrite.expected
@@ -27,8 +27,8 @@ edges
 | main.cpp:9:29:9:32 | *argv | tests_restrict.c:15:41:15:44 | *argv | provenance |  |
 | main.cpp:9:29:9:32 | tests_restrict_main output argument | main.cpp:10:20:10:23 | **argv | provenance |  |
 | main.cpp:9:29:9:32 | tests_restrict_main output argument | main.cpp:10:20:10:23 | *argv | provenance |  |
-| main.cpp:10:20:10:23 | **argv | tests.cpp:689:32:689:35 | **argv | provenance |  |
-| main.cpp:10:20:10:23 | *argv | tests.cpp:689:32:689:35 | *argv | provenance |  |
+| main.cpp:10:20:10:23 | **argv | tests.cpp:730:32:730:35 | **argv | provenance |  |
+| main.cpp:10:20:10:23 | *argv | tests.cpp:730:32:730:35 | *argv | provenance |  |
 | overflowdestination.cpp:23:45:23:48 | **argv | overflowdestination.cpp:23:45:23:48 | **argv | provenance |  |
 | overflowdestination.cpp:23:45:23:48 | **argv | overflowdestination.cpp:23:45:23:48 | *argv | provenance |  |
 | test_buffer_overrun.cpp:32:46:32:49 | **argv | test_buffer_overrun.cpp:32:46:32:49 | **argv | provenance |  |
@@ -41,12 +41,12 @@ edges
 | tests.cpp:628:14:628:14 | *s [*home] | tests.cpp:628:14:628:19 | *home | provenance |  |
 | tests.cpp:628:14:628:14 | *s [*home] | tests.cpp:628:16:628:19 | *home | provenance |  |
 | tests.cpp:628:16:628:19 | *home | tests.cpp:628:14:628:19 | *home | provenance |  |
-| tests.cpp:689:32:689:35 | **argv | tests.cpp:714:9:714:15 | *access to array | provenance |  |
-| tests.cpp:689:32:689:35 | **argv | tests.cpp:715:9:715:15 | *access to array | provenance |  |
-| tests.cpp:689:32:689:35 | *argv | tests.cpp:714:9:714:15 | *access to array | provenance |  |
-| tests.cpp:689:32:689:35 | *argv | tests.cpp:715:9:715:15 | *access to array | provenance |  |
-| tests.cpp:714:9:714:15 | *access to array | tests.cpp:613:19:613:24 | *source | provenance |  |
-| tests.cpp:715:9:715:15 | *access to array | tests.cpp:622:19:622:24 | *source | provenance |  |
+| tests.cpp:730:32:730:35 | **argv | tests.cpp:755:9:755:15 | *access to array | provenance |  |
+| tests.cpp:730:32:730:35 | **argv | tests.cpp:756:9:756:15 | *access to array | provenance |  |
+| tests.cpp:730:32:730:35 | *argv | tests.cpp:755:9:755:15 | *access to array | provenance |  |
+| tests.cpp:730:32:730:35 | *argv | tests.cpp:756:9:756:15 | *access to array | provenance |  |
+| tests.cpp:755:9:755:15 | *access to array | tests.cpp:613:19:613:24 | *source | provenance |  |
+| tests.cpp:756:9:756:15 | *access to array | tests.cpp:622:19:622:24 | *source | provenance |  |
 | tests_restrict.c:15:41:15:44 | **argv | tests_restrict.c:15:41:15:44 | **argv | provenance |  |
 | tests_restrict.c:15:41:15:44 | *argv | tests_restrict.c:15:41:15:44 | *argv | provenance |  |
 nodes
@@ -80,10 +80,10 @@ nodes
 | tests.cpp:628:14:628:14 | *s [*home] | semmle.label | *s [*home] |
 | tests.cpp:628:14:628:19 | *home | semmle.label | *home |
 | tests.cpp:628:16:628:19 | *home | semmle.label | *home |
-| tests.cpp:689:32:689:35 | **argv | semmle.label | **argv |
-| tests.cpp:689:32:689:35 | *argv | semmle.label | *argv |
-| tests.cpp:714:9:714:15 | *access to array | semmle.label | *access to array |
-| tests.cpp:715:9:715:15 | *access to array | semmle.label | *access to array |
+| tests.cpp:730:32:730:35 | **argv | semmle.label | **argv |
+| tests.cpp:730:32:730:35 | *argv | semmle.label | *argv |
+| tests.cpp:755:9:755:15 | *access to array | semmle.label | *access to array |
+| tests.cpp:756:9:756:15 | *access to array | semmle.label | *access to array |
 | tests_restrict.c:15:41:15:44 | **argv | semmle.label | **argv |
 | tests_restrict.c:15:41:15:44 | **argv | semmle.label | **argv |
 | tests_restrict.c:15:41:15:44 | *argv | semmle.label | *argv |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -685,6 +685,47 @@ int test28(MYSTRUCTREF g)
 	return memcmp(&g, &_myStruct, sizeof(MYSTRUCT)); // GOOD
 }
 
+#define offsetof(s, m) __builtin_offsetof(s, m)
+
+struct HasSomeFields {
+	unsigned long a;
+	unsigned long b;
+	unsigned long c;
+
+	void test29() {
+		memset(&a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD [FALSE POSITIVE]
+	};
+
+	void test30() {
+		memset(&b, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b)); // GOOD [FALSE POSITIVE]
+	};
+
+	void test31() {
+		memset(&c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, c)); // GOOD
+	};
+
+	void test32() {
+		memset(&c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // BAD
+	};
+
+	void test33() {
+		memset(&c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b)); // BAD
+	};
+
+	void test34() {
+		memset(&c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b)); // BAD
+	};
+
+	void test35() {
+		memset(&b, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b) - sizeof(unsigned long)); // GOOD
+	};
+};
+
+void test36() {
+	HasSomeFields hsf;
+	memset(&hsf.a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD [FALSE POSITIVE]
+	memset(&hsf.c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // BAD
+}
 
 int tests_main(int argc, char *argv[])
 {

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-119/semmle/tests/tests.cpp
@@ -693,11 +693,11 @@ struct HasSomeFields {
 	unsigned long c;
 
 	void test29() {
-		memset(&a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD [FALSE POSITIVE]
+		memset(&a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD
 	};
 
 	void test30() {
-		memset(&b, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b)); // GOOD [FALSE POSITIVE]
+		memset(&b, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, b)); // GOOD
 	};
 
 	void test31() {
@@ -723,7 +723,7 @@ struct HasSomeFields {
 
 void test36() {
 	HasSomeFields hsf;
-	memset(&hsf.a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD [FALSE POSITIVE]
+	memset(&hsf.a, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // GOOD
 	memset(&hsf.c, 0, sizeof(HasSomeFields) - offsetof(HasSomeFields, a)); // BAD
 }
 


### PR DESCRIPTION
Consider this snippet:
```
struct S {
  uint8_t a;
  uint8_t b;
  uint8_t c;

  void test() {
    memset(&b, 0, sizeof(S) - offsetof(S, b));
  };
};
```
The `cpp/overflow-buffer` query flags this up claiming that we overrun the buffer `b` (of size 8) because the `memset` may access 16 bytes starting at the address `&b`. However, this access is fine, and this is just a fancy way of zero'ing `b` and `c`.

This PR fixes this by modifying the initial size deduced from `&b` so that it correctly reflects that it's fine to access 16 bytes starting at this address.

Commit-by-commit review encouraged.