### PR TITLE
C++: Don't infer lambda calls when there is a static dispatch

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -1339,7 +1339,12 @@ predicate lambdaCreation(Node creation, LambdaCallKind kind, DataFlowCallable c)
 /** Holds if `call` is a lambda call of kind `kind` where `receiver` is the lambda expression. */
 predicate lambdaCall(DataFlowCall call, LambdaCallKind kind, Node receiver) {
   (
-    call.(SummaryCall).getReceiver() = receiver.(FlowSummaryNode).getSummaryNode() or
+    call.(SummaryCall).getReceiver() = receiver.(FlowSummaryNode).getSummaryNode()
+    or
+    // No need to infer a lambda call if we already have a static dispatch target.
+    // We only need to check this in the disjunct since a `SummaryCall` never
+    // has a result for `getStaticCallTarget`.
+    not exists(call.getStaticCallTarget()) and
     call.asCallInstruction().getCallTargetOperand() = receiver.asOperand()
   ) and
   exists(kind)


### PR DESCRIPTION
This gives us the missing result that we lost after the all the bugfixes in https://github.com/github/codeql/pull/18592

The alert changes are completely identical to the original PR. All these results are _good changes_. I'll paste that description here for reference:

## Query result changes
#### `cpp/path-injection`

We gain 1 new result on `cpp/path-injection`. I've confirmed that this is because we now stay below the default field flow branch limit (i.e., `2`) for flow out of [this call to push_back](https://github.com/openjdk/jdk/blob/8dc43aa0fe8cdba2a2953258de02c6afa072987a/src/jdk.jpackage/share/native/applauncher/AppLauncher.h#L49). Before, we had out flow from both the MaD summary and the source code which resulted in going over the limit. But now we only have the MaD summary-proided out flow which keeps us below the threshold. So, unlike on `main`, field flow is now permitted in the enclosing function.

#### `cpp/non-constant-format`

We lose 60 results on SAMATE for this query. They all appear to be false positives that happen because of the generous [`isSource` in the query](https://github.com/github/codeql/blob/4d2ec75ef22ffe8be19fd2a08d4bc2ff16aa5152/cpp/ql/src/Likely%20Bugs/Format/NonConstantFormat.ql#L97) that makes us start flow at some random output parameter of a call to `delete` deep inside the destructor of an iterator inside the libstdc++. Obviously, that's not what the query is supposed to be finding and I doubt that any of our queries will benefit from starting flow deep inside the implementation of a MaD summarized function.

## Query result _tuple count_ changes

Other than the two changes to query results above, we also see some query result tuple count changes on the `cpp/uncontrolled-allocation-size` query on Samate. Jeroen asked about those in the original PR, and the reason is identical here:

The reduction in result tuples on Samate for `cpp/uncontrolled-allocation-size` happens because we find lots of results where the sink is an allocation deep inside the implementation of `std::vector`. However, because that location is outside the source root the result is filtered away. So after excluding results outside the source root (i.e., the results that are actually surfaced in the alert view) there are 38 results before and after these changes.