### PR TITLE
JS: Treat more file patterns as tsconfig-like files

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -394,7 +394,7 @@ public class AutoBuild {
     for (FileType filetype : defaultExtract)
       for (String extension : filetype.getExtensions()) patterns.add("**/*" + extension);
 
-    // include .eslintrc files, .xsaccess files, package.json files, 
+    // include .eslintrc files, .xsaccess files, package.json files,
     // tsconfig.json files, and codeql-javascript-*.json files
     patterns.add("**/.eslintrc*");
     patterns.add("**/.xsaccess");
@@ -895,7 +895,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
           // For named packages, find the main file.
           String name = packageJson.getName();
           if (name != null) {
-            Path entryPoint = null; 
+            Path entryPoint = null;
             try {
               entryPoint = guessPackageMainFile(path, packageJson, FileType.TYPESCRIPT.getExtensions());
               if (entryPoint == null) {

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1108,6 +1108,10 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
     return false;
   }
 
+  public static boolean treatAsTSConfig(String basename) {
+    return basename.contains("tsconfig.") && basename.endsWith(".json");
+  }
+
   private void findFilesToExtract(
       FileExtractor extractor, final Set<Path> filesToExtract, final List<Path> tsconfigFiles)
       throws IOException {
@@ -1140,7 +1144,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
 
             // extract TypeScript projects from 'tsconfig.json'
             if (typeScriptMode == TypeScriptMode.FULL
-                && (file.getFileName().toString().contains("tsconfig.") && file.getFileName().toString().endsWith(".json"))
+                && treatAsTSConfig(file.getFileName().toString())
                 && !excludes.contains(file)
                 && isFileIncluded(file)) {
               tsconfigFiles.add(file);

--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1140,7 +1140,7 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
 
             // extract TypeScript projects from 'tsconfig.json'
             if (typeScriptMode == TypeScriptMode.FULL
-                && file.getFileName().endsWith("tsconfig.json")
+                && (file.getFileName().toString().contains("tsconfig.") && file.getFileName().toString().endsWith(".json"))
                 && !excludes.contains(file)
                 && isFileIncluded(file)) {
               tsconfigFiles.add(file);

--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -539,7 +539,7 @@ public class Main {
       }
 
       if (extractorConfig.getTypeScriptMode() == TypeScriptMode.FULL
-          && root.getName().equals("tsconfig.json")
+          && AutoBuild.treatAsTSConfig(root.getName())
           && !excludeMatcher.matches(path)) {
         projectFiles.add(root);
       }

--- a/javascript/ql/src/change-notes/2025-01-30-typescript-tsconfig-names.md
+++ b/javascript/ql/src/change-notes/2025-01-30-typescript-tsconfig-names.md
@@ -1,0 +1,5 @@
+---
+category: majorAnalysis
+---
+* TypeScript extraction is now better at analyzing projects where the main `tsconfig.json` file does not include any
+  source files, but references other `tsconfig.json`-like files that do include source files.

--- a/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/src/main.ts
+++ b/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/src/main.ts
@@ -1,0 +1,4 @@
+export function main(foo: string) {
+    let x = foo;
+    console.log(x);
+}

--- a/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/test.expected
@@ -1,0 +1,9 @@
+types
+| (...data: any[]) => void |
+| (foo: string) => void |
+| Console |
+| any |
+| any[] |
+| string |
+| void |
+jsonFiles

--- a/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/test.ql
@@ -1,0 +1,5 @@
+import javascript
+
+query predicate types(Type type) { any() }
+
+query predicate jsonFiles(File file) { file.getExtension() = "json" }

--- a/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/tsconfig.foo.json
+++ b/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/tsconfig.foo.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "include": [
+        "src"
+    ],
+    "compilerOptions": {
+        "composite": true
+    }
+}

--- a/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/tsconfig.json
+++ b/javascript/ql/test/library-tests/TypeScript/TSConfigReferences/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "include": [],
+    "files": [],
+    "references": [
+        { "path": "./tsconfig.foo.json" },
+    ],
+}


### PR DESCRIPTION
Improves our handling of the situation where the `tsconfig.json` file includes nothing, but references another file that does, but is not called `tsconfig.json`.

We could do this by following `"references"` and `"extends"` and extract more files based on that, but for now I've done the simple thing by just treating more files as tsconfig-like files.