### PR TITLE
Ruby: Avoid a forced CP.

### DIFF
--- a/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
+++ b/ruby/ql/lib/codeql/ruby/frameworks/http_clients/NetHttp.qll
@@ -54,7 +54,15 @@ class NetHttpRequest extends Http::Client::Request::Range, DataFlow::CallNode {
   override DataFlow::Node getAUrlPart() {
     result = request.getArgument(0)
     or
-    // Net::HTTP.new(...).get(...)
+    result = this.getAUrlPartHelper()
+  }
+
+  /**
+   * Helper predicate for `getAUrlPart`.
+   *
+   * This handles `Net::HTTP.new(...).get(...)` etc.
+   */
+  private DataFlow::Node getAUrlPartHelper() {
     exists(API::Node new |
       new = API::getTopLevelMember("Net").getMember("HTTP").getInstance() and
       requestNode = new.getReturn(_)


### PR DESCRIPTION
The disjunction mentions `request` on one side and `requestNode` on the other. This means that the disjunction can't go first and the call the the charpred must be done first. Due to a `inline_late bindingset[...]` call inside the inlined `new.getReturn(_)`  we can't start with that inside the disjunct and we therefore must choose a CP. Luckily in most databases the CP ends up small.

This is not important at all for the new join orderer as better heuristics now means it picks the correct CP but I felt it was better to avoid it in case someone creates a project with many `Net::HTTP.new(...).get(...)` calls.