### PR TITLE
C++: Share indirect dataflow nodes across `CopyValue` instructions

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternalsCommon.qll
@@ -630,10 +630,18 @@ private module Cached {
     Operand operand, int indirectionIndex, Operand operandRepr, int indirectionIndexRepr
   ) {
     indirectionIndex = [1 .. countIndirectionsForCppType(getLanguageType(operand))] and
-    exists(Instruction load |
-      isDereference(load, operand, false) and
-      operandRepr = unique( | | getAUse(load)) and
-      indirectionIndexRepr = indirectionIndex - 1
+    (
+      exists(Instruction load |
+        isDereference(load, operand, false) and
+        operandRepr = unique( | | getAUse(load)) and
+        indirectionIndexRepr = indirectionIndex - 1
+      )
+      or
+      exists(CopyValueInstruction copy |
+        copy.getSourceValueOperand() = operand and
+        operandRepr = unique( | | getAUse(copy)) and
+        indirectionIndexRepr = indirectionIndex
+      )
     )
   }
 
@@ -649,11 +657,19 @@ private module Cached {
     Instruction instr, int indirectionIndex, Instruction instrRepr, int indirectionIndexRepr
   ) {
     indirectionIndex = [1 .. countIndirectionsForCppType(getResultLanguageType(instr))] and
-    exists(Instruction load, Operand address |
-      address = unique( | | getAUse(instr)) and
-      isDereference(load, address, false) and
-      instrRepr = load and
-      indirectionIndexRepr = indirectionIndex - 1
+    (
+      exists(Instruction load, Operand address |
+        address = unique( | | getAUse(instr)) and
+        isDereference(load, address, false) and
+        instrRepr = load and
+        indirectionIndexRepr = indirectionIndex - 1
+      )
+      or
+      exists(CopyValueInstruction copy |
+        copy.getSourceValueOperand() = unique( | | getAUse(instr)) and
+        instrRepr = copy and
+        indirectionIndexRepr = indirectionIndex
+      )
     )
   }
 

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/localFlow-ir.expected
@@ -53,11 +53,9 @@
 | example.c:26:18:26:24 | *& ... | example.c:26:2:26:7 | *coords |
 | example.c:26:18:26:24 | getX output argument | example.c:26:2:26:7 | *coords |
 | example.c:26:18:26:24 | pointer to getX output argument | example.c:26:2:26:7 | coords |
-| example.c:26:19:26:24 | *coords | example.c:26:18:26:24 | *& ... |
 | example.c:26:19:26:24 | coords | example.c:26:18:26:24 | & ... |
 | example.c:28:22:28:25 | & ... | example.c:28:14:28:25 | & ... |
 | example.c:28:22:28:25 | *& ... | example.c:28:14:28:25 | *& ... |
-| example.c:28:23:28:25 | *pos | example.c:28:22:28:25 | *& ... |
 | example.c:28:23:28:25 | pos | example.c:28:22:28:25 | & ... |
 | test.cpp:6:12:6:17 | call to source | test.cpp:6:12:6:17 | call to source |
 | test.cpp:6:12:6:17 | call to source | test.cpp:7:8:7:9 | t1 |
@@ -134,7 +132,6 @@
 | test.cpp:384:10:384:13 | *& ... | test.cpp:384:10:384:13 | *& ... |
 | test.cpp:384:10:384:13 | memcpy output argument | test.cpp:385:8:385:10 | tmp |
 | test.cpp:384:10:384:13 | pointer to memcpy output argument | test.cpp:385:8:385:10 | tmp |
-| test.cpp:384:11:384:13 | *tmp | test.cpp:384:10:384:13 | *& ... |
 | test.cpp:384:11:384:13 | tmp | test.cpp:384:10:384:13 | & ... |
 | test.cpp:384:16:384:23 | & ... | test.cpp:384:16:384:23 | & ... |
 | test.cpp:384:16:384:23 | *& ... | test.cpp:384:3:384:8 | **call to memcpy |
@@ -143,7 +140,6 @@
 | test.cpp:384:16:384:23 | *& ... | test.cpp:384:16:384:23 | *& ... |
 | test.cpp:384:16:384:23 | **& ... | test.cpp:384:3:384:8 | **call to memcpy |
 | test.cpp:384:16:384:23 | **& ... | test.cpp:384:10:384:13 | memcpy output argument |
-| test.cpp:384:17:384:23 | *source1 | test.cpp:384:16:384:23 | *& ... |
 | test.cpp:384:17:384:23 | source1 | test.cpp:384:16:384:23 | & ... |
 | test.cpp:388:53:388:59 | source1 | test.cpp:391:16:391:23 | *& ... |
 | test.cpp:388:66:388:66 | b | test.cpp:393:7:393:7 | b |
@@ -153,7 +149,6 @@
 | test.cpp:390:18:390:21 | & ... | test.cpp:391:10:391:13 | & ... |
 | test.cpp:390:18:390:21 | *& ... | test.cpp:390:18:390:21 | *& ... |
 | test.cpp:390:18:390:21 | *& ... | test.cpp:391:10:391:13 | *& ... |
-| test.cpp:390:19:390:21 | *tmp | test.cpp:390:18:390:21 | *& ... |
 | test.cpp:390:19:390:21 | tmp | test.cpp:390:18:390:21 | & ... |
 | test.cpp:391:10:391:13 | & ... | test.cpp:391:3:391:8 | call to memcpy |
 | test.cpp:391:10:391:13 | & ... | test.cpp:391:10:391:13 | & ... |
@@ -161,7 +156,6 @@
 | test.cpp:391:10:391:13 | *& ... | test.cpp:391:10:391:13 | *& ... |
 | test.cpp:391:10:391:13 | memcpy output argument | test.cpp:392:8:392:10 | tmp |
 | test.cpp:391:10:391:13 | pointer to memcpy output argument | test.cpp:392:8:392:10 | tmp |
-| test.cpp:391:11:391:13 | *tmp | test.cpp:391:10:391:13 | *& ... |
 | test.cpp:391:11:391:13 | tmp | test.cpp:391:10:391:13 | & ... |
 | test.cpp:391:16:391:23 | & ... | test.cpp:391:16:391:23 | & ... |
 | test.cpp:391:16:391:23 | *& ... | test.cpp:391:3:391:8 | **call to memcpy |
@@ -170,7 +164,6 @@
 | test.cpp:391:16:391:23 | *& ... | test.cpp:391:16:391:23 | *& ... |
 | test.cpp:391:16:391:23 | **& ... | test.cpp:391:3:391:8 | **call to memcpy |
 | test.cpp:391:16:391:23 | **& ... | test.cpp:391:10:391:13 | memcpy output argument |
-| test.cpp:391:17:391:23 | *source1 | test.cpp:391:16:391:23 | *& ... |
 | test.cpp:391:17:391:23 | source1 | test.cpp:391:16:391:23 | & ... |
 | test.cpp:392:8:392:10 | tmp | test.cpp:394:10:394:12 | tmp |
 | test.cpp:392:8:392:10 | tmp | test.cpp:394:10:394:12 | tmp |
@@ -209,5 +202,4 @@
 | test.cpp:1087:3:1087:3 | a [post update] | test.cpp:1088:8:1088:9 | & ... |
 | test.cpp:1087:15:1087:21 | 0 | test.cpp:1087:3:1087:21 | ... = ... |
 | test.cpp:1087:15:1087:21 | *0 | test.cpp:1087:3:1087:21 | *... = ... |
-| test.cpp:1088:9:1088:9 | *a | test.cpp:1088:8:1088:9 | *& ... |
 | test.cpp:1088:9:1088:9 | a | test.cpp:1088:8:1088:9 | & ... |


### PR DESCRIPTION
Intuitively, C++ has (at least) the following dataflow nodes:

- A dataflow node for each instruction
- A dataflow node for each operand
- A dataflow node for each possible indirection of an instruction
- A dataflow node for each possible indirection of an operand

Because many of these nodes semantically represent the same concept we merge some of these into a single dataflow node tuple. This has two benefits:
- We allocate less dataflow nodes which saves on memory, and
- It's easier to pick the right dataflow node for sources, sinks, and (especially) barriers.

For example, for IR such as:
```cpp
r1(glval<int>) = VariableAddress[a]     : 
r2(int)        = Load[a]                : &:r1, m1
```
there will be a single dataflow node representing both the _instruction_ `r1` and the _operand_ `&:r1`. That is, operands and instruction often share the same underlying IPA tuple (when the instruction has a unique use).

Similarly, if we have a piece of IR such as
```cpp
r2(glval<int>) = VariableAddress[a]     :
r3(int*)       = Load[a]                : &:r2, m1
r4(void)       = Call[foo]              : func:r1 0:r3
```
the dataflow node representing the indirection of `&:r2` (i.e., `*&:r2`) is represented by the same dataflow node as the one representing `0:r3` because they both represent the same concept: the result of dereferencing `&:r2`. It just so happens that (in this case) this concept is captured already in the IR and thus there's no need to create a new kind of dataflow node for it.

(For more information on this sharing see https://github.com/github/codeql/pull/11218, https://github.com/github/codeql/pull/12004, and https://github.com/github/codeql/pull/14008.)

This PR extends the sharing so that we recognize equivalent nodes across `CopyValue` instructions. So now `*&:r4`, `*r3`, and `**&:r2` all share tuple number in:
```cpp
r2(glval<int **>) = VariableAddress[a]  :
r3(int **)        = Load[a]             : &:r2
r4(glval<int *>)  = CopyValue           : r3
m1(int *)         = Store[?]            : &:r4, r1
```
whereas on `main` there was a tuple for `*&:r4`, and another tuple number for `*r3` and `**&:r2`.