### PR TITLE
JS: Resolve calls downward in class hierarchy

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -1066,6 +1066,32 @@ class ClassNode extends DataFlow::SourceNode instanceof ClassNode::Range {
     result = this.getAnInstanceReference(DataFlow::TypeTracker::end())
   }
 
+  pragma[nomagic]
+  private DataFlow::PropRead getAnOwnInstanceMemberAccess(string name, DataFlow::TypeTracker t) {
+    result = this.getAnInstanceReference(t.continue()).getAPropertyRead(name)
+  }
+
+  pragma[nomagic]
+  private DataFlow::PropRead getAnInstanceMemberAccessOnSubClass(
+    string name, DataFlow::TypeTracker t
+  ) {
+    exists(DataFlow::ClassNode subclass |
+      subclass = this.getADirectSubClass() and
+      not exists(subclass.getInstanceMember(name, _))
+    |
+      result = subclass.getAnOwnInstanceMemberAccess(name, t)
+      or
+      result = subclass.getAnInstanceMemberAccessOnSubClass(name, t)
+    )
+  }
+
+  pragma[nomagic]
+  private DataFlow::PropRead getAnInstanceMemberAccessOnSuperClass(string name) {
+    result = this.getADirectSuperClass().getAReceiverNode().getAPropertyRead(name)
+    or
+    result = this.getADirectSuperClass().getAnInstanceMemberAccessOnSuperClass(name)
+  }
+
   /**
    * Gets a property read that accesses the property `name` on an instance of this class.
    *
@@ -1073,13 +1099,12 @@ class ClassNode extends DataFlow::SourceNode instanceof ClassNode::Range {
    */
   pragma[nomagic]
   DataFlow::PropRead getAnInstanceMemberAccess(string name, DataFlow::TypeTracker t) {
-    result = this.getAnInstanceReference(t.continue()).getAPropertyRead(name)
+    result = this.getAnOwnInstanceMemberAccess(name, t)
     or
-    exists(DataFlow::ClassNode subclass |
-      result = subclass.getAnInstanceMemberAccess(name, t) and
-      not exists(subclass.getInstanceMember(name, _)) and
-      this = subclass.getADirectSuperClass()
-    )
+    result = this.getAnInstanceMemberAccessOnSubClass(name, t)
+    or
+    t.start() and
+    result = this.getAnInstanceMemberAccessOnSuperClass(name)
   }
 
   /**

--- a/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Nodes.qll
@@ -1095,7 +1095,8 @@ class ClassNode extends DataFlow::SourceNode instanceof ClassNode::Range {
   /**
    * Gets a property read that accesses the property `name` on an instance of this class.
    *
-   * Concretely, this holds when the base is an instance of this class or a subclass thereof.
+   * This includes accesses on subclasses (if the member is not overridden) and accesses in a base class
+   * (only if accessed on `this`).
    */
   pragma[nomagic]
   DataFlow::PropRead getAnInstanceMemberAccess(string name, DataFlow::TypeTracker t) {

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
@@ -583,19 +583,14 @@ class DataFlowType extends TDataFlowType {
   DataFlow::ClassNode asInstanceOfClass() { this = TInstanceType(result) }
 }
 
-private predicate typeStrongerThan1(DataFlowType t1, DataFlowType t2) {
-  // 't1' is a subclass of 't2'
-  t1.asInstanceOfClass() = t2.asInstanceOfClass().getADirectSubClass()
-}
-
 /**
  * Holds if `t1` is strictly stronger than `t2`.
  */
 predicate typeStrongerThan(DataFlowType t1, DataFlowType t2) {
-  typeStrongerThan1(t1, t2)
+  // 't1' is a subclass of 't2'
+  t1.asInstanceOfClass() = t2.asInstanceOfClass().getADirectSubClass+()
   or
-  // Ensure all types are transitively stronger than 'any'
-  not typeStrongerThan1(t1, _) and
+  // Ensure all types are stronger than 'any'
   not t1 = TAnyType() and
   t2 = TAnyType()
 }

--- a/javascript/ql/src/change-notes/2025-02-17-downward-calls.md
+++ b/javascript/ql/src/change-notes/2025-02-17-downward-calls.md
@@ -1,0 +1,6 @@
+---
+category: majorAnalysis
+---
+* Improved call resolution logic to better handle calls resolving "downwards", targeting
+  a method declared in a subclass of the enclosing class. Data flow analysis
+  has also improved to avoid spurious flow between unrelated classes in the class hierarchy.

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -1,4 +1,5 @@
 spuriousCallee
+| accessors.js:54:1:54:7 | new D() | accessors.js:32:9:32:8 | () {} | -1 | calls |
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -1,5 +1,4 @@
 spuriousCallee
-| accessors.js:54:1:54:7 | new D() | accessors.js:32:9:32:8 | () {} | -1 | calls |
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} | -1 | calls |
@@ -13,4 +12,4 @@ accessorCall
 | accessors.js:44:1:44:9 | new D().f | accessors.js:37:8:37:13 | (x) {} |
 | accessors.js:48:1:48:5 | obj.f | accessors.js:5:8:5:12 | () {} |
 | accessors.js:51:1:51:3 | C.f | accessors.js:19:15:19:19 | () {} |
