### PR TITLE
JS: Add support for the regex V flag

### DIFF
--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -788,6 +788,7 @@ public class Parser {
       String validFlags = "gim";
       if (this.options.ecmaVersion() >= 6) validFlags = "gimuy";
       if (this.options.ecmaVersion() >= 9) validFlags = "gimsuy";
+      if (this.options.ecmaVersion() >= 12) validFlags = "gimsuyv";
       if (!mods.matches("^[" + validFlags + "]*$"))
         this.raise(start, "Invalid regular expression flag");
       if (mods.indexOf('u') >= 0) {

--- a/javascript/extractor/src/com/semmle/jcorn/Parser.java
+++ b/javascript/extractor/src/com/semmle/jcorn/Parser.java
@@ -788,7 +788,7 @@ public class Parser {
       String validFlags = "gim";
       if (this.options.ecmaVersion() >= 6) validFlags = "gimuy";
       if (this.options.ecmaVersion() >= 9) validFlags = "gimsuy";
-      if (this.options.ecmaVersion() >= 12) validFlags = "gimsuyv";
+      if (this.options.ecmaVersion() >= 15) validFlags = "gimsuyv";
       if (!mods.matches("^[" + validFlags + "]*$"))
         this.raise(start, "Invalid regular expression flag");
       if (mods.indexOf('u') >= 0) {

--- a/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
@@ -41,7 +41,8 @@ public class ExtractorConfig {
     ECMA2017(2017, 8),
     ECMA2018(2018, 9),
     ECMA2019(2019, 10),
-    ECMA2020(2020, 11);
+    ECMA2020(2020, 11),
+    ECMA2021(2021, 12);
 
     private final int version;
     public final int legacyVersion;
@@ -232,7 +233,7 @@ public class ExtractorConfig {
   private VirtualSourceRoot virtualSourceRoot;
 
   public ExtractorConfig(boolean experimental) {
-    this.ecmaVersion = experimental ? ECMAVersion.ECMA2020 : ECMAVersion.ECMA2019;
+    this.ecmaVersion = experimental ? ECMAVersion.ECMA2021 : ECMAVersion.ECMA2019;
     this.platform = Platform.AUTO;
     this.jsx = true;
     this.sourceType = SourceType.AUTO;

--- a/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/ExtractorConfig.java
@@ -42,7 +42,7 @@ public class ExtractorConfig {
     ECMA2018(2018, 9),
     ECMA2019(2019, 10),
     ECMA2020(2020, 11),
-    ECMA2021(2021, 12);
+    ECMA2024(2024, 15);
 
     private final int version;
     public final int legacyVersion;
@@ -233,7 +233,7 @@ public class ExtractorConfig {
   private VirtualSourceRoot virtualSourceRoot;
 
   public ExtractorConfig(boolean experimental) {
-    this.ecmaVersion = experimental ? ECMAVersion.ECMA2021 : ECMAVersion.ECMA2019;
+    this.ecmaVersion = experimental ? ECMAVersion.ECMA2024 : ECMAVersion.ECMA2019;
     this.platform = Platform.AUTO;
     this.jsx = true;
     this.sourceType = SourceType.AUTO;

--- a/javascript/ql/lib/change-notes/2025-02-16-v-flag.md
+++ b/javascript/ql/lib/change-notes/2025-02-16-v-flag.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Added support for regular expressions using the `v` flag.

--- a/javascript/ql/lib/semmle/javascript/Expr.qll
+++ b/javascript/ql/lib/semmle/javascript/Expr.qll
@@ -481,6 +481,9 @@ class RegExpLiteral extends @regexp_literal, Literal, RegExpParent {
   /** Holds if this regular expression has an `s` flag. */
   predicate isDotAll() { RegExp::isDotAll(this.getFlags()) }
 
+  /** Holds if this regular expression has an `v` flag. */
+  predicate isUnicodeSets() { RegExp::isUnicodeSets(this.getFlags()) }
+
   override string getAPrimaryQlClass() { result = "RegExpLiteral" }
 }
 

--- a/javascript/ql/lib/semmle/javascript/Regexp.qll
+++ b/javascript/ql/lib/semmle/javascript/Regexp.qll
@@ -1162,6 +1162,10 @@ module RegExp {
   bindingset[flags]
   predicate isDotAll(string flags) { flags.matches("%s%") }
 
+  /** Holds if `flags` includes the `v` flag. */
+  bindingset[flags]
+  predicate isUnicodeSets(string flags) { flags.matches("%v%") }
+
   /** Holds if `flags` includes the `m` flag or is the unknown flag `?`. */
   bindingset[flags]
   predicate maybeMultiline(string flags) { flags = unknownFlag() or isMultiline(flags) }

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/PolynomialBackTracking.expected
@@ -538,3 +538,4 @@
 | tst.js:407:128:407:129 |  * | Strings starting with '0/*' and with many repetitions of ' ' can start matching anywhere after the start of the preceeding \\s* |
 | tst.js:409:23:409:29 | [\\w.-]* | Strings starting with '//' and with many repetitions of '//' can start matching anywhere after the start of the preceeding (\\/(?:\\/[\\w.-]*)*){0,1}:([\\w.-]+) |
 | tst.js:411:15:411:19 | a{1,} | Strings with many repetitions of 'a' can start matching anywhere after the start of the preceeding (a{1,})* |
+| tst.js:417:20:417:25 | (aa?)* | Strings with many repetitions of 'aa' can start matching anywhere after the start of the preceeding (aa?)*b |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/ReDoS.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/ReDoS.expected
@@ -201,3 +201,4 @@
 | tst.js:411:15:411:19 | a{1,} | This part of the regular expression may cause exponential backtracking on strings containing many repetitions of 'a'. |
 | tst.js:413:25:413:35 | (\\u0000\|.)+ | This part of the regular expression may cause exponential backtracking on strings starting with '\\n\\u0000' and containing many repetitions of '\\u0000'. |
 | tst.js:415:44:415:57 | (\ud83d\ude80\|.)+ | This part of the regular expression may cause exponential backtracking on strings starting with '\\n\\u{1f680}' and containing many repetitions of '\\u{1f680}'. |
+| tst.js:417:22:417:23 | a? | This part of the regular expression may cause exponential backtracking on strings starting with 'a' and containing many repetitions of 'aa'. |

--- a/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-400/ReDoS/tst.js
@@ -413,3 +413,5 @@ var bad99 = /(a{1,})*b/;
 var unicode = /^\n\u0000(\u0000|.)+$/;
 
 var largeUnicode = new RegExp("^\n\u{1F680}(\u{1F680}|.)+X$");
+
+var unicodeSets = /(aa?)*b/v;


### PR DESCRIPTION
The first commits are picked from this WIP PR: https://github.com/github/codeql/pull/18055 

This is an alternative to: https://github.com/github/codeql/pull/18727