### PR TITLE
Rust: strengthen linting script

### DIFF
--- a/rust/ast-generator/BUILD.bazel
+++ b/rust/ast-generator/BUILD.bazel
@@ -66,7 +66,9 @@ write_file(
         'DST_DIR="$(dirname "$(rlocation "$1")")"',
         'mkdir -p "$DST_DIR/src/codegen/grammar"',
     ] + [
-        'cp -f --no-preserve=mode "$(rlocation "$%s")" "$DST_DIR/%s"' % item
+        # using cat instead of cp to honor default umask
+        # (also, macOS does not support `cp --no-preserve=mode`)
+        'cat "$(rlocation "$%s")" > "$DST_DIR/%s"' % item
         for item in enumerate(_codegen_outs, 2)
     ],
     is_executable = True,

--- a/rust/lint.py
+++ b/rust/lint.py
@@ -1,20 +1,38 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import subprocess
 import pathlib
 import shutil
 import sys
 
+
+def tool(name):
+    ret = shutil.which(name)
+    assert ret, f"no {name} binary found on `PATH`"
+    return ret
+
+
 this_dir = pathlib.Path(__file__).resolve().parent
 
-cargo = shutil.which("cargo")
-assert cargo, "no cargo binary found on `PATH`"
+cargo = tool("cargo")
+bazel = tool("bazel")
 
 runs = []
-runs.append(subprocess.run([cargo, "fmt", "--all", "--quiet"], cwd=this_dir))
+
+
+def run(tool, args, *, cwd=this_dir):
+    print("+", tool, args)
+    runs.append(subprocess.run([tool] + args.split(), cwd=cwd))
+
+
+# make sure bazel-provided sources are put in tree for `cargo` to work with them
+run(bazel, "run ast-generator:inject-sources")
+run(cargo, "fmt --all --quiet")
 
 for manifest in this_dir.rglob("Cargo.toml"):
     if not manifest.is_relative_to(this_dir / "ql") and not manifest.is_relative_to(this_dir / "integration-tests"):
-        runs.append(subprocess.run([cargo, "clippy", "--fix", "--allow-dirty", "--allow-staged", "--quiet", "--", "-D", "warnings"],
-                                   cwd=manifest.parent))
+        run(cargo,
+            "clippy --fix --allow-dirty --allow-staged --quiet -- -D warnings",
+            cwd=manifest.parent)
+
 sys.exit(max(r.returncode for r in runs))


### PR DESCRIPTION
* `bazel run //rust/ast-generator:inject-sources` could fail on macOS if a non-coreutils `cp` was used
* that is now also run by `lint.py` to ensure the sources cargo needs are present