-| accessors.js:54:1:54:9 | new D().f | accessors.js:34:8:34:12 | () {} |
+| accessors.js:55:1:55:3 | d.f | accessors.js:34:8:34:12 | () {} |

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.ql
@@ -58,20 +58,23 @@ class AnnotatedCall extends DataFlow::Node {
   string getKind() { result = kind }
 }
 
-predicate callEdge(AnnotatedCall call, AnnotatedFunction target, int boundArgs) {
+predicate callEdge(AnnotatedCall call, Function target, int boundArgs) {
   FlowSteps::calls(call, target) and boundArgs = -1
   or
   FlowSteps::callsBound(call, target, boundArgs)
 }
 
-query predicate spuriousCallee(
-  AnnotatedCall call, AnnotatedFunction target, int boundArgs, string kind
-) {
+query predicate spuriousCallee(AnnotatedCall call, Function target, int boundArgs, string kind) {
   callEdge(call, target, boundArgs) and
   kind = call.getKind() and
   not (
     target = call.getAnExpectedCallee(kind) and
     boundArgs = call.getBoundArgsOrMinusOne()
+  ) and
+  (
+    target instanceof AnnotatedFunction
+    or
+    call.getCallTargetName() = "NONE"
   )
 }
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/accessors.js
@@ -50,5 +50,6 @@ obj.f();
 /** calls:NONE */
 C.f();
 
+const d = new D();
 /** calls:NONE */
-new D().f();
+d.f();

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
@@ -7,6 +7,9 @@ class Base {
 
         /** calls:NONE */
         this.methodInSub();
+
+        /** calls:overridenInSub0 */
+        this.overridenInSub();
     }
 
     /** name:methodInBase */
@@ -14,15 +17,27 @@ class Base {
         /** calls:NONE */
         this.methodInSub();
     }
+
+    /** name:overridenInSub0 */
+    overridenInSub() {
+    }
 }
 
 class Subclass1 extends Base {
     workInSub() {
         /** calls:methodInBase */
         this.methodInBase();
+
+        /** calls:overridenInSub1 */
+        this.overridenInSub();
     }
 
+    /** name:methodInSub1 */
     methodInSub() {
+    }
+
+    /** name:overridenInSub1 */
+    overridenInSub() {
     }
 }
 
@@ -30,8 +45,16 @@ class Subclass2 extends Base {
     workInSub() {
         /** calls:methodInBase */
         this.methodInBase();
+
+        /** calls:overridenInSub2 */
+        this.overridenInSub();
     }
 
+    /** name:methodInSub2 */
     methodInSub() {
+    }
+
+    /** name:overridenInSub2 */
+    overridenInSub() {
     }
 }

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
@@ -5,16 +5,16 @@ class Base {
         /** calls:methodInBase */
         this.methodInBase();
 
-        /** calls:NONE */
+        /** calls:methodInSub1 calls:methodInSub2 */
         this.methodInSub();
 
-        /** calls:overridenInSub0 */
+        /** calls:overridenInSub0 calls:overridenInSub1 calls:overridenInSub2 */
         this.overridenInSub();
     }
 
     /** name:methodInBase */
     methodInBase() {
-        /** calls:NONE */
+        /** calls:methodInSub1 calls:methodInSub2 */
         this.methodInSub();
     }
 

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
@@ -1,0 +1,37 @@
+import 'dummy';
+
+class Base {
+    workInBase() {
+        /** calls:methodInBase */
+        this.methodInBase();
+
+        /** calls:NONE */
+        this.methodInSub();
+    }
+
+    /** name:methodInBase */
+    methodInBase() {
+        /** calls:NONE */
+        this.methodInSub();
+    }
+}
+
+class Subclass1 extends Base {
+    workInSub() {
+        /** calls:methodInBase */
+        this.methodInBase();
+    }
+
+    methodInSub() {
+    }
+}
+
+class Subclass2 extends Base {
+    workInSub() {
+        /** calls:methodInBase */
+        this.methodInBase();
+    }
+
+    methodInSub() {
+    }
+}

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/subclasses.js
@@ -8,8 +8,8 @@ class Base {
         /** calls:methodInSub1 calls:methodInSub2 */
         this.methodInSub();
 
-        /** calls:overridenInSub0 calls:overridenInSub1 calls:overridenInSub2 */
-        this.overridenInSub();
+        /** calls:overriddenInSub0 calls:overriddenInSub1 calls:overriddenInSub2 */
+        this.overriddenInSub();
     }
 
     /** name:methodInBase */
@@ -18,8 +18,8 @@ class Base {
         this.methodInSub();
     }
 
-    /** name:overridenInSub0 */
-    overridenInSub() {
+    /** name:overriddenInSub0 */
+    overriddenInSub() {
     }
 }
 
@@ -28,16 +28,16 @@ class Subclass1 extends Base {
         /** calls:methodInBase */
         this.methodInBase();
 
-        /** calls:overridenInSub1 */
-        this.overridenInSub();
+        /** calls:overriddenInSub1 */
+        this.overriddenInSub();
     }
 
     /** name:methodInSub1 */
     methodInSub() {
     }
 
-    /** name:overridenInSub1 */
-    overridenInSub() {
+    /** name:overriddenInSub1 */
+    overriddenInSub() {
     }
 }
 
@@ -46,15 +46,15 @@ class Subclass2 extends Base {
         /** calls:methodInBase */
         this.methodInBase();
 
-        /** calls:overridenInSub2 */
-        this.overridenInSub();
+        /** calls:overriddenInSub2 */
+        this.overriddenInSub();
     }
 
     /** name:methodInSub2 */
     methodInSub() {
     }
 
-    /** name:overridenInSub2 */
-    overridenInSub() {
+    /** name:overriddenInSub2 */
+    overriddenInSub() {
     }
 }

--- a/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/FullTest/tests.expected
@@ -56,6 +56,7 @@ test_getAFunctionValue
 | classes.js:3:10:5:5 | () {\\n   ... ;\\n    } | classes.js:3:10:5:5 | () {\\n   ... ;\\n    } |
 | classes.js:7:6:9:5 | () {\\n   ... ;\\n    } | classes.js:7:6:9:5 | () {\\n   ... ;\\n    } |
 | classes.js:8:7:8:16 | this.hello | classes.js:3:10:5:5 | () {\\n   ... ;\\n    } |
+| classes.js:8:7:8:16 | this.hello | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } |
 | classes.js:12:3:16:3 | B | classes.js:12:21:12:20 | (...arg ... rgs); } |
 | classes.js:12:3:16:3 | class B ...   }\\n  } | classes.js:12:21:12:20 | (...arg ... rgs); } |
 | classes.js:12:19:12:19 | A | classes.js:2:11:2:10 | () {} |
