### PR TITLE
Go: Improve bad join order in guardingCall

### DIFF
--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -385,9 +385,9 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     Node nd, Node resNode
   ) {
     guardingFunction(g, f, inp, outp, p) and
-    c = f.getACall() and
+    c = pragma[only_bind_into](f).getACall() and
     nd = inp.getNode(c) and
-    localFlow(pragma[only_bind_out](outp.getNode(c)), resNode)
+    localFlow(outp.getNode(c), resNode)
   }
 
   private predicate onlyPossibleReturnSatisfyingProperty(

--- a/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
+++ b/go/ql/lib/semmle/go/dataflow/internal/DataFlowUtil.qll
@@ -379,15 +379,23 @@ module BarrierGuard<guardChecksSig/3 guardChecks> {
     )
   }
 
+  bindingset[inp, c]
+  pragma[inline_late]
+  private Node getInputNode(FunctionInput inp, CallNode c) { result = inp.getNode(c) }
+
+  bindingset[outp, c]
+  pragma[inline_late]
+  private Node getOutputNode(FunctionOutput outp, CallNode c) { result = outp.getNode(c) }
+
   pragma[noinline]
   private predicate guardingCall(
     Node g, Function f, FunctionInput inp, FunctionOutput outp, DataFlow::Property p, CallNode c,
     Node nd, Node resNode
   ) {
     guardingFunction(g, f, inp, outp, p) and
-    c = pragma[only_bind_into](f).getACall() and
-    nd = inp.getNode(c) and
-    localFlow(outp.getNode(c), resNode)
+    c = f.getACall() and
+    nd = getInputNode(inp, c) and
+    localFlow(getOutputNode(outp, c), resNode)
   }
 
   private predicate onlyPossibleReturnSatisfyingProperty(


### PR DESCRIPTION
Old code:
```ql
guardingFunction(g, f, inp, outp, p) and
c = f.getACall() and
nd = inp.getNode(c) and
localFlow(pragma[only_bind_out](outp.getNode(c)), resNode)
```

Old join order (note that `FunctionOutput.getExitNode` comes from ``outp.getNode`, which is just a wrapper for it):
```
Pipeline standard for DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingCall/8#aa0defc4#fffffffb@dfedaw8n was evaluated in 2 iterations totaling 7ms (delta sizes total: 4).
             6   ~0%    {5} r1 = SCAN `DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingFunction/5#1f27d9d8#fffbf#prev_delta` OUTPUT In.3, In.0, In.1, In.2, In.4
        722106   ~6%    {7}    | JOIN WITH `FunctionInputsAndOutputs::FunctionOutput.getExitNode/1#dispred#4c5ce77c` ON FIRST 1 OUTPUT Lhs.2, Rhs.1, Lhs.1, Lhs.3, Lhs.0, Lhs.4, Rhs.2
            19   ~0%    {7}    | JOIN WITH `Scopes::Function.getACall/0#ab99e5da` ON FIRST 2 OUTPUT Lhs.3, Lhs.1, Lhs.2, Lhs.0, Lhs.4, Lhs.5, Lhs.6
            19   ~0%    {8}    | JOIN WITH `FunctionInputsAndOutputs::FunctionInput.getNode/1#dispred#bca71294` ON FIRST 2 OUTPUT Lhs.6, Lhs.2, Lhs.3, Lhs.0, Lhs.4, Lhs.5, Lhs.1, Rhs.2
                    
             4   ~0%    {8} r2 = JOIN r1 WITH `project#Properties::Property.checkOn/3#dispred#43ad13f2` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.0
                    
            14   ~0%    {8} r3 = JOIN r1 WITH `#DataFlowUtil::localFlowStep/2#edbc0f9aPlus` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
             0   ~0%    {8}    | JOIN WITH `project#Properties::Property.checkOn/3#dispred#43ad13f2` ON FIRST 1 OUTPUT Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7, Lhs.0
                    
             4   ~0%    {8} r4 = r2 UNION r3
             4   ~0%    {8}    | AND NOT `DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingCall/8#aa0defc4#fffffffb#prev`(FIRST 8)
                        return r4
```

It is finding the exit node corresponding to `inp` of all calls `c`, and only afterwards restricting `c` to be a call to `f`. This doesn't seem to be taking a long time, but it seems worth fixing the join order in case it takes a long time on some other database.

New code:
```ql
guardingFunction(g, f, inp, outp, p) and
c = pragma[only_bind_into](f).getACall() and
nd = inp.getNode(c) and
localFlow(outp.getNode(c), resNode)
```

New join order:
```
Pipeline standard for DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingCall/8#aa0defc4#fffffffb@fc684wgo was evaluated in 2 iterations totaling 0ms (delta sizes total: 4).
         6   ~0%    {5} r1 = SCAN `DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingFunction/5#1f27d9d8#fffbf#prev_delta` OUTPUT In.1, In.0, In.2, In.3, In.4
        19   ~0%    {6}    | JOIN WITH `Scopes::Function.getACall/0#ab99e5da` ON FIRST 1 OUTPUT Lhs.3, Rhs.1, Lhs.0, Lhs.1, Lhs.2, Lhs.4
        19   ~0%    {7}    | JOIN WITH `FunctionInputsAndOutputs::FunctionOutput.getExitNode/1#dispred#4c5ce77c` ON FIRST 2 OUTPUT Lhs.4, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.5, Rhs.2
        19   ~0%    {8}    | JOIN WITH `FunctionInputsAndOutputs::FunctionInput.getNode/1#dispred#bca71294` ON FIRST 2 OUTPUT Lhs.6, Lhs.1, Lhs.2, Lhs.3, Lhs.0, Lhs.4, Lhs.5, Rhs.2
                
         4   ~0%    {8} r2 = JOIN r1 WITH `#DataFlowUtil::localFlowStep/2#edbc0f9aPlus#sinkBound#3` ON FIRST 1 OUTPUT Lhs.3, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.1, Lhs.7, Lhs.0
                
         0   ~0%    {8} r3 = JOIN r1 WITH `#DataFlowUtil::localFlowStep/2#edbc0f9aPlus#bounded` ON FIRST 1 OUTPUT Rhs.1, Lhs.1, Lhs.2, Lhs.3, Lhs.4, Lhs.5, Lhs.6, Lhs.7
         0   ~0%    {8}    | JOIN WITH `#DataFlowUtil::localFlowStep/2#edbc0f9aPlus#sinkBound#3` ON FIRST 1 OUTPUT Lhs.3, Lhs.2, Lhs.4, Lhs.5, Lhs.6, Lhs.1, Lhs.7, Lhs.0
                
         4   ~0%    {8} r4 = r2 UNION r3
         4   ~0%    {8}    | AND NOT `DataFlowUtil::BarrierGuard<WrappedErrorAlwaysNil::nilTestGuard>::guardingCall/8#aa0defc4#fffffffb#prev`(FIRST 8)
                    return r4
```
