### PR TITLE
Rust: Path resolution for inherited associated items

### DIFF
--- a/rust/ql/lib/codeql/rust/elements/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PathResolution.qll
@@ -130,6 +130,16 @@ abstract class ItemNode extends AstNode {
       call = this.getASuccessorRec(_) and
       result = call.(ItemNode).getASuccessorRec(name)
     )
+    or
+    // an inherited function, either from a trait bound or from an `impl` block
+    exists(ItemNode node |
+      result = node.(ItemNode).getASuccessorRec(name) and
+      result instanceof Function
+    |
+      node = this.(TraitItemNode).resolveABound()
+      or
+      this = node.(ImplItemNode).resolveSelfTy()
+    )
   }
 
   /** Gets a successor named `name` of this item, if any. */
@@ -269,6 +279,13 @@ private class StructItemNode extends ItemNode instanceof Struct {
 }
 
 class TraitItemNode extends ImplOrTraitItemNode instanceof Trait {
+  pragma[nomagic]
+  Path getABoundPath() {
+    result = super.getTypeBoundList().getABound().getTypeRepr().(PathTypeRepr).getPath()
+  }
+
+  ItemNode resolveABound() { result = resolvePath(this.getABoundPath()) }
+
   override string getName() { result = Trait.super.getName().getText() }
 
   override Namespace getNamespace() { result.isType() }

--- a/rust/ql/lib/codeql/rust/elements/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PathResolution.qll
@@ -131,14 +131,15 @@ abstract class ItemNode extends AstNode {
       result = call.(ItemNode).getASuccessorRec(name)
     )
     or
-    // an inherited function, either from a trait bound or from an `impl` block
+    // a trait has access to the associated items of its supertraits
+    result = this.(TraitItemNode).resolveABound().getASuccessorRec(name) and
+    result instanceof AssocItemNode
+    or
+    // items made available by an implementation where `this` is the implementing type
     exists(ItemNode node |
-      result = node.(ItemNode).getASuccessorRec(name) and
-      result instanceof Function
-    |
-      node = this.(TraitItemNode).resolveABound()
-      or
-      this = node.(ImplItemNode).resolveSelfTy()
+      this = node.(ImplItemNode).resolveSelfTy() and
+      result = node.getASuccessorRec(name) and
+      result instanceof AssocItemNode
     )
   }
 
@@ -189,7 +190,10 @@ private class SourceFileItemNode extends ModuleLikeNode, SourceFile {
   override Visibility getVisibility() { none() }
 }
 
