### PR TITLE
Ssa: Refactor the data flow integration module

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1291,10 +1291,10 @@ class SsaNode extends NodeImpl, TSsaNode {
 class SsaDefinitionNode extends SsaNode {
   override SsaImpl::DataFlowIntegration::SsaDefinitionNode node;
 
-  SsaImpl::Definition getDefinition() { result = node.getDefinition() }
+  Ssa::Definition getDefinition() { result = node.getDefinition() }
 
   override ControlFlow::Node getControlFlowNodeImpl() {
-    result = this.getDefinition().(Ssa::Definition).getControlFlowNode()
+    result = this.getDefinition().getControlFlowNode()
   }
 }
 
@@ -1688,7 +1688,7 @@ private module ReturnNodes {
 
     OutRefReturnNode() {
       exists(Parameter p |
-        this.getDefinition().(Ssa::Definition).isLiveOutRefParameterDefinition(p) and
+        this.getDefinition().isLiveOutRefParameterDefinition(p) and
         kind.getPosition() = p.getPosition()
       |
         p.isOut() and kind instanceof OutReturnKind

--- a/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -533,8 +533,6 @@
 | LocalDataFlow.cs:381:17:381:29 | "not tainted" | LocalDataFlow.cs:381:13:381:13 | access to local variable x |
 | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) | LocalDataFlow.cs:382:15:382:15 | access to local variable x |
 | SSA.cs:5:17:5:17 | SSA entry def(this.S) | SSA.cs:67:9:67:14 | access to field S |
-| SSA.cs:5:17:5:17 | [input] SSA def(this.S) | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:5:17:5:17 | this | SSA.cs:67:9:67:12 | this access |
 | SSA.cs:5:26:5:32 | SSA param(tainted) | SSA.cs:8:24:8:30 | access to parameter tainted |
 | SSA.cs:5:26:5:32 | tainted | SSA.cs:5:26:5:32 | SSA param(tainted) |
@@ -664,28 +662,28 @@
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:23 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
-| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
-| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
-| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) |
+| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
 | SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
-| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:68:23:68:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
@@ -695,15 +693,15 @@
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
-| SSA.cs:73:23:73:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
@@ -752,15 +750,9 @@
 | SSA.cs:89:13:89:22 | [post] access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
-| SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
 | SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
-| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:93:21:93:28 | access to local variable ssaSink4 |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:95:21:95:28 | access to local variable ssaSink4 |
@@ -785,9 +777,9 @@
 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
-| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
-| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:101:16:101:23 | access to local variable nonSink3 | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
 | SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:23 | access to local variable nonSink3 |
@@ -795,7 +787,6 @@
 | SSA.cs:102:13:102:22 | [post] access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
-| SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
@@ -823,9 +814,9 @@
 | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
-| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
-| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
@@ -841,7 +832,6 @@
 | SSA.cs:115:13:115:22 | [post] access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
-| SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
 | SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
@@ -881,14 +871,14 @@
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:123:9:123:30 | SSA phi read(this.S) | SSA.cs:123:23:123:28 | access to field S |
-| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
-| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
-| SSA.cs:123:23:123:28 | access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
+| SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
@@ -906,10 +896,8 @@
 | SSA.cs:127:35:127:36 | "" | SSA.cs:127:9:127:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
-| SSA.cs:128:13:128:33 | [input] SSA def(this.S) | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
 | SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
@@ -939,13 +927,13 @@
 | SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi read(this.S) | SSA.cs:136:23:136:28 | access to field S |
-| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
-| SSA.cs:136:23:136:28 | access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:144:34:144:34 | SSA param(t) | SSA.cs:146:13:146:13 | access to parameter t |
 | SSA.cs:144:34:144:34 | t | SSA.cs:144:34:144:34 | SSA param(t) |

--- a/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
+++ b/csharp/ql/test/library-tests/dataflow/local/TaintTrackingStep.expected
@@ -643,8 +643,6 @@
 | LocalDataFlow.cs:381:17:381:29 | "not tainted" | LocalDataFlow.cs:381:13:381:13 | access to local variable x |
 | LocalDataFlow.cs:382:9:382:17 | SSA phi(x) | LocalDataFlow.cs:382:15:382:15 | access to local variable x |
 | SSA.cs:5:17:5:17 | SSA entry def(this.S) | SSA.cs:67:9:67:14 | access to field S |
-| SSA.cs:5:17:5:17 | [input] SSA def(this.S) | SSA.cs:136:23:136:28 | SSA def(this.S) |
-| SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:5:17:5:17 | this | SSA.cs:67:9:67:12 | this access |
 | SSA.cs:5:26:5:32 | SSA param(tainted) | SSA.cs:8:24:8:30 | access to parameter tainted |
 | SSA.cs:5:26:5:32 | tainted | SSA.cs:5:26:5:32 | SSA param(tainted) |
@@ -780,28 +778,28 @@
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:58:16:58:23 | access to local variable ssaSink3 |
 | SSA.cs:58:27:58:33 | access to parameter tainted | SSA.cs:67:32:67:38 | access to parameter tainted |
 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) | SSA.cs:60:15:60:22 | access to local variable ssaSink3 |
-| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | [post] access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) |
+| SSA.cs:59:23:59:30 | access to local variable ssaSink3 | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
 | SSA.cs:63:23:63:30 | SSA def(nonSink0) | SSA.cs:64:15:64:22 | access to local variable nonSink0 |
-| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | [post] access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) |
+| SSA.cs:63:23:63:30 | access to local variable nonSink0 | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
 | SSA.cs:67:9:67:12 | [post] this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:12 | this access | SSA.cs:68:23:68:26 | this access |
 | SSA.cs:67:9:67:14 | [post] access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:14 | access to field S | SSA.cs:68:23:68:28 | access to field S |
 | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 | SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) |
-| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) |
+| SSA.cs:67:9:67:38 | SSA def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:67:9:67:28 | access to field SsaFieldSink0 |
 | SSA.cs:67:32:67:38 | access to parameter tainted | SSA.cs:77:20:77:26 | access to parameter tainted |
 | SSA.cs:68:23:68:26 | [post] this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:26 | this access | SSA.cs:69:15:69:18 | this access |
 | SSA.cs:68:23:68:28 | SSA def(this.S) | SSA.cs:69:15:69:20 | access to field S |
 | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:69:15:69:34 | access to field SsaFieldSink0 |
-| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:68:23:68:28 | [post] access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:68:23:68:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:68:23:68:28 | access to field S | SSA.cs:68:23:68:28 | SSA def(this.S) |
 | SSA.cs:69:15:69:18 | [post] this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:18 | this access | SSA.cs:72:9:72:12 | this access |
 | SSA.cs:69:15:69:20 | [post] access to field S | SSA.cs:72:9:72:14 | access to field S |
@@ -811,15 +809,15 @@
 | SSA.cs:72:9:72:14 | [post] access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:14 | access to field S | SSA.cs:73:23:73:28 | access to field S |
 | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 | SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) |
-| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:72:9:72:36 | SSA def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:72:35:72:36 | "" | SSA.cs:72:9:72:31 | access to field SsaFieldNonSink0 |
 | SSA.cs:73:23:73:26 | [post] this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:26 | this access | SSA.cs:74:15:74:18 | this access |
 | SSA.cs:73:23:73:28 | SSA def(this.S) | SSA.cs:74:15:74:20 | access to field S |
 | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:74:15:74:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:73:23:73:28 | [post] access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
-| SSA.cs:73:23:73:28 | access to field S | SSA.cs:89:13:89:33 | [input] SSA def(this.S) |
+| SSA.cs:73:23:73:28 | access to field S | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:74:15:74:18 | [post] this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:18 | this access | SSA.cs:80:9:80:12 | this access |
 | SSA.cs:74:15:74:20 | [post] access to field S | SSA.cs:80:9:80:14 | access to field S |
@@ -869,15 +867,9 @@
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:22 | access to parameter nonTainted | SSA.cs:92:17:92:26 | access to parameter nonTainted |
 | SSA.cs:89:13:89:29 | access to property Length | SSA.cs:89:13:89:33 | ... > ... |
-| SSA.cs:89:13:89:33 | [input] SSA def(nonSink0) | SSA.cs:63:23:63:30 | SSA def(nonSink0) |
-| SSA.cs:89:13:89:33 | [input] SSA def(ssaSink3) | SSA.cs:59:23:59:30 | SSA def(ssaSink3) |
-| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:68:23:68:28 | SSA def(this.S) |
-| SSA.cs:89:13:89:33 | [input] SSA def(this.S) | SSA.cs:73:23:73:28 | SSA def(this.S) |
 | SSA.cs:89:13:89:33 | [input] SSA phi read(nonTainted) | SSA.cs:97:9:97:32 | SSA phi read(nonTainted) |
 | SSA.cs:89:13:89:33 | [input] SSA phi read(ssaSink0) | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) |
 | SSA.cs:89:13:89:33 | [input] SSA phi(ssaSink4) | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) |
-| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:73:23:73:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
-| SSA.cs:89:13:89:33 | [input] SSA qualifier def(this.S.SsaFieldSink0) | SSA.cs:68:23:68:28 | SSA qualifier def(this.S.SsaFieldSink0) |
 | SSA.cs:91:13:91:20 | access to local variable ssaSink4 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:93:21:93:28 | access to local variable ssaSink4 |
 | SSA.cs:91:13:91:31 | SSA def(ssaSink4) | SSA.cs:95:21:95:28 | access to local variable ssaSink4 |
@@ -903,9 +895,9 @@
 | SSA.cs:97:9:97:32 | SSA phi read(ssaSink0) | SSA.cs:117:36:117:43 | access to local variable ssaSink0 |
 | SSA.cs:97:9:97:32 | SSA phi(ssaSink4) | SSA.cs:97:23:97:30 | access to local variable ssaSink4 |
 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) | SSA.cs:98:15:98:22 | access to local variable ssaSink4 |
-| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | [post] access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
-| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) |
+| SSA.cs:97:23:97:30 | access to local variable ssaSink4 | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:101:16:101:23 | access to local variable nonSink3 | SSA.cs:101:16:101:28 | SSA def(nonSink3) |
 | SSA.cs:101:16:101:28 | SSA def(nonSink3) | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) |
 | SSA.cs:101:27:101:28 | "" | SSA.cs:101:16:101:23 | access to local variable nonSink3 |
@@ -914,7 +906,6 @@
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:22 | access to parameter nonTainted | SSA.cs:105:17:105:26 | access to parameter nonTainted |
 | SSA.cs:102:13:102:29 | access to property Length | SSA.cs:102:13:102:33 | ... > ... |
-| SSA.cs:102:13:102:33 | [input] SSA def(ssaSink4) | SSA.cs:97:23:97:30 | SSA def(ssaSink4) |
 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonSink0) | SSA.cs:110:9:110:32 | SSA phi read(nonSink0) |
 | SSA.cs:102:13:102:33 | [input] SSA phi read(nonTainted) | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) |
 | SSA.cs:102:13:102:33 | [input] SSA phi(nonSink3) | SSA.cs:110:9:110:32 | SSA phi(nonSink3) |
@@ -943,9 +934,9 @@
 | SSA.cs:110:9:110:32 | SSA phi read(nonTainted) | SSA.cs:115:13:115:22 | access to parameter nonTainted |
 | SSA.cs:110:9:110:32 | SSA phi(nonSink3) | SSA.cs:110:23:110:30 | access to local variable nonSink3 |
 | SSA.cs:110:23:110:30 | SSA def(nonSink3) | SSA.cs:111:15:111:22 | access to local variable nonSink3 |
-| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | [post] access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
-| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) |
+| SSA.cs:110:23:110:30 | access to local variable nonSink3 | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:117:13:117:16 | this access |
 | SSA.cs:114:9:114:12 | [post] this access | SSA.cs:123:23:123:26 | this access |
 | SSA.cs:114:9:114:12 | this access | SSA.cs:117:13:117:16 | this access |
@@ -962,7 +953,6 @@
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:22 | access to parameter nonTainted | SSA.cs:118:17:118:26 | access to parameter nonTainted |
 | SSA.cs:115:13:115:29 | access to property Length | SSA.cs:115:13:115:33 | ... > ... |
-| SSA.cs:115:13:115:33 | [input] SSA def(nonSink3) | SSA.cs:110:23:110:30 | SSA def(nonSink3) |
 | SSA.cs:115:13:115:33 | [input] SSA phi read(nonTainted) | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) |
 | SSA.cs:115:13:115:33 | [input] SSA phi read(this.S) | SSA.cs:123:9:123:30 | SSA phi read(this.S) |
 | SSA.cs:115:13:115:33 | [input] SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) |
