### PR TITLE
Move list of immutable actions into internal model pack for now.

### DIFF
--- a/actions/ql/extensions/immutable-actions-list/ext/immutable_actions.yml
+++ b/actions/ql/extensions/immutable-actions-list/ext/immutable_actions.yml
@@ -1,0 +1,28 @@
+extensions:
+  - addsTo:
+      pack: codeql/actions-all
+      extensible: immutableActionsDataModel
+    data:
+      - ["actions/checkout"]
+      - ["actions/cache"]
+      - ["actions/setup-node"]
+      - ["actions/upload-artifact"]
+      - ["actions/setup-python"]
+      - ["actions/download-artifact"]
+      - ["actions/github-script"]
+      - ["actions/setup-java"]
+      - ["actions/setup-go"]
+      - ["actions/upload-pages-artifact"]
+      - ["actions/deploy-pages"]
+      - ["actions/setup-dotnet"]
+      - ["actions/stale"]
+      - ["actions/labeler"]
+      - ["actions/create-github-app-token"]
+      - ["actions/configure-pages"]
+      - ["github/codeql-action/analyze"]
+      - ["github/codeql-action/autobuild"]
+      - ["github/codeql-action/init"]
+      - ["github/codeql-action/resolve-environment"]
+      - ["github/codeql-action/start-proxy"]
+      - ["github/codeql-action/upload-sarif"]
+      - ["octokit/request-action"]

--- a/actions/ql/extensions/immutable-actions-list/qlpack.yml
+++ b/actions/ql/extensions/immutable-actions-list/qlpack.yml
@@ -4,6 +4,7 @@
 name: github/immutable-actions-list
 version: 0.0.1-dev
 library: true
+warnOnImplicitThis: true
 extensionTargets:
   # We expect to need this model pack even after GA of Actions analysis, so make it compatible with
   # all future prereleases plus 1.x.x. We should be able to remove this back before we need to

--- a/actions/ql/extensions/immutable-actions-list/qlpack.yml
+++ b/actions/ql/extensions/immutable-actions-list/qlpack.yml
@@ -1,0 +1,13 @@
+# Model pack containing the list of known immutable actions. The Immutable Actions feature is not
+# yet released, so this pack will only be used within GitHub. Once the feature is available to
+# customers, we will move the contents of this pack back into the standard library pack.
+name: github/immutable-actions-list
+version: 0.0.1-dev
+library: true
+extensionTargets:
+  # We expect to need this model pack even after GA of Actions analysis, so make it compatible with
+  # all future prereleases plus 1.x.x. We should be able to remove this back before we need to
+  # bump the major version to 2.
+  codeql/actions-all: ">=0.4.3 <2.0.0"
+dataExtensions:
+- ext/**/*.yml

--- a/actions/ql/extensions/immutable-actions-list/qlpack.yml
+++ b/actions/ql/extensions/immutable-actions-list/qlpack.yml
@@ -1,7 +1,7 @@
 # Model pack containing the list of known immutable actions. The Immutable Actions feature is not
 # yet released, so this pack will only be used within GitHub. Once the feature is available to
 # customers, we will move the contents of this pack back into the standard library pack.
-name: github/immutable-actions-list
+name: codeql/immutable-actions-list
 version: 0.0.1-dev
 library: true
 warnOnImplicitThis: true

--- a/actions/ql/lib/ext/config/immutable_actions.yml
+++ b/actions/ql/lib/ext/config/immutable_actions.yml
@@ -4,7 +4,7 @@ extensions:
       extensible: immutableActionsDataModel
     # Since the Immutable Actions feature is not yet available to customers, we won't alert about
     # any unversioned immutable action references for now. Within GitHub, we'll include the
-    # `github/immutable-actions-list` model pack, which will provide the necessary list of actions
+    # `codeql/immutable-actions-list` model pack, which will provide the necessary list of actions
     # for internal use. Once the feature is available to customers, we'll move that list back into
     # this file.
     data: []

--- a/actions/ql/lib/ext/config/immutable_actions.yml
+++ b/actions/ql/lib/ext/config/immutable_actions.yml
@@ -2,21 +2,9 @@ extensions:
   - addsTo:
       pack: codeql/actions-all
       extensible: immutableActionsDataModel
