### PR TITLE
Rust: Fix a bad join

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -284,7 +284,7 @@ private predicate isControlFlowJump(Expr e) { e instanceof CallExprBase or e ins
 private predicate capturedCallRead(Expr call, BasicBlock bb, int i, Variable v) {
   isControlFlowJump(call) and
   exists(Cfg::CfgScope scope |
-    hasCapturedRead(v, scope) and
+    hasCapturedRead(pragma[only_bind_into](v), pragma[only_bind_into](scope)) and
     (
       variableWriteInOuterScope(bb, any(int j | j < i), v, scope) or
       variableWriteInOuterScope(bb.getAPredecessor+(), _, v, scope)


### PR DESCRIPTION
Before
```
[2025-01-31 14:40:10] Evaluated non-recursive predicate SsaImpl::capturedCallRead/4#1f9b0af4@6f60dcog in 10553ms (size: 372366).
Evaluated relational algebra for predicate SsaImpl::capturedCallRead/4#1f9b0af4@6f60dcog with tuple counts:
        1992868487   ~4%    {6} r1 = JOIN `_BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::get__#shared` WITH `SsaImpl::variableWriteInOuterScope/4#aca2ef34` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Rhs.1, Rhs.2, Rhs.3
                            {6}    | REWRITE WITH TEST InOut.3 < InOut.2
         998449075   ~0%    {5}    | SCAN OUTPUT In.4, In.5, In.0, In.1, In.2

          12205909   ~1%    {4} r2 = JOIN `_BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::get__#shared` WITH `boundedFastTC:BasicBlocks::BasicBlock.getAPredecessor/0#dispred#268ed41b:_BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::get__#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.0, Lhs.2
          34440992   ~9%    {5}    | JOIN WITH `project#SsaImpl::variableWriteInOuterScope/4#aca2ef34` ON FIRST 1 OUTPUT Rhs.1, Rhs.2, Lhs.1, Lhs.2, Lhs.3

        1032890067   ~0%    {5} r3 = r1 UNION r2
            680217  ~74%    {4}    | JOIN WITH `SsaImpl::hasCapturedRead/2#847e9f91` ON FIRST 2 OUTPUT Lhs.2, Lhs.3, Lhs.4, Lhs.0
                            return r3
```

After
```
[2025-01-31 14:43:05] Evaluated non-recursive predicate SsaImpl::capturedCallRead/4#1f9b0af4@15fdf34h in 74ms (size: 373835).
Evaluated relational algebra for predicate SsaImpl::capturedCallRead/4#1f9b0af4@15fdf34h with tuple counts:
        1106129   ~0%    {3} r1 = SCAN `project#SsaImpl::variableWriteInOuterScope/4#aca2ef34` OUTPUT In.1, In.2, In.0
          25209  ~20%    {2}    | JOIN WITH `SsaImpl::hasCapturedRead/2#847e9f91` ON FIRST 2 OUTPUT Lhs.2, Lhs.0
         339364   ~6%    {2}    | JOIN WITH `boundedFastTC:BasicBlocks::BasicBlock.getAPredecessor/0#dispred#268ed41b_10#higher_order_body:_SsaImpl::hasCapturedRead/2#847e9f91_project#SsaImpl::variableWriteInOuterScope/4#aca2ef34#higher_order_body` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
        2095088   ~0%    {4}    | JOIN WITH `BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::getNode/2#4226f9fe` ON FIRST 1 OUTPUT Lhs.0, Rhs.1, Rhs.2, Lhs.1

        1121531   ~0%    {4} r2 = SCAN `SsaImpl::variableWriteInOuterScope/4#aca2ef34` OUTPUT In.2, In.3, In.0, In.1
          25820  ~22%    {3}    | JOIN WITH `SsaImpl::hasCapturedRead/2#847e9f91` ON FIRST 2 OUTPUT Lhs.2, Lhs.0, Lhs.3
         505208   ~1%    {5}    | JOIN WITH `BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::getNode/2#4226f9fe` ON FIRST 1 OUTPUT Lhs.1, Lhs.0, Lhs.2, Rhs.1, Rhs.2
                         {5}    | REWRITE WITH TEST InOut.2 < InOut.3
         344294   ~6%    {4}    | SCAN OUTPUT In.1, In.3, In.4, In.0

        2439382   ~0%    {4} r3 = r1 UNION r2
        2434485   ~7%    {4}    | JOIN WITH `BasicBlock::Make<Locations::Location,BasicBlocks::BasicBlocksImpl::BasicBlockInputSig>::Cached::getNode/2#4226f9fe` ON FIRST 3 OUTPUT Lhs.2, Lhs.3, Lhs.0, Lhs.1
        2393182   ~3%    {4}    | JOIN WITH ControlFlowGraphImpl::CfgImpl::Cached::TAstNode#8f9a3aff_31#join_rhs ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
         380879   ~0%    {4}    | JOIN WITH `SsaImpl::isControlFlowJump/1#c535656e` ON FIRST 1 OUTPUT Lhs.0, Lhs.2, Lhs.3, Lhs.1
                         return r3
```