### PR TITLE
Ssa: Update qltests including consistency checks

### DIFF
--- a/csharp/ql/consistency-queries/SsaConsistency.ql
+++ b/csharp/ql/consistency-queries/SsaConsistency.ql
@@ -3,22 +3,6 @@ import semmle.code.csharp.dataflow.internal.SsaImpl as Impl
 import Impl::Consistency
 import Ssa
 
-class MyRelevantDefinition extends RelevantDefinition, Ssa::Definition {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}
-
-class MyRelevantDefinitionExt extends RelevantDefinitionExt, Impl::DefinitionExt {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}
-
 query predicate localDeclWithSsaDef(LocalVariableDeclExpr d) {
   // Local variables in C# must be initialized before every use, so uninitialized
   // local variables should not have an SSA definition, as that would imply that

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -967,13 +967,13 @@ private module Cached {
     import DataFlowIntegrationImpl
 
     cached
-    predicate localFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
-      DataFlowIntegrationImpl::localFlowStep(def, nodeFrom, nodeTo, isUseStep)
+    predicate localFlowStep(Ssa::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+      DataFlowIntegrationImpl::localFlowStep(v, nodeFrom, nodeTo, isUseStep)
     }
 
     cached
-    predicate localMustFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo) {
-      DataFlowIntegrationImpl::localMustFlowStep(def, nodeFrom, nodeTo)
+    predicate localMustFlowStep(Ssa::SourceVariable v, Node nodeFrom, Node nodeTo) {
+      DataFlowIntegrationImpl::localMustFlowStep(v, nodeFrom, nodeTo)
     }
 
     signature predicate guardChecksSig(Guards::Guard g, Expr e, Guards::AbstractValue v);

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -994,9 +994,9 @@ private module Cached {
 
 import Cached
 
-private string getSplitString(DefinitionExt def) {
+private string getSplitString(Definition def) {
   exists(ControlFlow::BasicBlock bb, int i, ControlFlow::Node cfn |
-    def.definesAt(_, bb, i, _) and
+    def.definesAt(_, bb, i) and
     result = cfn.(ControlFlow::Nodes::ElementNode).getSplitsString()
   |
     cfn = bb.getNode(i)
@@ -1006,46 +1006,11 @@ private string getSplitString(DefinitionExt def) {
   )
 }
 
-string getToStringPrefix(DefinitionExt def) {
+string getToStringPrefix(Definition def) {
   result = "[" + getSplitString(def) + "] "
   or
   not exists(getSplitString(def)) and
   result = ""
-}
-
-/**
- * An extended static single assignment (SSA) definition.
- *
- * This is either a normal SSA definition (`Definition`) or a
- * phi-read node (`PhiReadNode`).
- *
- * Only intended for internal use.
- */
-class DefinitionExt extends Impl::DefinitionExt {
-  override string toString() { result = this.(Ssa::Definition).toString() }
-
-  /** Gets the location of this definition. */
-  override Location getLocation() { result = this.(Ssa::Definition).getLocation() }
-
-  /** Gets the enclosing callable of this definition. */
-  Callable getEnclosingCallable() { result = this.(Ssa::Definition).getEnclosingCallable() }
-}
-
-/**
- * A phi-read node.
- *
- * Only intended for internal use.
- */
-class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
-  override string toString() {
-    result = getToStringPrefix(this) + "SSA phi read(" + this.getSourceVariable() + ")"
-  }
-
-  override Location getLocation() { result = this.getBasicBlock().getLocation() }
-
-  override Callable getEnclosingCallable() {
-    result = this.getSourceVariable().getEnclosingCallable()
-  }
 }
 
 private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -60,12 +60,6 @@ class PhiNode = Impl::PhiNode;
 
 module Consistency = Impl::Consistency;
 
-module ExposedForTestingOnly {
-  predicate ssaDefReachesReadExt = Impl::ssaDefReachesReadExt/4;
-
-  predicate phiHasInputFromBlockExt = Impl::phiHasInputFromBlockExt/3;
-}
-
 /**
  * Holds if the `i`th node of basic block `bb` reads source variable `v`.
  */

--- a/csharp/ql/test/library-tests/dataflow/ssa/SSAPhiRead.expected
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SSAPhiRead.expected
@@ -6,7 +6,7 @@ phiReadNode
 | Test.cs:25:16:25:16 | SSA phi read(x) | Test.cs:8:13:8:13 | x |
 | Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:78:13:78:13 | x |
 | Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:78:13:78:13 | x |
-phiReadNodeRead
+phiReadNodeFirstRead
 | DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) | DefUse.cs:63:9:63:14 | this.Field2 | DefUse.cs:80:37:80:42 | access to field Field2 |
 | Fields.cs:63:16:63:28 | SSA phi read(this.LoopField) | Fields.cs:65:24:65:32 | this.LoopField | Fields.cs:65:24:65:32 | access to field LoopField |
 | Patterns.cs:20:9:38:9 | SSA phi read(o) | Patterns.cs:7:16:7:16 | o | Patterns.cs:20:17:20:17 | access to local variable o |
@@ -15,16 +15,21 @@ phiReadNodeRead
 | Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:78:13:78:13 | x | Test.cs:92:17:92:17 | access to local variable x |
 | Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:78:13:78:13 | x | Test.cs:96:17:96:17 | access to local variable x |
 | Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:78:13:78:13 | x | Test.cs:99:13:99:13 | access to local variable x |
-| Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:78:13:78:13 | x | Test.cs:104:17:104:17 | access to local variable x |
 phiReadInput
-| DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) | DefUse.cs:63:9:63:18 | SSA def(this.Field2) |
-| DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) | DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) |
+| DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) | DefUse.cs:64:13:64:18 | SSA read(this.Field2) |
+| DefUse.cs:80:30:80:31 | SSA phi read(this.Field2) | DefUse.cs:80:37:80:42 | SSA read(this.Field2) |
 | Fields.cs:63:16:63:28 | SSA phi read(this.LoopField) | Fields.cs:61:17:61:17 | SSA entry def(this.LoopField) |
