### PR TITLE
Java: update `java/spring-disabled-csrf-protection` QHelp

### DIFF
--- a/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-352/SpringCSRFProtection.qhelp
@@ -2,11 +2,21 @@
 <qhelp>
 
 <overview>
-<p>When you set up a web server to receive a request from a client without any mechanism
-for verifying that it was intentionally sent, then it is vulnerable to attack. An attacker can
-trick a client into making an unintended request to the web server that will be treated as
-an authentic request. This can be done via a URL, image load, XMLHttpRequest, etc. and can
-result in exposure of data or unintended code execution.</p>
+    <p>
+      Cross-site request forgery (CSRF) is a type of vulnerability in which an
+      attacker is able to force a user to carry out an action that the user did
+      not intend.
+    </p>
+
+    <p>
+      The attacker tricks an authenticated user into submitting a request to the
+      web application. Typically, this request will result in a state change on
+      the server, such as changing the user's password. The request can be
+      initiated when the user visits a site controlled by the attacker. If the
+      web application relies only on cookies for authentication, or on other
+      credentials that are automatically included in the request, then this
+      request will appear as legitimate to the server.
+    </p>
 </overview>
 
 <recommendation>
@@ -26,7 +36,7 @@ by non-browser clients.</p>
 <references>
 <li>
 OWASP:
-<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)">Cross-Site Request Forgery (CSRF)</a>.
+<a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)">Cross Site Request Forgery (CSRF)</a>.
 </li>
 <li>
 Spring Security Reference:


### PR DESCRIPTION
### Description
Updates the overview section of the `java/spring-disabled-csrf-protection` QHelp to align with other CSRF queries. Context:  https://github.com/github/codeql/pull/18288#issuecomment-2634786516

Also updates the name of the OWASP website. Context: https://github.com/github/codeql/pull/18288#discussion_r1943166158

**Autofix validation:** I quickly checked the effect on autofix for a couple alerts. Autofix still successfully removes the `.disable()` call, but it now also discusses handling CSRF tokens in the fix descriptions and includes code related to CSRF tokens in one of the fix suggestions. Let me know if this sounds like a reason to avoid this wording update? 
(Note that I purposefully did not include any explicit mention of tokens in this update, but the related [Python](https://github.com/github/codeql/blob/f1140530c08d77334f4d9ea380c395ff8bf9a119/python/ql/src/Security/CWE-352/CSRFProtectionDisabled.qhelp#L23-L29) and [Ruby](https://github.com/github/codeql/blob/f1140530c08d77334f4d9ea380c395ff8bf9a119/ruby/ql/src/queries/security/cwe-352/CSRFProtectionDisabled.qhelp#L23-L29) QHelp files do mention tokens.)