### PR TITLE
Add CodeQL recommendation against Path.Combine

### DIFF
--- a/csharp/ql/src/Bad Practices/PathCombine.qhelp
+++ b/csharp/ql/src/Bad Practices/PathCombine.qhelp
@@ -1,0 +1,16 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p><code>Path.Combine</code> may silently drop its earlier arguments if its later arguments are absolute paths. E.g. <code>Path.Combine("C:\\Users\\Me\\Documents", "C:\\Program Files\\") == "C:\\Program Files"</code>.</p>
+
+</overview>
+<recommendation>
+<p>Use <code>Path.Join</code> instead.</p>
+</recommendation>
+<references>
+
+
+</references>
+</qhelp>

--- a/csharp/ql/src/Bad Practices/PathCombine.qhelp
+++ b/csharp/ql/src/Bad Practices/PathCombine.qhelp
@@ -11,6 +11,8 @@
 </recommendation>
 <references>
 
+  <li>Microsoft Learn, .NET API browser, <a href="https://learn.microsoft.com/en-us/dotnet/api/system.io.path.combine?view=net-9.0">Path.Combine</a>.</li>
+  <li>Microsoft Learn, .NET API browser, <a href="https://learn.microsoft.com/en-us/dotnet/api/system.io.path.join?view=net-9.0">Path.Join</a>.</li>
 
 </references>
 </qhelp>

--- a/csharp/ql/src/Bad Practices/PathCombine.ql
+++ b/csharp/ql/src/Bad Practices/PathCombine.ql
@@ -1,3 +1,13 @@
+/**
+ * @name Call to System.IO.Path.Combine
+ * @description Finds calls to System.IO.Path's Combine method
+ * @kind problem
+ * @problem.severity recommendation
+ * @precision very-high
+ * @id cs/path-combine
+ * @tags reliability
+ *       readability
+ */
 
 import csharp
 import semmle.code.csharp.frameworks.System

--- a/csharp/ql/src/Bad Practices/PathCombine.ql
+++ b/csharp/ql/src/Bad Practices/PathCombine.ql
@@ -14,4 +14,4 @@ import semmle.code.csharp.frameworks.System
 
 from MethodCall call
 where call.getTarget().hasFullyQualifiedName("System.IO", "Path", "Combine")
-select call, "Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them."
+select call, "Call to System.IO.Path.Combine."

--- a/csharp/ql/src/Bad Practices/PathCombine.ql
+++ b/csharp/ql/src/Bad Practices/PathCombine.ql
@@ -6,7 +6,6 @@
  * @precision very-high
  * @id cs/path-combine
  * @tags reliability
- *       readability
  */
 
 import csharp
@@ -14,4 +13,4 @@ import semmle.code.csharp.frameworks.System
 
 from MethodCall call
 where call.getTarget().hasFullyQualifiedName("System.IO", "Path", "Combine")
-select call, "Call to System.IO.Path.Combine."
+select call, "Call to 'System.IO.Path.Combine'."

--- a/csharp/ql/src/Bad Practices/PathCombine.ql
+++ b/csharp/ql/src/Bad Practices/PathCombine.ql
@@ -1,0 +1,7 @@
+
+import csharp
+import semmle.code.csharp.frameworks.System
+
+from MethodCall call
+where call.getTarget().hasFullyQualifiedName("System.IO", "Path", "Combine")
+select call, "Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them."

--- a/csharp/ql/src/change-notes/2025-02-26-path-combine.md
+++ b/csharp/ql/src/change-notes/2025-02-26-path-combine.md
@@ -1,0 +1,4 @@
+---
+category: newQuery
+---
+* Added a new query, `csharp/path-combine`, to recommend against the `Path.Combine` method due to it silently discarding its earlier parameters if later parameters are rooted.

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+class EmptyCatchBlock
+{
+    void bad()
+    {
+        Path.Combine(@"C:\Users", @"C:\Program Files");
+    }
+
+    void good()
+    {
+        Path.Join(@"C:\Users", @"C:\Program Files");
+    }
+}

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.cs
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.cs
@@ -1,6 +1,6 @@
 using System.IO;
 
-class EmptyCatchBlock
+class PathCombine
 {
     void bad()
     {

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
@@ -1,1 +1,1 @@
-| PathCombine.cs:7:9:7:55 | catch (...) {...} | Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them. |
+| PathCombine.cs:7:9:7:54 | call to method Combine | Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them. |

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
@@ -1,1 +1,1 @@
-| PathCombine.cs:7:9:7:54 | call to method Combine | Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them. |
+| PathCombine.cs:7:9:7:54 | call to method Combine | Call to System.IO.Path.Combine. |

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
@@ -1,0 +1,1 @@
+| PathCombine.cs:7:9:7:55 | catch (...) {...} | Path.Combine may silently discard its initial arguments if the latter are absolute paths. Use Path.Join to consistently join them. |

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.expected
@@ -1,1 +1,1 @@
-| PathCombine.cs:7:9:7:54 | call to method Combine | Call to System.IO.Path.Combine. |
+| PathCombine.cs:7:9:7:54 | call to method Combine | Call to 'System.IO.Path.Combine'. |

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.qlref
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/PathCombine.qlref
@@ -1,0 +1,1 @@
+Bad Practices/PathCombine.ql

--- a/csharp/ql/test/query-tests/Bad Practices/Path Combine/options
+++ b/csharp/ql/test/query-tests/Bad Practices/Path Combine/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj


### PR DESCRIPTION
The docs for [Path.Combine](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.combine?view=net-9.0) warns:

> [!IMPORTANT]  
> This method assumes that the first argument is an absolute path and that the following argument or arguments are relative paths. If this is not the case, and particularly if any subsequent arguments are strings input by the user, call the [Join](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.join?view=net-9.0) or [TryJoin](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.tryjoin?view=net-9.0) method instead.

This commit adds a corresponding CodeQL query to recommend against Path.Combine.