### PR TITLE
JS: Unfold local type aliases in getAnUnderlyingType

### DIFF
--- a/javascript/ql/lib/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/lib/semmle/javascript/TypeScript.qll
@@ -773,6 +773,17 @@ class LocalTypeAccess extends @local_type_access, TypeAccess, Identifier, Lexica
    */
   LocalTypeName getLocalTypeName() { result.getAnAccess() = this }
 
+  private TypeAliasDeclaration getAlias() {
+    this.getLocalTypeName().getADeclaration() = result.getIdentifier()
+  }
+
+  override TypeExpr getAnUnderlyingType() {
+    result = this.getAlias().getDefinition().getAnUnderlyingType()
+    or
+    not exists(this.getAlias()) and
+    result = this
+  }
+
   override string getAPrimaryQlClass() { result = "LocalTypeAccess" }
 }
 

--- a/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.expected
@@ -1,6 +1,7 @@
 | connect.js:6:5:6:11 | req.url | url |
 | connect.js:7:5:7:21 | req.cookies.get() | cookie |
 | express-typed.ts:4:5:4:12 | req.body | body |
+| express-typed.ts:10:5:10:12 | req.body | body |
 | express.js:12:5:12:19 | req.param("p1") | parameter |
 | express.js:13:5:13:17 | req.params.p2 | parameter |
 | express.js:14:5:14:16 | req.query.p3 | parameter |

--- a/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.expected
+++ b/javascript/ql/test/library-tests/frameworks/HTTP/RemoteRequestInput.expected
@@ -1,5 +1,6 @@
 | connect.js:6:5:6:11 | req.url | url |
 | connect.js:7:5:7:21 | req.cookies.get() | cookie |
+| express-typed.ts:4:5:4:12 | req.body | body |
 | express.js:12:5:12:19 | req.param("p1") | parameter |
 | express.js:13:5:13:17 | req.params.p2 | parameter |
 | express.js:14:5:14:16 | req.query.p3 | parameter |

--- a/javascript/ql/test/library-tests/frameworks/HTTP/express-typed.ts
+++ b/javascript/ql/test/library-tests/frameworks/HTTP/express-typed.ts
@@ -1,0 +1,11 @@
+import { Request } from "express";
+
+export function f1(req: Request) {
+    req.body;
+}
+
+type Alias = Request & { foo: string };
+
+export function f2(req: Alias) {
+    req.body;
+}


### PR DESCRIPTION
Something changed in the TypeScript compiler at some point which means we handle code like this differently:
```ts
import { Request } from "express";
type Alias = Request & { foo: string };
```
Previously the type `Alias` would be extracted as its own type, and we could recognise that it contained `Request` as an "underlying type", so things like `hasUnderlyingType("express", "Request")` would hold for things annotated with `Alias`.

Unfortunately the type `Alias` is now extracted as `any`. Note that `Request` is an unresolved type because no `.d.ts` file is found for `express` as we don't install dependencies. My theory is that the change comes down to how the compiler handles unresolved types internally.

The good thing is that we're expecting to move away from type extraction anyway, and this PR takes a small step in this direction by moving more alias-resolution logic into `getUnderlyingType()`. More work will follow, so omitting a change note for now.