### PR TITLE
C++: Fix regression from #18629

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/commons/Buffer.qll
+++ b/cpp/ql/lib/semmle/code/cpp/commons/Buffer.qll
@@ -49,7 +49,11 @@ private Class getRootType(FieldAccess fa) {
   exists(VariableAccess root |
     root = fa.getQualifier+() and
     not exists(root.getQualifier()) and
-    result = root.getUnspecifiedType()
+    // We strip the type because the root may be a pointer. For example `p` in:
+    // struct S { char buffer[10]; };
+    // S* p = ...;
+    // strcpy(p->buffer, "abc");
+    result = root.getUnspecifiedType().stripType()
   )
 }
 


### PR DESCRIPTION
In #18629 we fixed a source of FPs in buffer-overflow queries that look like:
```cpp
struct B { int c; };
struct A { B b; int x; };

A a;
memset(&a.b.c, 0, sizeof(A));
```

In order to compute the size of the buffer starting at `c` we compute the size of the "base" (in this case `A`) and subtract that from how far "we've gone" through the object.

This works fine on the above example, but when the code looks like:
```cpp
struct B { int c; };
struct A { B b; int x; };

A* a = ...;
memset(a->b.c, 0, sizeof(A));
```
we need to strip the pointer off `a` in order to get the `Class` type.

We already have tests that would have caught this, but CI didn't run on #18629 which is why it was missed