### PR TITLE
C++: Update template test to also output the value of template arguments

### DIFF
--- a/cpp/ql/test/library-tests/templates/nontype_instantiations/general/test.expected
+++ b/cpp/ql/test/library-tests/templates/nontype_instantiations/general/test.expected
@@ -1,13 +1,13 @@
-| test.cpp:3:8:3:8 | C<1> | 0 | int | test.cpp:5:25:5:25 | 1 |
-| test.cpp:3:8:3:8 | C<2> | 0 | int | file://:0:0:0:0 | 2 |
-| test.cpp:3:8:3:8 | C<x> | 0 | int | file://:0:0:0:0 | x |
-| test.cpp:10:8:10:8 | D<T, X> | 0 | <none> | test.cpp:9:19:9:19 | T |
-| test.cpp:10:8:10:8 | D<T, X> | 1 | T | file://:0:0:0:0 | X |
-| test.cpp:10:8:10:8 | D<int, 2> | 0 | <none> | file://:0:0:0:0 | int |
-| test.cpp:10:8:10:8 | D<int, 2> | 1 | int | test.cpp:12:8:12:8 | 2 |
-| test.cpp:10:8:10:8 | D<long, 2L> | 0 | <none> | file://:0:0:0:0 | long |
-| test.cpp:10:8:10:8 | D<long, 2L> | 1 | long | file://:0:0:0:0 | 2 |
-| test.cpp:16:8:16:8 | E<T, X> | 0 | <none> | test.cpp:15:19:15:19 | T |
-| test.cpp:16:8:16:8 | E<T, X> | 1 | T * | file://:0:0:0:0 | X |
-| test.cpp:16:8:16:8 | E<int, (int *)nullptr> | 0 | <none> | file://:0:0:0:0 | int |
-| test.cpp:16:8:16:8 | E<int, (int *)nullptr> | 1 | int * | file://:0:0:0:0 | 0 |
+| test.cpp:3:8:3:8 | C<1> | 0 | int | test.cpp:5:25:5:25 | 1 | 1 |
+| test.cpp:3:8:3:8 | C<2> | 0 | int | file://:0:0:0:0 | 2 | 2 |
+| test.cpp:3:8:3:8 | C<x> | 0 | int | file://:0:0:0:0 | x | x |
+| test.cpp:10:8:10:8 | D<T, X> | 0 | <none> | test.cpp:9:19:9:19 | T | <none> |
+| test.cpp:10:8:10:8 | D<T, X> | 1 | T | file://:0:0:0:0 | X | X |
+| test.cpp:10:8:10:8 | D<int, 2> | 0 | <none> | file://:0:0:0:0 | int | <none> |
+| test.cpp:10:8:10:8 | D<int, 2> | 1 | int | test.cpp:12:8:12:8 | 2 | 2 |
+| test.cpp:10:8:10:8 | D<long, 2L> | 0 | <none> | file://:0:0:0:0 | long | <none> |
+| test.cpp:10:8:10:8 | D<long, 2L> | 1 | long | file://:0:0:0:0 | 2 | 2 |
+| test.cpp:16:8:16:8 | E<T, X> | 0 | <none> | test.cpp:15:19:15:19 | T | <none> |
+| test.cpp:16:8:16:8 | E<T, X> | 1 | T * | file://:0:0:0:0 | X | X |
+| test.cpp:16:8:16:8 | E<int, (int *)nullptr> | 0 | <none> | file://:0:0:0:0 | int | <none> |
+| test.cpp:16:8:16:8 | E<int, (int *)nullptr> | 1 | int * | file://:0:0:0:0 | 0 | 0 |

--- a/cpp/ql/test/library-tests/templates/nontype_instantiations/general/test.ql
+++ b/cpp/ql/test/library-tests/templates/nontype_instantiations/general/test.ql
@@ -9,6 +9,16 @@ string maybeGetTemplateArgumentKind(Declaration d, int i) {
   i = [0 .. d.getNumberOfTemplateArguments()]
 }
 
+string maybeGetTemplateArgumentValue(Declaration d, int i) {
+  (
+    if exists(d.getTemplateArgument(i).(Expr).getValue())
+    then result = d.getTemplateArgument(i).(Expr).getValue()
+    else result = "<none>"
+  ) and
+  i = [0 .. d.getNumberOfTemplateArguments()]
+}
+
 from Declaration d, int i
 where i >= 0 and i < d.getNumberOfTemplateArguments()
-select d, i, maybeGetTemplateArgumentKind(d, i), d.getTemplateArgument(i)
+select d, i, maybeGetTemplateArgumentKind(d, i), d.getTemplateArgument(i),
+  maybeGetTemplateArgumentValue(d, i)


### PR DESCRIPTION
These values are currently the same as the result that `getTemplateArgument` yields. However, this will change with the upcoming frontend update.