### PR TITLE
JS: Provide more precise related locations

### DIFF
--- a/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSQuery.qll
+++ b/javascript/ql/lib/semmle/javascript/security/regexp/PolynomialReDoSQuery.qll
@@ -29,8 +29,6 @@ module PolynomialReDoSConfig implements DataFlow::ConfigSig {
   predicate observeDiffInformedIncrementalMode() { any() }
 
   Location getASelectedSinkLocation(DataFlow::Node sink) {
-    result = sink.(Sink).getLocation()
-    or
     result = sink.(Sink).getHighlight().getLocation()
     or
     result = sink.(Sink).getRegExp().getLocation()

--- a/javascript/ql/src/experimental/Security/CWE-918/SSRF.qll
+++ b/javascript/ql/src/experimental/Security/CWE-918/SSRF.qll
@@ -29,6 +29,10 @@ module SsrfConfig implements DataFlow::ConfigSig {
 
   predicate isBarrierOut(DataFlow::Node node) { strictSanitizingPrefixEdge(node, _) }
 
+  Location getASelectedSourceLocation(DataFlow::Node source) {
+    none() // Does not select the source
+  }
+
   predicate observeDiffInformedIncrementalMode() { any() }
 }
 


### PR DESCRIPTION
Removes some superfluous related locations to more accurately restrict the queries to the diff range.

Note that this only fixes the test failures that are fixable without refactoring the query or using `AlertFiltering` directly