### PR TITLE
Rust: tweak qltest logs

### DIFF
--- a/rust/tools/qltest.cmd
+++ b/rust/tools/qltest.cmd
@@ -3,7 +3,7 @@
 set "RUST_BACKTRACE=full"
 set "QLTEST_LOG=%CODEQL_EXTRACTOR_RUST_LOG_DIR%/qltest.log"
 
-type NUL && "%CODEQL_EXTRACTOR_RUST_ROOT%/tools/%CODEQL_PLATFORM%/extractor" --qltest >"%QLTEST_LOG%" 2>&1
+type NUL && "%CODEQL_EXTRACTOR_RUST_ROOT%/tools/%CODEQL_PLATFORM%/extractor" --qltest --logging-verbosity=progress+ >"%QLTEST_LOG%" 2>&1
 
 if %ERRORLEVEL% neq 0 (
     type "%QLTEST_LOG%"

--- a/rust/tools/qltest.sh
+++ b/rust/tools/qltest.sh
@@ -5,7 +5,8 @@ set -o pipefail
 
 export RUST_BACKTRACE=full
 QLTEST_LOG="$CODEQL_EXTRACTOR_RUST_LOG_DIR"/qltest.log
-TMP_OUT="$(mktemp)"
+mkdir -p "$CODEQL_EXTRACTOR_RUST_SCRATCH_DIR"
+TMP_OUT="$(mktemp --tmpdir="$CODEQL_EXTRACTOR_RUST_SCRATCH_DIR" qltest-XXXXXX.log))"
 trap 'rm -f "$TMP_OUT"' EXIT
 # put full-color output on the side, but remove the color codes from the log file
 # also, print (colored) output only in case of failure

--- a/rust/tools/qltest.sh
+++ b/rust/tools/qltest.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
 set -eu
+set -o pipefail
 
 export RUST_BACKTRACE=full
 QLTEST_LOG="$CODEQL_EXTRACTOR_RUST_LOG_DIR"/qltest.log
-if ! "$CODEQL_EXTRACTOR_RUST_ROOT/tools/$CODEQL_PLATFORM/extractor" --qltest >> "$QLTEST_LOG" 2>&1; then
-  cat "$QLTEST_LOG"
+TMP_OUT="$(mktemp)"
+trap 'rm -f "$TMP_OUT"' EXIT
+# put full-color output on the side, but remove the color codes from the log file
+# also, print (colored) output only in case of failure
+if ! "$CODEQL_EXTRACTOR_RUST_ROOT/tools/$CODEQL_PLATFORM/extractor" \
+     --qltest \
+     --logging-verbosity=progress+ \
+     2>&1 \
+     | tee "$TMP_OUT" \
+     | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' \
+     > "$QLTEST_LOG"; then
+  cat "$TMP_OUT"
   exit 1
 fi


### PR DESCRIPTION
* verbosity is raised to DEBUG to have more information in the logs
* color codes are now skipped in the `qltest.log` file
* they are still printed out on the console when running with `--show-extractor-output`.