### PR TITLE
Java: make diff-informed queries exact

### DIFF
--- a/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/CommandLineQuery.qll
@@ -59,12 +59,15 @@ module InputToArgumentToExecFlowConfig implements DataFlow::ConfigSig {
     any(CommandInjectionAdditionalTaintStep s).step(n1, n2)
   }
 
-  // It's valid to use diff-informed data flow for this configuration because
-  // the location of the selected element in the query is contained inside the
-  // location of the sink. The query, as a predicate, is used negated in
-  // another query, but that's only to prevent overlapping results between two
-  // queries.
+  // The query, as a predicate, is used negated in another query, but that's
+  // only to prevent overlapping results between two queries.
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  // All queries use the argument as the primary location and do not use the
+  // sink as an associated location.
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(Expr argument | argumentToExec(argument, sink) | result = argument.getLocation())
+  }
 }
 
 /**

--- a/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/WebviewDebuggingEnabledQuery.qll
@@ -46,6 +46,12 @@ module WebviewDebugEnabledConfig implements DataFlow::ConfigSig {
   }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    // This module is only used in `WebviewDebuggingEnabled.ql`, which doesn't
+    // select the source in any "$@" column.
+    none()
+  }
 }
 
 /**


### PR DESCRIPTION
Similar to the reasoning behind https://github.com/github/codeql/pull/17648, diff-informed queries have to be exact. Over-approximations may cause alert wobble over the lifetime of a PR.