### PR TITLE
Rust: Basic support for future content and `.await`

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/FlowSummaryImpl.qll
@@ -97,6 +97,10 @@ module Input implements InputSig<Location, RustDataFlow> {
         c = TTuplePositionContent(pos) and
         arg = pos.toString()
       )
+      or
+      result = "Future" and
+      c = TFutureContent() and
+      arg = ""
     )
   }
 

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -203,6 +203,16 @@ fn test_apply_flow_through() {
     sink(t); // $ hasValueFlow=33
 }
 
+async fn get_async_number(a: i64) -> i64 {
+    37
+}
+
+async fn test_get_async_number() {
+    let s = source(46);
+    let t = get_async_number(s).await;
+    sink(t); // $ MISSING: hasValueFlow=46
+}
+
 impl MyFieldEnum {
     // has a source model
     fn source(&self, i: i64) -> MyFieldEnum {
@@ -268,7 +278,8 @@ fn test_simple_sink() {
     simple_sink(s); // $ hasValueFlow=17
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     test_identify();
     test_get_var_pos();
     test_set_var_pos();
@@ -286,5 +297,6 @@ fn main() {
     test_enum_method_sink();
     test_simple_source();
     test_simple_sink();
+    test_get_async_number().await;
     let dummy = Some(0); // ensure that the the `lang:core` crate is extracted
 }

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -203,6 +203,7 @@ fn test_apply_flow_through() {
     sink(t); // $ hasValueFlow=33
 }
 
+// has a flow model with value flow from argument to returned future
 async fn get_async_number(a: i64) -> i64 {
     37
 }

--- a/rust/ql/test/library-tests/dataflow/models/main.rs
+++ b/rust/ql/test/library-tests/dataflow/models/main.rs
@@ -210,7 +210,7 @@ async fn get_async_number(a: i64) -> i64 {
 async fn test_get_async_number() {
     let s = source(46);
     let t = get_async_number(s).await;
-    sink(t); // $ MISSING: hasValueFlow=46
+    sink(t); // $ hasValueFlow=46
 }
 
 impl MyFieldEnum {

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -177,62 +177,62 @@ edges
 | main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
-| main.rs:222:9:222:9 | s [D] | main.rs:223:11:223:11 | s [D] | provenance |  |
-| main.rs:222:9:222:9 | s [D] | main.rs:223:11:223:11 | s [D] | provenance |  |
-| main.rs:222:13:222:23 | enum_source | main.rs:222:13:222:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:222:13:222:23 | enum_source | main.rs:222:13:222:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:222:13:222:27 | enum_source(...) [D] | main.rs:222:9:222:9 | s [D] | provenance |  |
-| main.rs:222:13:222:27 | enum_source(...) [D] | main.rs:222:9:222:9 | s [D] | provenance |  |
-| main.rs:223:11:223:11 | s [D] | main.rs:225:9:225:37 | ...::D {...} [D] | provenance |  |
-| main.rs:223:11:223:11 | s [D] | main.rs:225:9:225:37 | ...::D {...} [D] | provenance |  |
-| main.rs:225:9:225:37 | ...::D {...} [D] | main.rs:225:35:225:35 | i | provenance |  |
-| main.rs:225:9:225:37 | ...::D {...} [D] | main.rs:225:35:225:35 | i | provenance |  |
-| main.rs:225:35:225:35 | i | main.rs:225:47:225:47 | i | provenance |  |
-| main.rs:225:35:225:35 | i | main.rs:225:47:225:47 | i | provenance |  |
-| main.rs:231:9:231:9 | s [C] | main.rs:232:11:232:11 | s [C] | provenance |  |
-| main.rs:231:9:231:9 | s [C] | main.rs:232:11:232:11 | s [C] | provenance |  |
-| main.rs:231:13:231:24 | e.source(...) [C] | main.rs:231:9:231:9 | s [C] | provenance |  |
-| main.rs:231:13:231:24 | e.source(...) [C] | main.rs:231:9:231:9 | s [C] | provenance |  |
-| main.rs:231:15:231:20 | source | main.rs:231:13:231:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:231:15:231:20 | source | main.rs:231:13:231:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:232:11:232:11 | s [C] | main.rs:233:9:233:37 | ...::C {...} [C] | provenance |  |
-| main.rs:232:11:232:11 | s [C] | main.rs:233:9:233:37 | ...::C {...} [C] | provenance |  |
-| main.rs:233:9:233:37 | ...::C {...} [C] | main.rs:233:35:233:35 | i | provenance |  |
-| main.rs:233:9:233:37 | ...::C {...} [C] | main.rs:233:35:233:35 | i | provenance |  |
-| main.rs:233:35:233:35 | i | main.rs:233:47:233:47 | i | provenance |  |
-| main.rs:233:35:233:35 | i | main.rs:233:47:233:47 | i | provenance |  |
-| main.rs:242:9:242:9 | s | main.rs:243:41:243:41 | s | provenance |  |
-| main.rs:242:9:242:9 | s | main.rs:243:41:243:41 | s | provenance |  |
-| main.rs:242:13:242:22 | source(...) | main.rs:242:9:242:9 | s | provenance |  |
-| main.rs:242:13:242:22 | source(...) | main.rs:242:9:242:9 | s | provenance |  |
-| main.rs:243:15:243:43 | ...::C {...} [C] | main.rs:243:5:243:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:243:15:243:43 | ...::C {...} [C] | main.rs:243:5:243:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:243:41:243:41 | s | main.rs:243:15:243:43 | ...::C {...} [C] | provenance |  |
-| main.rs:243:41:243:41 | s | main.rs:243:15:243:43 | ...::C {...} [C] | provenance |  |
-| main.rs:248:9:248:9 | s | main.rs:249:39:249:39 | s | provenance |  |
-| main.rs:248:9:248:9 | s | main.rs:249:39:249:39 | s | provenance |  |
-| main.rs:248:13:248:22 | source(...) | main.rs:248:9:248:9 | s | provenance |  |
-| main.rs:248:13:248:22 | source(...) | main.rs:248:9:248:9 | s | provenance |  |
-| main.rs:249:9:249:9 | e [D] | main.rs:250:5:250:5 | e [D] | provenance |  |
-| main.rs:249:9:249:9 | e [D] | main.rs:250:5:250:5 | e [D] | provenance |  |
-| main.rs:249:13:249:41 | ...::D {...} [D] | main.rs:249:9:249:9 | e [D] | provenance |  |
-| main.rs:249:13:249:41 | ...::D {...} [D] | main.rs:249:9:249:9 | e [D] | provenance |  |
-| main.rs:249:39:249:39 | s | main.rs:249:13:249:41 | ...::D {...} [D] | provenance |  |
-| main.rs:249:39:249:39 | s | main.rs:249:13:249:41 | ...::D {...} [D] | provenance |  |
-| main.rs:250:5:250:5 | e [D] | main.rs:250:7:250:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:250:5:250:5 | e [D] | main.rs:250:7:250:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:259:9:259:9 | s | main.rs:260:10:260:10 | s | provenance |  |
-| main.rs:259:9:259:9 | s | main.rs:260:10:260:10 | s | provenance |  |
-| main.rs:259:13:259:25 | simple_source | main.rs:259:13:259:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:259:13:259:25 | simple_source | main.rs:259:13:259:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:259:13:259:29 | simple_source(...) | main.rs:259:9:259:9 | s | provenance |  |
-| main.rs:259:13:259:29 | simple_source(...) | main.rs:259:9:259:9 | s | provenance |  |
-| main.rs:267:9:267:9 | s | main.rs:268:17:268:17 | s | provenance |  |
-| main.rs:267:9:267:9 | s | main.rs:268:17:268:17 | s | provenance |  |
-| main.rs:267:13:267:22 | source(...) | main.rs:267:9:267:9 | s | provenance |  |
-| main.rs:267:13:267:22 | source(...) | main.rs:267:9:267:9 | s | provenance |  |
-| main.rs:268:17:268:17 | s | main.rs:268:5:268:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:268:17:268:17 | s | main.rs:268:5:268:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
+| main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
+| main.rs:232:13:232:23 | enum_source | main.rs:232:13:232:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:232:13:232:23 | enum_source | main.rs:232:13:232:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:232:13:232:27 | enum_source(...) [D] | main.rs:232:9:232:9 | s [D] | provenance |  |
+| main.rs:232:13:232:27 | enum_source(...) [D] | main.rs:232:9:232:9 | s [D] | provenance |  |
+| main.rs:233:11:233:11 | s [D] | main.rs:235:9:235:37 | ...::D {...} [D] | provenance |  |
+| main.rs:233:11:233:11 | s [D] | main.rs:235:9:235:37 | ...::D {...} [D] | provenance |  |
+| main.rs:235:9:235:37 | ...::D {...} [D] | main.rs:235:35:235:35 | i | provenance |  |
+| main.rs:235:9:235:37 | ...::D {...} [D] | main.rs:235:35:235:35 | i | provenance |  |
+| main.rs:235:35:235:35 | i | main.rs:235:47:235:47 | i | provenance |  |
+| main.rs:235:35:235:35 | i | main.rs:235:47:235:47 | i | provenance |  |
+| main.rs:241:9:241:9 | s [C] | main.rs:242:11:242:11 | s [C] | provenance |  |
+| main.rs:241:9:241:9 | s [C] | main.rs:242:11:242:11 | s [C] | provenance |  |
+| main.rs:241:13:241:24 | e.source(...) [C] | main.rs:241:9:241:9 | s [C] | provenance |  |
+| main.rs:241:13:241:24 | e.source(...) [C] | main.rs:241:9:241:9 | s [C] | provenance |  |
+| main.rs:241:15:241:20 | source | main.rs:241:13:241:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:241:15:241:20 | source | main.rs:241:13:241:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:242:11:242:11 | s [C] | main.rs:243:9:243:37 | ...::C {...} [C] | provenance |  |
+| main.rs:242:11:242:11 | s [C] | main.rs:243:9:243:37 | ...::C {...} [C] | provenance |  |
+| main.rs:243:9:243:37 | ...::C {...} [C] | main.rs:243:35:243:35 | i | provenance |  |
+| main.rs:243:9:243:37 | ...::C {...} [C] | main.rs:243:35:243:35 | i | provenance |  |
+| main.rs:243:35:243:35 | i | main.rs:243:47:243:47 | i | provenance |  |
+| main.rs:243:35:243:35 | i | main.rs:243:47:243:47 | i | provenance |  |
+| main.rs:252:9:252:9 | s | main.rs:253:41:253:41 | s | provenance |  |
+| main.rs:252:9:252:9 | s | main.rs:253:41:253:41 | s | provenance |  |
+| main.rs:252:13:252:22 | source(...) | main.rs:252:9:252:9 | s | provenance |  |
+| main.rs:252:13:252:22 | source(...) | main.rs:252:9:252:9 | s | provenance |  |
+| main.rs:253:15:253:43 | ...::C {...} [C] | main.rs:253:5:253:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:253:15:253:43 | ...::C {...} [C] | main.rs:253:5:253:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:253:41:253:41 | s | main.rs:253:15:253:43 | ...::C {...} [C] | provenance |  |
+| main.rs:253:41:253:41 | s | main.rs:253:15:253:43 | ...::C {...} [C] | provenance |  |
+| main.rs:258:9:258:9 | s | main.rs:259:39:259:39 | s | provenance |  |
+| main.rs:258:9:258:9 | s | main.rs:259:39:259:39 | s | provenance |  |
+| main.rs:258:13:258:22 | source(...) | main.rs:258:9:258:9 | s | provenance |  |
+| main.rs:258:13:258:22 | source(...) | main.rs:258:9:258:9 | s | provenance |  |
+| main.rs:259:9:259:9 | e [D] | main.rs:260:5:260:5 | e [D] | provenance |  |
+| main.rs:259:9:259:9 | e [D] | main.rs:260:5:260:5 | e [D] | provenance |  |
+| main.rs:259:13:259:41 | ...::D {...} [D] | main.rs:259:9:259:9 | e [D] | provenance |  |
+| main.rs:259:13:259:41 | ...::D {...} [D] | main.rs:259:9:259:9 | e [D] | provenance |  |
+| main.rs:259:39:259:39 | s | main.rs:259:13:259:41 | ...::D {...} [D] | provenance |  |
+| main.rs:259:39:259:39 | s | main.rs:259:13:259:41 | ...::D {...} [D] | provenance |  |
+| main.rs:260:5:260:5 | e [D] | main.rs:260:7:260:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:260:5:260:5 | e [D] | main.rs:260:7:260:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:269:9:269:9 | s | main.rs:270:10:270:10 | s | provenance |  |
+| main.rs:269:9:269:9 | s | main.rs:270:10:270:10 | s | provenance |  |
+| main.rs:269:13:269:25 | simple_source | main.rs:269:13:269:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:269:13:269:25 | simple_source | main.rs:269:13:269:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:269:13:269:29 | simple_source(...) | main.rs:269:9:269:9 | s | provenance |  |
+| main.rs:269:13:269:29 | simple_source(...) | main.rs:269:9:269:9 | s | provenance |  |
+| main.rs:277:9:277:9 | s | main.rs:278:17:278:17 | s | provenance |  |
+| main.rs:277:9:277:9 | s | main.rs:278:17:278:17 | s | provenance |  |
+| main.rs:277:13:277:22 | source(...) | main.rs:277:9:277:9 | s | provenance |  |
+| main.rs:277:13:277:22 | source(...) | main.rs:277:9:277:9 | s | provenance |  |
+| main.rs:278:17:278:17 | s | main.rs:278:5:278:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:278:17:278:17 | s | main.rs:278:5:278:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -416,74 +416,74 @@ nodes
 | main.rs:202:19:202:19 | s | semmle.label | s |
 | main.rs:203:10:203:10 | t | semmle.label | t |
 | main.rs:203:10:203:10 | t | semmle.label | t |
-| main.rs:222:9:222:9 | s [D] | semmle.label | s [D] |
-| main.rs:222:9:222:9 | s [D] | semmle.label | s [D] |
-| main.rs:222:13:222:23 | enum_source | semmle.label | enum_source |
-| main.rs:222:13:222:23 | enum_source | semmle.label | enum_source |
-| main.rs:222:13:222:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:222:13:222:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:223:11:223:11 | s [D] | semmle.label | s [D] |
-| main.rs:223:11:223:11 | s [D] | semmle.label | s [D] |
-| main.rs:225:9:225:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:225:9:225:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:225:35:225:35 | i | semmle.label | i |
-| main.rs:225:35:225:35 | i | semmle.label | i |
-| main.rs:225:47:225:47 | i | semmle.label | i |
-| main.rs:225:47:225:47 | i | semmle.label | i |
-| main.rs:231:9:231:9 | s [C] | semmle.label | s [C] |
-| main.rs:231:9:231:9 | s [C] | semmle.label | s [C] |
-| main.rs:231:13:231:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:231:13:231:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:231:15:231:20 | source | semmle.label | source |
-| main.rs:231:15:231:20 | source | semmle.label | source |
-| main.rs:232:11:232:11 | s [C] | semmle.label | s [C] |
-| main.rs:232:11:232:11 | s [C] | semmle.label | s [C] |
-| main.rs:233:9:233:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:233:9:233:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:233:35:233:35 | i | semmle.label | i |
-| main.rs:233:35:233:35 | i | semmle.label | i |
-| main.rs:233:47:233:47 | i | semmle.label | i |
-| main.rs:233:47:233:47 | i | semmle.label | i |
-| main.rs:242:9:242:9 | s | semmle.label | s |
-| main.rs:242:9:242:9 | s | semmle.label | s |
-| main.rs:242:13:242:22 | source(...) | semmle.label | source(...) |
-| main.rs:242:13:242:22 | source(...) | semmle.label | source(...) |
-| main.rs:243:5:243:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:243:5:243:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:243:15:243:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:243:15:243:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:243:41:243:41 | s | semmle.label | s |
-| main.rs:243:41:243:41 | s | semmle.label | s |
-| main.rs:248:9:248:9 | s | semmle.label | s |
-| main.rs:248:9:248:9 | s | semmle.label | s |
-| main.rs:248:13:248:22 | source(...) | semmle.label | source(...) |
-| main.rs:248:13:248:22 | source(...) | semmle.label | source(...) |
-| main.rs:249:9:249:9 | e [D] | semmle.label | e [D] |
-| main.rs:249:9:249:9 | e [D] | semmle.label | e [D] |
-| main.rs:249:13:249:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:249:13:249:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:249:39:249:39 | s | semmle.label | s |
-| main.rs:249:39:249:39 | s | semmle.label | s |
-| main.rs:250:5:250:5 | e [D] | semmle.label | e [D] |
-| main.rs:250:5:250:5 | e [D] | semmle.label | e [D] |
-| main.rs:250:7:250:10 | sink | semmle.label | sink |
-| main.rs:250:7:250:10 | sink | semmle.label | sink |
-| main.rs:259:9:259:9 | s | semmle.label | s |
-| main.rs:259:9:259:9 | s | semmle.label | s |
-| main.rs:259:13:259:25 | simple_source | semmle.label | simple_source |
-| main.rs:259:13:259:25 | simple_source | semmle.label | simple_source |
-| main.rs:259:13:259:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:259:13:259:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:260:10:260:10 | s | semmle.label | s |
-| main.rs:260:10:260:10 | s | semmle.label | s |
-| main.rs:267:9:267:9 | s | semmle.label | s |
-| main.rs:267:9:267:9 | s | semmle.label | s |
-| main.rs:267:13:267:22 | source(...) | semmle.label | source(...) |
-| main.rs:267:13:267:22 | source(...) | semmle.label | source(...) |
-| main.rs:268:5:268:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:268:5:268:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:268:17:268:17 | s | semmle.label | s |
-| main.rs:268:17:268:17 | s | semmle.label | s |
+| main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
+| main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
+| main.rs:232:13:232:23 | enum_source | semmle.label | enum_source |
+| main.rs:232:13:232:23 | enum_source | semmle.label | enum_source |
+| main.rs:232:13:232:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:232:13:232:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:233:11:233:11 | s [D] | semmle.label | s [D] |
+| main.rs:233:11:233:11 | s [D] | semmle.label | s [D] |
+| main.rs:235:9:235:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:235:9:235:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:235:35:235:35 | i | semmle.label | i |
+| main.rs:235:35:235:35 | i | semmle.label | i |
+| main.rs:235:47:235:47 | i | semmle.label | i |
+| main.rs:235:47:235:47 | i | semmle.label | i |
+| main.rs:241:9:241:9 | s [C] | semmle.label | s [C] |
+| main.rs:241:9:241:9 | s [C] | semmle.label | s [C] |
+| main.rs:241:13:241:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:241:13:241:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:241:15:241:20 | source | semmle.label | source |
+| main.rs:241:15:241:20 | source | semmle.label | source |
+| main.rs:242:11:242:11 | s [C] | semmle.label | s [C] |
+| main.rs:242:11:242:11 | s [C] | semmle.label | s [C] |
+| main.rs:243:9:243:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:243:9:243:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:243:35:243:35 | i | semmle.label | i |
+| main.rs:243:35:243:35 | i | semmle.label | i |
+| main.rs:243:47:243:47 | i | semmle.label | i |
+| main.rs:243:47:243:47 | i | semmle.label | i |
+| main.rs:252:9:252:9 | s | semmle.label | s |
+| main.rs:252:9:252:9 | s | semmle.label | s |
+| main.rs:252:13:252:22 | source(...) | semmle.label | source(...) |
+| main.rs:252:13:252:22 | source(...) | semmle.label | source(...) |
+| main.rs:253:5:253:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:253:5:253:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:253:15:253:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:253:15:253:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:253:41:253:41 | s | semmle.label | s |
+| main.rs:253:41:253:41 | s | semmle.label | s |
+| main.rs:258:9:258:9 | s | semmle.label | s |
+| main.rs:258:9:258:9 | s | semmle.label | s |
+| main.rs:258:13:258:22 | source(...) | semmle.label | source(...) |
+| main.rs:258:13:258:22 | source(...) | semmle.label | source(...) |
+| main.rs:259:9:259:9 | e [D] | semmle.label | e [D] |
+| main.rs:259:9:259:9 | e [D] | semmle.label | e [D] |
+| main.rs:259:13:259:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:259:13:259:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:259:39:259:39 | s | semmle.label | s |
+| main.rs:259:39:259:39 | s | semmle.label | s |
+| main.rs:260:5:260:5 | e [D] | semmle.label | e [D] |
+| main.rs:260:5:260:5 | e [D] | semmle.label | e [D] |
+| main.rs:260:7:260:10 | sink | semmle.label | sink |
+| main.rs:260:7:260:10 | sink | semmle.label | sink |
+| main.rs:269:9:269:9 | s | semmle.label | s |
+| main.rs:269:9:269:9 | s | semmle.label | s |
+| main.rs:269:13:269:25 | simple_source | semmle.label | simple_source |
+| main.rs:269:13:269:25 | simple_source | semmle.label | simple_source |
+| main.rs:269:13:269:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:269:13:269:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:270:10:270:10 | s | semmle.label | s |
+| main.rs:270:10:270:10 | s | semmle.label | s |
+| main.rs:277:9:277:9 | s | semmle.label | s |
+| main.rs:277:9:277:9 | s | semmle.label | s |
+| main.rs:277:13:277:22 | source(...) | semmle.label | source(...) |
+| main.rs:277:13:277:22 | source(...) | semmle.label | source(...) |
+| main.rs:278:5:278:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:278:5:278:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:278:17:278:17 | s | semmle.label | s |
+| main.rs:278:17:278:17 | s | semmle.label | s |
 subpaths
 | main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
 | main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
@@ -519,15 +519,15 @@ invalidSpecComponent
 | main.rs:196:10:196:10 | t | main.rs:193:13:193:22 | source(...) | main.rs:196:10:196:10 | t | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
-| main.rs:225:47:225:47 | i | main.rs:222:13:222:23 | enum_source | main.rs:225:47:225:47 | i | $@ | main.rs:222:13:222:23 | enum_source | enum_source |
-| main.rs:225:47:225:47 | i | main.rs:222:13:222:23 | enum_source | main.rs:225:47:225:47 | i | $@ | main.rs:222:13:222:23 | enum_source | enum_source |
-| main.rs:233:47:233:47 | i | main.rs:231:15:231:20 | source | main.rs:233:47:233:47 | i | $@ | main.rs:231:15:231:20 | source | source |
-| main.rs:233:47:233:47 | i | main.rs:231:15:231:20 | source | main.rs:233:47:233:47 | i | $@ | main.rs:231:15:231:20 | source | source |
-| main.rs:243:5:243:13 | enum_sink | main.rs:242:13:242:22 | source(...) | main.rs:243:5:243:13 | enum_sink | $@ | main.rs:242:13:242:22 | source(...) | source(...) |
-| main.rs:243:5:243:13 | enum_sink | main.rs:242:13:242:22 | source(...) | main.rs:243:5:243:13 | enum_sink | $@ | main.rs:242:13:242:22 | source(...) | source(...) |
-| main.rs:250:7:250:10 | sink | main.rs:248:13:248:22 | source(...) | main.rs:250:7:250:10 | sink | $@ | main.rs:248:13:248:22 | source(...) | source(...) |
-| main.rs:250:7:250:10 | sink | main.rs:248:13:248:22 | source(...) | main.rs:250:7:250:10 | sink | $@ | main.rs:248:13:248:22 | source(...) | source(...) |
-| main.rs:260:10:260:10 | s | main.rs:259:13:259:25 | simple_source | main.rs:260:10:260:10 | s | $@ | main.rs:259:13:259:25 | simple_source | simple_source |
-| main.rs:260:10:260:10 | s | main.rs:259:13:259:25 | simple_source | main.rs:260:10:260:10 | s | $@ | main.rs:259:13:259:25 | simple_source | simple_source |
-| main.rs:268:5:268:15 | simple_sink | main.rs:267:13:267:22 | source(...) | main.rs:268:5:268:15 | simple_sink | $@ | main.rs:267:13:267:22 | source(...) | source(...) |
-| main.rs:268:5:268:15 | simple_sink | main.rs:267:13:267:22 | source(...) | main.rs:268:5:268:15 | simple_sink | $@ | main.rs:267:13:267:22 | source(...) | source(...) |
+| main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
+| main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
+| main.rs:243:47:243:47 | i | main.rs:241:15:241:20 | source | main.rs:243:47:243:47 | i | $@ | main.rs:241:15:241:20 | source | source |
+| main.rs:243:47:243:47 | i | main.rs:241:15:241:20 | source | main.rs:243:47:243:47 | i | $@ | main.rs:241:15:241:20 | source | source |
+| main.rs:253:5:253:13 | enum_sink | main.rs:252:13:252:22 | source(...) | main.rs:253:5:253:13 | enum_sink | $@ | main.rs:252:13:252:22 | source(...) | source(...) |
+| main.rs:253:5:253:13 | enum_sink | main.rs:252:13:252:22 | source(...) | main.rs:253:5:253:13 | enum_sink | $@ | main.rs:252:13:252:22 | source(...) | source(...) |
+| main.rs:260:7:260:10 | sink | main.rs:258:13:258:22 | source(...) | main.rs:260:7:260:10 | sink | $@ | main.rs:258:13:258:22 | source(...) | source(...) |
+| main.rs:260:7:260:10 | sink | main.rs:258:13:258:22 | source(...) | main.rs:260:7:260:10 | sink | $@ | main.rs:258:13:258:22 | source(...) | source(...) |
+| main.rs:270:10:270:10 | s | main.rs:269:13:269:25 | simple_source | main.rs:270:10:270:10 | s | $@ | main.rs:269:13:269:25 | simple_source | simple_source |
+| main.rs:270:10:270:10 | s | main.rs:269:13:269:25 | simple_source | main.rs:270:10:270:10 | s | $@ | main.rs:269:13:269:25 | simple_source | simple_source |
+| main.rs:278:5:278:15 | simple_sink | main.rs:277:13:277:22 | source(...) | main.rs:278:5:278:15 | simple_sink | $@ | main.rs:277:13:277:22 | source(...) | source(...) |
+| main.rs:278:5:278:15 | simple_sink | main.rs:277:13:277:22 | source(...) | main.rs:278:5:278:15 | simple_sink | $@ | main.rs:277:13:277:22 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -9,14 +9,15 @@ models
 | 8 | Summary: repo::test; crate::apply; Argument[1].ReturnValue; ReturnValue; value |
 | 9 | Summary: repo::test; crate::coerce; Argument[0]; ReturnValue; taint |
 | 10 | Summary: repo::test; crate::get_array_element; Argument[0].Element; ReturnValue; value |
-| 11 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
-| 12 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
-| 13 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
-| 14 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
-| 15 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
-| 16 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
-| 17 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
-| 18 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
+| 11 | Summary: repo::test; crate::get_async_number; Argument[0]; ReturnValue.Future; value |
+| 12 | Summary: repo::test; crate::get_struct_field; Argument[0].Struct[crate::MyStruct::field1]; ReturnValue; value |
+| 13 | Summary: repo::test; crate::get_tuple_element; Argument[0].Tuple[0]; ReturnValue; value |
+| 14 | Summary: repo::test; crate::get_var_field; Argument[0].Variant[crate::MyFieldEnum::C::field_c]; ReturnValue; value |
+| 15 | Summary: repo::test; crate::get_var_pos; Argument[0].Variant[crate::MyPosEnum::A(0)]; ReturnValue; value |
+| 16 | Summary: repo::test; crate::set_array_element; Argument[0]; ReturnValue.Element; value |
+| 17 | Summary: repo::test; crate::set_tuple_element; Argument[0]; ReturnValue.Tuple[1]; value |
+| 18 | Summary: repo::test; crate::set_var_field; Argument[0]; ReturnValue.Variant[crate::MyFieldEnum::D::field_d]; value |
+| 19 | Summary: repo::test; crate::set_var_pos; Argument[0]; ReturnValue.Variant[crate::MyPosEnum::B(0)]; value |
 edges
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
 | main.rs:15:9:15:9 | s | main.rs:16:19:16:19 | s | provenance |  |
@@ -37,8 +38,8 @@ edges
 | main.rs:41:14:41:28 | ...::A(...) [A] | main.rs:41:9:41:10 | e1 [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
 | main.rs:41:27:41:27 | s | main.rs:41:14:41:28 | ...::A(...) [A] | provenance |  |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:14 |
-| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:14 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:15 |
+| main.rs:42:22:42:23 | e1 [A] | main.rs:42:10:42:24 | get_var_pos(...) | provenance | MaD:15 |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:9:53:9 | s | main.rs:54:26:54:26 | s | provenance |  |
 | main.rs:53:13:53:21 | source(...) | main.rs:53:9:53:9 | s | provenance |  |
@@ -47,8 +48,8 @@ edges
 | main.rs:54:9:54:10 | e1 [B] | main.rs:55:11:55:12 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
 | main.rs:54:14:54:27 | set_var_pos(...) [B] | main.rs:54:9:54:10 | e1 [B] | provenance |  |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:18 |
-| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:18 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:19 |
+| main.rs:54:26:54:26 | s | main.rs:54:14:54:27 | set_var_pos(...) [B] | provenance | MaD:19 |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:55:11:55:12 | e1 [B] | main.rs:57:9:57:23 | ...::B(...) [B] | provenance |  |
 | main.rs:57:9:57:23 | ...::B(...) [B] | main.rs:57:22:57:22 | i | provenance |  |
@@ -65,8 +66,8 @@ edges
 | main.rs:73:14:73:42 | ...::C {...} [C] | main.rs:73:9:73:10 | e1 [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
 | main.rs:73:40:73:40 | s | main.rs:73:14:73:42 | ...::C {...} [C] | provenance |  |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:13 |
-| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:13 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:14 |
+| main.rs:74:24:74:25 | e1 [C] | main.rs:74:10:74:26 | get_var_field(...) | provenance | MaD:14 |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:9:85:9 | s | main.rs:86:28:86:28 | s | provenance |  |
 | main.rs:85:13:85:21 | source(...) | main.rs:85:9:85:9 | s | provenance |  |
@@ -75,8 +76,8 @@ edges
 | main.rs:86:9:86:10 | e1 [D] | main.rs:87:11:87:12 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
 | main.rs:86:14:86:29 | set_var_field(...) [D] | main.rs:86:9:86:10 | e1 [D] | provenance |  |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:17 |
-| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:17 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:18 |
+| main.rs:86:28:86:28 | s | main.rs:86:14:86:29 | set_var_field(...) [D] | provenance | MaD:18 |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:87:11:87:12 | e1 [D] | main.rs:89:9:89:37 | ...::D {...} [D] | provenance |  |
 | main.rs:89:9:89:37 | ...::D {...} [D] | main.rs:89:35:89:35 | i | provenance |  |
@@ -93,8 +94,8 @@ edges
 | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | main.rs:105:9:105:17 | my_struct [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
 | main.rs:106:17:106:17 | s | main.rs:105:21:108:5 | MyStruct {...} [MyStruct.field1] | provenance |  |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:11 |
-| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:11 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:12 |
+| main.rs:109:27:109:35 | my_struct [MyStruct.field1] | main.rs:109:10:109:36 | get_struct_field(...) | provenance | MaD:12 |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:9:138:9 | s | main.rs:139:29:139:29 | s | provenance |  |
 | main.rs:138:13:138:21 | source(...) | main.rs:138:9:138:9 | s | provenance |  |
@@ -111,8 +112,8 @@ edges
 | main.rs:149:9:149:11 | arr [element] | main.rs:150:10:150:12 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
 | main.rs:149:15:149:34 | set_array_element(...) [element] | main.rs:149:9:149:11 | arr [element] | provenance |  |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:15 |
-| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:15 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:16 |
+| main.rs:149:33:149:33 | s | main.rs:149:15:149:34 | set_array_element(...) [element] | provenance | MaD:16 |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:150:10:150:12 | arr [element] | main.rs:150:10:150:15 | arr[0] | provenance |  |
 | main.rs:159:9:159:9 | s | main.rs:160:14:160:14 | s | provenance |  |
@@ -125,8 +126,8 @@ edges
 | main.rs:160:13:160:18 | TupleExpr [tuple.0] | main.rs:160:9:160:9 | t [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
 | main.rs:160:14:160:14 | s | main.rs:160:13:160:18 | TupleExpr [tuple.0] | provenance |  |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:12 |
-| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:12 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:13 |
+| main.rs:161:28:161:28 | t [tuple.0] | main.rs:161:10:161:29 | get_tuple_element(...) | provenance | MaD:13 |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:9:172:9 | s | main.rs:173:31:173:31 | s | provenance |  |
 | main.rs:172:13:172:22 | source(...) | main.rs:172:9:172:9 | s | provenance |  |
@@ -135,8 +136,8 @@ edges
 | main.rs:173:9:173:9 | t [tuple.1] | main.rs:175:10:175:10 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
 | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | main.rs:173:9:173:9 | t [tuple.1] | provenance |  |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:16 |
-| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:16 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:17 |
+| main.rs:173:31:173:31 | s | main.rs:173:13:173:32 | set_tuple_element(...) [tuple.1] | provenance | MaD:17 |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:175:10:175:10 | t [tuple.1] | main.rs:175:10:175:12 | t.1 | provenance |  |
 | main.rs:184:9:184:9 | s | main.rs:189:11:189:11 | s | provenance |  |
@@ -177,6 +178,18 @@ edges
 | main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
+| main.rs:211:9:211:9 | s | main.rs:212:30:212:30 | s | provenance |  |
+| main.rs:211:9:211:9 | s | main.rs:212:30:212:30 | s | provenance |  |
+| main.rs:211:13:211:22 | source(...) | main.rs:211:9:211:9 | s | provenance |  |
+| main.rs:211:13:211:22 | source(...) | main.rs:211:9:211:9 | s | provenance |  |
+| main.rs:212:9:212:9 | t | main.rs:213:10:213:10 | t | provenance |  |
+| main.rs:212:9:212:9 | t | main.rs:213:10:213:10 | t | provenance |  |
+| main.rs:212:13:212:31 | get_async_number(...) [future] | main.rs:212:13:212:37 | await ... | provenance |  |
+| main.rs:212:13:212:31 | get_async_number(...) [future] | main.rs:212:13:212:37 | await ... | provenance |  |
+| main.rs:212:13:212:37 | await ... | main.rs:212:9:212:9 | t | provenance |  |
+| main.rs:212:13:212:37 | await ... | main.rs:212:9:212:9 | t | provenance |  |
+| main.rs:212:30:212:30 | s | main.rs:212:13:212:31 | get_async_number(...) [future] | provenance | MaD:11 |
+| main.rs:212:30:212:30 | s | main.rs:212:13:212:31 | get_async_number(...) [future] | provenance | MaD:11 |
 | main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
 | main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
 | main.rs:232:13:232:23 | enum_source | main.rs:232:13:232:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
@@ -416,6 +429,20 @@ nodes
 | main.rs:202:19:202:19 | s | semmle.label | s |
 | main.rs:203:10:203:10 | t | semmle.label | t |
 | main.rs:203:10:203:10 | t | semmle.label | t |
+| main.rs:211:9:211:9 | s | semmle.label | s |
+| main.rs:211:9:211:9 | s | semmle.label | s |
+| main.rs:211:13:211:22 | source(...) | semmle.label | source(...) |
+| main.rs:211:13:211:22 | source(...) | semmle.label | source(...) |
+| main.rs:212:9:212:9 | t | semmle.label | t |
+| main.rs:212:9:212:9 | t | semmle.label | t |
+| main.rs:212:13:212:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
+| main.rs:212:13:212:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
+| main.rs:212:13:212:37 | await ... | semmle.label | await ... |
+| main.rs:212:13:212:37 | await ... | semmle.label | await ... |
+| main.rs:212:30:212:30 | s | semmle.label | s |
+| main.rs:212:30:212:30 | s | semmle.label | s |
+| main.rs:213:10:213:10 | t | semmle.label | t |
+| main.rs:213:10:213:10 | t | semmle.label | t |
 | main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
 | main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
 | main.rs:232:13:232:23 | enum_source | semmle.label | enum_source |
@@ -519,6 +546,8 @@ invalidSpecComponent
 | main.rs:196:10:196:10 | t | main.rs:193:13:193:22 | source(...) | main.rs:196:10:196:10 | t | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
+| main.rs:213:10:213:10 | t | main.rs:211:13:211:22 | source(...) | main.rs:213:10:213:10 | t | $@ | main.rs:211:13:211:22 | source(...) | source(...) |
+| main.rs:213:10:213:10 | t | main.rs:211:13:211:22 | source(...) | main.rs:213:10:213:10 | t | $@ | main.rs:211:13:211:22 | source(...) | source(...) |
 | main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
 | main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
 | main.rs:243:47:243:47 | i | main.rs:241:15:241:20 | source | main.rs:243:47:243:47 | i | $@ | main.rs:241:15:241:20 | source | source |

--- a/rust/ql/test/library-tests/dataflow/models/models.expected
+++ b/rust/ql/test/library-tests/dataflow/models/models.expected
@@ -178,74 +178,74 @@ edges
 | main.rs:202:19:202:19 | s | main.rs:201:14:201:14 | ... | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
 | main.rs:202:19:202:19 | s | main.rs:202:13:202:23 | apply(...) | provenance | MaD:7 |
-| main.rs:211:9:211:9 | s | main.rs:212:30:212:30 | s | provenance |  |
-| main.rs:211:9:211:9 | s | main.rs:212:30:212:30 | s | provenance |  |
-| main.rs:211:13:211:22 | source(...) | main.rs:211:9:211:9 | s | provenance |  |
-| main.rs:211:13:211:22 | source(...) | main.rs:211:9:211:9 | s | provenance |  |
-| main.rs:212:9:212:9 | t | main.rs:213:10:213:10 | t | provenance |  |
-| main.rs:212:9:212:9 | t | main.rs:213:10:213:10 | t | provenance |  |
-| main.rs:212:13:212:31 | get_async_number(...) [future] | main.rs:212:13:212:37 | await ... | provenance |  |
-| main.rs:212:13:212:31 | get_async_number(...) [future] | main.rs:212:13:212:37 | await ... | provenance |  |
-| main.rs:212:13:212:37 | await ... | main.rs:212:9:212:9 | t | provenance |  |
-| main.rs:212:13:212:37 | await ... | main.rs:212:9:212:9 | t | provenance |  |
-| main.rs:212:30:212:30 | s | main.rs:212:13:212:31 | get_async_number(...) [future] | provenance | MaD:11 |
-| main.rs:212:30:212:30 | s | main.rs:212:13:212:31 | get_async_number(...) [future] | provenance | MaD:11 |
-| main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
-| main.rs:232:9:232:9 | s [D] | main.rs:233:11:233:11 | s [D] | provenance |  |
-| main.rs:232:13:232:23 | enum_source | main.rs:232:13:232:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:232:13:232:23 | enum_source | main.rs:232:13:232:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
-| main.rs:232:13:232:27 | enum_source(...) [D] | main.rs:232:9:232:9 | s [D] | provenance |  |
-| main.rs:232:13:232:27 | enum_source(...) [D] | main.rs:232:9:232:9 | s [D] | provenance |  |
-| main.rs:233:11:233:11 | s [D] | main.rs:235:9:235:37 | ...::D {...} [D] | provenance |  |
-| main.rs:233:11:233:11 | s [D] | main.rs:235:9:235:37 | ...::D {...} [D] | provenance |  |
-| main.rs:235:9:235:37 | ...::D {...} [D] | main.rs:235:35:235:35 | i | provenance |  |
-| main.rs:235:9:235:37 | ...::D {...} [D] | main.rs:235:35:235:35 | i | provenance |  |
-| main.rs:235:35:235:35 | i | main.rs:235:47:235:47 | i | provenance |  |
-| main.rs:235:35:235:35 | i | main.rs:235:47:235:47 | i | provenance |  |
-| main.rs:241:9:241:9 | s [C] | main.rs:242:11:242:11 | s [C] | provenance |  |
-| main.rs:241:9:241:9 | s [C] | main.rs:242:11:242:11 | s [C] | provenance |  |
-| main.rs:241:13:241:24 | e.source(...) [C] | main.rs:241:9:241:9 | s [C] | provenance |  |
-| main.rs:241:13:241:24 | e.source(...) [C] | main.rs:241:9:241:9 | s [C] | provenance |  |
-| main.rs:241:15:241:20 | source | main.rs:241:13:241:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:241:15:241:20 | source | main.rs:241:13:241:24 | e.source(...) [C] | provenance | Src:MaD:4  |
-| main.rs:242:11:242:11 | s [C] | main.rs:243:9:243:37 | ...::C {...} [C] | provenance |  |
-| main.rs:242:11:242:11 | s [C] | main.rs:243:9:243:37 | ...::C {...} [C] | provenance |  |
-| main.rs:243:9:243:37 | ...::C {...} [C] | main.rs:243:35:243:35 | i | provenance |  |
-| main.rs:243:9:243:37 | ...::C {...} [C] | main.rs:243:35:243:35 | i | provenance |  |
-| main.rs:243:35:243:35 | i | main.rs:243:47:243:47 | i | provenance |  |
-| main.rs:243:35:243:35 | i | main.rs:243:47:243:47 | i | provenance |  |
-| main.rs:252:9:252:9 | s | main.rs:253:41:253:41 | s | provenance |  |
-| main.rs:252:9:252:9 | s | main.rs:253:41:253:41 | s | provenance |  |
-| main.rs:252:13:252:22 | source(...) | main.rs:252:9:252:9 | s | provenance |  |
-| main.rs:252:13:252:22 | source(...) | main.rs:252:9:252:9 | s | provenance |  |
-| main.rs:253:15:253:43 | ...::C {...} [C] | main.rs:253:5:253:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:253:15:253:43 | ...::C {...} [C] | main.rs:253:5:253:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
-| main.rs:253:41:253:41 | s | main.rs:253:15:253:43 | ...::C {...} [C] | provenance |  |
-| main.rs:253:41:253:41 | s | main.rs:253:15:253:43 | ...::C {...} [C] | provenance |  |
-| main.rs:258:9:258:9 | s | main.rs:259:39:259:39 | s | provenance |  |
-| main.rs:258:9:258:9 | s | main.rs:259:39:259:39 | s | provenance |  |
-| main.rs:258:13:258:22 | source(...) | main.rs:258:9:258:9 | s | provenance |  |
-| main.rs:258:13:258:22 | source(...) | main.rs:258:9:258:9 | s | provenance |  |
-| main.rs:259:9:259:9 | e [D] | main.rs:260:5:260:5 | e [D] | provenance |  |
-| main.rs:259:9:259:9 | e [D] | main.rs:260:5:260:5 | e [D] | provenance |  |
-| main.rs:259:13:259:41 | ...::D {...} [D] | main.rs:259:9:259:9 | e [D] | provenance |  |
-| main.rs:259:13:259:41 | ...::D {...} [D] | main.rs:259:9:259:9 | e [D] | provenance |  |
-| main.rs:259:39:259:39 | s | main.rs:259:13:259:41 | ...::D {...} [D] | provenance |  |
-| main.rs:259:39:259:39 | s | main.rs:259:13:259:41 | ...::D {...} [D] | provenance |  |
-| main.rs:260:5:260:5 | e [D] | main.rs:260:7:260:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:260:5:260:5 | e [D] | main.rs:260:7:260:10 | sink | provenance | MaD:1 Sink:MaD:1 |
-| main.rs:269:9:269:9 | s | main.rs:270:10:270:10 | s | provenance |  |
-| main.rs:269:9:269:9 | s | main.rs:270:10:270:10 | s | provenance |  |
-| main.rs:269:13:269:25 | simple_source | main.rs:269:13:269:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:269:13:269:25 | simple_source | main.rs:269:13:269:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
-| main.rs:269:13:269:29 | simple_source(...) | main.rs:269:9:269:9 | s | provenance |  |
-| main.rs:269:13:269:29 | simple_source(...) | main.rs:269:9:269:9 | s | provenance |  |
-| main.rs:277:9:277:9 | s | main.rs:278:17:278:17 | s | provenance |  |
-| main.rs:277:9:277:9 | s | main.rs:278:17:278:17 | s | provenance |  |
-| main.rs:277:13:277:22 | source(...) | main.rs:277:9:277:9 | s | provenance |  |
-| main.rs:277:13:277:22 | source(...) | main.rs:277:9:277:9 | s | provenance |  |
-| main.rs:278:17:278:17 | s | main.rs:278:5:278:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
-| main.rs:278:17:278:17 | s | main.rs:278:5:278:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:212:9:212:9 | s | main.rs:213:30:213:30 | s | provenance |  |
+| main.rs:212:9:212:9 | s | main.rs:213:30:213:30 | s | provenance |  |
+| main.rs:212:13:212:22 | source(...) | main.rs:212:9:212:9 | s | provenance |  |
+| main.rs:212:13:212:22 | source(...) | main.rs:212:9:212:9 | s | provenance |  |
+| main.rs:213:9:213:9 | t | main.rs:214:10:214:10 | t | provenance |  |
+| main.rs:213:9:213:9 | t | main.rs:214:10:214:10 | t | provenance |  |
+| main.rs:213:13:213:31 | get_async_number(...) [future] | main.rs:213:13:213:37 | await ... | provenance |  |
+| main.rs:213:13:213:31 | get_async_number(...) [future] | main.rs:213:13:213:37 | await ... | provenance |  |
+| main.rs:213:13:213:37 | await ... | main.rs:213:9:213:9 | t | provenance |  |
+| main.rs:213:13:213:37 | await ... | main.rs:213:9:213:9 | t | provenance |  |
+| main.rs:213:30:213:30 | s | main.rs:213:13:213:31 | get_async_number(...) [future] | provenance | MaD:11 |
+| main.rs:213:30:213:30 | s | main.rs:213:13:213:31 | get_async_number(...) [future] | provenance | MaD:11 |
+| main.rs:233:9:233:9 | s [D] | main.rs:234:11:234:11 | s [D] | provenance |  |
+| main.rs:233:9:233:9 | s [D] | main.rs:234:11:234:11 | s [D] | provenance |  |
+| main.rs:233:13:233:23 | enum_source | main.rs:233:13:233:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:233:13:233:23 | enum_source | main.rs:233:13:233:27 | enum_source(...) [D] | provenance | Src:MaD:5  |
+| main.rs:233:13:233:27 | enum_source(...) [D] | main.rs:233:9:233:9 | s [D] | provenance |  |
+| main.rs:233:13:233:27 | enum_source(...) [D] | main.rs:233:9:233:9 | s [D] | provenance |  |
+| main.rs:234:11:234:11 | s [D] | main.rs:236:9:236:37 | ...::D {...} [D] | provenance |  |
+| main.rs:234:11:234:11 | s [D] | main.rs:236:9:236:37 | ...::D {...} [D] | provenance |  |
+| main.rs:236:9:236:37 | ...::D {...} [D] | main.rs:236:35:236:35 | i | provenance |  |
+| main.rs:236:9:236:37 | ...::D {...} [D] | main.rs:236:35:236:35 | i | provenance |  |
+| main.rs:236:35:236:35 | i | main.rs:236:47:236:47 | i | provenance |  |
+| main.rs:236:35:236:35 | i | main.rs:236:47:236:47 | i | provenance |  |
+| main.rs:242:9:242:9 | s [C] | main.rs:243:11:243:11 | s [C] | provenance |  |
+| main.rs:242:9:242:9 | s [C] | main.rs:243:11:243:11 | s [C] | provenance |  |
+| main.rs:242:13:242:24 | e.source(...) [C] | main.rs:242:9:242:9 | s [C] | provenance |  |
+| main.rs:242:13:242:24 | e.source(...) [C] | main.rs:242:9:242:9 | s [C] | provenance |  |
+| main.rs:242:15:242:20 | source | main.rs:242:13:242:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:242:15:242:20 | source | main.rs:242:13:242:24 | e.source(...) [C] | provenance | Src:MaD:4  |
+| main.rs:243:11:243:11 | s [C] | main.rs:244:9:244:37 | ...::C {...} [C] | provenance |  |
+| main.rs:243:11:243:11 | s [C] | main.rs:244:9:244:37 | ...::C {...} [C] | provenance |  |
+| main.rs:244:9:244:37 | ...::C {...} [C] | main.rs:244:35:244:35 | i | provenance |  |
+| main.rs:244:9:244:37 | ...::C {...} [C] | main.rs:244:35:244:35 | i | provenance |  |
+| main.rs:244:35:244:35 | i | main.rs:244:47:244:47 | i | provenance |  |
+| main.rs:244:35:244:35 | i | main.rs:244:47:244:47 | i | provenance |  |
+| main.rs:253:9:253:9 | s | main.rs:254:41:254:41 | s | provenance |  |
+| main.rs:253:9:253:9 | s | main.rs:254:41:254:41 | s | provenance |  |
+| main.rs:253:13:253:22 | source(...) | main.rs:253:9:253:9 | s | provenance |  |
+| main.rs:253:13:253:22 | source(...) | main.rs:253:9:253:9 | s | provenance |  |
+| main.rs:254:15:254:43 | ...::C {...} [C] | main.rs:254:5:254:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:254:15:254:43 | ...::C {...} [C] | main.rs:254:5:254:13 | enum_sink | provenance | MaD:2 Sink:MaD:2 |
+| main.rs:254:41:254:41 | s | main.rs:254:15:254:43 | ...::C {...} [C] | provenance |  |
+| main.rs:254:41:254:41 | s | main.rs:254:15:254:43 | ...::C {...} [C] | provenance |  |
+| main.rs:259:9:259:9 | s | main.rs:260:39:260:39 | s | provenance |  |
+| main.rs:259:9:259:9 | s | main.rs:260:39:260:39 | s | provenance |  |
+| main.rs:259:13:259:22 | source(...) | main.rs:259:9:259:9 | s | provenance |  |
+| main.rs:259:13:259:22 | source(...) | main.rs:259:9:259:9 | s | provenance |  |
+| main.rs:260:9:260:9 | e [D] | main.rs:261:5:261:5 | e [D] | provenance |  |
+| main.rs:260:9:260:9 | e [D] | main.rs:261:5:261:5 | e [D] | provenance |  |
+| main.rs:260:13:260:41 | ...::D {...} [D] | main.rs:260:9:260:9 | e [D] | provenance |  |
+| main.rs:260:13:260:41 | ...::D {...} [D] | main.rs:260:9:260:9 | e [D] | provenance |  |
+| main.rs:260:39:260:39 | s | main.rs:260:13:260:41 | ...::D {...} [D] | provenance |  |
+| main.rs:260:39:260:39 | s | main.rs:260:13:260:41 | ...::D {...} [D] | provenance |  |
+| main.rs:261:5:261:5 | e [D] | main.rs:261:7:261:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:261:5:261:5 | e [D] | main.rs:261:7:261:10 | sink | provenance | MaD:1 Sink:MaD:1 |
+| main.rs:270:9:270:9 | s | main.rs:271:10:271:10 | s | provenance |  |
+| main.rs:270:9:270:9 | s | main.rs:271:10:271:10 | s | provenance |  |
+| main.rs:270:13:270:25 | simple_source | main.rs:270:13:270:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:270:13:270:25 | simple_source | main.rs:270:13:270:29 | simple_source(...) | provenance | Src:MaD:6 MaD:6 |
+| main.rs:270:13:270:29 | simple_source(...) | main.rs:270:9:270:9 | s | provenance |  |
+| main.rs:270:13:270:29 | simple_source(...) | main.rs:270:9:270:9 | s | provenance |  |
+| main.rs:278:9:278:9 | s | main.rs:279:17:279:17 | s | provenance |  |
+| main.rs:278:9:278:9 | s | main.rs:279:17:279:17 | s | provenance |  |
+| main.rs:278:13:278:22 | source(...) | main.rs:278:9:278:9 | s | provenance |  |
+| main.rs:278:13:278:22 | source(...) | main.rs:278:9:278:9 | s | provenance |  |
+| main.rs:279:17:279:17 | s | main.rs:279:5:279:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
+| main.rs:279:17:279:17 | s | main.rs:279:5:279:15 | simple_sink | provenance | MaD:3 Sink:MaD:3 |
 nodes
 | main.rs:15:9:15:9 | s | semmle.label | s |
 | main.rs:15:9:15:9 | s | semmle.label | s |
@@ -429,88 +429,88 @@ nodes
 | main.rs:202:19:202:19 | s | semmle.label | s |
 | main.rs:203:10:203:10 | t | semmle.label | t |
 | main.rs:203:10:203:10 | t | semmle.label | t |
-| main.rs:211:9:211:9 | s | semmle.label | s |
-| main.rs:211:9:211:9 | s | semmle.label | s |
-| main.rs:211:13:211:22 | source(...) | semmle.label | source(...) |
-| main.rs:211:13:211:22 | source(...) | semmle.label | source(...) |
-| main.rs:212:9:212:9 | t | semmle.label | t |
-| main.rs:212:9:212:9 | t | semmle.label | t |
-| main.rs:212:13:212:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
-| main.rs:212:13:212:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
-| main.rs:212:13:212:37 | await ... | semmle.label | await ... |
-| main.rs:212:13:212:37 | await ... | semmle.label | await ... |
-| main.rs:212:30:212:30 | s | semmle.label | s |
-| main.rs:212:30:212:30 | s | semmle.label | s |
-| main.rs:213:10:213:10 | t | semmle.label | t |
-| main.rs:213:10:213:10 | t | semmle.label | t |
-| main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
-| main.rs:232:9:232:9 | s [D] | semmle.label | s [D] |
-| main.rs:232:13:232:23 | enum_source | semmle.label | enum_source |
-| main.rs:232:13:232:23 | enum_source | semmle.label | enum_source |
-| main.rs:232:13:232:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:232:13:232:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
-| main.rs:233:11:233:11 | s [D] | semmle.label | s [D] |
-| main.rs:233:11:233:11 | s [D] | semmle.label | s [D] |
-| main.rs:235:9:235:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:235:9:235:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:235:35:235:35 | i | semmle.label | i |
-| main.rs:235:35:235:35 | i | semmle.label | i |
-| main.rs:235:47:235:47 | i | semmle.label | i |
-| main.rs:235:47:235:47 | i | semmle.label | i |
-| main.rs:241:9:241:9 | s [C] | semmle.label | s [C] |
-| main.rs:241:9:241:9 | s [C] | semmle.label | s [C] |
-| main.rs:241:13:241:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:241:13:241:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
-| main.rs:241:15:241:20 | source | semmle.label | source |
-| main.rs:241:15:241:20 | source | semmle.label | source |
-| main.rs:242:11:242:11 | s [C] | semmle.label | s [C] |
-| main.rs:242:11:242:11 | s [C] | semmle.label | s [C] |
-| main.rs:243:9:243:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:243:9:243:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:243:35:243:35 | i | semmle.label | i |
-| main.rs:243:35:243:35 | i | semmle.label | i |
-| main.rs:243:47:243:47 | i | semmle.label | i |
-| main.rs:243:47:243:47 | i | semmle.label | i |
-| main.rs:252:9:252:9 | s | semmle.label | s |
-| main.rs:252:9:252:9 | s | semmle.label | s |
-| main.rs:252:13:252:22 | source(...) | semmle.label | source(...) |
-| main.rs:252:13:252:22 | source(...) | semmle.label | source(...) |
-| main.rs:253:5:253:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:253:5:253:13 | enum_sink | semmle.label | enum_sink |
-| main.rs:253:15:253:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:253:15:253:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
-| main.rs:253:41:253:41 | s | semmle.label | s |
-| main.rs:253:41:253:41 | s | semmle.label | s |
-| main.rs:258:9:258:9 | s | semmle.label | s |
-| main.rs:258:9:258:9 | s | semmle.label | s |
-| main.rs:258:13:258:22 | source(...) | semmle.label | source(...) |
-| main.rs:258:13:258:22 | source(...) | semmle.label | source(...) |
-| main.rs:259:9:259:9 | e [D] | semmle.label | e [D] |
-| main.rs:259:9:259:9 | e [D] | semmle.label | e [D] |
-| main.rs:259:13:259:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:259:13:259:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
-| main.rs:259:39:259:39 | s | semmle.label | s |
-| main.rs:259:39:259:39 | s | semmle.label | s |
-| main.rs:260:5:260:5 | e [D] | semmle.label | e [D] |
-| main.rs:260:5:260:5 | e [D] | semmle.label | e [D] |
-| main.rs:260:7:260:10 | sink | semmle.label | sink |
-| main.rs:260:7:260:10 | sink | semmle.label | sink |
-| main.rs:269:9:269:9 | s | semmle.label | s |
-| main.rs:269:9:269:9 | s | semmle.label | s |
-| main.rs:269:13:269:25 | simple_source | semmle.label | simple_source |
-| main.rs:269:13:269:25 | simple_source | semmle.label | simple_source |
-| main.rs:269:13:269:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:269:13:269:29 | simple_source(...) | semmle.label | simple_source(...) |
-| main.rs:270:10:270:10 | s | semmle.label | s |
-| main.rs:270:10:270:10 | s | semmle.label | s |
-| main.rs:277:9:277:9 | s | semmle.label | s |
-| main.rs:277:9:277:9 | s | semmle.label | s |
-| main.rs:277:13:277:22 | source(...) | semmle.label | source(...) |
-| main.rs:277:13:277:22 | source(...) | semmle.label | source(...) |
-| main.rs:278:5:278:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:278:5:278:15 | simple_sink | semmle.label | simple_sink |
-| main.rs:278:17:278:17 | s | semmle.label | s |
-| main.rs:278:17:278:17 | s | semmle.label | s |
+| main.rs:212:9:212:9 | s | semmle.label | s |
+| main.rs:212:9:212:9 | s | semmle.label | s |
+| main.rs:212:13:212:22 | source(...) | semmle.label | source(...) |
+| main.rs:212:13:212:22 | source(...) | semmle.label | source(...) |
+| main.rs:213:9:213:9 | t | semmle.label | t |
+| main.rs:213:9:213:9 | t | semmle.label | t |
+| main.rs:213:13:213:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
+| main.rs:213:13:213:31 | get_async_number(...) [future] | semmle.label | get_async_number(...) [future] |
+| main.rs:213:13:213:37 | await ... | semmle.label | await ... |
+| main.rs:213:13:213:37 | await ... | semmle.label | await ... |
+| main.rs:213:30:213:30 | s | semmle.label | s |
+| main.rs:213:30:213:30 | s | semmle.label | s |
+| main.rs:214:10:214:10 | t | semmle.label | t |
+| main.rs:214:10:214:10 | t | semmle.label | t |
+| main.rs:233:9:233:9 | s [D] | semmle.label | s [D] |
+| main.rs:233:9:233:9 | s [D] | semmle.label | s [D] |
+| main.rs:233:13:233:23 | enum_source | semmle.label | enum_source |
+| main.rs:233:13:233:23 | enum_source | semmle.label | enum_source |
+| main.rs:233:13:233:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:233:13:233:27 | enum_source(...) [D] | semmle.label | enum_source(...) [D] |
+| main.rs:234:11:234:11 | s [D] | semmle.label | s [D] |
+| main.rs:234:11:234:11 | s [D] | semmle.label | s [D] |
+| main.rs:236:9:236:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:236:9:236:37 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:236:35:236:35 | i | semmle.label | i |
+| main.rs:236:35:236:35 | i | semmle.label | i |
+| main.rs:236:47:236:47 | i | semmle.label | i |
+| main.rs:236:47:236:47 | i | semmle.label | i |
+| main.rs:242:9:242:9 | s [C] | semmle.label | s [C] |
+| main.rs:242:9:242:9 | s [C] | semmle.label | s [C] |
+| main.rs:242:13:242:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:242:13:242:24 | e.source(...) [C] | semmle.label | e.source(...) [C] |
+| main.rs:242:15:242:20 | source | semmle.label | source |
+| main.rs:242:15:242:20 | source | semmle.label | source |
+| main.rs:243:11:243:11 | s [C] | semmle.label | s [C] |
+| main.rs:243:11:243:11 | s [C] | semmle.label | s [C] |
+| main.rs:244:9:244:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:244:9:244:37 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:244:35:244:35 | i | semmle.label | i |
+| main.rs:244:35:244:35 | i | semmle.label | i |
+| main.rs:244:47:244:47 | i | semmle.label | i |
+| main.rs:244:47:244:47 | i | semmle.label | i |
+| main.rs:253:9:253:9 | s | semmle.label | s |
+| main.rs:253:9:253:9 | s | semmle.label | s |
+| main.rs:253:13:253:22 | source(...) | semmle.label | source(...) |
+| main.rs:253:13:253:22 | source(...) | semmle.label | source(...) |
+| main.rs:254:5:254:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:254:5:254:13 | enum_sink | semmle.label | enum_sink |
+| main.rs:254:15:254:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:254:15:254:43 | ...::C {...} [C] | semmle.label | ...::C {...} [C] |
+| main.rs:254:41:254:41 | s | semmle.label | s |
+| main.rs:254:41:254:41 | s | semmle.label | s |
+| main.rs:259:9:259:9 | s | semmle.label | s |
+| main.rs:259:9:259:9 | s | semmle.label | s |
+| main.rs:259:13:259:22 | source(...) | semmle.label | source(...) |
+| main.rs:259:13:259:22 | source(...) | semmle.label | source(...) |
+| main.rs:260:9:260:9 | e [D] | semmle.label | e [D] |
+| main.rs:260:9:260:9 | e [D] | semmle.label | e [D] |
+| main.rs:260:13:260:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:260:13:260:41 | ...::D {...} [D] | semmle.label | ...::D {...} [D] |
+| main.rs:260:39:260:39 | s | semmle.label | s |
+| main.rs:260:39:260:39 | s | semmle.label | s |
+| main.rs:261:5:261:5 | e [D] | semmle.label | e [D] |
+| main.rs:261:5:261:5 | e [D] | semmle.label | e [D] |
+| main.rs:261:7:261:10 | sink | semmle.label | sink |
+| main.rs:261:7:261:10 | sink | semmle.label | sink |
+| main.rs:270:9:270:9 | s | semmle.label | s |
+| main.rs:270:9:270:9 | s | semmle.label | s |
+| main.rs:270:13:270:25 | simple_source | semmle.label | simple_source |
+| main.rs:270:13:270:25 | simple_source | semmle.label | simple_source |
+| main.rs:270:13:270:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:270:13:270:29 | simple_source(...) | semmle.label | simple_source(...) |
+| main.rs:271:10:271:10 | s | semmle.label | s |
+| main.rs:271:10:271:10 | s | semmle.label | s |
+| main.rs:278:9:278:9 | s | semmle.label | s |
+| main.rs:278:9:278:9 | s | semmle.label | s |
+| main.rs:278:13:278:22 | source(...) | semmle.label | source(...) |
+| main.rs:278:13:278:22 | source(...) | semmle.label | source(...) |
+| main.rs:279:5:279:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:279:5:279:15 | simple_sink | semmle.label | simple_sink |
+| main.rs:279:17:279:17 | s | semmle.label | s |
+| main.rs:279:17:279:17 | s | semmle.label | s |
 subpaths
 | main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
 | main.rs:195:23:195:23 | f [captured s] | main.rs:194:40:194:40 | s | main.rs:194:17:194:42 | if ... {...} else {...} | main.rs:195:13:195:24 | apply(...) |
@@ -546,17 +546,17 @@ invalidSpecComponent
 | main.rs:196:10:196:10 | t | main.rs:193:13:193:22 | source(...) | main.rs:196:10:196:10 | t | $@ | main.rs:193:13:193:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
 | main.rs:203:10:203:10 | t | main.rs:200:13:200:22 | source(...) | main.rs:203:10:203:10 | t | $@ | main.rs:200:13:200:22 | source(...) | source(...) |
-| main.rs:213:10:213:10 | t | main.rs:211:13:211:22 | source(...) | main.rs:213:10:213:10 | t | $@ | main.rs:211:13:211:22 | source(...) | source(...) |
-| main.rs:213:10:213:10 | t | main.rs:211:13:211:22 | source(...) | main.rs:213:10:213:10 | t | $@ | main.rs:211:13:211:22 | source(...) | source(...) |
-| main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
-| main.rs:235:47:235:47 | i | main.rs:232:13:232:23 | enum_source | main.rs:235:47:235:47 | i | $@ | main.rs:232:13:232:23 | enum_source | enum_source |
-| main.rs:243:47:243:47 | i | main.rs:241:15:241:20 | source | main.rs:243:47:243:47 | i | $@ | main.rs:241:15:241:20 | source | source |
-| main.rs:243:47:243:47 | i | main.rs:241:15:241:20 | source | main.rs:243:47:243:47 | i | $@ | main.rs:241:15:241:20 | source | source |
-| main.rs:253:5:253:13 | enum_sink | main.rs:252:13:252:22 | source(...) | main.rs:253:5:253:13 | enum_sink | $@ | main.rs:252:13:252:22 | source(...) | source(...) |
-| main.rs:253:5:253:13 | enum_sink | main.rs:252:13:252:22 | source(...) | main.rs:253:5:253:13 | enum_sink | $@ | main.rs:252:13:252:22 | source(...) | source(...) |
-| main.rs:260:7:260:10 | sink | main.rs:258:13:258:22 | source(...) | main.rs:260:7:260:10 | sink | $@ | main.rs:258:13:258:22 | source(...) | source(...) |
-| main.rs:260:7:260:10 | sink | main.rs:258:13:258:22 | source(...) | main.rs:260:7:260:10 | sink | $@ | main.rs:258:13:258:22 | source(...) | source(...) |
-| main.rs:270:10:270:10 | s | main.rs:269:13:269:25 | simple_source | main.rs:270:10:270:10 | s | $@ | main.rs:269:13:269:25 | simple_source | simple_source |
-| main.rs:270:10:270:10 | s | main.rs:269:13:269:25 | simple_source | main.rs:270:10:270:10 | s | $@ | main.rs:269:13:269:25 | simple_source | simple_source |
-| main.rs:278:5:278:15 | simple_sink | main.rs:277:13:277:22 | source(...) | main.rs:278:5:278:15 | simple_sink | $@ | main.rs:277:13:277:22 | source(...) | source(...) |
-| main.rs:278:5:278:15 | simple_sink | main.rs:277:13:277:22 | source(...) | main.rs:278:5:278:15 | simple_sink | $@ | main.rs:277:13:277:22 | source(...) | source(...) |
+| main.rs:214:10:214:10 | t | main.rs:212:13:212:22 | source(...) | main.rs:214:10:214:10 | t | $@ | main.rs:212:13:212:22 | source(...) | source(...) |
+| main.rs:214:10:214:10 | t | main.rs:212:13:212:22 | source(...) | main.rs:214:10:214:10 | t | $@ | main.rs:212:13:212:22 | source(...) | source(...) |
+| main.rs:236:47:236:47 | i | main.rs:233:13:233:23 | enum_source | main.rs:236:47:236:47 | i | $@ | main.rs:233:13:233:23 | enum_source | enum_source |
+| main.rs:236:47:236:47 | i | main.rs:233:13:233:23 | enum_source | main.rs:236:47:236:47 | i | $@ | main.rs:233:13:233:23 | enum_source | enum_source |
+| main.rs:244:47:244:47 | i | main.rs:242:15:242:20 | source | main.rs:244:47:244:47 | i | $@ | main.rs:242:15:242:20 | source | source |
+| main.rs:244:47:244:47 | i | main.rs:242:15:242:20 | source | main.rs:244:47:244:47 | i | $@ | main.rs:242:15:242:20 | source | source |
+| main.rs:254:5:254:13 | enum_sink | main.rs:253:13:253:22 | source(...) | main.rs:254:5:254:13 | enum_sink | $@ | main.rs:253:13:253:22 | source(...) | source(...) |
+| main.rs:254:5:254:13 | enum_sink | main.rs:253:13:253:22 | source(...) | main.rs:254:5:254:13 | enum_sink | $@ | main.rs:253:13:253:22 | source(...) | source(...) |
+| main.rs:261:7:261:10 | sink | main.rs:259:13:259:22 | source(...) | main.rs:261:7:261:10 | sink | $@ | main.rs:259:13:259:22 | source(...) | source(...) |
+| main.rs:261:7:261:10 | sink | main.rs:259:13:259:22 | source(...) | main.rs:261:7:261:10 | sink | $@ | main.rs:259:13:259:22 | source(...) | source(...) |
+| main.rs:271:10:271:10 | s | main.rs:270:13:270:25 | simple_source | main.rs:271:10:271:10 | s | $@ | main.rs:270:13:270:25 | simple_source | simple_source |
+| main.rs:271:10:271:10 | s | main.rs:270:13:270:25 | simple_source | main.rs:271:10:271:10 | s | $@ | main.rs:270:13:270:25 | simple_source | simple_source |
+| main.rs:279:5:279:15 | simple_sink | main.rs:278:13:278:22 | source(...) | main.rs:279:5:279:15 | simple_sink | $@ | main.rs:278:13:278:22 | source(...) | source(...) |
+| main.rs:279:5:279:15 | simple_sink | main.rs:278:13:278:22 | source(...) | main.rs:279:5:279:15 | simple_sink | $@ | main.rs:278:13:278:22 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/models/models.ext.yml
+++ b/rust/ql/test/library-tests/dataflow/models/models.ext.yml
@@ -30,3 +30,4 @@ extensions:
       - ["repo::test", "crate::set_tuple_element", "Argument[0]", "ReturnValue.Tuple[1]", "value", "manual"]
       - ["repo::test", "crate::apply", "Argument[0]", "Argument[1].Parameter[0]", "value", "manual"]
       - ["repo::test", "crate::apply", "Argument[1].ReturnValue", "ReturnValue", "value", "manual"]
+      - ["repo::test", "crate::get_async_number", "Argument[0]", "ReturnValue.Future", "value", "manual"]

--- a/rust/ql/test/library-tests/dataflow/models/options.yml
+++ b/rust/ql/test/library-tests/dataflow/models/options.yml
@@ -1,0 +1,2 @@
+qltest_dependencies:
+  - tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
This PR takes a small step towards handling async Rust:

* Adds a content type for things stored in the `Future` trait.
* `.await` reads from the future content.

Notably this doesn't handle non-modeled calls to `async` functions.