### PR TITLE
Add missing dependency

### DIFF
--- a/actions/ql/src/qlpack.yml
+++ b/actions/ql/src/qlpack.yml
@@ -8,3 +8,4 @@ extractor: actions
 defaultSuiteFile: codeql-suites/actions-code-scanning.qls
 dependencies:
   codeql/actions-all: ${workspace}
+  codeql/suite-helpers: ${workspace}


### PR DESCRIPTION
The query pack has suites that rely on the `codeql/suite-helpers` pack, but doesn't include it as a dependency. This will cause error when resolving suites referring the Actions query pack.