### PR TITLE
Fix typo in shared DataFlowImplConsistency.qll

### DIFF
--- a/rust/ql/test/query-tests/diagnostics/DataFlowConsistencyCounts.expected
+++ b/rust/ql/test/query-tests/diagnostics/DataFlowConsistencyCounts.expected
@@ -24,6 +24,6 @@
 | PostUpdateNode should not be the target of local flow | 0 |
 | PostUpdateNode should not equal its pre-update node | 0 |
 | Read step does not preserve enclosing callable | 0 |
-| Speculative step already hasM Model | 0 |
+| Speculative step already has Model | 0 |
 | Store step does not preserve enclosing callable | 0 |
 | Type compatibility predicate is not reflexive | 0 |

--- a/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
+++ b/shared/dataflow/codeql/dataflow/internal/DataFlowImplConsistency.qll
@@ -441,7 +441,7 @@ module MakeConsistency<
     result =
       count(DataFlowCall call, Node receiver | lambdaCallEnclosingCallableMismatch(call, receiver))
     or
-    type = "Speculative step already hasM Model" and
+    type = "Speculative step already has Model" and
     result = count(Node n1, Node n2 | speculativeStepAlreadyHasModel(n1, n2, _))
   }
 }


### PR DESCRIPTION
Fix typo in shared `DataFlowImplConsistency.qll`.