### PR TITLE
Rust: Higher order function model generation

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -871,6 +871,36 @@ final class TuplePositionContent extends Content, TTuplePositionContent {
   override Location getLocation() { result instanceof EmptyLocation }
 }
 
+/**
+ * A content for the index of an argument to at function call.
+ *
+ * Used by the model generator to create flow summaries for higher-order
+ * functions.
+ */
+final class FunctionCallArgumentContent extends Content, TFunctionCallArgumentContent {
+  private int pos;
+
+  FunctionCallArgumentContent() { this = TFunctionCallArgumentContent(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "function argument at " + pos }
+
+  override Location getLocation() { result instanceof EmptyLocation }
+}
+
+/**
+ * A content for the index of an argument to at function call.
+ *
+ * Used by the model generator to create flow summaries for higher-order
+ * functions.
+ */
+final class FunctionCallReturnContent extends Content, TFunctionCallReturnContent {
+  override string toString() { result = "function return" }
+
+  override Location getLocation() { result instanceof EmptyLocation }
+}
+
 /** Holds if `access` indexes a tuple at an index corresponding to `c`. */
 private predicate fieldTuplePositionContent(FieldExprCfgNode access, TuplePositionContent c) {
   access.getNameRef().getText().toInt() = c.getPosition()
@@ -1192,6 +1222,13 @@ module RustDataFlow implements InputSig<Location> {
         node2.asExpr() = deref
       )
       or
+      // Read from function return
+      exists(DataFlowCall call |
+        lambdaCall(call, _, node1) and
+        call = node2.(OutNode).getCall(TNormalReturnKind()) and
+        c instanceof FunctionCallReturnContent
+      )
+      or
       VariableCapture::readStep(node1, c, node2)
     )
     or
@@ -1271,6 +1308,13 @@ module RustDataFlow implements InputSig<Location> {
       c instanceof ReferenceContent and
       node1.asExpr() = ref.getExpr() and
       node2.asExpr() = ref
+    )
+    or
+    // Store in function argument
+    exists(DataFlowCall call, int i |
+      isArgumentNode(node1, call, TPositionalParameterPosition(i)) and
+      lambdaCall(call, _, node2.(PostUpdateNode).getPreUpdateNode()) and
+      c.(FunctionCallArgumentContent).getPosition() = i
     )
     or
     VariableCapture::storeStep(node1, c, node2)
@@ -1614,6 +1658,10 @@ private module Cached {
     } or
     TStructFieldContent(Struct s, string field) {
       field = s.getFieldList().(RecordFieldList).getAField().getName().getText()
+    } or
+    TFunctionCallReturnContent() or
+    TFunctionCallArgumentContent(int pos) {
+      pos in [0 .. any(CallExpr c).getArgList().getNumberOfArgs()]
     } or
     TCapturedVariableContent(VariableCapture::CapturedVariable v) or
     TReferenceContent()

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -890,7 +890,7 @@ final class FunctionCallArgumentContent extends Content, TFunctionCallArgumentCo
 }
 
 /**
- * A content for the index of an argument to at function call.
+ * A content for the return value of function call.
  *
  * Used by the model generator to create flow summaries for higher-order
  * functions.
@@ -1661,7 +1661,7 @@ private module Cached {
     } or
     TFunctionCallReturnContent() or
     TFunctionCallArgumentContent(int pos) {
-      pos in [0 .. any(CallExpr c).getArgList().getNumberOfArgs()]
+      pos in [0 .. any(CallExpr c).getArgList().getNumberOfArgs() - 1]
     } or
     TCapturedVariableContent(VariableCapture::CapturedVariable v) or
     TReferenceContent()

--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -51,7 +51,7 @@ module Input implements InputSig<Location, RustDataFlow> {
     override MethodCallExpr getCall() { result = call }
   }
 
-  RustDataFlow::ArgumentPosition callbackSelfParameterPosition() { none() }
+  RustDataFlow::ArgumentPosition callbackSelfParameterPosition() { result.isClosureSelf() }
 
   ReturnKind getStandardReturnValueKind() { result = TNormalReturnKind() }
 

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -603,6 +603,8 @@ storeStep
 | main.rs:414:41:414:67 | default_name | captured default_name | main.rs:414:41:414:67 | \|...\| ... |
 | main.rs:436:27:436:27 | 0 | Some | main.rs:436:22:436:28 | Some(...) |
 readStep
+| file://:0:0:0:0 | [summary param] 0 in lang:core::_::<crate::option::Option>::unwrap_or_else | function return | file://:0:0:0:0 | [summary] read: Argument[0].ReturnValue in lang:core::_::<crate::option::Option>::unwrap_or_else |
+| file://:0:0:0:0 | [summary param] 0 in lang:core::_::<crate::result::Result>::unwrap_or_else | function return | file://:0:0:0:0 | [summary] read: Argument[0].ReturnValue in lang:core::_::<crate::result::Result>::unwrap_or_else |
 | file://:0:0:0:0 | [summary param] self in lang:core::_::<crate::option::Option>::expect | Some | file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::option::Option::Some(0)] in lang:core::_::<crate::option::Option>::expect |
 | file://:0:0:0:0 | [summary param] self in lang:core::_::<crate::option::Option>::unwrap | Some | file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::option::Option::Some(0)] in lang:core::_::<crate::option::Option>::unwrap |
 | file://:0:0:0:0 | [summary param] self in lang:core::_::<crate::option::Option>::unwrap_or | Some | file://:0:0:0:0 | [summary] read: Argument[self].Variant[crate::option::Option::Some(0)] in lang:core::_::<crate::option::Option>::unwrap_or |

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -175,6 +175,34 @@ fn test_set_tuple_element() {
     sink(t.1); // $ hasValueFlow=11
 }
 
+// has a flow model
+pub fn apply<F>(n: i64, f: F) -> i64 where F : FnOnce(i64) -> i64 {
+    0
+}
+
+fn test_apply_flow_in() {
+    let s = source(83);
+    let f = |n| {
+        sink(n); // $ hasValueFlow=83
+        n + 3
+    };
+    apply(s, f);
+}
+
+fn test_apply_flow_out() {
+    let s = source(86);
+    let f = |n| if n != 0 { n } else { s };
+    let t = apply(34, f);
+    sink(t); // $ MISSING: hasValueFlow=86
+}
+
+fn test_apply_flow_through() {
+    let s = source(33);
+    let f = |n| if n != 0 { n } else { 0 };
+    let t = apply(s, f);
+    sink(t); // $ hasValueFlow=33
+}
+
 impl MyFieldEnum {
     // has a source model
     fn source(&self, i: i64) -> MyFieldEnum {

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -193,7 +193,7 @@ fn test_apply_flow_out() {
     let s = source(86);
     let f = |n| if n != 0 { n } else { s };
     let t = apply(34, f);
-    sink(t); // $ MISSING: hasValueFlow=86
+    sink(t); // $ hasValueFlow=86
 }
 
 fn test_apply_flow_through() {

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -6,16 +6,17 @@ models
 | 5 | Source: repo::test; crate::enum_source; test-source; ReturnValue.Variant[crate::MyFieldEnum::D::field_d] |
 | 6 | Source: repo::test; crate::simple_source; test-source; ReturnValue |
 | 7 | Summary: repo::test; crate::apply; Argument[0]; Argument[1].Parameter[0]; value |
-| 8 | Summary: repo::test; crate::coerce; Argument[0]; ReturnValue; taint |
-| 9 | Summary: repo::test; crate::get_array_element; Argument[0].Element; ReturnValue; value |
-| 10 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
-| 11 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
-| 12 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 13 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
-| 14 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 15 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
-| 16 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
-| 17 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
+| 8 | Summary: repo::test; crate::apply; Argument[1].ReturnValue; ReturnValue; value |
+| 9 | Summary: repo::test; crate::coerce; Argument[0]; ReturnValue; taint |
+| 10 | Summary: repo::test; crate::get_array_element; Argument[0].Element; ReturnValue; value |
+| 11 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
+| 12 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
+| 13 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 14 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
+| 15 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 16 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
+| 17 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
+| 18 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -25,7 +26,7 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:8 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:9 |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:13:40:21 | source(...) | main.rs:40:9:40:9 | s | provenance |  |
@@ -36,8 +37,8 @@ edges
 | main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:13 |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:13 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:14 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:14 |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
@@ -46,8 +47,8 @@ edges
 | main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:17 |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:17 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:18 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:18 |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
@@ -64,8 +65,8 @@ edges
 | main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:12 |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:12 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:13 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:13 |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
@@ -74,8 +75,8 @@ edges
 | main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:16 |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:16 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:17 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:17 |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
@@ -92,14 +93,14 @@ edges
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:10 |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:10 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:11 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:11 |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:9 |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:9 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:10 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:10 |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:148:9:148:9 | s | main.rs:149:33:149:33 | s | provenance |  |
@@ -110,8 +111,8 @@ edges
 | main.rs:149:9:149:11 | arr [element] | main.rs:150:10:150:12 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:14 |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:14 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:15 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:15 |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
@@ -124,8 +125,8 @@ edges
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:11 |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:11 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:12 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:12 |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
@@ -134,8 +135,8 @@ edges
 | main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:15 |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:15 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:16 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:16 |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:184:9:184:9 | s | main.rs:189:11:189:11 | s | provenance |  |
@@ -146,6 +147,22 @@ edges
 | main.rs:185:14:185:14 | ... | main.rs:186:14:186:14 | n | provenance |  |
 | main.rs:189:11:189:11 | s | main.rs:185:14:185:14 | ... | provenance | MaD:7 |
 | main.rs:189:11:189:11 | s | main.rs:185:14:185:14 | ... | provenance | MaD:7 |
+| main.rs:193:13:193:22 | source(...) | main.rs:195:23:195:23 | f [captured s] | provenance |  |
+| main.rs:193:13:193:22 | source(...) | main.rs:195:23:195:23 | f [captured s] | provenance |  |
+| main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | provenance |  |
+| main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | provenance |  |
+| main.rs:195:9:195:9 | t | main.rs:196:10:196:10 | t | provenance |  |
+| main.rs:195:9:195:9 | t | main.rs:196:10:196:10 | t | provenance |  |
+| main.rs:195:13:195:24 | apply(...) | main.rs:195:9:195:9 | t | provenance |  |
+| main.rs:195:13:195:24 | apply(...) | main.rs:195:9:195:9 | t | provenance |  |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | provenance | MaD:7 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | provenance | MaD:7 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | provenance | MaD:8 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | provenance | MaD:8 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:195:13:195:24 | apply(...) | provenance | MaD:7 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:195:13:195:24 | apply(...) | provenance | MaD:7 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:195:13:195:24 | apply(...) | provenance | MaD:8 |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:195:13:195:24 | apply(...) | provenance | MaD:8 |
 | main.rs:200:9:200:9 | s | main.rs:202:19:202:19 | s | provenance |  |
 | main.rs:200:9:200:9 | s | main.rs:202:19:202:19 | s | provenance |  |
 | main.rs:200:13:200:22 | source(...) | main.rs:200:9:200:9 | s | provenance |  |
@@ -369,6 +386,20 @@ nodes
 | main.rs:186:14:186:14 | n | semmle.label | n |
 | main.rs:189:11:189:11 | s | semmle.label | s |
 | main.rs:189:11:189:11 | s | semmle.label | s |
+| main.rs:193:13:193:22 | source(...) | semmle.label | source(...) |
+| main.rs:193:13:193:22 | source(...) | semmle.label | source(...) |
+| main.rs:194:17:194:42 | if ... {...} else {...} | semmle.label | if ... {...} else {...} |
+| main.rs:194:17:194:42 | if ... {...} else {...} | semmle.label | if ... {...} else {...} |
+| main.rs:194:40:194:40 | s | semmle.label | s |
+| main.rs:194:40:194:40 | s | semmle.label | s |
+| main.rs:195:9:195:9 | t | semmle.label | t |
+| main.rs:195:9:195:9 | t | semmle.label | t |
+| main.rs:195:13:195:24 | apply(...) | semmle.label | apply(...) |
+| main.rs:195:13:195:24 | apply(...) | semmle.label | apply(...) |
+| main.rs:195:23:195:23 | f [captured s] | semmle.label | f [captured s] |
+| main.rs:195:23:195:23 | f [captured s] | semmle.label | f [captured s] |
+| main.rs:196:10:196:10 | t | semmle.label | t |
+| main.rs:196:10:196:10 | t | semmle.label | t |
 | main.rs:200:9:200:9 | s | semmle.label | s |
 | main.rs:200:9:200:9 | s | semmle.label | s |
 | main.rs:200:13:200:22 | source(...) | semmle.label | source(...) |
@@ -454,6 +485,8 @@ nodes
 | main.rs:268:17:268:17 | s | semmle.label | s |
 | main.rs:268:17:268:17 | s | semmle.label | s |
 subpaths
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
+| main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
 | main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | main.rs:202:13:202:23 | apply(...) |
 | main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | main.rs:202:13:202:23 | apply(...) |
 testFailures
@@ -482,6 +515,8 @@ invalidSpecComponent
 | main.rs:175:10:175:12 | t.1 | main.rs:172:13:172:22 | source(...) | main.rs:175:10:175:12 | t.1 | $@ | main.rs:172:13:172:22 | source(...) | source(...) |
 | main.rs:186:14:186:14 | n | main.rs:184:13:184:22 | source(...) | main.rs:186:14:186:14 | n | $@ | main.rs:184:13:184:22 | source(...) | source(...) |
 | main.rs:186:14:186:14 | n | main.rs:184:13:184:22 | source(...) | main.rs:186:14:186:14 | n | $@ | main.rs:184:13:184:22 | source(...) | source(...) |
+| main.rs:196:10:196:10 | t | main.rs:193:13:193:22 | source(...) | main.rs:196:10:196:10 | t | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
+| main.rs:196:10:196:10 | t | main.rs:193:13:193:22 | source(...) | main.rs:196:10:196:10 | t | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
 | main.rs:225:47:225:47 | i | main.rs:222:13:222:23 | enum_source | main.rs:225:47:225:47 | i | $@ | main.rs:222:13:222:23 | enum_source | enum_source |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -5,16 +5,17 @@ models
 | 4 | Source: repo::test; <crate::MyFieldEnum>::source; test-source; ReturnValue.Variant[crate::MyFieldEnum::C::field_c] |
 | 5 | Source: repo::test; crate::enum_source; test-source; ReturnValue.Variant[crate::MyFieldEnum::D::field_d] |
 | 6 | Source: repo::test; crate::simple_source; test-source; ReturnValue |
-| 7 | Summary: repo::test; crate::coerce; Argument[0]; ReturnValue; taint |
-| 8 | Summary: repo::test; crate::get_array_element; Argument[0].Element; ReturnValue; value |
-| 9 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
-| 10 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
-| 11 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 12 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
-| 13 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 14 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
-| 15 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
-| 16 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
+| 7 | Summary: repo::test; crate::apply; Argument[0]; Argument[1].Parameter[0]; value |
+| 8 | Summary: repo::test; crate::coerce; Argument[0]; ReturnValue; taint |
+| 9 | Summary: repo::test; crate::get_array_element; Argument[0].Element; ReturnValue; value |
+| 10 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
+| 11 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
+| 12 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 13 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
+| 14 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 15 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
+| 16 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
+| 17 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -24,7 +25,7 @@ edges
 | main.rs:16:19:16:19 | s | main.rs:16:10:16:20 | identity(...) | provenance | QL |
 | main.rs:25:9:25:9 | s | main.rs:26:17:26:17 | s | provenance |  |
 | main.rs:25:13:25:22 | source(...) | main.rs:25:9:25:9 | s | provenance |  |
-| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:7 |
+| main.rs:26:17:26:17 | s | main.rs:26:10:26:18 | coerce(...) | provenance | MaD:8 |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:9:40:9 | s | main.rs:41:27:41:27 | s | provenance |  |
 | main.rs:40:13:40:21 | source(...) | main.rs:40:9:40:9 | s | provenance |  |
@@ -35,8 +36,8 @@ edges
 | main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:12 |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:12 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:13 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:13 |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
@@ -45,8 +46,8 @@ edges
 | main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:16 |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:16 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:17 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:17 |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
@@ -63,8 +64,8 @@ edges
 | main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:11 |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:11 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:12 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:12 |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
@@ -73,8 +74,8 @@ edges
 | main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:15 |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:15 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:16 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:16 |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
@@ -91,14 +92,14 @@ edges
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:9 |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:9 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:10 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:10 |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:8 |
-| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:8 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:9 |
+| main.rs:139:28:139:30 | [...] [element] | main.rs:139:10:139:31 | get_array_element(...) | provenance | MaD:9 |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:139:29:139:29 | s | main.rs:139:28:139:30 | [...] [element] | provenance |  |
 | main.rs:148:9:148:9 | s | main.rs:149:33:149:33 | s | provenance |  |
@@ -109,8 +110,8 @@ edges
 | main.rs:149:9:149:11 | arr [element] | main.rs:150:10:150:12 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:13 |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:13 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:14 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:14 |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
@@ -123,8 +124,8 @@ edges
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:10 |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:10 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:11 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:11 |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
@@ -133,66 +134,88 @@ edges
 | main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:14 |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:14 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:15 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:15 |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
-| main.rs:194:9:194:9 | s [D] | main.rs:195:11:195:11 | s [D] | provenance |  |
-| main.rs:194:9:194:9 | s [D] | main.rs:195:11:195:11 | s [D] | provenance |  |
-| main.rs:194:13:194:23 | enum_source | main.rs:194:13:194:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:194:13:194:23 | enum_source | main.rs:194:13:194:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:194:13:194:27 | enum_source(...) [D] | main.rs:194:9:194:9 | s [D] | provenance |  |
-| main.rs:194:13:194:27 | enum_source(...) [D] | main.rs:194:9:194:9 | s [D] | provenance |  |
-| main.rs:195:11:195:11 | s [D] | main.rs:197:9:197:37 | ...::D {...} [D] | provenance |  |
-| main.rs:195:11:195:11 | s [D] | main.rs:197:9:197:37 | ...::D {...} [D] | provenance |  |
-| main.rs:197:9:197:37 | ...::D {...} [D] | main.rs:197:35:197:35 | i | provenance |  |
-| main.rs:197:9:197:37 | ...::D {...} [D] | main.rs:197:35:197:35 | i | provenance |  |
-| main.rs:197:35:197:35 | i | main.rs:197:47:197:47 | i | provenance |  |
-| main.rs:197:35:197:35 | i | main.rs:197:47:197:47 | i | provenance |  |
-| main.rs:203:9:203:9 | s [C] | main.rs:204:11:204:11 | s [C] | provenance |  |
-| main.rs:203:9:203:9 | s [C] | main.rs:204:11:204:11 | s [C] | provenance |  |
-| main.rs:203:13:203:24 | e.source(...) [C] | main.rs:203:9:203:9 | s [C] | provenance |  |
-| main.rs:203:13:203:24 | e.source(...) [C] | main.rs:203:9:203:9 | s [C] | provenance |  |
-| main.rs:203:15:203:20 | source | main.rs:203:13:203:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:203:15:203:20 | source | main.rs:203:13:203:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:204:11:204:11 | s [C] | main.rs:205:9:205:37 | ...::C {...} [C] | provenance |  |
-| main.rs:204:11:204:11 | s [C] | main.rs:205:9:205:37 | ...::C {...} [C] | provenance |  |
-| main.rs:205:9:205:37 | ...::C {...} [C] | main.rs:205:35:205:35 | i | provenance |  |
-| main.rs:205:9:205:37 | ...::C {...} [C] | main.rs:205:35:205:35 | i | provenance |  |
-| main.rs:205:35:205:35 | i | main.rs:205:47:205:47 | i | provenance |  |
-| main.rs:205:35:205:35 | i | main.rs:205:47:205:47 | i | provenance |  |
-| main.rs:214:9:214:9 | s | main.rs:215:41:215:41 | s | provenance |  |
-| main.rs:214:9:214:9 | s | main.rs:215:41:215:41 | s | provenance |  |
-| main.rs:214:13:214:22 | source(...) | main.rs:214:9:214:9 | s | provenance |  |
-| main.rs:214:13:214:22 | source(...) | main.rs:214:9:214:9 | s | provenance |  |
-| main.rs:215:15:215:43 | ...::C {...} [C] | main.rs:215:5:215:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:215:15:215:43 | ...::C {...} [C] | main.rs:215:5:215:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:215:41:215:41 | s | main.rs:215:15:215:43 | ...::C {...} [C] | provenance |  |
-| main.rs:215:41:215:41 | s | main.rs:215:15:215:43 | ...::C {...} [C] | provenance |  |
-| main.rs:220:9:220:9 | s | main.rs:221:39:221:39 | s | provenance |  |
-| main.rs:220:9:220:9 | s | main.rs:221:39:221:39 | s | provenance |  |
-| main.rs:220:13:220:22 | source(...) | main.rs:220:9:220:9 | s | provenance |  |
-| main.rs:220:13:220:22 | source(...) | main.rs:220:9:220:9 | s | provenance |  |
-| main.rs:221:9:221:9 | e [D] | main.rs:222:5:222:5 | e [D] | provenance |  |
-| main.rs:221:9:221:9 | e [D] | main.rs:222:5:222:5 | e [D] | provenance |  |
-| main.rs:221:13:221:41 | ...::D {...} [D] | main.rs:221:9:221:9 | e [D] | provenance |  |
-| main.rs:221:13:221:41 | ...::D {...} [D] | main.rs:221:9:221:9 | e [D] | provenance |  |
-| main.rs:221:39:221:39 | s | main.rs:221:13:221:41 | ...::D {...} [D] | provenance |  |
-| main.rs:221:39:221:39 | s | main.rs:221:13:221:41 | ...::D {...} [D] | provenance |  |
-| main.rs:222:5:222:5 | e [D] | main.rs:222:7:222:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:222:5:222:5 | e [D] | main.rs:222:7:222:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:231:9:231:9 | s | main.rs:232:10:232:10 | s | provenance |  |
-| main.rs:231:9:231:9 | s | main.rs:232:10:232:10 | s | provenance |  |
-| main.rs:231:13:231:25 | simple_source | main.rs:231:13:231:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:231:13:231:25 | simple_source | main.rs:231:13:231:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:231:13:231:29 | simple_source(...) | main.rs:231:9:231:9 | s | provenance |  |
-| main.rs:231:13:231:29 | simple_source(...) | main.rs:231:9:231:9 | s | provenance |  |
-| main.rs:239:9:239:9 | s | main.rs:240:17:240:17 | s | provenance |  |
-| main.rs:239:9:239:9 | s | main.rs:240:17:240:17 | s | provenance |  |
-| main.rs:239:13:239:22 | source(...) | main.rs:239:9:239:9 | s | provenance |  |
-| main.rs:239:13:239:22 | source(...) | main.rs:239:9:239:9 | s | provenance |  |
-| main.rs:240:17:240:17 | s | main.rs:240:5:240:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:240:17:240:17 | s | main.rs:240:5:240:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:184:9:184:9 | s | main.rs:189:11:189:11 | s | provenance |  |
+| main.rs:184:9:184:9 | s | main.rs:189:11:189:11 | s | provenance |  |
+| main.rs:184:13:184:22 | source(...) | main.rs:184:9:184:9 | s | provenance |  |
+| main.rs:184:13:184:22 | source(...) | main.rs:184:9:184:9 | s | provenance |  |
+| main.rs:185:14:185:14 | ... | main.rs:186:14:186:14 | n | provenance |  |
+| main.rs:185:14:185:14 | ... | main.rs:186:14:186:14 | n | provenance |  |
+| main.rs:189:11:189:11 | s | main.rs:185:14:185:14 | ... | provenance | MaD:7 |
+| main.rs:189:11:189:11 | s | main.rs:185:14:185:14 | ... | provenance | MaD:7 |
+| main.rs:200:9:200:9 | s | main.rs:202:19:202:19 | s | provenance |  |
+| main.rs:200:9:200:9 | s | main.rs:202:19:202:19 | s | provenance |  |
+| main.rs:200:13:200:22 | source(...) | main.rs:200:9:200:9 | s | provenance |  |
+| main.rs:200:13:200:22 | source(...) | main.rs:200:9:200:9 | s | provenance |  |
+| main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | provenance |  |
+| main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | provenance |  |
+| main.rs:202:9:202:9 | t | main.rs:203:10:203:10 | t | provenance |  |
+| main.rs:202:9:202:9 | t | main.rs:203:10:203:10 | t | provenance |  |
+| main.rs:202:13:202:23 | apply(...) | main.rs:202:9:202:9 | t | provenance |  |
+| main.rs:202:13:202:23 | apply(...) | main.rs:202:9:202:9 | t | provenance |  |
+| main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | provenance | MaD:7 |
+| main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | provenance | MaD:7 |
+| main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
+| main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
+| main.rs:222:9:222:9 | s [D] | main.rs:223:11:223:11 | s [D] | provenance |  |
+| main.rs:222:9:222:9 | s [D] | main.rs:223:11:223:11 | s [D] | provenance |  |
+| main.rs:222:13:222:23 | enum_source | main.rs:222:13:222:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:222:13:222:23 | enum_source | main.rs:222:13:222:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:222:13:222:27 | enum_source(...) [D] | main.rs:222:9:222:9 | s [D] | provenance |  |
+| main.rs:222:13:222:27 | enum_source(...) [D] | main.rs:222:9:222:9 | s [D] | provenance |  |
+| main.rs:223:11:223:11 | s [D] | main.rs:225:9:225:37 | ...::D {...} [D] | provenance |  |
+| main.rs:223:11:223:11 | s [D] | main.rs:225:9:225:37 | ...::D {...} [D] | provenance |  |
+| main.rs:225:9:225:37 | ...::D {...} [D] | main.rs:225:35:225:35 | i | provenance |  |
+| main.rs:225:9:225:37 | ...::D {...} [D] | main.rs:225:35:225:35 | i | provenance |  |
+| main.rs:225:35:225:35 | i | main.rs:225:47:225:47 | i | provenance |  |
+| main.rs:225:35:225:35 | i | main.rs:225:47:225:47 | i | provenance |  |
+| main.rs:231:9:231:9 | s [C] | main.rs:232:11:232:11 | s [C] | provenance |  |
+| main.rs:231:9:231:9 | s [C] | main.rs:232:11:232:11 | s [C] | provenance |  |
+| main.rs:231:13:231:24 | e.source(...) [C] | main.rs:231:9:231:9 | s [C] | provenance |  |
+| main.rs:231:13:231:24 | e.source(...) [C] | main.rs:231:9:231:9 | s [C] | provenance |  |
+| main.rs:231:15:231:20 | source | main.rs:231:13:231:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:231:15:231:20 | source | main.rs:231:13:231:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:232:11:232:11 | s [C] | main.rs:233:9:233:37 | ...::C {...} [C] | provenance |  |
+| main.rs:232:11:232:11 | s [C] | main.rs:233:9:233:37 | ...::C {...} [C] | provenance |  |
+| main.rs:233:9:233:37 | ...::C {...} [C] | main.rs:233:35:233:35 | i | provenance |  |
+| main.rs:233:9:233:37 | ...::C {...} [C] | main.rs:233:35:233:35 | i | provenance |  |
+| main.rs:233:35:233:35 | i | main.rs:233:47:233:47 | i | provenance |  |
+| main.rs:233:35:233:35 | i | main.rs:233:47:233:47 | i | provenance |  |
+| main.rs:242:9:242:9 | s | main.rs:243:41:243:41 | s | provenance |  |
+| main.rs:242:9:242:9 | s | main.rs:243:41:243:41 | s | provenance |  |
+| main.rs:242:13:242:22 | source(...) | main.rs:242:9:242:9 | s | provenance |  |
+| main.rs:242:13:242:22 | source(...) | main.rs:242:9:242:9 | s | provenance |  |
+| main.rs:243:15:243:43 | ...::C {...} [C] | main.rs:243:5:243:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:243:15:243:43 | ...::C {...} [C] | main.rs:243:5:243:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:243:41:243:41 | s | main.rs:243:15:243:43 | ...::C {...} [C] | provenance |  |
+| main.rs:243:41:243:41 | s | main.rs:243:15:243:43 | ...::C {...} [C] | provenance |  |
+| main.rs:248:9:248:9 | s | main.rs:249:39:249:39 | s | provenance |  |
+| main.rs:248:9:248:9 | s | main.rs:249:39:249:39 | s | provenance |  |
+| main.rs:248:13:248:22 | source(...) | main.rs:248:9:248:9 | s | provenance |  |
+| main.rs:248:13:248:22 | source(...) | main.rs:248:9:248:9 | s | provenance |  |
+| main.rs:249:9:249:9 | e [D] | main.rs:250:5:250:5 | e [D] | provenance |  |
+| main.rs:249:9:249:9 | e [D] | main.rs:250:5:250:5 | e [D] | provenance |  |
+| main.rs:249:13:249:41 | ...::D {...} [D] | main.rs:249:9:249:9 | e [D] | provenance |  |
+| main.rs:249:13:249:41 | ...::D {...} [D] | main.rs:249:9:249:9 | e [D] | provenance |  |
+| main.rs:249:39:249:39 | s | main.rs:249:13:249:41 | ...::D {...} [D] | provenance |  |
+| main.rs:249:39:249:39 | s | main.rs:249:13:249:41 | ...::D {...} [D] | provenance |  |
+| main.rs:250:5:250:5 | e [D] | main.rs:250:7:250:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:250:5:250:5 | e [D] | main.rs:250:7:250:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:259:9:259:9 | s | main.rs:260:10:260:10 | s | provenance |  |
+| main.rs:259:9:259:9 | s | main.rs:260:10:260:10 | s | provenance |  |
+| main.rs:259:13:259:25 | simple_source | main.rs:259:13:259:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:259:13:259:25 | simple_source | main.rs:259:13:259:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:259:13:259:29 | simple_source(...) | main.rs:259:9:259:9 | s | provenance |  |
+| main.rs:259:13:259:29 | simple_source(...) | main.rs:259:9:259:9 | s | provenance |  |
+| main.rs:267:9:267:9 | s | main.rs:268:17:268:17 | s | provenance |  |
+| main.rs:267:9:267:9 | s | main.rs:268:17:268:17 | s | provenance |  |
+| main.rs:267:13:267:22 | source(...) | main.rs:267:9:267:9 | s | provenance |  |
+| main.rs:267:13:267:22 | source(...) | main.rs:267:9:267:9 | s | provenance |  |
+| main.rs:268:17:268:17 | s | main.rs:268:5:268:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:268:17:268:17 | s | main.rs:268:5:268:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -336,75 +359,103 @@ nodes
 | main.rs:175:10:175:10 | t [tuple.1] | semmle.label | t [tuple.1] |
 | main.rs:175:10:175:12 | t.1 | semmle.label | t.1 |
 | main.rs:175:10:175:12 | t.1 | semmle.label | t.1 |
-| main.rs:194:9:194:9 | s [D] | semmle.label | s [D] |
-| main.rs:194:9:194:9 | s [D] | semmle.label | s [D] |
-| main.rs:194:13:194:23 | enum_source | semmle.label | enum_source |
-| main.rs:194:13:194:23 | enum_source | semmle.label | enum_source |
-| main.rs:194:13:194:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:194:13:194:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:195:11:195:11 | s [D] | semmle.label | s [D] |
-| main.rs:195:11:195:11 | s [D] | semmle.label | s [D] |
-| main.rs:197:9:197:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:197:9:197:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:197:35:197:35 | i | semmle.label | i |
-| main.rs:197:35:197:35 | i | semmle.label | i |
-| main.rs:197:47:197:47 | i | semmle.label | i |
-| main.rs:197:47:197:47 | i | semmle.label | i |
-| main.rs:203:9:203:9 | s [C] | semmle.label | s [C] |
-| main.rs:203:9:203:9 | s [C] | semmle.label | s [C] |
-| main.rs:203:13:203:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:203:13:203:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:203:15:203:20 | source | semmle.label | source |
-| main.rs:203:15:203:20 | source | semmle.label | source |
-| main.rs:204:11:204:11 | s [C] | semmle.label | s [C] |
-| main.rs:204:11:204:11 | s [C] | semmle.label | s [C] |
-| main.rs:205:9:205:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:205:9:205:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:205:35:205:35 | i | semmle.label | i |
-| main.rs:205:35:205:35 | i | semmle.label | i |
-| main.rs:205:47:205:47 | i | semmle.label | i |
-| main.rs:205:47:205:47 | i | semmle.label | i |
-| main.rs:214:9:214:9 | s | semmle.label | s |
-| main.rs:214:9:214:9 | s | semmle.label | s |
-| main.rs:214:13:214:22 | source(...) | semmle.label | source(...) |
-| main.rs:214:13:214:22 | source(...) | semmle.label | source(...) |
-| main.rs:215:5:215:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:215:5:215:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:215:15:215:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:215:15:215:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:215:41:215:41 | s | semmle.label | s |
-| main.rs:215:41:215:41 | s | semmle.label | s |
-| main.rs:220:9:220:9 | s | semmle.label | s |
-| main.rs:220:9:220:9 | s | semmle.label | s |
-| main.rs:220:13:220:22 | source(...) | semmle.label | source(...) |
-| main.rs:220:13:220:22 | source(...) | semmle.label | source(...) |
-| main.rs:221:9:221:9 | e [D] | semmle.label | e [D] |
-| main.rs:221:9:221:9 | e [D] | semmle.label | e [D] |
-| main.rs:221:13:221:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:221:13:221:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:221:39:221:39 | s | semmle.label | s |
-| main.rs:221:39:221:39 | s | semmle.label | s |
-| main.rs:222:5:222:5 | e [D] | semmle.label | e [D] |
-| main.rs:222:5:222:5 | e [D] | semmle.label | e [D] |
-| main.rs:222:7:222:10 | sink | semmle.label | sink |
-| main.rs:222:7:222:10 | sink | semmle.label | sink |
-| main.rs:231:9:231:9 | s | semmle.label | s |
-| main.rs:231:9:231:9 | s | semmle.label | s |
-| main.rs:231:13:231:25 | simple_source | semmle.label | simple_source |
-| main.rs:231:13:231:25 | simple_source | semmle.label | simple_source |
-| main.rs:231:13:231:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:231:13:231:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:232:10:232:10 | s | semmle.label | s |
-| main.rs:232:10:232:10 | s | semmle.label | s |
-| main.rs:239:9:239:9 | s | semmle.label | s |
-| main.rs:239:9:239:9 | s | semmle.label | s |
-| main.rs:239:13:239:22 | source(...) | semmle.label | source(...) |
-| main.rs:239:13:239:22 | source(...) | semmle.label | source(...) |
-| main.rs:240:5:240:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:240:5:240:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:240:17:240:17 | s | semmle.label | s |
-| main.rs:240:17:240:17 | s | semmle.label | s |
+| main.rs:184:9:184:9 | s | semmle.label | s |
+| main.rs:184:9:184:9 | s | semmle.label | s |
+| main.rs:184:13:184:22 | source(...) | semmle.label | source(...) |
+| main.rs:184:13:184:22 | source(...) | semmle.label | source(...) |
+| main.rs:185:14:185:14 | ... | semmle.label | ... |
+| main.rs:185:14:185:14 | ... | semmle.label | ... |
+| main.rs:186:14:186:14 | n | semmle.label | n |
+| main.rs:186:14:186:14 | n | semmle.label | n |
+| main.rs:189:11:189:11 | s | semmle.label | s |
+| main.rs:189:11:189:11 | s | semmle.label | s |
+| main.rs:200:9:200:9 | s | semmle.label | s |
+| main.rs:200:9:200:9 | s | semmle.label | s |
+| main.rs:200:13:200:22 | source(...) | semmle.label | source(...) |
+| main.rs:200:13:200:22 | source(...) | semmle.label | source(...) |
+| main.rs:201:14:201:14 | ... | semmle.label | ... |
+| main.rs:201:14:201:14 | ... | semmle.label | ... |
+| main.rs:201:17:201:42 | if ... {...} else {...} | semmle.label | if ... {...} else {...} |
+| main.rs:201:17:201:42 | if ... {...} else {...} | semmle.label | if ... {...} else {...} |
+| main.rs:202:9:202:9 | t | semmle.label | t |
+| main.rs:202:9:202:9 | t | semmle.label | t |
+| main.rs:202:13:202:23 | apply(...) | semmle.label | apply(...) |
+| main.rs:202:13:202:23 | apply(...) | semmle.label | apply(...) |
+| main.rs:202:19:202:19 | s | semmle.label | s |
+| main.rs:202:19:202:19 | s | semmle.label | s |
+| main.rs:203:10:203:10 | t | semmle.label | t |
+| main.rs:203:10:203:10 | t | semmle.label | t |
+| main.rs:222:9:222:9 | s [D] | semmle.label | s [D] |
+| main.rs:222:9:222:9 | s [D] | semmle.label | s [D] |
+| main.rs:222:13:222:23 | enum_source | semmle.label | enum_source |
+| main.rs:222:13:222:23 | enum_source | semmle.label | enum_source |
+| main.rs:222:13:222:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:222:13:222:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:223:11:223:11 | s [D] | semmle.label | s [D] |
+| main.rs:223:11:223:11 | s [D] | semmle.label | s [D] |
+| main.rs:225:9:225:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:225:9:225:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:225:35:225:35 | i | semmle.label | i |
+| main.rs:225:35:225:35 | i | semmle.label | i |
+| main.rs:225:47:225:47 | i | semmle.label | i |
+| main.rs:225:47:225:47 | i | semmle.label | i |
+| main.rs:231:9:231:9 | s [C] | semmle.label | s [C] |
+| main.rs:231:9:231:9 | s [C] | semmle.label | s [C] |
+| main.rs:231:13:231:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:231:13:231:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:231:15:231:20 | source | semmle.label | source |
+| main.rs:231:15:231:20 | source | semmle.label | source |
+| main.rs:232:11:232:11 | s [C] | semmle.label | s [C] |
+| main.rs:232:11:232:11 | s [C] | semmle.label | s [C] |
+| main.rs:233:9:233:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:233:9:233:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:233:35:233:35 | i | semmle.label | i |
+| main.rs:233:35:233:35 | i | semmle.label | i |
+| main.rs:233:47:233:47 | i | semmle.label | i |
+| main.rs:233:47:233:47 | i | semmle.label | i |
+| main.rs:242:9:242:9 | s | semmle.label | s |
+| main.rs:242:9:242:9 | s | semmle.label | s |
+| main.rs:242:13:242:22 | source(...) | semmle.label | source(...) |
+| main.rs:242:13:242:22 | source(...) | semmle.label | source(...) |
+| main.rs:243:5:243:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:243:5:243:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:243:15:243:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:243:15:243:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:243:41:243:41 | s | semmle.label | s |
+| main.rs:243:41:243:41 | s | semmle.label | s |
+| main.rs:248:9:248:9 | s | semmle.label | s |
+| main.rs:248:9:248:9 | s | semmle.label | s |
+| main.rs:248:13:248:22 | source(...) | semmle.label | source(...) |
+| main.rs:248:13:248:22 | source(...) | semmle.label | source(...) |
+| main.rs:249:9:249:9 | e [D] | semmle.label | e [D] |
+| main.rs:249:9:249:9 | e [D] | semmle.label | e [D] |
+| main.rs:249:13:249:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:249:13:249:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:249:39:249:39 | s | semmle.label | s |
+| main.rs:249:39:249:39 | s | semmle.label | s |
+| main.rs:250:5:250:5 | e [D] | semmle.label | e [D] |
+| main.rs:250:5:250:5 | e [D] | semmle.label | e [D] |
+| main.rs:250:7:250:10 | sink | semmle.label | sink |
+| main.rs:250:7:250:10 | sink | semmle.label | sink |
+| main.rs:259:9:259:9 | s | semmle.label | s |
+| main.rs:259:9:259:9 | s | semmle.label | s |
+| main.rs:259:13:259:25 | simple_source | semmle.label | simple_source |
+| main.rs:259:13:259:25 | simple_source | semmle.label | simple_source |
+| main.rs:259:13:259:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:259:13:259:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:260:10:260:10 | s | semmle.label | s |
+| main.rs:260:10:260:10 | s | semmle.label | s |
+| main.rs:267:9:267:9 | s | semmle.label | s |
+| main.rs:267:9:267:9 | s | semmle.label | s |
+| main.rs:267:13:267:22 | source(...) | semmle.label | source(...) |
+| main.rs:267:13:267:22 | source(...) | semmle.label | source(...) |
+| main.rs:268:5:268:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:268:5:268:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:268:17:268:17 | s | semmle.label | s |
+| main.rs:268:17:268:17 | s | semmle.label | s |
 subpaths
+| main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | main.rs:202:13:202:23 | apply(...) |
+| main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | main.rs:201:17:201:42 | if ... {...} else {...} | main.rs:202:13:202:23 | apply(...) |
 testFailures
 invalidSpecComponent
 #select
@@ -429,15 +480,19 @@ invalidSpecComponent
 | main.rs:161:10:161:29 | get_tuple_element(...) | main.rs:159:13:159:22 | source(...) | main.rs:161:10:161:29 | get_tuple_element(...) | $@ | main.rs:159:13:159:22 | source(...) | source(...) |
 | main.rs:175:10:175:12 | t.1 | main.rs:172:13:172:22 | source(...) | main.rs:175:10:175:12 | t.1 | $@ | main.rs:172:13:172:22 | source(...) | source(...) |
 | main.rs:175:10:175:12 | t.1 | main.rs:172:13:172:22 | source(...) | main.rs:175:10:175:12 | t.1 | $@ | main.rs:172:13:172:22 | source(...) | source(...) |
-| main.rs:197:47:197:47 | i | main.rs:194:13:194:23 | enum_source | main.rs:197:47:197:47 | i | $@ | main.rs:194:13:194:23 | enum_source | enum_source |
-| main.rs:197:47:197:47 | i | main.rs:194:13:194:23 | enum_source | main.rs:197:47:197:47 | i | $@ | main.rs:194:13:194:23 | enum_source | enum_source |
-| main.rs:205:47:205:47 | i | main.rs:203:15:203:20 | source | main.rs:205:47:205:47 | i | $@ | main.rs:203:15:203:20 | source | source |
-| main.rs:205:47:205:47 | i | main.rs:203:15:203:20 | source | main.rs:205:47:205:47 | i | $@ | main.rs:203:15:203:20 | source | source |
-| main.rs:215:5:215:13 | enum_sink | main.rs:214:13:214:22 | source(...) | main.rs:215:5:215:13 | enum_sink | $@ | main.rs:214:13:214:22 | source(...) | source(...) |
-| main.rs:215:5:215:13 | enum_sink | main.rs:214:13:214:22 | source(...) | main.rs:215:5:215:13 | enum_sink | $@ | main.rs:214:13:214:22 | source(...) | source(...) |
-| main.rs:222:7:222:10 | sink | main.rs:220:13:220:22 | source(...) | main.rs:222:7:222:10 | sink | $@ | main.rs:220:13:220:22 | source(...) | source(...) |
-| main.rs:222:7:222:10 | sink | main.rs:220:13:220:22 | source(...) | main.rs:222:7:222:10 | sink | $@ | main.rs:220:13:220:22 | source(...) | source(...) |
-| main.rs:232:10:232:10 | s | main.rs:231:13:231:25 | simple_source | main.rs:232:10:232:10 | s | $@ | main.rs:231:13:231:25 | simple_source | simple_source |
-| main.rs:232:10:232:10 | s | main.rs:231:13:231:25 | simple_source | main.rs:232:10:232:10 | s | $@ | main.rs:231:13:231:25 | simple_source | simple_source |
-| main.rs:240:5:240:15 | simple_sink | main.rs:239:13:239:22 | source(...) | main.rs:240:5:240:15 | simple_sink | $@ | main.rs:239:13:239:22 | source(...) | source(...) |
-| main.rs:240:5:240:15 | simple_sink | main.rs:239:13:239:22 | source(...) | main.rs:240:5:240:15 | simple_sink | $@ | main.rs:239:13:239:22 | source(...) | source(...) |
+| main.rs:186:14:186:14 | n | main.rs:184:13:184:22 | source(...) | main.rs:186:14:186:14 | n | $@ | main.rs:184:13:184:22 | source(...) | source(...) |
+| main.rs:186:14:186:14 | n | main.rs:184:13:184:22 | source(...) | main.rs:186:14:186:14 | n | $@ | main.rs:184:13:184:22 | source(...) | source(...) |
+| main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
+| main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
+| main.rs:225:47:225:47 | i | main.rs:222:13:222:23 | enum_source | main.rs:225:47:225:47 | i | $@ | main.rs:222:13:222:23 | enum_source | enum_source |
+| main.rs:225:47:225:47 | i | main.rs:222:13:222:23 | enum_source | main.rs:225:47:225:47 | i | $@ | main.rs:222:13:222:23 | enum_source | enum_source |
+| main.rs:233:47:233:47 | i | main.rs:231:15:231:20 | source | main.rs:233:47:233:47 | i | $@ | main.rs:231:15:231:20 | source | source |
+| main.rs:233:47:233:47 | i | main.rs:231:15:231:20 | source | main.rs:233:47:233:47 | i | $@ | main.rs:231:15:231:20 | source | source |
+| main.rs:243:5:243:13 | enum_sink | main.rs:242:13:242:22 | source(...) | main.rs:243:5:243:13 | enum_sink | $@ | main.rs:242:13:242:22 | source(...) | source(...) |
+| main.rs:243:5:243:13 | enum_sink | main.rs:242:13:242:22 | source(...) | main.rs:243:5:243:13 | enum_sink | $@ | main.rs:242:13:242:22 | source(...) | source(...) |
+| main.rs:250:7:250:10 | sink | main.rs:248:13:248:22 | source(...) | main.rs:250:7:250:10 | sink | $@ | main.rs:248:13:248:22 | source(...) | source(...) |
+| main.rs:250:7:250:10 | sink | main.rs:248:13:248:22 | source(...) | main.rs:250:7:250:10 | sink | $@ | main.rs:248:13:248:22 | source(...) | source(...) |
+| main.rs:260:10:260:10 | s | main.rs:259:13:259:25 | simple_source | main.rs:260:10:260:10 | s | $@ | main.rs:259:13:259:25 | simple_source | simple_source |
+| main.rs:260:10:260:10 | s | main.rs:259:13:259:25 | simple_source | main.rs:260:10:260:10 | s | $@ | main.rs:259:13:259:25 | simple_source | simple_source |
+| main.rs:268:5:268:15 | simple_sink | main.rs:267:13:267:22 | source(...) | main.rs:268:5:268:15 | simple_sink | $@ | main.rs:267:13:267:22 | source(...) | source(...) |
+| main.rs:268:5:268:15 | simple_sink | main.rs:267:13:267:22 | source(...) | main.rs:268:5:268:15 | simple_sink | $@ | main.rs:267:13:267:22 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -28,3 +28,5 @@ extensions:
       - ["repo::test", "crate::set_array_element", "Argument[0]", "ReturnValue.Element", "value", "manual"]
       - ["repo::test", "crate::get_tuple_element", "Argument[0].Tuple[0]", "ReturnValue", "value", "manual"]
       - ["repo::test", "crate::set_tuple_element", "Argument[0]", "ReturnValue.Tuple[1]", "value", "manual"]
+      - ["repo::test", "crate::apply", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
+      - ["repo::test", "crate::apply", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]

--- a/rust/ql/test/utils-tests/modelgenerator/summaries.rs
+++ b/rust/ql/test/utils-tests/modelgenerator/summaries.rs
@@ -68,3 +68,11 @@ impl MyStruct {
         }
     }
 }
+
+// Higher-order functions
+
+// MISSING: summary=repo::test;crate::summaries::apply;Argument[0];Argument[1].Parameter[0];value;dfc-generated
+// MISSING: summary=repo::test;crate::summaries::apply;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
+pub fn apply<F>(n: i64, f: F) -> i64 where F : FnOnce(i64) -> i64 {
+    f(n)
+}

--- a/rust/ql/test/utils-tests/modelgenerator/summaries.rs
+++ b/rust/ql/test/utils-tests/modelgenerator/summaries.rs
@@ -71,8 +71,8 @@ impl MyStruct {
 
 // Higher-order functions
 
-// MISSING: summary=repo::test;crate::summaries::apply;Argument[0];Argument[1].Parameter[0];value;dfc-generated
-// MISSING: summary=repo::test;crate::summaries::apply;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
+// summary=repo::test;crate::summaries::apply;Argument[0];Argument[1].Parameter[0];value;dfc-generated
+// summary=repo::test;crate::summaries::apply;Argument[1].ReturnValue;ReturnValue;value;dfc-generated
 pub fn apply<F>(n: i64, f: F) -> i64 where F : FnOnce(i64) -> i64 {
     f(n)
 }


### PR DESCRIPTION
Implementation is similar to the one in C#. This is primarily 1/ adding and using two new content types and 2/ properly implementing more of the model generation signature.