### PR TITLE
Set the executable bit on the scripts in the Actions extractor

### DIFF
--- a/actions/extractor/BUILD.bazel
+++ b/actions/extractor/BUILD.bazel
@@ -5,7 +5,8 @@ codeql_pkg_files(
     srcs = [
         "codeql-extractor.yml",
         "//:LICENSE",
-    ] + glob(["tools/**"]),
+    ],
+    exes = glob(["tools/**"]),
     strip_prefix = strip_prefix.from_pkg(),
     visibility = ["//actions:__pkg__"],
 )


### PR DESCRIPTION
The Bash script in the `actions` extractor has its executable bit set in the repo, but was losing that bit somewhere along the way from the repo checkout to the CLI zip file. The fix is to specify the scripts in the `exes` parameter of `codeql_pkg_files` rather than in the `srcs` parameter.

We didn't notice this because everywhere we test the Actions extractor, it's being picked up from the repo, not the CLI distribution. It also didn't affect anyone using the CodeQL Action, because the Action had an embedded copy of the `actions` extractor, and that copy _does_ have the executable bit set correctly 🤦‍♂️.

