### PR TITLE
Python: Include `py/not-named-self` and `py/not-named-cls` in the CCR suite

### DIFF
--- a/python/ql/src/codeql-suites/python-ccr.qls
+++ b/python/ql/src/codeql-suites/python-ccr.qls
@@ -1,1 +1,5 @@
-[]
+- queries: .
+- include:
+    id:
+      - py/not-named-self 
+      - py/not-named-cls


### PR DESCRIPTION
Adds `py/not-named-self` and `py/not-named-cls` to the CCR suite.