### PR TITLE
Java: path sanitizer for `replace`, `replaceAll`, and `matches`

### DIFF
--- a/java/ql/lib/change-notes/2025-03-10-matches-replace-path-sanitizer.md
+++ b/java/ql/lib/change-notes/2025-03-10-matches-replace-path-sanitizer.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added a path injection sanitizer for calls to `java.lang.String.matches`, `java.lang.String.replace`, and `java.lang.String.replaceAll` that make sure '/', '\', '..' are not in the path.

--- a/java/ql/lib/semmle/code/java/JDK.qll
+++ b/java/ql/lib/semmle/code/java/JDK.qll
@@ -45,6 +45,36 @@ class StringContainsMethod extends Method {
   }
 }
 
+/** A call to the `java.lang.String.matches` method. */
+class StringMatchesCall extends MethodCall {
+  StringMatchesCall() {
+    exists(Method m | m = this.getMethod() |
+      m.getDeclaringType() instanceof TypeString and
+      m.hasName("matches")
+    )
+  }
+}
+
+/** A call to the `java.lang.String.replaceAll` method. */
+class StringReplaceAllCall extends MethodCall {
+  StringReplaceAllCall() {
+    exists(Method m | m = this.getMethod() |
+      m.getDeclaringType() instanceof TypeString and
+      m.hasName("replaceAll")
+    )
+  }
+}
+
+/** A call to the `java.lang.String.replace` method. */
+class StringReplaceCall extends MethodCall {
+  StringReplaceCall() {
+    exists(Method m | m = this.getMethod() |
+      m.getDeclaringType() instanceof TypeString and
+      m.hasName("replace")
+    )
+  }
+}
+
 /**
  * The methods on the class `java.lang.String` that are used to perform partial matches with a specified substring or char.
  */

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -414,7 +414,9 @@ private predicate isReplaceTarget(StringReplaceCall replaceCall, CompileTimeCons
 }
 
 /** Holds if a single `replaceAllCall` replaces all directory characters. */
