### PR TITLE
Go: Document support for Go 1.24

### DIFF
--- a/docs/codeql/reusables/supported-versions-compilers.rst
+++ b/docs/codeql/reusables/supported-versions-compilers.rst
@@ -16,7 +16,7 @@
    .NET Core up to 3.1
 
    .NET 5, .NET 6, .NET 7, .NET 8, .NET 9","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-   Go (aka Golang), "Go up to 1.23", "Go 1.11 or more recent", ``.go``
+   Go (aka Golang), "Go up to 1.24", "Go 1.11 or more recent", ``.go``
    Java,"Java 7 to 22 [5]_","javac (OpenJDK and Oracle JDK),
 
    Eclipse compiler for Java (ECJ) [6]_",``.java``


### PR DESCRIPTION
I assume that docs which use this fragment will be regenerated without me having to do anything.