### PR TITLE
Rust: Tweak `toString` on identity pattern

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/IdentPatImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/IdentPatImpl.qll
@@ -28,6 +28,18 @@ module Impl {
    * ```
    */
   class IdentPat extends Generated::IdentPat {
-    override string toString() { result = this.getName().getText() }
+    override string toString() {
+      result = strictconcat(int i | | this.toStringPart(i), " " order by i)
+    }
+
+    private string toStringPart(int index) {
+      index = 0 and this.isRef() and result = "ref"
+      or
+      index = 1 and this.isMut() and result = "mut"
+      or
+      index = 2 and result = this.getName().getText()
+      or
+      index = 3 and this.hasPat() and result = "@ ..."
+    }
   }
 }

--- a/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat.expected
+++ b/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat.expected
@@ -1,2 +1,2 @@
 | gen_ident_pat.rs:6:22:6:22 | y | getNumberOfAttrs: | 0 | isMut: | no | isRef: | no | hasName: | yes | hasPat: | no |
-| gen_ident_pat.rs:10:9:10:25 | y | getNumberOfAttrs: | 0 | isMut: | no | isRef: | no | hasName: | yes | hasPat: | yes |
+| gen_ident_pat.rs:10:9:10:25 | y @ ... | getNumberOfAttrs: | 0 | isMut: | no | isRef: | no | hasName: | yes | hasPat: | yes |

--- a/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat_getName.expected
+++ b/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat_getName.expected
@@ -1,2 +1,2 @@
 | gen_ident_pat.rs:6:22:6:22 | y | gen_ident_pat.rs:6:22:6:22 | y |
-| gen_ident_pat.rs:10:9:10:25 | y | gen_ident_pat.rs:10:9:10:9 | y |
+| gen_ident_pat.rs:10:9:10:25 | y @ ... | gen_ident_pat.rs:10:9:10:9 | y |

--- a/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat_getPat.expected
+++ b/rust/ql/test/extractor-tests/generated/IdentPat/IdentPat_getPat.expected
@@ -1,1 +1,1 @@
-| gen_ident_pat.rs:10:9:10:25 | y | gen_ident_pat.rs:10:11:10:25 | ...::Some(...) |
+| gen_ident_pat.rs:10:9:10:25 | y @ ... | gen_ident_pat.rs:10:11:10:25 | ...::Some(...) |

--- a/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
+++ b/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
@@ -610,69 +610,97 @@ dominates
 | test.rs:395:13:395:15 | RangePat | test.rs:396:13:396:13 | _ |
 | test.rs:395:20:395:20 | 3 | test.rs:395:20:395:20 | 3 |
 | test.rs:396:13:396:13 | _ | test.rs:396:13:396:13 | _ |
-| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:402:5:407:5 | enter fn test_infinite_loop |
-| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:404:13:404:14 | TupleExpr |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr |
-| test.rs:411:5:413:5 | enter fn say_hello | test.rs:411:5:413:5 | enter fn say_hello |
-| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:5:434:5 | enter fn async_block |
-| test.rs:416:26:418:9 | enter { ... } | test.rs:416:26:418:9 | enter { ... } |
-| test.rs:419:31:421:9 | enter { ... } | test.rs:419:31:421:9 | enter { ... } |
-| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:22:433:9 | enter \|...\| ... |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | exit { ... } (normal) |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } (normal) |
-| test.rs:429:13:431:13 | if b {...} | test.rs:429:13:431:13 | if b {...} |
-| test.rs:430:17:430:41 | ExprStmt | test.rs:430:17:430:41 | ExprStmt |
-| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:5:442:5 | enter fn add_two |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:13:450:49 | ExprStmt |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | if ... {...} |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | ExprStmt |
-| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | enter fn panic_cold_explicit |
-| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | [boolean(false)] ! ... |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | if ... {...} |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:456:5:465:5 | enter fn const_block_panic |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} |
-| test.rs:458:9:463:9 | if false {...} | test.rs:458:9:463:9 | if false {...} |
-| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | enter fn panic_cold_explicit |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:468:1:473:1 | enter fn dead_code |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt |
-| test.rs:470:9:470:17 | ExprStmt | test.rs:470:9:470:17 | ExprStmt |
-| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:1:475:16 | enter fn do_thing |
-| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:477:1:479:1 | enter fn condition_not_met |
-| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:1:481:21 | enter fn do_next_thing |
-| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:1:483:21 | enter fn do_last_thing |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:486:18:497:5 | 'block: { ... } |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:492:9:494:9 | if ... {...} |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:493:13:493:27 | ExprStmt |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:18:497:5 | 'block: { ... } |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt |
-| test.rs:489:13:489:27 | ExprStmt | test.rs:489:13:489:27 | ExprStmt |
-| test.rs:492:9:494:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
-| test.rs:493:13:493:27 | ExprStmt | test.rs:493:13:493:27 | ExprStmt |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:501:1:509:1 | enter fn labelled_block2 |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:502:18:508:5 | 'block: { ... } |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:504:18:504:18 | y |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:505:13:505:27 | ExprStmt |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:18:508:5 | 'block: { ... } |
-| test.rs:504:18:504:18 | y | test.rs:504:18:504:18 | y |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:401:9:404:9 | match 43 { ... } |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:17:402:17 | 1 |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:20:402:21 | 10 |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:403:13:403:13 | _ |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:401:9:404:9 | match 43 { ... } |
+| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:17:402:17 | 1 | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |
+| test.rs:402:17:402:17 | 1 | test.rs:402:20:402:21 | 10 |
+| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |
+| test.rs:403:13:403:13 | _ | test.rs:403:13:403:13 | _ |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:409:9:412:9 | match a { ... } |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:25:410:25 | 1 |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:28:410:29 | 10 |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:411:13:411:21 | n |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:409:9:412:9 | match a { ... } |
+| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:25:410:25 | 1 | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |
+| test.rs:410:25:410:25 | 1 | test.rs:410:28:410:29 | 10 |
+| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |
+| test.rs:411:13:411:21 | n | test.rs:411:13:411:21 | n |
+| test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:418:5:423:5 | enter fn test_infinite_loop |
+| test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:420:13:420:14 | TupleExpr |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr |
+| test.rs:427:5:429:5 | enter fn say_hello | test.rs:427:5:429:5 | enter fn say_hello |
+| test.rs:431:5:450:5 | enter fn async_block | test.rs:431:5:450:5 | enter fn async_block |
+| test.rs:432:26:434:9 | enter { ... } | test.rs:432:26:434:9 | enter { ... } |
+| test.rs:435:31:437:9 | enter { ... } | test.rs:435:31:437:9 | enter { ... } |
+| test.rs:444:22:449:9 | enter \|...\| ... | test.rs:444:22:449:9 | enter \|...\| ... |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:444:28:449:9 | exit { ... } (normal) |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:445:13:447:13 | if b {...} |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:446:17:446:41 | ExprStmt |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | exit { ... } (normal) |
+| test.rs:445:13:447:13 | if b {...} | test.rs:445:13:447:13 | if b {...} |
+| test.rs:446:17:446:41 | ExprStmt | test.rs:446:17:446:41 | ExprStmt |
+| test.rs:456:5:458:5 | enter fn add_two | test.rs:456:5:458:5 | enter fn add_two |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:13:466:49 | ExprStmt |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(false)] ! ... |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | if ... {...} |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:13:466:49 | ExprStmt |
+| test.rs:466:13:466:49 | enter fn panic_cold_explicit | test.rs:466:13:466:49 | enter fn panic_cold_explicit |
+| test.rs:466:21:466:48 | [boolean(false)] ! ... | test.rs:466:21:466:48 | [boolean(false)] ! ... |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:13:466:49 | ExprStmt |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | if ... {...} |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:472:5:481:5 | enter fn const_block_panic |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:474:9:479:9 | if false {...} |
+| test.rs:474:9:479:9 | if false {...} | test.rs:474:9:479:9 | if false {...} |
+| test.rs:477:17:477:24 | enter fn panic_cold_explicit | test.rs:477:17:477:24 | enter fn panic_cold_explicit |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:484:1:489:1 | enter fn dead_code |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:486:9:486:17 | ExprStmt |
+| test.rs:486:9:486:17 | ExprStmt | test.rs:486:9:486:17 | ExprStmt |
+| test.rs:491:1:491:16 | enter fn do_thing | test.rs:491:1:491:16 | enter fn do_thing |
+| test.rs:493:1:495:1 | enter fn condition_not_met | test.rs:493:1:495:1 | enter fn condition_not_met |
+| test.rs:497:1:497:21 | enter fn do_next_thing | test.rs:497:1:497:21 | enter fn do_next_thing |
+| test.rs:499:1:499:21 | enter fn do_last_thing | test.rs:499:1:499:21 | enter fn do_last_thing |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:502:18:513:5 | 'block: { ... } |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:504:9:506:9 | if ... {...} |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:508:9:510:9 | if ... {...} |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:509:13:509:27 | ExprStmt |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:502:18:513:5 | 'block: { ... } |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:504:9:506:9 | if ... {...} |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:508:9:510:9 | if ... {...} |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:509:13:509:27 | ExprStmt |
 | test.rs:505:13:505:27 | ExprStmt | test.rs:505:13:505:27 | ExprStmt |
-| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:511:1:517:1 | enter fn test_nested_function2 |
-| test.rs:513:5:515:5 | enter fn nested | test.rs:513:5:515:5 | enter fn nested |
-| test.rs:528:5:530:5 | enter fn new | test.rs:528:5:530:5 | enter fn new |
-| test.rs:532:5:534:5 | enter fn negated | test.rs:532:5:534:5 | enter fn negated |
-| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:5:538:5 | enter fn multifly_add |
+| test.rs:508:9:510:9 | if ... {...} | test.rs:508:9:510:9 | if ... {...} |
+| test.rs:509:13:509:27 | ExprStmt | test.rs:509:13:509:27 | ExprStmt |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:517:1:525:1 | enter fn labelled_block2 |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:518:18:524:5 | 'block: { ... } |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:520:18:520:18 | y |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:521:13:521:27 | ExprStmt |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:518:18:524:5 | 'block: { ... } |
+| test.rs:520:18:520:18 | y | test.rs:520:18:520:18 | y |
+| test.rs:521:13:521:27 | ExprStmt | test.rs:521:13:521:27 | ExprStmt |
+| test.rs:527:1:533:1 | enter fn test_nested_function2 | test.rs:527:1:533:1 | enter fn test_nested_function2 |
+| test.rs:529:5:531:5 | enter fn nested | test.rs:529:5:531:5 | enter fn nested |
+| test.rs:544:5:546:5 | enter fn new | test.rs:544:5:546:5 | enter fn new |
+| test.rs:548:5:550:5 | enter fn negated | test.rs:548:5:550:5 | enter fn negated |
+| test.rs:552:5:554:5 | enter fn multifly_add | test.rs:552:5:554:5 | enter fn multifly_add |
 postDominance
 | test.rs:5:5:8:5 | enter fn function_call | test.rs:5:5:8:5 | enter fn function_call |
 | test.rs:10:5:13:5 | enter fn method_call | test.rs:10:5:13:5 | enter fn method_call |
@@ -1192,66 +1220,88 @@ postDominance
 | test.rs:395:13:395:15 | RangePat | test.rs:395:13:395:15 | RangePat |
 | test.rs:395:20:395:20 | 3 | test.rs:395:20:395:20 | 3 |
 | test.rs:396:13:396:13 | _ | test.rs:396:13:396:13 | _ |
-| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:402:5:407:5 | enter fn test_infinite_loop |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr |
-| test.rs:411:5:413:5 | enter fn say_hello | test.rs:411:5:413:5 | enter fn say_hello |
-| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:5:434:5 | enter fn async_block |
-| test.rs:416:26:418:9 | enter { ... } | test.rs:416:26:418:9 | enter { ... } |
-| test.rs:419:31:421:9 | enter { ... } | test.rs:419:31:421:9 | enter { ... } |
-| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:22:433:9 | enter \|...\| ... |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } (normal) |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:429:13:431:13 | if b {...} |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:430:17:430:41 | ExprStmt |
-| test.rs:429:13:431:13 | if b {...} | test.rs:429:13:431:13 | if b {...} |
-| test.rs:430:17:430:41 | ExprStmt | test.rs:430:17:430:41 | ExprStmt |
-| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:5:442:5 | enter fn add_two |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | ExprStmt |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | enter fn panic_cold_explicit |
-| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | [boolean(false)] ! ... |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:13:450:49 | ExprStmt |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(false)] ! ... |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | if ... {...} |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:456:5:465:5 | enter fn const_block_panic |
-| test.rs:458:9:463:9 | if false {...} | test.rs:456:5:465:5 | enter fn const_block_panic |
-| test.rs:458:9:463:9 | if false {...} | test.rs:458:9:463:9 | if false {...} |
-| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | enter fn panic_cold_explicit |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:468:1:473:1 | enter fn dead_code |
-| test.rs:470:9:470:17 | ExprStmt | test.rs:468:1:473:1 | enter fn dead_code |
-| test.rs:470:9:470:17 | ExprStmt | test.rs:470:9:470:17 | ExprStmt |
-| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:1:475:16 | enter fn do_thing |
-| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:477:1:479:1 | enter fn condition_not_met |
-| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:1:481:21 | enter fn do_next_thing |
-| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:1:483:21 | enter fn do_last_thing |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:18:497:5 | 'block: { ... } |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:489:13:489:27 | ExprStmt |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:492:9:494:9 | if ... {...} |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:493:13:493:27 | ExprStmt |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:489:13:489:27 | ExprStmt | test.rs:489:13:489:27 | ExprStmt |
-| test.rs:492:9:494:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} |
-| test.rs:493:13:493:27 | ExprStmt | test.rs:493:13:493:27 | ExprStmt |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:501:1:509:1 | enter fn labelled_block2 |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:501:1:509:1 | enter fn labelled_block2 |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:18:508:5 | 'block: { ... } |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:504:18:504:18 | y |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt |
-| test.rs:504:18:504:18 | y | test.rs:504:18:504:18 | y |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:401:9:404:9 | match 43 { ... } |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:17:402:17 | 1 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:20:402:21 | 10 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:403:13:403:13 | _ |
+| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |
+| test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |
+| test.rs:403:13:403:13 | _ | test.rs:403:13:403:13 | _ |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:409:9:412:9 | match a { ... } |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:25:410:25 | 1 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:28:410:29 | 10 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | n |
+| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |
+| test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |
+| test.rs:411:13:411:21 | n | test.rs:411:13:411:21 | n |
+| test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:418:5:423:5 | enter fn test_infinite_loop |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr |
+| test.rs:427:5:429:5 | enter fn say_hello | test.rs:427:5:429:5 | enter fn say_hello |
+| test.rs:431:5:450:5 | enter fn async_block | test.rs:431:5:450:5 | enter fn async_block |
+| test.rs:432:26:434:9 | enter { ... } | test.rs:432:26:434:9 | enter { ... } |
+| test.rs:435:31:437:9 | enter { ... } | test.rs:435:31:437:9 | enter { ... } |
+| test.rs:444:22:449:9 | enter \|...\| ... | test.rs:444:22:449:9 | enter \|...\| ... |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | exit { ... } (normal) |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:445:13:447:13 | if b {...} |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:446:17:446:41 | ExprStmt |
+| test.rs:445:13:447:13 | if b {...} | test.rs:445:13:447:13 | if b {...} |
+| test.rs:446:17:446:41 | ExprStmt | test.rs:446:17:446:41 | ExprStmt |
+| test.rs:456:5:458:5 | enter fn add_two | test.rs:456:5:458:5 | enter fn add_two |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:13:466:49 | ExprStmt |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:466:13:466:49 | enter fn panic_cold_explicit | test.rs:466:13:466:49 | enter fn panic_cold_explicit |
+| test.rs:466:21:466:48 | [boolean(false)] ! ... | test.rs:466:21:466:48 | [boolean(false)] ! ... |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:13:466:49 | ExprStmt |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | [boolean(false)] ! ... |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | if ... {...} |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:472:5:481:5 | enter fn const_block_panic |
+| test.rs:474:9:479:9 | if false {...} | test.rs:472:5:481:5 | enter fn const_block_panic |
+| test.rs:474:9:479:9 | if false {...} | test.rs:474:9:479:9 | if false {...} |
+| test.rs:477:17:477:24 | enter fn panic_cold_explicit | test.rs:477:17:477:24 | enter fn panic_cold_explicit |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:484:1:489:1 | enter fn dead_code |
+| test.rs:486:9:486:17 | ExprStmt | test.rs:484:1:489:1 | enter fn dead_code |
+| test.rs:486:9:486:17 | ExprStmt | test.rs:486:9:486:17 | ExprStmt |
+| test.rs:491:1:491:16 | enter fn do_thing | test.rs:491:1:491:16 | enter fn do_thing |
+| test.rs:493:1:495:1 | enter fn condition_not_met | test.rs:493:1:495:1 | enter fn condition_not_met |
+| test.rs:497:1:497:21 | enter fn do_next_thing | test.rs:497:1:497:21 | enter fn do_next_thing |
+| test.rs:499:1:499:21 | enter fn do_last_thing | test.rs:499:1:499:21 | enter fn do_last_thing |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:502:18:513:5 | 'block: { ... } |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:504:9:506:9 | if ... {...} |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:508:9:510:9 | if ... {...} |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:509:13:509:27 | ExprStmt |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:504:9:506:9 | if ... {...} |
 | test.rs:505:13:505:27 | ExprStmt | test.rs:505:13:505:27 | ExprStmt |
-| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:511:1:517:1 | enter fn test_nested_function2 |
-| test.rs:513:5:515:5 | enter fn nested | test.rs:513:5:515:5 | enter fn nested |
-| test.rs:528:5:530:5 | enter fn new | test.rs:528:5:530:5 | enter fn new |
-| test.rs:532:5:534:5 | enter fn negated | test.rs:532:5:534:5 | enter fn negated |
-| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:5:538:5 | enter fn multifly_add |
+| test.rs:508:9:510:9 | if ... {...} | test.rs:508:9:510:9 | if ... {...} |
+| test.rs:509:13:509:27 | ExprStmt | test.rs:509:13:509:27 | ExprStmt |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:517:1:525:1 | enter fn labelled_block2 |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:517:1:525:1 | enter fn labelled_block2 |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:518:18:524:5 | 'block: { ... } |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:520:18:520:18 | y |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:521:13:521:27 | ExprStmt |
+| test.rs:520:18:520:18 | y | test.rs:520:18:520:18 | y |
+| test.rs:521:13:521:27 | ExprStmt | test.rs:521:13:521:27 | ExprStmt |
+| test.rs:527:1:533:1 | enter fn test_nested_function2 | test.rs:527:1:533:1 | enter fn test_nested_function2 |
+| test.rs:529:5:531:5 | enter fn nested | test.rs:529:5:531:5 | enter fn nested |
+| test.rs:544:5:546:5 | enter fn new | test.rs:544:5:546:5 | enter fn new |
+| test.rs:548:5:550:5 | enter fn negated | test.rs:548:5:550:5 | enter fn negated |
+| test.rs:552:5:554:5 | enter fn multifly_add | test.rs:552:5:554:5 | enter fn multifly_add |
 immediateDominator
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:18:5:24:5 | enter fn next |
 | test.rs:20:13:20:13 | n | test.rs:18:5:24:5 | enter fn next |
@@ -1452,24 +1502,34 @@ immediateDominator
 | test.rs:395:13:395:15 | RangePat | test.rs:394:13:394:16 | RangePat |
 | test.rs:395:20:395:20 | 3 | test.rs:395:13:395:13 | 5 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:402:5:407:5 | enter fn test_infinite_loop |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:429:13:431:13 | if b {...} | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:430:17:430:41 | ExprStmt | test.rs:428:28:433:9 | enter { ... } |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:21:450:48 | [boolean(true)] ! ... |
-| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:446:5:454:5 | enter fn const_block_assert |
-| test.rs:458:9:463:9 | if false {...} | test.rs:456:5:465:5 | enter fn const_block_panic |
-| test.rs:470:9:470:17 | ExprStmt | test.rs:468:1:473:1 | enter fn dead_code |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:489:13:489:27 | ExprStmt | test.rs:485:1:499:1 | enter fn labelled_block1 |
-| test.rs:492:9:494:9 | if ... {...} | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:493:13:493:27 | ExprStmt | test.rs:488:9:490:9 | if ... {...} |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:501:1:509:1 | enter fn labelled_block2 |
-| test.rs:504:18:504:18 | y | test.rs:501:1:509:1 | enter fn labelled_block2 |
-| test.rs:505:13:505:27 | ExprStmt | test.rs:501:1:509:1 | enter fn labelled_block2 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:20:402:21 | 10 |
+| test.rs:402:17:402:17 | 1 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:402:20:402:21 | 10 | test.rs:402:17:402:17 | 1 |
+| test.rs:403:13:403:13 | _ | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:28:410:29 | 10 |
+| test.rs:410:25:410:25 | 1 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:410:28:410:29 | 10 | test.rs:410:25:410:25 | 1 |
+| test.rs:411:13:411:21 | n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:418:5:423:5 | enter fn test_infinite_loop |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:445:13:447:13 | if b {...} | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:446:17:446:41 | ExprStmt | test.rs:444:28:449:9 | enter { ... } |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:21:466:48 | [boolean(true)] ! ... |
+| test.rs:466:21:466:48 | [boolean(false)] ! ... | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:462:5:470:5 | enter fn const_block_assert |
+| test.rs:474:9:479:9 | if false {...} | test.rs:472:5:481:5 | enter fn const_block_panic |
+| test.rs:486:9:486:17 | ExprStmt | test.rs:484:1:489:1 | enter fn dead_code |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:505:13:505:27 | ExprStmt | test.rs:501:1:515:1 | enter fn labelled_block1 |
+| test.rs:508:9:510:9 | if ... {...} | test.rs:504:9:506:9 | if ... {...} |
+| test.rs:509:13:509:27 | ExprStmt | test.rs:504:9:506:9 | if ... {...} |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:517:1:525:1 | enter fn labelled_block2 |
+| test.rs:520:18:520:18 | y | test.rs:517:1:525:1 | enter fn labelled_block2 |
+| test.rs:521:13:521:27 | ExprStmt | test.rs:517:1:525:1 | enter fn labelled_block2 |
 controls
 | test.rs:18:5:24:5 | enter fn next | test.rs:20:13:20:13 | n | true |
 | test.rs:18:5:24:5 | enter fn next | test.rs:22:13:22:13 | 3 | false |
@@ -1659,20 +1719,20 @@ controls
 | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | test.rs:349:15:349:18 | cond | true |
 | test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | true |
 | test.rs:347:18:347:18 | a | test.rs:349:15:349:18 | cond | true |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} | false |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt | true |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:13:450:49 | ExprStmt | false |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} | false |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt | true |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} | false |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt | true |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:492:9:494:9 | if ... {...} | false |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:493:13:493:27 | ExprStmt | false |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} | false |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt | true |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:445:13:447:13 | if b {...} | false |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:446:17:446:41 | ExprStmt | true |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:13:466:49 | ExprStmt | false |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(false)] ! ... | true |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(true)] ! ... | false |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:13:466:49 | ExprStmt | true |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:474:9:479:9 | if false {...} | false |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:486:9:486:17 | ExprStmt | true |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:504:9:506:9 | if ... {...} | false |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:505:13:505:27 | ExprStmt | true |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:508:9:510:9 | if ... {...} | false |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:509:13:509:27 | ExprStmt | false |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:508:9:510:9 | if ... {...} | false |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:509:13:509:27 | ExprStmt | true |
 successor
 | test.rs:18:5:24:5 | enter fn next | test.rs:20:13:20:13 | n | true |
 | test.rs:18:5:24:5 | enter fn next | test.rs:22:13:22:13 | 3 | false |
@@ -1808,18 +1868,18 @@ successor
 | test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
 | test.rs:347:18:347:18 | a | test.rs:346:10:349:9 | [boolean(true)] match r { ... } | true |
 | test.rs:348:13:348:13 | _ | test.rs:346:10:349:9 | [boolean(false)] match r { ... } | false |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:13 | if b {...} | false |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:430:17:430:41 | ExprStmt | true |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
-| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | if ... {...} | false |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:458:9:463:9 | if false {...} | false |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:470:9:470:17 | ExprStmt | true |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:488:9:490:9 | if ... {...} | false |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:489:13:489:27 | ExprStmt | true |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:492:9:494:9 | if ... {...} | false |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:493:13:493:27 | ExprStmt | true |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:445:13:447:13 | if b {...} | false |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:446:17:446:41 | ExprStmt | true |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(false)] ! ... | true |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:466:21:466:48 | [boolean(true)] ! ... | false |
+| test.rs:466:21:466:48 | [boolean(false)] ! ... | test.rs:466:21:466:48 | if ... {...} | false |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:13:466:49 | ExprStmt | true |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:474:9:479:9 | if false {...} | false |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:486:9:486:17 | ExprStmt | true |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:504:9:506:9 | if ... {...} | false |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:505:13:505:27 | ExprStmt | true |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:508:9:510:9 | if ... {...} | false |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:509:13:509:27 | ExprStmt | true |
 joinBlockPredecessor
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:20:13:20:13 | n | 1 |
 | test.rs:19:9:23:9 | if ... {...} else {...} | test.rs:22:13:22:13 | 3 | 0 |
@@ -1951,14 +2011,24 @@ joinBlockPredecessor
 | test.rs:395:13:395:15 | RangePat | test.rs:394:16:394:16 | 2 | 0 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:13 | 5 | 0 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat | 1 |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:402:5:407:5 | enter fn test_infinite_loop | 1 |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:404:13:404:14 | TupleExpr | 0 |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:429:13:431:13 | if b {...} | 1 |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:430:17:430:41 | ExprStmt | 0 |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:13:450:49 | ExprStmt | 1 |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | [boolean(false)] ! ... | 0 |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:489:13:489:27 | ExprStmt | 0 |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:492:9:494:9 | if ... {...} | 2 |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:493:13:493:27 | ExprStmt | 1 |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:504:18:504:18 | y | 1 |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt | 0 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n | 0 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:403:13:403:13 | _ | 1 |
+| test.rs:403:13:403:13 | _ | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | 2 |
+| test.rs:403:13:403:13 | _ | test.rs:402:17:402:17 | 1 | 1 |
+| test.rs:403:13:403:13 | _ | test.rs:402:20:402:21 | 10 | 0 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] n | 0 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | n | 1 |
+| test.rs:411:13:411:21 | n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | 2 |
+| test.rs:411:13:411:21 | n | test.rs:410:25:410:25 | 1 | 1 |
+| test.rs:411:13:411:21 | n | test.rs:410:28:410:29 | 10 | 0 |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:418:5:423:5 | enter fn test_infinite_loop | 1 |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr | 0 |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:445:13:447:13 | if b {...} | 1 |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:446:17:446:41 | ExprStmt | 0 |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:13:466:49 | ExprStmt | 1 |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | [boolean(false)] ! ... | 0 |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:505:13:505:27 | ExprStmt | 0 |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:508:9:510:9 | if ... {...} | 2 |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:509:13:509:27 | ExprStmt | 1 |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:520:18:520:18 | y | 1 |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:521:13:521:27 | ExprStmt | 0 |

--- a/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
+++ b/rust/ql/test/library-tests/controlflow/BasicBlocks.expected
@@ -612,32 +612,32 @@ dominates
 | test.rs:396:13:396:13 | _ | test.rs:396:13:396:13 | _ |
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:401:9:404:9 | match 43 { ... } |
-| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:13:402:21 | [match(true)] n @ ... |
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:17:402:17 | 1 |
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:402:20:402:21 | 10 |
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:403:13:403:13 | _ |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:401:9:404:9 | match 43 { ... } |
-| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:13:402:21 | [match(true)] n |
-| test.rs:402:17:402:17 | 1 | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:13:402:21 | [match(true)] n @ ... | test.rs:402:13:402:21 | [match(true)] n @ ... |
+| test.rs:402:17:402:17 | 1 | test.rs:402:13:402:21 | [match(true)] n @ ... |
 | test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |
 | test.rs:402:17:402:17 | 1 | test.rs:402:20:402:21 | 10 |
-| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n @ ... |
 | test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |
 | test.rs:403:13:403:13 | _ | test.rs:403:13:403:13 | _ |
 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:409:9:412:9 | match a { ... } |
-| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:25:410:25 | 1 |
 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:410:28:410:29 | 10 |
-| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:411:13:411:21 | n |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:411:13:411:21 | ref mut n |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:409:9:412:9 | match a { ... } |
-| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:13:410:29 | [match(true)] n |
-| test.rs:410:25:410:25 | 1 | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
+| test.rs:410:25:410:25 | 1 | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
 | test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |
 | test.rs:410:25:410:25 | 1 | test.rs:410:28:410:29 | 10 |
-| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
 | test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |
-| test.rs:411:13:411:21 | n | test.rs:411:13:411:21 | n |
+| test.rs:411:13:411:21 | ref mut n | test.rs:411:13:411:21 | ref mut n |
 | test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:418:5:423:5 | enter fn test_infinite_loop |
 | test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:420:13:420:14 | TupleExpr |
 | test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr |
@@ -1223,25 +1223,25 @@ postDominance
 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:401:9:404:9 | match 43 { ... } |
-| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n @ ... |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:17:402:17 | 1 |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:20:402:21 | 10 |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:403:13:403:13 | _ |
-| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:13:402:21 | [match(true)] n |
+| test.rs:402:13:402:21 | [match(true)] n @ ... | test.rs:402:13:402:21 | [match(true)] n @ ... |
 | test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |
 | test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |
 | test.rs:403:13:403:13 | _ | test.rs:403:13:403:13 | _ |
 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:409:9:412:9 | match a { ... } |
-| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:410:25:410:25 | 1 |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:410:28:410:29 | 10 |
-| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | n |
-| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:13:410:29 | [match(true)] n |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | ref mut n |
+| test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... |
 | test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |
 | test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |
-| test.rs:411:13:411:21 | n | test.rs:411:13:411:21 | n |
+| test.rs:411:13:411:21 | ref mut n | test.rs:411:13:411:21 | ref mut n |
 | test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:418:5:423:5 | enter fn test_infinite_loop |
 | test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr |
 | test.rs:427:5:429:5 | enter fn say_hello | test.rs:427:5:429:5 | enter fn say_hello |
@@ -1503,15 +1503,15 @@ immediateDominator
 | test.rs:395:20:395:20 | 3 | test.rs:395:13:395:13 | 5 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
-| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:20:402:21 | 10 |
+| test.rs:402:13:402:21 | [match(true)] n @ ... | test.rs:402:20:402:21 | 10 |
 | test.rs:402:17:402:17 | 1 | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
 | test.rs:402:20:402:21 | 10 | test.rs:402:17:402:17 | 1 |
 | test.rs:403:13:403:13 | _ | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
-| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:28:410:29 | 10 |
+| test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | test.rs:410:28:410:29 | 10 |
 | test.rs:410:25:410:25 | 1 | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
 | test.rs:410:28:410:29 | 10 | test.rs:410:25:410:25 | 1 |
-| test.rs:411:13:411:21 | n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
+| test.rs:411:13:411:21 | ref mut n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref |
 | test.rs:420:13:420:14 | TupleExpr | test.rs:418:5:423:5 | enter fn test_infinite_loop |
 | test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | enter { ... } |
 | test.rs:445:13:447:13 | if b {...} | test.rs:444:28:449:9 | enter { ... } |
@@ -2011,16 +2011,16 @@ joinBlockPredecessor
 | test.rs:395:13:395:15 | RangePat | test.rs:394:16:394:16 | 2 | 0 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:13 | 5 | 0 |
 | test.rs:396:13:396:13 | _ | test.rs:395:13:395:15 | RangePat | 1 |
-| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n | 0 |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:402:13:402:21 | [match(true)] n @ ... | 0 |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:403:13:403:13 | _ | 1 |
 | test.rs:403:13:403:13 | _ | test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | 2 |
 | test.rs:403:13:403:13 | _ | test.rs:402:17:402:17 | 1 | 1 |
 | test.rs:403:13:403:13 | _ | test.rs:402:20:402:21 | 10 | 0 |
-| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] n | 0 |
-| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | n | 1 |
-| test.rs:411:13:411:21 | n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | 2 |
-| test.rs:411:13:411:21 | n | test.rs:410:25:410:25 | 1 | 1 |
-| test.rs:411:13:411:21 | n | test.rs:410:28:410:29 | 10 | 0 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | 0 |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:411:13:411:21 | ref mut n | 1 |
+| test.rs:411:13:411:21 | ref mut n | test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | 2 |
+| test.rs:411:13:411:21 | ref mut n | test.rs:410:25:410:25 | 1 | 1 |
+| test.rs:411:13:411:21 | ref mut n | test.rs:410:28:410:29 | 10 | 0 |
 | test.rs:420:13:420:14 | TupleExpr | test.rs:418:5:423:5 | enter fn test_infinite_loop | 1 |
 | test.rs:420:13:420:14 | TupleExpr | test.rs:420:13:420:14 | TupleExpr | 0 |
 | test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:445:13:447:13 | if b {...} | 1 |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -901,282 +901,329 @@ edges
 | test.rs:395:20:395:20 | 3 | test.rs:392:9:397:9 | match 42 { ... } |  |
 | test.rs:396:13:396:13 | _ | test.rs:396:18:396:18 | 4 | match |
 | test.rs:396:18:396:18 | 4 | test.rs:392:9:397:9 | match 42 { ... } |  |
-| test.rs:402:5:407:5 | enter fn test_infinite_loop | test.rs:403:9:405:9 | ExprStmt |  |
-| test.rs:403:9:405:9 | ExprStmt | test.rs:404:13:404:14 | TupleExpr |  |
-| test.rs:403:14:405:9 | { ... } | test.rs:404:13:404:14 | TupleExpr |  |
-| test.rs:404:13:404:14 | TupleExpr | test.rs:403:14:405:9 | { ... } |  |
-| test.rs:411:5:413:5 | enter fn say_hello | test.rs:412:9:412:34 | ExprStmt |  |
-| test.rs:411:5:413:5 | exit fn say_hello (normal) | test.rs:411:5:413:5 | exit fn say_hello |  |
-| test.rs:411:26:413:5 | { ... } | test.rs:411:5:413:5 | exit fn say_hello (normal) |  |
-| test.rs:412:9:412:33 | ...::_print | test.rs:412:18:412:32 | "hello, world!\\n" |  |
-| test.rs:412:9:412:33 | MacroExpr | test.rs:411:26:413:5 | { ... } |  |
-| test.rs:412:9:412:33 | println!... | test.rs:412:9:412:33 | MacroExpr |  |
-| test.rs:412:9:412:34 | ExprStmt | test.rs:412:18:412:32 | MacroStmts |  |
-| test.rs:412:18:412:32 | "hello, world!\\n" | test.rs:412:18:412:32 | FormatArgsExpr |  |
-| test.rs:412:18:412:32 | ...::_print(...) | test.rs:412:18:412:32 | { ... } |  |
-| test.rs:412:18:412:32 | ...::format_args_nl!... | test.rs:412:18:412:32 | MacroExpr |  |
-| test.rs:412:18:412:32 | ExprStmt | test.rs:412:9:412:33 | ...::_print |  |
-| test.rs:412:18:412:32 | FormatArgsExpr | test.rs:412:18:412:32 | ...::format_args_nl!... |  |
-| test.rs:412:18:412:32 | MacroExpr | test.rs:412:18:412:32 | ...::_print(...) |  |
-| test.rs:412:18:412:32 | MacroStmts | test.rs:412:18:412:32 | ExprStmt |  |
-| test.rs:412:18:412:32 | { ... } | test.rs:412:9:412:33 | println!... |  |
-| test.rs:415:5:434:5 | enter fn async_block | test.rs:415:26:415:26 | b |  |
-| test.rs:415:5:434:5 | exit fn async_block (normal) | test.rs:415:5:434:5 | exit fn async_block |  |
-| test.rs:415:26:415:26 | b | test.rs:415:26:415:32 | ...: bool | match |
-| test.rs:415:26:415:32 | ...: bool | test.rs:416:9:418:10 | let ... = ... |  |
-| test.rs:415:35:434:5 | { ... } | test.rs:415:5:434:5 | exit fn async_block (normal) |  |
-| test.rs:416:9:418:10 | let ... = ... | test.rs:416:26:418:9 | { ... } |  |
-| test.rs:416:13:416:22 | say_godbye | test.rs:419:9:421:10 | let ... = ... | match |
-| test.rs:416:26:418:9 | enter { ... } | test.rs:417:13:417:42 | ExprStmt |  |
-| test.rs:416:26:418:9 | exit { ... } (normal) | test.rs:416:26:418:9 | exit { ... } |  |
-| test.rs:416:26:418:9 | { ... } | test.rs:416:13:416:22 | say_godbye |  |
-| test.rs:417:13:417:41 | ...::_print | test.rs:417:22:417:40 | "godbye, everyone!\\n" |  |
-| test.rs:417:13:417:41 | MacroExpr | test.rs:416:26:418:9 | exit { ... } (normal) |  |
-| test.rs:417:13:417:41 | println!... | test.rs:417:13:417:41 | MacroExpr |  |
-| test.rs:417:13:417:42 | ExprStmt | test.rs:417:22:417:40 | MacroStmts |  |
-| test.rs:417:22:417:40 | "godbye, everyone!\\n" | test.rs:417:22:417:40 | FormatArgsExpr |  |
-| test.rs:417:22:417:40 | ...::_print(...) | test.rs:417:22:417:40 | { ... } |  |
-| test.rs:417:22:417:40 | ...::format_args_nl!... | test.rs:417:22:417:40 | MacroExpr |  |
-| test.rs:417:22:417:40 | ExprStmt | test.rs:417:13:417:41 | ...::_print |  |
-| test.rs:417:22:417:40 | FormatArgsExpr | test.rs:417:22:417:40 | ...::format_args_nl!... |  |
-| test.rs:417:22:417:40 | MacroExpr | test.rs:417:22:417:40 | ...::_print(...) |  |
-| test.rs:417:22:417:40 | MacroStmts | test.rs:417:22:417:40 | ExprStmt |  |
-| test.rs:417:22:417:40 | { ... } | test.rs:417:13:417:41 | println!... |  |
-| test.rs:419:9:421:10 | let ... = ... | test.rs:419:31:421:9 | { ... } |  |
-| test.rs:419:13:419:27 | say_how_are_you | test.rs:422:9:422:28 | let ... = ... | match |
-| test.rs:419:31:421:9 | enter { ... } | test.rs:420:13:420:37 | ExprStmt |  |
-| test.rs:419:31:421:9 | exit { ... } (normal) | test.rs:419:31:421:9 | exit { ... } |  |
-| test.rs:419:31:421:9 | { ... } | test.rs:419:13:419:27 | say_how_are_you |  |
-| test.rs:420:13:420:36 | ...::_print | test.rs:420:22:420:35 | "how are you?\\n" |  |
-| test.rs:420:13:420:36 | MacroExpr | test.rs:419:31:421:9 | exit { ... } (normal) |  |
-| test.rs:420:13:420:36 | println!... | test.rs:420:13:420:36 | MacroExpr |  |
-| test.rs:420:13:420:37 | ExprStmt | test.rs:420:22:420:35 | MacroStmts |  |
-| test.rs:420:22:420:35 | "how are you?\\n" | test.rs:420:22:420:35 | FormatArgsExpr |  |
-| test.rs:420:22:420:35 | ...::_print(...) | test.rs:420:22:420:35 | { ... } |  |
-| test.rs:420:22:420:35 | ...::format_args_nl!... | test.rs:420:22:420:35 | MacroExpr |  |
-| test.rs:420:22:420:35 | ExprStmt | test.rs:420:13:420:36 | ...::_print |  |
-| test.rs:420:22:420:35 | FormatArgsExpr | test.rs:420:22:420:35 | ...::format_args_nl!... |  |
-| test.rs:420:22:420:35 | MacroExpr | test.rs:420:22:420:35 | ...::_print(...) |  |
-| test.rs:420:22:420:35 | MacroStmts | test.rs:420:22:420:35 | ExprStmt |  |
-| test.rs:420:22:420:35 | { ... } | test.rs:420:13:420:36 | println!... |  |
-| test.rs:422:9:422:28 | let ... = ... | test.rs:422:20:422:27 | { ... } |  |
-| test.rs:422:13:422:16 | noop | test.rs:423:9:423:26 | ExprStmt | match |
-| test.rs:422:20:422:27 | { ... } | test.rs:422:13:422:16 | noop |  |
-| test.rs:423:9:423:17 | say_hello | test.rs:423:9:423:19 | say_hello(...) |  |
-| test.rs:423:9:423:19 | say_hello(...) | test.rs:423:9:423:25 | await ... |  |
-| test.rs:423:9:423:25 | await ... | test.rs:424:9:424:30 | ExprStmt |  |
-| test.rs:423:9:423:26 | ExprStmt | test.rs:423:9:423:17 | say_hello |  |
-| test.rs:424:9:424:23 | say_how_are_you | test.rs:424:9:424:29 | await say_how_are_you |  |
-| test.rs:424:9:424:29 | await say_how_are_you | test.rs:425:9:425:25 | ExprStmt |  |
-| test.rs:424:9:424:30 | ExprStmt | test.rs:424:9:424:23 | say_how_are_you |  |
-| test.rs:425:9:425:18 | say_godbye | test.rs:425:9:425:24 | await say_godbye |  |
-| test.rs:425:9:425:24 | await say_godbye | test.rs:426:9:426:19 | ExprStmt |  |
-| test.rs:425:9:425:25 | ExprStmt | test.rs:425:9:425:18 | say_godbye |  |
-| test.rs:426:9:426:12 | noop | test.rs:426:9:426:18 | await noop |  |
-| test.rs:426:9:426:18 | await noop | test.rs:428:9:433:10 | let ... = ... |  |
-| test.rs:426:9:426:19 | ExprStmt | test.rs:426:9:426:12 | noop |  |
-| test.rs:428:9:433:10 | let ... = ... | test.rs:428:22:433:9 | \|...\| ... |  |
-| test.rs:428:13:428:18 | lambda | test.rs:415:35:434:5 | { ... } | match |
-| test.rs:428:22:433:9 | \|...\| ... | test.rs:428:13:428:18 | lambda |  |
-| test.rs:428:22:433:9 | enter \|...\| ... | test.rs:428:23:428:25 | foo |  |
-| test.rs:428:22:433:9 | exit \|...\| ... (normal) | test.rs:428:22:433:9 | exit \|...\| ... |  |
-| test.rs:428:23:428:25 | ... | test.rs:428:28:433:9 | { ... } |  |
-| test.rs:428:23:428:25 | foo | test.rs:428:23:428:25 | ... | match |
-| test.rs:428:28:433:9 | enter { ... } | test.rs:429:13:431:14 | ExprStmt |  |
-| test.rs:428:28:433:9 | exit { ... } (normal) | test.rs:428:28:433:9 | exit { ... } |  |
-| test.rs:428:28:433:9 | { ... } | test.rs:428:22:433:9 | exit \|...\| ... (normal) |  |
-| test.rs:429:13:431:13 | if b {...} | test.rs:432:13:432:15 | foo |  |
-| test.rs:429:13:431:14 | ExprStmt | test.rs:429:16:429:16 | b |  |
-| test.rs:429:16:429:16 | b | test.rs:429:13:431:13 | if b {...} | false |
-| test.rs:429:16:429:16 | b | test.rs:430:17:430:41 | ExprStmt | true |
-| test.rs:430:17:430:40 | return ... | test.rs:428:28:433:9 | exit { ... } (normal) | return |
-| test.rs:430:17:430:41 | ExprStmt | test.rs:430:24:430:34 | async_block |  |
-| test.rs:430:24:430:34 | async_block | test.rs:430:36:430:39 | true |  |
-| test.rs:430:24:430:40 | async_block(...) | test.rs:430:17:430:40 | return ... |  |
-| test.rs:430:36:430:39 | true | test.rs:430:24:430:40 | async_block(...) |  |
-| test.rs:432:13:432:15 | foo | test.rs:428:28:433:9 | exit { ... } (normal) |  |
-| test.rs:440:5:442:5 | enter fn add_two | test.rs:440:22:440:22 | n |  |
-| test.rs:440:5:442:5 | exit fn add_two (normal) | test.rs:440:5:442:5 | exit fn add_two |  |
-| test.rs:440:22:440:22 | n | test.rs:440:22:440:27 | ...: i64 | match |
-| test.rs:440:22:440:27 | ...: i64 | test.rs:441:9:441:9 | n |  |
-| test.rs:440:37:442:5 | { ... } | test.rs:440:5:442:5 | exit fn add_two (normal) |  |
-| test.rs:441:9:441:9 | n | test.rs:441:13:441:13 | 2 |  |
-| test.rs:441:9:441:13 | ... + ... | test.rs:440:37:442:5 | { ... } |  |
-| test.rs:441:13:441:13 | 2 | test.rs:441:9:441:13 | ... + ... |  |
-| test.rs:446:5:454:5 | enter fn const_block_assert | test.rs:449:9:451:9 | ExprStmt |  |
-| test.rs:446:5:454:5 | exit fn const_block_assert (normal) | test.rs:446:5:454:5 | exit fn const_block_assert |  |
-| test.rs:446:41:454:5 | { ... } | test.rs:446:5:454:5 | exit fn const_block_assert (normal) |  |
-| test.rs:449:9:451:9 | ExprStmt | test.rs:450:13:450:50 | ExprStmt |  |
-| test.rs:449:9:451:9 | { ... } | test.rs:453:9:453:10 | 42 |  |
-| test.rs:450:13:450:49 | ...::panic_2021!... | test.rs:450:13:450:49 | MacroExpr |  |
-| test.rs:450:13:450:49 | ...::panic_explicit | test.rs:450:13:450:49 | ...::panic_explicit(...) |  |
-| test.rs:450:13:450:49 | ...::panic_explicit(...) | test.rs:450:13:450:49 | { ... } |  |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | MacroStmts |  |
-| test.rs:450:13:450:49 | ExprStmt | test.rs:450:13:450:49 | panic_cold_explicit |  |
-| test.rs:450:13:450:49 | MacroExpr | test.rs:449:9:451:9 | { ... } |  |
-| test.rs:450:13:450:49 | MacroExpr | test.rs:450:13:450:49 | { ... } |  |
-| test.rs:450:13:450:49 | MacroStmts | test.rs:450:13:450:49 | fn panic_cold_explicit |  |
-| test.rs:450:13:450:49 | assert!... | test.rs:450:13:450:49 | MacroExpr |  |
-| test.rs:450:13:450:49 | enter fn panic_cold_explicit | test.rs:450:13:450:49 | ...::panic_explicit |  |
-| test.rs:450:13:450:49 | exit fn panic_cold_explicit (normal) | test.rs:450:13:450:49 | exit fn panic_cold_explicit |  |
-| test.rs:450:13:450:49 | fn panic_cold_explicit | test.rs:450:13:450:49 | ExprStmt |  |
-| test.rs:450:13:450:49 | panic_cold_explicit | test.rs:450:13:450:49 | panic_cold_explicit(...) |  |
-| test.rs:450:13:450:49 | panic_cold_explicit(...) | test.rs:450:13:450:49 | { ... } |  |
-| test.rs:450:13:450:49 | { ... } | test.rs:450:13:450:49 | ...::panic_2021!... |  |
-| test.rs:450:13:450:49 | { ... } | test.rs:450:13:450:49 | exit fn panic_cold_explicit (normal) |  |
-| test.rs:450:13:450:49 | { ... } | test.rs:450:21:450:48 | if ... {...} |  |
-| test.rs:450:13:450:50 | ExprStmt | test.rs:450:21:450:48 | MacroStmts |  |
-| test.rs:450:21:450:42 | ...::size_of::<...> | test.rs:450:21:450:44 | ...::size_of::<...>(...) |  |
-| test.rs:450:21:450:44 | ...::size_of::<...>(...) | test.rs:450:48:450:48 | 0 |  |
-| test.rs:450:21:450:48 | ... > ... | test.rs:450:21:450:48 | [boolean(false)] ! ... | true |
-| test.rs:450:21:450:48 | ... > ... | test.rs:450:21:450:48 | [boolean(true)] ! ... | false |
-| test.rs:450:21:450:48 | MacroStmts | test.rs:450:21:450:42 | ...::size_of::<...> |  |
-| test.rs:450:21:450:48 | [boolean(false)] ! ... | test.rs:450:21:450:48 | if ... {...} | false |
-| test.rs:450:21:450:48 | [boolean(true)] ! ... | test.rs:450:13:450:49 | ExprStmt | true |
-| test.rs:450:21:450:48 | if ... {...} | test.rs:450:21:450:48 | { ... } |  |
-| test.rs:450:21:450:48 | { ... } | test.rs:450:13:450:49 | assert!... |  |
-| test.rs:450:48:450:48 | 0 | test.rs:450:21:450:48 | ... > ... |  |
-| test.rs:453:9:453:10 | 42 | test.rs:446:41:454:5 | { ... } |  |
-| test.rs:456:5:465:5 | enter fn const_block_panic | test.rs:457:9:457:30 | Const |  |
-| test.rs:456:5:465:5 | exit fn const_block_panic (normal) | test.rs:456:5:465:5 | exit fn const_block_panic |  |
-| test.rs:456:35:465:5 | { ... } | test.rs:456:5:465:5 | exit fn const_block_panic (normal) |  |
-| test.rs:457:9:457:30 | Const | test.rs:458:9:463:9 | ExprStmt |  |
-| test.rs:458:9:463:9 | ExprStmt | test.rs:458:12:458:16 | false |  |
-| test.rs:458:9:463:9 | if false {...} | test.rs:464:9:464:9 | N |  |
-| test.rs:458:12:458:16 | false | test.rs:458:9:463:9 | if false {...} | false |
-| test.rs:461:17:461:24 | ...::panic_explicit | test.rs:461:17:461:24 | ...::panic_explicit(...) |  |
-| test.rs:461:17:461:24 | ...::panic_explicit(...) | test.rs:461:17:461:24 | { ... } |  |
-| test.rs:461:17:461:24 | enter fn panic_cold_explicit | test.rs:461:17:461:24 | ...::panic_explicit |  |
-| test.rs:461:17:461:24 | exit fn panic_cold_explicit (normal) | test.rs:461:17:461:24 | exit fn panic_cold_explicit |  |
-| test.rs:461:17:461:24 | { ... } | test.rs:461:17:461:24 | exit fn panic_cold_explicit (normal) |  |
-| test.rs:464:9:464:9 | N | test.rs:456:35:465:5 | { ... } |  |
-| test.rs:468:1:473:1 | enter fn dead_code | test.rs:469:5:471:5 | ExprStmt |  |
-| test.rs:468:1:473:1 | exit fn dead_code (normal) | test.rs:468:1:473:1 | exit fn dead_code |  |
-| test.rs:469:5:471:5 | ExprStmt | test.rs:469:9:469:12 | true |  |
-| test.rs:469:9:469:12 | true | test.rs:470:9:470:17 | ExprStmt | true |
-| test.rs:470:9:470:16 | return 0 | test.rs:468:1:473:1 | exit fn dead_code (normal) | return |
-| test.rs:470:9:470:17 | ExprStmt | test.rs:470:16:470:16 | 0 |  |
-| test.rs:470:16:470:16 | 0 | test.rs:470:9:470:16 | return 0 |  |
-| test.rs:475:1:475:16 | enter fn do_thing | test.rs:475:15:475:16 | { ... } |  |
-| test.rs:475:1:475:16 | exit fn do_thing (normal) | test.rs:475:1:475:16 | exit fn do_thing |  |
-| test.rs:475:15:475:16 | { ... } | test.rs:475:1:475:16 | exit fn do_thing (normal) |  |
-| test.rs:477:1:479:1 | enter fn condition_not_met | test.rs:478:5:478:9 | false |  |
-| test.rs:477:1:479:1 | exit fn condition_not_met (normal) | test.rs:477:1:479:1 | exit fn condition_not_met |  |
-| test.rs:477:32:479:1 | { ... } | test.rs:477:1:479:1 | exit fn condition_not_met (normal) |  |
-| test.rs:478:5:478:9 | false | test.rs:477:32:479:1 | { ... } |  |
-| test.rs:481:1:481:21 | enter fn do_next_thing | test.rs:481:20:481:21 | { ... } |  |
-| test.rs:481:1:481:21 | exit fn do_next_thing (normal) | test.rs:481:1:481:21 | exit fn do_next_thing |  |
-| test.rs:481:20:481:21 | { ... } | test.rs:481:1:481:21 | exit fn do_next_thing (normal) |  |
-| test.rs:483:1:483:21 | enter fn do_last_thing | test.rs:483:20:483:21 | { ... } |  |
-| test.rs:483:1:483:21 | exit fn do_last_thing (normal) | test.rs:483:1:483:21 | exit fn do_last_thing |  |
-| test.rs:483:20:483:21 | { ... } | test.rs:483:1:483:21 | exit fn do_last_thing (normal) |  |
-| test.rs:485:1:499:1 | enter fn labelled_block1 | test.rs:486:5:497:6 | let ... = ... |  |
-| test.rs:485:1:499:1 | exit fn labelled_block1 (normal) | test.rs:485:1:499:1 | exit fn labelled_block1 |  |
-| test.rs:485:29:499:1 | { ... } | test.rs:485:1:499:1 | exit fn labelled_block1 (normal) |  |
-| test.rs:486:5:497:6 | let ... = ... | test.rs:487:9:487:19 | ExprStmt |  |
-| test.rs:486:9:486:14 | result | test.rs:498:5:498:10 | result | match |
-| test.rs:486:18:497:5 | 'block: { ... } | test.rs:486:9:486:14 | result |  |
-| test.rs:487:9:487:16 | do_thing | test.rs:487:9:487:18 | do_thing(...) |  |
-| test.rs:487:9:487:18 | do_thing(...) | test.rs:488:9:490:9 | ExprStmt |  |
-| test.rs:487:9:487:19 | ExprStmt | test.rs:487:9:487:16 | do_thing |  |
-| test.rs:488:9:490:9 | ExprStmt | test.rs:488:12:488:28 | condition_not_met |  |
-| test.rs:488:9:490:9 | if ... {...} | test.rs:491:9:491:24 | ExprStmt |  |
-| test.rs:488:12:488:28 | condition_not_met | test.rs:488:12:488:30 | condition_not_met(...) |  |
-| test.rs:488:12:488:30 | condition_not_met(...) | test.rs:488:9:490:9 | if ... {...} | false |
-| test.rs:488:12:488:30 | condition_not_met(...) | test.rs:489:13:489:27 | ExprStmt | true |
-| test.rs:489:13:489:26 | break ''block 1 | test.rs:486:18:497:5 | 'block: { ... } | break |
-| test.rs:489:13:489:27 | ExprStmt | test.rs:489:26:489:26 | 1 |  |
-| test.rs:489:26:489:26 | 1 | test.rs:489:13:489:26 | break ''block 1 |  |
-| test.rs:491:9:491:21 | do_next_thing | test.rs:491:9:491:23 | do_next_thing(...) |  |
-| test.rs:491:9:491:23 | do_next_thing(...) | test.rs:492:9:494:9 | ExprStmt |  |
-| test.rs:491:9:491:24 | ExprStmt | test.rs:491:9:491:21 | do_next_thing |  |
-| test.rs:492:9:494:9 | ExprStmt | test.rs:492:12:492:28 | condition_not_met |  |
-| test.rs:492:9:494:9 | if ... {...} | test.rs:495:9:495:24 | ExprStmt |  |
-| test.rs:492:12:492:28 | condition_not_met | test.rs:492:12:492:30 | condition_not_met(...) |  |
-| test.rs:492:12:492:30 | condition_not_met(...) | test.rs:492:9:494:9 | if ... {...} | false |
-| test.rs:492:12:492:30 | condition_not_met(...) | test.rs:493:13:493:27 | ExprStmt | true |
-| test.rs:493:13:493:26 | break ''block 2 | test.rs:486:18:497:5 | 'block: { ... } | break |
-| test.rs:493:13:493:27 | ExprStmt | test.rs:493:26:493:26 | 2 |  |
-| test.rs:493:26:493:26 | 2 | test.rs:493:13:493:26 | break ''block 2 |  |
-| test.rs:495:9:495:21 | do_last_thing | test.rs:495:9:495:23 | do_last_thing(...) |  |
-| test.rs:495:9:495:23 | do_last_thing(...) | test.rs:496:9:496:9 | 3 |  |
-| test.rs:495:9:495:24 | ExprStmt | test.rs:495:9:495:21 | do_last_thing |  |
-| test.rs:496:9:496:9 | 3 | test.rs:486:18:497:5 | 'block: { ... } |  |
-| test.rs:498:5:498:10 | result | test.rs:485:29:499:1 | { ... } |  |
-| test.rs:501:1:509:1 | enter fn labelled_block2 | test.rs:502:5:508:6 | let ... = ... |  |
-| test.rs:501:1:509:1 | exit fn labelled_block2 (normal) | test.rs:501:1:509:1 | exit fn labelled_block2 |  |
-| test.rs:501:22:509:1 | { ... } | test.rs:501:1:509:1 | exit fn labelled_block2 (normal) |  |
-| test.rs:502:5:508:6 | let ... = ... | test.rs:503:9:503:34 | let ... = None |  |
-| test.rs:502:9:502:14 | result | test.rs:501:22:509:1 | { ... } | match |
-| test.rs:502:18:508:5 | 'block: { ... } | test.rs:502:9:502:14 | result |  |
-| test.rs:503:9:503:34 | let ... = None | test.rs:503:30:503:33 | None |  |
-| test.rs:503:13:503:13 | x | test.rs:504:9:506:10 | let ... = x else {...} | match |
-| test.rs:503:30:503:33 | None | test.rs:503:13:503:13 | x |  |
-| test.rs:504:9:506:10 | let ... = x else {...} | test.rs:504:23:504:23 | x |  |
-| test.rs:504:13:504:19 | Some(...) | test.rs:504:18:504:18 | y | match |
-| test.rs:504:13:504:19 | Some(...) | test.rs:505:13:505:27 | ExprStmt | no-match |
-| test.rs:504:18:504:18 | y | test.rs:507:9:507:9 | 0 | match |
-| test.rs:504:23:504:23 | x | test.rs:504:13:504:19 | Some(...) |  |
-| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:508:5 | 'block: { ... } | break |
+| test.rs:400:5:405:5 | enter fn identifier_pattern_with_subpattern | test.rs:401:15:401:16 | 43 |  |
+| test.rs:400:5:405:5 | exit fn identifier_pattern_with_subpattern (normal) | test.rs:400:5:405:5 | exit fn identifier_pattern_with_subpattern |  |
+| test.rs:400:52:405:5 | { ... } | test.rs:400:5:405:5 | exit fn identifier_pattern_with_subpattern (normal) |  |
+| test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:52:405:5 | { ... } |  |
+| test.rs:401:15:401:16 | 43 | test.rs:402:17:402:21 | RangePat |  |
+| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:26:402:26 | 2 | match |
+| test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |  |
+| test.rs:402:17:402:17 | 1 | test.rs:402:20:402:21 | 10 | match |
+| test.rs:402:17:402:17 | 1 | test.rs:403:13:403:13 | _ | no-match |
+| test.rs:402:17:402:21 | RangePat | test.rs:402:17:402:17 | 1 | match |
+| test.rs:402:17:402:21 | RangePat | test.rs:403:13:403:13 | _ | no-match |
+| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n | match |
+| test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |  |
+| test.rs:402:20:402:21 | 10 | test.rs:403:13:403:13 | _ | no-match |
+| test.rs:402:26:402:26 | 2 | test.rs:402:30:402:30 | n |  |
+| test.rs:402:26:402:30 | ... * ... | test.rs:401:9:404:9 | match 43 { ... } |  |
+| test.rs:402:30:402:30 | n | test.rs:402:26:402:30 | ... * ... |  |
+| test.rs:403:13:403:13 | _ | test.rs:403:18:403:18 | 0 | match |
+| test.rs:403:18:403:18 | 0 | test.rs:401:9:404:9 | match 43 { ... } |  |
+| test.rs:407:5:414:5 | enter fn identifier_pattern_with_ref | test.rs:408:9:408:23 | let ... = 10 |  |
+| test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref (normal) | test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref |  |
+| test.rs:407:45:414:5 | { ... } | test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref (normal) |  |
+| test.rs:408:9:408:23 | let ... = 10 | test.rs:408:21:408:22 | 10 |  |
+| test.rs:408:13:408:17 | a | test.rs:409:9:412:10 | ExprStmt | match |
+| test.rs:408:21:408:22 | 10 | test.rs:408:13:408:17 | a |  |
+| test.rs:409:9:412:9 | match a { ... } | test.rs:413:9:413:9 | a |  |
+| test.rs:409:9:412:10 | ExprStmt | test.rs:409:15:409:15 | a |  |
+| test.rs:409:15:409:15 | a | test.rs:410:25:410:29 | RangePat |  |
+| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:35:410:35 | n | match |
+| test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |  |
+| test.rs:410:25:410:25 | 1 | test.rs:410:28:410:29 | 10 | match |
+| test.rs:410:25:410:25 | 1 | test.rs:411:13:411:21 | n | no-match |
+| test.rs:410:25:410:29 | RangePat | test.rs:410:25:410:25 | 1 | match |
+| test.rs:410:25:410:29 | RangePat | test.rs:411:13:411:21 | n | no-match |
+| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] n | match |
+| test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |  |
+| test.rs:410:28:410:29 | 10 | test.rs:411:13:411:21 | n | no-match |
+| test.rs:410:34:410:35 | * ... | test.rs:410:40:410:41 | 10 |  |
+| test.rs:410:34:410:41 | ... += ... | test.rs:409:9:412:9 | match a { ... } |  |
+| test.rs:410:35:410:35 | n | test.rs:410:34:410:35 | * ... |  |
+| test.rs:410:40:410:41 | 10 | test.rs:410:34:410:41 | ... += ... |  |
+| test.rs:411:13:411:21 | n | test.rs:411:27:411:27 | n | match |
+| test.rs:411:26:411:27 | * ... | test.rs:411:31:411:31 | 0 |  |
+| test.rs:411:26:411:31 | ... = ... | test.rs:409:9:412:9 | match a { ... } |  |
+| test.rs:411:27:411:27 | n | test.rs:411:26:411:27 | * ... |  |
+| test.rs:411:31:411:31 | 0 | test.rs:411:26:411:31 | ... = ... |  |
+| test.rs:413:9:413:9 | a | test.rs:407:45:414:5 | { ... } |  |
+| test.rs:418:5:423:5 | enter fn test_infinite_loop | test.rs:419:9:421:9 | ExprStmt |  |
+| test.rs:419:9:421:9 | ExprStmt | test.rs:420:13:420:14 | TupleExpr |  |
+| test.rs:419:14:421:9 | { ... } | test.rs:420:13:420:14 | TupleExpr |  |
+| test.rs:420:13:420:14 | TupleExpr | test.rs:419:14:421:9 | { ... } |  |
+| test.rs:427:5:429:5 | enter fn say_hello | test.rs:428:9:428:34 | ExprStmt |  |
+| test.rs:427:5:429:5 | exit fn say_hello (normal) | test.rs:427:5:429:5 | exit fn say_hello |  |
+| test.rs:427:26:429:5 | { ... } | test.rs:427:5:429:5 | exit fn say_hello (normal) |  |
+| test.rs:428:9:428:33 | ...::_print | test.rs:428:18:428:32 | "hello, world!\\n" |  |
+| test.rs:428:9:428:33 | MacroExpr | test.rs:427:26:429:5 | { ... } |  |
+| test.rs:428:9:428:33 | println!... | test.rs:428:9:428:33 | MacroExpr |  |
+| test.rs:428:9:428:34 | ExprStmt | test.rs:428:18:428:32 | MacroStmts |  |
+| test.rs:428:18:428:32 | "hello, world!\\n" | test.rs:428:18:428:32 | FormatArgsExpr |  |
+| test.rs:428:18:428:32 | ...::_print(...) | test.rs:428:18:428:32 | { ... } |  |
+| test.rs:428:18:428:32 | ...::format_args_nl!... | test.rs:428:18:428:32 | MacroExpr |  |
+| test.rs:428:18:428:32 | ExprStmt | test.rs:428:9:428:33 | ...::_print |  |
+| test.rs:428:18:428:32 | FormatArgsExpr | test.rs:428:18:428:32 | ...::format_args_nl!... |  |
+| test.rs:428:18:428:32 | MacroExpr | test.rs:428:18:428:32 | ...::_print(...) |  |
+| test.rs:428:18:428:32 | MacroStmts | test.rs:428:18:428:32 | ExprStmt |  |
+| test.rs:428:18:428:32 | { ... } | test.rs:428:9:428:33 | println!... |  |
+| test.rs:431:5:450:5 | enter fn async_block | test.rs:431:26:431:26 | b |  |
+| test.rs:431:5:450:5 | exit fn async_block (normal) | test.rs:431:5:450:5 | exit fn async_block |  |
+| test.rs:431:26:431:26 | b | test.rs:431:26:431:32 | ...: bool | match |
+| test.rs:431:26:431:32 | ...: bool | test.rs:432:9:434:10 | let ... = ... |  |
+| test.rs:431:35:450:5 | { ... } | test.rs:431:5:450:5 | exit fn async_block (normal) |  |
+| test.rs:432:9:434:10 | let ... = ... | test.rs:432:26:434:9 | { ... } |  |
+| test.rs:432:13:432:22 | say_godbye | test.rs:435:9:437:10 | let ... = ... | match |
+| test.rs:432:26:434:9 | enter { ... } | test.rs:433:13:433:42 | ExprStmt |  |
+| test.rs:432:26:434:9 | exit { ... } (normal) | test.rs:432:26:434:9 | exit { ... } |  |
+| test.rs:432:26:434:9 | { ... } | test.rs:432:13:432:22 | say_godbye |  |
+| test.rs:433:13:433:41 | ...::_print | test.rs:433:22:433:40 | "godbye, everyone!\\n" |  |
+| test.rs:433:13:433:41 | MacroExpr | test.rs:432:26:434:9 | exit { ... } (normal) |  |
+| test.rs:433:13:433:41 | println!... | test.rs:433:13:433:41 | MacroExpr |  |
+| test.rs:433:13:433:42 | ExprStmt | test.rs:433:22:433:40 | MacroStmts |  |
+| test.rs:433:22:433:40 | "godbye, everyone!\\n" | test.rs:433:22:433:40 | FormatArgsExpr |  |
+| test.rs:433:22:433:40 | ...::_print(...) | test.rs:433:22:433:40 | { ... } |  |
+| test.rs:433:22:433:40 | ...::format_args_nl!... | test.rs:433:22:433:40 | MacroExpr |  |
+| test.rs:433:22:433:40 | ExprStmt | test.rs:433:13:433:41 | ...::_print |  |
+| test.rs:433:22:433:40 | FormatArgsExpr | test.rs:433:22:433:40 | ...::format_args_nl!... |  |
+| test.rs:433:22:433:40 | MacroExpr | test.rs:433:22:433:40 | ...::_print(...) |  |
+| test.rs:433:22:433:40 | MacroStmts | test.rs:433:22:433:40 | ExprStmt |  |
+| test.rs:433:22:433:40 | { ... } | test.rs:433:13:433:41 | println!... |  |
+| test.rs:435:9:437:10 | let ... = ... | test.rs:435:31:437:9 | { ... } |  |
+| test.rs:435:13:435:27 | say_how_are_you | test.rs:438:9:438:28 | let ... = ... | match |
+| test.rs:435:31:437:9 | enter { ... } | test.rs:436:13:436:37 | ExprStmt |  |
+| test.rs:435:31:437:9 | exit { ... } (normal) | test.rs:435:31:437:9 | exit { ... } |  |
+| test.rs:435:31:437:9 | { ... } | test.rs:435:13:435:27 | say_how_are_you |  |
+| test.rs:436:13:436:36 | ...::_print | test.rs:436:22:436:35 | "how are you?\\n" |  |
+| test.rs:436:13:436:36 | MacroExpr | test.rs:435:31:437:9 | exit { ... } (normal) |  |
+| test.rs:436:13:436:36 | println!... | test.rs:436:13:436:36 | MacroExpr |  |
+| test.rs:436:13:436:37 | ExprStmt | test.rs:436:22:436:35 | MacroStmts |  |
+| test.rs:436:22:436:35 | "how are you?\\n" | test.rs:436:22:436:35 | FormatArgsExpr |  |
+| test.rs:436:22:436:35 | ...::_print(...) | test.rs:436:22:436:35 | { ... } |  |
+| test.rs:436:22:436:35 | ...::format_args_nl!... | test.rs:436:22:436:35 | MacroExpr |  |
+| test.rs:436:22:436:35 | ExprStmt | test.rs:436:13:436:36 | ...::_print |  |
+| test.rs:436:22:436:35 | FormatArgsExpr | test.rs:436:22:436:35 | ...::format_args_nl!... |  |
+| test.rs:436:22:436:35 | MacroExpr | test.rs:436:22:436:35 | ...::_print(...) |  |
+| test.rs:436:22:436:35 | MacroStmts | test.rs:436:22:436:35 | ExprStmt |  |
+| test.rs:436:22:436:35 | { ... } | test.rs:436:13:436:36 | println!... |  |
+| test.rs:438:9:438:28 | let ... = ... | test.rs:438:20:438:27 | { ... } |  |
+| test.rs:438:13:438:16 | noop | test.rs:439:9:439:26 | ExprStmt | match |
+| test.rs:438:20:438:27 | { ... } | test.rs:438:13:438:16 | noop |  |
+| test.rs:439:9:439:17 | say_hello | test.rs:439:9:439:19 | say_hello(...) |  |
+| test.rs:439:9:439:19 | say_hello(...) | test.rs:439:9:439:25 | await ... |  |
+| test.rs:439:9:439:25 | await ... | test.rs:440:9:440:30 | ExprStmt |  |
+| test.rs:439:9:439:26 | ExprStmt | test.rs:439:9:439:17 | say_hello |  |
+| test.rs:440:9:440:23 | say_how_are_you | test.rs:440:9:440:29 | await say_how_are_you |  |
+| test.rs:440:9:440:29 | await say_how_are_you | test.rs:441:9:441:25 | ExprStmt |  |
+| test.rs:440:9:440:30 | ExprStmt | test.rs:440:9:440:23 | say_how_are_you |  |
+| test.rs:441:9:441:18 | say_godbye | test.rs:441:9:441:24 | await say_godbye |  |
+| test.rs:441:9:441:24 | await say_godbye | test.rs:442:9:442:19 | ExprStmt |  |
+| test.rs:441:9:441:25 | ExprStmt | test.rs:441:9:441:18 | say_godbye |  |
+| test.rs:442:9:442:12 | noop | test.rs:442:9:442:18 | await noop |  |
+| test.rs:442:9:442:18 | await noop | test.rs:444:9:449:10 | let ... = ... |  |
+| test.rs:442:9:442:19 | ExprStmt | test.rs:442:9:442:12 | noop |  |
+| test.rs:444:9:449:10 | let ... = ... | test.rs:444:22:449:9 | \|...\| ... |  |
+| test.rs:444:13:444:18 | lambda | test.rs:431:35:450:5 | { ... } | match |
+| test.rs:444:22:449:9 | \|...\| ... | test.rs:444:13:444:18 | lambda |  |
+| test.rs:444:22:449:9 | enter \|...\| ... | test.rs:444:23:444:25 | foo |  |
+| test.rs:444:22:449:9 | exit \|...\| ... (normal) | test.rs:444:22:449:9 | exit \|...\| ... |  |
+| test.rs:444:23:444:25 | ... | test.rs:444:28:449:9 | { ... } |  |
+| test.rs:444:23:444:25 | foo | test.rs:444:23:444:25 | ... | match |
+| test.rs:444:28:449:9 | enter { ... } | test.rs:445:13:447:14 | ExprStmt |  |
+| test.rs:444:28:449:9 | exit { ... } (normal) | test.rs:444:28:449:9 | exit { ... } |  |
+| test.rs:444:28:449:9 | { ... } | test.rs:444:22:449:9 | exit \|...\| ... (normal) |  |
+| test.rs:445:13:447:13 | if b {...} | test.rs:448:13:448:15 | foo |  |
+| test.rs:445:13:447:14 | ExprStmt | test.rs:445:16:445:16 | b |  |
+| test.rs:445:16:445:16 | b | test.rs:445:13:447:13 | if b {...} | false |
+| test.rs:445:16:445:16 | b | test.rs:446:17:446:41 | ExprStmt | true |
+| test.rs:446:17:446:40 | return ... | test.rs:444:28:449:9 | exit { ... } (normal) | return |
+| test.rs:446:17:446:41 | ExprStmt | test.rs:446:24:446:34 | async_block |  |
+| test.rs:446:24:446:34 | async_block | test.rs:446:36:446:39 | true |  |
+| test.rs:446:24:446:40 | async_block(...) | test.rs:446:17:446:40 | return ... |  |
+| test.rs:446:36:446:39 | true | test.rs:446:24:446:40 | async_block(...) |  |
+| test.rs:448:13:448:15 | foo | test.rs:444:28:449:9 | exit { ... } (normal) |  |
+| test.rs:456:5:458:5 | enter fn add_two | test.rs:456:22:456:22 | n |  |
+| test.rs:456:5:458:5 | exit fn add_two (normal) | test.rs:456:5:458:5 | exit fn add_two |  |
+| test.rs:456:22:456:22 | n | test.rs:456:22:456:27 | ...: i64 | match |
+| test.rs:456:22:456:27 | ...: i64 | test.rs:457:9:457:9 | n |  |
+| test.rs:456:37:458:5 | { ... } | test.rs:456:5:458:5 | exit fn add_two (normal) |  |
+| test.rs:457:9:457:9 | n | test.rs:457:13:457:13 | 2 |  |
+| test.rs:457:9:457:13 | ... + ... | test.rs:456:37:458:5 | { ... } |  |
+| test.rs:457:13:457:13 | 2 | test.rs:457:9:457:13 | ... + ... |  |
+| test.rs:462:5:470:5 | enter fn const_block_assert | test.rs:465:9:467:9 | ExprStmt |  |
+| test.rs:462:5:470:5 | exit fn const_block_assert (normal) | test.rs:462:5:470:5 | exit fn const_block_assert |  |
+| test.rs:462:41:470:5 | { ... } | test.rs:462:5:470:5 | exit fn const_block_assert (normal) |  |
+| test.rs:465:9:467:9 | ExprStmt | test.rs:466:13:466:50 | ExprStmt |  |
+| test.rs:465:9:467:9 | { ... } | test.rs:469:9:469:10 | 42 |  |
+| test.rs:466:13:466:49 | ...::panic_2021!... | test.rs:466:13:466:49 | MacroExpr |  |
+| test.rs:466:13:466:49 | ...::panic_explicit | test.rs:466:13:466:49 | ...::panic_explicit(...) |  |
+| test.rs:466:13:466:49 | ...::panic_explicit(...) | test.rs:466:13:466:49 | { ... } |  |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:13:466:49 | MacroStmts |  |
+| test.rs:466:13:466:49 | ExprStmt | test.rs:466:13:466:49 | panic_cold_explicit |  |
+| test.rs:466:13:466:49 | MacroExpr | test.rs:465:9:467:9 | { ... } |  |
+| test.rs:466:13:466:49 | MacroExpr | test.rs:466:13:466:49 | { ... } |  |
+| test.rs:466:13:466:49 | MacroStmts | test.rs:466:13:466:49 | fn panic_cold_explicit |  |
+| test.rs:466:13:466:49 | assert!... | test.rs:466:13:466:49 | MacroExpr |  |
+| test.rs:466:13:466:49 | enter fn panic_cold_explicit | test.rs:466:13:466:49 | ...::panic_explicit |  |
+| test.rs:466:13:466:49 | exit fn panic_cold_explicit (normal) | test.rs:466:13:466:49 | exit fn panic_cold_explicit |  |
+| test.rs:466:13:466:49 | fn panic_cold_explicit | test.rs:466:13:466:49 | ExprStmt |  |
+| test.rs:466:13:466:49 | panic_cold_explicit | test.rs:466:13:466:49 | panic_cold_explicit(...) |  |
+| test.rs:466:13:466:49 | panic_cold_explicit(...) | test.rs:466:13:466:49 | { ... } |  |
+| test.rs:466:13:466:49 | { ... } | test.rs:466:13:466:49 | ...::panic_2021!... |  |
+| test.rs:466:13:466:49 | { ... } | test.rs:466:13:466:49 | exit fn panic_cold_explicit (normal) |  |
+| test.rs:466:13:466:49 | { ... } | test.rs:466:21:466:48 | if ... {...} |  |
+| test.rs:466:13:466:50 | ExprStmt | test.rs:466:21:466:48 | MacroStmts |  |
+| test.rs:466:21:466:42 | ...::size_of::<...> | test.rs:466:21:466:44 | ...::size_of::<...>(...) |  |
+| test.rs:466:21:466:44 | ...::size_of::<...>(...) | test.rs:466:48:466:48 | 0 |  |
+| test.rs:466:21:466:48 | ... > ... | test.rs:466:21:466:48 | [boolean(false)] ! ... | true |
+| test.rs:466:21:466:48 | ... > ... | test.rs:466:21:466:48 | [boolean(true)] ! ... | false |
+| test.rs:466:21:466:48 | MacroStmts | test.rs:466:21:466:42 | ...::size_of::<...> |  |
+| test.rs:466:21:466:48 | [boolean(false)] ! ... | test.rs:466:21:466:48 | if ... {...} | false |
+| test.rs:466:21:466:48 | [boolean(true)] ! ... | test.rs:466:13:466:49 | ExprStmt | true |
+| test.rs:466:21:466:48 | if ... {...} | test.rs:466:21:466:48 | { ... } |  |
+| test.rs:466:21:466:48 | { ... } | test.rs:466:13:466:49 | assert!... |  |
+| test.rs:466:48:466:48 | 0 | test.rs:466:21:466:48 | ... > ... |  |
+| test.rs:469:9:469:10 | 42 | test.rs:462:41:470:5 | { ... } |  |
+| test.rs:472:5:481:5 | enter fn const_block_panic | test.rs:473:9:473:30 | Const |  |
+| test.rs:472:5:481:5 | exit fn const_block_panic (normal) | test.rs:472:5:481:5 | exit fn const_block_panic |  |
+| test.rs:472:35:481:5 | { ... } | test.rs:472:5:481:5 | exit fn const_block_panic (normal) |  |
+| test.rs:473:9:473:30 | Const | test.rs:474:9:479:9 | ExprStmt |  |
+| test.rs:474:9:479:9 | ExprStmt | test.rs:474:12:474:16 | false |  |
+| test.rs:474:9:479:9 | if false {...} | test.rs:480:9:480:9 | N |  |
+| test.rs:474:12:474:16 | false | test.rs:474:9:479:9 | if false {...} | false |
+| test.rs:477:17:477:24 | ...::panic_explicit | test.rs:477:17:477:24 | ...::panic_explicit(...) |  |
+| test.rs:477:17:477:24 | ...::panic_explicit(...) | test.rs:477:17:477:24 | { ... } |  |
+| test.rs:477:17:477:24 | enter fn panic_cold_explicit | test.rs:477:17:477:24 | ...::panic_explicit |  |
+| test.rs:477:17:477:24 | exit fn panic_cold_explicit (normal) | test.rs:477:17:477:24 | exit fn panic_cold_explicit |  |
+| test.rs:477:17:477:24 | { ... } | test.rs:477:17:477:24 | exit fn panic_cold_explicit (normal) |  |
+| test.rs:480:9:480:9 | N | test.rs:472:35:481:5 | { ... } |  |
+| test.rs:484:1:489:1 | enter fn dead_code | test.rs:485:5:487:5 | ExprStmt |  |
+| test.rs:484:1:489:1 | exit fn dead_code (normal) | test.rs:484:1:489:1 | exit fn dead_code |  |
+| test.rs:485:5:487:5 | ExprStmt | test.rs:485:9:485:12 | true |  |
+| test.rs:485:9:485:12 | true | test.rs:486:9:486:17 | ExprStmt | true |
+| test.rs:486:9:486:16 | return 0 | test.rs:484:1:489:1 | exit fn dead_code (normal) | return |
+| test.rs:486:9:486:17 | ExprStmt | test.rs:486:16:486:16 | 0 |  |
+| test.rs:486:16:486:16 | 0 | test.rs:486:9:486:16 | return 0 |  |
+| test.rs:491:1:491:16 | enter fn do_thing | test.rs:491:15:491:16 | { ... } |  |
+| test.rs:491:1:491:16 | exit fn do_thing (normal) | test.rs:491:1:491:16 | exit fn do_thing |  |
+| test.rs:491:15:491:16 | { ... } | test.rs:491:1:491:16 | exit fn do_thing (normal) |  |
+| test.rs:493:1:495:1 | enter fn condition_not_met | test.rs:494:5:494:9 | false |  |
+| test.rs:493:1:495:1 | exit fn condition_not_met (normal) | test.rs:493:1:495:1 | exit fn condition_not_met |  |
+| test.rs:493:32:495:1 | { ... } | test.rs:493:1:495:1 | exit fn condition_not_met (normal) |  |
+| test.rs:494:5:494:9 | false | test.rs:493:32:495:1 | { ... } |  |
+| test.rs:497:1:497:21 | enter fn do_next_thing | test.rs:497:20:497:21 | { ... } |  |
+| test.rs:497:1:497:21 | exit fn do_next_thing (normal) | test.rs:497:1:497:21 | exit fn do_next_thing |  |
+| test.rs:497:20:497:21 | { ... } | test.rs:497:1:497:21 | exit fn do_next_thing (normal) |  |
+| test.rs:499:1:499:21 | enter fn do_last_thing | test.rs:499:20:499:21 | { ... } |  |
+| test.rs:499:1:499:21 | exit fn do_last_thing (normal) | test.rs:499:1:499:21 | exit fn do_last_thing |  |
+| test.rs:499:20:499:21 | { ... } | test.rs:499:1:499:21 | exit fn do_last_thing (normal) |  |
+| test.rs:501:1:515:1 | enter fn labelled_block1 | test.rs:502:5:513:6 | let ... = ... |  |
+| test.rs:501:1:515:1 | exit fn labelled_block1 (normal) | test.rs:501:1:515:1 | exit fn labelled_block1 |  |
+| test.rs:501:29:515:1 | { ... } | test.rs:501:1:515:1 | exit fn labelled_block1 (normal) |  |
+| test.rs:502:5:513:6 | let ... = ... | test.rs:503:9:503:19 | ExprStmt |  |
+| test.rs:502:9:502:14 | result | test.rs:514:5:514:10 | result | match |
+| test.rs:502:18:513:5 | 'block: { ... } | test.rs:502:9:502:14 | result |  |
+| test.rs:503:9:503:16 | do_thing | test.rs:503:9:503:18 | do_thing(...) |  |
+| test.rs:503:9:503:18 | do_thing(...) | test.rs:504:9:506:9 | ExprStmt |  |
+| test.rs:503:9:503:19 | ExprStmt | test.rs:503:9:503:16 | do_thing |  |
+| test.rs:504:9:506:9 | ExprStmt | test.rs:504:12:504:28 | condition_not_met |  |
+| test.rs:504:9:506:9 | if ... {...} | test.rs:507:9:507:24 | ExprStmt |  |
+| test.rs:504:12:504:28 | condition_not_met | test.rs:504:12:504:30 | condition_not_met(...) |  |
+| test.rs:504:12:504:30 | condition_not_met(...) | test.rs:504:9:506:9 | if ... {...} | false |
+| test.rs:504:12:504:30 | condition_not_met(...) | test.rs:505:13:505:27 | ExprStmt | true |
+| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:513:5 | 'block: { ... } | break |
 | test.rs:505:13:505:27 | ExprStmt | test.rs:505:26:505:26 | 1 |  |
 | test.rs:505:26:505:26 | 1 | test.rs:505:13:505:26 | break ''block 1 |  |
-| test.rs:507:9:507:9 | 0 | test.rs:502:18:508:5 | 'block: { ... } |  |
-| test.rs:511:1:517:1 | enter fn test_nested_function2 | test.rs:512:5:512:18 | let ... = 0 |  |
-| test.rs:511:1:517:1 | exit fn test_nested_function2 (normal) | test.rs:511:1:517:1 | exit fn test_nested_function2 |  |
-| test.rs:511:28:517:1 | { ... } | test.rs:511:1:517:1 | exit fn test_nested_function2 (normal) |  |
-| test.rs:512:5:512:18 | let ... = 0 | test.rs:512:17:512:17 | 0 |  |
-| test.rs:512:9:512:13 | x | test.rs:513:5:515:5 | fn nested | match |
-| test.rs:512:17:512:17 | 0 | test.rs:512:9:512:13 | x |  |
-| test.rs:513:5:515:5 | enter fn nested | test.rs:513:15:513:15 | x |  |
-| test.rs:513:5:515:5 | exit fn nested (normal) | test.rs:513:5:515:5 | exit fn nested |  |
-| test.rs:513:5:515:5 | fn nested | test.rs:516:5:516:19 | ExprStmt |  |
-| test.rs:513:15:513:15 | x | test.rs:513:15:513:25 | ...: ... | match |
-| test.rs:513:15:513:25 | ...: ... | test.rs:514:9:514:16 | ExprStmt |  |
-| test.rs:513:28:515:5 | { ... } | test.rs:513:5:515:5 | exit fn nested (normal) |  |
-| test.rs:514:9:514:10 | * ... | test.rs:514:15:514:15 | 1 |  |
-| test.rs:514:9:514:15 | ... += ... | test.rs:513:28:515:5 | { ... } |  |
-| test.rs:514:9:514:16 | ExprStmt | test.rs:514:10:514:10 | x |  |
-| test.rs:514:10:514:10 | x | test.rs:514:9:514:10 | * ... |  |
-| test.rs:514:15:514:15 | 1 | test.rs:514:9:514:15 | ... += ... |  |
-| test.rs:516:5:516:10 | nested | test.rs:516:17:516:17 | x |  |
-| test.rs:516:5:516:18 | nested(...) | test.rs:511:28:517:1 | { ... } |  |
-| test.rs:516:5:516:19 | ExprStmt | test.rs:516:5:516:10 | nested |  |
-| test.rs:516:12:516:17 | &mut x | test.rs:516:5:516:18 | nested(...) |  |
-| test.rs:516:17:516:17 | x | test.rs:516:12:516:17 | &mut x |  |
-| test.rs:528:5:530:5 | enter fn new | test.rs:528:12:528:12 | a |  |
-| test.rs:528:5:530:5 | exit fn new (normal) | test.rs:528:5:530:5 | exit fn new |  |
-| test.rs:528:12:528:12 | a | test.rs:528:12:528:17 | ...: i64 | match |
-| test.rs:528:12:528:17 | ...: i64 | test.rs:529:23:529:23 | a |  |
-| test.rs:528:28:530:5 | { ... } | test.rs:528:5:530:5 | exit fn new (normal) |  |
-| test.rs:529:9:529:25 | MyNumber {...} | test.rs:528:28:530:5 | { ... } |  |
-| test.rs:529:23:529:23 | a | test.rs:529:9:529:25 | MyNumber {...} |  |
-| test.rs:532:5:534:5 | enter fn negated | test.rs:532:16:532:19 | self |  |
-| test.rs:532:5:534:5 | exit fn negated (normal) | test.rs:532:5:534:5 | exit fn negated |  |
-| test.rs:532:16:532:19 | SelfParam | test.rs:533:23:533:26 | self |  |
-| test.rs:532:16:532:19 | self | test.rs:532:16:532:19 | SelfParam |  |
-| test.rs:532:30:534:5 | { ... } | test.rs:532:5:534:5 | exit fn negated (normal) |  |
-| test.rs:533:9:533:30 | MyNumber {...} | test.rs:532:30:534:5 | { ... } |  |
-| test.rs:533:23:533:26 | self | test.rs:533:23:533:28 | self.n |  |
-| test.rs:533:23:533:28 | self.n | test.rs:533:9:533:30 | MyNumber {...} |  |
-| test.rs:536:5:538:5 | enter fn multifly_add | test.rs:536:26:536:29 | self |  |
-| test.rs:536:5:538:5 | exit fn multifly_add (normal) | test.rs:536:5:538:5 | exit fn multifly_add |  |
-| test.rs:536:21:536:29 | SelfParam | test.rs:536:32:536:32 | a |  |
-| test.rs:536:26:536:29 | self | test.rs:536:21:536:29 | SelfParam |  |
-| test.rs:536:32:536:32 | a | test.rs:536:32:536:37 | ...: i64 | match |
-| test.rs:536:32:536:37 | ...: i64 | test.rs:536:40:536:40 | b |  |
-| test.rs:536:40:536:40 | b | test.rs:536:40:536:45 | ...: i64 | match |
-| test.rs:536:40:536:45 | ...: i64 | test.rs:537:9:537:34 | ExprStmt |  |
-| test.rs:536:48:538:5 | { ... } | test.rs:536:5:538:5 | exit fn multifly_add (normal) |  |
-| test.rs:537:9:537:12 | self | test.rs:537:9:537:14 | self.n |  |
-| test.rs:537:9:537:14 | self.n | test.rs:537:19:537:22 | self |  |
-| test.rs:537:9:537:33 | ... = ... | test.rs:536:48:538:5 | { ... } |  |
-| test.rs:537:9:537:34 | ExprStmt | test.rs:537:9:537:12 | self |  |
-| test.rs:537:18:537:33 | ... + ... | test.rs:537:9:537:33 | ... = ... |  |
-| test.rs:537:19:537:22 | self | test.rs:537:19:537:24 | self.n |  |
-| test.rs:537:19:537:24 | self.n | test.rs:537:28:537:28 | a |  |
-| test.rs:537:19:537:28 | ... * ... | test.rs:537:33:537:33 | b |  |
-| test.rs:537:28:537:28 | a | test.rs:537:19:537:28 | ... * ... |  |
-| test.rs:537:33:537:33 | b | test.rs:537:18:537:33 | ... + ... |  |
+| test.rs:507:9:507:21 | do_next_thing | test.rs:507:9:507:23 | do_next_thing(...) |  |
+| test.rs:507:9:507:23 | do_next_thing(...) | test.rs:508:9:510:9 | ExprStmt |  |
+| test.rs:507:9:507:24 | ExprStmt | test.rs:507:9:507:21 | do_next_thing |  |
+| test.rs:508:9:510:9 | ExprStmt | test.rs:508:12:508:28 | condition_not_met |  |
+| test.rs:508:9:510:9 | if ... {...} | test.rs:511:9:511:24 | ExprStmt |  |
+| test.rs:508:12:508:28 | condition_not_met | test.rs:508:12:508:30 | condition_not_met(...) |  |
+| test.rs:508:12:508:30 | condition_not_met(...) | test.rs:508:9:510:9 | if ... {...} | false |
+| test.rs:508:12:508:30 | condition_not_met(...) | test.rs:509:13:509:27 | ExprStmt | true |
+| test.rs:509:13:509:26 | break ''block 2 | test.rs:502:18:513:5 | 'block: { ... } | break |
+| test.rs:509:13:509:27 | ExprStmt | test.rs:509:26:509:26 | 2 |  |
+| test.rs:509:26:509:26 | 2 | test.rs:509:13:509:26 | break ''block 2 |  |
+| test.rs:511:9:511:21 | do_last_thing | test.rs:511:9:511:23 | do_last_thing(...) |  |
+| test.rs:511:9:511:23 | do_last_thing(...) | test.rs:512:9:512:9 | 3 |  |
+| test.rs:511:9:511:24 | ExprStmt | test.rs:511:9:511:21 | do_last_thing |  |
+| test.rs:512:9:512:9 | 3 | test.rs:502:18:513:5 | 'block: { ... } |  |
+| test.rs:514:5:514:10 | result | test.rs:501:29:515:1 | { ... } |  |
+| test.rs:517:1:525:1 | enter fn labelled_block2 | test.rs:518:5:524:6 | let ... = ... |  |
+| test.rs:517:1:525:1 | exit fn labelled_block2 (normal) | test.rs:517:1:525:1 | exit fn labelled_block2 |  |
+| test.rs:517:22:525:1 | { ... } | test.rs:517:1:525:1 | exit fn labelled_block2 (normal) |  |
+| test.rs:518:5:524:6 | let ... = ... | test.rs:519:9:519:34 | let ... = None |  |
+| test.rs:518:9:518:14 | result | test.rs:517:22:525:1 | { ... } | match |
+| test.rs:518:18:524:5 | 'block: { ... } | test.rs:518:9:518:14 | result |  |
+| test.rs:519:9:519:34 | let ... = None | test.rs:519:30:519:33 | None |  |
+| test.rs:519:13:519:13 | x | test.rs:520:9:522:10 | let ... = x else {...} | match |
+| test.rs:519:30:519:33 | None | test.rs:519:13:519:13 | x |  |
+| test.rs:520:9:522:10 | let ... = x else {...} | test.rs:520:23:520:23 | x |  |
+| test.rs:520:13:520:19 | Some(...) | test.rs:520:18:520:18 | y | match |
+| test.rs:520:13:520:19 | Some(...) | test.rs:521:13:521:27 | ExprStmt | no-match |
+| test.rs:520:18:520:18 | y | test.rs:523:9:523:9 | 0 | match |
+| test.rs:520:23:520:23 | x | test.rs:520:13:520:19 | Some(...) |  |
+| test.rs:521:13:521:26 | break ''block 1 | test.rs:518:18:524:5 | 'block: { ... } | break |
+| test.rs:521:13:521:27 | ExprStmt | test.rs:521:26:521:26 | 1 |  |
+| test.rs:521:26:521:26 | 1 | test.rs:521:13:521:26 | break ''block 1 |  |
+| test.rs:523:9:523:9 | 0 | test.rs:518:18:524:5 | 'block: { ... } |  |
+| test.rs:527:1:533:1 | enter fn test_nested_function2 | test.rs:528:5:528:18 | let ... = 0 |  |
+| test.rs:527:1:533:1 | exit fn test_nested_function2 (normal) | test.rs:527:1:533:1 | exit fn test_nested_function2 |  |
+| test.rs:527:28:533:1 | { ... } | test.rs:527:1:533:1 | exit fn test_nested_function2 (normal) |  |
+| test.rs:528:5:528:18 | let ... = 0 | test.rs:528:17:528:17 | 0 |  |
+| test.rs:528:9:528:13 | x | test.rs:529:5:531:5 | fn nested | match |
+| test.rs:528:17:528:17 | 0 | test.rs:528:9:528:13 | x |  |
+| test.rs:529:5:531:5 | enter fn nested | test.rs:529:15:529:15 | x |  |
+| test.rs:529:5:531:5 | exit fn nested (normal) | test.rs:529:5:531:5 | exit fn nested |  |
+| test.rs:529:5:531:5 | fn nested | test.rs:532:5:532:19 | ExprStmt |  |
+| test.rs:529:15:529:15 | x | test.rs:529:15:529:25 | ...: ... | match |
+| test.rs:529:15:529:25 | ...: ... | test.rs:530:9:530:16 | ExprStmt |  |
+| test.rs:529:28:531:5 | { ... } | test.rs:529:5:531:5 | exit fn nested (normal) |  |
+| test.rs:530:9:530:10 | * ... | test.rs:530:15:530:15 | 1 |  |
+| test.rs:530:9:530:15 | ... += ... | test.rs:529:28:531:5 | { ... } |  |
+| test.rs:530:9:530:16 | ExprStmt | test.rs:530:10:530:10 | x |  |
+| test.rs:530:10:530:10 | x | test.rs:530:9:530:10 | * ... |  |
+| test.rs:530:15:530:15 | 1 | test.rs:530:9:530:15 | ... += ... |  |
+| test.rs:532:5:532:10 | nested | test.rs:532:17:532:17 | x |  |
+| test.rs:532:5:532:18 | nested(...) | test.rs:527:28:533:1 | { ... } |  |
+| test.rs:532:5:532:19 | ExprStmt | test.rs:532:5:532:10 | nested |  |
+| test.rs:532:12:532:17 | &mut x | test.rs:532:5:532:18 | nested(...) |  |
+| test.rs:532:17:532:17 | x | test.rs:532:12:532:17 | &mut x |  |
+| test.rs:544:5:546:5 | enter fn new | test.rs:544:12:544:12 | a |  |
+| test.rs:544:5:546:5 | exit fn new (normal) | test.rs:544:5:546:5 | exit fn new |  |
+| test.rs:544:12:544:12 | a | test.rs:544:12:544:17 | ...: i64 | match |
+| test.rs:544:12:544:17 | ...: i64 | test.rs:545:23:545:23 | a |  |
+| test.rs:544:28:546:5 | { ... } | test.rs:544:5:546:5 | exit fn new (normal) |  |
+| test.rs:545:9:545:25 | MyNumber {...} | test.rs:544:28:546:5 | { ... } |  |
+| test.rs:545:23:545:23 | a | test.rs:545:9:545:25 | MyNumber {...} |  |
+| test.rs:548:5:550:5 | enter fn negated | test.rs:548:16:548:19 | self |  |
+| test.rs:548:5:550:5 | exit fn negated (normal) | test.rs:548:5:550:5 | exit fn negated |  |
+| test.rs:548:16:548:19 | SelfParam | test.rs:549:23:549:26 | self |  |
+| test.rs:548:16:548:19 | self | test.rs:548:16:548:19 | SelfParam |  |
+| test.rs:548:30:550:5 | { ... } | test.rs:548:5:550:5 | exit fn negated (normal) |  |
+| test.rs:549:9:549:30 | MyNumber {...} | test.rs:548:30:550:5 | { ... } |  |
+| test.rs:549:23:549:26 | self | test.rs:549:23:549:28 | self.n |  |
+| test.rs:549:23:549:28 | self.n | test.rs:549:9:549:30 | MyNumber {...} |  |
+| test.rs:552:5:554:5 | enter fn multifly_add | test.rs:552:26:552:29 | self |  |
+| test.rs:552:5:554:5 | exit fn multifly_add (normal) | test.rs:552:5:554:5 | exit fn multifly_add |  |
+| test.rs:552:21:552:29 | SelfParam | test.rs:552:32:552:32 | a |  |
+| test.rs:552:26:552:29 | self | test.rs:552:21:552:29 | SelfParam |  |
+| test.rs:552:32:552:32 | a | test.rs:552:32:552:37 | ...: i64 | match |
+| test.rs:552:32:552:37 | ...: i64 | test.rs:552:40:552:40 | b |  |
+| test.rs:552:40:552:40 | b | test.rs:552:40:552:45 | ...: i64 | match |
+| test.rs:552:40:552:45 | ...: i64 | test.rs:553:9:553:34 | ExprStmt |  |
+| test.rs:552:48:554:5 | { ... } | test.rs:552:5:554:5 | exit fn multifly_add (normal) |  |
+| test.rs:553:9:553:12 | self | test.rs:553:9:553:14 | self.n |  |
+| test.rs:553:9:553:14 | self.n | test.rs:553:19:553:22 | self |  |
+| test.rs:553:9:553:33 | ... = ... | test.rs:552:48:554:5 | { ... } |  |
+| test.rs:553:9:553:34 | ExprStmt | test.rs:553:9:553:12 | self |  |
+| test.rs:553:18:553:33 | ... + ... | test.rs:553:9:553:33 | ... = ... |  |
+| test.rs:553:19:553:22 | self | test.rs:553:19:553:24 | self.n |  |
+| test.rs:553:19:553:24 | self.n | test.rs:553:28:553:28 | a |  |
+| test.rs:553:19:553:28 | ... * ... | test.rs:553:33:553:33 | b |  |
+| test.rs:553:28:553:28 | a | test.rs:553:19:553:28 | ... * ... |  |
+| test.rs:553:33:553:33 | b | test.rs:553:18:553:33 | ... + ... |  |
 breakTarget
 | test.rs:34:17:34:21 | break | test.rs:28:9:40:9 | loop { ... } |
 | test.rs:48:21:48:25 | break | test.rs:46:13:53:13 | 'inner: loop { ... } |
@@ -1189,9 +1236,9 @@ breakTarget
 | test.rs:216:17:216:28 | break ... | test.rs:214:13:219:9 | loop { ... } |
 | test.rs:229:17:229:35 | break ''label ... | test.rs:227:13:232:9 | 'label: loop { ... } |
 | test.rs:241:13:241:30 | break ''block ... | test.rs:240:13:242:9 | 'block: { ... } |
-| test.rs:489:13:489:26 | break ''block 1 | test.rs:486:18:497:5 | 'block: { ... } |
-| test.rs:493:13:493:26 | break ''block 2 | test.rs:486:18:497:5 | 'block: { ... } |
-| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:508:5 | 'block: { ... } |
+| test.rs:505:13:505:26 | break ''block 1 | test.rs:502:18:513:5 | 'block: { ... } |
+| test.rs:509:13:509:26 | break ''block 2 | test.rs:502:18:513:5 | 'block: { ... } |
+| test.rs:521:13:521:26 | break ''block 1 | test.rs:518:18:524:5 | 'block: { ... } |
 continueTarget
 | test.rs:37:17:37:24 | continue | test.rs:28:9:40:9 | loop { ... } |
 | test.rs:63:21:63:28 | continue | test.rs:61:13:68:13 | 'inner: loop { ... } |

--- a/rust/ql/test/library-tests/controlflow/Cfg.expected
+++ b/rust/ql/test/library-tests/controlflow/Cfg.expected
@@ -15,9 +15,9 @@ edges
 | test.rs:10:5:13:5 | exit fn method_call (normal) | test.rs:10:5:13:5 | exit fn method_call |  |
 | test.rs:10:22:13:5 | { ... } | test.rs:10:5:13:5 | exit fn method_call (normal) |  |
 | test.rs:11:9:11:37 | let ... = ... | test.rs:11:23:11:34 | ...::new |  |
-| test.rs:11:13:11:19 | map | test.rs:12:9:12:28 | ExprStmt | match |
+| test.rs:11:13:11:19 | mut map | test.rs:12:9:12:28 | ExprStmt | match |
 | test.rs:11:23:11:34 | ...::new | test.rs:11:23:11:36 | ...::new(...) |  |
-| test.rs:11:23:11:36 | ...::new(...) | test.rs:11:13:11:19 | map |  |
+| test.rs:11:23:11:36 | ...::new(...) | test.rs:11:13:11:19 | mut map |  |
 | test.rs:12:9:12:11 | map | test.rs:12:20:12:21 | 37 |  |
 | test.rs:12:9:12:27 | map.insert(...) | test.rs:10:22:13:5 | { ... } |  |
 | test.rs:12:9:12:28 | ExprStmt | test.rs:12:9:12:11 | map |  |
@@ -50,8 +50,8 @@ edges
 | test.rs:26:32:26:32 | n | test.rs:26:32:26:37 | ...: i64 | match |
 | test.rs:26:32:26:37 | ...: i64 | test.rs:27:9:27:22 | let ... = n |  |
 | test.rs:27:9:27:22 | let ... = n | test.rs:27:21:27:21 | n |  |
-| test.rs:27:13:27:17 | i | test.rs:28:9:40:9 | ExprStmt | match |
-| test.rs:27:21:27:21 | n | test.rs:27:13:27:17 | i |  |
+| test.rs:27:13:27:17 | mut i | test.rs:28:9:40:9 | ExprStmt | match |
+| test.rs:27:21:27:21 | n | test.rs:27:13:27:17 | mut i |  |
 | test.rs:28:9:40:9 | ExprStmt | test.rs:29:13:29:24 | ExprStmt |  |
 | test.rs:28:9:40:9 | loop { ... } | test.rs:41:9:41:20 | ExprStmt |  |
 | test.rs:28:14:40:9 | { ... } | test.rs:29:13:29:24 | ExprStmt |  |
@@ -161,8 +161,8 @@ edges
 | test.rs:86:19:86:24 | ...: i64 | test.rs:87:9:87:25 | let ... = true |  |
 | test.rs:86:27:95:5 | { ... } | test.rs:86:5:95:5 | exit fn test_while (normal) |  |
 | test.rs:87:9:87:25 | let ... = true | test.rs:87:21:87:24 | true |  |
-| test.rs:87:13:87:17 | b | test.rs:88:15:88:15 | b | match |
-| test.rs:87:21:87:24 | true | test.rs:87:13:87:17 | b |  |
+| test.rs:87:13:87:17 | mut b | test.rs:88:15:88:15 | b | match |
+| test.rs:87:21:87:24 | true | test.rs:87:13:87:17 | mut b |  |
 | test.rs:88:9:94:9 | while b { ... } | test.rs:86:27:95:5 | { ... } |  |
 | test.rs:88:15:88:15 | b | test.rs:88:9:94:9 | while b { ... } | false |
 | test.rs:88:15:88:15 | b | test.rs:89:13:89:14 | ExprStmt | true |
@@ -185,9 +185,9 @@ edges
 | test.rs:97:5:104:5 | exit fn test_while_let (normal) | test.rs:97:5:104:5 | exit fn test_while_let |  |
 | test.rs:97:25:104:5 | { ... } | test.rs:97:5:104:5 | exit fn test_while_let (normal) |  |
 | test.rs:98:9:98:29 | let ... = ... | test.rs:98:24:98:24 | 1 |  |
-| test.rs:98:13:98:20 | iter | test.rs:99:15:99:39 | let ... = ... | match |
+| test.rs:98:13:98:20 | mut iter | test.rs:99:15:99:39 | let ... = ... | match |
 | test.rs:98:24:98:24 | 1 | test.rs:98:27:98:28 | 10 |  |
-| test.rs:98:24:98:28 | 1..10 | test.rs:98:13:98:20 | iter |  |
+| test.rs:98:24:98:28 | 1..10 | test.rs:98:13:98:20 | mut iter |  |
 | test.rs:98:27:98:28 | 10 | test.rs:98:24:98:28 | 1..10 |  |
 | test.rs:99:9:103:9 | while ... { ... } | test.rs:97:25:104:5 | { ... } |  |
 | test.rs:99:15:99:39 | let ... = ... | test.rs:99:29:99:32 | iter |  |
@@ -273,8 +273,8 @@ edges
 | test.rs:137:29:137:35 | ...: bool | test.rs:138:9:138:22 | let ... = 3 |  |
 | test.rs:137:45:143:5 | { ... } | test.rs:137:5:143:5 | exit fn test_if_without_else (normal) |  |
 | test.rs:138:9:138:22 | let ... = 3 | test.rs:138:21:138:21 | 3 |  |
-| test.rs:138:13:138:17 | i | test.rs:139:9:141:9 | ExprStmt | match |
-| test.rs:138:21:138:21 | 3 | test.rs:138:13:138:17 | i |  |
+| test.rs:138:13:138:17 | mut i | test.rs:139:9:141:9 | ExprStmt | match |
+| test.rs:138:21:138:21 | 3 | test.rs:138:13:138:17 | mut i |  |
 | test.rs:139:9:141:9 | ExprStmt | test.rs:139:12:139:12 | b |  |
 | test.rs:139:9:141:9 | if b {...} | test.rs:142:9:142:9 | i |  |
 | test.rs:139:12:139:12 | b | test.rs:139:9:141:9 | if b {...} | false |
@@ -442,8 +442,8 @@ edges
 | test.rs:201:27:201:32 | ...: i64 | test.rs:202:9:202:26 | let ... = false |  |
 | test.rs:201:42:211:5 | { ... } | test.rs:201:5:211:5 | exit fn test_if_assignment (normal) |  |
 | test.rs:202:9:202:26 | let ... = false | test.rs:202:21:202:25 | false |  |
-| test.rs:202:13:202:17 | x | test.rs:204:13:204:21 | ExprStmt | match |
-| test.rs:202:21:202:25 | false | test.rs:202:13:202:17 | x |  |
+| test.rs:202:13:202:17 | mut x | test.rs:204:13:204:21 | ExprStmt | match |
+| test.rs:202:21:202:25 | false | test.rs:202:13:202:17 | mut x |  |
 | test.rs:203:9:210:9 | if ... {...} else {...} | test.rs:201:42:211:5 | { ... } |  |
 | test.rs:203:12:206:9 | [boolean(false)] { ... } | test.rs:209:13:209:13 | 0 | false |
 | test.rs:203:12:206:9 | [boolean(true)] { ... } | test.rs:207:13:207:13 | 1 | true |
@@ -906,13 +906,13 @@ edges
 | test.rs:400:52:405:5 | { ... } | test.rs:400:5:405:5 | exit fn identifier_pattern_with_subpattern (normal) |  |
 | test.rs:401:9:404:9 | match 43 { ... } | test.rs:400:52:405:5 | { ... } |  |
 | test.rs:401:15:401:16 | 43 | test.rs:402:17:402:21 | RangePat |  |
-| test.rs:402:13:402:21 | [match(true)] n | test.rs:402:26:402:26 | 2 | match |
+| test.rs:402:13:402:21 | [match(true)] n @ ... | test.rs:402:26:402:26 | 2 | match |
 | test.rs:402:17:402:17 | 1 | test.rs:402:17:402:17 | 1 |  |
 | test.rs:402:17:402:17 | 1 | test.rs:402:20:402:21 | 10 | match |
 | test.rs:402:17:402:17 | 1 | test.rs:403:13:403:13 | _ | no-match |
 | test.rs:402:17:402:21 | RangePat | test.rs:402:17:402:17 | 1 | match |
 | test.rs:402:17:402:21 | RangePat | test.rs:403:13:403:13 | _ | no-match |
-| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n | match |
+| test.rs:402:20:402:21 | 10 | test.rs:402:13:402:21 | [match(true)] n @ ... | match |
 | test.rs:402:20:402:21 | 10 | test.rs:402:20:402:21 | 10 |  |
 | test.rs:402:20:402:21 | 10 | test.rs:403:13:403:13 | _ | no-match |
 | test.rs:402:26:402:26 | 2 | test.rs:402:30:402:30 | n |  |
@@ -924,25 +924,25 @@ edges
 | test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref (normal) | test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref |  |
 | test.rs:407:45:414:5 | { ... } | test.rs:407:5:414:5 | exit fn identifier_pattern_with_ref (normal) |  |
 | test.rs:408:9:408:23 | let ... = 10 | test.rs:408:21:408:22 | 10 |  |
-| test.rs:408:13:408:17 | a | test.rs:409:9:412:10 | ExprStmt | match |
-| test.rs:408:21:408:22 | 10 | test.rs:408:13:408:17 | a |  |
+| test.rs:408:13:408:17 | mut a | test.rs:409:9:412:10 | ExprStmt | match |
+| test.rs:408:21:408:22 | 10 | test.rs:408:13:408:17 | mut a |  |
 | test.rs:409:9:412:9 | match a { ... } | test.rs:413:9:413:9 | a |  |
 | test.rs:409:9:412:10 | ExprStmt | test.rs:409:15:409:15 | a |  |
 | test.rs:409:15:409:15 | a | test.rs:410:25:410:29 | RangePat |  |
-| test.rs:410:13:410:29 | [match(true)] n | test.rs:410:35:410:35 | n | match |
+| test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | test.rs:410:35:410:35 | n | match |
 | test.rs:410:25:410:25 | 1 | test.rs:410:25:410:25 | 1 |  |
 | test.rs:410:25:410:25 | 1 | test.rs:410:28:410:29 | 10 | match |
-| test.rs:410:25:410:25 | 1 | test.rs:411:13:411:21 | n | no-match |
+| test.rs:410:25:410:25 | 1 | test.rs:411:13:411:21 | ref mut n | no-match |
 | test.rs:410:25:410:29 | RangePat | test.rs:410:25:410:25 | 1 | match |
-| test.rs:410:25:410:29 | RangePat | test.rs:411:13:411:21 | n | no-match |
-| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] n | match |
+| test.rs:410:25:410:29 | RangePat | test.rs:411:13:411:21 | ref mut n | no-match |
+| test.rs:410:28:410:29 | 10 | test.rs:410:13:410:29 | [match(true)] ref mut n @ ... | match |
 | test.rs:410:28:410:29 | 10 | test.rs:410:28:410:29 | 10 |  |
-| test.rs:410:28:410:29 | 10 | test.rs:411:13:411:21 | n | no-match |
+| test.rs:410:28:410:29 | 10 | test.rs:411:13:411:21 | ref mut n | no-match |
 | test.rs:410:34:410:35 | * ... | test.rs:410:40:410:41 | 10 |  |
 | test.rs:410:34:410:41 | ... += ... | test.rs:409:9:412:9 | match a { ... } |  |
 | test.rs:410:35:410:35 | n | test.rs:410:34:410:35 | * ... |  |
 | test.rs:410:40:410:41 | 10 | test.rs:410:34:410:41 | ... += ... |  |
-| test.rs:411:13:411:21 | n | test.rs:411:27:411:27 | n | match |
+| test.rs:411:13:411:21 | ref mut n | test.rs:411:27:411:27 | n | match |
 | test.rs:411:26:411:27 | * ... | test.rs:411:31:411:31 | 0 |  |
 | test.rs:411:26:411:31 | ... = ... | test.rs:409:9:412:9 | match a { ... } |  |
 | test.rs:411:27:411:27 | n | test.rs:411:26:411:27 | * ... |  |
@@ -1172,8 +1172,8 @@ edges
 | test.rs:527:1:533:1 | exit fn test_nested_function2 (normal) | test.rs:527:1:533:1 | exit fn test_nested_function2 |  |
 | test.rs:527:28:533:1 | { ... } | test.rs:527:1:533:1 | exit fn test_nested_function2 (normal) |  |
 | test.rs:528:5:528:18 | let ... = 0 | test.rs:528:17:528:17 | 0 |  |
-| test.rs:528:9:528:13 | x | test.rs:529:5:531:5 | fn nested | match |
-| test.rs:528:17:528:17 | 0 | test.rs:528:9:528:13 | x |  |
+| test.rs:528:9:528:13 | mut x | test.rs:529:5:531:5 | fn nested | match |
+| test.rs:528:17:528:17 | 0 | test.rs:528:9:528:13 | mut x |  |
 | test.rs:529:5:531:5 | enter fn nested | test.rs:529:15:529:15 | x |  |
 | test.rs:529:5:531:5 | exit fn nested (normal) | test.rs:529:5:531:5 | exit fn nested |  |
 | test.rs:529:5:531:5 | fn nested | test.rs:532:5:532:19 | ExprStmt |  |

--- a/rust/ql/test/library-tests/controlflow/test.rs
+++ b/rust/ql/test/library-tests/controlflow/test.rs
@@ -396,6 +396,22 @@ mod patterns {
             _ => 4,
         }
     }
+
+    fn identifier_pattern_with_subpattern() -> i64 {
+        match 43 {
+            n @ 1..10 => 2 * n,
+            _ => 0,
+        }
+    }
+
+    fn identifier_pattern_with_ref() -> i64 {
+        let mut a = 10;
+        match a {
+            ref mut n @ 1..10 => *n += 10,
+            ref mut n => *n = 0,
+        };
+        a
+    }
 }
 
 mod divergence {

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -72,9 +72,9 @@ localStep
 | main.rs:44:13:46:5 | loop { ... } | main.rs:44:9:44:9 | b |  |
 | main.rs:45:9:45:23 | break ... | main.rs:44:13:46:5 | loop { ... } |  |
 | main.rs:45:15:45:23 | source(...) | main.rs:45:9:45:23 | break ... |  |
-| main.rs:51:9:51:13 | [SSA] i | main.rs:52:10:52:10 | i |  |
-| main.rs:51:9:51:13 | i | main.rs:51:9:51:13 | [SSA] i |  |
-| main.rs:51:17:51:17 | 1 | main.rs:51:9:51:13 | i |  |
+| main.rs:51:9:51:13 | [SSA] mut i | main.rs:52:10:52:10 | i |  |
+| main.rs:51:9:51:13 | mut i | main.rs:51:9:51:13 | [SSA] mut i |  |
+| main.rs:51:17:51:17 | 1 | main.rs:51:9:51:13 | mut i |  |
 | main.rs:53:5:53:5 | [SSA] i | main.rs:54:10:54:10 | i |  |
 | main.rs:53:5:53:5 | i | main.rs:53:5:53:5 | [SSA] i |  |
 | main.rs:53:9:53:17 | source(...) | main.rs:53:5:53:5 | i |  |
@@ -122,9 +122,9 @@ localStep
 | main.rs:101:18:101:19 | [SSA] a2 | main.rs:104:10:104:11 | a2 |  |
 | main.rs:101:18:101:19 | a2 | main.rs:101:18:101:19 | [SSA] a2 |  |
 | main.rs:101:24:101:24 | a | main.rs:101:9:101:20 | TuplePat |  |
-| main.rs:108:9:108:13 | [SSA] a | main.rs:109:10:109:10 | a |  |
-| main.rs:108:9:108:13 | a | main.rs:108:9:108:13 | [SSA] a |  |
-| main.rs:108:17:108:31 | TupleExpr | main.rs:108:9:108:13 | a |  |
+| main.rs:108:9:108:13 | [SSA] mut a | main.rs:109:10:109:10 | a |  |
+| main.rs:108:9:108:13 | mut a | main.rs:108:9:108:13 | [SSA] mut a |  |
+| main.rs:108:17:108:31 | TupleExpr | main.rs:108:9:108:13 | mut a |  |
 | main.rs:109:10:109:10 | [post] a | main.rs:110:10:110:10 | a |  |
 | main.rs:109:10:109:10 | a | main.rs:110:10:110:10 | a |  |
 | main.rs:110:10:110:10 | [post] a | main.rs:111:5:111:5 | a |  |
@@ -152,9 +152,9 @@ localStep
 | main.rs:134:13:134:40 | Point {...} | main.rs:134:9:134:9 | p |  |
 | main.rs:135:10:135:10 | [post] p | main.rs:136:10:136:10 | p |  |
 | main.rs:135:10:135:10 | p | main.rs:136:10:136:10 | p |  |
-| main.rs:140:9:140:13 | [SSA] p | main.rs:141:10:141:10 | p |  |
-| main.rs:140:9:140:13 | p | main.rs:140:9:140:13 | [SSA] p |  |
-| main.rs:140:17:140:44 | Point {...} | main.rs:140:9:140:13 | p |  |
+| main.rs:140:9:140:13 | [SSA] mut p | main.rs:141:10:141:10 | p |  |
+| main.rs:140:9:140:13 | mut p | main.rs:140:9:140:13 | [SSA] mut p |  |
+| main.rs:140:17:140:44 | Point {...} | main.rs:140:9:140:13 | mut p |  |
 | main.rs:141:10:141:10 | [post] p | main.rs:142:5:142:5 | p |  |
 | main.rs:141:10:141:10 | p | main.rs:142:5:142:5 | p |  |
 | main.rs:142:5:142:5 | [post] p | main.rs:143:10:143:10 | p |  |
@@ -477,9 +477,9 @@ localStep
 | main.rs:403:16:403:16 | [SSA] c | main.rs:406:18:406:18 | c |  |
 | main.rs:403:16:403:16 | c | main.rs:403:16:403:16 | [SSA] c |  |
 | main.rs:403:22:407:9 | { ... } | main.rs:402:5:408:5 | match arr1 { ... } |  |
-| main.rs:412:9:412:19 | [SSA] mut_arr | main.rs:413:10:413:16 | mut_arr |  |
-| main.rs:412:9:412:19 | mut_arr | main.rs:412:9:412:19 | [SSA] mut_arr |  |
-| main.rs:412:23:412:31 | [...] | main.rs:412:9:412:19 | mut_arr |  |
+| main.rs:412:9:412:19 | [SSA] mut mut_arr | main.rs:413:10:413:16 | mut_arr |  |
+| main.rs:412:9:412:19 | mut mut_arr | main.rs:412:9:412:19 | [SSA] mut mut_arr |  |
+| main.rs:412:23:412:31 | [...] | main.rs:412:9:412:19 | mut mut_arr |  |
 | main.rs:413:10:413:16 | [post] mut_arr | main.rs:415:5:415:11 | mut_arr |  |
 | main.rs:413:10:413:16 | mut_arr | main.rs:415:5:415:11 | mut_arr |  |
 | main.rs:415:5:415:11 | [post] mut_arr | main.rs:416:13:416:19 | mut_arr |  |

--- a/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/local/inline-flow.expected
@@ -28,8 +28,8 @@ edges
 | main.rs:100:17:100:26 | source(...) | main.rs:100:13:100:30 | TupleExpr [tuple.1] | provenance |  |
 | main.rs:101:9:101:20 | TuplePat [tuple.1] | main.rs:101:14:101:15 | a1 | provenance |  |
 | main.rs:101:14:101:15 | a1 | main.rs:103:10:103:11 | a1 | provenance |  |
-| main.rs:108:9:108:13 | a [tuple.1] | main.rs:110:10:110:10 | a [tuple.1] | provenance |  |
-| main.rs:108:17:108:31 | TupleExpr [tuple.1] | main.rs:108:9:108:13 | a [tuple.1] | provenance |  |
+| main.rs:108:9:108:13 | mut a [tuple.1] | main.rs:110:10:110:10 | a [tuple.1] | provenance |  |
+| main.rs:108:17:108:31 | TupleExpr [tuple.1] | main.rs:108:9:108:13 | mut a [tuple.1] | provenance |  |
 | main.rs:108:21:108:30 | source(...) | main.rs:108:17:108:31 | TupleExpr [tuple.1] | provenance |  |
 | main.rs:110:10:110:10 | a [tuple.1] | main.rs:110:10:110:12 | a.1 | provenance |  |
 | main.rs:111:5:111:5 | [post] a [tuple.0] | main.rs:112:5:112:5 | a [tuple.0] | provenance |  |
@@ -217,7 +217,7 @@ nodes
 | main.rs:101:9:101:20 | TuplePat [tuple.1] | semmle.label | TuplePat [tuple.1] |
 | main.rs:101:14:101:15 | a1 | semmle.label | a1 |
 | main.rs:103:10:103:11 | a1 | semmle.label | a1 |
-| main.rs:108:9:108:13 | a [tuple.1] | semmle.label | a [tuple.1] |
+| main.rs:108:9:108:13 | mut a [tuple.1] | semmle.label | mut a [tuple.1] |
 | main.rs:108:17:108:31 | TupleExpr [tuple.1] | semmle.label | TupleExpr [tuple.1] |
 | main.rs:108:21:108:30 | source(...) | semmle.label | source(...) |
 | main.rs:110:10:110:10 | a [tuple.1] | semmle.label | a [tuple.1] |

--- a/rust/ql/test/library-tests/variables/Cfg.expected
+++ b/rust/ql/test/library-tests/variables/Cfg.expected
@@ -58,8 +58,8 @@ edges
 | main.rs:20:1:25:1 | exit fn mutable_variable (normal) | main.rs:20:1:25:1 | exit fn mutable_variable |  |
 | main.rs:20:23:25:1 | { ... } | main.rs:20:1:25:1 | exit fn mutable_variable (normal) |  |
 | main.rs:21:5:21:19 | let ... = 4 | main.rs:21:18:21:18 | 4 |  |
-| main.rs:21:9:21:14 | x2 | main.rs:22:5:22:18 | ExprStmt | match |
-| main.rs:21:18:21:18 | 4 | main.rs:21:9:21:14 | x2 |  |
+| main.rs:21:9:21:14 | mut x2 | main.rs:22:5:22:18 | ExprStmt | match |
+| main.rs:21:18:21:18 | 4 | main.rs:21:9:21:14 | mut x2 |  |
 | main.rs:22:5:22:13 | print_i64 | main.rs:22:15:22:16 | x2 |  |
 | main.rs:22:5:22:17 | print_i64(...) | main.rs:23:5:23:11 | ExprStmt |  |
 | main.rs:22:5:22:18 | ExprStmt | main.rs:22:5:22:13 | print_i64 |  |
@@ -76,8 +76,8 @@ edges
 | main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow (normal) | main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow |  |
 | main.rs:27:40:32:1 | { ... } | main.rs:27:1:32:1 | exit fn mutable_variable_immutable_borrow (normal) |  |
 | main.rs:28:5:28:18 | let ... = 1 | main.rs:28:17:28:17 | 1 |  |
-| main.rs:28:9:28:13 | x | main.rs:29:5:29:22 | ExprStmt | match |
-| main.rs:28:17:28:17 | 1 | main.rs:28:9:28:13 | x |  |
+| main.rs:28:9:28:13 | mut x | main.rs:29:5:29:22 | ExprStmt | match |
+| main.rs:28:17:28:17 | 1 | main.rs:28:9:28:13 | mut x |  |
 | main.rs:29:5:29:17 | print_i64_ref | main.rs:29:20:29:20 | x |  |
 | main.rs:29:5:29:21 | print_i64_ref(...) | main.rs:30:5:30:10 | ExprStmt |  |
 | main.rs:29:5:29:22 | ExprStmt | main.rs:29:5:29:17 | print_i64_ref |  |
@@ -202,8 +202,8 @@ edges
 | main.rs:87:5:90:5 | if ... {...} | main.rs:84:19:91:1 | { ... } |  |
 | main.rs:87:8:88:12 | let ... = s1 | main.rs:88:11:88:12 | s1 |  |
 | main.rs:87:12:87:23 | Some(...) | main.rs:87:5:90:5 | if ... {...} | no-match |
-| main.rs:87:12:87:23 | Some(...) | main.rs:87:17:87:22 | s2 | match |
-| main.rs:87:17:87:22 | s2 | main.rs:89:9:89:22 | ExprStmt | match |
+| main.rs:87:12:87:23 | Some(...) | main.rs:87:17:87:22 | ref s2 | match |
+| main.rs:87:17:87:22 | ref s2 | main.rs:89:9:89:22 | ExprStmt | match |
 | main.rs:88:11:88:12 | s1 | main.rs:87:12:87:23 | Some(...) |  |
 | main.rs:88:14:90:5 | { ... } | main.rs:87:5:90:5 | if ... {...} |  |
 | main.rs:89:9:89:17 | print_str | main.rs:89:19:89:20 | s2 |  |
@@ -243,8 +243,8 @@ edges
 | main.rs:104:5:107:5 | while ... { ... } | main.rs:101:19:108:1 | { ... } |  |
 | main.rs:104:11:105:12 | let ... = s1 | main.rs:105:11:105:12 | s1 |  |
 | main.rs:104:15:104:26 | Some(...) | main.rs:104:5:107:5 | while ... { ... } | no-match |
-| main.rs:104:15:104:26 | Some(...) | main.rs:104:20:104:25 | s2 | match |
-| main.rs:104:20:104:25 | s2 | main.rs:106:9:106:22 | ExprStmt | match |
+| main.rs:104:15:104:26 | Some(...) | main.rs:104:20:104:25 | ref s2 | match |
+| main.rs:104:20:104:25 | ref s2 | main.rs:106:9:106:22 | ExprStmt | match |
 | main.rs:105:11:105:12 | s1 | main.rs:104:15:104:26 | Some(...) |  |
 | main.rs:105:14:107:5 | { ... } | main.rs:104:11:105:12 | let ... = s1 |  |
 | main.rs:106:9:106:17 | print_str | main.rs:106:19:106:20 | s2 |  |
@@ -363,13 +363,13 @@ edges
 | main.rs:171:11:171:13 | msg | main.rs:172:9:174:9 | ...::Hello {...} |  |
 | main.rs:172:9:174:9 | ...::Hello {...} | main.rs:173:31:173:35 | RangePat | match |
 | main.rs:172:9:174:9 | ...::Hello {...} | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
-| main.rs:173:17:173:35 | [match(true)] id_variable | main.rs:174:14:174:22 | print_i64 | match |
+| main.rs:173:17:173:35 | [match(true)] id_variable @ ... | main.rs:174:14:174:22 | print_i64 | match |
 | main.rs:173:31:173:31 | 3 | main.rs:173:31:173:31 | 3 |  |
 | main.rs:173:31:173:31 | 3 | main.rs:173:35:173:35 | 7 | match |
 | main.rs:173:31:173:31 | 3 | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
 | main.rs:173:31:173:35 | RangePat | main.rs:173:31:173:31 | 3 | match |
 | main.rs:173:31:173:35 | RangePat | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
-| main.rs:173:35:173:35 | 7 | main.rs:173:17:173:35 | [match(true)] id_variable | match |
+| main.rs:173:35:173:35 | 7 | main.rs:173:17:173:35 | [match(true)] id_variable @ ... | match |
 | main.rs:173:35:173:35 | 7 | main.rs:173:35:173:35 | 7 |  |
 | main.rs:173:35:173:35 | 7 | main.rs:175:9:175:38 | ...::Hello {...} | no-match |
 | main.rs:174:14:174:22 | print_i64 | main.rs:174:24:174:34 | id_variable |  |
@@ -513,11 +513,11 @@ edges
 | main.rs:229:31:229:32 | 32 | main.rs:229:18:229:33 | ...::Left(...) |  |
 | main.rs:231:5:242:5 | match either { ... } | main.rs:228:21:243:1 | { ... } |  |
 | main.rs:231:11:231:16 | either | main.rs:233:14:233:30 | ...::Left(...) |  |
-| main.rs:232:9:233:52 | [match(true)] e | main.rs:235:13:235:27 | ExprStmt | match |
+| main.rs:232:9:233:52 | [match(true)] ref e @ ... | main.rs:235:13:235:27 | ExprStmt | match |
 | main.rs:233:14:233:30 | ...::Left(...) | main.rs:233:27:233:29 | a11 | match |
 | main.rs:233:14:233:30 | ...::Left(...) | main.rs:233:34:233:51 | ...::Right(...) | no-match |
 | main.rs:233:14:233:51 | [match(false)] ... \| ... | main.rs:241:9:241:9 | _ | no-match |
-| main.rs:233:14:233:51 | [match(true)] ... \| ... | main.rs:232:9:233:52 | [match(true)] e | match |
+| main.rs:233:14:233:51 | [match(true)] ... \| ... | main.rs:232:9:233:52 | [match(true)] ref e @ ... | match |
 | main.rs:233:27:233:29 | a11 | main.rs:233:14:233:51 | [match(true)] ... \| ... | match |
 | main.rs:233:34:233:51 | ...::Right(...) | main.rs:233:14:233:51 | [match(false)] ... \| ... | no-match |
 | main.rs:233:34:233:51 | ...::Right(...) | main.rs:233:48:233:50 | a11 | match |
@@ -607,10 +607,10 @@ edges
 | main.rs:277:1:312:1 | exit fn destruct_assignment (normal) | main.rs:277:1:312:1 | exit fn destruct_assignment |  |
 | main.rs:277:26:312:1 | { ... } | main.rs:277:1:312:1 | exit fn destruct_assignment (normal) |  |
 | main.rs:278:5:282:18 | let ... = ... | main.rs:282:10:282:10 | 1 |  |
-| main.rs:278:9:282:5 | TuplePat | main.rs:279:9:279:15 | a10 | match |
-| main.rs:279:9:279:15 | a10 | main.rs:280:9:280:14 | b4 | match |
-| main.rs:280:9:280:14 | b4 | main.rs:281:9:281:14 | c2 | match |
-| main.rs:281:9:281:14 | c2 | main.rs:283:5:283:19 | ExprStmt | match |
+| main.rs:278:9:282:5 | TuplePat | main.rs:279:9:279:15 | mut a10 | match |
+| main.rs:279:9:279:15 | mut a10 | main.rs:280:9:280:14 | mut b4 | match |
+| main.rs:280:9:280:14 | mut b4 | main.rs:281:9:281:14 | mut c2 | match |
+| main.rs:281:9:281:14 | mut c2 | main.rs:283:5:283:19 | ExprStmt | match |
 | main.rs:282:9:282:17 | TupleExpr | main.rs:278:9:282:5 | TuplePat |  |
 | main.rs:282:10:282:10 | 1 | main.rs:282:13:282:13 | 2 |  |
 | main.rs:282:13:282:13 | 2 | main.rs:282:16:282:16 | 3 |  |
@@ -807,8 +807,8 @@ edges
 | main.rs:370:1:376:1 | exit fn add_assign (normal) | main.rs:370:1:376:1 | exit fn add_assign |  |
 | main.rs:370:17:376:1 | { ... } | main.rs:370:1:376:1 | exit fn add_assign (normal) |  |
 | main.rs:371:5:371:18 | let ... = 0 | main.rs:371:17:371:17 | 0 |  |
-| main.rs:371:9:371:13 | a | main.rs:372:5:372:11 | ExprStmt | match |
-| main.rs:371:17:371:17 | 0 | main.rs:371:9:371:13 | a |  |
+| main.rs:371:9:371:13 | mut a | main.rs:372:5:372:11 | ExprStmt | match |
+| main.rs:371:17:371:17 | 0 | main.rs:371:9:371:13 | mut a |  |
 | main.rs:372:5:372:5 | a | main.rs:372:10:372:10 | 1 |  |
 | main.rs:372:5:372:10 | ... += ... | main.rs:373:5:373:17 | ExprStmt |  |
 | main.rs:372:5:372:11 | ExprStmt | main.rs:372:5:372:5 | a |  |
@@ -830,8 +830,8 @@ edges
 | main.rs:378:1:384:1 | exit fn mutate (normal) | main.rs:378:1:384:1 | exit fn mutate |  |
 | main.rs:378:13:384:1 | { ... } | main.rs:378:1:384:1 | exit fn mutate (normal) |  |
 | main.rs:379:5:379:18 | let ... = 1 | main.rs:379:17:379:17 | 1 |  |
-| main.rs:379:9:379:13 | i | main.rs:380:5:381:15 | let ... = ... | match |
-| main.rs:379:17:379:17 | 1 | main.rs:379:9:379:13 | i |  |
+| main.rs:379:9:379:13 | mut i | main.rs:380:5:381:15 | let ... = ... | match |
+| main.rs:379:17:379:17 | 1 | main.rs:379:9:379:13 | mut i |  |
 | main.rs:380:5:381:15 | let ... = ... | main.rs:381:14:381:14 | i |  |
 | main.rs:380:9:380:13 | ref_i | main.rs:382:5:382:15 | ExprStmt | match |
 | main.rs:381:9:381:14 | &mut i | main.rs:380:9:380:13 | ref_i |  |
@@ -886,8 +886,8 @@ edges
 | main.rs:401:1:419:1 | exit fn mutate_arg (normal) | main.rs:401:1:419:1 | exit fn mutate_arg |  |
 | main.rs:401:17:419:1 | { ... } | main.rs:401:1:419:1 | exit fn mutate_arg (normal) |  |
 | main.rs:402:5:402:18 | let ... = 2 | main.rs:402:17:402:17 | 2 |  |
-| main.rs:402:9:402:13 | x | main.rs:403:5:404:29 | let ... = ... | match |
-| main.rs:402:17:402:17 | 2 | main.rs:402:9:402:13 | x |  |
+| main.rs:402:9:402:13 | mut x | main.rs:403:5:404:29 | let ... = ... | match |
+| main.rs:402:17:402:17 | 2 | main.rs:402:9:402:13 | mut x |  |
 | main.rs:403:5:404:29 | let ... = ... | main.rs:404:9:404:20 | mutate_param |  |
 | main.rs:403:9:403:9 | y | main.rs:405:5:405:12 | ExprStmt | match |
 | main.rs:404:9:404:20 | mutate_param | main.rs:404:27:404:27 | x |  |
@@ -904,8 +904,8 @@ edges
 | main.rs:407:5:407:17 | ExprStmt | main.rs:407:5:407:13 | print_i64 |  |
 | main.rs:407:15:407:15 | x | main.rs:407:5:407:16 | print_i64(...) |  |
 | main.rs:409:5:409:18 | let ... = 4 | main.rs:409:17:409:17 | 4 |  |
-| main.rs:409:9:409:13 | z | main.rs:410:5:411:20 | let ... = ... | match |
-| main.rs:409:17:409:17 | 4 | main.rs:409:9:409:13 | z |  |
+| main.rs:409:9:409:13 | mut z | main.rs:410:5:411:20 | let ... = ... | match |
+| main.rs:409:17:409:17 | 4 | main.rs:409:9:409:13 | mut z |  |
 | main.rs:410:5:411:20 | let ... = ... | main.rs:411:19:411:19 | x |  |
 | main.rs:410:9:410:9 | w | main.rs:412:5:415:6 | ExprStmt | match |
 | main.rs:411:9:411:19 | &mut ... | main.rs:410:9:410:9 | w |  |
@@ -931,8 +931,8 @@ edges
 | main.rs:421:1:427:1 | exit fn alias (normal) | main.rs:421:1:427:1 | exit fn alias |  |
 | main.rs:421:12:427:1 | { ... } | main.rs:421:1:427:1 | exit fn alias (normal) |  |
 | main.rs:422:5:422:18 | let ... = 1 | main.rs:422:17:422:17 | 1 |  |
-| main.rs:422:9:422:13 | x | main.rs:423:5:424:15 | let ... = ... | match |
-| main.rs:422:17:422:17 | 1 | main.rs:422:9:422:13 | x |  |
+| main.rs:422:9:422:13 | mut x | main.rs:423:5:424:15 | let ... = ... | match |
+| main.rs:422:17:422:17 | 1 | main.rs:422:9:422:13 | mut x |  |
 | main.rs:423:5:424:15 | let ... = ... | main.rs:424:14:424:14 | x |  |
 | main.rs:423:9:423:9 | y | main.rs:425:5:425:11 | ExprStmt | match |
 | main.rs:424:9:424:14 | &mut x | main.rs:423:9:423:9 | y |  |
@@ -973,8 +973,8 @@ edges
 | main.rs:439:1:463:1 | exit fn capture_mut (normal) | main.rs:439:1:463:1 | exit fn capture_mut |  |
 | main.rs:439:18:463:1 | { ... } | main.rs:439:1:463:1 | exit fn capture_mut (normal) |  |
 | main.rs:440:5:440:18 | let ... = 1 | main.rs:440:17:440:17 | 1 |  |
-| main.rs:440:9:440:13 | x | main.rs:442:5:444:6 | let ... = ... | match |
-| main.rs:440:17:440:17 | 1 | main.rs:440:9:440:13 | x |  |
+| main.rs:440:9:440:13 | mut x | main.rs:442:5:444:6 | let ... = ... | match |
+| main.rs:440:17:440:17 | 1 | main.rs:440:9:440:13 | mut x |  |
 | main.rs:442:5:444:6 | let ... = ... | main.rs:442:20:444:5 | \|...\| ... |  |
 | main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:15 | ExprStmt | match |
 | main.rs:442:20:444:5 | \|...\| ... | main.rs:442:9:442:16 | closure1 |  |
@@ -993,11 +993,11 @@ edges
 | main.rs:446:5:446:17 | ExprStmt | main.rs:446:5:446:13 | print_i64 |  |
 | main.rs:446:15:446:15 | x | main.rs:446:5:446:16 | print_i64(...) |  |
 | main.rs:448:5:448:18 | let ... = 2 | main.rs:448:17:448:17 | 2 |  |
-| main.rs:448:9:448:13 | y | main.rs:450:5:452:6 | let ... = ... | match |
-| main.rs:448:17:448:17 | 2 | main.rs:448:9:448:13 | y |  |
+| main.rs:448:9:448:13 | mut y | main.rs:450:5:452:6 | let ... = ... | match |
+| main.rs:448:17:448:17 | 2 | main.rs:448:9:448:13 | mut y |  |
 | main.rs:450:5:452:6 | let ... = ... | main.rs:450:24:452:5 | \|...\| ... |  |
-| main.rs:450:9:450:20 | closure2 | main.rs:453:5:453:15 | ExprStmt | match |
-| main.rs:450:24:452:5 | \|...\| ... | main.rs:450:9:450:20 | closure2 |  |
+| main.rs:450:9:450:20 | mut closure2 | main.rs:453:5:453:15 | ExprStmt | match |
+| main.rs:450:24:452:5 | \|...\| ... | main.rs:450:9:450:20 | mut closure2 |  |
 | main.rs:450:24:452:5 | enter \|...\| ... | main.rs:451:9:451:14 | ExprStmt |  |
 | main.rs:450:24:452:5 | exit \|...\| ... (normal) | main.rs:450:24:452:5 | exit \|...\| ... |  |
 | main.rs:450:27:452:5 | { ... } | main.rs:450:24:452:5 | exit \|...\| ... (normal) |  |
@@ -1013,11 +1013,11 @@ edges
 | main.rs:454:5:454:17 | ExprStmt | main.rs:454:5:454:13 | print_i64 |  |
 | main.rs:454:15:454:15 | y | main.rs:454:5:454:16 | print_i64(...) |  |
 | main.rs:456:5:456:18 | let ... = 2 | main.rs:456:17:456:17 | 2 |  |
-| main.rs:456:9:456:13 | z | main.rs:458:5:460:6 | let ... = ... | match |
-| main.rs:456:17:456:17 | 2 | main.rs:456:9:456:13 | z |  |
+| main.rs:456:9:456:13 | mut z | main.rs:458:5:460:6 | let ... = ... | match |
+| main.rs:456:17:456:17 | 2 | main.rs:456:9:456:13 | mut z |  |
 | main.rs:458:5:460:6 | let ... = ... | main.rs:458:24:460:5 | \|...\| ... |  |
-| main.rs:458:9:458:20 | closure3 | main.rs:461:5:461:15 | ExprStmt | match |
-| main.rs:458:24:460:5 | \|...\| ... | main.rs:458:9:458:20 | closure3 |  |
+| main.rs:458:9:458:20 | mut closure3 | main.rs:461:5:461:15 | ExprStmt | match |
+| main.rs:458:24:460:5 | \|...\| ... | main.rs:458:9:458:20 | mut closure3 |  |
 | main.rs:458:24:460:5 | enter \|...\| ... | main.rs:459:9:459:24 | ExprStmt |  |
 | main.rs:458:24:460:5 | exit \|...\| ... (normal) | main.rs:458:24:460:5 | exit \|...\| ... |  |
 | main.rs:458:27:460:5 | { ... } | main.rs:458:24:460:5 | exit \|...\| ... (normal) |  |
@@ -1036,8 +1036,8 @@ edges
 | main.rs:465:1:473:1 | exit fn async_block_capture (normal) | main.rs:465:1:473:1 | exit fn async_block_capture |  |
 | main.rs:465:32:473:1 | { ... } | main.rs:465:1:473:1 | exit fn async_block_capture (normal) |  |
 | main.rs:466:5:466:23 | let ... = 0 | main.rs:466:22:466:22 | 0 |  |
-| main.rs:466:9:466:13 | i | main.rs:467:5:469:6 | let ... = ... | match |
-| main.rs:466:22:466:22 | 0 | main.rs:466:9:466:13 | i |  |
+| main.rs:466:9:466:13 | mut i | main.rs:467:5:469:6 | let ... = ... | match |
+| main.rs:466:22:466:22 | 0 | main.rs:466:9:466:13 | mut i |  |
 | main.rs:467:5:469:6 | let ... = ... | main.rs:467:17:469:5 | { ... } |  |
 | main.rs:467:9:467:13 | block | main.rs:471:5:471:16 | ExprStmt | match |
 | main.rs:467:17:469:5 | enter { ... } | main.rs:468:9:468:14 | ExprStmt |  |
@@ -1060,8 +1060,8 @@ edges
 | main.rs:475:8:475:15 | ...: bool | main.rs:476:5:476:18 | let ... = 1 |  |
 | main.rs:475:18:489:1 | { ... } | main.rs:475:1:489:1 | exit fn phi (normal) |  |
 | main.rs:476:5:476:18 | let ... = 1 | main.rs:476:17:476:17 | 1 |  |
-| main.rs:476:9:476:13 | x | main.rs:477:5:477:17 | ExprStmt | match |
-| main.rs:476:17:476:17 | 1 | main.rs:476:9:476:13 | x |  |
+| main.rs:476:9:476:13 | mut x | main.rs:477:5:477:17 | ExprStmt | match |
+| main.rs:476:17:476:17 | 1 | main.rs:476:9:476:13 | mut x |  |
 | main.rs:477:5:477:13 | print_i64 | main.rs:477:15:477:15 | x |  |
 | main.rs:477:5:477:16 | print_i64(...) | main.rs:478:5:478:21 | ExprStmt |  |
 | main.rs:477:5:477:17 | ExprStmt | main.rs:477:5:477:13 | print_i64 |  |
@@ -1167,8 +1167,8 @@ edges
 | main.rs:520:23:520:26 | self | main.rs:520:18:520:26 | SelfParam |  |
 | main.rs:520:29:527:5 | { ... } | main.rs:520:5:527:5 | exit fn my_method (normal) |  |
 | main.rs:521:9:524:10 | let ... = ... | main.rs:521:21:524:9 | \|...\| ... |  |
-| main.rs:521:13:521:17 | f | main.rs:525:9:525:13 | ExprStmt | match |
-| main.rs:521:21:524:9 | \|...\| ... | main.rs:521:13:521:17 | f |  |
+| main.rs:521:13:521:17 | mut f | main.rs:525:9:525:13 | ExprStmt | match |
+| main.rs:521:21:524:9 | \|...\| ... | main.rs:521:13:521:17 | mut f |  |
 | main.rs:521:21:524:9 | enter \|...\| ... | main.rs:521:22:521:22 | n |  |
 | main.rs:521:21:524:9 | exit \|...\| ... (normal) | main.rs:521:21:524:9 | exit \|...\| ... |  |
 | main.rs:521:22:521:22 | ... | main.rs:523:13:523:26 | ExprStmt |  |
@@ -1191,8 +1191,8 @@ edges
 | main.rs:530:1:537:1 | exit fn structs (normal) | main.rs:530:1:537:1 | exit fn structs |  |
 | main.rs:530:14:537:1 | { ... } | main.rs:530:1:537:1 | exit fn structs (normal) |  |
 | main.rs:531:5:531:36 | let ... = ... | main.rs:531:33:531:33 | 1 |  |
-| main.rs:531:9:531:13 | a | main.rs:532:5:532:26 | ExprStmt | match |
-| main.rs:531:17:531:35 | MyStruct {...} | main.rs:531:9:531:13 | a |  |
+| main.rs:531:9:531:13 | mut a | main.rs:532:5:532:26 | ExprStmt | match |
+| main.rs:531:17:531:35 | MyStruct {...} | main.rs:531:9:531:13 | mut a |  |
 | main.rs:531:33:531:33 | 1 | main.rs:531:17:531:35 | MyStruct {...} |  |
 | main.rs:532:5:532:13 | print_i64 | main.rs:532:15:532:15 | a |  |
 | main.rs:532:5:532:25 | print_i64(...) | main.rs:533:5:533:14 | ExprStmt |  |
@@ -1223,8 +1223,8 @@ edges
 | main.rs:539:1:546:1 | exit fn arrays (normal) | main.rs:539:1:546:1 | exit fn arrays |  |
 | main.rs:539:13:546:1 | { ... } | main.rs:539:1:546:1 | exit fn arrays (normal) |  |
 | main.rs:540:5:540:26 | let ... = ... | main.rs:540:18:540:18 | 1 |  |
-| main.rs:540:9:540:13 | a | main.rs:541:5:541:20 | ExprStmt | match |
-| main.rs:540:17:540:25 | [...] | main.rs:540:9:540:13 | a |  |
+| main.rs:540:9:540:13 | mut a | main.rs:541:5:541:20 | ExprStmt | match |
+| main.rs:540:17:540:25 | [...] | main.rs:540:9:540:13 | mut a |  |
 | main.rs:540:18:540:18 | 1 | main.rs:540:21:540:21 | 2 |  |
 | main.rs:540:21:540:21 | 2 | main.rs:540:24:540:24 | 3 |  |
 | main.rs:540:24:540:24 | 3 | main.rs:540:17:540:25 | [...] |  |
@@ -1297,8 +1297,8 @@ edges
 | main.rs:567:1:572:1 | exit fn ref_methodcall_receiver (normal) | main.rs:567:1:572:1 | exit fn ref_methodcall_receiver |  |
 | main.rs:567:30:572:1 | { ... } | main.rs:567:1:572:1 | exit fn ref_methodcall_receiver (normal) |  |
 | main.rs:568:3:568:34 | let ... = ... | main.rs:568:31:568:31 | 1 |  |
-| main.rs:568:7:568:11 | a | main.rs:569:3:569:10 | ExprStmt | match |
-| main.rs:568:15:568:33 | MyStruct {...} | main.rs:568:7:568:11 | a |  |
+| main.rs:568:7:568:11 | mut a | main.rs:569:3:569:10 | ExprStmt | match |
+| main.rs:568:15:568:33 | MyStruct {...} | main.rs:568:7:568:11 | mut a |  |
 | main.rs:568:31:568:31 | 1 | main.rs:568:15:568:33 | MyStruct {...} |  |
 | main.rs:569:3:569:3 | a | main.rs:569:3:569:9 | a.bar(...) |  |
 | main.rs:569:3:569:9 | a.bar(...) | main.rs:571:3:571:19 | ExprStmt |  |

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -12,9 +12,9 @@ definition
 | main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i |
 | main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i |
 | main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 |
-| main.rs:21:9:21:14 | x2 | main.rs:21:13:21:14 | x2 |
+| main.rs:21:9:21:14 | mut x2 | main.rs:21:13:21:14 | x2 |
 | main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 |
-| main.rs:28:9:28:13 | x | main.rs:28:13:28:13 | x |
+| main.rs:28:9:28:13 | mut x | main.rs:28:13:28:13 | x |
 | main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x |
 | main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 |
 | main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 |
@@ -28,10 +28,10 @@ definition
 | main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 |
 | main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 |
 | main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 |
-| main.rs:87:17:87:22 | s2 | main.rs:87:21:87:22 | s2 |
+| main.rs:87:17:87:22 | ref s2 | main.rs:87:21:87:22 | s2 |
 | main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 |
 | main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 |
-| main.rs:104:20:104:25 | s2 | main.rs:104:24:104:25 | s2 |
+| main.rs:104:20:104:25 | ref s2 | main.rs:104:24:104:25 | s2 |
 | main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 |
 | main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 |
 | main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 |
@@ -44,7 +44,7 @@ definition
 | main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 |
 | main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 |
 | main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg |
-| main.rs:173:17:173:35 | [match(true)] id_variable | main.rs:173:17:173:27 | id_variable |
+| main.rs:173:17:173:35 | [match(true)] id_variable @ ... | main.rs:173:17:173:27 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either |
 | main.rs:191:9:191:44 | [match(true)] phi | main.rs:191:9:191:44 | a3 |
@@ -70,7 +70,7 @@ definition
 | main.rs:221:22:221:23 | a7 | main.rs:221:9:221:44 | a7 |
 | main.rs:221:42:221:43 | a7 | main.rs:221:9:221:44 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either |
-| main.rs:232:9:233:52 | [match(true)] e | main.rs:232:13:232:13 | e |
+| main.rs:232:9:233:52 | [match(true)] ref e @ ... | main.rs:232:13:232:13 | e |
 | main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 |
 | main.rs:233:27:233:29 | a11 | main.rs:233:14:233:51 | a11 |
 | main.rs:233:48:233:50 | a11 | main.rs:233:14:233:51 | a11 |
@@ -88,9 +88,9 @@ definition
 | main.rs:272:6:272:41 | [match(true)] phi | main.rs:272:6:272:41 | a9 |
 | main.rs:272:19:272:20 | a9 | main.rs:272:6:272:41 | a9 |
 | main.rs:272:39:272:40 | a9 | main.rs:272:6:272:41 | a9 |
-| main.rs:279:9:279:15 | a10 | main.rs:279:13:279:15 | a10 |
-| main.rs:280:9:280:14 | b4 | main.rs:280:13:280:14 | b4 |
-| main.rs:281:9:281:14 | c2 | main.rs:281:13:281:14 | c2 |
+| main.rs:279:9:279:15 | mut a10 | main.rs:279:13:279:15 | a10 |
+| main.rs:280:9:280:14 | mut b4 | main.rs:280:13:280:14 | b4 |
+| main.rs:281:9:281:14 | mut c2 | main.rs:281:13:281:14 | c2 |
 | main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 |
 | main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 |
 | main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 |
@@ -120,20 +120,20 @@ definition
 | main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x |
 | main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap |
 | main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x |
-| main.rs:440:9:440:13 | x | main.rs:440:13:440:13 | x |
+| main.rs:440:9:440:13 | mut x | main.rs:440:13:440:13 | x |
 | main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 |
 | main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x |
-| main.rs:448:9:448:13 | y | main.rs:448:13:448:13 | y |
-| main.rs:450:9:450:20 | closure2 | main.rs:450:13:450:20 | closure2 |
+| main.rs:448:9:448:13 | mut y | main.rs:448:13:448:13 | y |
+| main.rs:450:9:450:20 | mut closure2 | main.rs:450:13:450:20 | closure2 |
 | main.rs:451:9:451:9 | y | main.rs:448:13:448:13 | y |
 | main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y |
-| main.rs:458:9:458:20 | closure3 | main.rs:458:13:458:20 | closure3 |
-| main.rs:466:9:466:13 | i | main.rs:466:13:466:13 | i |
+| main.rs:458:9:458:20 | mut closure3 | main.rs:458:13:458:20 | closure3 |
+| main.rs:466:9:466:13 | mut i | main.rs:466:13:466:13 | i |
 | main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block |
 | main.rs:468:9:468:9 | i | main.rs:466:13:466:13 | i |
 | main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i |
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b |
-| main.rs:476:9:476:13 | x | main.rs:476:13:476:13 | x |
+| main.rs:476:9:476:13 | mut x | main.rs:476:13:476:13 | x |
 | main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x |
@@ -143,10 +143,10 @@ definition
 | main.rs:512:15:512:23 | SelfParam | main.rs:512:20:512:23 | self |
 | main.rs:516:11:516:14 | SelfParam | main.rs:516:11:516:14 | self |
 | main.rs:520:18:520:26 | SelfParam | main.rs:520:23:520:26 | self |
-| main.rs:521:13:521:17 | f | main.rs:521:17:521:17 | f |
+| main.rs:521:13:521:17 | mut f | main.rs:521:17:521:17 | f |
 | main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self |
 | main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a |
 | main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x |
 | main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z |
@@ -160,9 +160,9 @@ read
 | main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i | main.rs:8:20:8:20 | i |
 | main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i | main.rs:12:16:12:16 | i |
 | main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 | main.rs:17:15:17:16 | x1 |
-| main.rs:21:9:21:14 | x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
+| main.rs:21:9:21:14 | mut x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
 | main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 | main.rs:24:15:24:16 | x2 |
-| main.rs:28:9:28:13 | x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
+| main.rs:28:9:28:13 | mut x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
 | main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x | main.rs:31:20:31:20 | x |
 | main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:36:15:36:16 | x3 |
 | main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:38:9:38:10 | x3 |
@@ -178,10 +178,10 @@ read
 | main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 | main.rs:80:15:80:16 | a2 |
 | main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 | main.rs:81:15:81:16 | b2 |
 | main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 | main.rs:88:11:88:12 | s1 |
-| main.rs:87:17:87:22 | s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
+| main.rs:87:17:87:22 | ref s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
 | main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 | main.rs:98:15:98:16 | x5 |
 | main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:104:20:104:25 | s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
+| main.rs:104:20:104:25 | ref s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
 | main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 | main.rs:114:11:114:12 | x6 |
 | main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 | main.rs:124:15:124:16 | y1 |
 | main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 | main.rs:119:23:119:24 | y1 |
@@ -195,7 +195,7 @@ read
 | main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 | main.rs:157:11:157:12 | p2 |
 | main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 | main.rs:160:24:160:25 | x7 |
 | main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg | main.rs:171:11:171:13 | msg |
-| main.rs:173:17:173:35 | [match(true)] id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
+| main.rs:173:17:173:35 | [match(true)] id_variable @ ... | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
 | main.rs:191:9:191:44 | [match(true)] phi | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
@@ -209,7 +209,7 @@ read
 | main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
 | main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:223:26:223:27 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
-| main.rs:232:9:233:52 | [match(true)] e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
+| main.rs:232:9:233:52 | [match(true)] ref e @ ... | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
 | main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
 | main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
 | main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
@@ -218,9 +218,9 @@ read
 | main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
 | main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
 | main.rs:272:6:272:41 | [match(true)] phi | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
-| main.rs:279:9:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
-| main.rs:280:9:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
-| main.rs:281:9:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
+| main.rs:279:9:279:15 | mut a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
+| main.rs:280:9:280:14 | mut b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
+| main.rs:281:9:281:14 | mut c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
 | main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 |
 | main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:298:15:298:16 | c2 |
 | main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 |
@@ -263,17 +263,17 @@ read
 | main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x | main.rs:436:15:436:15 | x |
 | main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap | main.rs:435:5:435:7 | cap |
 | main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x | main.rs:433:19:433:19 | x |
-| main.rs:440:9:440:13 | x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
+| main.rs:440:9:440:13 | mut x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
 | main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:12 | closure1 |
 | main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x | main.rs:443:19:443:19 | x |
-| main.rs:450:9:450:20 | closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
+| main.rs:450:9:450:20 | mut closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
 | main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y | main.rs:454:15:454:15 | y |
-| main.rs:458:9:458:20 | closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
+| main.rs:458:9:458:20 | mut closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
 | main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block | main.rs:471:5:471:9 | block |
 | main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i | main.rs:472:15:472:15 | i |
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
-| main.rs:476:9:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
-| main.rs:476:9:476:13 | x | main.rs:476:13:476:13 | x | main.rs:478:15:478:15 | x |
+| main.rs:476:9:476:13 | mut x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
+| main.rs:476:9:476:13 | mut x | main.rs:476:13:476:13 | x | main.rs:478:15:478:15 | x |
 | main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:482:19:482:19 | x |
@@ -287,13 +287,13 @@ read
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:502:19:502:19 | x |
 | main.rs:512:15:512:23 | SelfParam | main.rs:512:20:512:23 | self | main.rs:513:16:513:19 | self |
 | main.rs:516:11:516:14 | SelfParam | main.rs:516:11:516:14 | self | main.rs:517:9:517:12 | self |
-| main.rs:521:13:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
-| main.rs:521:13:521:17 | f | main.rs:521:17:521:17 | f | main.rs:526:9:526:9 | f |
+| main.rs:521:13:521:17 | mut f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
+| main.rs:521:13:521:17 | mut f | main.rs:521:17:521:17 | f | main.rs:526:9:526:9 | f |
 | main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self | main.rs:523:13:523:16 | self |
 | main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n | main.rs:523:25:523:25 | n |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:543:15:543:15 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:543:15:543:15 | a |
 | main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a | main.rs:545:15:545:15 | a |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:551:15:551:15 | x |
@@ -308,9 +308,9 @@ firstRead
 | main.rs:7:14:7:14 | i | main.rs:7:14:7:14 | i | main.rs:8:20:8:20 | i |
 | main.rs:11:18:11:18 | i | main.rs:11:18:11:18 | i | main.rs:12:16:12:16 | i |
 | main.rs:16:9:16:10 | x1 | main.rs:16:9:16:10 | x1 | main.rs:17:15:17:16 | x1 |
-| main.rs:21:9:21:14 | x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
+| main.rs:21:9:21:14 | mut x2 | main.rs:21:13:21:14 | x2 | main.rs:22:15:22:16 | x2 |
 | main.rs:23:5:23:6 | x2 | main.rs:21:13:21:14 | x2 | main.rs:24:15:24:16 | x2 |
-| main.rs:28:9:28:13 | x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
+| main.rs:28:9:28:13 | mut x | main.rs:28:13:28:13 | x | main.rs:29:20:29:20 | x |
 | main.rs:30:5:30:5 | x | main.rs:28:13:28:13 | x | main.rs:31:20:31:20 | x |
 | main.rs:35:9:35:10 | x3 | main.rs:35:9:35:10 | x3 | main.rs:36:15:36:16 | x3 |
 | main.rs:37:9:37:10 | x3 | main.rs:37:9:37:10 | x3 | main.rs:39:15:39:16 | x3 |
@@ -324,10 +324,10 @@ firstRead
 | main.rs:77:12:77:13 | a2 | main.rs:77:12:77:13 | a2 | main.rs:80:15:80:16 | a2 |
 | main.rs:78:12:78:13 | b2 | main.rs:78:12:78:13 | b2 | main.rs:81:15:81:16 | b2 |
 | main.rs:85:9:85:10 | s1 | main.rs:85:9:85:10 | s1 | main.rs:88:11:88:12 | s1 |
-| main.rs:87:17:87:22 | s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
+| main.rs:87:17:87:22 | ref s2 | main.rs:87:21:87:22 | s2 | main.rs:89:19:89:20 | s2 |
 | main.rs:94:14:94:15 | x5 | main.rs:94:14:94:15 | x5 | main.rs:98:15:98:16 | x5 |
 | main.rs:102:9:102:10 | s1 | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
-| main.rs:104:20:104:25 | s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
+| main.rs:104:20:104:25 | ref s2 | main.rs:104:24:104:25 | s2 | main.rs:106:19:106:20 | s2 |
 | main.rs:111:9:111:10 | x6 | main.rs:111:9:111:10 | x6 | main.rs:114:11:114:12 | x6 |
 | main.rs:112:9:112:10 | y1 | main.rs:112:9:112:10 | y1 | main.rs:124:15:124:16 | y1 |
 | main.rs:116:14:116:15 | y1 | main.rs:116:14:116:15 | y1 | main.rs:119:23:119:24 | y1 |
@@ -340,7 +340,7 @@ firstRead
 | main.rs:155:9:155:10 | p2 | main.rs:155:9:155:10 | p2 | main.rs:157:11:157:12 | p2 |
 | main.rs:159:16:159:17 | x7 | main.rs:159:16:159:17 | x7 | main.rs:160:24:160:25 | x7 |
 | main.rs:169:9:169:11 | msg | main.rs:169:9:169:11 | msg | main.rs:171:11:171:13 | msg |
-| main.rs:173:17:173:35 | [match(true)] id_variable | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
+| main.rs:173:17:173:35 | [match(true)] id_variable @ ... | main.rs:173:17:173:27 | id_variable | main.rs:174:24:174:34 | id_variable |
 | main.rs:178:26:178:27 | id | main.rs:178:26:178:27 | id | main.rs:179:23:179:24 | id |
 | main.rs:189:9:189:14 | either | main.rs:189:9:189:14 | either | main.rs:190:11:190:16 | either |
 | main.rs:191:9:191:44 | [match(true)] phi | main.rs:191:9:191:44 | a3 | main.rs:192:26:192:27 | a3 |
@@ -351,7 +351,7 @@ firstRead
 | main.rs:219:9:219:14 | either | main.rs:219:9:219:14 | either | main.rs:220:11:220:16 | either |
 | main.rs:221:9:221:44 | [match(true)] phi | main.rs:221:9:221:44 | a7 | main.rs:222:16:222:17 | a7 |
 | main.rs:229:9:229:14 | either | main.rs:229:9:229:14 | either | main.rs:231:11:231:16 | either |
-| main.rs:232:9:233:52 | [match(true)] e | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
+| main.rs:232:9:233:52 | [match(true)] ref e @ ... | main.rs:232:13:232:13 | e | main.rs:237:15:237:15 | e |
 | main.rs:233:14:233:51 | [match(true)] phi | main.rs:233:14:233:51 | a11 | main.rs:235:23:235:25 | a11 |
 | main.rs:236:33:236:35 | a12 | main.rs:236:33:236:35 | a12 | main.rs:238:28:238:30 | a12 |
 | main.rs:253:9:253:10 | fv | main.rs:253:9:253:10 | fv | main.rs:254:11:254:12 | fv |
@@ -360,9 +360,9 @@ firstRead
 | main.rs:263:9:263:10 | b3 | main.rs:263:9:263:10 | b3 | main.rs:267:15:267:16 | b3 |
 | main.rs:264:9:264:10 | c1 | main.rs:264:9:264:10 | c1 | main.rs:268:15:268:16 | c1 |
 | main.rs:272:6:272:41 | [match(true)] phi | main.rs:272:6:272:41 | a9 | main.rs:274:15:274:16 | a9 |
-| main.rs:279:9:279:15 | a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
-| main.rs:280:9:280:14 | b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
-| main.rs:281:9:281:14 | c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
+| main.rs:279:9:279:15 | mut a10 | main.rs:279:13:279:15 | a10 | main.rs:283:15:283:17 | a10 |
+| main.rs:280:9:280:14 | mut b4 | main.rs:280:13:280:14 | b4 | main.rs:284:15:284:16 | b4 |
+| main.rs:281:9:281:14 | mut c2 | main.rs:281:13:281:14 | c2 | main.rs:285:15:285:16 | c2 |
 | main.rs:288:9:288:10 | c2 | main.rs:281:13:281:14 | c2 | main.rs:294:9:294:10 | c2 |
 | main.rs:289:9:289:10 | b4 | main.rs:280:13:280:14 | b4 | main.rs:293:9:293:10 | b4 |
 | main.rs:290:9:290:11 | a10 | main.rs:279:13:279:15 | a10 | main.rs:292:9:292:11 | a10 |
@@ -392,16 +392,16 @@ firstRead
 | main.rs:430:9:430:9 | x | main.rs:430:9:430:9 | x | main.rs:436:15:436:15 | x |
 | main.rs:432:9:432:11 | cap | main.rs:432:9:432:11 | cap | main.rs:435:5:435:7 | cap |
 | main.rs:432:15:434:5 | <captured entry> x | main.rs:430:9:430:9 | x | main.rs:433:19:433:19 | x |
-| main.rs:440:9:440:13 | x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
+| main.rs:440:9:440:13 | mut x | main.rs:440:13:440:13 | x | main.rs:446:15:446:15 | x |
 | main.rs:442:9:442:16 | closure1 | main.rs:442:9:442:16 | closure1 | main.rs:445:5:445:12 | closure1 |
 | main.rs:442:20:444:5 | <captured entry> x | main.rs:440:13:440:13 | x | main.rs:443:19:443:19 | x |
-| main.rs:450:9:450:20 | closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
+| main.rs:450:9:450:20 | mut closure2 | main.rs:450:13:450:20 | closure2 | main.rs:453:5:453:12 | closure2 |
 | main.rs:453:5:453:14 | <captured exit> y | main.rs:448:13:448:13 | y | main.rs:454:15:454:15 | y |
-| main.rs:458:9:458:20 | closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
+| main.rs:458:9:458:20 | mut closure3 | main.rs:458:13:458:20 | closure3 | main.rs:461:5:461:12 | closure3 |
 | main.rs:467:9:467:13 | block | main.rs:467:9:467:13 | block | main.rs:471:5:471:9 | block |
 | main.rs:471:5:471:15 | <captured exit> i | main.rs:466:13:466:13 | i | main.rs:472:15:472:15 | i |
 | main.rs:475:8:475:8 | b | main.rs:475:8:475:8 | b | main.rs:479:8:479:8 | b |
-| main.rs:476:9:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
+| main.rs:476:9:476:13 | mut x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x |
 | main.rs:479:5:487:5 | phi | main.rs:476:13:476:13 | x | main.rs:488:15:488:15 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x |
@@ -411,10 +411,10 @@ firstRead
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x |
 | main.rs:512:15:512:23 | SelfParam | main.rs:512:20:512:23 | self | main.rs:513:16:513:19 | self |
 | main.rs:516:11:516:14 | SelfParam | main.rs:516:11:516:14 | self | main.rs:517:9:517:12 | self |
-| main.rs:521:13:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
+| main.rs:521:13:521:17 | mut f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f |
 | main.rs:521:21:524:9 | <captured entry> self | main.rs:520:23:520:26 | self | main.rs:523:13:523:16 | self |
 | main.rs:521:22:521:22 | n | main.rs:521:22:521:22 | n | main.rs:523:25:523:25 | n |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a |
 | main.rs:544:5:544:5 | a | main.rs:540:13:540:13 | a | main.rs:545:15:545:15 | a |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x |
 | main.rs:553:9:553:9 | z | main.rs:553:9:553:9 | z | main.rs:554:20:554:20 | z |
@@ -444,16 +444,16 @@ adjacentReads
 | main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:395:10:395:10 | x | main.rs:396:10:396:10 | x |
 | main.rs:393:22:393:22 | x | main.rs:393:22:393:22 | x | main.rs:396:10:396:10 | x | main.rs:398:9:398:9 | x |
 | main.rs:410:9:410:9 | w | main.rs:410:9:410:9 | w | main.rs:414:9:414:9 | w | main.rs:416:7:416:7 | w |
-| main.rs:476:9:476:13 | x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x | main.rs:478:15:478:15 | x |
+| main.rs:476:9:476:13 | mut x | main.rs:476:13:476:13 | x | main.rs:477:15:477:15 | x | main.rs:478:15:478:15 | x |
 | main.rs:480:9:480:9 | x | main.rs:476:13:476:13 | x | main.rs:481:19:481:19 | x | main.rs:482:19:482:19 | x |
 | main.rs:484:9:484:9 | x | main.rs:476:13:476:13 | x | main.rs:485:19:485:19 | x | main.rs:486:19:486:19 | x |
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x | main.rs:500:19:500:19 | x |
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:494:19:494:19 | x | main.rs:502:19:502:19 | x |
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x | main.rs:500:19:500:19 | x |
 | main.rs:492:9:492:9 | x | main.rs:492:9:492:9 | x | main.rs:496:19:496:19 | x | main.rs:502:19:502:19 | x |
-| main.rs:521:13:521:17 | f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f | main.rs:526:9:526:9 | f |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a | main.rs:542:5:542:5 | a |
-| main.rs:540:9:540:13 | a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a | main.rs:543:15:543:15 | a |
+| main.rs:521:13:521:17 | mut f | main.rs:521:17:521:17 | f | main.rs:525:9:525:9 | f | main.rs:526:9:526:9 | f |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:541:15:541:15 | a | main.rs:542:5:542:5 | a |
+| main.rs:540:9:540:13 | mut a | main.rs:540:13:540:13 | a | main.rs:542:5:542:5 | a | main.rs:543:15:543:15 | a |
 | main.rs:549:9:549:9 | x | main.rs:549:9:549:9 | x | main.rs:550:20:550:20 | x | main.rs:551:15:551:15 | x |
 phi
 | main.rs:191:9:191:44 | [match(true)] phi | main.rs:191:9:191:44 | a3 | main.rs:191:22:191:23 | a3 |
@@ -525,9 +525,9 @@ ultimateDef
 | main.rs:479:5:487:5 | phi | main.rs:484:9:484:9 | x |
 assigns
 | main.rs:16:9:16:10 | x1 | main.rs:16:14:16:16 | "a" |
-| main.rs:21:9:21:14 | x2 | main.rs:21:18:21:18 | 4 |
+| main.rs:21:9:21:14 | mut x2 | main.rs:21:18:21:18 | 4 |
 | main.rs:23:5:23:6 | x2 | main.rs:23:10:23:10 | 5 |
-| main.rs:28:9:28:13 | x | main.rs:28:17:28:17 | 1 |
+| main.rs:28:9:28:13 | mut x | main.rs:28:17:28:17 | 1 |
 | main.rs:30:5:30:5 | x | main.rs:30:9:30:9 | 2 |
 | main.rs:35:9:35:10 | x3 | main.rs:35:14:35:14 | 1 |
 | main.rs:37:9:37:10 | x3 | main.rs:38:9:38:14 | ... + ... |
@@ -559,21 +559,21 @@ assigns
 | main.rs:423:9:423:9 | y | main.rs:424:9:424:14 | &mut x |
 | main.rs:430:9:430:9 | x | main.rs:430:13:430:15 | 100 |
 | main.rs:432:9:432:11 | cap | main.rs:432:15:434:5 | \|...\| ... |
-| main.rs:440:9:440:13 | x | main.rs:440:17:440:17 | 1 |
+| main.rs:440:9:440:13 | mut x | main.rs:440:17:440:17 | 1 |
 | main.rs:442:9:442:16 | closure1 | main.rs:442:20:444:5 | \|...\| ... |
-| main.rs:448:9:448:13 | y | main.rs:448:17:448:17 | 2 |
-| main.rs:450:9:450:20 | closure2 | main.rs:450:24:452:5 | \|...\| ... |
+| main.rs:448:9:448:13 | mut y | main.rs:448:17:448:17 | 2 |
+| main.rs:450:9:450:20 | mut closure2 | main.rs:450:24:452:5 | \|...\| ... |
 | main.rs:451:9:451:9 | y | main.rs:451:13:451:13 | 3 |
-| main.rs:458:9:458:20 | closure3 | main.rs:458:24:460:5 | \|...\| ... |
-| main.rs:466:9:466:13 | i | main.rs:466:22:466:22 | 0 |
+| main.rs:458:9:458:20 | mut closure3 | main.rs:458:24:460:5 | \|...\| ... |
+| main.rs:466:9:466:13 | mut i | main.rs:466:22:466:22 | 0 |
 | main.rs:467:9:467:13 | block | main.rs:467:17:469:5 | { ... } |
 | main.rs:468:9:468:9 | i | main.rs:468:13:468:13 | 1 |
-| main.rs:476:9:476:13 | x | main.rs:476:17:476:17 | 1 |
+| main.rs:476:9:476:13 | mut x | main.rs:476:17:476:17 | 1 |
 | main.rs:480:9:480:9 | x | main.rs:480:13:480:13 | 2 |
 | main.rs:484:9:484:9 | x | main.rs:484:13:484:13 | 3 |
 | main.rs:492:9:492:9 | x | main.rs:492:13:492:13 | 1 |
-| main.rs:521:13:521:17 | f | main.rs:521:21:524:9 | \|...\| ... |
-| main.rs:540:9:540:13 | a | main.rs:540:17:540:25 | [...] |
+| main.rs:521:13:521:17 | mut f | main.rs:521:21:524:9 | \|...\| ... |
+| main.rs:540:9:540:13 | mut a | main.rs:540:17:540:25 | [...] |
 | main.rs:544:5:544:5 | a | main.rs:544:9:544:17 | [...] |
 | main.rs:549:9:549:9 | x | main.rs:549:13:549:14 | 16 |
 | main.rs:553:9:553:9 | z | main.rs:553:13:553:14 | 17 |

--- a/rust/ql/test/query-tests/unusedentities/UnusedValue.expected
+++ b/rust/ql/test/query-tests/unusedentities/UnusedValue.expected
@@ -18,4 +18,4 @@
 | main.rs:519:9:519:20 | var_in_macro | Variable $@ is assigned a value that is never used. | main.rs:519:9:519:20 | var_in_macro | var_in_macro |
 | more.rs:44:9:44:14 | a_ptr4 | Variable $@ is assigned a value that is never used. | more.rs:44:9:44:14 | a_ptr4 | a_ptr4 |
 | more.rs:59:9:59:13 | d_ptr | Variable $@ is assigned a value that is never used. | more.rs:59:9:59:13 | d_ptr | d_ptr |
-| more.rs:65:9:65:17 | f_ptr | Variable $@ is assigned a value that is never used. | more.rs:65:13:65:17 | f_ptr | f_ptr |
+| more.rs:65:9:65:17 | mut f_ptr | Variable $@ is assigned a value that is never used. | more.rs:65:13:65:17 | f_ptr | f_ptr |


### PR DESCRIPTION
In particular, this makes it possible to distinguish an identity pattern from the name inside it in the string representation.