### PR TITLE
Data flow: Improve doc for defaultImplicitTaintRead.

### DIFF
--- a/shared/dataflow/codeql/dataflow/TaintTracking.qll
+++ b/shared/dataflow/codeql/dataflow/TaintTracking.qll
@@ -26,7 +26,11 @@ signature module InputSig<LocationSig Location, DF::InputSig<Location> Lang> {
 
   /**
    * Holds if taint flow configurations should allow implicit reads of `c` at sinks
-   * and inputs to additional taint steps.
+   * and inputs to additional taint steps defined in the flow `Config`.
+   *
+   * Note that this (deliberately) does not include at additional taint steps defined
+   * globally in `defaultAdditionalTaintStep`. These models are expected to be precise
+   * and therefore to not require implicit reads.
    */
   bindingset[node]
   predicate defaultImplicitTaintRead(Lang::Node node, Lang::ContentSet c);


### PR DESCRIPTION
I'm not the first person to have been [surprised](https://github.com/github/codeql/pull/18776#issuecomment-2687337289) the the behaviour of `defaultImplicitTaintRead`.  Lets make the doc comment more accurate.