-private predicate isSingleReplaceAll(StringReplaceAllCall replaceAllCall) {
+private predicate replacesDirectoryCharactersWithSingleReplaceAll(
+  StringReplaceAllCall replaceAllCall
+) {
   exists(CompileTimeConstantExpr target, string targetValue |
     isReplaceAllTarget(replaceAllCall, target) and
     target.getStringValue() = targetValue
@@ -436,7 +438,9 @@ private predicate isSingleReplaceAll(StringReplaceAllCall replaceAllCall) {
  * Holds if there are two chained replacement calls, `rc1` and `rc2`, that replace
  * '.' and one of '/' or '\'.
  */
-private predicate isDoubleReplaceOrReplaceAll(StringReplaceOrReplaceAllCall rc1) {
+private predicate replacesDirectoryCharactersWithDoubleReplaceOrReplaceAll(
+  StringReplaceOrReplaceAllCall rc1
+) {
   exists(
     CompileTimeConstantExpr target1, string targetValue1, StringReplaceOrReplaceAllCall rc2,
     CompileTimeConstantExpr target2, string targetValue2
@@ -471,8 +475,8 @@ private predicate isDoubleReplaceOrReplaceAll(StringReplaceOrReplaceAllCall rc1)
  */
 private class ReplaceDirectoryCharactersSanitizer extends StringReplaceOrReplaceAllCall {
   ReplaceDirectoryCharactersSanitizer() {
-    isSingleReplaceAll(this) or
-    isDoubleReplaceOrReplaceAll(this)
+    replacesDirectoryCharactersWithSingleReplaceAll(this) or
+    replacesDirectoryCharactersWithDoubleReplaceOrReplaceAll(this)
   }
 }
 

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -384,30 +384,135 @@ private class FileConstructorChildArgumentStep extends AdditionalTaintStep {
   }
 }
 
+/** A call to `java.lang.String.replace` or `java.lang.String.replaceAll`. */
+private class StringReplaceOrReplaceAllCall extends MethodCall {
+  StringReplaceOrReplaceAllCall() {
+    this instanceof StringReplaceCall or
+    this instanceof StringReplaceAllCall
+  }
+}
+
+/** Gets a character used for replacement. */
+private string getAReplacementChar() { result = ["", "_", "-"] }
+
+/** Gets a directory character represented as regex. */
+private string getADirRegexChar() { result = ["\\.", "/", "\\\\"] }
+
+/** Gets a directory character represented as a char. */
+private string getADirChar() { result = [".", "/", "\\"] }
+
+/** Holds if `target` is the first argument of `replaceAllCall`. */
+private predicate isReplaceAllTarget(
+  StringReplaceAllCall replaceAllCall, CompileTimeConstantExpr target
+) {
+  target = replaceAllCall.getArgument(0)
+}
+
+/** Holds if `target` is the first argument of `replaceCall`. */
+private predicate isReplaceTarget(StringReplaceCall replaceCall, CompileTimeConstantExpr target) {
+  target = replaceCall.getArgument(0)
+}
+
+/** Holds if a single `replaceAllCall` replaces all directory characters. */
+private predicate isSingleReplaceAll(StringReplaceAllCall replaceAllCall) {
+  exists(CompileTimeConstantExpr target, string targetValue |
+    isReplaceAllTarget(replaceAllCall, target) and
+    target.getStringValue() = targetValue
+  |
+    not targetValue.matches("%[^%]%") and
+    targetValue.matches("[%.%]") and
+    targetValue.matches("[%/%]") and
+    // Search for "\\\\" (needs extra backslashes to avoid escaping the '%')
+    targetValue.matches("[%\\\\\\\\%]")
+    or
+    targetValue.matches("%|%") and
+    targetValue.matches("%" + ["\\.\\.", "[.][.]", "\\."] + "%") and
+    targetValue.matches("%/%") and
+    targetValue.matches("%\\\\\\\\%")
+  )
+}
+
+/**
+ * Holds if there are two chained replacement calls, `rc1` and `rc2`, that replace
+ * '.' and one of '/' or '\'.
+ */
+private predicate isDoubleReplaceOrReplaceAll(StringReplaceOrReplaceAllCall rc1) {
+  exists(
+    CompileTimeConstantExpr target1, string targetValue1, StringReplaceOrReplaceAllCall rc2,
+    CompileTimeConstantExpr target2, string targetValue2
+  |
+    rc1 instanceof StringReplaceAllCall and
+    isReplaceAllTarget(rc1, target1) and
+    isReplaceAllTarget(rc2, target2) and
+    targetValue1 = getADirRegexChar() and
+    targetValue2 = getADirRegexChar()
+    or
+    rc1 instanceof StringReplaceCall and
+    isReplaceTarget(rc1, target1) and
+    isReplaceTarget(rc2, target2) and
+    targetValue1 = getADirChar() and
+    targetValue2 = getADirChar()
+  |
+    rc2.getQualifier() = rc1 and
+    target1.getStringValue() = targetValue1 and
+    target2.getStringValue() = targetValue2 and
+    rc2.getArgument(1).(CompileTimeConstantExpr).getStringValue() = getAReplacementChar() and
+    // make sure the calls replace different characters
+    targetValue2 != targetValue1 and
+    // make sure one of the calls replaces '.'
+    // then the other call must replace one of '/' or '\' if they are not equal
+    (targetValue2.matches("%.%") or targetValue1.matches("%.%"))
+  )
+}
+
 /**
  * A complementary sanitizer that protects against path injection vulnerabilities
- * by replacing all directory characters ('..', '/', and '\') with safe characters.
+ * by replacing directory characters ('..', '/', and '\') with safe characters.
  */
-private class ReplaceDirectoryCharactersSanitizer extends MethodCall {
+private class ReplaceDirectoryCharactersSanitizer extends StringReplaceOrReplaceAllCall {
   ReplaceDirectoryCharactersSanitizer() {
-    exists(MethodCall mc |
-      // TODO: "java.lang.String.replace" as well
-      mc.getMethod().hasQualifiedName("java.lang", "String", "replaceAll") and
-      // TODO: unhardcode all of the below to handle more valid replacements and several calls
-      (
-        mc.getArgument(0).(CompileTimeConstantExpr).getStringValue() = "\\.\\.|[/\\\\]"
-        or
-        exists(MethodCall mc2 |
-          mc2.getMethod().hasQualifiedName("java.lang", "String", "replaceAll") and
-          mc.getArgument(0).(CompileTimeConstantExpr).getStringValue() = "\\." and
-          mc2.getArgument(0).(CompileTimeConstantExpr).getStringValue() = "/"
-        )
-      ) and
-      // TODO: accept more replacement characters?
-      mc.getArgument(1).(CompileTimeConstantExpr).getStringValue() = ["", "_"] and
-      this = mc
-    )
+    isSingleReplaceAll(this) or
+    isDoubleReplaceOrReplaceAll(this)
   }
+}
+
+/** Holds if `target` is the first argument of `matchesCall`. */
+private predicate isMatchesTarget(StringMatchesCall matchesCall, CompileTimeConstantExpr target) {
+  target = matchesCall.getArgument(0)
+}
+
+/**
+ * Holds if `matchesCall` confirms that `checkedExpr` does not contain any directory characters
+ * on the given `branch`.
+ */
+private predicate isMatchesCall(StringMatchesCall matchesCall, Expr checkedExpr, boolean branch) {
+  exists(CompileTimeConstantExpr target, string targetValue |
+    isMatchesTarget(matchesCall, target) and
+    target.getStringValue() = targetValue and
+    checkedExpr = matchesCall.getQualifier()
+  |
+    targetValue.matches(["[%]*", "[%]+", "[%]{%}"]) and
+    (
+      // Allow anything except `.`, '/', '\'
+      (
+        // Note: we do not account for when '.', '/', '\' are inside a character range
+        not targetValue.matches("[%" + [".", "/", "\\\\\\\\"] + "%]%") and
+        not targetValue.matches("%[^%]%")
+        or
+        targetValue.matches("[^%.%]%") and
+        targetValue.matches("[^%/%]%") and
+        targetValue.matches("[^%\\\\\\\\%]%")
+      ) and
+      branch = true
+      or
+      // Disallow `.`, '/', '\'
+      targetValue.matches("[%.%]%") and
+      targetValue.matches("[%/%]%") and
+      targetValue.matches("[%\\\\\\\\%]%") and
+      not targetValue.matches("%[^%]%") and
+      branch = false
+    )
+  )
 }
 
 /**
@@ -416,19 +521,13 @@ private class ReplaceDirectoryCharactersSanitizer extends MethodCall {
  */
 private class DirectoryCharactersGuard extends PathGuard {
   Expr checkedExpr;
+  boolean branch;
 
-  DirectoryCharactersGuard() {
-    exists(MethodCall mc, Method m | m = mc.getMethod() |
-      m.getDeclaringType() instanceof TypeString and
-      m.hasName("matches") and
-      // TODO: unhardcode to handle more valid matches
-      mc.getAnArgument().(CompileTimeConstantExpr).getStringValue() = "[0-9a-fA-F]{20,}" and
-      checkedExpr = mc.getQualifier() and
-      this = mc
-    )
-  }
+  DirectoryCharactersGuard() { isMatchesCall(this, checkedExpr, branch) }
 
   override Expr getCheckedExpr() { result = checkedExpr }
+
+  boolean getBranch() { result = branch }
 }
 
 /**
@@ -436,8 +535,7 @@ private class DirectoryCharactersGuard extends PathGuard {
  * sure it does not contain any directory characters: '..', '/', and '\'.
  */
 private predicate directoryCharactersGuard(Guard g, Expr e, boolean branch) {
-  branch = true and
-  g instanceof DirectoryCharactersGuard and
+  branch = g.(DirectoryCharactersGuard).getBranch() and
   localTaintFlowToPathGuard(e, g)
 }
 

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -428,7 +428,7 @@ private predicate replacesDirectoryCharactersWithSingleReplaceAll(
     targetValue.matches("[%\\\\\\\\%]")
     or
     targetValue.matches("%|%") and
-    targetValue.matches("%" + ["\\.\\.", "[.][.]", "\\."] + "%") and
+    targetValue.matches("%" + ["[.]", "\\."] + "%") and
     targetValue.matches("%/%") and
     targetValue.matches("%\\\\\\\\%")
   )

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -497,9 +497,9 @@ private predicate isMatchesCall(StringMatchesCall matchesCall, Expr checkedExpr,
     target.getStringValue() = targetValue and
     checkedExpr = matchesCall.getQualifier()
   |
-    targetValue.matches(["[%]*", "[%]+", "[%]{%}"]) and
     (
       // Allow anything except `.`, '/', '\'
+      targetValue.matches(["[%]*", "[%]+", "[%]{%}"]) and
       (
         // Note: we do not account for when '.', '/', '\' are inside a character range
         not targetValue.matches("[%" + [".", "/", "\\\\\\\\"] + "%]%") and
@@ -512,9 +512,10 @@ private predicate isMatchesCall(StringMatchesCall matchesCall, Expr checkedExpr,
       branch = true
       or
       // Disallow `.`, '/', '\'
-      targetValue.matches("[%.%]%") and
-      targetValue.matches("[%/%]%") and
-      targetValue.matches("[%\\\\\\\\%]%") and
+      targetValue.matches([".*[%].*", ".+[%].+"]) and
+      targetValue.matches("%[%.%]%") and
+      targetValue.matches("%[%/%]%") and
+      targetValue.matches("%[%\\\\\\\\%]%") and
       not targetValue.matches("%[^%]%") and
       branch = false
     )

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -470,8 +470,8 @@ private predicate replacesDirectoryCharactersWithDoubleReplaceOrReplaceAll(
 }
 
 /**
- * A complementary sanitizer that protects against path injection vulnerabilities
- * by replacing directory characters ('..', '/', and '\') with safe characters.
+ * A sanitizer that protects against path injection vulnerabilities by replacing
+ * directory characters ('..', '/', and '\') with safe characters.
  */
 private class ReplaceDirectoryCharactersSanitizer extends StringReplaceOrReplaceAllCall {
   ReplaceDirectoryCharactersSanitizer() {
@@ -520,8 +520,8 @@ private predicate isMatchesCall(StringMatchesCall matchesCall, Expr checkedExpr,
 }
 
 /**
- * A complementary guard that protects against path traversal by looking
- * for patterns that exclude directory characters: `..`, '/', and '\'.
+ * A guard that protects against path traversal by looking for patterns
+ * that exclude directory characters: `..`, '/', and '\'.
  */
 private class DirectoryCharactersGuard extends PathGuard {
   Expr checkedExpr;

--- a/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
+++ b/java/ql/lib/semmle/code/java/security/PathSanitizer.qll
@@ -419,7 +419,8 @@ private predicate replacesDirectoryCharactersWithSingleReplaceAll(
 ) {
   exists(CompileTimeConstantExpr target, string targetValue |
     isReplaceAllTarget(replaceAllCall, target) and
-    target.getStringValue() = targetValue
+    target.getStringValue() = targetValue and
+    replaceAllCall.getArgument(1).(CompileTimeConstantExpr).getStringValue() = getAReplacementChar()
   |
     not targetValue.matches("%[^%]%") and
     targetValue.matches("[%.%]") and
@@ -460,6 +461,7 @@ private predicate replacesDirectoryCharactersWithDoubleReplaceOrReplaceAll(
     rc2.getQualifier() = rc1 and
     target1.getStringValue() = targetValue1 and
     target2.getStringValue() = targetValue2 and
+    rc1.getArgument(1).(CompileTimeConstantExpr).getStringValue() = getAReplacementChar() and
     rc2.getArgument(1).(CompileTimeConstantExpr).getStringValue() = getAReplacementChar() and
     // make sure the calls replace different characters
     targetValue2 != targetValue1 and

--- a/java/ql/test/library-tests/pathsanitizer/Test.java
+++ b/java/ql/test/library-tests/pathsanitizer/Test.java
@@ -716,13 +716,19 @@ public class Test {
         }
         {
             String source = (String) source();
-            source = source.replaceAll("\\.|[/\\\\]", "");
+            source = source.replaceAll("\\.|[/\\\\]", "-");
             sink(source); // Safe
         }
         {
             String source = (String) source();
-            source = source.replaceAll("[.][.]|[/\\\\]", "");
+            source = source.replaceAll("[.][.]|[/\\\\]", "_");
             sink(source); // Safe
+        }
+        {
+            String source = (String) source();
+            // test a not-accepted replacement character
+            source = source.replaceAll("[.][.]|[/\\\\]", "/");
+            sink(source); // $ hasTaintFlow
         }
         {
             String source = (String) source();
@@ -760,6 +766,24 @@ public class Test {
             String source = (String) source();
             source = source.replaceAll("\\.", "").replaceAll("/", "");
             sink(source); // Safe
+        }
+        {
+            String source = (String) source();
+            // test a not-accepted replacement character in each call
+            source = source.replaceAll("\\.", "/").replaceAll("/", ".");
+            sink(source); // $ hasTaintFlow
+        }
+        {
+            String source = (String) source();
+            // test a not-accepted replacement character in first call
+            source = source.replaceAll("\\.", "/").replaceAll("/", "-");
+            sink(source); // $ hasTaintFlow
+        }
+        {
+            String source = (String) source();
+            // test a not-accepted replacement character in second call
+            source = source.replaceAll("\\.", "_").replaceAll("/", ".");
+            sink(source); // $ hasTaintFlow
         }
         {
             String source = (String) source();

--- a/java/ql/test/library-tests/pathsanitizer/Test.java
+++ b/java/ql/test/library-tests/pathsanitizer/Test.java
@@ -684,16 +684,33 @@ public class Test {
         // branch = false
         {
             String source = (String) source();
+            if (source.matches(".*[\\./\\\\].*")) {
+                sink(source); // $ hasTaintFlow
+            } else {
+                sink(source); // Safe
+            }
+        }
+        {
+            String source = (String) source();
+            if (source.matches(".+[\\./\\\\].+")) {
+                sink(source); // $ hasTaintFlow
+            } else {
+                sink(source); // Safe
+            }
+        }
+        {
+            String source = (String) source();
+            // does not match whole string
             if (source.matches("[\\./\\\\]+")) {
                 sink(source); // $ hasTaintFlow
             } else {
-                sink(source); // $ Safe
+                sink(source); // $ hasTaintFlow
             }
         }
         {
             String source = (String) source();
             // not a complete sanitizer since it doesn't protect against absolute path injection
-            if (source.matches("[\\.]+")) {
+            if (source.matches(".+[\\.].+")) {
                 sink(source); // $ hasTaintFlow
             } else {
                 sink(source); // $ hasTaintFlow

--- a/java/ql/test/library-tests/pathsanitizer/Test.java
+++ b/java/ql/test/library-tests/pathsanitizer/Test.java
@@ -731,6 +731,11 @@ public class Test {
         }
         {
             String source = (String) source();
+            source = source.replaceAll("\\.|/|\\\\", "");
+            sink(source); // Safe
+        }
+        {
+            String source = (String) source();
             source = source.replaceAll("[\\./\\\\]", "");
             sink(source); // Safe
         }

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
@@ -6,7 +6,6 @@ import java.io.InputStreamReader;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.FileSystems;
 
 public class TaintedPath {
     public void sendUserFile(Socket sock, String user) throws IOException {
@@ -87,51 +86,4 @@ public class TaintedPath {
             fileLine = fileReader.readLine();
         }
     }
-
-    // TODO : New tests
-
-    public void sendUserFileGood5(Socket sock, String user) throws IOException {
-        BufferedReader filenameReader = new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
-        // GOOD: remove all ".." sequences and path separators from the filename
-        String filename = filenameReader.readLine().replaceAll("\\.", "").replaceAll("/", "");
-        BufferedReader fileReader = new BufferedReader(new FileReader(filename)); // GOOD
-        String fileLine = fileReader.readLine();
-        while(fileLine != null) {
-            sock.getOutputStream().write(fileLine.getBytes());
-            fileLine = fileReader.readLine();
-        }
-    }
-
-    public void sendUserFileGood6(Socket sock, String user) throws IOException {
-        BufferedReader filenameReader = new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
-        String filename = filenameReader.readLine();
-        // GOOD: remove all ".." sequences and path separators from the filename
-        filename = filename.replaceAll("\\.\\.|[/\\\\]", "");
-        BufferedReader fileReader = new BufferedReader(new FileReader(filename)); // GOOD
-        String fileLine = fileReader.readLine();
-        while(fileLine != null) {
-            sock.getOutputStream().write(fileLine.getBytes());
-            fileLine = fileReader.readLine();
-        }
-    }
-
-    public void sendUserFileGood7(Socket sock, String user) throws Exception {
-        BufferedReader filenameReader =
-                new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
-        String filename = filenameReader.readLine();
-
-        // GOOD: ensure that that /, \ and .. cannot possibly be in the payload
-        if (filename.matches("[0-9a-fA-F]{20,}")) {
-            final Path pathObject = FileSystems.getDefault().getPath(filename); // summary now, see https://github.com/github/codeql/commit/19cb7adb6db17a3131b7db93482abc6a0d93ceff#diff-4b91db1bd2a19ab607f83fbe858f0ceffd942d1fb246739c731112367c865f88L8
-
-            BufferedReader fileReader = new BufferedReader(new FileReader(pathObject.toString())); // GOOD
-            String fileLine = fileReader.readLine();
-            while (fileLine != null) {
-                sock.getOutputStream().write(fileLine.getBytes());
-                fileLine = fileReader.readLine();
-            }
-        }
-
-    }
-
 }

--- a/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
+++ b/java/ql/test/query-tests/security/CWE-022/semmle/tests/TaintedPath.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.FileSystems;
 
 public class TaintedPath {
     public void sendUserFile(Socket sock, String user) throws IOException {
@@ -86,4 +87,51 @@ public class TaintedPath {
             fileLine = fileReader.readLine();
         }
     }
+
+    // TODO : New tests
+
+    public void sendUserFileGood5(Socket sock, String user) throws IOException {
+        BufferedReader filenameReader = new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
+        // GOOD: remove all ".." sequences and path separators from the filename
+        String filename = filenameReader.readLine().replaceAll("\\.", "").replaceAll("/", "");
+        BufferedReader fileReader = new BufferedReader(new FileReader(filename)); // GOOD
+        String fileLine = fileReader.readLine();
+        while(fileLine != null) {
+            sock.getOutputStream().write(fileLine.getBytes());
+            fileLine = fileReader.readLine();
+        }
+    }
+
+    public void sendUserFileGood6(Socket sock, String user) throws IOException {
+        BufferedReader filenameReader = new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
+        String filename = filenameReader.readLine();
+        // GOOD: remove all ".." sequences and path separators from the filename
+        filename = filename.replaceAll("\\.\\.|[/\\\\]", "");
+        BufferedReader fileReader = new BufferedReader(new FileReader(filename)); // GOOD
+        String fileLine = fileReader.readLine();
+        while(fileLine != null) {
+            sock.getOutputStream().write(fileLine.getBytes());
+            fileLine = fileReader.readLine();
+        }
+    }
+
+    public void sendUserFileGood7(Socket sock, String user) throws Exception {
+        BufferedReader filenameReader =
+                new BufferedReader(new InputStreamReader(sock.getInputStream(), "UTF-8"));
+        String filename = filenameReader.readLine();
+
+        // GOOD: ensure that that /, \ and .. cannot possibly be in the payload
+        if (filename.matches("[0-9a-fA-F]{20,}")) {
+            final Path pathObject = FileSystems.getDefault().getPath(filename); // summary now, see https://github.com/github/codeql/commit/19cb7adb6db17a3131b7db93482abc6a0d93ceff#diff-4b91db1bd2a19ab607f83fbe858f0ceffd942d1fb246739c731112367c865f88L8
+
+            BufferedReader fileReader = new BufferedReader(new FileReader(pathObject.toString())); // GOOD
+            String fileLine = fileReader.readLine();
+            while (fileLine != null) {
+                sock.getOutputStream().write(fileLine.getBytes());
+                fileLine = fileReader.readLine();
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
### Description

Adds a path injection sanitizer for calls to `replace`, `replaceAll`, and `matches` that make sure `/`, `\`, `..` are not in the path.

### Consideration

- This PR does not attempt to handle all possible regexes, but instead heuristically covers some common cases. Let me know if you want any adjustments to the heuristics applied.
- Note that some of the QL is structured to optimize performance, such as the use of the predicates `isReplaceTarget`, `isReplaceAllTarget`, and `isMatchesTarget`.