### PR TITLE
C#: Fewer alerts in `cs/useless-if-statement`.

### DIFF
--- a/csharp/ql/src/Useless code/FutileConditional.ql
+++ b/csharp/ql/src/Useless code/FutileConditional.ql
@@ -16,7 +16,8 @@ predicate emptyStmt(Stmt s) {
   or
   s =
     any(BlockStmt bs |
-      bs.getNumberOfStmts() = 0
+      bs.getNumberOfStmts() = 0 and
+      not any(CommentBlock cb).getParent() = bs
       or
       bs.getNumberOfStmts() = 1 and
       emptyStmt(bs.getStmt(0))

--- a/csharp/ql/src/change-notes/2025-03-05-useless-if-statement.md
+++ b/csharp/ql/src/change-notes/2025-03-05-useless-if-statement.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Don't consider an if-statement to be *useless* in `cs/useless-if-statement` if there is at least a comment.

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.cs
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.cs
@@ -1,0 +1,29 @@
+using System;
+
+class FutileConditionalTest
+{
+
+    public void M(string s)
+    {
+        if (s.Length > 0) ; // $ Alert
+
+        if (s.Length > 1)
+        {
+        } // $ Alert
+
+        if (s.Length > 2) // GOOD: because of else-branch
+        {
+        }
+        else
+        {
+            Console.WriteLine("hello");
+        }
+
+        if (s.Length > 3)
+        {
+        }
+        else
+        {
+        } // $ Alert
+    }
+}

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.cs
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.cs
@@ -25,5 +25,10 @@ class FutileConditionalTest
         else
         {
         } // $ Alert
+
+        if (s.Length > 4)
+        {
+            // GOOD: Because of the comment.
+        }
     }
 }

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
@@ -1,0 +1,3 @@
+| FutileConditional.cs:8:9:8:27 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
+| FutileConditional.cs:10:9:12:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
+| FutileConditional.cs:22:9:27:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
@@ -1,7 +1,3 @@
-#select
 | FutileConditional.cs:8:9:8:27 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
 | FutileConditional.cs:10:9:12:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
 | FutileConditional.cs:22:9:27:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
-| FutileConditional.cs:29:9:32:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
-testFailures
-| FutileConditional.cs:29:9:32:9 | If-statement with an empty then-branch and no else-branch. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.expected
@@ -1,3 +1,7 @@
+#select
 | FutileConditional.cs:8:9:8:27 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
 | FutileConditional.cs:10:9:12:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
 | FutileConditional.cs:22:9:27:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
+| FutileConditional.cs:29:9:32:9 | if (...) ... | If-statement with an empty then-branch and no else-branch. |
+testFailures
+| FutileConditional.cs:29:9:32:9 | If-statement with an empty then-branch and no else-branch. | Unexpected result: Alert |

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.qlref
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/FutileConditional.qlref
@@ -1,0 +1,2 @@
+query: Useless code/FutileConditional.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/csharp/ql/test/query-tests/Useless Code/FutileConditional/options
+++ b/csharp/ql/test/query-tests/Useless Code/FutileConditional/options
@@ -1,0 +1,2 @@
+semmle-extractor-options: /nostdlib /noconfig
+semmle-extractor-options: --load-sources-from-project:${testdir}/../../../resources/stubs/_frameworks/Microsoft.NETCore.App/Microsoft.NETCore.App.csproj


### PR DESCRIPTION
It is not an un-common pattern to write something like
```csharp
if (b) {
  // Insert some relevant debugging statements here
  // My commented out code.
}
```
Due to the above our query might seem a bit to noisy. In this PR we remove the alerts, if the empty if-block contains a comment.
We still catch the following examples (where the first one is the most important as it is most likely unintentional).
```csharp
if (b);

if (b)
{
}
```