### PR TITLE
Go: Add .gitignore for artifacts of `make test`

### DIFF
--- a/go/.gitignore
+++ b/go/.gitignore
@@ -1,0 +1,4 @@
+# artifacts of running `make test`
+data/
+lock
+size


### PR DESCRIPTION
Ignore files which are left behind when you run `make test` in `go`.