### PR TITLE
SSA: Replace the Guards interface in the SSA data flow integration.

### DIFF
--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -1047,8 +1047,17 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
   }
 
   class Guard extends Guards::Guard {
-    predicate hasCfgNode(ControlFlow::BasicBlock bb, int i) {
-      this.getAControlFlowNode() = bb.getNode(i)
+    /**
+     * Holds if the control flow branching from `bb1` is dependent on this guard,
+     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+     * guard to `branch`.
+     */
+    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
+      exists(ControlFlow::SuccessorTypes::ConditionalSuccessor s |
+        this.getAControlFlowNode() = bb1.getLastNode() and
+        bb2 = bb1.getASuccessorByType(s) and
+        s.getValue() = branch
+      )
     }
   }
 
@@ -1058,16 +1067,6 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
       guard.getAControlFlowNode() = conditionBlock.getLastNode() and
       s.getValue() = branch and
       conditionBlock.edgeDominates(bb, s)
-    )
-  }
-
-  /** Gets an immediate conditional successor of basic block `bb`, if any. */
-  ControlFlow::BasicBlock getAConditionalBasicBlockSuccessor(
-    ControlFlow::BasicBlock bb, boolean branch
-  ) {
-    exists(ControlFlow::SuccessorTypes::ConditionalSuccessor s |
-      result = bb.getASuccessorByType(s) and
-      s.getValue() = branch
     )
   }
 }

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -667,21 +667,19 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
   }
 
   class Guard extends Guards::Guard {
-    predicate hasCfgNode(BasicBlock bb, int i) {
-      this = bb.getNode(i).asExpr()
-      or
-      this = bb.getNode(i).asStmt()
+    /**
+     * Holds if the control flow branching from `bb1` is dependent on this guard,
+     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+     * guard to `branch`.
+     */
+    predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch) {
+      super.hasBranchEdge(bb1, bb2, branch)
     }
   }
 
   /** Holds if the guard `guard` controls block `bb` upon evaluating to `branch`. */
   predicate guardControlsBlock(Guard guard, BasicBlock bb, boolean branch) {
     guard.controls(bb, branch)
-  }
-
-  /** Gets an immediate conditional successor of basic block `bb`, if any. */
-  BasicBlock getAConditionalBasicBlockSuccessor(BasicBlock bb, boolean branch) {
-    result = bb.(Guards::ConditionBlock).getTestSuccessor(branch)
   }
 }
 

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
@@ -81,7 +81,19 @@ module SsaDataflowInput implements DataFlowIntegrationInputSig {
   class Guard extends js::ControlFlowNode {
     Guard() { this = any(js::ConditionGuardNode g).getTest() }
 
-    predicate hasCfgNode(js::BasicBlock bb, int i) { this = bb.getNode(i) }
+    /**
+     * Holds if the control flow branching from `bb1` is dependent on this guard,
+     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+     * guard to `branch`.
+     */
+    predicate controlsBranchEdge(js::BasicBlock bb1, js::BasicBlock bb2, boolean branch) {
+      exists(js::ConditionGuardNode g |
+        g.getTest() = this and
+        bb1 = this.getBasicBlock() and
+        bb2 = g.getBasicBlock() and
+        branch = g.getOutcome()
+      )
+    }
   }
 
   pragma[inline]
@@ -89,14 +101,6 @@ module SsaDataflowInput implements DataFlowIntegrationInputSig {
     exists(js::ConditionGuardNode g |
       g.getTest() = guard and
       g.dominates(bb) and
-      branch = g.getOutcome()
-    )
-  }
-
-  js::BasicBlock getAConditionalBasicBlockSuccessor(js::BasicBlock bb, boolean branch) {
-    exists(js::ConditionGuardNode g |
-      bb = g.getTest().getBasicBlock() and
-      result = g.getBasicBlock() and
       branch = g.getOutcome()
     )
   }

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -74,10 +74,10 @@ CfgNodes::ExprCfgNode getAPostUpdateNodeForArg(Argument arg) {
 
 /** Gets the SSA definition node corresponding to parameter `p`. */
 pragma[nomagic]
-SsaImpl::DefinitionExt getParameterDef(NamedParameter p) {
+Ssa::Definition getParameterDef(NamedParameter p) {
   exists(BasicBlock bb, int i |
     bb.getNode(i).getAstNode() = p.getDefiningAccess() and
-    result.definesAt(_, bb, i, _)
+    result.definesAt(_, bb, i)
   )
 }
 
@@ -388,15 +388,15 @@ module VariableCapture {
     Flow::clearsContent(asClosureNode(node), c.getVariable())
   }
 
-  class CapturedSsaDefinitionExt extends SsaImpl::DefinitionExt {
-    CapturedSsaDefinitionExt() { this.getSourceVariable() instanceof CapturedVariable }
+  class CapturedSsaDefinition extends SsaImpl::Definition {
+    CapturedSsaDefinition() { this.getSourceVariable() instanceof CapturedVariable }
   }
 
   // From an assignment or implicit initialization of a captured variable to its flow-insensitive node
   private predicate flowInsensitiveWriteStep(
     SsaDefinitionNodeImpl node1, CapturedVariableNode node2, CapturedVariable v
   ) {
-    exists(CapturedSsaDefinitionExt def |
+    exists(CapturedSsaDefinition def |
       def = node1.getDefinition() and
       def.getSourceVariable() = v and
       (
@@ -412,7 +412,7 @@ module VariableCapture {
   private predicate flowInsensitiveReadStep(
     CapturedVariableNode node1, SsaDefinitionNodeImpl node2, CapturedVariable v
   ) {
-    exists(CapturedSsaDefinitionExt def |
+    exists(CapturedSsaDefinition def |
       node1.getVariable() = v and
       def = node2.getDefinition() and
       def.getSourceVariable() = v and
@@ -772,7 +772,7 @@ class SsaNode extends NodeImpl, TSsaNode {
 class SsaDefinitionNodeImpl extends SsaNode {
   override SsaImpl::DataFlowIntegration::SsaDefinitionNode node;
 
-  SsaImpl::Definition getDefinition() { result = node.getDefinition() }
+  Ssa::Definition getDefinition() { result = node.getDefinition() }
 
   override predicate isHidden() {
     exists(SsaImpl::Definition def | def = this.getDefinition() |
@@ -2478,7 +2478,7 @@ module TypeInference {
       n = def or
       n.asExpr() =
         any(CfgNodes::ExprCfgNode read |
-          read = def.getDefinition().(SsaImpl::DefinitionExt).getARead() and
+          read = def.getDefinition().getARead() and
           not isTypeCheckedRead(read, _) // could in principle be checked against a new type
         )
     )

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -421,7 +421,7 @@ import Cached
  *
  * Only intended for internal use.
  */
-class DefinitionExt extends Impl::DefinitionExt {
+deprecated class DefinitionExt extends Impl::DefinitionExt {
   VariableReadAccessCfgNode getARead() { result = getARead(this) }
 
   override string toString() { result = this.(Ssa::Definition).toString() }
@@ -434,7 +434,7 @@ class DefinitionExt extends Impl::DefinitionExt {
  *
  * Only intended for internal use.
  */
-class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
+deprecated class PhiReadNode extends DefinitionExt, Impl::PhiReadNode {
   override string toString() { result = "SSA phi read(" + this.getSourceVariable() + ")" }
 
   override Location getLocation() { result = Impl::PhiReadNode.super.getLocation() }
@@ -453,10 +453,10 @@ class NormalParameter extends Parameter {
 
 /** Gets the SSA definition node corresponding to parameter `p`. */
 pragma[nomagic]
-DefinitionExt getParameterDef(NamedParameter p) {
+Definition getParameterDef(NamedParameter p) {
   exists(Cfg::BasicBlock bb, int i |
     bb.getNode(i).getAstNode() = p.getDefiningAccess() and
-    result.definesAt(_, bb, i, _)
+    result.definesAt(_, bb, i)
   )
 }
 

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -515,20 +515,23 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
   predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { p.isInitializedBy(def) }
 
   class Guard extends Cfg::CfgNodes::AstCfgNode {
-    predicate hasCfgNode(SsaInput::BasicBlock bb, int i) { this = bb.getNode(i) }
+    /**
+     * Holds if the control flow branching from `bb1` is dependent on this guard,
+     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+     * guard to `branch`.
+     */
+    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+      exists(Cfg::SuccessorTypes::ConditionalSuccessor s |
+        this.getBasicBlock() = bb1 and
+        bb2 = bb1.getASuccessor(s) and
+        s.getValue() = branch
+      )
+    }
   }
 
   /** Holds if the guard `guard` controls block `bb` upon evaluating to `branch`. */
   predicate guardControlsBlock(Guard guard, SsaInput::BasicBlock bb, boolean branch) {
     Guards::guardControlsBlock(guard, bb, branch)
-  }
-
-  /** Gets an immediate conditional successor of basic block `bb`, if any. */
-  SsaInput::BasicBlock getAConditionalBasicBlockSuccessor(SsaInput::BasicBlock bb, boolean branch) {
-    exists(Cfg::SuccessorTypes::ConditionalSuccessor s |
-      result = bb.getASuccessor(s) and
-      s.getValue() = branch
-    )
   }
 }
 

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -361,7 +361,18 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
   }
 
   class Guard extends CfgNodes::AstCfgNode {
-    predicate hasCfgNode(SsaInput::BasicBlock bb, int i) { this = bb.getNode(i) }
+    /**
+     * Holds if the control flow branching from `bb1` is dependent on this guard,
+     * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+     * guard to `branch`.
+     */
+    predicate controlsBranchEdge(SsaInput::BasicBlock bb1, SsaInput::BasicBlock bb2, boolean branch) {
+      exists(Cfg::ConditionalSuccessor s |
+        this = bb1.getANode() and
+        bb2 = bb1.getASuccessor(s) and
+        s.getValue() = branch
+      )
+    }
   }
 
   /** Holds if the guard `guard` controls block `bb` upon evaluating to `branch`. */
@@ -370,14 +381,6 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
       guard = conditionBlock.getLastNode() and
       s.getValue() = branch and
       conditionBlock.edgeDominates(bb, s)
-    )
-  }
-
-  /** Gets an immediate conditional successor of basic block `bb`, if any. */
-  SsaInput::BasicBlock getAConditionalBasicBlockSuccessor(SsaInput::BasicBlock bb, boolean branch) {
-    exists(Cfg::ConditionalSuccessor s |
-      result = bb.getASuccessor(s) and
-      s.getValue() = branch
     )
   }
 }

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1434,15 +1434,16 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       /** Gets a textual representation of this guard. */
       string toString();
 
-      /** Holds if the `i`th node of basic block `bb` evaluates this guard. */
-      predicate hasCfgNode(BasicBlock bb, int i);
+      /**
+       * Holds if the control flow branching from `bb1` is dependent on this guard,
+       * and that the edge from `bb1` to `bb2` corresponds to the evaluation of this
+       * guard to `branch`.
+       */
+      predicate controlsBranchEdge(BasicBlock bb1, BasicBlock bb2, boolean branch);
     }
 
     /** Holds if `guard` controls block `bb` upon evaluating to `branch`. */
     predicate guardControlsBlock(Guard guard, BasicBlock bb, boolean branch);
-
-    /** Gets an immediate conditional successor of basic block `bb`, if any. */
-    BasicBlock getAConditionalBasicBlockSuccessor(BasicBlock bb, boolean branch);
   }
 
   /**
@@ -1891,11 +1892,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
           |
             DfInput::guardControlsBlock(g, bb, branch)
             or
-            exists(int last |
-              last = bb.length() - 1 and
-              g.hasCfgNode(bb, last) and
-              DfInput::getAConditionalBasicBlockSuccessor(bb, branch) = phi.getBasicBlock()
-            )
+            g.controlsBranchEdge(bb, phi.getBasicBlock(), branch)
           )
         )
       }


### PR DESCRIPTION
One small cleanup commit for Ruby, and then the primary commit, which updates the Guards-related part of the SSA data flow integration module interface. This should be equivalent, but removes the implicit assumption that guards coincide with the CFG node where the branching happens, this is e.g. false if we want to support indirect guards through a local boolean variable in the SSA interface.
```
b = someGuard;
...
if (b) ...
```