-    data:
-      - ["actions/checkout"]
-      - ["actions/cache"]
-      - ["actions/setup-node"]
-      - ["actions/upload-artifact"]
-      - ["actions/setup-python"]
-      - ["actions/download-artifact"]
-      - ["actions/github-script"]
-      - ["actions/setup-java"]
-      - ["actions/setup-go"]
-      - ["actions/upload-pages-artifact"]
-      - ["actions/deploy-pages"]
-      - ["actions/setup-dotnet"]
-      - ["actions/stale"]
-      - ["actions/labeler"]
-      - ["actions/create-github-app-token"]
-      - ["actions/configure-pages"]
-      - ["octokit/request-action"]
+    # Since the Immutable Actions feature is not yet available to customers, we won't alert about
+    # any unversioned immutable action references for now. Within GitHub, we'll include the
+    # `github/immutable-actions-list` model pack, which will provide the necessary list of actions
+    # for internal use. Once the feature is available to customers, we'll move that list back into
+    # this file.
+    data: []

--- a/actions/ql/lib/ext/config/trusted_actions_owner.yml
+++ b/actions/ql/lib/ext/config/trusted_actions_owner.yml
@@ -6,4 +6,3 @@ extensions:
       - ["actions"]
       - ["github"]
       - ["advanced-security"]
-      - ["octokit"]

--- a/actions/ql/lib/ext/config/trusted_actions_owner.yml
+++ b/actions/ql/lib/ext/config/trusted_actions_owner.yml
@@ -6,3 +6,4 @@ extensions:
       - ["actions"]
       - ["github"]
       - ["advanced-security"]
+      - ["octokit"]

--- a/actions/ql/src/change-notes/2025-02-27-immutable-actions-list.md
+++ b/actions/ql/src/change-notes/2025-02-27-immutable-actions-list.md
@@ -1,0 +1,7 @@
+---
+category: fix
+---
+* The `actions/unversioned-immutable-action` query will no longer report any alerts, since the
+  Immutable Actions feature is not yet available for customer use. The query remains in the
+  default Code Scanning suites for use internal to GitHub. Once the Immutable Actions feature is
+  available, the query will be updated to report alerts again.

--- a/actions/ql/test/qlpack.yml
+++ b/actions/ql/test/qlpack.yml
@@ -3,6 +3,10 @@ groups: [codeql, test]
 dependencies:
   codeql/actions-all: ${workspace}
   codeql/actions-queries: ${workspace}
+  # Use the `immutable-actions-list` model pack so that we have some actual data to test against.
+  # We can remove this dependency when we incorporate the data from that model pack back into the
+  # standard library pack.
+  github/immutable-actions-list: ${workspace}
 extractor: actions
 tests: .
 warnOnImplicitThis: true

--- a/actions/ql/test/qlpack.yml
+++ b/actions/ql/test/qlpack.yml
@@ -6,7 +6,7 @@ dependencies:
   # Use the `immutable-actions-list` model pack so that we have some actual data to test against.
   # We can remove this dependency when we incorporate the data from that model pack back into the
   # standard library pack.
-  github/immutable-actions-list: ${workspace}
+  codeql/immutable-actions-list: ${workspace}
 extractor: actions
 tests: .
 warnOnImplicitThis: true

--- a/codeql-workspace.yml
+++ b/codeql-workspace.yml
@@ -17,7 +17,7 @@ provide:
   - "misc/legacy-support/*/qlpack.yml"
   - "misc/suite-helpers/qlpack.yml"
   - ".github/codeql/extensions/**/codeql-pack.yml"
-
+  - "actions/ql/extensions/**/qlpack.yml"
 versionPolicies:
   default:
     requireChangeNotes: true


### PR DESCRIPTION
This PR removes the current list of immutable actions from the standard library pack, and moves it into a new model pack, `github/immutable-actions-list`.

We have an existing Actions query, `actions/unversioned-immutable-action`, which alerts about references to an action without a semantic version if there's an immutable version of that action available. However, since the immutable actions feature isn't available to customers yet, we're currently reporting alerts that our customers have no way of fixing. We don't want to remove the query from the default suite, though, because then we couldn't run it internally on repos that use Default Setup, which is nearly all of them.

Instead, I've created a new model pack containing the list. We'll deploy this model pack internally for now. Once the Immutable Actions feature ships to customers, we'll add the list back into the standard library pack.

I've also added all of the `codeql-action` actions to the list, since they were missing.

To keep our tests running, I've simply added the new model pack as a dependency of our test pack.

~~Separately but related, I've added the `octokit` org to the list of trusted Actions owners. The `actions/unpinned-tag` query ignores actions which are known to have immutable versions available, so removing `octokit/request-action` from that list made us start reporting `unpinned-tag` on uses of that action.~~ Update: we decided that `octokit` doesn't meet our current criteria for "trusted owner", so I've removed it from the list. We'll start reporting `unpinned-tag` for `octokit/request-action`.

The new pack will be published manually, and only when needed, rather than as part of the usual CodeQL release process. We'll likely only need to publish it once.