@@ -1003,14 +993,14 @@
 | SSA.cs:121:21:121:40 | access to field SsaFieldSink1 | SSA.cs:121:17:121:41 | [input] SSA phi(this.S.SsaFieldSink1) |
 | SSA.cs:123:9:123:30 | SSA phi read(nonTainted) | SSA.cs:128:13:128:22 | access to parameter nonTainted |
 | SSA.cs:123:9:123:30 | SSA phi read(this.S) | SSA.cs:123:23:123:28 | access to field S |
-| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) |
+| SSA.cs:123:9:123:30 | SSA phi(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:123:23:123:26 | [post] this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:26 | this access | SSA.cs:124:15:124:18 | this access |
 | SSA.cs:123:23:123:28 | SSA def(this.S) | SSA.cs:124:15:124:20 | access to field S |
 | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:124:15:124:34 | access to field SsaFieldSink1 |
-| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
+| SSA.cs:123:23:123:28 | [post] access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
-| SSA.cs:123:23:123:28 | access to field S | SSA.cs:128:13:128:33 | [input] SSA def(this.S) |
+| SSA.cs:123:23:123:28 | access to field S | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:124:15:124:18 | [post] this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:18 | this access | SSA.cs:127:9:127:12 | this access |
 | SSA.cs:124:15:124:20 | [post] access to field S | SSA.cs:127:9:127:14 | access to field S |
@@ -1029,10 +1019,8 @@
 | SSA.cs:128:13:128:22 | [post] access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:22 | access to parameter nonTainted | SSA.cs:131:17:131:26 | access to parameter nonTainted |
 | SSA.cs:128:13:128:29 | access to property Length | SSA.cs:128:13:128:33 | ... > ... |
-| SSA.cs:128:13:128:33 | [input] SSA def(this.S) | SSA.cs:123:23:123:28 | SSA def(this.S) |
 | SSA.cs:128:13:128:33 | [input] SSA phi read(this.S) | SSA.cs:136:9:136:30 | SSA phi read(this.S) |
 | SSA.cs:128:13:128:33 | [input] SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) |
-| SSA.cs:128:13:128:33 | [input] SSA qualifier def(this.S.SsaFieldSink1) | SSA.cs:123:23:123:28 | SSA qualifier def(this.S.SsaFieldSink1) |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:132:21:132:24 | this access |
 | SSA.cs:130:13:130:16 | [post] this access | SSA.cs:134:21:134:24 | this access |
 | SSA.cs:130:13:130:16 | this access | SSA.cs:132:21:132:24 | this access |
@@ -1063,13 +1051,13 @@
 | SSA.cs:134:21:134:43 | [post] access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:134:21:134:43 | access to field SsaFieldNonSink0 | SSA.cs:134:17:134:44 | [input] SSA phi(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:9:136:30 | SSA phi read(this.S) | SSA.cs:136:23:136:28 | access to field S |
-| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:5:17:5:17 | [input] SSA qualifier def(this.S.SsaFieldNonSink0) |
+| SSA.cs:136:9:136:30 | SSA phi(this.S.SsaFieldNonSink0) | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) |
 | SSA.cs:136:23:136:26 | [post] this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:26 | this access | SSA.cs:137:15:137:18 | this access |
 | SSA.cs:136:23:136:28 | SSA def(this.S) | SSA.cs:137:15:137:20 | access to field S |
 | SSA.cs:136:23:136:28 | SSA qualifier def(this.S.SsaFieldNonSink0) | SSA.cs:137:15:137:37 | access to field SsaFieldNonSink0 |
-| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
-| SSA.cs:136:23:136:28 | access to field S | SSA.cs:5:17:5:17 | [input] SSA def(this.S) |
+| SSA.cs:136:23:136:28 | [post] access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
+| SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:136:23:136:28 | access to field S | SSA.cs:136:23:136:28 | SSA def(this.S) |
 | SSA.cs:144:34:144:34 | SSA param(t) | SSA.cs:146:13:146:13 | access to parameter t |
 | SSA.cs:144:34:144:34 | t | SSA.cs:144:34:144:34 | SSA param(t) |

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -167,7 +167,7 @@ module Public {
       or
       result instanceof TypeObject and this instanceof AdditionalNode
       or
-      result = this.(SsaNode).getDefinitionExt().getSourceVariable().getType()
+      result = this.(SsaNode).getTypeImpl()
     }
 
     /** Gets the callable in which this node occurs. */
