### PR TITLE
JS: Extract TS snippets with no tsconfig.json file

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/AutoBuild.java
@@ -1087,6 +1087,12 @@ protected DependencyInstallationResult preparePackagesAndDependencies(Set<Path> 
           remainingTypeScriptFiles.add(f);
         }
       }
+      for (Map.Entry<Path, FileSnippet> entry : state.getSnippets().entrySet()) {
+        if (!extractedFiles.contains(entry.getKey())
+            && FileType.forFileExtension(entry.getKey().toFile()) == FileType.TYPESCRIPT) {
+            remainingTypeScriptFiles.add(entry.getKey());
+        }
+      }
       if (!remainingTypeScriptFiles.isEmpty()) {
         extractTypeScriptFiles(remainingTypeScriptFiles, extractedFiles, extractors);
       }


### PR DESCRIPTION
Fixes https://github.com/github/codeql/issues/18801

This fixes the bug that was supposed to be fixed in https://github.com/github/codeql/pull/18550, but that PR only fixed it in the legacy entry-point used by qltest. Meaning it worked in tests but not in production 🤦. This PR uses the same fix in AutoBuild entry point. We should unify the two entry points ASAP but for now this PR just fixes the bug.