### PR TITLE
Regularise extractor pack licenses to all cite the MIT license that covers the whole CodeQL repository

### DIFF
--- a/actions/extractor/BUILD.bazel
+++ b/actions/extractor/BUILD.bazel
@@ -4,6 +4,7 @@ codeql_pkg_files(
     name = "extractor",
     srcs = [
         "codeql-extractor.yml",
+        "//:LICENSE",
     ] + glob(["tools/**"]),
     strip_prefix = strip_prefix.from_pkg(),
     visibility = ["//actions:__pkg__"],

--- a/javascript/extractor/README.md
+++ b/javascript/extractor/README.md
@@ -6,4 +6,4 @@ The extractor consists of a parser for the latest version of ECMAScript, includi
 
 ## License
 
-Like the CodeQL queries, the JavaScript extractor is licensed under [Apache License 2.0](LICENSE) by [GitHub](https://github.com). Some code is derived from other projects, whose licenses are noted in other `LICENSE-*.md` files in this folder.
+Like the CodeQL queries, the JavaScript extractor is licensed under the [MIT License](https://github.com/github/codeql/blob/main/LICENSE) by [GitHub](https://github.com). Some code is derived from other projects, whose licenses are noted in other `LICENSE-*.md` files in this folder.

--- a/javascript/resources/BUILD.bazel
+++ b/javascript/resources/BUILD.bazel
@@ -8,7 +8,7 @@ codeql_pkg_files(
             "tools/*.sh",
             "BUILD.bazel",
         ],
-    ),
+    ) + ["//:LICENSE"],
     exes = glob(["tools/*.sh"]),
     strip_prefix = "",
     visibility = ["//javascript:__pkg__"],

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -32,7 +32,10 @@ pkg_filegroup(
 
 pkg_files(
     name = "resources",
-    srcs = ["codeql-extractor.yml", "//:LICENSE"],
+    srcs = [
+        "codeql-extractor.yml",
+        "//:LICENSE",
+    ],
     strip_prefix = None,
 )
 
@@ -47,9 +50,9 @@ codeql_pkg_files(
 codeql_pack(
     name = "python",
     srcs = [
-        ":resources",
         ":dbscheme-group",
         ":extractor-arch",
+        ":resources",
         "//python/downgrades",
         "//python/extractor",
         "//python/tools",

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -31,8 +31,8 @@ pkg_filegroup(
 )
 
 pkg_files(
-    name = "codeql-extractor-yml",
-    srcs = ["codeql-extractor.yml"],
+    name = "resources",
+    srcs = ["codeql-extractor.yml", "//:LICENSE"],
     strip_prefix = None,
 )
 
@@ -47,7 +47,7 @@ codeql_pkg_files(
 codeql_pack(
     name = "python",
     srcs = [
-        ":codeql-extractor-yml",
+        ":resources",
         ":dbscheme-group",
         ":extractor-arch",
         "//python/downgrades",

--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -32,7 +32,7 @@ pkg_filegroup(
 
 codeql_pkg_files(
     name = "codeql-extractor-yml",
-    srcs = ["codeql-extractor.yml"],
+    srcs = ["codeql-extractor.yml", "//:LICENSE"],
     strip_prefix = None,
 )
 

--- a/ruby/BUILD.bazel
+++ b/ruby/BUILD.bazel
@@ -32,7 +32,10 @@ pkg_filegroup(
 
 codeql_pkg_files(
     name = "codeql-extractor-yml",
-    srcs = ["codeql-extractor.yml", "//:LICENSE"],
+    srcs = [
+        "codeql-extractor.yml",
+        "//:LICENSE",
+    ],
     strip_prefix = None,
 )
 

--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -83,6 +83,7 @@ codeql_pkg_files(
         "codeql-extractor.yml",
         "ql/lib/swift.dbscheme.stats",
         "//swift/extractor/trap:generated_dbscheme",
+        "//:LICENSE",
     ],
 )
 

--- a/swift/BUILD.bazel
+++ b/swift/BUILD.bazel
@@ -82,8 +82,8 @@ codeql_pkg_files(
     srcs = [
         "codeql-extractor.yml",
         "ql/lib/swift.dbscheme.stats",
-        "//swift/extractor/trap:generated_dbscheme",
         "//:LICENSE",
+        "//swift/extractor/trap:generated_dbscheme",
     ],
 )
 


### PR DESCRIPTION
Previously some extractors did and some didn't provide an explicit license alongside the codeql-extractor.yml, though those that did all used the MIT license.