### PR TITLE
Data flow: Add aliases for removing `DataFlow` prefixes

### DIFF
--- a/csharp/ql/test/library-tests/dataflow/delegates/DelegateFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/delegates/DelegateFlow.ql
@@ -4,19 +4,19 @@ import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 
 query predicate delegateCall(DelegateLikeCall dc, Callable c) { c = dc.getARuntimeTarget() }
 
-private class LocatableDataFlowCallOption extends DataFlowCallOption {
+private class LocatableCallOption extends CallOption {
   Location getLocation() {
-    this = TDataFlowCallNone() and
+    this = TCallNone() and
     result instanceof EmptyLocation
     or
     exists(DataFlowCall call |
-      this = TDataFlowCallSome(call) and
+      this = TCallSome(call) and
       result = call.getLocation()
     )
   }
 }
 
-private class LocatableDataFlowCall extends TDataFlowCall {
+private class LocatableCall extends TDataFlowCall {
   string toString() { result = this.(DataFlowCall).toString() }
 
   Location getLocation() {
@@ -28,7 +28,7 @@ private class LocatableDataFlowCall extends TDataFlowCall {
 }
 
 query predicate viableLambda(
-  LocatableDataFlowCall call, LocatableDataFlowCallOption lastCall, DataFlowCallable target
+  LocatableCall call, LocatableCallOption lastCall, DataFlowCallable target
 ) {
   target = viableCallableLambda(call, lastCall)
 }

--- a/csharp/ql/test/library-tests/dataflow/functionpointers/FunctionPointerFlow.ql
+++ b/csharp/ql/test/library-tests/dataflow/functionpointers/FunctionPointerFlow.ql
@@ -4,13 +4,13 @@ import semmle.code.csharp.dataflow.internal.DataFlowDispatch
 
 query predicate fptrCall(FunctionPointerCall dc, Callable c) { c = dc.getARuntimeTarget() }
 
-private class LocatableDataFlowCallOption extends DataFlowCallOption {
+private class LocatableDataFlowCallOption extends CallOption {
   Location getLocation() {
-    this = TDataFlowCallNone() and
+    this = TCallNone() and
     result instanceof EmptyLocation
     or
     exists(DataFlowCall call |
-      this = TDataFlowCallSome(call) and
+      this = TCallSome(call) and
       result = call.getLocation()
     )
   }

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplCommon.qll
@@ -9,6 +9,19 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   private import Lang
   import Cached
 
+  /** Provides short-hand aliases for making the code less verbose. */
+  module Aliases {
+    class Call = Lang::DataFlowCall;
+
+    class Callable = Lang::DataFlowCallable;
+
+    class Type = Lang::DataFlowType;
+
+    class Expr = Lang::DataFlowExpr;
+  }
+
+  private import Aliases
+
   module DataFlowImplCommonPublic {
     /**
      * DEPRECATED: Generally, a custom `FlowState` type should be used instead,
@@ -176,7 +189,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    * parameter position `ppos`.
    */
   pragma[noinline]
-  predicate argumentPositionMatch(DataFlowCall call, ArgNode arg, ParameterPosition ppos) {
+  predicate argumentPositionMatch(Call call, ArgNode arg, ParameterPosition ppos) {
     exists(ArgumentPosition apos |
       arg.argumentOf(call, apos) and
       parameterMatch(ppos, apos)
@@ -193,23 +206,23 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    */
   private module LambdaFlow {
     pragma[noinline]
-    private predicate viableParamNonLambda(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    private predicate viableParamNonLambda(Call call, ParameterPosition ppos, ParamNode p) {
       p.isParameterOf(viableCallable(call), ppos)
     }
 
     pragma[noinline]
-    private predicate viableParamLambda(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    private predicate viableParamLambda(Call call, ParameterPosition ppos, ParamNode p) {
       p.isParameterOf(viableCallableLambda(call, _), ppos)
     }
 
-    private predicate viableParamArgNonLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
+    private predicate viableParamArgNonLambda(Call call, ParamNode p, ArgNode arg) {
       exists(ParameterPosition ppos |
         viableParamNonLambda(call, ppos, p) and
         argumentPositionMatch(call, arg, ppos)
       )
     }
 
-    private predicate viableParamArgLambda(DataFlowCall call, ParamNode p, ArgNode arg) {
+    private predicate viableParamArgLambda(Call call, ParamNode p, ArgNode arg) {
       exists(ParameterPosition ppos |
         viableParamLambda(call, ppos, p) and
         argumentPositionMatch(call, arg, ppos)
@@ -217,7 +230,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     private newtype TReturnPositionSimple =
-      TReturnPositionSimple0(DataFlowCallable c, ReturnKind kind) {
+      TReturnPositionSimple0(Callable c, ReturnKind kind) {
         exists(ReturnNode ret |
           c = getNodeEnclosingCallable(ret) and
           kind = ret.getKind()
@@ -225,32 +238,30 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       }
 
     pragma[nomagic]
-    private predicate hasSimpleReturnKindIn(ReturnNode ret, ReturnKind kind, DataFlowCallable c) {
+    private predicate hasSimpleReturnKindIn(ReturnNode ret, ReturnKind kind, Callable c) {
       c = getNodeEnclosingCallable(ret) and
       kind = ret.getKind()
     }
 
     pragma[nomagic]
     private TReturnPositionSimple getReturnPositionSimple(ReturnNode ret) {
-      exists(ReturnKind kind, DataFlowCallable c |
+      exists(ReturnKind kind, Callable c |
         hasSimpleReturnKindIn(ret, kind, c) and
         result = TReturnPositionSimple0(c, kind)
       )
     }
 
     pragma[nomagic]
-    private TReturnPositionSimple viableReturnPosNonLambda(DataFlowCall call, ReturnKind kind) {
+    private TReturnPositionSimple viableReturnPosNonLambda(Call call, ReturnKind kind) {
       result = TReturnPositionSimple0(viableCallable(call), kind)
     }
 
     pragma[nomagic]
-    private TReturnPositionSimple viableReturnPosLambda(DataFlowCall call, ReturnKind kind) {
+    private TReturnPositionSimple viableReturnPosLambda(Call call, ReturnKind kind) {
       result = TReturnPositionSimple0(viableCallableLambda(call, _), kind)
     }
 
-    private predicate viableReturnPosOutNonLambda(
-      DataFlowCall call, TReturnPositionSimple pos, OutNode out
-    ) {
+    private predicate viableReturnPosOutNonLambda(Call call, TReturnPositionSimple pos, OutNode out) {
       exists(ReturnKind kind |
         pos = viableReturnPosNonLambda(call, kind) and
         out = getAnOutNode(call, kind)
@@ -258,9 +269,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private predicate viableReturnPosOutLambda(
-      DataFlowCall call, TReturnPositionSimple pos, OutNode out
-    ) {
+    private predicate viableReturnPosOutLambda(Call call, TReturnPositionSimple pos, OutNode out) {
       exists(ReturnKind kind |
         pos = viableReturnPosLambda(call, kind) and
         out = getAnOutNode(call, kind)
@@ -281,8 +290,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      */
     pragma[nomagic]
     predicate revLambdaFlow(
-      DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
-      boolean toJump, DataFlowCallOption lastCall
+      Call lambdaCall, LambdaCallKind kind, Node node, Type t, boolean toReturn, boolean toJump,
+      CallOption lastCall
     ) {
       revLambdaFlow0(lambdaCall, kind, node, t, toReturn, toJump, lastCall) and
       not expectsContent(node, _) and
@@ -293,17 +302,17 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     predicate revLambdaFlow0(
-      DataFlowCall lambdaCall, LambdaCallKind kind, Node node, DataFlowType t, boolean toReturn,
-      boolean toJump, DataFlowCallOption lastCall
+      Call lambdaCall, LambdaCallKind kind, Node node, Type t, boolean toReturn, boolean toJump,
+      CallOption lastCall
     ) {
       lambdaCall(lambdaCall, kind, node) and
       t = getNodeDataFlowType(node) and
       toReturn = false and
       toJump = false and
-      lastCall = TDataFlowCallNone()
+      lastCall = TCallNone()
       or
       // local flow
-      exists(Node mid, DataFlowType t0 |
+      exists(Node mid, Type t0 |
         revLambdaFlow(lambdaCall, kind, mid, t0, toReturn, toJump, lastCall)
       |
         simpleLocalFlowStep(node, mid, _) and
@@ -322,7 +331,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       )
       or
       // jump step
-      exists(Node mid, DataFlowType t0 |
+      exists(Node mid, Type t0 |
         revLambdaFlow(lambdaCall, kind, mid, t0, _, _, lastCall) and
         toReturn = false and
         toJump = true
@@ -343,11 +352,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       )
       or
       // flow into a callable
-      exists(ParamNode p, DataFlowCallOption lastCall0, DataFlowCall call |
+      exists(ParamNode p, CallOption lastCall0, Call call |
         revLambdaFlowIn(lambdaCall, kind, p, t, toJump, lastCall0) and
         (
-          if lastCall0 = TDataFlowCallNone() and toJump = false
-          then lastCall = TDataFlowCallSome(call)
+          if lastCall0 = TCallNone() and toJump = false
+          then lastCall = TCallSome(call)
           else lastCall = lastCall0
         ) and
         toReturn = false
@@ -367,8 +376,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     predicate revLambdaFlowOutLambdaCall(
-      DataFlowCall lambdaCall, LambdaCallKind kind, OutNode out, DataFlowType t, boolean toJump,
-      DataFlowCall call, DataFlowCallOption lastCall
+      Call lambdaCall, LambdaCallKind kind, OutNode out, Type t, boolean toJump, Call call,
+      CallOption lastCall
     ) {
       revLambdaFlow(lambdaCall, kind, out, t, _, toJump, lastCall) and
       exists(ReturnKindExt rk |
@@ -379,10 +388,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     predicate revLambdaFlowOut(
-      DataFlowCall lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, DataFlowType t,
-      boolean toJump, DataFlowCallOption lastCall
+      Call lambdaCall, LambdaCallKind kind, TReturnPositionSimple pos, Type t, boolean toJump,
+      CallOption lastCall
     ) {
-      exists(DataFlowCall call, OutNode out |
+      exists(Call call, OutNode out |
         revLambdaFlow(lambdaCall, kind, out, t, _, toJump, lastCall) and
         viableReturnPosOutNonLambda(call, pos, out)
         or
@@ -394,14 +403,13 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     pragma[nomagic]
     predicate revLambdaFlowIn(
-      DataFlowCall lambdaCall, LambdaCallKind kind, ParamNode p, DataFlowType t, boolean toJump,
-      DataFlowCallOption lastCall
+      Call lambdaCall, LambdaCallKind kind, ParamNode p, Type t, boolean toJump, CallOption lastCall
     ) {
       revLambdaFlow(lambdaCall, kind, p, t, false, toJump, lastCall)
     }
   }
 
-  private DataFlowCallable viableCallableExt(DataFlowCall call) {
+  private Callable viableCallableExt(Call call) {
     result = viableCallableCached(call)
     or
     result = viableCallableLambda(call, _)
@@ -409,18 +417,16 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   signature module CallContextSensitivityInputSig {
     /** Holds if the edge is possibly needed in the direction `call` to `c`. */
-    predicate relevantCallEdgeIn(DataFlowCall call, DataFlowCallable c);
+    predicate relevantCallEdgeIn(Call call, Callable c);
 
     /** Holds if the edge is possibly needed in the direction `c` to `call`. */
-    predicate relevantCallEdgeOut(DataFlowCall call, DataFlowCallable c);
+    predicate relevantCallEdgeOut(Call call, Callable c);
 
     /**
      * Holds if the call context `ctx` may reduce the set of viable run-time
      * dispatch targets of call `call` in `c`.
      */
-    default predicate reducedViableImplInCallContextCand(
-      DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
-    ) {
+    default predicate reducedViableImplInCallContextCand(Call call, Callable c, Call ctx) {
       relevantCallEdgeIn(ctx, c) and
       mayBenefitFromCallContextExt(call, c)
     }
@@ -430,7 +436,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * further and if this path may restrict the set of call sites that can be
      * returned to.
      */
-    default predicate reducedViableImplInReturnCand(DataFlowCallable c, DataFlowCall call) {
+    default predicate reducedViableImplInReturnCand(Callable c, Call call) {
       relevantCallEdgeOut(call, c) and
       mayBenefitFromCallContextExt(call, _)
     }
@@ -441,7 +447,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     private import Input
 
     pragma[nomagic]
-    private DataFlowCallable viableImplInCallContextExtIn(DataFlowCall call, DataFlowCall ctx) {
+    private Callable viableImplInCallContextExtIn(Call call, Call ctx) {
       reducedViableImplInCallContextCand(call, _, ctx) and
       result = viableImplInCallContextExt(call, ctx) and
       relevantCallEdgeIn(call, result)
@@ -452,11 +458,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * dispatch targets of call `call` in `c`.
      */
     pragma[nomagic]
-    predicate reducedViableImplInCallContext(DataFlowCall call, DataFlowCallable c, DataFlowCall ctx) {
+    predicate reducedViableImplInCallContext(Call call, Callable c, Call ctx) {
       exists(int tgts, int ctxtgts |
         reducedViableImplInCallContextCand(call, c, ctx) and
         ctxtgts = count(viableImplInCallContextExtIn(call, ctx)) and
-        tgts = strictcount(DataFlowCallable tgt | relevantCallEdgeIn(call, tgt)) and
+        tgts = strictcount(Callable tgt | relevantCallEdgeIn(call, tgt)) and
         ctxtgts < tgts
       )
     }
@@ -465,7 +471,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if the call context `call` allows us to prune unreachable nodes in `callable`.
      */
     pragma[nomagic]
-    predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable callable) {
+    predicate recordCallSiteUnreachable(Call call, Callable callable) {
       exists(NodeRegion nr |
         relevantCallEdgeIn(call, callable) and
         getNodeRegionEnclosingCallable(nr) = callable and
@@ -474,8 +480,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private DataFlowCallable viableImplInCallContextExtOut(DataFlowCall call, DataFlowCall ctx) {
-      exists(DataFlowCallable c |
+    private Callable viableImplInCallContextExtOut(Call call, Call ctx) {
+      exists(Callable c |
         reducedViableImplInReturnCand(result, call) and
         result = viableImplInCallContextExt(call, ctx) and
         mayBenefitFromCallContextExt(call, c) and
@@ -489,27 +495,27 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * returned to.
      */
     pragma[nomagic]
-    predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+    predicate reducedViableImplInReturn(Callable c, Call call) {
       exists(int tgts, int ctxtgts |
         reducedViableImplInReturnCand(c, call) and
-        ctxtgts = count(DataFlowCall ctx | c = viableImplInCallContextExtOut(call, ctx)) and
+        ctxtgts = count(Call ctx | c = viableImplInCallContextExtOut(call, ctx)) and
         tgts =
-          strictcount(DataFlowCall ctx |
-            callEnclosingCallable(call, any(DataFlowCallable encl | relevantCallEdgeOut(ctx, encl)))
+          strictcount(Call ctx |
+            callEnclosingCallable(call, any(Callable encl | relevantCallEdgeOut(ctx, encl)))
           ) and
         ctxtgts < tgts
       )
     }
 
-    private DataFlowCall getACallWithReducedViableImpl(TCallEdge ctxEdge) {
-      exists(DataFlowCall ctx, DataFlowCallable c |
+    private Call getACallWithReducedViableImpl(TCallEdge ctxEdge) {
+      exists(Call ctx, Callable c |
         ctxEdge = TMkCallEdge(ctx, c) and
         reducedViableImplInCallContext(result, c, ctx)
       )
     }
 
     private module CallSets =
-      QlBuiltins::InternSets<TCallEdge, DataFlowCall, getACallWithReducedViableImpl/1>;
+      QlBuiltins::InternSets<TCallEdge, Call, getACallWithReducedViableImpl/1>;
 
     private class CallSet0 extends CallSets::Set {
       string toString() { result = "CallSet" }
@@ -525,7 +531,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     private class CallSet = CallSetOption::Option;
 
     private TCallEdge getAReducedViableEdge(TCallEdge ctxEdge) {
-      exists(DataFlowCall ctx, DataFlowCallable c, DataFlowCall call, DataFlowCallable tgt |
+      exists(Call ctx, Callable c, Call call, Callable tgt |
         ctxEdge = mkCallEdge(ctx, c) and
         result = mkCallEdge(call, tgt) and
         viableImplInCallContextExtIn(call, ctx) = tgt and
@@ -585,7 +591,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         hasCtx(_, calls, tgts, unreachable)
       } or
       TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
+      TReturn(Callable c, Call call) { reducedViableImplInReturn(c, call) }
 
     /**
      * A call context to restrict the targets of virtual dispatch and prune local flow.
@@ -600,7 +606,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * - `TSomeCall()` : Flow entered through a parameter. The
      *    originating call does not improve the set of dispatch targets for any
      *    method call in the current callable and was therefore not recorded.
-     * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+     * - `TReturn(Callable c, Call call)` : Flow reached `call` from `c` and
      *    this dispatch target of `call` implies a reduced set of dispatch origins
      *    to which data may flow if it should reach a `return` statement.
      */
@@ -626,12 +632,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     private class CallContextReturn extends CallContextNoCall, TReturn {
       override string toString() {
-        exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+        exists(Call call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
       }
     }
 
     pragma[nomagic]
-    CallContextCall getSpecificCallContextCall(DataFlowCall call, DataFlowCallable c) {
+    CallContextCall getSpecificCallContextCall(Call call, Callable c) {
       exists(CallSet calls, DispatchSet tgts, UnreachableSetOption unreachable |
         hasCtx(TMkCallEdge(call, c), calls, tgts, unreachable) and
         result = TSpecificCall(calls, tgts, unreachable)
@@ -639,26 +645,24 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    predicate callContextAffectsDispatch(DataFlowCall call, CallContext ctx) {
+    predicate callContextAffectsDispatch(Call call, CallContext ctx) {
       exists(CallSet calls | ctx = TSpecificCall(calls, _, _) | calls.asSome().contains(call))
     }
 
-    CallContextNoCall getSpecificCallContextReturn(DataFlowCallable c, DataFlowCall call) {
+    CallContextNoCall getSpecificCallContextReturn(Callable c, Call call) {
       result = TReturn(c, call)
     }
 
     signature module PrunedViableImplInputSig {
-      predicate reducedViableImplInCallContext(
-        DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
-      );
+      predicate reducedViableImplInCallContext(Call call, Callable c, Call ctx);
 
-      predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable c);
+      predicate recordCallSiteUnreachable(Call call, Callable c);
 
-      CallContextCall getSpecificCallContextCall(DataFlowCall call, DataFlowCallable c);
+      CallContextCall getSpecificCallContextCall(Call call, Callable c);
 
-      predicate callContextAffectsDispatch(DataFlowCall call, CallContext ctx);
+      predicate callContextAffectsDispatch(Call call, CallContext ctx);
 
-      CallContextNoCall getSpecificCallContextReturn(DataFlowCallable c, DataFlowCall call);
+      CallContextNoCall getSpecificCallContextReturn(Callable c, Call call);
     }
 
     /**
@@ -671,7 +675,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       class CcCall = CallContextCall;
 
       pragma[inline]
-      predicate matchesCall(CcCall cc, DataFlowCall call) {
+      predicate matchesCall(CcCall cc, Call call) {
         cc = Input2::getSpecificCallContextCall(call, _) or
         cc = ccSomeCall()
       }
@@ -696,7 +700,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * makes a difference.
        */
       pragma[nomagic]
-      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CallContextCall ctx) {
+      Callable viableImplCallContextReduced(Call call, CallContextCall ctx) {
         exists(DispatchSet tgts | ctx = TSpecificCall(_, tgts, _) |
           tgts.asSome().contains(TMkCallEdge(call, result))
         )
@@ -704,7 +708,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
       /** Holds if `call` does not have a reduced set of dispatch targets in call context `ctx`. */
       bindingset[call, ctx]
-      predicate viableImplNotCallContextReduced(DataFlowCall call, CallContext ctx) {
+      predicate viableImplNotCallContextReduced(Call call, CallContext ctx) {
         not Input2::callContextAffectsDispatch(call, ctx)
       }
 
@@ -713,7 +717,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * restricted by `relevantResolveTarget`.
        */
       bindingset[call, cc]
-      DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+      Callable resolveCall(Call call, CallContext cc) {
         result = viableImplCallContextReduced(call, cc)
         or
         viableImplNotCallContextReduced(call, cc) and
@@ -726,10 +730,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * the possible call sites are restricted.
        */
       pragma[nomagic]
-      DataFlowCall viableImplCallContextReducedReverse(
-        DataFlowCallable callable, CallContextNoCall ctx
-      ) {
-        exists(DataFlowCallable c0, DataFlowCall call0 |
+      Call viableImplCallContextReducedReverse(Callable callable, CallContextNoCall ctx) {
+        exists(Callable c0, Call call0 |
           callEnclosingCallable(call0, callable) and
           ctx = TReturn(c0, call0) and
           c0 = viableImplInCallContextExtOut(call0, result) and
@@ -749,7 +751,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * Resolves a return from `callable` in `cc` to `call`.
        */
       bindingset[cc, callable]
-      predicate resolveReturn(CallContextNoCall cc, DataFlowCallable callable, DataFlowCall call) {
+      predicate resolveReturn(CallContextNoCall cc, Callable callable, Call call) {
         cc instanceof CallContextAny and relevantCallEdgeOut(call, callable)
         or
         call = viableImplCallContextReducedReverse(callable, cc)
@@ -757,7 +759,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
       /** Gets the call context when returning from `c` to `call`. */
       bindingset[call, c]
-      CallContextNoCall getCallContextReturn(DataFlowCallable c, DataFlowCall call) {
+      CallContextNoCall getCallContextReturn(Callable c, Call call) {
         result = Input2::getSpecificCallContextReturn(c, call)
         or
         not exists(Input2::getSpecificCallContextReturn(c, call)) and result = TAnyCallContext()
@@ -767,7 +769,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * Holds if the call context `call` improves virtual dispatch in `callable`.
        */
       pragma[nomagic]
-      private predicate recordDataFlowCallSiteDispatch(DataFlowCall call, DataFlowCallable callable) {
+      private predicate recordCallSiteDispatch(Call call, Callable callable) {
         Input2::reducedViableImplInCallContext(_, callable, call)
       }
 
@@ -775,9 +777,9 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
        * Holds if the call context `call` either improves virtual dispatch in
        * `callable` or if it allows us to prune unreachable nodes in `callable`.
        */
-      predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable c) {
-        Input2::recordDataFlowCallSiteUnreachable(call, c) or
-        recordDataFlowCallSiteDispatch(call, c)
+      predicate recordCallSite(Call call, Callable c) {
+        Input2::recordCallSiteUnreachable(call, c) or
+        recordCallSiteDispatch(call, c)
       }
 
       module NoLocalCallContext {
@@ -787,8 +789,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         LocalCc getLocalCc(CallContext cc) { any() }
 
         bindingset[call, c]
-        CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
-          if recordDataFlowCallSiteDispatch(call, c)
+        CallContextCall getCallContextCall(Call call, Callable c) {
+          if recordCallSiteDispatch(call, c)
           then result = Input2::getSpecificCallContextCall(call, c)
           else result = TSomeCall()
         }
@@ -815,8 +817,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         LocalCc getLocalCc(CallContext cc) { result = getLocalCallContext(cc) }
 
         bindingset[call, c]
-        CallContextCall getCallContextCall(DataFlowCall call, DataFlowCallable c) {
-          if recordDataFlowCallSite(call, c)
+        CallContextCall getCallContextCall(Call call, Callable c) {
+          if recordCallSite(call, c)
           then result = Input2::getSpecificCallContextCall(call, c)
           else result = TSomeCall()
         }
@@ -825,7 +827,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     private predicate reducedViableImplInCallContextAlias = reducedViableImplInCallContext/3;
 
-    private predicate recordDataFlowCallSiteUnreachableAlias = recordDataFlowCallSiteUnreachable/2;
+    private predicate recordCallSiteUnreachableAlias = recordCallSiteUnreachable/2;
 
     private predicate getSpecificCallContextCallAlias = getSpecificCallContextCall/2;
 
@@ -836,7 +838,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     private module DefaultPrunedViableImplInput implements PrunedViableImplInputSig {
       predicate reducedViableImplInCallContext = reducedViableImplInCallContextAlias/3;
 
-      predicate recordDataFlowCallSiteUnreachable = recordDataFlowCallSiteUnreachableAlias/2;
+      predicate recordCallSiteUnreachable = recordCallSiteUnreachableAlias/2;
 
       predicate getSpecificCallContextCall = getSpecificCallContextCallAlias/2;
 
@@ -881,28 +883,24 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private DataFlowCallable getEnclosingCallable0() {
-      nodeEnclosingCallable(this.projectToNode(), result)
-    }
+    private Callable getEnclosingCallable0() { nodeEnclosingCallable(this.projectToNode(), result) }
 
     pragma[inline]
-    DataFlowCallable getEnclosingCallable() {
+    Callable getEnclosingCallable() {
       pragma[only_bind_out](this).getEnclosingCallable0() = pragma[only_bind_into](result)
     }
 
     pragma[nomagic]
-    private DataFlowType getDataFlowType0() {
-      nodeDataFlowType(this.asNode(), result)
+    private Type getType0() {
+      nodeType(this.asNode(), result)
       or
-      nodeDataFlowType(this.asParamReturnNode(), result)
+      nodeType(this.asParamReturnNode(), result)
       or
       isTopType(result) and this.isImplicitReadNode(_)
     }
 
     pragma[inline]
-    DataFlowType getDataFlowType() {
-      pragma[only_bind_out](this).getDataFlowType0() = pragma[only_bind_into](result)
-    }
+    Type getType() { pragma[only_bind_out](this).getType0() = pragma[only_bind_into](result) }
 
     Location getLocation() { result = this.projectToNode().getLocation() }
   }
@@ -915,26 +913,26 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   }
 
   final class ArgNodeEx extends NodeEx {
-    private DataFlowCall call_;
+    private Call call_;
     private ArgumentPosition pos_;
 
     ArgNodeEx() { this.asNode().(ArgNode).argumentOf(call_, pos_) }
 
-    predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
+    predicate argumentOf(Call call, ArgumentPosition pos) {
       call = call_ and
       pos = pos_
     }
 
-    DataFlowCall getCall() { result = call_ }
+    Call getCall() { result = call_ }
   }
 
   final class ParamNodeEx extends NodeEx {
-    private DataFlowCallable c_;
+    private Callable c_;
     private ParameterPosition pos_;
 
     ParamNodeEx() { this.asNode().(ParamNode).isParameterOf(c_, pos_) }
 
-    predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) { c = c_ and pos = pos_ }
+    predicate isParameterOf(Callable c, ParameterPosition pos) { c = c_ and pos = pos_ }
 
     ParameterPosition getPosition() { result = pos_ }
   }
@@ -981,29 +979,27 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     cached
-    predicate nodeEnclosingCallable(Node n, DataFlowCallable c) { c = nodeGetEnclosingCallable(n) }
+    predicate nodeEnclosingCallable(Node n, Callable c) { c = nodeGetEnclosingCallable(n) }
 
     cached
-    predicate callEnclosingCallable(DataFlowCall call, DataFlowCallable c) {
-      c = call.getEnclosingCallable()
+    predicate callEnclosingCallable(Call call, Callable c) { c = call.getEnclosingCallable() }
+
+    cached
+    predicate nodeType(Node n, Type t) { t = getNodeType(n) }
+
+    cached
+    predicate compatibleTypesCached(Type t1, Type t2) { compatibleTypes(t1, t2) }
+
+    private predicate relevantType(Type t) { t = getNodeType(_) }
+
+    cached
+    predicate isTopType(Type t) {
+      strictcount(Type t0 | relevantType(t0)) =
+        strictcount(Type t0 | relevantType(t0) and compatibleTypesCached(t, t0))
     }
 
     cached
-    predicate nodeDataFlowType(Node n, DataFlowType t) { t = getNodeType(n) }
-
-    cached
-    predicate compatibleTypesCached(DataFlowType t1, DataFlowType t2) { compatibleTypes(t1, t2) }
-
-    private predicate relevantType(DataFlowType t) { t = getNodeType(_) }
-
-    cached
-    predicate isTopType(DataFlowType t) {
-      strictcount(DataFlowType t0 | relevantType(t0)) =
-        strictcount(DataFlowType t0 | relevantType(t0) and compatibleTypesCached(t, t0))
-    }
-
-    cached
-    predicate typeStrongerThanCached(DataFlowType t1, DataFlowType t2) { typeStrongerThan(t1, t2) }
+    predicate typeStrongerThanCached(Type t1, Type t2) { typeStrongerThan(t1, t2) }
 
     cached
     predicate jumpStepCached(Node node1, Node node2) { jumpStep(node1, node2) }
@@ -1018,9 +1014,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     predicate expectsContentSet(NodeEx n, ContentSet c) { expectsContent(n.asNode(), c) }
 
     cached
-    predicate isUnreachableInCallCached(NodeRegion nr, DataFlowCall call) {
-      isUnreachableInCall(nr, call)
-    }
+    predicate isUnreachableInCallCached(NodeRegion nr, Call call) { isUnreachableInCall(nr, call) }
 
     cached
     predicate outNodeExt(Node n) {
@@ -1037,7 +1031,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     cached
-    OutNodeEx getAnOutNodeEx(DataFlowCall call, ReturnKindExt k) {
+    OutNodeEx getAnOutNodeEx(Call call, ReturnKindExt k) {
       result.asNode() = getAnOutNodeExt(call, k)
     }
 
@@ -1074,17 +1068,15 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     string getSinkModel(NodeEx node) { knownSinkModel(node.asNodeOrImplicitRead(), result) }
 
     cached
-    predicate parameterNode(Node p, DataFlowCallable c, ParameterPosition pos) {
+    predicate parameterNode(Node p, Callable c, ParameterPosition pos) {
       isParameterNode(p, c, pos)
     }
 
     cached
-    predicate argumentNode(Node n, DataFlowCall call, ArgumentPosition pos) {
-      isArgumentNode(n, call, pos)
-    }
+    predicate argumentNode(Node n, Call call, ArgumentPosition pos) { isArgumentNode(n, call, pos) }
 
     cached
-    DataFlowCallable viableCallableCached(DataFlowCall call) { result = viableCallable(call) }
+    Callable viableCallableCached(Call call) { result = viableCallable(call) }
 
     /**
      * Gets a viable target for the lambda call `call`.
@@ -1093,7 +1085,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * to be a viable target, if any.
      */
     cached
-    DataFlowCallable viableCallableLambda(DataFlowCall call, DataFlowCallOption lastCall) {
+    Callable viableCallableLambda(Call call, CallOption lastCall) {
       exists(Node creation, LambdaCallKind kind |
         LambdaFlow::revLambdaFlow(call, kind, creation, _, _, _, lastCall) and
         lambdaCreation(creation, kind, result)
@@ -1105,11 +1097,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * might be improved by knowing the call context.
      */
     cached
-    predicate mayBenefitFromCallContextExt(DataFlowCall call, DataFlowCallable callable) {
+    predicate mayBenefitFromCallContextExt(Call call, Callable callable) {
       (
         mayBenefitFromCallContext(call)
         or
-        exists(viableCallableLambda(call, TDataFlowCallSome(_)))
+        exists(viableCallableLambda(call, TCallSome(_)))
       ) and
       callEnclosingCallable(call, callable)
     }
@@ -1119,16 +1111,16 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * restricted to those `call`s for which a context might make a difference.
      */
     cached
-    DataFlowCallable viableImplInCallContextExt(DataFlowCall call, DataFlowCall ctx) {
+    Callable viableImplInCallContextExt(Call call, Call ctx) {
       result = viableImplInCallContext(call, ctx) and
       result = viableCallable(call)
       or
-      result = viableCallableLambda(call, TDataFlowCallSome(ctx))
+      result = viableCallableLambda(call, TCallSome(ctx))
       or
-      exists(DataFlowCallable enclosing |
+      exists(Callable enclosing |
         mayBenefitFromCallContextExt(call, enclosing) and
         enclosing = viableCallableExt(ctx) and
-        result = viableCallableLambda(call, TDataFlowCallNone())
+        result = viableCallableLambda(call, TCallNone())
       )
     }
 
@@ -1140,46 +1132,40 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     cached
     module CachedCallContextSensitivity {
       private module CallContextSensitivityInput implements CallContextSensitivityInputSig {
-        predicate relevantCallEdgeIn(DataFlowCall call, DataFlowCallable c) {
-          c = viableCallableExt(call)
-        }
+        predicate relevantCallEdgeIn(Call call, Callable c) { c = viableCallableExt(call) }
 
-        predicate relevantCallEdgeOut(DataFlowCall call, DataFlowCallable c) {
-          c = viableCallableExt(call)
-        }
+        predicate relevantCallEdgeOut(Call call, Callable c) { c = viableCallableExt(call) }
       }
 
       private module Impl1 = CallContextSensitivity<CallContextSensitivityInput>;
 
       cached
-      predicate reducedViableImplInCallContext(
-        DataFlowCall call, DataFlowCallable c, DataFlowCall ctx
-      ) {
+      predicate reducedViableImplInCallContext(Call call, Callable c, Call ctx) {
         Impl1::reducedViableImplInCallContext(call, c, ctx)
       }
 
       cached
-      predicate recordDataFlowCallSiteUnreachable(DataFlowCall call, DataFlowCallable c) {
-        Impl1::recordDataFlowCallSiteUnreachable(call, c)
+      predicate recordCallSiteUnreachable(Call call, Callable c) {
+        Impl1::recordCallSiteUnreachable(call, c)
       }
 
       cached
-      predicate reducedViableImplInReturn(DataFlowCallable c, DataFlowCall call) {
+      predicate reducedViableImplInReturn(Callable c, Call call) {
         Impl1::reducedViableImplInReturn(c, call)
       }
 
       cached
-      CcCall getSpecificCallContextCall(DataFlowCall call, DataFlowCallable c) {
+      CcCall getSpecificCallContextCall(Call call, Callable c) {
         result = Impl1::getSpecificCallContextCall(call, c)
       }
 
       cached
-      predicate callContextAffectsDispatch(DataFlowCall call, Cc ctx) {
+      predicate callContextAffectsDispatch(Call call, Cc ctx) {
         Impl1::callContextAffectsDispatch(call, ctx)
       }
 
       cached
-      CcNoCall getSpecificCallContextReturn(DataFlowCallable c, DataFlowCall call) {
+      CcNoCall getSpecificCallContextReturn(Callable c, Call call) {
         result = Impl1::getSpecificCallContextReturn(c, call)
       }
 
@@ -1187,8 +1173,8 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         predicate reducedViableImplInCallContext =
           CachedCallContextSensitivity::reducedViableImplInCallContext/3;
 
-        predicate recordDataFlowCallSiteUnreachable =
-          CachedCallContextSensitivity::recordDataFlowCallSiteUnreachable/2;
+        predicate recordCallSiteUnreachable =
+          CachedCallContextSensitivity::recordCallSiteUnreachable/2;
 
         predicate getSpecificCallContextCall =
           CachedCallContextSensitivity::getSpecificCallContextCall/2;
@@ -1214,12 +1200,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       predicate instanceofCcNoCall(CcNoCall cc) { any() }
 
       cached
-      DataFlowCallable viableImplCallContextReduced(DataFlowCall call, CcCall ctx) {
+      Callable viableImplCallContextReduced(Call call, CcCall ctx) {
         result = Impl2::viableImplCallContextReduced(call, ctx)
       }
 
       cached
-      DataFlowCall viableImplCallContextReducedReverse(DataFlowCallable callable, CcNoCall ctx) {
+      Call viableImplCallContextReducedReverse(Callable callable, CcNoCall ctx) {
         result = Impl2::viableImplCallContextReducedReverse(callable, ctx)
       }
     }
@@ -1229,7 +1215,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * and `p` has position `ppos`.
      */
     pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, ParameterPosition ppos, ParamNode p) {
+    private predicate viableParam(Call call, ParameterPosition ppos, ParamNode p) {
       p.isParameterOf(viableCallableExt(call), ppos)
     }
 
@@ -1238,7 +1224,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * dispatch into account.
      */
     cached
-    predicate viableParamArg(DataFlowCall call, ParamNode p, ArgNode arg) {
+    predicate viableParamArg(Call call, ParamNode p, ArgNode arg) {
       exists(ParameterPosition ppos |
         viableParam(call, ppos, p) and
         argumentPositionMatch(call, arg, ppos) and
@@ -1252,12 +1238,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * dispatch into account.
      */
     cached
-    predicate viableParamArgEx(DataFlowCall call, ParamNodeEx p, ArgNodeEx arg) {
+    predicate viableParamArgEx(Call call, ParamNodeEx p, ArgNodeEx arg) {
       viableParamArg(call, p.asNode(), arg.asNode())
     }
 
     pragma[nomagic]
-    private ReturnPosition viableReturnPos(DataFlowCall call, ReturnKindExt kind) {
+    private ReturnPosition viableReturnPos(Call call, ReturnKindExt kind) {
       viableCallableExt(call) = result.getCallable() and
       kind = result.getKind()
     }
@@ -1267,7 +1253,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * taking virtual dispatch into account.
      */
     cached
-    predicate viableReturnPosOut(DataFlowCall call, ReturnPosition pos, OutNodeExt out) {
+    predicate viableReturnPosOut(Call call, ReturnPosition pos, OutNodeExt out) {
       exists(ReturnKindExt kind |
         pos = viableReturnPos(call, kind) and
         out = getAnOutNodeExt(call, kind)
@@ -1279,7 +1265,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * taking virtual dispatch into account.
      */
     cached
-    predicate viableReturnPosOutEx(DataFlowCall call, ReturnPosition pos, OutNodeEx out) {
+    predicate viableReturnPosOutEx(Call call, ReturnPosition pos, OutNodeEx out) {
       viableReturnPosOut(call, pos, out.asNode())
     }
 
@@ -1360,7 +1346,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate argumentValueFlowsThroughCand0(
-          DataFlowCall call, ArgNode arg, ReturnKind kind, boolean read
+          Call call, ArgNode arg, ReturnKind kind, boolean read
         ) {
           exists(ParamNode param | viableParamArg(call, param, arg) |
             parameterValueFlowReturnCand(param, kind, read)
@@ -1374,7 +1360,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
          * `read` indicates whether it is contents of `arg` that can flow to `out`.
          */
         predicate argumentValueFlowsThroughCand(ArgNode arg, Node out, boolean read) {
-          exists(DataFlowCall call, ReturnKind kind |
+          exists(Call call, ReturnKind kind |
             argumentValueFlowsThroughCand0(call, arg, kind, read) and
             out = getAnOutNode(call, kind)
           )
@@ -1475,7 +1461,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
             else
               // check that `ctx1` is compatible with `ctx2` for at least _some_ outer call,
               // and then (arbitrarily) continue with `ctx2`
-              exists(DataFlowCall someOuterCall, DataFlowCallable callable |
+              exists(Call someOuterCall, Callable callable |
                 someOuterCall =
                   CachedCallContextSensitivity::viableImplCallContextReducedReverse(callable, ctx1) and
                 someOuterCall =
@@ -1517,12 +1503,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
         pragma[nomagic]
         private predicate argumentValueFlowsThrough0(
-          DataFlowCall call, ArgNode arg, ReturnKind kind, ReadStepTypesOption read, string model,
+          Call call, ArgNode arg, ReturnKind kind, ReadStepTypesOption read, string model,
           CachedCallContextSensitivity::CcNoCall outerCtx
         ) {
           exists(
-            ParamNode param, DataFlowCallable callable,
-            CachedCallContextSensitivity::CcNoCall innerCtx
+            ParamNode param, Callable callable, CachedCallContextSensitivity::CcNoCall innerCtx
           |
             viableParamArg(call, param, arg) and
             parameterValueFlowReturn(param, kind, read, model, innerCtx) and
@@ -1541,7 +1526,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
           ArgNode arg, ReadStepTypesOption read, Node out, string model,
           CachedCallContextSensitivity::CcNoCall ctx
         ) {
-          exists(DataFlowCall call, ReturnKind kind |
+          exists(Call call, ReturnKind kind |
             argumentValueFlowsThrough0(call, arg, kind, read, model, ctx) and
             out = getAnOutNode(call, kind)
           |
@@ -1622,9 +1607,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     cached
-    predicate storeSet(
-      Node node1, ContentSet c, Node node2, DataFlowType contentType, DataFlowType containerType
-    ) {
+    predicate storeSet(Node node1, ContentSet c, Node node2, Type contentType, Type containerType) {
       storeStep(node1, c, node2) and
       contentType = getNodeDataFlowType(node1) and
       containerType = getNodeDataFlowType(node2)
@@ -1649,9 +1632,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * been stored into, in order to handle cases like `x.f1.f2 = y`.
      */
     cached
-    predicate storeEx(
-      NodeEx node1, Content c, NodeEx node2, DataFlowType contentType, DataFlowType containerType
-    ) {
+    predicate storeEx(NodeEx node1, Content c, NodeEx node2, Type contentType, Type containerType) {
       exists(ContentSet cs |
         c = cs.getAStoreContent() and
         storeSet(pragma[only_bind_into](node1.asNode()), cs, pragma[only_bind_into](node2.asNode()),
@@ -1672,7 +1653,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         fromPre = fromNode.getPreUpdateNode() and
         toPre = toNode.getPreUpdateNode()
       |
-        exists(DataFlowCall c |
+        exists(Call c |
           // Does the language-specific simpleLocalFlowStep already model flow
           // from function input to output?
           fromPre = getAnOutNode(c, _) and
@@ -1700,11 +1681,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     ContentApprox getContentApproxCached(Content c) { result = getContentApprox(c) }
 
     cached
-    newtype TCallEdge =
-      TMkCallEdge(DataFlowCall call, DataFlowCallable tgt) { viableCallableExt(call) = tgt }
+    newtype TCallEdge = TMkCallEdge(Call call, Callable tgt) { viableCallableExt(call) = tgt }
 
     private NodeRegion getAnUnreachableRegion(TCallEdge edge) {
-      exists(DataFlowCall call, DataFlowCallable tgt |
+      exists(Call call, Callable tgt |
         edge = mkCallEdge(call, tgt) and
         getNodeRegionEnclosingCallable(result) = tgt and
         isUnreachableInCallCached(result, call)
@@ -1726,7 +1706,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       }
 
       cached
-      DataFlowCallable getEnclosingCallable() {
+      Callable getEnclosingCallable() {
         exists(NodeRegion nr | super.contains(nr) and result = getNodeRegionEnclosingCallable(nr))
       }
     }
@@ -1739,14 +1719,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     class UnreachableSetOption = UnreachableSetOption::Option;
 
     pragma[nomagic]
-    private predicate hasValueReturnKindIn(ReturnNode ret, ReturnKindExt kind, DataFlowCallable c) {
+    private predicate hasValueReturnKindIn(ReturnNode ret, ReturnKindExt kind, Callable c) {
       c = getNodeEnclosingCallable(ret) and
       kind = TValueReturn(ret.getKind())
     }
 
     pragma[nomagic]
     private predicate hasParamReturnKindIn(
-      PostUpdateNode n, ParamNode p, ReturnKindExt kind, DataFlowCallable c
+      PostUpdateNode n, ParamNode p, ReturnKindExt kind, Callable c
     ) {
       c = getNodeEnclosingCallable(n) and
       paramReturnNode(n, p, _, kind)
@@ -1754,7 +1734,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     cached
     newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      TReturnPosition0(Callable c, ReturnKindExt kind) {
         hasValueReturnKindIn(_, kind, c)
         or
         hasParamReturnKindIn(_, _, kind, c)
@@ -1762,7 +1742,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     cached
     ReturnPosition getValueReturnPosition(ReturnNode ret) {
-      exists(ReturnKindExt kind, DataFlowCallable c |
+      exists(ReturnKindExt kind, Callable c |
         hasValueReturnKindIn(ret, kind, c) and
         result = TReturnPosition0(c, kind)
       )
@@ -1770,7 +1750,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     cached
     ReturnPosition getParamReturnPosition(PostUpdateNode n, ParamNode p) {
-      exists(ReturnKindExt kind, DataFlowCallable c |
+      exists(ReturnKindExt kind, Callable c |
         hasParamReturnKindIn(n, p, kind, c) and
         result = TReturnPosition0(c, kind)
       )
@@ -1792,9 +1772,9 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       TBooleanSome(boolean b) { b = true or b = false }
 
     cached
-    newtype TDataFlowCallOption =
-      TDataFlowCallNone() or
-      TDataFlowCallSome(DataFlowCall call)
+    newtype TCallOption =
+      TCallNone() or
+      TCallSome(Call call)
 
     cached
     newtype TReturnCtx =
@@ -1863,23 +1843,17 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   bindingset[call, tgt]
   pragma[inline_late]
-  private TCallEdge mkCallEdge(DataFlowCall call, DataFlowCallable tgt) {
-    result = TMkCallEdge(call, tgt)
-  }
+  private TCallEdge mkCallEdge(Call call, Callable tgt) { result = TMkCallEdge(call, tgt) }
 
   bindingset[t1, t2]
   pragma[inline_late]
-  predicate compatibleTypesFilter(DataFlowType t1, DataFlowType t2) {
-    compatibleTypesCached(t1, t2)
-  }
+  predicate compatibleTypesFilter(Type t1, Type t2) { compatibleTypesCached(t1, t2) }
 
   bindingset[t1, t2]
   pragma[inline_late]
-  predicate typeStrongerThanFilter(DataFlowType t1, DataFlowType t2) {
-    typeStrongerThanCached(t1, t2)
-  }
+  predicate typeStrongerThanFilter(Type t1, Type t2) { typeStrongerThanCached(t1, t2) }
 
-  private predicate callEdge(DataFlowCall call, DataFlowCallable c, ArgNode arg, ParamNode p) {
+  private predicate callEdge(Call call, Callable c, ArgNode arg, ParamNode p) {
     viableParamArg(call, p, arg) and
     c = getNodeEnclosingCallable(p)
   }
@@ -1888,27 +1862,27 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     predicate enableTypeFlow();
 
     /** Holds if the edge is possibly needed in the direction `call` to `c`. */
-    predicate relevantCallEdgeIn(DataFlowCall call, DataFlowCallable c);
+    predicate relevantCallEdgeIn(Call call, Callable c);
 
     /** Holds if the edge is possibly needed in the direction `c` to `call`. */
-    predicate relevantCallEdgeOut(DataFlowCall call, DataFlowCallable c);
+    predicate relevantCallEdgeOut(Call call, Callable c);
 
     /**
      * Holds if the edge is followed in data flow in the direction `call` to `c`
      * and the call context `cc`.
      */
-    predicate dataFlowTakenCallEdgeIn(DataFlowCall call, DataFlowCallable c, boolean cc);
+    predicate dataFlowTakenCallEdgeIn(Call call, Callable c, boolean cc);
 
     /**
      * Holds if the edge is followed in data flow in the direction `c` to `call`.
      */
-    predicate dataFlowTakenCallEdgeOut(DataFlowCall call, DataFlowCallable c);
+    predicate dataFlowTakenCallEdgeOut(Call call, Callable c);
 
     /**
      * Holds if data flow enters `c` with call context `cc` without using a call
      * edge.
      */
-    predicate dataFlowNonCallEntry(DataFlowCallable c, boolean cc);
+    predicate dataFlowNonCallEntry(Callable c, boolean cc);
   }
 
   /**
@@ -1924,9 +1898,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    * given in `typeFlowValidEdgeIn` and `typeFlowValidEdgeOut`.
    */
   module TypeFlow<TypeFlowInput Input> {
-    private predicate relevantCallEdge(
-      DataFlowCall call, DataFlowCallable c, ArgNode arg, ParamNode p
-    ) {
+    private predicate relevantCallEdge(Call call, Callable c, ArgNode arg, ParamNode p) {
       callEdge(call, c, arg, p) and
       (
         Input::relevantCallEdgeIn(call, c) or
@@ -1954,19 +1926,19 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     private predicate trackedArgTypeCand(ArgNode arg) {
       Input::enableTypeFlow() and
       (
-        exists(ParamNode p, DataFlowType at, DataFlowType pt |
-          nodeDataFlowType(arg, at) and
-          nodeDataFlowType(p, pt) and
+        exists(ParamNode p, Type at, Type pt |
+          nodeType(arg, at) and
+          nodeType(p, pt) and
           relevantCallEdge(_, _, arg, p) and
           typeStrongerThanFilter(pt, at)
         )
         or
-        exists(ParamNode p, DataFlowType at, DataFlowType pt |
+        exists(ParamNode p, Type at, Type pt |
           // A call edge may implicitly strengthen a type by ensuring that a
           // specific argument node was reached if the type of that argument was
           // strengthened via a cast.
-          nodeDataFlowType(arg, at) and
-          nodeDataFlowType(p, pt) and
+          nodeType(arg, at) and
+          nodeType(p, pt) and
           paramMustFlow(p, arg) and
           relevantCallEdge(_, _, arg, _) and
           typeStrongerThanFilter(at, pt)
@@ -1985,10 +1957,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * argument nodes.
      */
     private predicate trackedParamType(ParamNode p) {
-      exists(
-        DataFlowCall call1, DataFlowCallable c1, ArgNode argOut, DataFlowCall call2,
-        DataFlowCallable c2, ArgNode argIn
-      |
+      exists(Call call1, Callable c1, ArgNode argOut, Call call2, Callable c2, ArgNode argIn |
         // Data flow may exit `call1` and enter `call2`. If a stronger type is
         // known for `argOut`, `argIn` may reach a strengthening, and both are
         // determined by the same parameter `p` so we know they're equal, then
@@ -2004,10 +1973,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
         paramMustFlow(p, argIn)
       )
       or
-      exists(ArgNode arg, DataFlowType at, DataFlowType pt |
+      exists(ArgNode arg, Type at, Type pt |
         trackedParamTypeCand(p) and
-        nodeDataFlowType(arg, at) and
-        nodeDataFlowType(p, pt) and
+        nodeType(arg, at) and
+        nodeType(p, pt) and
         relevantCallEdge(_, _, arg, p) and
         typeStrongerThanFilter(at, pt)
       )
@@ -2033,7 +2002,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private predicate returnCallDeterminesParam(DataFlowCall call, ParamNode p) {
+    private predicate returnCallDeterminesParam(Call call, ParamNode p) {
       exists(ArgNode arg |
         trackedArgType(arg) and
         arg.argumentOf(call, _) and
@@ -2041,22 +2010,22 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
       )
     }
 
-    private predicate returnCallLeavesParamUndetermined(DataFlowCall call, ParamNode p) {
+    private predicate returnCallLeavesParamUndetermined(Call call, ParamNode p) {
       trackedParamType(p) and
       call.getEnclosingCallable() = getNodeEnclosingCallable(p) and
       not returnCallDeterminesParam(call, p)
     }
 
     pragma[nomagic]
-    private predicate trackedParamWithType(ParamNode p, DataFlowType t, DataFlowCallable c) {
+    private predicate trackedParamWithType(ParamNode p, Type t, Callable c) {
       trackedParamType(p) and
       c = getNodeEnclosingCallable(p) and
-      nodeDataFlowType(p, t)
+      nodeType(p, t)
     }
 
     pragma[nomagic]
     private predicate dataFlowTakenCallEdgeIn(
-      DataFlowCall call, DataFlowCallable c, ArgNode arg, ParamNode p, boolean cc
+      Call call, Callable c, ArgNode arg, ParamNode p, boolean cc
     ) {
       Input::dataFlowTakenCallEdgeIn(call, c, cc) and
       callEdge(call, c, arg, p) and
@@ -2064,9 +2033,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
 
     pragma[nomagic]
-    private predicate dataFlowTakenCallEdgeOut(
-      DataFlowCall call, DataFlowCallable c, ArgNode arg, ParamNode p
-    ) {
+    private predicate dataFlowTakenCallEdgeOut(Call call, Callable c, ArgNode arg, ParamNode p) {
       Input::dataFlowTakenCallEdgeOut(call, c) and
       callEdge(call, c, arg, p) and
       trackedArgType(arg) and
@@ -2079,7 +2046,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      */
     bindingset[t1, t2]
     pragma[inline_late]
-    DataFlowType getStrongestType(DataFlowType t1, DataFlowType t2) {
+    Type getStrongestType(Type t1, Type t2) {
       if typeStrongerThanCached(t2, t1)
       then result = t2
       else (
@@ -2092,10 +2059,10 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * parameter `p` through an in-going edge in the current data flow stage.
      */
     pragma[nomagic]
-    private predicate typeFlowParamTypeCand(ParamNode p, DataFlowType t) {
+    private predicate typeFlowParamTypeCand(ParamNode p, Type t) {
       exists(ArgNode arg, boolean outercc |
         dataFlowTakenCallEdgeIn(_, _, arg, p, outercc) and
-        if trackedArgType(arg) then typeFlowArgType(arg, t, outercc) else nodeDataFlowType(arg, t)
+        if trackedArgType(arg) then typeFlowArgType(arg, t, outercc) else nodeType(arg, t)
       )
     }
 
@@ -2104,32 +2071,32 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * context `cc` and that the current data flow stage has reached this
      * context.
      */
-    private predicate typeFlowParamType(ParamNode p, DataFlowType t, boolean cc) {
-      exists(DataFlowCallable c |
+    private predicate typeFlowParamType(ParamNode p, Type t, boolean cc) {
+      exists(Callable c |
         Input::dataFlowNonCallEntry(c, cc) and
         trackedParamWithType(p, t, c)
       )
       or
-      exists(DataFlowType t1, DataFlowType t2 |
+      exists(Type t1, Type t2 |
         cc = true and
         typeFlowParamTypeCand(p, t1) and
-        nodeDataFlowType(p, t2) and
+        nodeType(p, t2) and
         t = getStrongestType(t1, t2)
       )
       or
-      exists(ArgNode arg, DataFlowType t1, DataFlowType t2 |
+      exists(ArgNode arg, Type t1, Type t2 |
         cc = false and
         typeFlowArgTypeFromReturn(arg, t1) and
         paramMustFlow(p, arg) and
-        nodeDataFlowType(p, t2) and
+        nodeType(p, t2) and
         t = getStrongestType(t1, t2)
       )
       or
-      exists(DataFlowCall call |
+      exists(Call call |
         cc = false and
         Input::dataFlowTakenCallEdgeOut(call, _) and
         returnCallLeavesParamUndetermined(call, p) and
-        nodeDataFlowType(p, t)
+        nodeType(p, t)
       )
     }
 
@@ -2138,11 +2105,11 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * the current data flow stage has reached the call of `arg` from one of its
      * call targets.
      */
-    private predicate typeFlowArgTypeFromReturn(ArgNode arg, DataFlowType t) {
-      exists(ParamNode p, DataFlowType t1, DataFlowType t2 |
+    private predicate typeFlowArgTypeFromReturn(ArgNode arg, Type t) {
+      exists(ParamNode p, Type t1, Type t2 |
         dataFlowTakenCallEdgeOut(_, _, arg, p) and
-        (if trackedParamType(p) then typeFlowParamType(p, t1, false) else nodeDataFlowType(p, t1)) and
-        nodeDataFlowType(arg, t2) and
+        (if trackedParamType(p) then typeFlowParamType(p, t1, false) else nodeType(p, t1)) and
+        nodeType(arg, t2) and
         t = getStrongestType(t1, t2)
       )
     }
@@ -2152,19 +2119,19 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * context `cc` and that the current data flow stage has reached this
      * context.
      */
-    private predicate typeFlowArgType(ArgNode arg, DataFlowType t, boolean cc) {
+    private predicate typeFlowArgType(ArgNode arg, Type t, boolean cc) {
       trackedArgType(arg) and
       (
-        exists(ParamNode p, DataFlowType t1, DataFlowType t2 |
+        exists(ParamNode p, Type t1, Type t2 |
           paramMustFlow(p, arg) and
           typeFlowParamType(p, t1, cc) and
-          nodeDataFlowType(arg, t2) and
+          nodeType(arg, t2) and
           t = getStrongestType(t1, t2)
         )
         or
         cc = [true, false] and
         not paramMustFlow(_, arg) and
-        nodeDataFlowType(arg, t)
+        nodeType(arg, t)
       )
     }
 
@@ -2174,7 +2141,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
           typeFlowParamType(n, _, _) or typeFlowArgTypeFromReturn(n, _) or typeFlowArgType(n, _, _)
         ) and
       tuples =
-        count(Node n, DataFlowType t, boolean cc |
+        count(Node n, Type t, boolean cc |
           typeFlowParamType(n, t, cc)
           or
           typeFlowArgTypeFromReturn(n, t) and cc = false
@@ -2187,13 +2154,13 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if the `arg`-to-`p` edge should be considered for validation of the
      * corresponding call edge in the in-going direction.
      */
-    private predicate relevantArgParamIn(ArgNode arg, ParamNode p, DataFlowType pt) {
-      exists(DataFlowCall call, DataFlowCallable c |
+    private predicate relevantArgParamIn(ArgNode arg, ParamNode p, Type pt) {
+      exists(Call call, Callable c |
         Input::relevantCallEdgeIn(call, c) and
         callEdge(call, c, arg, p) and
         paramMustFlow(_, arg) and
         trackedArgType(arg) and
-        nodeDataFlowType(p, pt)
+        nodeType(p, pt)
       )
     }
 
@@ -2202,7 +2169,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * is consistent with the static type of `p`.
      */
     private predicate validArgParamIn(ArgNode arg, ParamNode p, boolean cc) {
-      exists(DataFlowType t1, DataFlowType t2 |
+      exists(Type t1, Type t2 |
         typeFlowArgType(arg, t1, cc) and
         relevantArgParamIn(arg, p, t2) and
         compatibleTypesFilter(t1, t2)
@@ -2214,7 +2181,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * call context `cc`.
      */
     pragma[nomagic]
-    predicate typeFlowValidEdgeIn(DataFlowCall call, DataFlowCallable c, boolean cc) {
+    predicate typeFlowValidEdgeIn(Call call, Callable c, boolean cc) {
       Input::relevantCallEdgeIn(call, c) and
       cc = [true, false] and
       (
@@ -2232,12 +2199,12 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if the `arg`-to-`p` edge should be considered for validation of the
      * corresponding call edge in the out-going direction.
      */
-    private predicate relevantArgParamOut(ArgNode arg, ParamNode p, DataFlowType argt) {
-      exists(DataFlowCall call, DataFlowCallable c |
+    private predicate relevantArgParamOut(ArgNode arg, ParamNode p, Type argt) {
+      exists(Call call, Callable c |
         Input::relevantCallEdgeOut(call, c) and
         callEdge(call, c, arg, p) and
         trackedParamType(p) and
-        nodeDataFlowType(arg, argt)
+        nodeType(arg, argt)
       )
     }
 
@@ -2246,7 +2213,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * that is consistent with the static type of `arg`.
      */
     private predicate validArgParamOut(ArgNode arg, ParamNode p) {
-      exists(DataFlowType t1, DataFlowType t2 |
+      exists(Type t1, Type t2 |
         typeFlowParamType(p, t1, false) and
         relevantArgParamOut(arg, p, t2) and
         compatibleTypesFilter(t1, t2)
@@ -2257,7 +2224,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if the edge `call`-to-`c` is valid in the out-going direction.
      */
     pragma[nomagic]
-    predicate typeFlowValidEdgeOut(DataFlowCall call, DataFlowCallable c) {
+    predicate typeFlowValidEdgeOut(Call call, Callable c) {
       Input::relevantCallEdgeOut(call, c) and
       (
         not Input::enableTypeFlow()
@@ -2286,9 +2253,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
   }
 
-  private predicate readStepWithTypes(
-    Node n1, DataFlowType container, ContentSet c, Node n2, DataFlowType content
-  ) {
+  private predicate readStepWithTypes(Node n1, Type container, ContentSet c, Node n2, Type content) {
     readSet(n1, c, n2) and
     container = getNodeDataFlowType(n1) and
     content = getNodeDataFlowType(n2)
@@ -2296,18 +2261,18 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   private newtype TReadStepTypesOption =
     TReadStepTypesNone() or
-    TReadStepTypesSome(DataFlowType container, ContentSet c, DataFlowType content) {
+    TReadStepTypesSome(Type container, ContentSet c, Type content) {
       readStepWithTypes(_, container, c, _, content)
     }
 
   private class ReadStepTypesOption extends TReadStepTypesOption {
     predicate isSome() { this instanceof TReadStepTypesSome }
 
-    DataFlowType getContainerType() { this = TReadStepTypesSome(result, _, _) }
+    Type getContainerType() { this = TReadStepTypesSome(result, _, _) }
 
     ContentSet getContent() { this = TReadStepTypesSome(_, result, _) }
 
-    DataFlowType getContentType() { this = TReadStepTypesSome(_, _, result) }
+    Type getContentType() { this = TReadStepTypesSome(_, _, result) }
 
     string toString() { if this.isSome() then result = "Some(..)" else result = "None()" }
   }
@@ -2319,13 +2284,13 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     abstract string toString();
 
     /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
+    abstract predicate relevantFor(Callable callable);
   }
 
   class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
     override string toString() { result = "LocalCcAny" }
 
-    override predicate relevantFor(DataFlowCallable callable) { any() }
+    override predicate relevantFor(Callable callable) { any() }
   }
 
   class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
@@ -2335,15 +2300,13 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
     override string toString() { result = "LocalCcCall" }
 
-    override predicate relevantFor(DataFlowCallable callable) {
-      ns.getEnclosingCallable() = callable
-    }
+    override predicate relevantFor(Callable callable) { ns.getEnclosingCallable() = callable }
 
     /** Holds if this call context makes `n` unreachable. */
     predicate unreachable(NodeEx n) { ns.contains(n) }
   }
 
-  private DataFlowCallable getNodeRegionEnclosingCallable(NodeRegion nr) {
+  private Callable getNodeRegionEnclosingCallable(NodeRegion nr) {
     exists(Node n | nr.contains(n) | getNodeEnclosingCallable(n) = result)
   }
 
@@ -2358,9 +2321,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
      * Holds if this node is the parameter of callable `c` at the specified
      * position.
      */
-    predicate isParameterOf(DataFlowCallable c, ParameterPosition pos) {
-      parameterNode(this, c, pos)
-    }
+    predicate isParameterOf(Callable c, ParameterPosition pos) { parameterNode(this, c, pos) }
   }
 
   /** A data-flow node that represents a call argument. */
@@ -2368,9 +2329,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     ArgNode() { argumentNode(this, _, _) }
 
     /** Holds if this argument occurs at the given position in the given call. */
-    final predicate argumentOf(DataFlowCall call, ArgumentPosition pos) {
-      argumentNode(this, call, pos)
-    }
+    final predicate argumentOf(Call call, ArgumentPosition pos) { argumentNode(this, call, pos) }
   }
 
   /**
@@ -2382,7 +2341,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
   }
 
   pragma[nomagic]
-  OutNodeExt getAnOutNodeExt(DataFlowCall call, ReturnKindExt k) {
+  OutNodeExt getAnOutNodeExt(Call call, ReturnKindExt k) {
     result = getAnOutNode(call, k.(ValueReturnKind).getKind())
     or
     exists(ArgNode arg |
@@ -2401,7 +2360,7 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     abstract string toString();
 
     /** Gets a node corresponding to data flow out of `call`. */
-    final OutNodeEx getAnOutNodeEx(DataFlowCall call) { result = getAnOutNodeEx(call, this) }
+    final OutNodeEx getAnOutNodeEx(Call call) { result = getAnOutNodeEx(call, this) }
   }
 
   class ValueReturnKind extends ReturnKindExt, TValueReturn {
@@ -2431,13 +2390,13 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
 
   /** A callable tagged with a relevant return kind. */
   class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
+    private Callable c;
     private ReturnKindExt kind;
 
     ReturnPosition() { this = TReturnPosition0(c, kind) }
 
     /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
+    Callable getCallable() { result = c }
 
     /** Gets the return kind. */
     ReturnKindExt getKind() { result = kind }
@@ -2452,14 +2411,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
    * way around.
    */
   pragma[inline]
-  DataFlowCallable getNodeEnclosingCallable(Node n) {
+  Callable getNodeEnclosingCallable(Node n) {
     nodeEnclosingCallable(pragma[only_bind_out](n), pragma[only_bind_into](result))
   }
 
   /** Gets the type of `n` used for type pruning. */
   pragma[inline]
-  DataFlowType getNodeDataFlowType(Node n) {
-    nodeDataFlowType(pragma[only_bind_out](n), pragma[only_bind_into](result))
+  Type getNodeDataFlowType(Node n) {
+    nodeType(pragma[only_bind_out](n), pragma[only_bind_into](result))
   }
 
   /** An optional Boolean value. */
@@ -2471,14 +2430,14 @@ module MakeImplCommon<LocationSig Location, InputSig<Location> Lang> {
     }
   }
 
-  /** An optional `DataFlowCall`. */
-  class DataFlowCallOption extends TDataFlowCallOption {
+  /** An optional `Call`. */
+  class CallOption extends TCallOption {
     string toString() {
-      this = TDataFlowCallNone() and
+      this = TCallNone() and
       result = "(none)"
       or
-      exists(DataFlowCall call |
-        this = TDataFlowCallSome(call) and
+      exists(Call call |
+        this = TCallSome(call) and
         result = call.toString()
       )
     }


### PR DESCRIPTION
Adds the following internal aliases in the data flow library to make the code less verbose
```ql
class Call = DataFlowCall;

class Callable = DataFlowCallable;

class Type = DataFlowType;

class Expr = DataFlowExpr;
```