@@ -447,6 +448,7 @@ test_getACallee
 | a.js:3:1:3:5 | bar() | b.js:2:8:2:24 | function bar() {} |
 | a.js:4:1:4:5 | qux() | c.js:2:8:2:24 | function bar() {} |
 | classes.js:8:7:8:18 | this.hello() | classes.js:3:10:5:5 | () {\\n   ... ;\\n    } |
+| classes.js:8:7:8:18 | this.hello() | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } |
 | classes.js:12:21:12:20 | super(...args) | classes.js:2:11:2:10 | () {} |
 | classes.js:18:3:18:9 | new B() | classes.js:12:21:12:20 | (...arg ... rgs); } |
 | classes.js:18:3:18:17 | new B().hello() | classes.js:13:10:15:5 | () {\\n   ... ;\\n    } |

--- a/javascript/ql/test/library-tests/TripleDot/subclass.js
+++ b/javascript/ql/test/library-tests/TripleDot/subclass.js
@@ -29,6 +29,6 @@ class Subclass3 extends Base {
         this.baseMethod("safe");
     }
     subclassMethod(x) {
-        sink(x); // $ SPURIOUS: hasValueFlow=sub1 hasValueFlow=sub2
+        sink(x);
     }
 }

--- a/javascript/ql/test/library-tests/TripleDot/subclass.js
+++ b/javascript/ql/test/library-tests/TripleDot/subclass.js
@@ -1,0 +1,34 @@
+import 'dummy';
+
+class Base {
+    baseMethod(x) {
+        this.subclassMethod(x);
+    }
+}
+
+class Subclass1 extends Base {
+    work() {
+        this.baseMethod(source("sub1"));
+    }
+    subclassMethod(x) {
+        sink(x); // $ hasValueFlow=sub1 SPURIOUS: hasValueFlow=sub2
+    }
+}
+
+class Subclass2 extends Base {
+    work() {
+        this.baseMethod(source("sub2"));
+    }
+    subclassMethod(x) {
+        sink(x); // $ hasValueFlow=sub2 SPURIOUS: hasValueFlow=sub1
+    }
+}
+
+class Subclass3 extends Base {
+    work() {
+        this.baseMethod("safe");
+    }
+    subclassMethod(x) {
+        sink(x); // $ SPURIOUS: hasValueFlow=sub1 hasValueFlow=sub2
+    }
+}

