### PR TITLE
C++: Iterator derefs are partial writes

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
+++ b/cpp/ql/lib/semmle/code/cpp/models/implementations/Iterator.qll
@@ -432,6 +432,8 @@ class IteratorPointerDereferenceMemberOperator extends MemberFunction, TaintFunc
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
     i = -1 and buffer = false
   }
+
+  override predicate isPartialWrite(FunctionOutput output) { output.isQualifierObject() }
 }
 
 /**
@@ -469,6 +471,8 @@ private class IteratorPointerDereferenceNonMemberOperatorModel extends IteratorP
   override predicate hasSpecificReadSideEffect(ParameterIndex i, boolean buffer) {
     i = 0 and buffer = false
   }
+
+  override predicate isPartialWrite(FunctionOutput output) { output.isParameterDeref(0) }
 }
 
 /**


### PR DESCRIPTION
**Background**
In https://github.com/github/codeql/pull/15633 we started to interpret flow out of a non-MaD dataflow/taint-flow model (i.e., a class that extends [DataFlowFunction](https://github.com/github/codeql/blob/2a32e8865d3f28edbdaafcf4d87ef7e64d4251ba/cpp/ql/lib/semmle/code/cpp/models/interfaces/DataFlow.qll#L22) or [TaintFlowFunction](https://github.com/github/codeql/blob/2a32e8865d3f28edbdaafcf4d87ef7e64d4251ba/cpp/ql/lib/semmle/code/cpp/models/interfaces/Taint.qll#L27)) as totally overwriting the destination buffer.

Obviously, since not all functions overwrite the entire destination buffer, we had to come up with a way to opt out of this now-default behavior. So we added an `isPartialWrite` predicate that could be overwritten on classes that did not overwrite the entire buffer. In https://github.com/github/codeql/pull/15633 I went through most of our classes to add this, but I see that I missed the `operator*` functions in iterators.

Why do `operator*` even have flow out, you may ask? That's a good question! It stems from a pretty neat idea we had back in the days of AST dataflow that we could provide flow from `source()` to `myIterator` in:
```
*myIterator = source()
```
(which would then have another step to its underlying container) by adding a dataflow model for `operator*` _from the return value to the qualifier_. That is, the opposite direction of what you'd normally add for flow out of `operator*` (the same idea is used [in dataflow](https://github.com/github/codeql/blob/2a32e8865d3f28edbdaafcf4d87ef7e64d4251ba/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll#L1628-L1636))

The end result is that `operator*` actually does "write" to its qualifier, and this write is obviously not meant to totally overwrite the qualifier.

For various reasons, it's not actually possible to observe any missing flow because of this, but I'm currently working on another PR where this matters.