### PR TITLE
JS: Do not taint whole array when storing into ArrayElement

### DIFF
--- a/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/TaintTracking.qll
@@ -409,7 +409,7 @@ module TaintTracking {
         not assgn.getWriteNode() instanceof Property and // not a write inside an object literal
         pred = assgn.getRhs() and
         assgn = obj.getAPropertyWrite() and
-        succ = obj
+        succ = assgn.getBase().getPostUpdateNode()
       |
         obj instanceof DataFlow::ObjectLiteralNode
         or

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
@@ -1432,6 +1432,23 @@ predicate readStep(Node node1, ContentSet c, Node node2) {
       c = ContentSet::arrayElementLowerBound(pos.asPositionalLowerBound())
     )
   )
+  or
+  // Implicitly read array elements before stringification
+  stringifiedNode(node1) and
+  node2 = node1 and
+  c = ContentSet::arrayElement()
+}
+
+private predicate stringifiedNode(Node node) {
+  exists(Expr e | node = TValueNode(e) |
+    e = any(AddExpr add).getAnOperand() and
+    not e instanceof StringLiteral
+    or
+    e = any(TemplateLiteral t).getAnElement() and
+    not e instanceof TemplateElement
+  )
+  or
+  node = DataFlow::globalVarRef("String").getAnInvocation().getArgument(0)
 }
 
 /** Gets the post-update node for which `node` is the corresponding pre-update node. */

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
@@ -14,11 +14,8 @@ predicate defaultAdditionalTaintStep(DataFlow::Node node1, DataFlow::Node node2)
   FlowSummaryPrivate::Steps::summaryLocalStep(node1.(FlowSummaryNode).getSummaryNode(),
     node2.(FlowSummaryNode).getSummaryNode(), false, _) // TODO: preserve 'model' parameter
   or
-  // Convert steps into and out of array elements to plain taint steps
+  // Convert steps out of array elements to plain taint steps
   FlowSummaryPrivate::Steps::summaryReadStep(node1.(FlowSummaryNode).getSummaryNode(),
-    ContentSet::arrayElement(), node2.(FlowSummaryNode).getSummaryNode())
-  or
-  FlowSummaryPrivate::Steps::summaryStoreStep(node1.(FlowSummaryNode).getSummaryNode(),
     ContentSet::arrayElement(), node2.(FlowSummaryNode).getSummaryNode())
   or
   // If the spread argument itself is tainted (not inside a content), store it into the dynamic argument array.

