### PR TITLE
Go: Fix bad join order in `comparesFirstCharacter`

### DIFF
--- a/go/ql/lib/semmle/go/StringOps.qll
+++ b/go/ql/lib/semmle/go/StringOps.qll
@@ -110,8 +110,8 @@ module StringOps {
       DataFlow::EqualityTestNode eq, DataFlow::Node str, DataFlow::Node rhs
     ) {
       exists(DataFlow::ElementReadNode read |
-        eq.hasOperands(globalValueNumber(read).getANode(), rhs) and
-        str = read.getBase() and
+        eq.hasOperands(globalValueNumber(pragma[only_bind_out](read)).getANode(), rhs) and
+        str = pragma[only_bind_out](read).getBase() and
         str.getType().getUnderlyingType() instanceof StringType and
         read.getIndex().getIntValue() = 0
       )

--- a/go/ql/lib/semmle/go/StringOps.qll
+++ b/go/ql/lib/semmle/go/StringOps.qll
@@ -102,6 +102,13 @@ module StringOps {
       override boolean getPolarity() { result = expr.getPolarity() }
     }
 
+    pragma[noinline]
+    private DataFlow::ElementReadNode getReadOfFirstChar(DataFlow::Node str) {
+      pragma[only_bind_into](result).getIndex().getIntValue() = 0 and
+      str = result.getBase() and
+      str.getType().getUnderlyingType() instanceof StringType
+    }
+
     /**
      * Holds if `eq` is of the form `str[0] == rhs` or `str[0] != rhs`.
      */
@@ -109,12 +116,8 @@ module StringOps {
     private predicate comparesFirstCharacter(
       DataFlow::EqualityTestNode eq, DataFlow::Node str, DataFlow::Node rhs
     ) {
-      exists(DataFlow::ElementReadNode read |
-        eq.hasOperands(globalValueNumber(pragma[only_bind_out](read)).getANode(), rhs) and
-        str = pragma[only_bind_out](read).getBase() and
-        str.getType().getUnderlyingType() instanceof StringType and
-        read.getIndex().getIntValue() = 0
-      )
+      eq.hasOperands(globalValueNumber(pragma[only_bind_out](getReadOfFirstChar(str))).getANode(),
+        rhs)
     }
 
     /**


### PR DESCRIPTION
Old join order (on `uber/aresdb`):

```
[2025-02-20 12:19:36] Evaluated non-recursive predicate StringOps::StringOps::HasPrefix::comparesFirstCharacter/3#24aa5857@5bcd38hd in 3ms (size: 1).
Evaluated relational algebra for predicate StringOps::StringOps::HasPrefix::comparesFirstCharacter/3#24aa5857@5bcd38hd with tuple counts:
           6528  ~0%    {3} r1 = JOIN project#DataFlowUtil::EqualityTestNode#9fb3a74a#2 WITH `DataFlowUtil::BinaryOperationNode.hasOperands/2#dispred#c32311b8` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Rhs.2
           6562  ~4%    {3}    | JOIN WITH `GlobalValueNumbering::globalValueNumber/1#39395ec1` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
        1766593  ~1%    {3}    | JOIN WITH `GlobalValueNumbering::globalValueNumber/1#39395ec1_10#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
             89  ~0%    {5}    | JOIN WITH `DataFlowUtil::ElementReadNode.getIndex/0#dispred#9e685477` ON FIRST 1 OUTPUT Rhs.1, _, Lhs.1, Lhs.2, Lhs.0
             89  ~0%    {5}    | REWRITE WITH Out.1 := 0
             17  ~0%    {3}    | JOIN WITH `DataFlowUtil::Node.getIntValue/0#dispred#95c22b0f#fb` ON FIRST 2 OUTPUT Lhs.4, Lhs.2, Lhs.3
             17  ~0%    {3}    | JOIN WITH `DataFlowUtil::ComponentReadNode.getBase/0#dispred#0757f222` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
             17  ~0%    {4}    | JOIN WITH `DataFlowUtil::InstructionNode.getType/0#dispred#98c46cd8` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.0
             17  ~0%    {4}    | JOIN WITH `Types::Type.getUnderlyingType/0#dispred#e61d6b4a` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3
              1  ~0%    {3}    | JOIN WITH @stringtype ON FIRST 1 OUTPUT Lhs.1, Lhs.3, Lhs.2
                        return r1
```

After the change:

```
[2025-02-20 14:46:40] Evaluated non-recursive predicate StringOps::StringOps::HasPrefix::comparesFirstCharacter/3#24aa5857@6a98c74d in 0ms (size: 1).
Evaluated relational algebra for predicate StringOps::StringOps::HasPrefix::comparesFirstCharacter/3#24aa5857@6a98c74d with tuple counts:
        1383  ~9%    {3} r1 = SCAN `DataFlowUtil::ElementReadNode.getIndex/0#dispred#9e685477` OUTPUT In.1, _, In.0
        1383  ~0%    {3}    | REWRITE WITH Out.1 := 0
         318  ~0%    {1}    | JOIN WITH `DataFlowUtil::Node.getIntValue/0#dispred#95c22b0f#fb` ON FIRST 2 OUTPUT Lhs.2
         318  ~0%    {2}    | JOIN WITH `DataFlowUtil::ComponentReadNode.getBase/0#dispred#0757f222` ON FIRST 1 OUTPUT Lhs.0, Rhs.1
         318  ~1%    {2}    | JOIN WITH `GlobalValueNumbering::globalValueNumber/1#39395ec1` ON FIRST 1 OUTPUT Rhs.1, Lhs.1
         669  ~0%    {2}    | JOIN WITH `GlobalValueNumbering::globalValueNumber/1#39395ec1_10#join_rhs` ON FIRST 1 OUTPUT Lhs.1, Rhs.1
         669  ~0%    {3}    | JOIN WITH `DataFlowUtil::InstructionNode.getType/0#dispred#98c46cd8` ON FIRST 1 OUTPUT Rhs.1, Lhs.0, Lhs.1
         669  ~0%    {3}    | JOIN WITH `Types::Type.getUnderlyingType/0#dispred#e61d6b4a` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2
           1  ~0%    {2}    | JOIN WITH @stringtype ON FIRST 1 OUTPUT Lhs.2, Lhs.1
           1  ~0%    {3}    | JOIN WITH `DataFlowUtil::BinaryOperationNode.hasOperands/2#dispred#c32311b8_102#join_rhs` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Rhs.2
           1  ~0%    {3}    | JOIN WITH project#DataFlowUtil::EqualityTestNode#9fb3a74a#2 ON FIRST 1 OUTPUT Lhs.0, Lhs.1, Lhs.2
                     return r1
```