### PR TITLE
Java: Simplify interpretOutput

### DIFF
--- a/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/FlowSummaryImpl.qll
@@ -301,7 +301,7 @@ module SourceSinkInterpretationInput implements
       ast = mid.asElement()
     |
       (c = "Parameter" or c = "") and
-      node.asNode().asParameter() = mid.asElement()
+      n.asParameter() = ast
       or
       c = "" and
       n.asExpr().(FieldRead).getField() = ast


### PR DESCRIPTION
I am pretty sure that this is equivalent and avoids weird join ordering issues as both disjuncts now use the same variables. Otherwise we need `n` and `ast` bound to do the disjunction but that is a CP externally. Currently it is Ok as it seems these cases are always empty before the CP by the `c = "Parameter" or c = ""` and we know the input data is static but the CP is there if someone ever writes one of those cases (or in my case we change the optimiser to be less aggressive about pushing equalities after join ordering)

I feel it might be possible to write QL4QL query for this case noting that the fact that `n` and `ast` are unused in the disjunct is what makes the substitution valid.