### PR TITLE
Java: precise diff-informed NumericCastTainted

### DIFF
--- a/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
+++ b/java/ql/lib/semmle/code/java/security/NumericCastTaintedQuery.qll
@@ -104,6 +104,13 @@ module NumericCastFlowConfig implements DataFlow::ConfigSig {
   predicate isBarrierIn(DataFlow::Node node) { isSource(node) }
 
   predicate observeDiffInformedIncrementalMode() { any() }
+
+  Location getASelectedSinkLocation(DataFlow::Node sink) {
+    exists(NumericNarrowingCastExpr cast |
+      cast.getExpr() = sink.asExpr() and
+      result = cast.getLocation()
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
It was discovered by the upcoming support for exact locations matching in diff-informed testing that this data-flow configuration did not correspond exactly to the query.