### PR TITLE
Java: add non-incremental tag to telemetry queries

### DIFF
--- a/java/ql/src/Telemetry/SupportedExternalApis.ql
+++ b/java/ql/src/Telemetry/SupportedExternalApis.ql
@@ -2,7 +2,7 @@
  * @name Usage of supported APIs coming from external libraries
  * @description A list of supported 3rd party APIs used in the codebase. Excludes test and generated code.
  * @kind metric
- * @tags summary telemetry
+ * @tags summary telemetry non-incremental
  * @id java/telemetry/supported-external-api
  */
 

--- a/java/ql/src/Telemetry/SupportedExternalSinks.ql
+++ b/java/ql/src/Telemetry/SupportedExternalSinks.ql
@@ -2,7 +2,7 @@
  * @name Supported sinks in external libraries
  * @description A list of 3rd party APIs detected as sinks. Excludes test and generated code.
  * @kind metric
- * @tags summary telemetry
+ * @tags summary telemetry non-incremental
  * @id java/telemetry/supported-external-api-sinks
  */
 

--- a/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
+++ b/java/ql/src/Telemetry/UnsupportedExternalAPIs.ql
@@ -2,7 +2,7 @@
  * @name Usage of unsupported APIs coming from external libraries
  * @description A list of 3rd party APIs used in the codebase. Excludes test and generated code.
  * @kind metric
- * @tags summary telemetry
+ * @tags summary telemetry non-incremental
  * @id java/telemetry/unsupported-external-api
  */
 


### PR DESCRIPTION
In the future, this tag should signal to the action that the queries should be excluded from incremental scans because they are too slow and/or produce too many results.

The three queries tagged here rely on global data-flow analysis to find all XSS sinks. All other metric and diagnostic queries are fast enough for incrementality.

Comments are welcome on the name or the approach.