### PR TITLE
JS: Remove TaintedNodes.ql from default meta query suite

### DIFF
--- a/javascript/ql/src/meta/alerts/TaintedNodes.ql
+++ b/javascript/ql/src/meta/alerts/TaintedNodes.ql
@@ -4,7 +4,7 @@
  *              via default taint-tracking steps.
  * @kind problem
  * @problem.severity recommendation
- * @tags meta
+ * @tags meta-expensive
  * @id js/meta/alerts/tainted-nodes
  * @precision very-low
  */


### PR DESCRIPTION
This explodes on some databases due to not restricting the set of sinks.