### PR TITLE
Ssa: Refactor shared SSA in preparation for eliminating phi-read definitions 

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -734,7 +734,7 @@ private predicate variableReadPseudo(ControlFlow::BasicBlock bb, int i, Ssa::Sou
 }
 
 pragma[noinline]
-private predicate adjacentDefRead(
+deprecated private predicate adjacentDefRead(
   Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2,
   SsaInput::SourceVariable v
 ) {
@@ -742,7 +742,7 @@ private predicate adjacentDefRead(
   v = def.getSourceVariable()
 }
 
-private predicate adjacentDefReachesRead(
+deprecated private predicate adjacentDefReachesRead(
   Definition def, SsaInput::SourceVariable v, SsaInput::BasicBlock bb1, int i1,
   SsaInput::BasicBlock bb2, int i2
 ) {
@@ -760,18 +760,7 @@ private predicate adjacentDefReachesRead(
   )
 }
 
-/** Same as `adjacentDefRead`, but skips uncertain reads. */
-pragma[nomagic]
-private predicate adjacentDefSkipUncertainReads(
-  Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
-) {
-  exists(SsaInput::SourceVariable v |
-    adjacentDefReachesRead(def, v, bb1, i1, bb2, i2) and
-    SsaInput::variableRead(bb2, i2, v, true)
-  )
-}
-
-private predicate adjacentDefReachesUncertainRead(
+deprecated private predicate adjacentDefReachesUncertainRead(
   Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
 ) {
   exists(SsaInput::SourceVariable v |
@@ -953,17 +942,6 @@ private module Cached {
       Impl::adjacentUseUse(bb1, i1, bb2, i2, v, true) and
       cfn1 = bb1.getNode(i1) and
       cfn2 = bb2.getNode(i2)
-    )
-  }
-
-  cached
-  predicate lastRefBeforeRedef(Definition def, ControlFlow::BasicBlock bb, int i, Definition next) {
-    Impl::lastRefRedef(def, bb, i, next) and
-    not SsaInput::variableRead(bb, i, def.getSourceVariable(), false)
-    or
-    exists(SsaInput::BasicBlock bb0, int i0 |
-      Impl::lastRefRedef(def, bb0, i0, next) and
-      adjacentDefReachesUncertainRead(def, bb, i, bb0, i0)
     )
   }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -933,10 +933,8 @@ private module Cached {
    */
   cached
   predicate firstReadSameVar(Definition def, ControlFlow::Node cfn) {
-    exists(ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2 |
-      def.definesAt(_, bb1, i1) and
-      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
-      cfn = bb2.getNode(i2)
+    exists(ControlFlow::BasicBlock bb, int i |
+      Impl::firstUse(def, bb, i, true) and cfn = bb.getNode(i)
     )
   }
 
@@ -947,10 +945,13 @@ private module Cached {
    */
   cached
   predicate adjacentReadPairSameVar(Definition def, ControlFlow::Node cfn1, ControlFlow::Node cfn2) {
-    exists(ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2 |
+    exists(
+      ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2,
+      Ssa::SourceVariable v
+    |
+      Impl::ssaDefReachesRead(v, def, bb1, i1) and
+      Impl::adjacentUseUse(bb1, i1, bb2, i2, v, true) and
       cfn1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, def.getSourceVariable()) and
-      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
       cfn2 = bb2.getNode(i2)
     )
   }

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -949,7 +949,7 @@ private module Cached {
   predicate adjacentReadPairSameVar(Definition def, ControlFlow::Node cfn1, ControlFlow::Node cfn2) {
     exists(ControlFlow::BasicBlock bb1, int i1, ControlFlow::BasicBlock bb2, int i2 |
       cfn1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, _) and
+      variableReadActual(bb1, i1, def.getSourceVariable()) and
       adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
       cfn2 = bb2.getNode(i2)
     )

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -490,26 +490,11 @@ private module Cached {
     )
   }
 
-  pragma[nomagic]
-  private predicate captureDefReaches(Definition def, SsaInput::BasicBlock bb2, int i2) {
-    variableCapture(def.getSourceVariable(), _, _, _) and
-    exists(SsaInput::BasicBlock bb1, int i1 |
-      Impl::adjacentDefRead(def, bb1, i1, bb2, i2) and
-      def.definesAt(_, bb1, i1)
-    )
-    or
-    exists(SsaInput::BasicBlock bb3, int i3 |
-      captureDefReaches(def, bb3, i3) and
-      SsaInput::variableRead(bb3, i3, _, _) and
-      Impl::adjacentDefRead(def, bb3, i3, bb2, i2)
-    )
-  }
-
   /** Holds if `init` is a closure variable that captures the value of `capturedvar`. */
   cached
   predicate captures(SsaImplicitInit init, SsaVariable capturedvar) {
     exists(BasicBlock bb, int i |
-      captureDefReaches(capturedvar, bb, i) and
+      Impl::ssaDefReachesRead(_, capturedvar, bb, i) and
       variableCapture(capturedvar.getSourceVariable(), init.getSourceVariable(), bb, i)
     )
   }

--- a/java/ql/test/library-tests/dataflow/ssa/A.java
+++ b/java/ql/test/library-tests/dataflow/ssa/A.java
@@ -1,0 +1,24 @@
+public class A {
+  Object source() { return null; }
+  void sink(Object o) { }
+
+  boolean isSafe(Object o) { return o == null; }
+
+  void foo() {
+    Object x = source();
+    if (!isSafe(x)) {
+      x = null;
+    }
+    sink(x);
+
+    x = source();
+    if (!isSafe(x)) {
+      if (isSafe(x)) {
+        sink(x);
+      } else {
+        throw new RuntimeException();
+      }
+    }
+    sink(x);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/ssa/test.ql
+++ b/java/ql/test/library-tests/dataflow/ssa/test.ql
@@ -1,0 +1,31 @@
+import java
+import semmle.code.java.controlflow.Guards
+import semmle.code.java.dataflow.DataFlow
+
+private predicate isSafe(Guard g, Expr checked, boolean branch) {
+  exists(MethodCall mc | g = mc |
+    mc.getMethod().hasName("isSafe") and
+    checked = mc.getAnArgument() and
+    branch = true
+  )
+}
+
+module TestConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.asExpr().(MethodCall).getMethod().hasName("source")
+  }
+
+  predicate isSink(DataFlow::Node sink) {
+    exists(MethodCall mc | mc.getMethod().hasName("sink") and mc.getAnArgument() = sink.asExpr())
+  }
+
+  predicate isBarrier(DataFlow::Node node) {
+    node = DataFlow::BarrierGuard<isSafe/3>::getABarrierNode()
+  }
+}
+
+module Flow = DataFlow::Global<TestConfig>;
+
+from DataFlow::Node source, DataFlow::Node sink
+where Flow::flow(source, sink)
+select source, sink

--- a/java/ql/test/library-tests/pattern-switch/dfg/GuardTest.java
+++ b/java/ql/test/library-tests/pattern-switch/dfg/GuardTest.java
@@ -24,13 +24,6 @@ public class GuardTest {
         break;
 
     }
-
-    String s2 = "string";
-
-    if (!isSafe(s2)) {
-      s2 = null;
-    }
-    sink(s2);
   }
 
 }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -223,37 +223,12 @@ private predicate hasVariableReadWithCapturedWrite(
 }
 
 pragma[noinline]
-private predicate adjacentDefRead(
-  Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2,
-  SsaInput::SourceVariable v
-) {
-  Impl::adjacentDefRead(def, bb1, i1, bb2, i2) and
-  v = def.getSourceVariable()
-}
-
-pragma[noinline]
 deprecated private predicate adjacentDefReadExt(
   DefinitionExt def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2,
   SsaInput::SourceVariable v
 ) {
   Impl::adjacentDefReadExt(def, _, bb1, i1, bb2, i2) and
   v = def.getSourceVariable()
-}
-
-private predicate adjacentDefReachesRead(
-  Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
-) {
-  exists(SsaInput::SourceVariable v | adjacentDefRead(def, bb1, i1, bb2, i2, v) |
-    def.definesAt(v, bb1, i1)
-    or
-    SsaInput::variableRead(bb1, i1, v, true)
-  )
-  or
-  exists(SsaInput::BasicBlock bb3, int i3 |
-    adjacentDefReachesRead(def, bb1, i1, bb3, i3) and
-    SsaInput::variableRead(bb3, i3, _, false) and
-    Impl::adjacentDefRead(def, bb3, i3, bb2, i2)
-  )
 }
 
 deprecated private predicate adjacentDefReachesReadExt(
@@ -270,15 +245,6 @@ deprecated private predicate adjacentDefReachesReadExt(
     SsaInput::variableRead(bb3, i3, _, false) and
     Impl::adjacentDefReadExt(def, _, bb3, i3, bb2, i2)
   )
-}
-
-/** Same as `adjacentDefRead`, but skips uncertain reads. */
-pragma[nomagic]
-private predicate adjacentDefSkipUncertainReads(
-  Definition def, SsaInput::BasicBlock bb1, int i1, SsaInput::BasicBlock bb2, int i2
-) {
-  adjacentDefReachesRead(def, bb1, i1, bb2, i2) and
-  SsaInput::variableRead(bb2, i2, _, true)
 }
 
 deprecated private predicate adjacentDefReachesUncertainReadExt(
@@ -391,11 +357,7 @@ private module Cached {
    */
   cached
   predicate firstRead(Definition def, VariableReadAccessCfgNode read) {
-    exists(Cfg::BasicBlock bb1, int i1, Cfg::BasicBlock bb2, int i2 |
-      def.definesAt(_, bb1, i1) and
-      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
-      read = bb2.getNode(i2)
-    )
+    exists(Cfg::BasicBlock bb, int i | Impl::firstUse(def, bb, i, true) and read = bb.getNode(i))
   }
 
   /**
@@ -407,10 +369,10 @@ private module Cached {
   predicate adjacentReadPair(
     Definition def, VariableReadAccessCfgNode read1, VariableReadAccessCfgNode read2
   ) {
-    exists(Cfg::BasicBlock bb1, int i1, Cfg::BasicBlock bb2, int i2 |
+    exists(Cfg::BasicBlock bb1, int i1, Cfg::BasicBlock bb2, int i2, LocalVariable v |
+      Impl::ssaDefReachesRead(v, def, bb1, i1) and
+      Impl::adjacentUseUse(bb1, i1, bb2, i2, v, true) and
       read1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, def.getSourceVariable()) and
-      adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
       read2 = bb2.getNode(i2)
     )
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -409,7 +409,7 @@ private module Cached {
   ) {
     exists(Cfg::BasicBlock bb1, int i1, Cfg::BasicBlock bb2, int i2 |
       read1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, _) and
+      variableReadActual(bb1, i1, def.getSourceVariable()) and
       adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
       read2 = bb2.getNode(i2)
     )

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -527,7 +527,6 @@ adjacentReads
 | nested_scopes.rb:8:5:35:7 | self (N) | nested_scopes.rb:8:5:35:7 | self | nested_scopes.rb:30:16:30:19 | self | nested_scopes.rb:34:7:34:12 | self |
 | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:13:11:13:11 | a | nested_scopes.rb:14:16:14:16 | a | nested_scopes.rb:15:11:15:11 | a |
 | nested_scopes.rb:27:7:29:9 | self (show) | nested_scopes.rb:27:7:29:9 | self | nested_scopes.rb:28:11:28:16 | self | nested_scopes.rb:28:16:28:16 | self |
-| nested_scopes.rb:30:16:30:19 | self (class << ...) | nested_scopes.rb:30:7:33:9 | self | nested_scopes.rb:30:16:30:19 | self | nested_scopes.rb:32:11:32:16 | self |
 | parameters.rb:1:9:5:3 | <captured entry> self | parameters.rb:1:1:62:1 | self | parameters.rb:3:4:3:9 | self | parameters.rb:4:4:4:9 | self |
 | parameters.rb:7:26:7:31 | pizzas | parameters.rb:7:26:7:31 | pizzas | parameters.rb:8:6:8:11 | pizzas | parameters.rb:11:14:11:19 | pizzas |
 | parameters.rb:25:1:28:3 | self (opt_param) | parameters.rb:25:1:28:3 | self | parameters.rb:26:3:26:11 | self | parameters.rb:27:3:27:11 | self |

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -330,7 +330,7 @@ private module Cached {
   predicate adjacentReadPair(Definition def, CfgNode read1, CfgNode read2) {
     exists(BasicBlock bb1, int i1, BasicBlock bb2, int i2 |
       read1 = bb1.getNode(i1) and
-      variableReadActual(bb1, i1, _) and
+      variableReadActual(bb1, i1, def.getSourceVariable()) and
       adjacentDefSkipUncertainReads(def, bb1, i1, bb2, i2) and
       read2 = bb2.getNode(i2)
     )

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -182,10 +182,6 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       not result + 1 = refRank(bb, _, v, _)
     }
 
-    predicate lastRefIsRead(BasicBlock bb, SourceVariable v) {
-      maxRefRank(bb, v) = refRank(bb, _, v, Read())
-    }
-
     /**
      * Gets the (1-based) rank of the first reference to `v` inside basic block `bb`
      * that is either a read or a certain write.
@@ -295,7 +291,8 @@ module Make<LocationSig Location, InputSig<Location> Input> {
   pragma[nomagic]
   private predicate inReadDominanceFrontier(BasicBlock bb, SourceVariable v) {
     exists(BasicBlock readbb | inDominanceFrontier(readbb, bb) |
-      lastRefIsRead(readbb, v)
+      variableRead(readbb, _, v, _) and
+      not variableWrite(readbb, _, v, _)
       or
       exists(TPhiReadNode(v, readbb)) and
       not ref(readbb, _, v, _)

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -388,7 +388,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     private predicate liveThrough(BasicBlock idom, BasicBlock bb, SourceVariable v) {
       idom = getImmediateBasicBlockDominator(bb) and
       liveAtExit(bb, v) and
-      not ssaRef(bb, _, v, Def())
+      not any(Definition def).definesAt(v, bb, _)
     }
 
     /**

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -779,7 +779,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     pragma[noinline]
     predicate ssaDefReachesThroughBlock(DefinitionExt def, BasicBlock bb) {
       exists(SourceVariable v |
-        ssaDefReachesEndOfBlockExt(bb, def, v) and
+        ssaDefReachesEndOfBlockExt0(bb, def, v) and
         not defOccursInBlock(_, bb, v, _)
       )
     }
@@ -863,7 +863,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     predicate varBlockReachesExitExt(DefinitionExt def, BasicBlock bb) {
       exists(BasicBlock bb2 | varBlockReachesExt(def, _, bb, bb2) |
         not defOccursInBlock(def, bb2, _, _) and
-        not ssaDefReachesEndOfBlockExt(bb2, def, _)
+        not ssaDefReachesEndOfBlockExt0(bb2, def, _)
       )
     }
 
@@ -872,7 +872,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       exists(BasicBlock bb2, SourceVariable v |
         varBlockReachesExt(def, v, bb, bb2) and
         not defOccursInBlock(def, bb2, _, _) and
-        not ssaDefReachesEndOfBlockExt(bb2, def, _) and
+        not ssaDefReachesEndOfBlockExt0(bb2, def, _) and
         not any(PhiReadNode phi).definesAt(v, bb2, _, _)
       )
       or
@@ -907,7 +907,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
    * SSA definition of `v`.
    */
   pragma[nomagic]
-  predicate ssaDefReachesEndOfBlockExt(BasicBlock bb, DefinitionExt def, SourceVariable v) {
+  private predicate ssaDefReachesEndOfBlockExt0(BasicBlock bb, DefinitionExt def, SourceVariable v) {
     exists(int last |
       last = maxSsaRefRank(pragma[only_bind_into](bb), pragma[only_bind_into](v)) and
       ssaDefReachesRank(bb, def, last, v) and
@@ -920,9 +920,11 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     // the node. If two definitions dominate a node then one must dominate the
     // other, so therefore the definition of _closest_ is given by the dominator
     // tree. Thus, reaching definitions can be calculated in terms of dominance.
-    ssaDefReachesEndOfBlockExt(getImmediateBasicBlockDominator(bb), def, pragma[only_bind_into](v)) and
+    ssaDefReachesEndOfBlockExt0(getImmediateBasicBlockDominator(bb), def, pragma[only_bind_into](v)) and
     liveThroughExt(bb, pragma[only_bind_into](v))
   }
+
+  deprecated predicate ssaDefReachesEndOfBlockExt = ssaDefReachesEndOfBlockExt0/3;
 
   /**
    * NB: If this predicate is exposed, it should be cached.
@@ -955,7 +957,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     exists(SourceVariable v, BasicBlock bbDef |
       phi.definesAt(v, bbDef, _, _) and
       getABasicBlockPredecessor(bbDef) = bb and
-      ssaDefReachesEndOfBlockExt(bb, inp, v)
+      ssaDefReachesEndOfBlockExt0(bb, inp, v)
     |
       phi instanceof PhiNode or
       phi instanceof PhiReadNode
@@ -973,7 +975,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     ssaDefReachesReadWithinBlock(v, def, bb, i)
     or
     ssaRef(bb, i, v, SsaActualRead()) and
-    ssaDefReachesEndOfBlockExt(getABasicBlockPredecessor(bb), def, v) and
+    ssaDefReachesEndOfBlockExt0(getABasicBlockPredecessor(bb), def, v) and
     not ssaDefReachesReadWithinBlock(v, _, bb, i)
   }
 

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -480,7 +480,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       ssaDefReachesReadWithinBlock(v, def, bb, i)
       or
       ssaRef(bb, i, v, SsaActualRead()) and
-      ssaDefReachesEndOfBlock(getABasicBlockPredecessor(bb), def, v) and
+      ssaDefReachesEndOfBlock(getImmediateBasicBlockDominator(bb), def, v) and
       not ssaDefReachesReadWithinBlock(v, _, bb, i)
     }
   }

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -318,7 +318,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
    * Holds if we should synthesize a pseudo-read of `v` at the beginning of `bb`.
    *
    * These reads are named phi-reads, since they are constructed in the same
-   * way as ordinary phi nodes except all all reads are treated as potential
+   * way as ordinary phi nodes except all reads are treated as potential
    * "definitions". This ensures that use-use flow has the same dominance
    * properties as def-use flow.
    */

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -229,18 +229,17 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     /**
-     * Holds if variable `v` is live in basic block `bb` at index `i`.
-     * The rank of `i` is `rnk` as defined by `refRank()`.
+     * Holds if variable `v` is live in basic block `bb` at rank `rnk`.
      */
-    private predicate liveAtRank(BasicBlock bb, int i, SourceVariable v, int rnk) {
-      exists(RefKind kind | rnk = refRank(bb, i, v, kind) |
+    private predicate liveAtRank(BasicBlock bb, SourceVariable v, int rnk) {
+      exists(RefKind kind | rnk = refRank(bb, _, v, kind) |
         rnk = maxRefRank(bb, v) and
         liveAtExit(bb, v)
         or
         kind = Read()
         or
         exists(RefKind nextKind |
-          liveAtRank(bb, _, v, rnk + 1) and
+          liveAtRank(bb, v, rnk + 1) and
           rnk + 1 = refRank(bb, _, v, nextKind) and
           nextKind != Write(true)
         )
@@ -252,7 +251,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
      * index `i` inside basic block `bb`.
      */
     predicate liveAfterWrite(BasicBlock bb, int i, SourceVariable v) {
-      exists(int rnk | rnk = refRank(bb, i, v, Write(_)) | liveAtRank(bb, i, v, rnk))
+      exists(int rnk | rnk = refRank(bb, i, v, Write(_)) | liveAtRank(bb, v, rnk))
     }
   }
 

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -189,6 +189,14 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     /**
      * Gets the (1-based) rank of the first reference to `v` inside basic block `bb`
      * that is either a read or a certain write.
+     *
+     * Note that uncertain writes have no impact on liveness: a variable is
+     * live before an uncertain write if and only if it is live after.
+     * The reference identified here therefore determines liveness at the
+     * beginning of `bb`: if it is a read then the variable is live and if it
+     * is a write then it is not. For basic blocks without reads or certain
+     * writes, liveness at the beginning of the block is equivalent to liveness
+     * at the end of the block.
      */
     private int firstReadOrCertainWrite(BasicBlock bb, SourceVariable v) {
       result =

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -237,7 +237,6 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         rnk = maxRefRank(bb, v) and
         liveAtExit(bb, v)
         or
-        ref(bb, i, v, kind) and
         kind = Read(_)
         or
         exists(RefKind nextKind |

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -376,7 +376,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       variableRead(bb, i, v, _) and
       k = SsaActualRead()
       or
-      any(DefinitionExt def).definesAt(v, bb, i, k)
+      any(Definition def).definesAt(v, bb, i) and
+      k = SsaDef()
+      or
+      synthPhiRead(bb, v) and i = -1 and k = SsaPhiRead()
     }
 
     /**

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -796,28 +796,12 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     liveThroughExt(bb, pragma[only_bind_into](v))
   }
 
-  pragma[nomagic]
-  private predicate phiReadReachesEndOfBlock(BasicBlock pred, BasicBlock bb, SourceVariable v) {
-    exists(PhiReadNode phi |
-      ssaDefReachesEndOfBlockExt(bb, phi, v) and
-      pred = getImmediateBasicBlockDominator(phi.getBasicBlock())
-    )
-  }
-
   /**
    * NB: If this predicate is exposed, it should be cached.
    *
    * Same as `ssaDefReachesEndOfBlockExt`, but ignores phi-reads.
    */
-  pragma[nomagic]
-  predicate ssaDefReachesEndOfBlock(BasicBlock bb, Definition def, SourceVariable v) {
-    ssaDefReachesEndOfBlockExt(bb, def, v)
-    or
-    exists(BasicBlock mid |
-      ssaDefReachesEndOfBlock(mid, def, v) and
-      phiReadReachesEndOfBlock(mid, bb, v)
-    )
-  }
+  predicate ssaDefReachesEndOfBlock = SsaDefReachesNew::ssaDefReachesEndOfBlock/3;
 
   /**
    * NB: If this predicate is exposed, it should be cached.
@@ -870,14 +854,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
    *
    * Same as `ssaDefReachesReadExt`, but ignores phi-reads.
    */
-  pragma[nomagic]
-  predicate ssaDefReachesRead(SourceVariable v, Definition def, BasicBlock bb, int i) {
-    ssaDefReachesReadWithinBlock(v, def, bb, i)
-    or
-    ssaRef(bb, i, v, SsaActualRead()) and
-    ssaDefReachesEndOfBlock(getABasicBlockPredecessor(bb), def, v) and
-    not exists(Definition other | ssaDefReachesReadWithinBlock(v, other, bb, i))
-  }
+  predicate ssaDefReachesRead = SsaDefReachesNew::ssaDefReachesRead/4;
 
   /**
    * NB: If this predicate is exposed, it should be cached.

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -123,18 +123,18 @@ module Make<LocationSig Location, InputSig<Location> Input> {
      * (certain or uncertain) writes.
      */
     private newtype TRefKind =
-      Read(boolean certain) { certain in [false, true] } or
+      Read() or
       Write(boolean certain) { certain in [false, true] }
 
     private class RefKind extends TRefKind {
       string toString() {
-        exists(boolean certain | this = Read(certain) and result = "read (" + certain + ")")
+        this = Read() and result = "read"
         or
         exists(boolean certain | this = Write(certain) and result = "write (" + certain + ")")
       }
 
       int getOrder() {
-        this = Read(_) and
+        this = Read() and
         result = 0
         or
         this = Write(_) and
@@ -146,7 +146,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
      * Holds if the `i`th node of basic block `bb` is a reference to `v` of kind `k`.
      */
     predicate ref(BasicBlock bb, int i, SourceVariable v, RefKind k) {
-      exists(boolean certain | variableRead(bb, i, v, certain) | k = Read(certain))
+      variableRead(bb, i, v, _) and k = Read()
       or
       exists(boolean certain | variableWrite(bb, i, v, certain) | k = Write(certain))
     }
@@ -183,7 +183,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     predicate lastRefIsRead(BasicBlock bb, SourceVariable v) {
-      maxRefRank(bb, v) = refRank(bb, _, v, Read(_))
+      maxRefRank(bb, v) = refRank(bb, _, v, Read())
     }
 
     /**
@@ -213,7 +213,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
      */
     predicate liveAtEntry(BasicBlock bb, SourceVariable v) {
       // The first read or certain write to `v` inside `bb` is a read
-      refRank(bb, _, v, Read(_)) = firstReadOrCertainWrite(bb, v)
+      refRank(bb, _, v, Read()) = firstReadOrCertainWrite(bb, v)
       or
       // There is no certain write to `v` inside `bb`, but `v` is live at entry
       // to a successor basic block of `bb`
@@ -237,7 +237,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         rnk = maxRefRank(bb, v) and
         liveAtExit(bb, v)
         or
-        kind = Read(_)
+        kind = Read()
         or
         exists(RefKind nextKind |
           liveAtRank(bb, _, v, rnk + 1) and

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -291,7 +291,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
   pragma[nomagic]
   private predicate inReadDominanceFrontier(BasicBlock bb, SourceVariable v) {
     exists(BasicBlock readbb | inDominanceFrontier(readbb, bb) |
-      variableRead(readbb, _, v, _) and
+      ssaDefReachesRead(v, _, readbb, _) and
       not variableWrite(readbb, _, v, _)
       or
       synthPhiRead(readbb, v) and


### PR DESCRIPTION
I want to reinterpret phi-reads as reads rather than definitions and hide them from the exposed interface of the SSA library. For normal SSA usage they should be irrelevant: they're only useful for getting an optimised use-use step relation, in particular for use in data-flow.

This PR leaves most of the existing implementation intact, but adds alternative predicates and switches the internal implementation of several others in preparation for this change.

The PR is structured as a long sequence of individually simple commits, so commit-by-commit review is very much encouraged.

There's more work to come, but each of the commits should make sense on their own, and I'd gathered so many that I wanted to merge them to main before adding too many more.