-private class ConstItemNode extends ItemNode instanceof Const {
+/** An item that can occur in a trait or an `impl` block. */
+abstract private class AssocItemNode extends ItemNode { }
+
+private class ConstItemNode extends AssocItemNode instanceof Const {
   override string getName() { result = Const.super.getName().getText() }
 
   override Namespace getNamespace() { result.isValue() }
@@ -215,7 +219,7 @@ private class VariantItemNode extends ItemNode instanceof Variant {
   override Visibility getVisibility() { result = Variant.super.getVisibility() }
 }
 
-private class FunctionItemNode extends ItemNode instanceof Function {
+private class FunctionItemNode extends AssocItemNode instanceof Function {
   override string getName() { result = Function.super.getName().getText() }
 
   override Namespace getNamespace() { result.isValue() }
@@ -249,7 +253,7 @@ class ImplItemNode extends ImplOrTraitItemNode instanceof Impl {
   override Visibility getVisibility() { result = Impl.super.getVisibility() }
 }
 
-private class MacroCallItemNode extends ItemNode instanceof MacroCall {
+private class MacroCallItemNode extends AssocItemNode instanceof MacroCall {
   override string getName() { result = "(macro call)" }
 
   override Namespace getNamespace() { none() }
@@ -293,7 +297,7 @@ class TraitItemNode extends ImplOrTraitItemNode instanceof Trait {
   override Visibility getVisibility() { result = Trait.super.getVisibility() }
 }
 
-class TypeAliasItemNode extends ItemNode instanceof TypeAlias {
+class TypeAliasItemNode extends AssocItemNode instanceof TypeAlias {
   override string getName() { result = TypeAlias.super.getName().getText() }
 
   override Namespace getNamespace() { result.isType() }

--- a/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
+++ b/rust/ql/test/library-tests/dataflow/global/inline-flow.expected
@@ -42,6 +42,15 @@ edges
 | main.rs:103:13:103:30 | mn.data_through(...) | main.rs:103:9:103:9 | b | provenance |  |
 | main.rs:103:29:103:29 | a | main.rs:79:28:79:33 | ...: i64 | provenance |  |
 | main.rs:103:29:103:29 | a | main.rs:103:13:103:30 | mn.data_through(...) | provenance |  |
+| main.rs:109:9:109:9 | a | main.rs:110:26:110:26 | a | provenance |  |
+| main.rs:109:13:109:21 | source(...) | main.rs:109:9:109:9 | a | provenance |  |
+| main.rs:110:26:110:26 | a | main.rs:67:23:67:28 | ...: i64 | provenance |  |
+| main.rs:115:9:115:9 | a | main.rs:116:39:116:39 | a | provenance |  |
+| main.rs:115:13:115:22 | source(...) | main.rs:115:9:115:9 | a | provenance |  |
+| main.rs:116:9:116:9 | b | main.rs:117:10:117:10 | b | provenance |  |
+| main.rs:116:13:116:40 | ...::data_through(...) | main.rs:116:9:116:9 | b | provenance |  |
+| main.rs:116:39:116:39 | a | main.rs:79:28:79:33 | ...: i64 | provenance |  |
+| main.rs:116:39:116:39 | a | main.rs:116:13:116:40 | ...::data_through(...) | provenance |  |
 | main.rs:128:12:128:17 | ...: i64 | main.rs:129:24:129:24 | n | provenance |  |
 | main.rs:129:9:129:26 | MyInt {...} [MyInt] | main.rs:128:28:130:5 | { ... } [MyInt] | provenance |  |
 | main.rs:129:24:129:24 | n | main.rs:129:9:129:26 | MyInt {...} [MyInt] | provenance |  |
@@ -130,6 +139,15 @@ nodes
 | main.rs:103:13:103:30 | mn.data_through(...) | semmle.label | mn.data_through(...) |
 | main.rs:103:29:103:29 | a | semmle.label | a |
 | main.rs:104:10:104:10 | b | semmle.label | b |
+| main.rs:109:9:109:9 | a | semmle.label | a |
+| main.rs:109:13:109:21 | source(...) | semmle.label | source(...) |
+| main.rs:110:26:110:26 | a | semmle.label | a |
+| main.rs:115:9:115:9 | a | semmle.label | a |
+| main.rs:115:13:115:22 | source(...) | semmle.label | source(...) |
+| main.rs:116:9:116:9 | b | semmle.label | b |
+| main.rs:116:13:116:40 | ...::data_through(...) | semmle.label | ...::data_through(...) |
+| main.rs:116:39:116:39 | a | semmle.label | a |
+| main.rs:117:10:117:10 | b | semmle.label | b |
 | main.rs:128:12:128:17 | ...: i64 | semmle.label | ...: i64 |
 | main.rs:128:28:130:5 | { ... } [MyInt] | semmle.label | { ... } [MyInt] |
 | main.rs:129:9:129:26 | MyInt {...} [MyInt] | semmle.label | MyInt {...} [MyInt] |
@@ -179,6 +197,7 @@ subpaths
 | main.rs:41:26:44:5 | { ... } | main.rs:30:17:30:22 | ...: i64 | main.rs:30:32:32:1 | { ... } | main.rs:41:13:44:6 | pass_through(...) |
 | main.rs:55:26:55:26 | a | main.rs:51:21:51:26 | ...: i64 | main.rs:51:36:53:5 | { ... } | main.rs:55:13:55:27 | pass_through(...) |
 | main.rs:103:29:103:29 | a | main.rs:79:28:79:33 | ...: i64 | main.rs:79:43:85:5 | { ... } | main.rs:103:13:103:30 | mn.data_through(...) |
+| main.rs:116:39:116:39 | a | main.rs:79:28:79:33 | ...: i64 | main.rs:79:43:85:5 | { ... } | main.rs:116:13:116:40 | ...::data_through(...) |
 | main.rs:134:24:134:33 | source(...) | main.rs:128:12:128:17 | ...: i64 | main.rs:128:28:130:5 | { ... } [MyInt] | main.rs:134:13:134:34 | ...::new(...) [MyInt] |
 | main.rs:187:49:187:49 | a [MyInt] | main.rs:175:18:175:21 | SelfParam [MyInt] | main.rs:175:48:177:5 | { ... } [MyInt] | main.rs:187:30:187:53 | ...::take_self(...) [MyInt] |
 | main.rs:192:54:192:54 | b [MyInt] | main.rs:179:26:179:37 | ...: MyInt [MyInt] | main.rs:179:49:181:5 | { ... } [MyInt] | main.rs:192:30:192:55 | ...::take_second(...) [MyInt] |
@@ -191,8 +210,10 @@ testFailures
 | main.rs:45:10:45:10 | a | main.rs:43:9:43:18 | source(...) | main.rs:45:10:45:10 | a | $@ | main.rs:43:9:43:18 | source(...) | source(...) |
 | main.rs:56:10:56:10 | b | main.rs:49:13:49:22 | source(...) | main.rs:56:10:56:10 | b | $@ | main.rs:49:13:49:22 | source(...) | source(...) |
 | main.rs:68:14:68:14 | n | main.rs:96:13:96:21 | source(...) | main.rs:68:14:68:14 | n | $@ | main.rs:96:13:96:21 | source(...) | source(...) |
+| main.rs:68:14:68:14 | n | main.rs:109:13:109:21 | source(...) | main.rs:68:14:68:14 | n | $@ | main.rs:109:13:109:21 | source(...) | source(...) |
 | main.rs:91:10:91:10 | a | main.rs:75:13:75:21 | source(...) | main.rs:91:10:91:10 | a | $@ | main.rs:75:13:75:21 | source(...) | source(...) |
 | main.rs:104:10:104:10 | b | main.rs:102:13:102:21 | source(...) | main.rs:104:10:104:10 | b | $@ | main.rs:102:13:102:21 | source(...) | source(...) |
+| main.rs:117:10:117:10 | b | main.rs:115:13:115:22 | source(...) | main.rs:117:10:117:10 | b | $@ | main.rs:115:13:115:22 | source(...) | source(...) |
 | main.rs:136:10:136:10 | m | main.rs:134:24:134:33 | source(...) | main.rs:136:10:136:10 | m | $@ | main.rs:134:24:134:33 | source(...) | source(...) |
 | main.rs:188:10:188:10 | c | main.rs:185:28:185:36 | source(...) | main.rs:188:10:188:10 | c | $@ | main.rs:185:28:185:36 | source(...) | source(...) |
 | main.rs:193:10:193:10 | c | main.rs:191:28:191:37 | source(...) | main.rs:193:10:193:10 | c | $@ | main.rs:191:28:191:37 | source(...) | source(...) |

--- a/rust/ql/test/library-tests/dataflow/global/main.rs
+++ b/rust/ql/test/library-tests/dataflow/global/main.rs
@@ -65,7 +65,7 @@ struct MyFlag {
 
 impl MyFlag {
     fn data_in(&self, n: i64) {
-        sink(n); // $ hasValueFlow=1 MISSING: hasValueFlow=8
+        sink(n); // $ hasValueFlow=1 hasValueFlow=8
     }
 
     fn get_data(&self) -> i64 {
@@ -114,7 +114,7 @@ fn data_through_method_called_as_function() {
     let mn = MyFlag { flag: true };
     let a = source(12);
     let b = MyFlag::data_through(&mn, a);
-    sink(b); // $ MISSING: hasValueFlow=12
+    sink(b); // $ hasValueFlow=12
 }
 
 use std::ops::Add;

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -347,6 +347,93 @@ mod m15 {
     } // I75
 }
 
+mod m16 {
+    #[rustfmt::skip]
+    trait Trait1<
+      T // I84
+    > {
+        fn f(&self) -> T; // $ item=I84
+
+        fn g(&self) -> T // $ item=I84
+        ; // I85
+
+        const c: T // $ item=I84
+        ; // I94
+    } // I86
+
+    #[rustfmt::skip]
+    trait Trait2<
+      T // I87
+    > // I88
+      : Trait1<
+          T // $ item=I87
+        > { // $ item=I86
+        fn f(&self) -> T { // $ item=I87
+            println!("m16::Trait2::f");
+            Self::g(self); // $ item=I85
+            self.g(); // $ MISSING: item=I85
+            Self::c // $ item=I94
+        }
+    } // I89
+
+    struct S; // I90
+
+    #[rustfmt::skip]
+    impl Trait1<
+      S // $ item=I90
+    > // $ item=I86
+      for S { // $ item=I90
+        fn f(&self) -> S { // $ item=I90
+            println!("m16::<S as Trait1<S>>::f");
+            Self::g(self); // $ item=I92
+            self.g() // $ MISSING: item=I92
+        } // I91
+
+        fn g(&self) -> S { // $ item=I90
+            println!("m16::<S as Trait1<S>>::g");
+            Self::c // $ item=I95
+        } // I92
+
+        const c: S = S // $ item=I90
+        ; // I95
+    }
+
+    #[rustfmt::skip]
+    impl Trait2<
+      S // $ item=I90
+    > // $ item=I89
+      for S { // $ item=I90
+        fn f(&self) -> S { // $ item=I90
+            println!("m16::<S as Trait2<S>>::f");
+            Self::c // $ MISSING: item=I95
+        } // I93
+    }
+
+    #[rustfmt::skip]
+    pub fn f() {
+        println!("m16::f");
+        let x = S; // $ item=I90
+        <S // $ item=I90
+          as Trait1<
+            S // $ item=I90
+          > // $ MISSING: item=I86
+        >::f(&x); // $ MISSING: item=I91
+        <S // $ item=I90
+          as Trait2<
+            S // $ item=I90
+          > // MISSING: item=I89
+        >::f(&x); // $ MISSING: item=I93
+        S::g(&x); // $ item=I92
+        x.g(); // $ MISSING: item=I92
+        S::c; // $ item=I95
+        <S // $ item=I90
+          as Trait1<
+            S // $ item=I90
+          > // $ MISSING: item=I86
+        >::c; // $ MISSING: item=I95
+    } // I83
+}
+
 fn main() {
     my::nested::nested1::nested2::f(); // $ item=I4
     my::f(); // $ item=I38
@@ -367,4 +454,5 @@ fn main() {
     m9::f(); // $ item=I57
     m11::f(); // $ item=I63
     m15::f(); // $ item=I75
+    m16::f(); // $ item=I83
 }

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -178,7 +178,7 @@ mod m8 {
     pub fn g() {
         let x = MyStruct {}; // $ item=I50
         MyTrait::f(&x); // $ item=I48
-        MyStruct::f(&x); // $ MISSING: item=I53
+        MyStruct::f(&x); // $ item=I53
         <MyStruct as // $ item=I50
          MyTrait // $ MISSING: item=I47
         > // $ MISSING: item=52
@@ -187,7 +187,7 @@ mod m8 {
         x.f(); // $ MISSING: item=I53
         let x = MyStruct {}; // $ item=I50
         x.g(); // $ MISSING: item=I54
-        MyStruct::h(&x); // $ MISSING: item=I74
+        MyStruct::h(&x); // $ item=I74
         x.h(); // $ MISSING: item=I74
     } // I55
 } // I46
@@ -303,7 +303,7 @@ mod m15 {
       : Trait1 { // $ item=I79
         fn f(&self) {
             println!("m15::Trait2::f");
-            Self::g(self); // $ MISSING: item=I80
+            Self::g(self); // $ item=I80
             self.g(); // $ MISSING: item=I80
         }
     } // I82
@@ -342,7 +342,7 @@ mod m15 {
         <S // $ item=I81
           as Trait2 // MISSING: item=I82
         >::f(&x); // $ MISSING: item=I78
-        S::g(&x); // $ MISSING: item=I77
+        S::g(&x); // $ item=I77
         x.g(); // $ MISSING: item=I77
     } // I75
 }

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -291,6 +291,62 @@ mod m13 {
     }
 }
 
+mod m15 {
+    trait Trait1 {
+        fn f(&self);
+
+        fn g(&self); // I80
+    } // I79
+
+    #[rustfmt::skip]
+    trait Trait2
+      : Trait1 { // $ item=I79
+        fn f(&self) {
+            println!("m15::Trait2::f");
+            Self::g(self); // $ MISSING: item=I80
+            self.g(); // $ MISSING: item=I80
+        }
+    } // I82
+
+    struct S; // I81
+
+    #[rustfmt::skip]
+    impl Trait1 // $ item=I79
+      for S { // $ item=I81
+        fn f(&self) {
+            println!("m15::<S as Trait1>::f");
+            Self::g(self); // $ item=I77
+            self.g(); // $ MISSING: item=I77
+        } // I76
+
+        fn g(&self) {
+            println!("m15::<S as Trait1>::g");
+        } // I77
+    }
+
+    #[rustfmt::skip]
+    impl Trait2 // $ item=I82
+      for S { // $ item=I81
+        fn f(&self) {
+            println!("m15::<S as Trait2>::f");
+        } // I78
+    }
+
+    #[rustfmt::skip]
+    pub fn f() {
+        println!("m15::f");
+        let x = S; // $ item=I81
+        <S // $ item=I81
+          as Trait1 // $ MISSING: item=I79
+        >::f(&x); // $ MISSING: item=I76
+        <S // $ item=I81
+          as Trait2 // MISSING: item=I82
+        >::f(&x); // $ MISSING: item=I78
+        S::g(&x); // $ MISSING: item=I77
+        x.g(); // $ MISSING: item=I77
+    } // I75
+}
+
 fn main() {
     my::nested::nested1::nested2::f(); // $ item=I4
     my::f(); // $ item=I38
@@ -310,4 +366,5 @@ fn main() {
     m8::g(); // $ item=I55
     m9::f(); // $ item=I57
     m11::f(); // $ item=I63
+    m15::f(); // $ item=I75
 }

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -18,6 +18,7 @@ mod
 | main.rs:265:1:277:1 | mod m12 |
 | main.rs:279:1:292:1 | mod m13 |
 | main.rs:283:5:291:5 | mod m14 |
+| main.rs:294:1:348:1 | mod m15 |
 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/nested2.rs:2:5:10:5 | mod nested4 |
@@ -43,7 +44,7 @@ resolvePath
 | main.rs:30:17:30:21 | super | main.rs:18:5:36:5 | mod m2 |
 | main.rs:30:17:30:24 | ...::f | main.rs:19:9:21:9 | fn f |
 | main.rs:33:17:33:17 | f | main.rs:19:9:21:9 | fn f |
-| main.rs:40:9:40:13 | super | main.rs:1:1:313:2 | SourceFile |
+| main.rs:40:9:40:13 | super | main.rs:1:1:370:2 | SourceFile |
 | main.rs:40:9:40:17 | ...::m1 | main.rs:13:1:37:1 | mod m1 |
 | main.rs:40:9:40:21 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
 | main.rs:40:9:40:24 | ...::g | main.rs:23:9:27:9 | fn g |
@@ -55,7 +56,7 @@ resolvePath
 | main.rs:61:17:61:19 | Foo | main.rs:59:9:59:21 | struct Foo |
 | main.rs:64:13:64:15 | Foo | main.rs:53:5:53:17 | struct Foo |
 | main.rs:66:5:66:5 | f | main.rs:55:5:62:5 | fn f |
-| main.rs:68:5:68:8 | self | main.rs:1:1:313:2 | SourceFile |
+| main.rs:68:5:68:8 | self | main.rs:1:1:370:2 | SourceFile |
 | main.rs:68:5:68:11 | ...::i | main.rs:71:1:83:1 | fn i |
 | main.rs:74:13:74:15 | Foo | main.rs:48:1:48:13 | struct Foo |
 | main.rs:81:17:81:19 | Foo | main.rs:77:9:79:9 | struct Foo |
@@ -69,7 +70,7 @@ resolvePath
 | main.rs:87:57:87:66 | ...::g | my2/nested2.rs:7:9:9:9 | fn g |
 | main.rs:87:80:87:86 | nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
 | main.rs:100:5:100:22 | f_defined_in_macro | main.rs:99:18:99:42 | fn f_defined_in_macro |
-| main.rs:117:13:117:17 | super | main.rs:1:1:313:2 | SourceFile |
+| main.rs:117:13:117:17 | super | main.rs:1:1:370:2 | SourceFile |
 | main.rs:117:13:117:21 | ...::m5 | main.rs:103:1:107:1 | mod m5 |
 | main.rs:118:9:118:9 | f | main.rs:104:5:106:5 | fn f |
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
@@ -122,51 +123,67 @@ resolvePath
 | main.rs:274:16:274:16 | T | main.rs:268:7:268:7 | T |
 | main.rs:275:14:275:17 | Self | main.rs:266:5:276:5 | trait MyParamTrait |
 | main.rs:275:14:275:33 | ...::AssociatedType | main.rs:270:9:270:28 | TypeAlias |
-| main.rs:284:13:284:17 | crate | main.rs:1:1:313:2 | SourceFile |
+| main.rs:284:13:284:17 | crate | main.rs:1:1:370:2 | SourceFile |
 | main.rs:284:13:284:22 | ...::m13 | main.rs:279:1:292:1 | mod m13 |
 | main.rs:284:13:284:25 | ...::f | main.rs:280:5:280:17 | fn f |
 | main.rs:284:13:284:25 | ...::f | main.rs:280:19:281:19 | struct f |
 | main.rs:287:17:287:17 | f | main.rs:280:19:281:19 | struct f |
 | main.rs:288:21:288:21 | f | main.rs:280:19:281:19 | struct f |
 | main.rs:289:13:289:13 | f | main.rs:280:5:280:17 | fn f |
-| main.rs:295:5:295:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:295:5:295:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
-| main.rs:295:5:295:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
-| main.rs:295:5:295:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
-| main.rs:295:5:295:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
-| main.rs:296:5:296:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:296:5:296:9 | ...::f | my.rs:5:1:7:1 | fn f |
-| main.rs:297:5:297:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
-| main.rs:297:5:297:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
-| main.rs:297:5:297:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
-| main.rs:297:5:297:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:298:5:298:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:299:5:299:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:300:5:300:9 | crate | main.rs:1:1:313:2 | SourceFile |
-| main.rs:300:5:300:12 | ...::h | main.rs:50:1:69:1 | fn h |
-| main.rs:301:5:301:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:301:5:301:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:301:5:301:13 | ...::g | main.rs:23:9:27:9 | fn g |
-| main.rs:302:5:302:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:302:5:302:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:302:5:302:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
-| main.rs:302:5:302:17 | ...::h | main.rs:30:27:34:13 | fn h |
-| main.rs:303:5:303:6 | m4 | main.rs:39:1:46:1 | mod m4 |
-| main.rs:303:5:303:9 | ...::i | main.rs:42:5:45:5 | fn i |
-| main.rs:304:5:304:5 | h | main.rs:50:1:69:1 | fn h |
-| main.rs:305:5:305:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:306:5:306:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:307:5:307:5 | j | main.rs:97:1:101:1 | fn j |
-| main.rs:308:5:308:6 | m6 | main.rs:109:1:120:1 | mod m6 |
-| main.rs:308:5:308:9 | ...::g | main.rs:114:5:119:5 | fn g |
-| main.rs:309:5:309:6 | m7 | main.rs:122:1:137:1 | mod m7 |
-| main.rs:309:5:309:9 | ...::f | main.rs:129:5:136:5 | fn f |
-| main.rs:310:5:310:6 | m8 | main.rs:139:1:193:1 | mod m8 |
-| main.rs:310:5:310:9 | ...::g | main.rs:177:5:192:5 | fn g |
-| main.rs:311:5:311:6 | m9 | main.rs:195:1:203:1 | mod m9 |
-| main.rs:311:5:311:9 | ...::f | main.rs:198:5:202:5 | fn f |
-| main.rs:312:5:312:7 | m11 | main.rs:226:1:263:1 | mod m11 |
-| main.rs:312:5:312:10 | ...::f | main.rs:231:5:234:5 | fn f |
+| main.rs:303:9:303:14 | Trait1 | main.rs:295:5:299:5 | trait Trait1 |
+| main.rs:306:13:306:16 | Self | main.rs:301:5:309:5 | trait Trait2 |
+| main.rs:314:10:314:15 | Trait1 | main.rs:295:5:299:5 | trait Trait1 |
+| main.rs:315:11:315:11 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:318:13:318:16 | Self | main.rs:313:5:325:5 | impl Trait1 for S { ... } |
+| main.rs:318:13:318:19 | ...::g | main.rs:322:9:324:9 | fn g |
+| main.rs:328:10:328:15 | Trait2 | main.rs:301:5:309:5 | trait Trait2 |
+| main.rs:329:11:329:11 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:338:17:338:17 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:339:10:339:10 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:339:10:339:10 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:342:10:342:10 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:342:10:342:10 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:345:9:345:9 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:351:5:351:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:351:5:351:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
+| main.rs:351:5:351:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
+| main.rs:351:5:351:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
+| main.rs:351:5:351:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
+| main.rs:352:5:352:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:352:5:352:9 | ...::f | my.rs:5:1:7:1 | fn f |
+| main.rs:353:5:353:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
+| main.rs:353:5:353:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
+| main.rs:353:5:353:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
+| main.rs:353:5:353:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:354:5:354:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:355:5:355:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:356:5:356:9 | crate | main.rs:1:1:370:2 | SourceFile |
+| main.rs:356:5:356:12 | ...::h | main.rs:50:1:69:1 | fn h |
+| main.rs:357:5:357:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:357:5:357:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:357:5:357:13 | ...::g | main.rs:23:9:27:9 | fn g |
+| main.rs:358:5:358:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:358:5:358:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:358:5:358:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
+| main.rs:358:5:358:17 | ...::h | main.rs:30:27:34:13 | fn h |
+| main.rs:359:5:359:6 | m4 | main.rs:39:1:46:1 | mod m4 |
+| main.rs:359:5:359:9 | ...::i | main.rs:42:5:45:5 | fn i |
+| main.rs:360:5:360:5 | h | main.rs:50:1:69:1 | fn h |
+| main.rs:361:5:361:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:362:5:362:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:363:5:363:5 | j | main.rs:97:1:101:1 | fn j |
+| main.rs:364:5:364:6 | m6 | main.rs:109:1:120:1 | mod m6 |
+| main.rs:364:5:364:9 | ...::g | main.rs:114:5:119:5 | fn g |
+| main.rs:365:5:365:6 | m7 | main.rs:122:1:137:1 | mod m7 |
+| main.rs:365:5:365:9 | ...::f | main.rs:129:5:136:5 | fn f |
+| main.rs:366:5:366:6 | m8 | main.rs:139:1:193:1 | mod m8 |
+| main.rs:366:5:366:9 | ...::g | main.rs:177:5:192:5 | fn g |
+| main.rs:367:5:367:6 | m9 | main.rs:195:1:203:1 | mod m9 |
+| main.rs:367:5:367:9 | ...::f | main.rs:198:5:202:5 | fn f |
+| main.rs:368:5:368:7 | m11 | main.rs:226:1:263:1 | mod m11 |
+| main.rs:368:5:368:10 | ...::f | main.rs:231:5:234:5 | fn f |
+| main.rs:369:5:369:7 | m15 | main.rs:294:1:348:1 | mod m15 |
+| main.rs:369:5:369:10 | ...::f | main.rs:335:5:347:5 | fn f |
 | my2/mod.rs:5:5:5:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/mod.rs:5:5:5:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/mod.rs:5:5:5:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -19,6 +19,7 @@ mod
 | main.rs:279:1:292:1 | mod m13 |
 | main.rs:283:5:291:5 | mod m14 |
 | main.rs:294:1:348:1 | mod m15 |
+| main.rs:350:1:435:1 | mod m16 |
 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/nested2.rs:2:5:10:5 | mod nested4 |
@@ -44,7 +45,7 @@ resolvePath
 | main.rs:30:17:30:21 | super | main.rs:18:5:36:5 | mod m2 |
 | main.rs:30:17:30:24 | ...::f | main.rs:19:9:21:9 | fn f |
 | main.rs:33:17:33:17 | f | main.rs:19:9:21:9 | fn f |
-| main.rs:40:9:40:13 | super | main.rs:1:1:370:2 | SourceFile |
+| main.rs:40:9:40:13 | super | main.rs:1:1:458:2 | SourceFile |
 | main.rs:40:9:40:17 | ...::m1 | main.rs:13:1:37:1 | mod m1 |
 | main.rs:40:9:40:21 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
 | main.rs:40:9:40:24 | ...::g | main.rs:23:9:27:9 | fn g |
@@ -56,7 +57,7 @@ resolvePath
 | main.rs:61:17:61:19 | Foo | main.rs:59:9:59:21 | struct Foo |
 | main.rs:64:13:64:15 | Foo | main.rs:53:5:53:17 | struct Foo |
 | main.rs:66:5:66:5 | f | main.rs:55:5:62:5 | fn f |
-| main.rs:68:5:68:8 | self | main.rs:1:1:370:2 | SourceFile |
+| main.rs:68:5:68:8 | self | main.rs:1:1:458:2 | SourceFile |
 | main.rs:68:5:68:11 | ...::i | main.rs:71:1:83:1 | fn i |
 | main.rs:74:13:74:15 | Foo | main.rs:48:1:48:13 | struct Foo |
 | main.rs:81:17:81:19 | Foo | main.rs:77:9:79:9 | struct Foo |
@@ -70,7 +71,7 @@ resolvePath
 | main.rs:87:57:87:66 | ...::g | my2/nested2.rs:7:9:9:9 | fn g |
 | main.rs:87:80:87:86 | nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
 | main.rs:100:5:100:22 | f_defined_in_macro | main.rs:99:18:99:42 | fn f_defined_in_macro |
-| main.rs:117:13:117:17 | super | main.rs:1:1:370:2 | SourceFile |
+| main.rs:117:13:117:17 | super | main.rs:1:1:458:2 | SourceFile |
 | main.rs:117:13:117:21 | ...::m5 | main.rs:103:1:107:1 | mod m5 |
 | main.rs:118:9:118:9 | f | main.rs:104:5:106:5 | fn f |
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
@@ -125,7 +126,7 @@ resolvePath
 | main.rs:274:16:274:16 | T | main.rs:268:7:268:7 | T |
 | main.rs:275:14:275:17 | Self | main.rs:266:5:276:5 | trait MyParamTrait |
 | main.rs:275:14:275:33 | ...::AssociatedType | main.rs:270:9:270:28 | TypeAlias |
-| main.rs:284:13:284:17 | crate | main.rs:1:1:370:2 | SourceFile |
+| main.rs:284:13:284:17 | crate | main.rs:1:1:458:2 | SourceFile |
 | main.rs:284:13:284:22 | ...::m13 | main.rs:279:1:292:1 | mod m13 |
 | main.rs:284:13:284:25 | ...::f | main.rs:280:5:280:17 | fn f |
 | main.rs:284:13:284:25 | ...::f | main.rs:280:19:281:19 | struct f |
@@ -148,46 +149,85 @@ resolvePath
 | main.rs:342:10:342:10 | S | main.rs:311:5:311:13 | struct S |
 | main.rs:345:9:345:9 | S | main.rs:311:5:311:13 | struct S |
 | main.rs:345:9:345:12 | ...::g | main.rs:322:9:324:9 | fn g |
-| main.rs:351:5:351:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:351:5:351:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
-| main.rs:351:5:351:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
-| main.rs:351:5:351:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
-| main.rs:351:5:351:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
-| main.rs:352:5:352:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:352:5:352:9 | ...::f | my.rs:5:1:7:1 | fn f |
-| main.rs:353:5:353:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
-| main.rs:353:5:353:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
-| main.rs:353:5:353:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
-| main.rs:353:5:353:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:354:5:354:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:355:5:355:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:356:5:356:9 | crate | main.rs:1:1:370:2 | SourceFile |
-| main.rs:356:5:356:12 | ...::h | main.rs:50:1:69:1 | fn h |
-| main.rs:357:5:357:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:357:5:357:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:357:5:357:13 | ...::g | main.rs:23:9:27:9 | fn g |
-| main.rs:358:5:358:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:358:5:358:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:358:5:358:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
-| main.rs:358:5:358:17 | ...::h | main.rs:30:27:34:13 | fn h |
-| main.rs:359:5:359:6 | m4 | main.rs:39:1:46:1 | mod m4 |
-| main.rs:359:5:359:9 | ...::i | main.rs:42:5:45:5 | fn i |
-| main.rs:360:5:360:5 | h | main.rs:50:1:69:1 | fn h |
-| main.rs:361:5:361:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:362:5:362:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:363:5:363:5 | j | main.rs:97:1:101:1 | fn j |
-| main.rs:364:5:364:6 | m6 | main.rs:109:1:120:1 | mod m6 |
-| main.rs:364:5:364:9 | ...::g | main.rs:114:5:119:5 | fn g |
-| main.rs:365:5:365:6 | m7 | main.rs:122:1:137:1 | mod m7 |
-| main.rs:365:5:365:9 | ...::f | main.rs:129:5:136:5 | fn f |
-| main.rs:366:5:366:6 | m8 | main.rs:139:1:193:1 | mod m8 |
-| main.rs:366:5:366:9 | ...::g | main.rs:177:5:192:5 | fn g |
-| main.rs:367:5:367:6 | m9 | main.rs:195:1:203:1 | mod m9 |
-| main.rs:367:5:367:9 | ...::f | main.rs:198:5:202:5 | fn f |
-| main.rs:368:5:368:7 | m11 | main.rs:226:1:263:1 | mod m11 |
-| main.rs:368:5:368:10 | ...::f | main.rs:231:5:234:5 | fn f |
-| main.rs:369:5:369:7 | m15 | main.rs:294:1:348:1 | mod m15 |
-| main.rs:369:5:369:10 | ...::f | main.rs:335:5:347:5 | fn f |
+| main.rs:355:24:355:24 | T | main.rs:353:7:353:7 | T |
+| main.rs:357:24:357:24 | T | main.rs:353:7:353:7 | T |
+| main.rs:360:18:360:18 | T | main.rs:353:7:353:7 | T |
+| main.rs:368:9:370:9 | Trait1::<...> | main.rs:351:5:362:5 | trait Trait1 |
+| main.rs:369:11:369:11 | T | main.rs:366:7:366:7 | T |
+| main.rs:371:24:371:24 | T | main.rs:366:7:366:7 | T |
+| main.rs:373:13:373:16 | Self | main.rs:364:5:377:5 | trait Trait2 |
+| main.rs:373:13:373:19 | ...::g | main.rs:357:9:358:9 | fn g |
+| main.rs:375:13:375:16 | Self | main.rs:364:5:377:5 | trait Trait2 |
+| main.rs:375:13:375:19 | ...::c | main.rs:360:9:361:9 | Const |
+| main.rs:382:10:384:5 | Trait1::<...> | main.rs:351:5:362:5 | trait Trait1 |
+| main.rs:383:7:383:7 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:385:11:385:11 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:386:24:386:24 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:388:13:388:16 | Self | main.rs:381:5:399:5 | impl Trait1::<...> for S { ... } |
+| main.rs:388:13:388:19 | ...::g | main.rs:392:9:395:9 | fn g |
+| main.rs:392:24:392:24 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:394:13:394:16 | Self | main.rs:381:5:399:5 | impl Trait1::<...> for S { ... } |
+| main.rs:394:13:394:19 | ...::c | main.rs:397:9:398:9 | Const |
+| main.rs:397:18:397:18 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:397:22:397:22 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:402:10:404:5 | Trait2::<...> | main.rs:364:5:377:5 | trait Trait2 |
+| main.rs:403:7:403:7 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:405:11:405:11 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:406:24:406:24 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:408:13:408:16 | Self | main.rs:401:5:410:5 | impl Trait2::<...> for S { ... } |
+| main.rs:415:17:415:17 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:416:10:416:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:416:10:416:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:421:10:421:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:421:10:421:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:426:9:426:9 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:426:9:426:12 | ...::g | main.rs:392:9:395:9 | fn g |
+| main.rs:428:9:428:9 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:428:9:428:12 | ...::c | main.rs:397:9:398:9 | Const |
+| main.rs:429:10:429:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:429:10:429:10 | S | main.rs:379:5:379:13 | struct S |
+| main.rs:438:5:438:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:438:5:438:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
+| main.rs:438:5:438:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
+| main.rs:438:5:438:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
+| main.rs:438:5:438:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
+| main.rs:439:5:439:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:439:5:439:9 | ...::f | my.rs:5:1:7:1 | fn f |
+| main.rs:440:5:440:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
+| main.rs:440:5:440:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
+| main.rs:440:5:440:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
+| main.rs:440:5:440:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:441:5:441:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:442:5:442:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:443:5:443:9 | crate | main.rs:1:1:458:2 | SourceFile |
+| main.rs:443:5:443:12 | ...::h | main.rs:50:1:69:1 | fn h |
+| main.rs:444:5:444:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:444:5:444:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:444:5:444:13 | ...::g | main.rs:23:9:27:9 | fn g |
+| main.rs:445:5:445:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:445:5:445:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:445:5:445:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
+| main.rs:445:5:445:17 | ...::h | main.rs:30:27:34:13 | fn h |
+| main.rs:446:5:446:6 | m4 | main.rs:39:1:46:1 | mod m4 |
+| main.rs:446:5:446:9 | ...::i | main.rs:42:5:45:5 | fn i |
+| main.rs:447:5:447:5 | h | main.rs:50:1:69:1 | fn h |
+| main.rs:448:5:448:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:449:5:449:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:450:5:450:5 | j | main.rs:97:1:101:1 | fn j |
+| main.rs:451:5:451:6 | m6 | main.rs:109:1:120:1 | mod m6 |
+| main.rs:451:5:451:9 | ...::g | main.rs:114:5:119:5 | fn g |
+| main.rs:452:5:452:6 | m7 | main.rs:122:1:137:1 | mod m7 |
+| main.rs:452:5:452:9 | ...::f | main.rs:129:5:136:5 | fn f |
+| main.rs:453:5:453:6 | m8 | main.rs:139:1:193:1 | mod m8 |
+| main.rs:453:5:453:9 | ...::g | main.rs:177:5:192:5 | fn g |
+| main.rs:454:5:454:6 | m9 | main.rs:195:1:203:1 | mod m9 |
+| main.rs:454:5:454:9 | ...::f | main.rs:198:5:202:5 | fn f |
+| main.rs:455:5:455:7 | m11 | main.rs:226:1:263:1 | mod m11 |
+| main.rs:455:5:455:10 | ...::f | main.rs:231:5:234:5 | fn f |
+| main.rs:456:5:456:7 | m15 | main.rs:294:1:348:1 | mod m15 |
+| main.rs:456:5:456:10 | ...::f | main.rs:335:5:347:5 | fn f |
+| main.rs:457:5:457:7 | m16 | main.rs:350:1:435:1 | mod m16 |
+| main.rs:457:5:457:10 | ...::f | main.rs:412:5:434:5 | fn f |
 | my2/mod.rs:5:5:5:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/mod.rs:5:5:5:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/mod.rs:5:5:5:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -95,11 +95,13 @@ resolvePath
 | main.rs:180:9:180:15 | MyTrait | main.rs:140:5:148:5 | trait MyTrait |
 | main.rs:180:9:180:18 | ...::f | main.rs:141:9:141:20 | fn f |
 | main.rs:181:9:181:16 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
+| main.rs:181:9:181:19 | ...::f | main.rs:157:33:162:9 | fn f |
 | main.rs:182:10:182:17 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
 | main.rs:182:10:182:17 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
 | main.rs:186:17:186:24 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
 | main.rs:188:17:188:24 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
 | main.rs:190:9:190:16 | MyStruct | main.rs:150:5:150:22 | struct MyStruct |
+| main.rs:190:9:190:19 | ...::h | main.rs:170:21:174:9 | fn h |
 | main.rs:199:19:199:22 | self | main.rs:195:1:203:1 | mod m9 |
 | main.rs:199:19:199:32 | ...::MyStruct | main.rs:196:5:196:26 | struct MyStruct |
 | main.rs:201:9:201:12 | self | main.rs:195:1:203:1 | mod m9 |
@@ -132,6 +134,7 @@ resolvePath
 | main.rs:289:13:289:13 | f | main.rs:280:5:280:17 | fn f |
 | main.rs:303:9:303:14 | Trait1 | main.rs:295:5:299:5 | trait Trait1 |
 | main.rs:306:13:306:16 | Self | main.rs:301:5:309:5 | trait Trait2 |
+| main.rs:306:13:306:19 | ...::g | main.rs:298:9:298:20 | fn g |
 | main.rs:314:10:314:15 | Trait1 | main.rs:295:5:299:5 | trait Trait1 |
 | main.rs:315:11:315:11 | S | main.rs:311:5:311:13 | struct S |
 | main.rs:318:13:318:16 | Self | main.rs:313:5:325:5 | impl Trait1 for S { ... } |
@@ -144,6 +147,7 @@ resolvePath
 | main.rs:342:10:342:10 | S | main.rs:311:5:311:13 | struct S |
 | main.rs:342:10:342:10 | S | main.rs:311:5:311:13 | struct S |
 | main.rs:345:9:345:9 | S | main.rs:311:5:311:13 | struct S |
+| main.rs:345:9:345:12 | ...::g | main.rs:322:9:324:9 | fn g |
 | main.rs:351:5:351:6 | my | main.rs:1:1:1:7 | mod my |
 | main.rs:351:5:351:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
 | main.rs:351:5:351:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |


### PR DESCRIPTION
Functions inherited through trait bounds or `impl` blocks are now modeled in the path resolution logic.