### PR TITLE
Python: Move min/maxParameter methods to `Function` class

### DIFF
--- a/python/ql/lib/change-notes/2025-02-26-add-get-min-max-parameters-to-function-class.md
+++ b/python/ql/lib/change-notes/2025-02-26-add-get-min-max-parameters-to-function-class.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+- Added the methods `getMinArguments` and `getMaxArguments` to the `Function` class. These return the minimum and maximum positional arguments that the given function accepts.

--- a/python/ql/lib/semmle/python/Function.qll
+++ b/python/ql/lib/semmle/python/Function.qll
@@ -165,12 +165,18 @@ class Function extends Function_, Scope, AstNode {
   }
 
   /** Gets the minimum number of positional arguments that can be correctly passed to this function. */
-  int getMinArguments() {
+  int getMinPositionalArguments() {
     result = count(this.getAnArg()) - count(this.getDefinition().getArgs().getADefault())
   }
 
-  /** Gets the maximum number of positional arguments that can be correctly passed to this function. */
-  int getMaxArguments() {
+  /**
+   * Gets the maximum number of positional arguments that can be correctly passed to this function.
+   *
+   * If the function has a `*vararg` parameter, there is no upper limit on the number of positional
+   * arguments that can be passed to the function. In this case, this method returns a very large
+   * number (currently `INT_MAX`, 2147483647, but this may change in the future).
+   */
+  int getMaxPositionalArguments() {
     if exists(this.getVararg())
     then result = 2147483647 // INT_MAX
     else result = count(this.getAnArg())

--- a/python/ql/lib/semmle/python/Function.qll
+++ b/python/ql/lib/semmle/python/Function.qll
@@ -163,6 +163,18 @@ class Function extends Function_, Scope, AstNode {
       ret.getValue() = result.getNode()
     )
   }
+
+  /** Gets the minimum number of positional arguments that can be correctly passed to this function. */
+  int getMinArguments() {
+    result = count(this.getAnArg()) - count(this.getDefinition().getArgs().getADefault())
+  }
+
+  /** Gets the maximum number of positional arguments that can be correctly passed to this function. */
+  int getMaxArguments() {
+    if exists(this.getVararg())
+    then result = 2147483647 // INT_MAX
+    else result = count(this.getAnArg())
+  }
 }
 
 /** A def statement. Note that FunctionDef extends Assign as a function definition binds the newly created function */

--- a/python/ql/lib/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/lib/semmle/python/objects/ObjectAPI.qll
@@ -738,21 +738,9 @@ class PythonFunctionValue extends FunctionValue {
     else result = "function " + this.getQualifiedName()
   }
 
-  override int minParameters() {
-    exists(Function f |
-      f = this.getScope() and
-      result = count(f.getAnArg()) - count(f.getDefinition().getArgs().getADefault())
-    )
-  }
+  override int minParameters() { result = this.getScope().getMinArguments() }
 
-  override int maxParameters() {
-    exists(Function f |
-      f = this.getScope() and
-      if exists(f.getVararg())
-      then result = 2147483647 // INT_MAX
-      else result = count(f.getAnArg())
-    )
-  }
+  override int maxParameters() { result = this.getScope().getMaxArguments() }
 
   /** Gets a control flow node corresponding to a return statement in this function */
   ControlFlowNode getAReturnedNode() { result = this.getScope().getAReturnValueFlowNode() }

--- a/python/ql/lib/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/lib/semmle/python/objects/ObjectAPI.qll
@@ -738,9 +738,9 @@ class PythonFunctionValue extends FunctionValue {
     else result = "function " + this.getQualifiedName()
   }
 
-  override int minParameters() { result = this.getScope().getMinArguments() }
+  override int minParameters() { result = this.getScope().getMinPositionalArguments() }
 
-  override int maxParameters() { result = this.getScope().getMaxArguments() }
+  override int maxParameters() { result = this.getScope().getMaxPositionalArguments() }
 
   /** Gets a control flow node corresponding to a return statement in this function */
   ControlFlowNode getAReturnedNode() { result = this.getScope().getAReturnValueFlowNode() }


### PR DESCRIPTION
These seem generally useful outside of points-to, and so it might be better to add them to the `Function` class instead.

I took the liberty of renaming these to say `Arguments` rather than `Parameters`, as this is more in line with the nomenclature that we're using elsewhere. (The internal points-to methods retain the old names.)

I'm somewhat ambivalent about the behaviour of `getMaxParameters` on functions with `*varargs`. The hard-coded `INT_MAX` return value is somewhat awkward, but the alternative (to only have the predicate defined when a specific maximum exists) seems like it would potentially cause a lot of headaches.