--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -96,7 +96,7 @@ module LodashUnderscore {
   /**
    * A data flow step propagating an exception thrown from a callback to a Lodash/Underscore function.
    */
-  private class ExceptionStep extends DataFlow::SharedFlowStep {
+  private class ExceptionStep extends DataFlow::LegacyFlowStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       exists(DataFlow::CallNode call, string name |
         // Members ending with By, With, or While indicate that they are a variant of

--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -278,7 +278,7 @@ module LodashUnderscore {
 
     override predicate propagatesFlow(string input, string output, boolean preservesValue) {
       input = "Argument[0].ArrayElement" and
-      output = ["Argument[1].Parameter[1]", "ReturnValue.ArrayElement"] and
+      output = ["Argument[1].Parameter[0]", "ReturnValue.ArrayElement"] and
       preservesValue = true
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -278,7 +278,11 @@ module LodashUnderscore {
 
     override predicate propagatesFlow(string input, string output, boolean preservesValue) {
       input = "Argument[0].ArrayElement" and
-      output = ["Argument[1].Parameter[0]", "ReturnValue.ArrayElement"] and
+      output =
+        [
+          "Argument[1].Parameter[0]", "Argument[1].ArrayElement.Parameter[0]",
+          "ReturnValue.ArrayElement"
+        ] and
       preservesValue = true
     }
   }

--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -144,7 +144,13 @@ module LodashUnderscore {
       name = ["union", "zip"] and
       pred = call.getAnArgument() and
       succ = call
-      or
+    )
+  }
+
+  private predicate underscoreTaintStepLegacy(DataFlow::Node pred, DataFlow::Node succ) {
+    exists(string name, DataFlow::CallNode call |
+      call = any(Member member | member.getName() = name).getACall()
+    |
       name =
         ["each", "map", "every", "some", "max", "min", "sortBy", "partition", "mapObject", "tap"] and
       pred = call.getArgument(0) and
@@ -166,6 +172,169 @@ module LodashUnderscore {
   private class UnderscoreTaintStep extends TaintTracking::SharedTaintStep {
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       underscoreTaintStep(pred, succ)
+    }
+  }
+
+  private class UnderscoreTaintStepLegacy extends TaintTracking::LegacyTaintStep {
+    override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
+      underscoreTaintStepLegacy(pred, succ)
+    }
+  }
+
+  private class LodashEach extends DataFlow::SummarizedCallable {
+    LodashEach() { this = "_.each-like" }
+
+    override DataFlow::CallNode getACall() {
+      result = member(["each", "eachRight", "forEach", "forEachRight", "every", "some"]).getACall()
+    }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      preservesValue = true and
+      input = "Argument[0].ArrayElement" and
+      output = "Argument[1].Parameter[0]"
+    }
+  }
+
+  private class LodashMap extends DataFlow::SummarizedCallable {
+    LodashMap() { this = "_.map" }
+
+    override DataFlow::CallNode getACall() { result = member("map").getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      (
+        input = "Argument[0].ArrayElement" and
+        output = "Argument[1].Parameter[0]"
+        or
+        input = "Argument[1].ReturnValue" and
+        output = "ReturnValue.ArrayElement"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class LodashFlatMap extends DataFlow::SummarizedCallable {
+    LodashFlatMap() { this = "_.flatMap" }
+
+    override DataFlow::CallNode getACall() { result = member("flatMap").getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      (
+        input = "Argument[0].ArrayElement" and
+        output = "Argument[1].Parameter[0]"
+        or
+        input = "Argument[1].ReturnValue.WithoutArrayElement" and
+        output = "ReturnValue.ArrayElement"
+        or
+        input = "Argument[1].ReturnValue.ArrayElement" and
+        output = "ReturnValue.ArrayElement"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class LodashFlatMapDeep extends DataFlow::SummarizedCallable {
+    LodashFlatMapDeep() { this = "_.flatMapDeep" }
+
+    override DataFlow::CallNode getACall() {
+      result = member(["flatMapDeep", "flatMapDepth"]).getACall()
+    }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      (
+        input = "Argument[0].ArrayElement" and
+        output = "Argument[1].Parameter[0]"
+        or
+        input = "Argument[1].ReturnValue.WithoutArrayElement" and
+        output = "ReturnValue.ArrayElement"
+        or
+        input = "Argument[1].ReturnValue.ArrayElementDeep" and
+        output = "ReturnValue.ArrayElement"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class LodashReduce extends DataFlow::SummarizedCallable {
+    LodashReduce() { this = "_.reduce-like" }
+
+    override DataFlow::CallNode getACall() { result = member(["reduce", "reduceRight"]).getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      (
+        input = "Argument[0].ArrayElement" and
+        output = "Argument[1].Parameter[1]"
+        or
+        input = ["Argument[1].ReturnValue", "Argument[2]"] and
+        output = ["ReturnValue", "Argument[1].Parameter[0]"]
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class LoashSortBy extends DataFlow::SummarizedCallable {
+    LoashSortBy() { this = "_.sortBy-like" }
+
+    override DataFlow::CallNode getACall() { result = member(["sortBy", "orderBy"]).getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ArrayElement" and
+      output = ["Argument[1].Parameter[1]", "ReturnValue.ArrayElement"] and
+      preservesValue = true
+    }
+  }
+
+  private class LodashMinMaxBy extends DataFlow::SummarizedCallable {
+    LodashMinMaxBy() { this = "_.minBy / _.maxBy" }
+
+    override DataFlow::CallNode getACall() { result = member(["minBy", "maxBy"]).getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ArrayElement" and
+      output = ["Argument[1].Parameter[1]", "ReturnValue"] and
+      preservesValue = true
+    }
+  }
+
+  private class LodashPartition extends DataFlow::SummarizedCallable {
+    LodashPartition() { this = "_.partition" }
+
+    override DataFlow::CallNode getACall() { result = member(["partition"]).getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      input = "Argument[0].ArrayElement" and
+      output = ["Argument[1].Parameter[1]", "ReturnValue.ArrayElement.ArrayElement"] and
+      preservesValue = true
+    }
+  }
+
+  private class UnderscoreMapObject extends DataFlow::SummarizedCallable {
+    UnderscoreMapObject() { this = "_.mapObject" }
+
+    override DataFlow::CallNode getACall() { result = member("mapObject").getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      // Just collapse all properties with AnyMember. We could be more precise by generating a summary
+      // for each property name, but for a rarely-used method like this it dosn't seem worth it.
+      (
+        input = "Argument[0].AnyMember" and
+        output = "Argument[1].Parameter[1]"
+        or
+        input = "Argument[1].ReturnValue" and
+        output = "ReturnValue.AnyMember"
+      ) and
+      preservesValue = true
+    }
+  }
+
+  private class LodashTap extends DataFlow::SummarizedCallable {
+    LodashTap() { this = "_.tap" }
+
+    override DataFlow::CallNode getACall() { result = member("tap").getACall() }
+
+    override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+      input = "Argument[0]" and
+      output = ["Argument[1].Parameter[0]", "ReturnValue"] and
+      preservesValue = true
     }
   }
 }

--- a/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/LodashUnderscore.qll
@@ -298,7 +298,7 @@ module LodashUnderscore {
   private class LodashPartition extends DataFlow::SummarizedCallable {
     LodashPartition() { this = "_.partition" }
 
-    override DataFlow::CallNode getACall() { result = member(["partition"]).getACall() }
+    override DataFlow::CallNode getACall() { result = member("partition").getACall() }
 
     override predicate propagatesFlow(string input, string output, boolean preservesValue) {
       input = "Argument[0].ArrayElement" and

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AmbiguousCoreMethods.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AmbiguousCoreMethods.qll
@@ -24,6 +24,7 @@
 private import javascript
 private import semmle.javascript.dataflow.internal.DataFlowNode
 private import semmle.javascript.dataflow.FlowSummary
+private import Arrays
 private import FlowSummaryUtil
 
 class At extends SummarizedCallable {
@@ -41,15 +42,18 @@ class At extends SummarizedCallable {
 }
 
 class Concat extends SummarizedCallable {
-  Concat() { this = "Array#concat / String#concat" }
+  Concat() { this = "Array#concat / String#concat / Buffer.concat" }
 
   override InstanceCall getACallSimple() { result.getMethodName() = "concat" }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    // Array#concat.
+    // Also models Buffer.concat as this happens to out work well with our toString() model.
     preservesValue = true and
     input = "Argument[this,0..].ArrayElement" and
     output = "ReturnValue.ArrayElement"
     or
+    // String#concat
     preservesValue = false and
     input = "Argument[this,0..]" and
     output = "ReturnValue"
@@ -147,5 +151,18 @@ class Values extends SummarizedCallable {
     preservesValue = true and
     input = "Argument[this]." + ["ArrayElement", "SetElement", "MapValue"] and
     output = "ReturnValue.IteratorElement"
+  }
+}
+
+class ToString extends SummarizedCallable {
+  ToString() { this = "Object#toString / Array#toString" }
+
+  override DataFlow::MethodCallNode getACallSimple() { result.getMethodName() = "toString" }
+
+  override predicate propagatesFlow(string input, string output, boolean preservesValue) {
+    preservesValue = false and
+    // Arrays stringify their contents and joins by ","
+    input = "Argument[this].ArrayElementDeep" and
+    output = "ReturnValue"
   }
 }

--- a/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AmbiguousCoreMethods.qll
+++ b/javascript/ql/lib/semmle/javascript/internal/flow_summaries/AmbiguousCoreMethods.qll
@@ -157,7 +157,11 @@ class Values extends SummarizedCallable {
 class ToString extends SummarizedCallable {
   ToString() { this = "Object#toString / Array#toString" }
 
-  override DataFlow::MethodCallNode getACallSimple() { result.getMethodName() = "toString" }
+  override InstanceCall getACallSimple() {
+    result.(DataFlow::MethodCallNode).getMethodName() = "toString"
+    or
+    result = arrayConstructorRef().getAPropertyRead("prototype").getAMemberCall("toString")
+  }
 
   override predicate propagatesFlow(string input, string output, boolean preservesValue) {
     preservesValue = false and

--- a/javascript/ql/src/change-notes/2025-02-18-no-implicit-array-taint.md
+++ b/javascript/ql/src/change-notes/2025-02-18-no-implicit-array-taint.md
@@ -1,0 +1,5 @@
+---
+category: majorAnalysis
+---
+* Improved precision of data flow through arrays, fixing some spurious flows
+  that would sometimes cause the `length` property of an array to be seen as tainted.

--- a/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
+++ b/javascript/ql/test/library-tests/FlowSummary/DataFlowConsistency.expected
@@ -20,6 +20,7 @@ reverseRead
 | tst.js:267:28:267:31 | map3 | Origin of readStep is missing a PostUpdateNode. |
 argHasPostUpdate
 postWithInFlow
+| file://:0:0:0:0 | [summary] to write: Argument[0] in _.tap | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[1] in Array method with flow into callback | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[1] in Array#filter | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[1] in Array#find / Array#findLast | PostUpdateNode should not be the target of local flow. |
@@ -29,6 +30,7 @@ postWithInFlow
 | file://:0:0:0:0 | [summary] to write: Argument[1] in Array#reduce / Array#reduceRight | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[2] in 'array.prototype.find' / 'array-find' | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[2] in Array.from(arg, callback, [thisArg]) | PostUpdateNode should not be the target of local flow. |
+| file://:0:0:0:0 | [summary] to write: Argument[2] in _.reduce-like | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[this] in Array#flatMap | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[this] in Array#forEach / Map#forEach / Set#forEach | PostUpdateNode should not be the target of local flow. |
 | file://:0:0:0:0 | [summary] to write: Argument[this] in Array#map | PostUpdateNode should not be the target of local flow. |

--- a/javascript/ql/test/library-tests/TripleDot/arrays.js
+++ b/javascript/ql/test/library-tests/TripleDot/arrays.js
@@ -25,18 +25,18 @@ function implicitToString() {
     const array = [source('implicitToString.1')];
     array.push(source('implicitToString.2'))
 
-    sink(array + "foo"); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink("foo" + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink("" + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink(array + 1); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink(1 + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink(unknown() + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink(array + unknown()); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array + "foo"); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink("foo" + array); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink("" + array); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array + 1); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(1 + array); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(unknown() + array); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array + unknown()); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 
-    sink(`${array}`); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
-    sink(`${array} foo`); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(`${array}`); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(`${array} foo`); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 
-    sink(String(array)); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(String(array)); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 
     sink(array.toString()); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
     sink(array.toString("utf8")); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2

--- a/javascript/ql/test/library-tests/TripleDot/arrays.js
+++ b/javascript/ql/test/library-tests/TripleDot/arrays.js
@@ -41,5 +41,5 @@ function implicitToString() {
     sink(array.toString()); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
     sink(array.toString("utf8")); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 
-    sink(Array.prototype.toString.call(array)); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(Array.prototype.toString.call(array)); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 }

--- a/javascript/ql/test/library-tests/TripleDot/arrays.js
+++ b/javascript/ql/test/library-tests/TripleDot/arrays.js
@@ -20,3 +20,26 @@ function shiftTaint() {
     sink(array.shift()); // $ hasTaintFlow=shift.directly-tainted
     sink(array.shift()); // $ hasTaintFlow=shift.directly-tainted
 }
+
+function implicitToString() {
+    const array = [source('implicitToString.1')];
+    array.push(source('implicitToString.2'))
+
+    sink(array + "foo"); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink("foo" + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink("" + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array + 1); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(1 + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(unknown() + array); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array + unknown()); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+
+    sink(`${array}`); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(`${array} foo`); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+
+    sink(String(array)); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+
+    sink(array.toString()); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(array.toString("utf8")); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+
+    sink(Array.prototype.toString.call(array)); // $ MISSING: hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+}

--- a/javascript/ql/test/library-tests/TripleDot/arrays.js
+++ b/javascript/ql/test/library-tests/TripleDot/arrays.js
@@ -42,4 +42,5 @@ function implicitToString() {
     sink(array.toString("utf8")); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
 
     sink(Array.prototype.toString.call(array)); // $ hasTaintFlow=implicitToString.1 hasTaintFlow=implicitToString.2
+    sink(Object.prototype.toString.call(array)); // OK - returns "[object Array]"
 }

--- a/javascript/ql/test/library-tests/TripleDot/buffer.js
+++ b/javascript/ql/test/library-tests/TripleDot/buffer.js
@@ -1,0 +1,7 @@
+import 'dummy';
+
+function t1() {
+    const b1 = Buffer.from(source("t1.1"));
+    const b2 = Buffer.from(source("t1.2"));
+    sink(Buffer.concat([b1, b2]).toString("utf8")); // $ MISSING: hasTaintFlow=t1.1 hasTaintFlow=t1.2
+}

--- a/javascript/ql/test/library-tests/TripleDot/buffer.js
+++ b/javascript/ql/test/library-tests/TripleDot/buffer.js
@@ -3,5 +3,5 @@ import 'dummy';
 function t1() {
     const b1 = Buffer.from(source("t1.1"));
     const b2 = Buffer.from(source("t1.2"));
-    sink(Buffer.concat([b1, b2]).toString("utf8")); // $ MISSING: hasTaintFlow=t1.1 hasTaintFlow=t1.2
+    sink(Buffer.concat([b1, b2]).toString("utf8")); // $ hasTaintFlow=t1.1 hasTaintFlow=t1.2
 }

--- a/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/IndirectCommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/IndirectCommandInjection/IndirectCommandInjection.expected
@@ -27,7 +27,6 @@ edges
 | command-line-parameter-command-injection.js:14:6:14:30 | fewerArgs [ArrayElement] | command-line-parameter-command-injection.js:18:13:18:21 | fewerArgs [ArrayElement] | provenance |  |
 | command-line-parameter-command-injection.js:14:18:14:21 | args | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) | provenance |  |
 | command-line-parameter-command-injection.js:14:18:14:21 | args | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) [ArrayElement] | provenance |  |
-| command-line-parameter-command-injection.js:14:18:14:21 | args [ArrayElement] | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) | provenance |  |
 | command-line-parameter-command-injection.js:14:18:14:21 | args [ArrayElement] | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) [ArrayElement] | provenance |  |
 | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) | command-line-parameter-command-injection.js:14:6:14:30 | fewerArgs | provenance |  |
 | command-line-parameter-command-injection.js:14:18:14:30 | args.slice(1) [ArrayElement] | command-line-parameter-command-injection.js:14:6:14:30 | fewerArgs [ArrayElement] | provenance |  |

--- a/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/UnsafeShellCommandConstruction/UnsafeShellCommandConstruction.expected
@@ -89,18 +89,14 @@ edges
 | lib/lib.js:414:40:414:43 | name | lib/lib.js:426:11:426:14 | name | provenance |  |
 | lib/lib.js:414:40:414:43 | name | lib/lib.js:426:11:426:14 | name | provenance |  |
 | lib/lib.js:414:40:414:43 | name | lib/lib.js:428:36:428:39 | name | provenance |  |
-| lib/lib.js:426:2:426:4 | [post update] arr | lib/lib.js:427:14:427:16 | arr | provenance |  |
 | lib/lib.js:426:2:426:4 | [post update] arr [ArrayElement] | lib/lib.js:427:14:427:16 | arr | provenance |  |
-| lib/lib.js:426:11:426:14 | name | lib/lib.js:426:2:426:4 | [post update] arr | provenance |  |
 | lib/lib.js:426:11:426:14 | name | lib/lib.js:426:2:426:4 | [post update] arr [ArrayElement] | provenance |  |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:428:14:428:58 | build(" ...  + '-') | provenance |  |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | provenance |  |
 | lib/lib.js:428:36:428:39 | name | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | provenance |  |
 | lib/lib.js:431:23:431:26 | last | lib/lib.js:436:19:436:22 | last | provenance |  |
 | lib/lib.js:431:23:431:26 | last | lib/lib.js:436:19:436:22 | last | provenance |  |
-| lib/lib.js:436:10:436:12 | [post update] arr | lib/lib.js:437:9:437:11 | arr | provenance |  |
 | lib/lib.js:436:10:436:12 | [post update] arr [ArrayElement] | lib/lib.js:437:9:437:11 | arr [ArrayElement] | provenance |  |
-| lib/lib.js:436:19:436:22 | last | lib/lib.js:436:10:436:12 | [post update] arr | provenance |  |
 | lib/lib.js:436:19:436:22 | last | lib/lib.js:436:10:436:12 | [post update] arr [ArrayElement] | provenance |  |
 | lib/lib.js:441:39:441:42 | name | lib/lib.js:442:24:442:27 | name | provenance |  |
 | lib/lib.js:446:20:446:23 | name | lib/lib.js:447:25:447:28 | name | provenance |  |
@@ -273,7 +269,6 @@ nodes
 | lib/lib.js:419:32:419:35 | name | semmle.label | name |
 | lib/lib.js:420:29:420:32 | name | semmle.label | name |
 | lib/lib.js:424:24:424:27 | name | semmle.label | name |
-| lib/lib.js:426:2:426:4 | [post update] arr | semmle.label | [post update] arr |
 | lib/lib.js:426:2:426:4 | [post update] arr [ArrayElement] | semmle.label | [post update] arr [ArrayElement] |
 | lib/lib.js:426:11:426:14 | name | semmle.label | name |
 | lib/lib.js:426:11:426:14 | name | semmle.label | name |
@@ -282,11 +277,9 @@ nodes
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | semmle.label | (name ? ... ) + '-' |
 | lib/lib.js:428:36:428:39 | name | semmle.label | name |
 | lib/lib.js:431:23:431:26 | last | semmle.label | last |
-| lib/lib.js:436:10:436:12 | [post update] arr | semmle.label | [post update] arr |
 | lib/lib.js:436:10:436:12 | [post update] arr [ArrayElement] | semmle.label | [post update] arr [ArrayElement] |
 | lib/lib.js:436:19:436:22 | last | semmle.label | last |
 | lib/lib.js:436:19:436:22 | last | semmle.label | last |
-| lib/lib.js:437:9:437:11 | arr | semmle.label | arr |
 | lib/lib.js:437:9:437:11 | arr [ArrayElement] | semmle.label | arr [ArrayElement] |
 | lib/lib.js:441:39:441:42 | name | semmle.label | name |
 | lib/lib.js:442:24:442:27 | name | semmle.label | name |
@@ -354,7 +347,6 @@ nodes
 subpaths
 | lib/lib.js:251:27:251:30 | name | lib/lib.js:239:28:239:28 | s | lib/lib.js:245:9:245:9 | s | lib/lib.js:251:16:251:31 | cleanInput(name) |
 | lib/lib.js:340:25:340:25 | n | lib/lib.js:329:13:329:13 | x | lib/lib.js:330:9:330:9 | x | lib/lib.js:340:22:340:26 | id(n) |
-| lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | lib/lib.js:437:9:437:11 | arr | lib/lib.js:428:14:428:58 | build(" ...  + '-') |
 | lib/lib.js:428:28:428:57 | (name ? ... ) + '-' | lib/lib.js:431:23:431:26 | last | lib/lib.js:437:9:437:11 | arr [ArrayElement] | lib/lib.js:428:14:428:58 | build(" ...  + '-') |
 #select
 | lib/isImported.js:6:10:6:25 | "rm -rf " + name | lib/isImported.js:5:49:5:52 | name | lib/isImported.js:6:22:6:25 | name | This string concatenation which depends on $@ is later used in a $@. | lib/isImported.js:5:49:5:52 | name | library input | lib/isImported.js:6:2:6:26 | cp.exec ... + name) | shell command |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/Xss.expected
@@ -1145,7 +1145,6 @@ edges
 | various-concat-obfuscations.js:18:10:18:59 | '<div a ... 'left') | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | provenance |  |
 | various-concat-obfuscations.js:18:32:18:36 | attrs | various-concat-obfuscations.js:18:32:18:58 | attrs.d ...  'left' | provenance |  |
 | various-concat-obfuscations.js:18:32:18:58 | attrs.d ...  'left' | various-concat-obfuscations.js:18:10:18:59 | '<div a ... 'left') | provenance | Config |

--- a/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/DomBasedXss/XssWithAdditionalSources.expected
@@ -1170,7 +1170,6 @@ edges
 | various-concat-obfuscations.js:18:10:18:59 | '<div a ... 'left') | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | provenance |  |
-| various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') | provenance |  |
 | various-concat-obfuscations.js:18:10:18:88 | '<div a ... ntent)) [ArrayElement] | various-concat-obfuscations.js:18:10:18:105 | '<div a ... /div>') [ArrayElement] | provenance |  |
 | various-concat-obfuscations.js:18:32:18:36 | attrs | various-concat-obfuscations.js:18:32:18:58 | attrs.d ...  'left' | provenance |  |
 | various-concat-obfuscations.js:18:32:18:58 | attrs.d ...  'left' | various-concat-obfuscations.js:18:10:18:59 | '<div a ... 'left') | provenance | Config |

--- a/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/ReflectedXss/ReflectedXss.expected
@@ -49,10 +49,8 @@ edges
 | ReflectedXssGood3.js:77:16:77:36 | value.s ... g(0, i) | ReflectedXssGood3.js:77:7:77:37 | parts | provenance |  |
 | ReflectedXssGood3.js:77:16:77:36 | value.s ... g(0, i) | ReflectedXssGood3.js:77:15:77:37 | [value. ... (0, i)] [0] | provenance |  |
 | ReflectedXssGood3.js:77:16:77:36 | value.s ... g(0, i) | ReflectedXssGood3.js:108:10:108:23 | parts.join('') | provenance |  |
-| ReflectedXssGood3.js:105:7:105:11 | [post update] parts | ReflectedXssGood3.js:108:10:108:14 | parts | provenance |  |
 | ReflectedXssGood3.js:105:7:105:11 | [post update] parts [ArrayElement] | ReflectedXssGood3.js:108:10:108:14 | parts [ArrayElement] | provenance |  |
 | ReflectedXssGood3.js:105:18:105:22 | value | ReflectedXssGood3.js:105:18:105:38 | value.s ... g(j, i) | provenance |  |
-| ReflectedXssGood3.js:105:18:105:38 | value.s ... g(j, i) | ReflectedXssGood3.js:105:7:105:11 | [post update] parts | provenance |  |
 | ReflectedXssGood3.js:105:18:105:38 | value.s ... g(j, i) | ReflectedXssGood3.js:105:7:105:11 | [post update] parts [ArrayElement] | provenance |  |
 | ReflectedXssGood3.js:108:10:108:14 | parts | ReflectedXssGood3.js:108:10:108:23 | parts.join('') | provenance |  |
 | ReflectedXssGood3.js:108:10:108:14 | parts [0] | ReflectedXssGood3.js:108:10:108:23 | parts.join('') | provenance |  |
@@ -217,7 +215,6 @@ nodes
 | ReflectedXssGood3.js:77:15:77:37 | [value. ... (0, i)] [0] | semmle.label | [value. ... (0, i)] [0] |
 | ReflectedXssGood3.js:77:16:77:20 | value | semmle.label | value |
 | ReflectedXssGood3.js:77:16:77:36 | value.s ... g(0, i) | semmle.label | value.s ... g(0, i) |
-| ReflectedXssGood3.js:105:7:105:11 | [post update] parts | semmle.label | [post update] parts |
 | ReflectedXssGood3.js:105:7:105:11 | [post update] parts [ArrayElement] | semmle.label | [post update] parts [ArrayElement] |
 | ReflectedXssGood3.js:105:18:105:22 | value | semmle.label | value |
 | ReflectedXssGood3.js:105:18:105:38 | value.s ... g(j, i) | semmle.label | value.s ... g(j, i) |

--- a/javascript/ql/test/query-tests/Security/CWE-079/StoredXss/StoredXss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/StoredXss/StoredXss.expected
@@ -1,46 +1,23 @@
 edges
 | xss-through-filenames.js:7:43:7:48 | files1 | xss-through-filenames.js:8:18:8:23 | files1 | provenance |  |
-| xss-through-filenames.js:17:21:17:26 | files2 | xss-through-filenames.js:19:9:19:14 | files2 | provenance |  |
 | xss-through-filenames.js:17:21:17:26 | files2 [ArrayElement] | xss-through-filenames.js:19:9:19:14 | files2 [ArrayElement] | provenance |  |
-| xss-through-filenames.js:19:9:19:14 | files2 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | provenance |  |
-| xss-through-filenames.js:19:9:19:14 | files2 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | provenance |  |
-| xss-through-filenames.js:19:9:19:14 | files2 [ArrayElement] | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | provenance |  |
 | xss-through-filenames.js:19:9:19:14 | files2 [ArrayElement] | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:22:16:22:21 | files3 | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:22:16:22:21 | files3 | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 | provenance |  |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:34:20:37 | file | provenance |  |
-| xss-through-filenames.js:20:25:20:47 | '<li>'  ... '</li>' | xss-through-filenames.js:20:13:20:18 | [post update] files3 | provenance |  |
 | xss-through-filenames.js:20:25:20:47 | '<li>'  ... '</li>' | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:20:34:20:37 | file | xss-through-filenames.js:20:25:20:47 | '<li>'  ... '</li>' | provenance |  |
-| xss-through-filenames.js:22:16:22:21 | files3 | xss-through-filenames.js:22:16:22:30 | files3.join('') | provenance |  |
-| xss-through-filenames.js:22:16:22:21 | files3 | xss-through-filenames.js:22:16:22:30 | files3.join('') | provenance |  |
-| xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | xss-through-filenames.js:22:16:22:30 | files3.join('') | provenance |  |
 | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | xss-through-filenames.js:22:16:22:30 | files3.join('') | provenance |  |
 | xss-through-filenames.js:25:43:25:48 | files1 | xss-through-filenames.js:26:19:26:24 | files1 | provenance |  |
 | xss-through-filenames.js:25:43:25:48 | files1 | xss-through-filenames.js:30:9:30:14 | files1 | provenance |  |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | provenance |  |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:33:19:33:24 | files2 | provenance |  |
-| xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:33:19:33:24 | files2 | provenance |  |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:25:31:28 | file | provenance |  |
-| xss-through-filenames.js:31:25:31:28 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | provenance |  |
 | xss-through-filenames.js:31:25:31:28 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | provenance |  |
-| xss-through-filenames.js:33:19:33:24 | files2 | xss-through-filenames.js:35:29:35:34 | files2 | provenance |  |
 | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:35:13:35:35 | files3 | xss-through-filenames.js:37:19:37:24 | files3 | provenance |  |
 | xss-through-filenames.js:35:22:35:35 | format(files2) | xss-through-filenames.js:35:13:35:35 | files3 | provenance |  |
-| xss-through-filenames.js:35:29:35:34 | files2 | xss-through-filenames.js:17:21:17:26 | files2 | provenance |  |
-| xss-through-filenames.js:35:29:35:34 | files2 | xss-through-filenames.js:35:22:35:35 | format(files2) | provenance |  |
 | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | xss-through-filenames.js:17:21:17:26 | files2 [ArrayElement] | provenance |  |
 | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | xss-through-filenames.js:35:22:35:35 | format(files2) | provenance |  |
 | xss-through-torrent.js:6:6:6:24 | name | xss-through-torrent.js:7:11:7:14 | name | provenance |  |
@@ -48,57 +25,34 @@ edges
 nodes
 | xss-through-filenames.js:7:43:7:48 | files1 | semmle.label | files1 |
 | xss-through-filenames.js:8:18:8:23 | files1 | semmle.label | files1 |
-| xss-through-filenames.js:17:21:17:26 | files2 | semmle.label | files2 |
 | xss-through-filenames.js:17:21:17:26 | files2 [ArrayElement] | semmle.label | files2 [ArrayElement] |
-| xss-through-filenames.js:19:9:19:14 | files2 | semmle.label | files2 |
 | xss-through-filenames.js:19:9:19:14 | files2 [ArrayElement] | semmle.label | files2 [ArrayElement] |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | semmle.label | files2.sort(sort) |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | semmle.label | files2.sort(sort) |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | semmle.label | files2.sort(sort) [ArrayElement] |
 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | semmle.label | files2.sort(sort) [ArrayElement] |
 | xss-through-filenames.js:19:45:19:48 | file | semmle.label | file |
-| xss-through-filenames.js:20:13:20:18 | [post update] files3 | semmle.label | [post update] files3 |
 | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | semmle.label | [post update] files3 [ArrayElement] |
 | xss-through-filenames.js:20:25:20:47 | '<li>'  ... '</li>' | semmle.label | '<li>'  ... '</li>' |
 | xss-through-filenames.js:20:34:20:37 | file | semmle.label | file |
-| xss-through-filenames.js:22:16:22:21 | files3 | semmle.label | files3 |
-| xss-through-filenames.js:22:16:22:21 | files3 | semmle.label | files3 |
 | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | semmle.label | files3 [ArrayElement] |
-| xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] | semmle.label | files3 [ArrayElement] |
-| xss-through-filenames.js:22:16:22:30 | files3.join('') | semmle.label | files3.join('') |
 | xss-through-filenames.js:22:16:22:30 | files3.join('') | semmle.label | files3.join('') |
 | xss-through-filenames.js:25:43:25:48 | files1 | semmle.label | files1 |
 | xss-through-filenames.js:26:19:26:24 | files1 | semmle.label | files1 |
 | xss-through-filenames.js:30:9:30:14 | files1 | semmle.label | files1 |
 | xss-through-filenames.js:30:34:30:37 | file | semmle.label | file |
-| xss-through-filenames.js:31:13:31:18 | [post update] files2 | semmle.label | [post update] files2 |
 | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | semmle.label | [post update] files2 [ArrayElement] |
 | xss-through-filenames.js:31:25:31:28 | file | semmle.label | file |
-| xss-through-filenames.js:33:19:33:24 | files2 | semmle.label | files2 |
 | xss-through-filenames.js:33:19:33:24 | files2 | semmle.label | files2 |
 | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] | semmle.label | files2 [ArrayElement] |
 | xss-through-filenames.js:35:13:35:35 | files3 | semmle.label | files3 |
 | xss-through-filenames.js:35:22:35:35 | format(files2) | semmle.label | format(files2) |
-| xss-through-filenames.js:35:29:35:34 | files2 | semmle.label | files2 |
 | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | semmle.label | files2 [ArrayElement] |
 | xss-through-filenames.js:37:19:37:24 | files3 | semmle.label | files3 |
 | xss-through-torrent.js:6:6:6:24 | name | semmle.label | name |
 | xss-through-torrent.js:6:13:6:24 | torrent.name | semmle.label | torrent.name |
 | xss-through-torrent.js:7:11:7:14 | name | semmle.label | name |
 subpaths
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 | xss-through-filenames.js:22:16:22:21 | files3 |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 | xss-through-filenames.js:22:16:22:21 | files3 |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 | xss-through-filenames.js:22:16:22:21 | files3 |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 | xss-through-filenames.js:22:16:22:21 | files3 |
 | xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] |
-| xss-through-filenames.js:19:9:19:25 | files2.sort(sort) [ArrayElement] | xss-through-filenames.js:19:45:19:48 | file | xss-through-filenames.js:20:13:20:18 | [post update] files3 [ArrayElement] | xss-through-filenames.js:22:16:22:21 | files3 [ArrayElement] |
-| xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | xss-through-filenames.js:33:19:33:24 | files2 |
-| xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 | xss-through-filenames.js:33:19:33:24 | files2 |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | xss-through-filenames.js:33:19:33:24 | files2 |
 | xss-through-filenames.js:30:9:30:14 | files1 | xss-through-filenames.js:30:34:30:37 | file | xss-through-filenames.js:31:13:31:18 | [post update] files2 [ArrayElement] | xss-through-filenames.js:33:19:33:24 | files2 [ArrayElement] |
-| xss-through-filenames.js:35:29:35:34 | files2 | xss-through-filenames.js:17:21:17:26 | files2 | xss-through-filenames.js:22:16:22:30 | files3.join('') | xss-through-filenames.js:35:22:35:35 | format(files2) |
 | xss-through-filenames.js:35:29:35:34 | files2 [ArrayElement] | xss-through-filenames.js:17:21:17:26 | files2 [ArrayElement] | xss-through-filenames.js:22:16:22:30 | files3.join('') | xss-through-filenames.js:35:22:35:35 | format(files2) |
 #select
 | xss-through-filenames.js:8:18:8:23 | files1 | xss-through-filenames.js:7:43:7:48 | files1 | xss-through-filenames.js:8:18:8:23 | files1 | Stored cross-site scripting vulnerability due to $@. | xss-through-filenames.js:7:43:7:48 | files1 | stored value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -52,12 +52,10 @@ nodes
 | json-schema-validator.js:61:22:61:26 | query | semmle.label | query |
 | koarouter.js:5:11:5:33 | version | semmle.label | version |
 | koarouter.js:5:13:5:19 | version | semmle.label | version |
-| koarouter.js:14:9:14:18 | [post update] conditions | semmle.label | [post update] conditions |
 | koarouter.js:14:9:14:18 | [post update] conditions [ArrayElement] | semmle.label | [post update] conditions [ArrayElement] |
 | koarouter.js:14:25:14:46 | `versio ... rsion}` | semmle.label | `versio ... rsion}` |
 | koarouter.js:14:38:14:44 | version | semmle.label | version |
 | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | semmle.label | `SELECT ... nd ')}` |
-| koarouter.js:17:52:17:61 | conditions | semmle.label | conditions |
 | koarouter.js:17:52:17:61 | conditions [ArrayElement] | semmle.label | conditions [ArrayElement] |
 | koarouter.js:17:52:17:75 | conditi ...  and ') | semmle.label | conditi ...  and ') |
 | ldap.js:20:7:20:34 | q | semmle.label | q |
@@ -324,12 +322,9 @@ edges
 | json-schema-validator.js:50:34:50:47 | req.query.data | json-schema-validator.js:50:23:50:48 | JSON.pa ... y.data) | provenance | Config |
 | koarouter.js:5:11:5:33 | version | koarouter.js:14:38:14:44 | version | provenance |  |
 | koarouter.js:5:13:5:19 | version | koarouter.js:5:11:5:33 | version | provenance |  |
-| koarouter.js:14:9:14:18 | [post update] conditions | koarouter.js:17:52:17:61 | conditions | provenance |  |
 | koarouter.js:14:9:14:18 | [post update] conditions [ArrayElement] | koarouter.js:17:52:17:61 | conditions [ArrayElement] | provenance |  |
-| koarouter.js:14:25:14:46 | `versio ... rsion}` | koarouter.js:14:9:14:18 | [post update] conditions | provenance |  |
 | koarouter.js:14:25:14:46 | `versio ... rsion}` | koarouter.js:14:9:14:18 | [post update] conditions [ArrayElement] | provenance |  |
 | koarouter.js:14:38:14:44 | version | koarouter.js:14:25:14:46 | `versio ... rsion}` | provenance |  |
-| koarouter.js:17:52:17:61 | conditions | koarouter.js:17:52:17:75 | conditi ...  and ') | provenance |  |
 | koarouter.js:17:52:17:61 | conditions [ArrayElement] | koarouter.js:17:52:17:75 | conditi ...  and ') | provenance |  |
 | koarouter.js:17:52:17:75 | conditi ...  and ') | koarouter.js:17:27:17:77 | `SELECT ... nd ')}` | provenance |  |
 | ldap.js:20:7:20:34 | q | ldap.js:22:18:22:18 | q | provenance |  |

--- a/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-094/CodeInjection/ImproperCodeSanitization.expected
@@ -1,23 +1,18 @@
 edges
 | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` | bad-code-sanitization.js:7:31:7:43 | safeProp(key) | provenance |  |
 | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` | provenance |  |
-| bad-code-sanitization.js:7:5:7:14 | [post update] statements | bad-code-sanitization.js:8:27:8:36 | statements | provenance |  |
 | bad-code-sanitization.js:7:5:7:14 | [post update] statements [ArrayElement] | bad-code-sanitization.js:8:27:8:36 | statements [ArrayElement] | provenance |  |
-| bad-code-sanitization.js:7:21:7:70 | `${name ... key])}` | bad-code-sanitization.js:7:5:7:14 | [post update] statements | provenance |  |
 | bad-code-sanitization.js:7:21:7:70 | `${name ... key])}` | bad-code-sanitization.js:7:5:7:14 | [post update] statements [ArrayElement] | provenance |  |
 | bad-code-sanitization.js:7:31:7:43 | safeProp(key) | bad-code-sanitization.js:7:21:7:70 | `${name ... key])}` | provenance |  |
-| bad-code-sanitization.js:8:27:8:36 | statements | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | provenance |  |
 | bad-code-sanitization.js:8:27:8:36 | statements [ArrayElement] | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | provenance |  |
 | bad-code-sanitization.js:63:11:63:55 | assignment | bad-code-sanitization.js:64:27:64:36 | assignment | provenance |  |
 | bad-code-sanitization.js:63:31:63:49 | JSON.stringify(key) | bad-code-sanitization.js:63:11:63:55 | assignment | provenance |  |
 nodes
 | bad-code-sanitization.js:2:12:2:90 | /^[_$a- ... key)}]` | semmle.label | /^[_$a- ... key)}]` |
 | bad-code-sanitization.js:2:69:2:87 | JSON.stringify(key) | semmle.label | JSON.stringify(key) |
-| bad-code-sanitization.js:7:5:7:14 | [post update] statements | semmle.label | [post update] statements |
 | bad-code-sanitization.js:7:5:7:14 | [post update] statements [ArrayElement] | semmle.label | [post update] statements [ArrayElement] |
 | bad-code-sanitization.js:7:21:7:70 | `${name ... key])}` | semmle.label | `${name ... key])}` |
 | bad-code-sanitization.js:7:31:7:43 | safeProp(key) | semmle.label | safeProp(key) |
-| bad-code-sanitization.js:8:27:8:36 | statements | semmle.label | statements |
 | bad-code-sanitization.js:8:27:8:36 | statements [ArrayElement] | semmle.label | statements [ArrayElement] |
 | bad-code-sanitization.js:8:27:8:46 | statements.join(';') | semmle.label | statements.join(';') |
 | bad-code-sanitization.js:15:44:15:63 | htmlescape(pathname) | semmle.label | htmlescape(pathname) |

--- a/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-730/RegExpInjection.expected
@@ -28,11 +28,8 @@ edges
 | RegExpInjection.js:29:21:29:21 | s | RegExpInjection.js:31:23:31:23 | s | provenance |  |
 | RegExpInjection.js:33:12:33:14 | key | RegExpInjection.js:29:21:29:21 | s | provenance |  |
 | RegExpInjection.js:34:12:34:19 | getKey() | RegExpInjection.js:29:21:29:21 | s | provenance |  |
-| RegExpInjection.js:54:14:54:16 | key | RegExpInjection.js:54:14:54:27 | key.split(".") | provenance |  |
 | RegExpInjection.js:54:14:54:16 | key | RegExpInjection.js:54:14:54:27 | key.split(".") [ArrayElement] | provenance |  |
-| RegExpInjection.js:54:14:54:27 | key.split(".") | RegExpInjection.js:54:14:54:42 | key.spl ... x => x) | provenance |  |
 | RegExpInjection.js:54:14:54:27 | key.split(".") [ArrayElement] | RegExpInjection.js:54:14:54:42 | key.spl ... x => x) [ArrayElement] | provenance |  |
-| RegExpInjection.js:54:14:54:42 | key.spl ... x => x) | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") | provenance |  |
 | RegExpInjection.js:54:14:54:42 | key.spl ... x => x) [ArrayElement] | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") | provenance |  |
 | RegExpInjection.js:60:31:60:56 | input | RegExpInjection.js:64:14:64:18 | input | provenance |  |
 | RegExpInjection.js:60:39:60:56 | req.param("input") | RegExpInjection.js:60:31:60:56 | input | provenance |  |
@@ -81,9 +78,7 @@ nodes
 | RegExpInjection.js:46:27:46:31 | input | semmle.label | input |
 | RegExpInjection.js:47:26:47:30 | input | semmle.label | input |
 | RegExpInjection.js:54:14:54:16 | key | semmle.label | key |
-| RegExpInjection.js:54:14:54:27 | key.split(".") | semmle.label | key.split(".") |
 | RegExpInjection.js:54:14:54:27 | key.split(".") [ArrayElement] | semmle.label | key.split(".") [ArrayElement] |
-| RegExpInjection.js:54:14:54:42 | key.spl ... x => x) | semmle.label | key.spl ... x => x) |
 | RegExpInjection.js:54:14:54:42 | key.spl ... x => x) [ArrayElement] | semmle.label | key.spl ... x => x) [ArrayElement] |
 | RegExpInjection.js:54:14:54:52 | key.spl ... in("-") | semmle.label | key.spl ... in("-") |
 | RegExpInjection.js:60:31:60:56 | input | semmle.label | input |


### PR DESCRIPTION
When a flow summary uses `ArrayElement` in its output column, we'd previously generate a taint step in addition to a store step into the array. This PR removes that rule, so that _reading_ from `ArrayElement` generates a taint step, but storing into `ArrayElement` does not.

The rule was there in order to be consistent with how things worked with the old data flow library, where arrays were generally considered tainted if they contained a tainted element, but we don't really do that anymore. This PR makes a couple of semi-related changes in order to recover from observed FPs/FNs resulting from the first commit.

The DCA run looks good:
- 4 fixed FPs
- 1 lost result from `ExceptionXss` which is due to that query having an AP limit of 1, which is no longer enough to find the flow. The result was not exploitable; it seemed like the sort of FP some users might have appreciated and fixed anyway, but on the whole it's not critical to preserve it.
- A minor but clean speedup: Average of 3.5% speedup with 8% and 9% speedup on the two slowest projects.