### PR TITLE
Swift: fix `KeyPathExpr` assertion

### DIFF
--- a/swift/extractor/translators/ExprTranslator.cpp
+++ b/swift/extractor/translators/ExprTranslator.cpp
@@ -379,12 +379,7 @@ codeql::KeyPathExpr ExprTranslator::translateKeyPathExpr(const swift::KeyPathExp
       entry.components.push_back(emitKeyPathComponent(component));
     }
     if (auto rootTypeRepr = expr.getExplicitRootType()) {
-      auto keyPathType = expr.getType()->getAs<swift::BoundGenericClassType>();
-      CODEQL_EXPECT_OR(return entry, keyPathType, "KeyPathExpr must have BoundGenericClassType");
-      auto keyPathTypeArgs = keyPathType->getGenericArgs();
-      CODEQL_EXPECT_OR(return entry, keyPathTypeArgs.size() != 0,
-                              "KeyPathExpr type must have generic args");
-      entry.root = dispatcher.fetchLabel(rootTypeRepr, keyPathTypeArgs[0]);
+      entry.root = dispatcher.fetchLabel(rootTypeRepr, expr.getRootType());
     }
   }
   return entry;


### PR DESCRIPTION
Closes https://github.com/github/codeql/issues/18678

Unfortunately, I wasn't really able to reproduce the issue in my code, but in any case that roundabout way of getting the type for the root type repr of a key path expression was done in the past only because `getRootType` was not present in the Swift compiler API at the time.