### PR TITLE
C#: Blazor: Support string literals as property names in jump nodes

### DIFF
--- a/csharp/ql/integration-tests/all-platforms/blazor/BlazorTest/Components/Pages/TestPage.razor
+++ b/csharp/ql/integration-tests/all-platforms/blazor/BlazorTest/Components/Pages/TestPage.razor
@@ -81,6 +81,10 @@
     <MyOutput Value="@InputValue6" />
 </div>
 
+<div>
+    <MyOutput Value="@QueryParam" />
+</div>
+
 @code {
 
     public class Container

--- a/csharp/ql/integration-tests/all-platforms/blazor/XSS.qlref
+++ b/csharp/ql/integration-tests/all-platforms/blazor/XSS.qlref
@@ -1,0 +1,1 @@
+Security Features/CWE-079/XSS.ql

--- a/csharp/ql/integration-tests/all-platforms/blazor_build_mode_none/BlazorTest/Components/Pages/TestPage.razor
+++ b/csharp/ql/integration-tests/all-platforms/blazor_build_mode_none/BlazorTest/Components/Pages/TestPage.razor
@@ -81,6 +81,10 @@
     <MyOutput Value="@InputValue6" />
 </div>
 
+<div>
+    <MyOutput Value="@QueryParam" />
+</div>
+
 @code {
 
     public class Container

--- a/csharp/ql/integration-tests/all-platforms/blazor_build_mode_none/XSS.qlref
+++ b/csharp/ql/integration-tests/all-platforms/blazor_build_mode_none/XSS.qlref
@@ -1,0 +1,1 @@
+Security Features/CWE-079/XSS.ql

--- a/csharp/ql/integration-tests/all-platforms/blazor_net_8/BlazorTest/Components/Pages/TestPage.razor
+++ b/csharp/ql/integration-tests/all-platforms/blazor_net_8/BlazorTest/Components/Pages/TestPage.razor
@@ -81,6 +81,10 @@
     <MyOutput Value="@InputValue6" />
 </div>
 
+<div>
+    <MyOutput Value="@QueryParam" />
+</div>
+
 @code {
 
     public class Container

--- a/csharp/ql/integration-tests/all-platforms/blazor_net_8/XSS.qlref
+++ b/csharp/ql/integration-tests/all-platforms/blazor_net_8/XSS.qlref
@@ -1,0 +1,1 @@
+Security Features/CWE-079/XSS.ql

--- a/csharp/ql/lib/change-notes/2025-03-08-blazor-parameter-passing-string-literal.md
+++ b/csharp/ql/lib/change-notes/2025-03-08-blazor-parameter-passing-string-literal.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Blazor support can now better recognize when a property being set is specified with a string literal, rather than referenced in a `nameof` expression.

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -159,8 +159,14 @@ private module JumpNodes {
      */
     Property getParameterProperty() {
       result.getAnAttribute() instanceof MicrosoftAspNetCoreComponentsParameterAttribute and
-      exists(NameOfExpr ne | ne = this.getArgument(1) |
-        result.getAnAccess() = ne.getAccess().(MemberAccess)
+      (
+        exists(NameOfExpr ne | ne = this.getArgument(1) |
+          result.getAnAccess() = ne.getAccess().(MemberAccess)
+        )
+        or
+        exists(string propertyName | propertyName = this.getArgument(1).(StringLiteral).getValue() |
+          result.hasName(propertyName)
+        )
       )
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -176,7 +176,6 @@ private module JumpNodes {
 
     ComponentParameterJump() {
       prop = call.getParameterProperty() and
-      // this.(DataFlowPrivate::PostUpdateNode).getPreUpdateNode().asExpr() = call.getParameterValue()
       this.asExpr() = call.getParameterValue()
     }
 

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -182,7 +182,7 @@ private module JumpNodes {
 
     override DataFlow::Node getAJumpSuccessor(boolean preservesValue) {
       preservesValue = true and
-      result.asExpr() = call.getParameterProperty().getAnAccess()
+      result.asExpr() = prop.getAnAccess()
     }
   }
 }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -186,4 +186,3 @@ private module JumpNodes {
     }
   }
 }
-

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -172,11 +172,16 @@ private module JumpNodes {
 
   private class ComponentParameterJump extends DataFlow::NonLocalJumpNode {
     ParameterPassingCall call;
+    Property prop;
 
-    ComponentParameterJump() { this.asExpr() = call.getParameterValue() }
+    ComponentParameterJump() {
+      prop = call.getParameterProperty() and
+      // this.(DataFlowPrivate::PostUpdateNode).getPreUpdateNode().asExpr() = call.getParameterValue()
+      this.asExpr() = call.getParameterValue()
+    }
 
     override DataFlow::Node getAJumpSuccessor(boolean preservesValue) {
-      preservesValue = false and
+      preservesValue = true and
       result.asExpr() = call.getParameterProperty().getAnAccess()
     }
   }

--- a/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
+++ b/csharp/ql/lib/semmle/code/csharp/frameworks/microsoft/aspnetcore/Components.qll
@@ -112,6 +112,16 @@ class MicrosoftAspNetCoreComponentsComponent extends Class {
   }
 }
 
+/**
+ * The `Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder::AddComponentParameter` method.
+ */
+private class MicrosoftAspNetCoreComponentsAddComponentParameterMethod extends Method {
+  MicrosoftAspNetCoreComponentsAddComponentParameterMethod() {
+    this.hasFullyQualifiedName("Microsoft.AspNetCore.Components.Rendering", "RenderTreeBuilder",
+      "AddComponentParameter")
+  }
+}
+
 private module Sources {
   private import semmle.code.csharp.security.dataflow.flowsources.Remote
 
@@ -133,3 +143,42 @@ private module Sources {
     override string getSourceType() { result = "ASP.NET Core component route parameter" }
   }
 }
+
+private module JumpNodes {
+  /**
+   * A call to `Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder::AddComponentParameter` which
+   * sets the value of a parameter.
+   */
+  private class ParameterPassingCall extends Call {
+    ParameterPassingCall() {
+      this.getTarget() instanceof MicrosoftAspNetCoreComponentsAddComponentParameterMethod
+    }
+
+    /**
+     * Gets the property whose value is being set.
+     */
+    Property getParameterProperty() {
+      result.getAnAttribute() instanceof MicrosoftAspNetCoreComponentsParameterAttribute and
+      exists(NameOfExpr ne | ne = this.getArgument(1) |
+        result.getAnAccess() = ne.getAccess().(MemberAccess)
+      )
+    }
+
+    /**
+     * Gets the value being set.
+     */
+    Expr getParameterValue() { result = this.getArgument(2) }
+  }
+
+  private class ComponentParameterJump extends DataFlow::NonLocalJumpNode {
+    ParameterPassingCall call;
+
+    ComponentParameterJump() { this.asExpr() = call.getParameterValue() }
+
+    override DataFlow::Node getAJumpSuccessor(boolean preservesValue) {
+      preservesValue = false and
+      result.asExpr() = call.getParameterProperty().getAnAccess()
+    }
+  }
+}
+

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Name.cs
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Name.cs
@@ -1,0 +1,22 @@
+namespace VulnerableBlazorApp.Components
+{
+    using Microsoft.AspNetCore.Components;
+
+    public partial class Name : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            if (TheName is not null)
+            {
+                builder.OpenElement(0, "div");
+                builder.OpenElement(1, "p");
+                builder.AddContent(2, (MarkupString)TheName);
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+        }
+
+        [Parameter]
+        public string TheName { get; set; }
+    }
+}

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/NameList.cs
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/NameList.cs
@@ -1,0 +1,50 @@
+namespace VulnerableBlazorApp.Components
+{
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Components;
+
+    [RouteAttribute("/names/{name?}")]
+    public partial class NameList : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            if (Names is not null)
+            {
+                builder.OpenElement(0, "div");
+                builder.OpenElement(1, "ul");
+                foreach (var name in Names)
+                {
+                    builder.OpenElement(2, "li");
+                    builder.OpenComponent<VulnerableBlazorApp.Components.Name>(3);
+                    builder.AddComponentParameter(4, nameof(VulnerableBlazorApp.Components.Name.TheName), name);
+                    builder.CloseComponent();
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+
+            builder.OpenElement(5, "div");
+            builder.OpenElement(6, "p");
+            builder.AddContent(7, "Name: ");
+            builder.OpenComponent<VulnerableBlazorApp.Components.Name>(8);
+            builder.AddComponentParameter(9, nameof(VulnerableBlazorApp.Components.Name.TheName), Name);
+            builder.CloseComponent();
+            builder.CloseElement();
+        }
+
+        [Parameter]
+        public string Name { get; set; }
+
+        protected override void OnParametersSet()
+        {
+            if (Name is not null)
+            {
+                Names.Add(Name);
+            }
+        }
+
+
+        public List<string> Names { get; set; } = new List<string>();
+    }
+}

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/NameList2.cs
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/NameList2.cs
@@ -1,0 +1,50 @@
+namespace VulnerableBlazorApp.Components
+{
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Components;
+
+    [RouteAttribute("/names2/{name?}")]
+    public partial class NameList2 : Microsoft.AspNetCore.Components.ComponentBase
+    {
+        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder builder)
+        {
+            if (Names is not null)
+            {
+                builder.OpenElement(0, "div");
+                builder.OpenElement(1, "ul");
+                foreach (var name in Names)
+                {
+                    builder.OpenElement(2, "li");
+                    builder.OpenComponent<VulnerableBlazorApp.Components.Name>(3);
+                    builder.AddComponentParameter(4, "TheName", name);
+                    builder.CloseComponent();
+                    builder.CloseElement();
+                }
+                builder.CloseElement();
+                builder.CloseElement();
+            }
+
+            builder.OpenElement(5, "div");
+            builder.OpenElement(6, "p");
+            builder.AddContent(7, "Name: ");
+            builder.OpenComponent<VulnerableBlazorApp.Components.Name>(8);
+            builder.AddComponentParameter(9, "TheName", Name);
+            builder.CloseComponent();
+            builder.CloseElement();
+        }
+
+        [Parameter]
+        public string Name { get; set; }
+
+        protected override void OnParametersSet()
+        {
+            if (Name is not null)
+            {
+                Names.Add(Name);
+            }
+        }
+
+
+        public List<string> Names { get; set; } = new List<string>();
+    }
+}

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.expected
@@ -1,0 +1,12 @@
+edges
+| NameList.cs:31:99:31:102 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | provenance | Sink:MaD:149 |
+nodes
+| Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | semmle.label | access to property UrlParam |
+| Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | semmle.label | access to property QueryParam |
+| Name.cs:13:53:13:59 | access to property TheName | semmle.label | access to property TheName |
+| NameList.cs:31:99:31:102 | access to property Name : String | semmle.label | access to property Name : String |
+subpaths
+#select
+| Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | $@ flows to here and is written to HTML or JavaScript. | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | User-provided value |
+| Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | $@ flows to here and is written to HTML or JavaScript. | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | User-provided value |
+| Name.cs:13:53:13:59 | access to property TheName | NameList.cs:31:99:31:102 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | $@ flows to here and is written to HTML or JavaScript. | NameList.cs:31:99:31:102 | access to property Name : String | User-provided value |

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.expected
@@ -1,12 +1,15 @@
 edges
+| NameList2.cs:31:57:31:60 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | provenance | Sink:MaD:149 |
 | NameList.cs:31:99:31:102 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | provenance | Sink:MaD:149 |
 nodes
 | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | semmle.label | access to property UrlParam |
 | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | semmle.label | access to property QueryParam |
 | Name.cs:13:53:13:59 | access to property TheName | semmle.label | access to property TheName |
+| NameList2.cs:31:57:31:60 | access to property Name : String | semmle.label | access to property Name : String |
 | NameList.cs:31:99:31:102 | access to property Name : String | semmle.label | access to property Name : String |
 subpaths
 #select
 | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | $@ flows to here and is written to HTML or JavaScript. | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | User-provided value |
 | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | $@ flows to here and is written to HTML or JavaScript. | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | User-provided value |
+| Name.cs:13:53:13:59 | access to property TheName | NameList2.cs:31:57:31:60 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | $@ flows to here and is written to HTML or JavaScript. | NameList2.cs:31:57:31:60 | access to property Name : String | User-provided value |
 | Name.cs:13:53:13:59 | access to property TheName | NameList.cs:31:99:31:102 | access to property Name : String | Name.cs:13:53:13:59 | access to property TheName | $@ flows to here and is written to HTML or JavaScript. | NameList.cs:31:99:31:102 | access to property Name : String | User-provided value |

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.qlref
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/Xss.qlref
@@ -1,0 +1,1 @@
+Security Features/CWE-079/XSS.ql

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
@@ -2,6 +2,9 @@
 | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | ASP.NET Core component route parameter |
 | Components_Pages_TestPage_razor.g.cs:176:1:176:10 | access to property QueryParam | external |
 | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | external |
+| NameList2.cs:31:57:31:60 | access to property Name | ASP.NET Core component route parameter |
+| NameList2.cs:41:17:41:20 | access to property Name | ASP.NET Core component route parameter |
+| NameList2.cs:43:27:43:30 | access to property Name | ASP.NET Core component route parameter |
 | NameList.cs:31:99:31:102 | access to property Name | ASP.NET Core component route parameter |
 | NameList.cs:41:17:41:20 | access to property Name | ASP.NET Core component route parameter |
 | NameList.cs:43:27:43:30 | access to property Name | ASP.NET Core component route parameter |

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
@@ -2,5 +2,6 @@
 | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | ASP.NET Core component route parameter |
 | Components_Pages_TestPage_razor.g.cs:176:1:176:10 | access to property QueryParam | external |
 | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | external |
-| NameList.cs:33:17:33:20 | access to property Name | ASP.NET Core component route parameter |
-| NameList.cs:35:27:35:30 | access to property Name | ASP.NET Core component route parameter |
+| NameList.cs:31:99:31:102 | access to property Name | ASP.NET Core component route parameter |
+| NameList.cs:41:17:41:20 | access to property Name | ASP.NET Core component route parameter |
+| NameList.cs:43:27:43:30 | access to property Name | ASP.NET Core component route parameter |

--- a/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
+++ b/csharp/ql/test/library-tests/frameworks/microsoft/aspnetcore/blazor/remoteFlowSource.expected
@@ -2,3 +2,5 @@
 | Components_Pages_TestPage_razor.g.cs:138:15:138:22 | access to property UrlParam | ASP.NET Core component route parameter |
 | Components_Pages_TestPage_razor.g.cs:176:1:176:10 | access to property QueryParam | external |
 | Components_Pages_TestPage_razor.g.cs:188:18:188:27 | access to property QueryParam | external |
+| NameList.cs:33:17:33:20 | access to property Name | ASP.NET Core component route parameter |
+| NameList.cs:35:27:35:30 | access to property Name | ASP.NET Core component route parameter |


### PR DESCRIPTION
Follow-up to #18930 (this should be rebased on that branch once the PR is merged).

Older versions of Blazor used a string literal instead of a `nameof` expression in order to specify the property being set. Therefore, it is necessary to modify the corresponding jump node in order to model the steps correctly.