### PR TITLE
TreeSitter extractors: log fewer lines

### DIFF
--- a/shared/tree-sitter-extractor/src/extractor/mod.rs
+++ b/shared/tree-sitter-extractor/src/extractor/mod.rs
@@ -192,7 +192,7 @@ pub fn extract(
 
     let _enter = span.enter();
 
-    tracing::info!("extracting: {}", path_str);
+    tracing::debug!("extracting: {}", path_str);
 
     let mut parser = Parser::new();
     parser.set_language(language).unwrap();


### PR DESCRIPTION
Printing a line for every extracted file is too verbose and for large projects makes it impossible to view the log in the Actions UI.