### PR TITLE
C++: #18592 follow-up

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1009,7 +1009,7 @@ class CastNode extends Node {
 }
 
 cached
-newtype TDataFlowCallable =
+private newtype TDataFlowCallable =
   TSourceCallable(Cpp::Declaration decl) or
   TSummarizedCallable(FlowSummaryImpl::Public::SummarizedCallable c)
 

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -66,7 +66,6 @@ private newtype TIRDataFlowNode =
   TFinalGlobalValue(Ssa::GlobalUse globalUse) or
   TInitialGlobalValue(Ssa::GlobalDef globalUse) or
   TBodyLessParameterNodeImpl(Parameter p, int indirectionIndex) {
-    not exists(TSummarizedCallable(p.getFunction())) and
     // Rule out parameters of catch blocks.
     not exists(p.getCatchBlock()) and
     // We subtract one because `getMaxIndirectionsForType` returns the maximum


### PR DESCRIPTION
In https://github.com/github/codeql/pull/18592 (after lots of back-and-forth) we identified a problem in the C++ MaD setup where we were conflating the summarized callables and the source callable whenever a summarized callable existed in the database.

Initially, I thought that the fix required us to remove parameter nodes for MaD summarized functions (something I now know we shouldn't do!), and thus I did ad80b36074bb41ece2b7fba1435449fc7ed97c41. However, in a later commit we re-introduced the parameter nodes. However, I forgot to revert ad80b36074bb41ece2b7fba1435449fc7ed97c41. So this PR reverts that commit.