### PR TITLE
Rust: Generate sources and sinks

### DIFF
--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -291,6 +291,9 @@ module Node {
       n.getAstNode() = pos.getParameterIn(c.asCfgScope().(Callable).getParamList())
     }
 
+    /** Get the parameter position of this parameter. */
+    ParameterPosition getPosition() { this.isParameterOf(_, result) }
+
     /** Gets the parameter in the CFG that this node corresponds to. */
     ParamBaseCfgNode getParameter() { result = n }
   }

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -107,6 +107,12 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
 
   predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
+  /**
+   * Holds if `source` is an API entrypoint, i.e., a source of input where data
+   * can flow in to a library. This is used for creating sink models, as we
+   * only want to mark functions as sinks if input to the function can reach
+   * (from an input source) a known sink.
+   */
   predicate apiSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
 
   bindingset[sourceEnclosing, api]

--- a/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
+++ b/rust/ql/src/utils/modelgenerator/internal/CaptureModels.qll
@@ -3,6 +3,8 @@ private import rust
 private import rust as R
 private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.internal.DataFlowImpl
+private import codeql.rust.dataflow.FlowSource as FlowSource
+private import codeql.rust.dataflow.FlowSink as FlowSink
 private import codeql.rust.dataflow.internal.TaintTrackingImpl
 private import codeql.mad.modelgenerator.internal.ModelGeneratorImpl
 private import codeql.rust.dataflow.internal.FlowSummaryImpl as FlowSummary
@@ -105,14 +107,13 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
 
   predicate sinkModelSanitizer(DataFlow::Node node) { none() }
 
-  predicate apiSource(DataFlow::Node source) { none() }
+  predicate apiSource(DataFlow::Node source) { source instanceof DataFlow::ParameterNode }
 
   bindingset[sourceEnclosing, api]
   predicate irrelevantSourceSinkApi(Callable sourceEnclosing, SourceTargetApi api) { none() }
 
   string getInputArgument(DataFlow::Node source) {
-    // TODO: Implement when we want to generate sources and sinks
-    result = "getInputArgument(" + source + ")"
+    result = "Argument[" + source.(Node::SourceParameterNode).getPosition().toString() + "]"
   }
 
   bindingset[kind]
@@ -174,11 +175,9 @@ module ModelGeneratorInput implements ModelGeneratorInputSig<Location, RustDataF
 
   string partialNeutralModelRow(Callable api, int i) { result = partialModelRow(api, i) }
 
-  // TODO: Implement this when we want to generate sources.
-  predicate sourceNode(DataFlow::Node node, string kind) { none() }
+  predicate sourceNode(DataFlow::Node node, string kind) { FlowSource::sourceNode(node, kind) }
 
-  // TODO: Implement this when we want to generate sinks.
-  predicate sinkNode(DataFlow::Node node, string kind) { none() }
+  predicate sinkNode(DataFlow::Node node, string kind) { FlowSink::sinkNode(node, kind) }
 }
 
 import MakeModelGenerator<Location, RustDataFlow, RustTaintTracking, ModelGeneratorInput>

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.expected
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.expected
@@ -1,0 +1,2 @@
+unexpectedModel
+expectedModel

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ext.yml
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ext.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: sinkModel
+    data:
+      - ["repo::test", "crate::sinks::known_sink", "Argument[0]", "test-sink", "manual"]

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ql
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSinkModels.ql
@@ -3,9 +3,9 @@ import utils.modelgenerator.internal.CaptureModels
 import utils.test.InlineMadTest
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {
-  string getCapturedModel(Function f) { result = ContentSensitive::captureFlow(f, _) }
+  string getCapturedModel(Function f) { result = captureSink(f) }
 
-  string getKind() { result = "summary" }
+  string getKind() { result = "sink" }
 }
 
 import InlineMadTest<InlineMadTestConfig>

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.expected
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.expected
@@ -1,0 +1,2 @@
+unexpectedModel
+expectedModel

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ext.yml
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ext.yml
@@ -1,0 +1,6 @@
+extensions:
+  - addsTo:
+      pack: codeql/rust-all
+      extensible: sourceModel
+    data:
+      - ["repo::test", "crate::sources::known_source", "ReturnValue", "test-source", "manual"]

--- a/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ql
+++ b/rust/ql/test/utils-tests/modelgenerator/CaptureSourceModels.ql
@@ -1,11 +1,12 @@
 import rust
 import utils.modelgenerator.internal.CaptureModels
 import utils.test.InlineMadTest
+import codeql.rust.dataflow.internal.ModelsAsData
 
 module InlineMadTestConfig implements InlineMadTestConfigSig {
-  string getCapturedModel(Function f) { result = ContentSensitive::captureFlow(f, _) }
+  string getCapturedModel(Function c) { result = captureSource(c) }
 
-  string getKind() { result = "summary" }
+  string getKind() { result = "source" }
 }
 
 import InlineMadTest<InlineMadTestConfig>

--- a/rust/ql/test/utils-tests/modelgenerator/sinks.rs
+++ b/rust/ql/test/utils-tests/modelgenerator/sinks.rs
@@ -1,0 +1,14 @@
+// A manually modeled sink
+fn known_sink(n: i64) {
+    ()
+}
+
+// sink=repo::test;crate::sinks::derived_sink;Argument[1];test-sink;df-generated
+pub fn derived_sink(c: bool, n: i64) -> i64 {
+    if c {
+        known_sink(n);
+        1
+    } else {
+        0
+    }
+}

--- a/rust/ql/test/utils-tests/modelgenerator/sources.rs
+++ b/rust/ql/test/utils-tests/modelgenerator/sources.rs
@@ -1,0 +1,14 @@
+// A manually modeled source
+fn known_source(n: i64) -> i64 {
+    n
+}
+
+// source=repo::test;crate::sources::derived_source;ReturnValue;test-source;df-generated
+// summary=repo::test;crate::sources::derived_source;Argument[1];ReturnValue;value;dfc-generated
+pub fn derived_source(c: bool, n: i64) -> i64 {
+    if c {
+        known_source(n)
+    } else {
+        0
+    }
+}


### PR DESCRIPTION
With this we should be able to generate sources and sinks from already modeled sources and sinks.