### PR TITLE
Rust: Re-categorize tokio-postgres sources as remote.

### DIFF
--- a/rust/ql/lib/codeql/rust/frameworks/tokio-postgres.model.yml
+++ b/rust/ql/lib/codeql/rust/frameworks/tokio-postgres.model.yml
@@ -20,5 +20,5 @@ extensions:
       pack: codeql/rust-all
       extensible: sourceModel
     data:
-      - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::get", "ReturnValue", "database", "manual"]
-      - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::try_get", "ReturnValue.Variant[crate::result::Result::Ok(0)]", "database", "manual"]
+      - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::get", "ReturnValue", "remote", "manual"]
+      - ["repo:https://github.com/sfackler/rust-postgres:tokio-postgres", "<crate::row::Row>::try_get", "ReturnValue.Variant[crate::result::Result::Ok(0)]", "remote", "manual"]


### PR DESCRIPTION
Re-categorize tokio-postgres sources as remote.  It turns out their existing type, `database`, is a `local` source type and this leads to the sources being disabled in the default configuration.  The new type, `remote`, reflects the fact that [tokio_postgres](https://docs.rs/tokio-postgres/latest/tokio_postgres/index.html) is intended to connect to a remote (and local) databases, so these are potentially remote data sources.

@GeekMasher FYI