### PR TITLE
Change note creation script uses EDITOR environment variable

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -50,6 +50,11 @@
                 "${input:name}",
                 "${input:categoryQuery}"
             ],
+            "options": {
+                "env": {
+                    "EDITOR": "code -r",
+                }
+            },
             "presentation": {
                 "reveal": "never",
                 "close": true
@@ -67,6 +72,11 @@
                 "${input:name}",
                 "${input:categoryLibrary}"
             ],
+            "options": {
+                "env": {
+                    "EDITOR": "code -r"
+                }
+            },
             "presentation": {
                 "reveal": "never",
                 "close": true

--- a/misc/scripts/create-change-note.py
+++ b/misc/scripts/create-change-note.py
@@ -52,6 +52,6 @@ category: {change_category}
 with open(change_note_file, "w") as f:
     f.write(change_note)
 
-editor = os.environ.get('EDITOR', 'code')
+editor = os.environ.get('EDITOR', 'code -r')
 
 os.system(f"{editor} {change_note_file}")

--- a/misc/scripts/create-change-note.py
+++ b/misc/scripts/create-change-note.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-# Creates a change note and opens it in VSCode for editing.
+# Creates a change note and opens it in $EDITOR (or VSCode if the environment
+# variable is not set) for editing.
 
 # Expects to receive the following arguments:
 # - What language the change note is for
@@ -51,5 +52,6 @@ category: {change_category}
 with open(change_note_file, "w") as f:
     f.write(change_note)
 
-# Open the change note file in VSCode, reusing the existing window if possible
-os.system(f"code -r {change_note_file}")
+editor = os.environ.get('EDITOR', 'code')
+
+os.system(f"{editor} {change_note_file}")


### PR DESCRIPTION
Changes the script for creating change notes to read the EDITOR environment variable, and use the editor specified therein. This makes the script more convenient when used from a terminal.

The VSCode task is updated to the set EDITOR to `code -r` which preserves the current behavior.