-| Fields.cs:63:16:63:28 | SSA phi read(this.LoopField) | Fields.cs:63:16:63:28 | SSA phi read(this.LoopField) |
-| Patterns.cs:20:9:38:9 | SSA phi read(o) | Patterns.cs:7:16:7:23 | SSA def(o) |
+| Fields.cs:63:16:63:28 | SSA phi read(this.LoopField) | Fields.cs:65:24:65:32 | SSA read(this.LoopField) |
+| Patterns.cs:20:9:38:9 | SSA phi read(o) | Patterns.cs:8:13:8:13 | SSA read(o) |
+| Patterns.cs:20:9:38:9 | SSA phi read(o) | Patterns.cs:12:18:12:18 | SSA read(o) |
+| Patterns.cs:20:9:38:9 | SSA phi read(o) | Patterns.cs:16:18:16:18 | SSA read(o) |
 | Properties.cs:63:16:63:16 | SSA phi read(this.LoopProp) | Properties.cs:61:17:61:17 | SSA entry def(this.LoopProp) |
-| Properties.cs:63:16:63:16 | SSA phi read(this.LoopProp) | Properties.cs:63:16:63:16 | SSA phi read(this.LoopProp) |
+| Properties.cs:63:16:63:16 | SSA phi read(this.LoopProp) | Properties.cs:65:24:65:31 | SSA read(this.LoopProp) |
 | Test.cs:25:16:25:16 | SSA phi read(x) | Test.cs:24:9:24:15 | SSA phi(x) |
-| Test.cs:25:16:25:16 | SSA phi read(x) | Test.cs:25:16:25:16 | SSA phi read(x) |
+| Test.cs:25:16:25:16 | SSA phi read(x) | Test.cs:25:16:25:16 | SSA read(x) |
 | Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:78:13:78:17 | SSA def(x) |
+| Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:82:17:82:17 | SSA read(x) |
+| Test.cs:90:9:97:9 | SSA phi read(x) | Test.cs:86:17:86:17 | SSA read(x) |
 | Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:90:9:97:9 | SSA phi read(x) |
+| Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:92:17:92:17 | SSA read(x) |
+| Test.cs:99:9:99:15 | SSA phi read(x) | Test.cs:96:17:96:17 | SSA read(x) |

--- a/csharp/ql/test/library-tests/dataflow/ssa/SSAPhiRead.ql
+++ b/csharp/ql/test/library-tests/dataflow/ssa/SSAPhiRead.ql
@@ -1,17 +1,21 @@
 import csharp
 import semmle.code.csharp.dataflow.internal.SsaImpl
-import ExposedForTestingOnly
+import Impl::TestAdjacentRefs as RefTest
 
-query predicate phiReadNode(PhiReadNode phi, Ssa::SourceVariable v) { phi.getSourceVariable() = v }
+query predicate phiReadNode(RefTest::Ref phi, Ssa::SourceVariable v) {
+  phi.isPhiRead() and phi.getSourceVariable() = v
+}
 
-query predicate phiReadNodeRead(PhiReadNode phi, Ssa::SourceVariable v, ControlFlow::Node read) {
-  phi.getSourceVariable() = v and
-  exists(ControlFlow::BasicBlock bb, int i |
-    ssaDefReachesReadExt(v, phi, bb, i) and
+query predicate phiReadNodeFirstRead(RefTest::Ref phi, Ssa::SourceVariable v, ControlFlow::Node read) {
+  exists(RefTest::Ref r, ControlFlow::BasicBlock bb, int i |
+    phi.isPhiRead() and
+    RefTest::adjacentRefRead(phi, r) and
+    r.accessAt(bb, i, v) and
     read = bb.getNode(i)
   )
 }
 
-query predicate phiReadInput(PhiReadNode phi, DefinitionExt inp) {
-  phiHasInputFromBlockExt(phi, inp, _)
+query predicate phiReadInput(RefTest::Ref phi, RefTest::Ref inp) {
+  phi.isPhiRead() and
+  RefTest::adjacentRefPhi(inp, phi)
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -36,14 +36,12 @@ module SsaFlow {
     TExplicitParameterNode(result.(Impl::ParameterNode).getParameter()) = n
   }
 
-  predicate localFlowStep(
-    SsaImpl::Impl::DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep
-  ) {
-    Impl::localFlowStep(def, asNode(nodeFrom), asNode(nodeTo), isUseStep)
+  predicate localFlowStep(SsaSourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+    Impl::localFlowStep(v, asNode(nodeFrom), asNode(nodeTo), isUseStep)
   }
 
-  predicate localMustFlowStep(SsaImpl::Impl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
-    Impl::localMustFlowStep(def, asNode(nodeFrom), asNode(nodeTo))
+  predicate localMustFlowStep(Node nodeFrom, Node nodeTo) {
+    Impl::localMustFlowStep(_, asNode(nodeFrom), asNode(nodeTo))
   }
 }
 

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -168,7 +168,7 @@ predicate localMustFlowStep(Node node1, Node node2) {
       node2.(ImplicitInstanceAccess).getInstanceAccess().(OwnInstanceAccess).getEnclosingCallable()
   )
   or
-  SsaFlow::localMustFlowStep(_, node1, node2)
+  SsaFlow::localMustFlowStep(node1, node2)
   or
   node2.asExpr().(CastingExpr).getExpr() = node1.asExpr()
   or

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -544,15 +544,13 @@ private module Cached {
     import DataFlowIntegrationImpl
 
     cached
-    predicate localFlowStep(Impl::DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
-      not def instanceof UntrackedDef and
-      DataFlowIntegrationImpl::localFlowStep(def, nodeFrom, nodeTo, isUseStep)
+    predicate localFlowStep(TrackedVar v, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+      DataFlowIntegrationImpl::localFlowStep(v, nodeFrom, nodeTo, isUseStep)
     }
 
     cached
-    predicate localMustFlowStep(Impl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
-      not def instanceof UntrackedDef and
-      DataFlowIntegrationImpl::localMustFlowStep(def, nodeFrom, nodeTo)
+    predicate localMustFlowStep(TrackedVar v, Node nodeFrom, Node nodeTo) {
+      DataFlowIntegrationImpl::localMustFlowStep(v, nodeFrom, nodeTo)
     }
 
     signature predicate guardChecksSig(Guards::Guard g, Expr e, boolean branch);

--- a/ruby/ql/consistency-queries/SsaConsistency.ql
+++ b/ruby/ql/consistency-queries/SsaConsistency.ql
@@ -1,19 +1,3 @@
 import codeql.ruby.dataflow.SSA
 import codeql.ruby.dataflow.internal.SsaImpl
 import Consistency
-
-class MyRelevantDefinition extends RelevantDefinition, Ssa::Definition {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}
-
-class MyRelevantDefinitionExt extends RelevantDefinitionExt, DefinitionExt {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -111,12 +111,14 @@ module SsaFlow {
     n = toParameterNode(result.(Impl::ParameterNode).getParameter())
   }
 
-  predicate localFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
-    Impl::localFlowStep(def, asNode(nodeFrom), asNode(nodeTo), isUseStep)
+  predicate localFlowStep(
+    SsaImpl::SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep
+  ) {
+    Impl::localFlowStep(v, asNode(nodeFrom), asNode(nodeTo), isUseStep)
   }
 
-  predicate localMustFlowStep(SsaImpl::DefinitionExt def, Node nodeFrom, Node nodeTo) {
-    Impl::localMustFlowStep(def, asNode(nodeFrom), asNode(nodeTo))
+  predicate localMustFlowStep(Node nodeFrom, Node nodeTo) {
+    Impl::localMustFlowStep(_, asNode(nodeFrom), asNode(nodeTo))
   }
 }
 
@@ -175,7 +177,7 @@ module LocalFlow {
   }
 
   predicate localMustFlowStep(Node node1, Node node2) {
-    SsaFlow::localMustFlowStep(_, node1, node2)
+    SsaFlow::localMustFlowStep(node1, node2)
     or
     node1.asExpr() = node2.asExpr().(CfgNodes::ExprNodes::AssignExprCfgNode).getRhs()
     or
@@ -525,10 +527,10 @@ private module Cached {
     (
       LocalFlow::localFlowStepCommon(nodeFrom, nodeTo)
       or
-      exists(SsaImpl::DefinitionExt def, boolean isUseStep |
-        SsaFlow::localFlowStep(def, nodeFrom, nodeTo, isUseStep) and
+      exists(SsaImpl::SsaInput::SourceVariable v, boolean isUseStep |
+        SsaFlow::localFlowStep(v, nodeFrom, nodeTo, isUseStep) and
         // captured variables are handled by the shared `VariableCapture` library
-        not def instanceof VariableCapture::CapturedSsaDefinitionExt
+        not v instanceof VariableCapture::CapturedVariable
       |
         isUseStep = false
         or

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -387,13 +387,13 @@ private module Cached {
     import DataFlowIntegrationImpl
 
     cached
-    predicate localFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
-      DataFlowIntegrationImpl::localFlowStep(def, nodeFrom, nodeTo, isUseStep)
+    predicate localFlowStep(SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+      DataFlowIntegrationImpl::localFlowStep(v, nodeFrom, nodeTo, isUseStep)
     }
 
     cached
-    predicate localMustFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo) {
-      DataFlowIntegrationImpl::localMustFlowStep(def, nodeFrom, nodeTo)
+    predicate localMustFlowStep(SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo) {
+      DataFlowIntegrationImpl::localMustFlowStep(v, nodeFrom, nodeTo)
     }
 
     signature predicate guardChecksSig(Cfg::CfgNodes::AstCfgNode g, Cfg::CfgNode e, boolean branch);

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -75,12 +75,6 @@ class PhiNode = Impl::PhiNode;
 
 module Consistency = Impl::Consistency;
 
-module ExposedForTestingOnly {
-  predicate ssaDefReachesReadExt = Impl::ssaDefReachesReadExt/4;
-
-  predicate phiHasInputFromBlockExt = Impl::phiHasInputFromBlockExt/3;
-}
-
 /** Holds if `v` is uninitialized at index `i` in entry block `bb`. */
 predicate uninitializedWrite(Cfg::EntryBasicBlock bb, int i, LocalVariable v) {
   v.getDeclaringScope() = bb.getScope() and
@@ -387,7 +381,9 @@ private module Cached {
     import DataFlowIntegrationImpl
 
     cached
-    predicate localFlowStep(SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {
+    predicate localFlowStep(
+      SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep
+    ) {
       DataFlowIntegrationImpl::localFlowStep(v, nodeFrom, nodeTo, isUseStep)
     }
 

--- a/ruby/ql/test/library-tests/variables/ssa.expected
+++ b/ruby/ql/test/library-tests/variables/ssa.expected
@@ -597,7 +597,7 @@ phiReadNode
 | ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |
 | ssa.rb:94:3:95:10 | SSA phi read(self) | ssa.rb:90:1:103:3 | self |
 | ssa.rb:94:3:95:10 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |
-phiReadNodeRead
+phiReadNodeFirstRead
 | parameters.rb:26:3:26:11 | SSA phi read(name) | parameters.rb:25:15:25:18 | name | parameters.rb:26:8:26:11 | name |
 | ssa.rb:5:3:13:5 | SSA phi read(self) | ssa.rb:1:1:16:3 | self | ssa.rb:15:3:15:8 | self |
 | ssa.rb:19:9:19:9 | SSA phi read(self) | ssa.rb:18:1:23:3 | self | ssa.rb:20:5:20:10 | self |
@@ -607,12 +607,16 @@ phiReadNodeRead
 | ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:91:3:91:3 | x | ssa.rb:101:10:101:10 | x |
 phiReadInput
 | parameters.rb:26:3:26:11 | SSA phi read(name) | parameters.rb:25:15:25:18 | name |
-| ssa.rb:5:3:13:5 | SSA phi read(self) | ssa.rb:1:1:16:3 | self (m) |
+| parameters.rb:26:3:26:11 | SSA phi read(name) | parameters.rb:25:40:25:43 | SSA read(name) |
+| ssa.rb:5:3:13:5 | SSA phi read(self) | ssa.rb:8:5:8:14 | SSA read(self) |
+| ssa.rb:5:3:13:5 | SSA phi read(self) | ssa.rb:12:5:12:14 | SSA read(self) |
 | ssa.rb:19:9:19:9 | SSA phi read(self) | ssa.rb:18:1:23:3 | self (m1) |
-| ssa.rb:19:9:19:9 | SSA phi read(self) | ssa.rb:19:9:19:9 | SSA phi read(self) |
-| ssa.rb:92:3:96:5 | SSA phi read(self) | ssa.rb:90:1:103:3 | self (m12) |
+| ssa.rb:19:9:19:9 | SSA phi read(self) | ssa.rb:20:5:20:10 | SSA read(self) |
+| ssa.rb:92:3:96:5 | SSA phi read(self) | ssa.rb:93:5:93:10 | SSA read(self) |
 | ssa.rb:92:3:96:5 | SSA phi read(self) | ssa.rb:94:3:95:10 | SSA phi read(self) |
-| ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |
+| ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:93:10:93:10 | SSA read(x) |
 | ssa.rb:92:3:96:5 | SSA phi read(x) | ssa.rb:94:3:95:10 | SSA phi read(x) |
 | ssa.rb:94:3:95:10 | SSA phi read(self) | ssa.rb:90:1:103:3 | self (m12) |
+| ssa.rb:94:3:95:10 | SSA phi read(self) | ssa.rb:95:5:95:10 | SSA read(self) |
 | ssa.rb:94:3:95:10 | SSA phi read(x) | ssa.rb:91:3:91:3 | x |
+| ssa.rb:94:3:95:10 | SSA phi read(x) | ssa.rb:95:10:95:10 | SSA read(x) |

--- a/rust/ql/consistency-queries/SsaConsistency.ql
+++ b/rust/ql/consistency-queries/SsaConsistency.ql
@@ -1,19 +1,3 @@
 import codeql.rust.dataflow.Ssa
 import codeql.rust.dataflow.internal.SsaImpl
 import Consistency
-
-class MyRelevantDefinition extends RelevantDefinition, Ssa::Definition {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}
-
-class MyRelevantDefinitionExt extends RelevantDefinitionExt, DefinitionExt {
-  override predicate hasLocationInfo(
-    string filepath, int startline, int startcolumn, int endline, int endcolumn
-  ) {
-    this.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
-  }
-}

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -303,13 +303,15 @@ private module Cached {
     import DataFlowIntegrationImpl
 
     cached
-    predicate localFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo, boolean isUseStep) {
-      DataFlowIntegrationImpl::localFlowStep(def, nodeFrom, nodeTo, isUseStep)
+    predicate localFlowStep(
+      SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep
+    ) {
+      DataFlowIntegrationImpl::localFlowStep(v, nodeFrom, nodeTo, isUseStep)
     }
 
     cached
-    predicate localMustFlowStep(DefinitionExt def, Node nodeFrom, Node nodeTo) {
-      DataFlowIntegrationImpl::localMustFlowStep(def, nodeFrom, nodeTo)
+    predicate localMustFlowStep(SsaInput::SourceVariable v, Node nodeFrom, Node nodeTo) {
+      DataFlowIntegrationImpl::localMustFlowStep(v, nodeFrom, nodeTo)
     }
 
     signature predicate guardChecksSig(CfgNodes::AstCfgNode g, Cfg::CfgNode e, boolean branch);

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -100,12 +100,6 @@ class PhiDefinition = Impl::PhiNode;
 
 module Consistency = Impl::Consistency;
 
-module ExposedForTestingOnly {
-  predicate ssaDefReachesReadExt = Impl::ssaDefReachesReadExt/4;
-
-  predicate phiHasInputFromBlockExt = Impl::phiHasInputFromBlockExt/3;
-}
-
 /** Holds if `v` is read at index `i` in basic block `bb`. */
 private predicate variableReadActual(BasicBlock bb, int i, Variable v) {
   exists(VariableAccess read |

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -330,33 +330,6 @@ private module Cached {
 import Cached
 private import codeql.rust.dataflow.Ssa
 
-/**
- * An extended static single assignment (SSA) definition.
- *
- * This is either a normal SSA definition (`Definition`) or a
- * phi-read node (`PhiReadNode`).
- *
- * Only intended for internal use.
- */
-class DefinitionExt extends Impl::DefinitionExt {
-  CfgNode getARead() { result = getARead(this) }
-
-  override string toString() { result = this.(Ssa::Definition).toString() }
-
-  override Location getLocation() { result = this.(Ssa::Definition).getLocation() }
-}
-
-/**
- * A phi-read node.
- *
- * Only intended for internal use.
- */
-class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
-  override string toString() { result = "SSA phi read(" + this.getSourceVariable() + ")" }
-
-  override Location getLocation() { result = Impl::PhiReadNode.super.getLocation() }
-}
-
 private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {
   class Expr extends CfgNodes::AstCfgNode {
     predicate hasCfgNode(SsaInput::BasicBlock bb, int i) { this = bb.getNode(i) }

--- a/rust/ql/test/library-tests/variables/Ssa.expected
+++ b/rust/ql/test/library-tests/variables/Ssa.expected
@@ -535,14 +535,15 @@ phi
 phiReadNode
 | main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 |
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x |
-phiReadNodeRead
+phiReadNodeFirstRead
 | main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 | main.rs:105:11:105:12 | s1 |
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x | main.rs:500:19:500:19 | x |
 | main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x | main.rs:502:19:502:19 | x |
 phiReadInput
 | main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:102:9:102:10 | s1 |
-| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:104:11:105:12 | SSA phi read(s1) |
-| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:492:9:492:9 | x |
+| main.rs:104:11:105:12 | SSA phi read(s1) | main.rs:105:11:105:12 | SSA read(s1) |
+| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:494:19:494:19 | SSA read(x) |
+| main.rs:493:5:497:5 | SSA phi read(x) | main.rs:496:19:496:19 | SSA read(x) |
 ultimateDef
 | main.rs:191:9:191:44 | phi | main.rs:191:22:191:23 | a3 |
 | main.rs:191:9:191:44 | phi | main.rs:191:42:191:43 | a3 |

--- a/rust/ql/test/library-tests/variables/Ssa.ql
+++ b/rust/ql/test/library-tests/variables/Ssa.ql
@@ -3,7 +3,7 @@ import codeql.rust.controlflow.BasicBlocks
 import codeql.rust.controlflow.ControlFlowGraph
 import codeql.rust.dataflow.Ssa
 import codeql.rust.dataflow.internal.SsaImpl
-import ExposedForTestingOnly
+import Impl::TestAdjacentRefs as RefTest
 
 query predicate definition(Ssa::Definition def, Variable v) { def.getSourceVariable() = v }
 
@@ -24,18 +24,22 @@ query predicate phi(Ssa::PhiDefinition phi, Variable v, Ssa::Definition input) {
   phi.getSourceVariable() = v and input = phi.getAnInput()
 }
 
-query predicate phiReadNode(PhiReadNode phi, Variable v) { phi.getSourceVariable() = v }
+query predicate phiReadNode(RefTest::Ref phi, Variable v) {
+  phi.isPhiRead() and phi.getSourceVariable() = v
+}
 
-query predicate phiReadNodeRead(PhiReadNode phi, Variable v, CfgNode read) {
-  phi.getSourceVariable() = v and
-  exists(BasicBlock bb, int i |
-    ssaDefReachesReadExt(v, phi, bb, i) and
+query predicate phiReadNodeFirstRead(RefTest::Ref phi, Variable v, CfgNode read) {
+  exists(RefTest::Ref r, BasicBlock bb, int i |
+    phi.isPhiRead() and
+    RefTest::adjacentRefRead(phi, r) and
+    r.accessAt(bb, i, v) and
     read = bb.getNode(i)
   )
 }
 
-query predicate phiReadInput(PhiReadNode phi, DefinitionExt inp) {
-  phiHasInputFromBlockExt(phi, inp, _)
+query predicate phiReadInput(RefTest::Ref phi, RefTest::Ref inp) {
+  phi.isPhiRead() and
+  RefTest::adjacentRefPhi(inp, phi)
 }
 
 query predicate ultimateDef(Ssa::Definition def, Definition ult) {

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1794,7 +1794,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def and
+      nodeTo.(SsaDefinitionNode).getDefinition() = def and
       isUseStep = false
       or
       // Flow from definition/read to next read
@@ -1810,7 +1810,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         AdjacentSsaRefs::adjacentRefRead(bb1, i1, bb2, i2, v) and
         exists(UncertainWriteDefinition def2 |
           DfInput::allowFlowIntoUncertainDef(def2) and
-          nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def2 and
+          nodeTo.(SsaDefinitionNode).getDefinition() = def2 and
           def2.definesAt(v, bb2, i2)
         )
       )
@@ -1841,7 +1841,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def
+      nodeTo.(SsaDefinitionNode).getDefinition() = def
       or
       // Flow from SSA definition to read
       nodeFrom.(SsaDefinitionExtNodeImpl).getDefExt() = def and

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1644,7 +1644,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     /** A synthesized SSA data flow node. */
     abstract private class SsaNodeImpl extends NodeImpl {
       /** Gets the underlying SSA definition. */
-      abstract DefinitionExt getDefinitionExt();
+      abstract deprecated DefinitionExt getDefinitionExt();
 
       /** Gets the SSA definition this node corresponds to, if any. */
       Definition asDefinition() { this = TSsaDefinitionNode(result) }
@@ -1664,7 +1664,9 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
       SsaDefinitionExtNodeImpl() { this = TSsaDefinitionNode(def) }
 
-      override DefinitionExt getDefinitionExt() { result = def }
+      DefinitionExt getDefExt() { result = def }
+
+      deprecated override DefinitionExt getDefinitionExt() { result = def }
 
       override BasicBlock getBasicBlock() { result = def.getBasicBlock() }
 
@@ -1692,7 +1694,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     /** A node that represents a synthetic read of a source variable. */
     final class SsaSynthReadNode extends SsaNode {
       SsaSynthReadNode() {
-        this.(SsaDefinitionExtNodeImpl).getDefinitionExt() instanceof PhiReadNode or
+        this.(SsaDefinitionExtNodeImpl).getDefExt() instanceof PhiReadNode or
         this instanceof SsaInputNodeImpl
       }
     }
@@ -1744,7 +1746,9 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         input = input_
       }
 
-      override SsaInputDefinitionExt getDefinitionExt() { result = def_ }
+      SsaInputDefinitionExt getPhi() { result = def_ }
+
+      deprecated override SsaInputDefinitionExt getDefinitionExt() { result = def_ }
 
       override BasicBlock getBasicBlock() { result = input_ }
 
@@ -1767,7 +1771,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     private predicate flowOutOf(
       DefinitionExt def, Node nodeFrom, SourceVariable v, BasicBlock bb, int i, boolean isUseStep
     ) {
-      nodeFrom.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
+      nodeFrom.(SsaDefinitionExtNodeImpl).getDefExt() = def and
       def.definesAt(v, bb, i, _) and
       isUseStep = false
       or
@@ -1790,7 +1794,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def and
       isUseStep = false
       or
       // Flow from definition/read to next read
@@ -1806,7 +1810,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         AdjacentSsaRefs::adjacentRefRead(bb1, i1, bb2, i2, v) and
         exists(UncertainWriteDefinition def2 |
           DfInput::allowFlowIntoUncertainDef(def2) and
-          nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def2 and
+          nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def2 and
           def2.definesAt(v, bb2, i2)
         )
       )
@@ -1823,8 +1827,8 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       )
       or
       // Flow from input node to def
-      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
-      def = nodeFrom.(SsaInputNodeImpl).getDefinitionExt() and
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def and
+      def = nodeFrom.(SsaInputNodeImpl).getPhi() and
       isUseStep = false
     }
 
@@ -1837,10 +1841,10 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         // Flow from parameter into entry definition
         DfInput::ssaDefInitializesParam(def, nodeFrom.(ParameterNode).getParameter())
       ) and
-      nodeTo.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def
+      nodeTo.(SsaDefinitionExtNodeImpl).getDefExt() = def
       or
       // Flow from SSA definition to read
-      nodeFrom.(SsaDefinitionExtNodeImpl).getDefinitionExt() = def and
+      nodeFrom.(SsaDefinitionExtNodeImpl).getDefExt() = def and
       nodeTo.(ExprNode).getExpr() = DfInput::getARead(def)
     }
 

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1610,6 +1610,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
 
       SsaDefinitionExtNodeImpl() { this = TSsaDefinitionNode(def) }
 
+      /** Gets the corresponding `DefinitionExt`. */
       DefinitionExt getDefExt() { result = def }
 
       deprecated override DefinitionExt getDefinitionExt() { result = def }
@@ -1925,6 +1926,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         this = TRefPhiRead(_, result)
       }
 
+      /** Holds if this reference is a synthesized phi read. */
       predicate isPhiRead() { this = TRefPhiRead(_, _) }
 
       /** Gets a textual representation of this SSA reference. */

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1256,11 +1256,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     string toString() { result = this.(Definition).toString() }
 
     /** Gets the location of this SSA definition. */
-    Location getLocation() {
-      exists(BasicBlock bb, int i | this.definesAt(_, bb, i, _) |
-        if i = -1 then result = bb.getLocation() else result = bb.getNode(i).getLocation()
-      )
-    }
+    Location getLocation() { result = this.(Definition).getLocation() }
   }
 
   /**
@@ -1346,6 +1342,8 @@ module Make<LocationSig Location, InputSig<Location> Input> {
    */
   class PhiReadNode extends DefinitionExt, TPhiReadNode {
     override string toString() { result = "SSA phi read(" + this.getSourceVariable() + ")" }
+
+    override Location getLocation() { result = this.getBasicBlock().getLocation() }
   }
 
   /** Provides a set of consistency queries. */


### PR DESCRIPTION
More SSA refactoring commits. This is mostly about adjusting qltests to avoid DefinitionExt references, and fixing up the consistency queries.