### PR TITLE
Support `v` flag in JS regexps

### DIFF
--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -787,7 +787,7 @@ public class Parser {
     if (mods != null) {
       String validFlags = "gim";
       if (this.options.ecmaVersion() >= 6) validFlags = "gimuy";
-      if (this.options.ecmaVersion() >= 9) validFlags = "gimsuy";
+      if (this.options.ecmaVersion() >= 9) validFlags = "gimsuvy";
       if (!mods.matches("^[" + validFlags + "]*$"))
         this.raise(start, "Invalid regular expression flag");
       if (mods.indexOf('u') >= 0) {


### PR DESCRIPTION
I just added it to the `this.options.ecmaVersion() >= 9` branch because it was introduced in ES2024, but it seems like you stopped tracking exact ECMAScript version since ES2020.

Fixes https://github.com/github/codeql/issues/18721