--- a/javascript/ql/test/library-tests/TripleDot/subclass.js
+++ b/javascript/ql/test/library-tests/TripleDot/subclass.js
@@ -11,7 +11,7 @@ class Subclass1 extends Base {
         this.baseMethod(source("sub1"));
     }
     subclassMethod(x) {
-        sink(x); // $ hasValueFlow=sub1 SPURIOUS: hasValueFlow=sub2
+        sink(x); // $ hasValueFlow=sub1
     }
 }
 
@@ -20,7 +20,7 @@ class Subclass2 extends Base {
         this.baseMethod(source("sub2"));
     }
     subclassMethod(x) {
-        sink(x); // $ hasValueFlow=sub2 SPURIOUS: hasValueFlow=sub1
+        sink(x); // $ hasValueFlow=sub2
     }
 }
 


### PR DESCRIPTION
Resolves calls targeting `this` downwards in the class hierarchy, for example:
```js
class Base {
  foo() {
    this.bar(); // calls Sub.bar
  }
}
class Sub extends Base {
  bar() { ... }
}
```
We already resolve calls upwards in the class hierarchy. One of the risks from resolving both upwards and downwards is that flow can start in one subclass, go upwards to a base class, and then move into a different subclass. This PR mitigates using some features of the shared data flow library involving `DataFlowType` and `viableImplInCallContext`.

Both DCA and QA run were very quiet (see backlinks). The DCA run showed 531 new call edges across 95 projects, resulting in 6 new sinks and 694 nodes now being tainted.