### PR TITLE
Dbartol/actions-suite-selectors

### DIFF
--- a/actions/ql/src/Security/CWE-077/EnvPathInjectionMedium.ql
+++ b/actions/ql/src/Security/CWE-077/EnvPathInjectionMedium.ql
@@ -2,9 +2,9 @@
  * @name PATH Enviroment Variable built from user-controlled sources
  * @description Building the PATH environment variable from user-controlled sources may alter the execution of following system commands
  * @kind path-problem
- * @problem.severity warning
+ * @problem.severity error
  * @security-severity 5.0
- * @precision high
+ * @precision medium
  * @id actions/envpath-injection/medium
  * @tags actions
  *       security

--- a/actions/ql/src/Security/CWE-077/EnvVarInjectionMedium.ql
+++ b/actions/ql/src/Security/CWE-077/EnvVarInjectionMedium.ql
@@ -2,9 +2,9 @@
  * @name Enviroment Variable built from user-controlled sources
  * @description Building an environment variable from user-controlled sources may alter the execution of following system commands
  * @kind path-problem
- * @problem.severity warning
+ * @problem.severity error
  * @security-severity 5.0
- * @precision high
+ * @precision medium
  * @id actions/envvar-injection/medium
  * @tags actions
  *       security

--- a/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
+++ b/actions/ql/src/Security/CWE-275/MissingActionsPermissions.ql
@@ -3,11 +3,12 @@
  * @description Workflows should contain permissions to provide a clear understanding has permissions to run the workflow.
  * @kind problem
  * @security-severity 5.0
- * @problem.severity recommendation
+ * @problem.severity warning
  * @precision high
  * @id actions/missing-workflow-permissions
  * @tags actions
  *       maintainability
+ *       security
  *       external/cwe/cwe-275
  */
 

--- a/actions/ql/src/Security/CWE-312/ExcessiveSecretsExposure.ql
+++ b/actions/ql/src/Security/CWE-312/ExcessiveSecretsExposure.ql
@@ -2,7 +2,8 @@
  * @name Excessive Secrets Exposure
  * @description All organization and repository secrets are passed to the workflow runner.
  * @kind problem
- * @problem.severity recommendation
+ * @precision high
+ * @problem.severity warning
  * @id actions/excessive-secrets-exposure
  * @tags actions
  *       security

--- a/actions/ql/src/Security/CWE-829/ArtifactPoisoningMedium.ql
+++ b/actions/ql/src/Security/CWE-829/ArtifactPoisoningMedium.ql
@@ -2,8 +2,8 @@
  * @name Artifact poisoning
  * @description An attacker may be able to poison the workflow's artifacts and influence on consequent steps.
  * @kind path-problem
- * @problem.severity warning
- * @precision high
+ * @problem.severity error
+ * @precision medium
  * @security-severity 5.0
  * @id actions/artifact-poisoning/medium
  * @tags actions

--- a/actions/ql/src/Security/CWE-829/UnpinnedActionsTag.ql
+++ b/actions/ql/src/Security/CWE-829/UnpinnedActionsTag.ql
@@ -3,8 +3,8 @@
  * @description Using a tag for a non-immutable Action that is not pinned to a commit can lead to executing an untrusted Action through a supply chain attack.
  * @kind problem
  * @security-severity 5.0
- * @problem.severity recommendation
- * @precision high
+ * @problem.severity warning
+ * @precision medium
  * @id actions/unpinned-tag
  * @tags security
  *       actions

--- a/actions/ql/src/codeql-suites/actions-code-scanning.qls
+++ b/actions/ql/src/codeql-suites/actions-code-scanning.qls
@@ -1,11 +1,4 @@
 - description: Standard Code Scanning queries for GitHub Actions
-- queries: '.'
-- include:
-    problem.severity: 
-      - error
-      - recommendation
-- exclude:
-    tags contain:
-      - experimental
-      - debug
-      - internal
+- queries: .
+- apply: code-scanning-selectors.yml
+  from: codeql/suite-helpers

--- a/actions/ql/src/codeql-suites/actions-security-extended.qls
+++ b/actions/ql/src/codeql-suites/actions-security-extended.qls
@@ -1,2 +1,4 @@
 - description: Security-extended queries for GitHub Actions
-- import: codeql-suites/actions-code-scanning.qls
+- queries: .
+- apply: security-extended-selectors.yml
+  from: codeql/suite-helpers


### PR DESCRIPTION
This PR switches the two primary Actions suites to use the same query selectors as all of the other languages. I've adjusted the severity and/or priority of several queries to make sure that they wind up in the right suite. The net changes in suite placement are:

## Removed from both suites
These queries are not security-related.
- `if-expression-always-true/critical`
- `if-expression-always-true/high`
- `unnecessary-use-of-advanced-config`

## Demoted to `security-extended`
- `unpinned-tag`

## Added to `security-extended` (previously not in either suite)
Most of these are just lower-precision versions of queries from the default suite.
- `unversioned-immutable-action`
- `envpath-injection/medium`
- `envvar-injection/medium`
- `code-injection/medium`
- `artifact-poisoning/medium`
- `untrusted-checkout/medium`
