### PR TITLE
JS: upgrade TypeScript to 5.8

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -25,7 +25,7 @@
    Python [8]_,"2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13",Not applicable,``.py``
    Ruby [9]_,"up to 3.3",Not applicable,"``.rb``, ``.erb``, ``.gemspec``, ``Gemfile``"
    Swift [10]_,"Swift 5.4-6.0","Swift compiler","``.swift``"
-   TypeScript [11]_,"2.6-5.7",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
+   TypeScript [11]_,"2.6-5.8",Standard TypeScript compiler,"``.ts``, ``.tsx``, ``.mts``, ``.cts``"
 
 .. container:: footnote-group
 

--- a/javascript/extractor/lib/typescript/package-lock.json
+++ b/javascript/extractor/lib/typescript/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "typescript-parser-wrapper",
             "dependencies": {
-                "typescript": "^5.8.1-rc"
+                "typescript": "^5.8.2"
             },
             "devDependencies": {
                 "@types/node": "18.15.3"
@@ -20,9 +20,9 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.8.1-rc",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.1-rc.tgz",
-            "integrity": "sha512-D8IlSOUk1E08jpFdK81reYkA1a/4XtEdV6MElOGdbu/uOy1RpEDqNO/onWmqUaLkTyeHmmU/QlWvjcM9cqF85g==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/javascript/extractor/lib/typescript/package-lock.json
+++ b/javascript/extractor/lib/typescript/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "typescript-parser-wrapper",
             "dependencies": {
-                "typescript": "^5.7.2"
+                "typescript": "^5.8.1-rc"
             },
             "devDependencies": {
                 "@types/node": "18.15.3"
@@ -20,9 +20,9 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.8.1-rc",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.1-rc.tgz",
+            "integrity": "sha512-D8IlSOUk1E08jpFdK81reYkA1a/4XtEdV6MElOGdbu/uOy1RpEDqNO/onWmqUaLkTyeHmmU/QlWvjcM9cqF85g==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "^5.7.2"
+        "typescript": "^5.8.1-rc"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json",

--- a/javascript/extractor/lib/typescript/package.json
+++ b/javascript/extractor/lib/typescript/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-parser-wrapper",
     "private": true,
     "dependencies": {
-        "typescript": "^5.8.1-rc"
+        "typescript": "^5.8.2"
     },
     "scripts": {
         "build": "tsc --project tsconfig.json",

--- a/javascript/ql/lib/change-notes/2025-02-17-typescript-5-8.md
+++ b/javascript/ql/lib/change-notes/2025-02-17-typescript-5-8.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* Added support for TypeScript 5.5.

--- a/javascript/ql/lib/change-notes/2025-02-17-typescript-5-8.md
+++ b/javascript/ql/lib/change-notes/2025-02-17-typescript-5-8.md
@@ -1,4 +1,4 @@
 ---
 category: majorAnalysis
 ---
-* Added support for TypeScript 5.5.
+* Added support for TypeScript 5.8.


### PR DESCRIPTION
All the changes are additional type-checking, or optional features that are only relevant under specific flags.  
No new syntax or other changes that seem to be relevant for our work.  

See the announcement blogpost: https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/

I'm running some DCA evaluations to confirm that everything is fine. 