### PR TITLE
C++ query to extract the number of errors due to include file resolution failure

### DIFF
--- a/cpp/ql/src/Metrics/Internal/IncludeResolutionStatus.ql
+++ b/cpp/ql/src/Metrics/Internal/IncludeResolutionStatus.ql
@@ -1,0 +1,20 @@
+/**
+ * @name Include file resolution status
+ * @description A count of successful includes and includes that failed to resolve.
+ *                This query is for internal use only and may change without notice.
+ * @kind table
+ * @id cpp/include-resolution-status
+ */
+
+import cpp
+
+/**
+ * A cannot open file error.
+ *
+ * Typically this is due to a missing include.
+ */
+class CannotOpenFileError extends CompilerError {
+  CannotOpenFileError() { this.hasTag(["cannot_open_file", "cannot_open_file_reason"]) }
+}
+
+select count(CannotOpenFileError e) as failed_includes, count(Include i) as successful_includes


### PR DESCRIPTION
This PR adds a query to get metrics to evaluate the include resolution status in C++ BMN.

It will be added to DCA as an uninterpreted query.