@@ -394,7 +394,9 @@ class SsaNode extends Node, TSsaNode {
 
   SsaNode() { this = TSsaNode(node) }
 
-  SsaImpl::Impl::DefinitionExt getDefinitionExt() { result = node.getDefinitionExt() }
+  BasicBlock getBasicBlock() { result = node.getBasicBlock() }
+
+  Type getTypeImpl() { result = node.getSourceVariable().getType() }
 
   override Location getLocation() { result = node.getLocation() }
 
@@ -442,7 +444,7 @@ module Private {
     result.asCallable() = n.(CaptureNode).getSynthesizedCaptureNode().getEnclosingCallable() or
     result.asFieldScope() = n.(FieldValueNode).getField() or
     result.asCallable() = any(Expr e | n.(AdditionalNode).nodeAt(e, _)).getEnclosingCallable() or
-    result.asCallable() = n.(SsaNode).getDefinitionExt().getBasicBlock().getEnclosingCallable()
+    result.asCallable() = n.(SsaNode).getBasicBlock().getEnclosingCallable()
   }
 
   /** Holds if `p` is a `ParameterNode` of `c` with position `pos`. */

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowNode.qll
@@ -34,10 +34,8 @@ private module Cached {
     TSsaDefNode(SsaDefinition d) or
     /** Use of a variable or 'this', with flow from a post-update node (from an earlier use) */
     TSsaUseNode(ControlFlowNode use) { use = any(Ssa2::SsaConfig::SourceVariable v).getAUse() } or
-    /** Phi-read node (new SSA library). Ordinary phi nodes are represented by TSsaDefNode. */
-    TSsaPhiReadNode(Ssa2::PhiReadNode phi) or
-    /** Input to a phi node (new SSA library) */
-    TSsaInputNode(Ssa2::SsaInputNode input) or
+    /** A synthesized variable read (new SSA library). Definitions are represented by TSsaDefNode. */
+    TSsaSynthReadNode(Ssa2::SsaSynthReadNode read) or
     TCapturedVariableNode(LocalVariable v) { v.isCaptured() } or
     TPropNode(@property p) or
     TRestPatternNode(DestructuringPattern dp, Expr rest) { rest = dp.getRest() } or

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
@@ -1270,8 +1270,8 @@ Node getNodeFromSsa2(Ssa2::Node node) {
 }
 
 private predicate useUseFlow(Node node1, Node node2) {
-  exists(Ssa2::DefinitionExt def, Ssa2::Node ssa1, Ssa2::Node ssa2 |
-    Ssa2::localFlowStep(def, ssa1, ssa2, _) and
+  exists(Ssa2::Node ssa1, Ssa2::Node ssa2 |
+    Ssa2::localFlowStep(_, ssa1, ssa2, _) and
     node1 = getNodeFromSsa2(ssa1) and
     node2 = getNodeFromSsa2(ssa2) and
     not node1.getTopLevel().isExterns()

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/DataFlowPrivate.qll
@@ -35,38 +35,21 @@ class SsaUseNode extends DataFlow::Node, TSsaUseNode {
   override Location getLocation() { result = expr.getLocation() }
 }
 
-class SsaPhiReadNode extends DataFlow::Node, TSsaPhiReadNode {
-  private Ssa2::PhiReadNode phi;
+class SsaSynthReadNode extends DataFlow::Node, TSsaSynthReadNode {
+  private Ssa2::SsaSynthReadNode read;
 
-  SsaPhiReadNode() { this = TSsaPhiReadNode(phi) }
-
-  cached
-  override string toString() { result = "[ssa-phi-read] " + phi.getSourceVariable().getName() }
+  SsaSynthReadNode() { this = TSsaSynthReadNode(read) }
 
   cached
-  override StmtContainer getContainer() { result = phi.getSourceVariable().getDeclaringContainer() }
-
-  cached
-  override Location getLocation() { result = phi.getLocation() }
-}
-
-class SsaInputNode extends DataFlow::Node, TSsaInputNode {
-  private Ssa2::SsaInputNode input;
-
-  SsaInputNode() { this = TSsaInputNode(input) }
-
-  cached
-  override string toString() {
-    result = "[ssa-input] " + input.getDefinitionExt().getSourceVariable().getName()
-  }
+  override string toString() { result = "[ssa-synth-read] " + read.getSourceVariable().getName() }
 
   cached
   override StmtContainer getContainer() {
-    result = input.getDefinitionExt().getSourceVariable().getDeclaringContainer()
+    result = read.getSourceVariable().getDeclaringContainer()
   }
 
   cached
-  override Location getLocation() { result = input.getLocation() }
+  override Location getLocation() { result = read.getLocation() }
 }
 
 class FlowSummaryNode extends DataFlow::Node, TFlowSummaryNode {
@@ -675,9 +658,7 @@ predicate nodeIsHidden(Node node) {
   or
   node instanceof SsaUseNode
   or
-  node instanceof SsaPhiReadNode
-  or
-  node instanceof SsaInputNode
+  node instanceof SsaSynthReadNode
 }
 
 predicate neverSkipInPathGraph(Node node) {
@@ -1258,12 +1239,10 @@ Node getNodeFromSsa2(Ssa2::Node node) {
     result = TImplicitThisUse(use, true)
   )
   or
-  result = TSsaPhiReadNode(node.(Ssa2::SsaDefinitionExtNode).getDefinitionExt())
-  or
-  result = TSsaInputNode(node.(Ssa2::SsaInputNode))
+  result = TSsaSynthReadNode(node)
   or
   exists(SsaPhiNode legacyPhi, Ssa2::PhiNode ssaPhi |
-    node.(Ssa2::SsaDefinitionExtNode).getDefinitionExt() = ssaPhi and
+    node.(Ssa2::SsaDefinitionNode).getDefinition() = ssaPhi and
     samePhi(legacyPhi, ssaPhi) and
     result = TSsaDefNode(legacyPhi)
   )

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/TaintTrackingPrivate.qll
@@ -41,7 +41,7 @@ pragma[inline_late]
 private BasicBlock getBasicBlockFromSsa2(Ssa2::Node node) {
   result = node.(Ssa2::ExprNode).getExpr().getBasicBlock()
   or
-  node.(Ssa2::SsaInputNode).isInputInto(_, result)
+  result = node.(Ssa2::SsaInputNode).getBasicBlock()
 }
 
 /**

--- a/javascript/ql/test/library-tests/TripleDot/useuse.js
+++ b/javascript/ql/test/library-tests/TripleDot/useuse.js
@@ -165,7 +165,7 @@ function t9() { // same as t8 but with a SanitizerGuard that isn't just a variab
         if (typeof obj === "undefined" || typeof obj === "undefined") {
             // The shared SSA library expects short-circuiting operators be pre-order in the CFG,
             // but in JS they are post-order (as per evaluation order).
-            sink(obj.field); // $ SPURIOUS: hasTaintFlow=t9.1
+            sink(obj.field);
         } else {
             sink(obj.field); // $ hasTaintFlow=t9.1
         }

--- a/javascript/ql/test/library-tests/TripleDot/useuse.js
+++ b/javascript/ql/test/library-tests/TripleDot/useuse.js
@@ -163,8 +163,6 @@ function t9() { // same as t8 but with a SanitizerGuard that isn't just a variab
         }
 
         if (typeof obj === "undefined" || typeof obj === "undefined") {
-            // The shared SSA library expects short-circuiting operators be pre-order in the CFG,
-            // but in JS they are post-order (as per evaluation order).
             sink(obj.field);
         } else {
             sink(obj.field); // $ hasTaintFlow=t9.1

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowDispatch.qll
@@ -641,7 +641,7 @@ private module TrackInstanceInput implements CallGraphConstruction::InputSig {
     // type being checked against
     localFlowStep(nodeFrom, nodeTo, summary) and
     not hasAdjacentTypeCheckedRead(nodeTo) and
-    not TypeInference::asModulePattern(nodeTo.(SsaDefinitionExtNode).getDefinitionExt(), _)
+    not TypeInference::asModulePattern(nodeTo.(SsaDefinitionNodeImpl).getDefinition(), _)
   }
 
   predicate stepCall(DataFlow::Node nodeFrom, DataFlow::Node nodeTo, StepSummary summary) {

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -783,43 +783,9 @@ class SsaDefinitionNodeImpl extends SsaNode {
   }
 }
 
-/**
- * A node that represents an input to an SSA phi (read) definition.
- *
- * This allows for barrier guards to filter input to phi nodes. For example, in
- *
- * ```rb
- * x = taint
- * if x != "safe" then
- *     x = "safe"
- * end
- * sink x
- * ```
- *
- * the `false` edge out of `x != "safe"` guards the input from `x = taint` into the
- * `phi` node after the condition.
- *
- * It is also relevant to filter input into phi read nodes:
- *
- * ```rb
- * x = taint
- * if b then
- *     if x != "safe1" then
- *         return
- *     end
- * else
- *     if x != "safe2" then
- *         return
- *     end
- * end
- *
- * sink x
- * ```
- *
- * both inputs into the phi read node after the outer condition are guarded.
- */
-class SsaInputNode extends SsaNode {
-  override SsaImpl::DataFlowIntegration::SsaInputNode node;
+/** A synthesized SSA read. */
+class SsaSynthReadNode extends SsaNode {
+  override SsaImpl::DataFlowIntegration::SsaSynthReadNode node;
 }
 
 /** An SSA definition for a `self` variable. */

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -93,9 +93,9 @@ module SsaFlow {
     result = TSelfToplevelParameterNode(p.asToplevelSelf())
   }
 
-  ParameterNodeImpl toParameterNodeImpl(SsaDefinitionExtNode node) {
+  ParameterNodeImpl toParameterNodeImpl(SsaDefinitionNodeImpl node) {
     exists(SsaImpl::WriteDefinition def, SsaImpl::ParameterExt p |
-      def = node.getDefinitionExt() and
+      def = node.getDefinition() and
       result = toParameterNode(p) and
       p.isInitializedBy(def)
     )
@@ -392,10 +392,10 @@ module VariableCapture {
 
   // From an assignment or implicit initialization of a captured variable to its flow-insensitive node
   private predicate flowInsensitiveWriteStep(
-    SsaDefinitionExtNode node1, CapturedVariableNode node2, CapturedVariable v
+    SsaDefinitionNodeImpl node1, CapturedVariableNode node2, CapturedVariable v
   ) {
     exists(CapturedSsaDefinitionExt def |
-      def = node1.getDefinitionExt() and
+      def = node1.getDefinition() and
       def.getSourceVariable() = v and
       (
         def instanceof Ssa::WriteDefinition
@@ -408,11 +408,11 @@ module VariableCapture {
 
   // From a captured variable node to its flow-sensitive capture nodes
   private predicate flowInsensitiveReadStep(
-    CapturedVariableNode node1, SsaDefinitionExtNode node2, CapturedVariable v
+    CapturedVariableNode node1, SsaDefinitionNodeImpl node2, CapturedVariable v
   ) {
     exists(CapturedSsaDefinitionExt def |
       node1.getVariable() = v and
-      def = node2.getDefinitionExt() and
+      def = node2.getDefinition() and
       def.getSourceVariable() = v and
       (
         def instanceof Ssa::CapturedCallDefinition
@@ -571,8 +571,8 @@ private module Cached {
   }
 
   /** Holds if `n` wraps an SSA definition without ingoing flow. */
-  private predicate entrySsaDefinition(SsaDefinitionExtNode n) {
-    n.getDefinitionExt() =
+  private predicate entrySsaDefinition(SsaDefinitionNodeImpl n) {
+    n.getDefinition() =
       any(SsaImpl::WriteDefinition def | not def.(Ssa::WriteDefinition).assigns(_))
   }
 
@@ -614,7 +614,7 @@ private module Cached {
     // to parameters (which are themselves local sources)
     entrySsaDefinition(n) and
     not exists(SsaImpl::ParameterExt p |
-      p.isInitializedBy(n.(SsaDefinitionExtNode).getDefinitionExt())
+      p.isInitializedBy(n.(SsaDefinitionNodeImpl).getDefinition())
     )
     or
     isStoreTargetNode(n)
@@ -749,51 +749,38 @@ predicate nodeIsHidden(Node n) {
 }
 
 /** An SSA node. */
-abstract class SsaNode extends NodeImpl, TSsaNode {
+class SsaNode extends NodeImpl, TSsaNode {
   SsaImpl::DataFlowIntegration::SsaNode node;
-  SsaImpl::DefinitionExt def;
 
-  SsaNode() {
-    this = TSsaNode(node) and
-    def = node.getDefinitionExt()
-  }
+  SsaNode() { this = TSsaNode(node) }
 
-  SsaImpl::DefinitionExt getDefinitionExt() { result = def }
+  /** Gets the underlying variable. */
+  Variable getVariable() { result = node.getSourceVariable() }
 
   /** Holds if this node should be hidden from path explanations. */
-  abstract predicate isHidden();
+  predicate isHidden() { any() }
+
+  override CfgScope getCfgScope() { result = node.getBasicBlock().getScope() }
 
   override Location getLocationImpl() { result = node.getLocation() }
 
   override string toStringImpl() { result = node.toString() }
 }
 
-/** An (extended) SSA definition, viewed as a node in a data flow graph. */
-class SsaDefinitionExtNode extends SsaNode {
-  override SsaImpl::DataFlowIntegration::SsaDefinitionExtNode node;
+class SsaDefinitionNodeImpl extends SsaNode {
+  override SsaImpl::DataFlowIntegration::SsaDefinitionNode node;
 
-  /** Gets the underlying variable. */
-  Variable getVariable() { result = def.getSourceVariable() }
+  SsaImpl::Definition getDefinition() { result = node.getDefinition() }
 
   override predicate isHidden() {
-    not def instanceof Ssa::WriteDefinition
-    or
-    isDesugarNode(def.(Ssa::WriteDefinition).getWriteAccess().getExpr())
-    or
-    def = getParameterDef(_)
+    exists(SsaImpl::Definition def | def = this.getDefinition() |
+      not def instanceof Ssa::WriteDefinition
+      or
+      isDesugarNode(def.(Ssa::WriteDefinition).getWriteAccess().getExpr())
+      or
+      def = getParameterDef(_)
+    )
   }
-
-  override CfgScope getCfgScope() { result = def.getBasicBlock().getScope() }
-}
-
-class SsaDefinitionNodeImpl extends SsaDefinitionExtNode {
-  Ssa::Definition ssaDef;
-
-  SsaDefinitionNodeImpl() { ssaDef = def }
-
-  override Location getLocationImpl() { result = ssaDef.getLocation() }
-
-  override string toStringImpl() { result = ssaDef.toString() }
 }
 
 /**
@@ -833,17 +820,13 @@ class SsaDefinitionNodeImpl extends SsaDefinitionExtNode {
  */
 class SsaInputNode extends SsaNode {
   override SsaImpl::DataFlowIntegration::SsaInputNode node;
-
-  override predicate isHidden() { any() }
-
-  override CfgScope getCfgScope() { result = node.getDefinitionExt().getBasicBlock().getScope() }
 }
 
 /** An SSA definition for a `self` variable. */
-class SsaSelfDefinitionNode extends SsaDefinitionExtNode {
+class SsaSelfDefinitionNode extends SsaDefinitionNodeImpl {
   private SelfVariable self;
 
-  SsaSelfDefinitionNode() { self = def.getSourceVariable() }
+  SsaSelfDefinitionNode() { self = super.getVariable() }
 
   /** Gets the scope in which the `self` variable is declared. */
   Scope getSelfScope() { result = self.getDeclaringScope() }
@@ -1976,9 +1959,9 @@ predicate localMustFlowStep(Node node1, Node node2) {
   or
   exists(SsaImpl::Definition def |
     def.(Ssa::WriteDefinition).assigns(node1.asExpr()) and
-    node2.(SsaDefinitionExtNode).getDefinitionExt() = def
+    node2.(SsaDefinitionNodeImpl).getDefinition() = def
     or
-    def = node1.(SsaDefinitionExtNode).getDefinitionExt() and
+    def = node1.(SsaDefinitionNodeImpl).getDefinition() and
     node2.asExpr() = SsaImpl::getARead(def)
   )
   or
@@ -2122,8 +2105,8 @@ class CastNode extends Node {
 predicate neverSkipInPathGraph(Node n) {
   // ensure that all variable assignments are included in the path graph
   n =
-    any(SsaDefinitionExtNode def |
-      def.getDefinitionExt() instanceof Ssa::WriteDefinition and
+    any(SsaDefinitionNodeImpl def |
+      def.getDefinition() instanceof Ssa::WriteDefinition and
       not def.isHidden()
     )
 }
@@ -2446,7 +2429,7 @@ module TypeInference {
   }
 
   pragma[nomagic]
-  private predicate ssaDefHasType(SsaDefinitionExtNode def, Module tp, boolean exact) {
+  private predicate ssaDefHasType(SsaDefinitionNodeImpl def, Module tp, boolean exact) {
     exists(ParameterNodeImpl p |
       parameterNodeHasType(p, tp, exact) and
       p = SsaFlow::toParameterNodeImpl(def)
@@ -2454,7 +2437,7 @@ module TypeInference {
     or
     selfInMethodOrToplevelHasType(def.getVariable(), tp, exact)
     or
-    asModulePattern(def.getDefinitionExt(), tp) and
+    asModulePattern(def.getDefinition(), tp) and
     exact = false
   }
 
@@ -2523,11 +2506,11 @@ module TypeInference {
     or
     parameterNodeHasType(n, tp, exact)
     or
-    exists(SsaDefinitionExtNode def | ssaDefHasType(def, tp, exact) |
+    exists(SsaDefinitionNodeImpl def | ssaDefHasType(def, tp, exact) |
       n = def or
       n.asExpr() =
         any(CfgNodes::ExprCfgNode read |
-          read = def.getDefinitionExt().getARead() and
+          read = def.getDefinition().(SsaImpl::DefinitionExt).getARead() and
           not isTypeCheckedRead(read, _) // could in principle be checked against a new type
         )
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPublic.qll
@@ -363,7 +363,7 @@ class PostUpdateNode extends Node {
 /** An SSA definition, viewed as a node in a data flow graph. */
 class SsaDefinitionNode extends Node instanceof SsaDefinitionNodeImpl {
   /** Gets the underlying SSA definition. */
-  Ssa::Definition getDefinition() { result = super.getDefinitionExt() }
+  Ssa::Definition getDefinition() { result = super.getDefinition() }
 
   /** Gets the underlying variable. */
   Variable getVariable() { result = this.getDefinition().getSourceVariable() }
@@ -434,7 +434,7 @@ private module Cached {
   LocalSourceNode getConstantAccessNode(ConstantAccess access) {
     // Namespaces don't evaluate to the constant being accessed, they return the value of their last statement.
     // Use the definition of 'self' in the namespace as the representative in this case.
-    result.(SsaDefinitionExtNode).getDefinitionExt().(Ssa::SelfDefinition).getSourceVariable() =
+    result.(SsaDefinitionNode).getDefinition().(Ssa::SelfDefinition).getSourceVariable() =
       access.(Namespace).getModuleSelfVariable()
     or
     not access instanceof Namespace and
@@ -1002,7 +1002,7 @@ class ModuleNode instanceof Module {
    * This only gets `self` at the module level, not inside any (singleton) method.
    */
   LocalSourceNode getModuleLevelSelf() {
-    result.(SsaDefinitionExtNode).getVariable() = super.getADeclaration().getModuleSelfVariable()
+    result.(SsaDefinitionNode).getVariable() = super.getADeclaration().getModuleSelfVariable()
   }
 
   /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/TaintTrackingPrivate.qll
@@ -88,7 +88,7 @@ private module Cached {
         nodeFrom.asExpr() = value and
         value = case.getValue() and
         clause = case.getBranch(_) and
-        def = nodeTo.(SsaDefinitionExtNode).getDefinitionExt() and
+        def = nodeTo.(SsaDefinitionNodeImpl).getDefinition() and
         def.getControlFlowNode() = variablesInPattern(clause.getPattern()) and
         not def.(Ssa::WriteDefinition).assigns(value)
       )

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.expected
@@ -2,40 +2,87 @@ testFailures
 newStyleBarrierGuards
 | barrier-guards.rb:3:16:4:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:4:5:4:7 | foo |
+| barrier-guards.rb:9:25:10:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:10:5:10:7 | foo |
+| barrier-guards.rb:17:1:18:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:18:5:18:7 | foo |
+| barrier-guards.rb:23:1:24:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:24:5:24:7 | foo |
+| barrier-guards.rb:27:20:28:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:28:5:28:7 | foo |
+| barrier-guards.rb:37:21:38:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:38:5:38:7 | foo |
+| barrier-guards.rb:43:16:46:5 | [input] SSA phi read(foo) |
 | barrier-guards.rb:45:9:45:11 | foo |
 | barrier-guards.rb:70:22:71:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:71:5:71:7 | foo |
+| barrier-guards.rb:82:26:83:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:83:5:83:7 | foo |
+| barrier-guards.rb:90:1:91:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:91:5:91:7 | foo |
+| barrier-guards.rb:125:11:126:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:126:5:126:7 | foo |
+| barrier-guards.rb:132:11:133:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:133:5:133:7 | foo |
+| barrier-guards.rb:134:11:135:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:135:5:135:7 | foo |
+| barrier-guards.rb:139:18:140:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:140:5:140:7 | foo |
+| barrier-guards.rb:141:19:142:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:142:5:142:7 | foo |
+| barrier-guards.rb:148:21:149:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:149:5:149:7 | foo |
+| barrier-guards.rb:153:18:154:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:154:5:154:7 | foo |
+| barrier-guards.rb:158:10:159:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:159:5:159:7 | foo |
+| barrier-guards.rb:163:11:164:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:164:5:164:7 | foo |
+| barrier-guards.rb:191:4:191:15 | [input] SSA phi read(foo) |
+| barrier-guards.rb:191:20:191:31 | [input] SSA phi read(foo) |
+| barrier-guards.rb:191:32:192:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:192:5:192:7 | foo |
+| barrier-guards.rb:195:4:195:15 | [input] SSA phi read(foo) |
+| barrier-guards.rb:195:4:195:31 | [input] SSA phi read(foo) |
+| barrier-guards.rb:195:20:195:31 | [input] SSA phi read(foo) |
+| barrier-guards.rb:195:36:195:47 | [input] SSA phi read(foo) |
+| barrier-guards.rb:195:48:196:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:196:5:196:7 | foo |
+| barrier-guards.rb:199:4:199:15 | [input] SSA phi read(foo) |
+| barrier-guards.rb:199:4:199:31 | [input] SSA phi read(foo) |
+| barrier-guards.rb:199:20:199:31 | [input] SSA phi read(foo) |
+| barrier-guards.rb:203:4:203:15 | [input] SSA phi read(foo) |
+| barrier-guards.rb:203:36:203:47 | [input] SSA phi read(foo) |
+| barrier-guards.rb:207:21:207:21 | [input] SSA phi read(foo) |
+| barrier-guards.rb:207:22:208:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:208:5:208:7 | foo |
+| barrier-guards.rb:211:22:212:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:212:5:212:7 | foo |
+| barrier-guards.rb:215:28:216:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:216:5:216:7 | foo |
 | barrier-guards.rb:219:21:219:23 | foo |
+| barrier-guards.rb:219:21:219:32 | [input] SSA phi read(foo) |
+| barrier-guards.rb:219:95:220:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:220:5:220:7 | foo |
+| barrier-guards.rb:227:21:227:21 | [input] SSA phi read(foo) |
+| barrier-guards.rb:227:22:228:7 | [input] SSA phi read(foo) |
+| barrier-guards.rb:232:18:233:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:233:5:233:7 | foo |
+| barrier-guards.rb:237:19:237:38 | [input] SSA phi read(foo) |
 | barrier-guards.rb:237:24:237:26 | foo |
+| barrier-guards.rb:243:9:244:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:244:5:244:7 | foo |
+| barrier-guards.rb:259:17:260:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:260:5:260:7 | foo |
+| barrier-guards.rb:264:17:265:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:265:5:265:7 | foo |
+| barrier-guards.rb:272:17:272:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:272:17:272:19 | foo |
+| barrier-guards.rb:275:20:276:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:276:5:276:7 | foo |
+| barrier-guards.rb:281:21:282:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:282:5:282:7 | foo |
+| barrier-guards.rb:291:7:292:19 | [input] SSA phi read(foo) |
 | barrier-guards.rb:292:5:292:7 | foo |
 | barrier_flow.rb:19:14:19:14 | x |
 | barrier_flow.rb:32:10:32:10 | x |

--- a/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.ql
+++ b/ruby/ql/test/library-tests/dataflow/barrier-guards/barrier-guards.ql
@@ -26,7 +26,7 @@ module BarrierGuardTest implements TestSig {
     tag = "guarded" and
     exists(DataFlow::Node n |
       newStyleBarrierGuards(n) and
-      not n instanceof SsaInputNode and
+      not n instanceof SsaSynthReadNode and
       location = n.getLocation() and
       element = n.toString() and
       value = ""

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -405,16 +405,15 @@ module Node {
   /** An SSA node. */
   class SsaNode extends Node, TSsaNode {
     SsaImpl::DataFlowIntegration::SsaNode node;
-    SsaImpl::DefinitionExt def;
 
-    SsaNode() {
-      this = TSsaNode(node) and
-      def = node.getDefinitionExt()
+    SsaNode() { this = TSsaNode(node) }
+
+    override CfgScope getCfgScope() { result = node.getBasicBlock().getScope() }
+
+    /** Gets the definition this node corresponds to, if any. */
+    SsaImpl::Definition asDefinition() {
+      result = node.(SsaImpl::DataFlowIntegration::SsaDefinitionNode).getDefinition()
     }
-
-    override CfgScope getCfgScope() { result = def.getBasicBlock().getScope() }
-
-    SsaImpl::DefinitionExt getDefinitionExt() { result = def }
 
     override Location getLocation() { result = node.getLocation() }
 
@@ -634,7 +633,7 @@ module LocalFlow {
     or
     // An edge from a pattern/expression to its corresponding SSA definition.
     nodeFrom.(Node::AstCfgFlowNode).getCfgNode() =
-      nodeTo.(Node::SsaNode).getDefinitionExt().(Ssa::WriteDefinition).getControlFlowNode()
+      nodeTo.(Node::SsaNode).asDefinition().(Ssa::WriteDefinition).getControlFlowNode()
     or
     nodeFrom.(Node::SourceParameterNode).getParameter().(ParamCfgNode).getPat() = nodeTo.asPat()
     or

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1715,6 +1715,15 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     abstract private class SsaNodeImpl extends NodeImpl {
       /** Gets the underlying SSA definition. */
       abstract DefinitionExt getDefinitionExt();
+
+      /** Gets the SSA definition this node corresponds to, if any. */
+      Definition asDefinition() { this = TSsaDefinitionNode(result) }
+
+      /** Gets the basic block to which this node belongs. */
+      abstract BasicBlock getBasicBlock();
+
+      /** Gets the underlying source variable that this node tracks flow for. */
+      abstract SourceVariable getSourceVariable();
     }
 
     final class SsaNode = SsaNodeImpl;
@@ -1726,6 +1735,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       SsaDefinitionExtNodeImpl() { this = TSsaDefinitionNode(def) }
 
       override DefinitionExt getDefinitionExt() { result = def }
+
+      override BasicBlock getBasicBlock() { result = def.getBasicBlock() }
+
+      override SourceVariable getSourceVariable() { result = def.getSourceVariable() }
 
       override Location getLocation() { result = def.getLocation() }
 
@@ -1782,6 +1795,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       }
 
       override SsaInputDefinitionExt getDefinitionExt() { result = def_ }
+
+      override BasicBlock getBasicBlock() { result = input_ }
+
+      override SourceVariable getSourceVariable() { result = def_.getSourceVariable() }
 
       override Location getLocation() { result = input_.getNode(input_.length() - 1).getLocation() }
 

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1563,8 +1563,6 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         this instanceof PhiNode
         or
         this instanceof PhiReadNode
-        or
-        DfInput::allowFlowIntoUncertainDef(this)
       }
 
       /** Holds if `def` may flow into this definition via basic block `input`. */

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1677,6 +1677,17 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
     final class SsaDefinitionExtNode = SsaDefinitionExtNodeImpl;
 
+    /** An SSA definition, viewed as a node in a data flow graph. */
+    private class SsaDefinitionNodeImpl extends SsaDefinitionExtNodeImpl {
+      private Definition def;
+
+      SsaDefinitionNodeImpl() { this = TSsaDefinitionNode(def) }
+
+      Definition getDefinition() { result = def }
+    }
+
+    final class SsaDefinitionNode = SsaDefinitionNodeImpl;
+
     /**
      * A node that represents an input to an SSA phi (read) definition.
      *

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1574,8 +1574,12 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     }
 
     cached
-    private DefinitionExt getAPhiInputDef(SsaInputDefinitionExt phi, BasicBlock bb) {
-      phi.hasInputFromBlock(result, _, _, _, bb)
+    private Definition getAPhiInputDef(SsaInputDefinitionExt phi, BasicBlock bb) {
+      exists(SourceVariable v, BasicBlock bbDef |
+        phi.definesAt(v, bbDef, _, _) and
+        getABasicBlockPredecessor(bbDef) = bb and
+        ssaDefReachesEndOfBlock(bb, result, v)
+      )
     }
 
     private newtype TNode =

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1688,6 +1688,13 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
     final class SsaDefinitionNode = SsaDefinitionNodeImpl;
 
+    final class SsaSynthReadNode extends SsaNode {
+      SsaSynthReadNode() {
+        this.(SsaDefinitionExtNodeImpl).getDefinitionExt() instanceof PhiReadNode or
+        this instanceof SsaInputNodeImpl
+      }
+    }
+
     /**
      * A node that represents an input to an SSA phi (read) definition.
      *

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1683,11 +1683,13 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
       SsaDefinitionNodeImpl() { this = TSsaDefinitionNode(def) }
 
+      /** Gets the underlying SSA definition. */
       Definition getDefinition() { result = def }
     }
 
     final class SsaDefinitionNode = SsaDefinitionNodeImpl;
 
+    /** A node that represents a synthetic read of a source variable. */
     final class SsaSynthReadNode extends SsaNode {
       SsaSynthReadNode() {
         this.(SsaDefinitionExtNodeImpl).getDefinitionExt() instanceof PhiReadNode or

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1675,7 +1675,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       override string toString() { result = def.toString() }
     }
 
-    final class SsaDefinitionExtNode = SsaDefinitionExtNodeImpl;
+    deprecated final class SsaDefinitionExtNode = SsaDefinitionExtNodeImpl;
 
     /** An SSA definition, viewed as a node in a data flow graph. */
     private class SsaDefinitionNodeImpl extends SsaDefinitionExtNodeImpl {
@@ -1753,7 +1753,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       override string toString() { result = "[input] " + def_.toString() }
     }
 
-    final class SsaInputNode = SsaInputNodeImpl;
+    deprecated final class SsaInputNode = SsaInputNodeImpl;
 
     /**
      * Holds if `nodeFrom` corresponds to the reference to `v` at index `i` in
@@ -1765,7 +1765,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     private predicate flowOutOf(
       DefinitionExt def, Node nodeFrom, SourceVariable v, BasicBlock bb, int i, boolean isUseStep
     ) {
-      nodeFrom.(SsaDefinitionExtNode).getDefinitionExt() = def and
+      nodeFrom.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
       def.definesAt(v, bb, i, _) and
       isUseStep = false
       or
@@ -1788,7 +1788,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def and
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
       isUseStep = false
       or
       // Flow from definition/read to next read
@@ -1804,7 +1804,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         AdjacentSsaRefs::adjacentRefRead(bb1, i1, bb2, i2, v) and
         exists(UncertainWriteDefinition def2 |
           DfInput::allowFlowIntoUncertainDef(def2) and
-          nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def2 and
+          nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def2 and
           def2.definesAt(v, bb2, i2)
         )
       )
@@ -1821,8 +1821,8 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       )
       or
       // Flow from input node to def
-      nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def and
-      def = nodeFrom.(SsaInputNode).getDefinitionExt() and
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
+      def = nodeFrom.(SsaInputNodeImpl).getDefinitionExt() and
       isUseStep = false
     }
 
@@ -1835,10 +1835,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNode).getDefinitionExt() = def
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def
       or
       // Flow from SSA definition to read
-      nodeFrom.(SsaDefinitionExtNode).getDefinitionExt() = def and
+      nodeFrom.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
       nodeTo.(ExprNode).getExpr() = DfInput::getARead(def)
     }
 
@@ -1852,7 +1852,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     signature predicate guardChecksSig(DfInput::Guard g, DfInput::Expr e, boolean branch);
 
     pragma[nomagic]
-    private Definition getAPhiInputDef(SsaInputNode n) {
+    private Definition getAPhiInputDef(SsaInputNodeImpl n) {
       exists(SsaInputDefinitionExt phi, BasicBlock bb |
         result = getAPhiInputDef(phi, bb) and
         n.isInputInto(phi, bb)
@@ -1927,7 +1927,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
           // guard controls input block to a phi node
           exists(SsaInputDefinitionExt phi |
             def = getAPhiInputDef(result) and
-            result.(SsaInputNode).isInputInto(phi, bb)
+            result.(SsaInputNodeImpl).isInputInto(phi, bb)
           |
             DfInput::guardControlsBlock(g, bb, branch)
             or


### PR DESCRIPTION
Commit-by-commit review encouraged. I've attempted to make every commit self-contained.

This PR includes a sequence of small changes, including:
* A bugfix for guards for SSA input nodes. The version on main accidentally had a cast from DefinitionExt to Definition that ruled out some guarded nodes.
* Replacement of the use-use calculation to use the revised implementation.
* Switch the JavaScript ad-hoc barrier-guard for falsy checks to use the out-of-the-box implementation. (This adds a few additional guarded nodes in the case I tested - no tuples were lost).
* Deprecate the public SsaDefinitionExtNode and SsaInputNode and replace them with a more general notion of synthesized reads.