### PR TITLE
CPP: Prevent forced bad join order which is saved by context.

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -869,10 +869,8 @@ private predicate elementSpecMatchesSignature(
 bindingset[nameWithoutArgs]
 pragma[inline_late]
 private Class getClassAndNameImpl(Function method, string nameWithoutArgs) {
-  exists(string memberName |
-    result = method.getClassAndName(memberName) and
-    nameWithoutArgs = "operator " + method.(ConversionOperator).getDestType()
-  )
+  result = method.getDeclaringType() and
+  nameWithoutArgs = "operator " + method.(ConversionOperator).getDestType()
   or
   result = method.getClassAndName(nameWithoutArgs) and
   not method instanceof ConversionOperator

--- a/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
+++ b/cpp/ql/lib/semmle/code/cpp/dataflow/ExternalFlow.qll
@@ -869,12 +869,13 @@ private predicate elementSpecMatchesSignature(
 bindingset[nameWithoutArgs]
 pragma[inline_late]
 private Class getClassAndNameImpl(Function method, string nameWithoutArgs) {
-  exists(string memberName | result = method.getClassAndName(memberName) |
+  exists(string memberName |
+    result = method.getClassAndName(memberName) and
     nameWithoutArgs = "operator " + method.(ConversionOperator).getDestType()
-    or
-    not method instanceof ConversionOperator and
-    memberName = nameWithoutArgs
   )
+  or
+  result = method.getClassAndName(nameWithoutArgs) and
+  not method instanceof ConversionOperator
 }
 
 /**


### PR DESCRIPTION
It is impossible to avoid a CP in this predicate on it's own.

Picking `getClassAndName` first is always a CP as it doesn't use `nameWithoutArgs`. This disjunct cannot be picked as `not method instanceof ConversionOperator` requires `method` to be bound first. 

In practice the argument `result` also happens to be bound at the call site, so `getClassAndName` is not a CP at the call site. However the call site has no idea that we need `method` to be bound and we join order assuming that it isn't so it. We also assume it isn't bound internally. This means that the join order is quite sensitive.

An alternative would be to add `result` to the binding set to get a similar effect to what we do now (I wasn't sure whether to make this do what seems to be intended or whether to preserve the existing join order).