### PR TITLE
Correct modelgenerator exclusion in suite helper

### DIFF
--- a/misc/suite-helpers/security-experimental-selectors.yml
+++ b/misc/suite-helpers/security-experimental-selectors.yml
@@ -43,4 +43,4 @@
 - exclude:
     tags contain:
       - modeleditor
-      - model-generator
+      - modelgenerator


### PR DESCRIPTION
Correct `model-generator` -> `modelgenerator` in the `security-experimental-selectors.yml` suite helper.
- no queries have `@tags model-generator`.
- something like 49 queries have `@tags modelgenerator`.
- all other [suite helpers](https://github.com/github/codeql/tree/main/misc/suite-helpers) use `modelgenerator`.

I'm guessing somehow `security-experimental-selectors.yml` was left out of a change at some point.