### PR TITLE
Fixing BasicIntTypes to allow C Standard Integers and 'bool'

### DIFF
--- a/cpp/ql/src/JPL_C/LOC-3/Rule 17/BasicIntTypes.ql
+++ b/cpp/ql/src/JPL_C/LOC-3/Rule 17/BasicIntTypes.ql
@@ -12,8 +12,11 @@
 import cpp
 
 predicate allowedTypedefs(TypedefType t) {
-  t.getName() = ["I64", "U64", "I32", "U32", "I16", "U16", "I8", "U8", "F64", "F32",
-                 "int64_t", "uint64_t", "int32_t", "uint32_t", "int16_t", "uint16_t", "int8_t", "uint8_t"]
+  t.getName() =
+    [
+      "I64", "U64", "I32", "U32", "I16", "U16", "I8", "U8", "F64", "F32", "int64_t", "uint64_t",
+      "int32_t", "uint32_t", "int16_t", "uint16_t", "int8_t", "uint8_t"
+    ]
 }
 
 /**
@@ -39,14 +42,16 @@ Type getAUsedType(Type t) {
 }
 
 predicate problematic(IntegralType t) {
-  // 'bool' is allowed as it represents a 'true' or 'false' value
-  t.getName() != ["bool"]
+  // List any exceptions that should be allowed.
+  any()
 }
 
 from Declaration d, Type usedType
 where
   usedType = getAUsedType*(getAnImmediateUsedType(d)) and
   problematic(usedType) and
+  // Allow uses of boolean types where defined by the language.
+  not usedType instanceof BoolType and
   // Ignore violations for which we do not have a valid location.
   not d.getLocation() instanceof UnknownLocation
 select d,

--- a/cpp/ql/src/JPL_C/LOC-3/Rule 17/BasicIntTypes.ql
+++ b/cpp/ql/src/JPL_C/LOC-3/Rule 17/BasicIntTypes.ql
@@ -12,7 +12,8 @@
 import cpp
 
 predicate allowedTypedefs(TypedefType t) {
-  t.getName() = ["I64", "U64", "I32", "U32", "I16", "U16", "I8", "U8", "F64", "F32"]
+  t.getName() = ["I64", "U64", "I32", "U32", "I16", "U16", "I8", "U8", "F64", "F32",
+                 "int64_t", "uint64_t", "int32_t", "uint32_t", "int16_t", "uint16_t", "int8_t", "uint8_t"]
 }
 
 /**
@@ -38,8 +39,8 @@ Type getAUsedType(Type t) {
 }
 
 predicate problematic(IntegralType t) {
-  // List any exceptions that should be allowed.
-  any()
+  // 'bool' is allowed as it represents a 'true' or 'false' value
+  t.getName() != ["bool"]
 }
 
 from Declaration d, Type usedType

--- a/cpp/ql/src/change-notes/2025-03-11-basic-int-types.md
+++ b/cpp/ql/src/change-notes/2025-03-11-basic-int-types.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The query "Basic Integral Types" in JPL_C has been updated to allow C standard integer types (uint8_t etc.) and 'bool'.

--- a/cpp/ql/src/change-notes/2025-03-11-basic-int-types.md
+++ b/cpp/ql/src/change-notes/2025-03-11-basic-int-types.md
@@ -1,4 +1,4 @@
 ---
-category: majorAnalysis
+category: minorAnalysis
 ---
-* The query "Basic Integral Types" in JPL_C has been updated to allow C standard integer types (uint8_t etc.) and 'bool'.
+* The query "Use of basic integral type" (`cpp/jpl-c/basic-int-types`) no longer produces alerts for the standard fixed width integer types (`int8_t`, `uint8_t`, etc.), and the `_Bool` and `bool` types.

--- a/cpp/ql/test/query-tests/JPL_C/LOC-3/Rule 17/BasicIntTypes.expected
+++ b/cpp/ql/test/query-tests/JPL_C/LOC-3/Rule 17/BasicIntTypes.expected
@@ -1,3 +1,1 @@
 | test.c:6:26:6:26 | x | x uses the basic integral type unsigned char rather than a typedef with size and signedness. |
-| test.c:7:20:7:20 | x | x uses the basic integral type unsigned char rather than a typedef with size and signedness. |
-| test.c:10:16:10:20 | test7 | test7 uses the basic integral type unsigned char rather than a typedef with size and signedness. |


### PR DESCRIPTION
The purpose of this check is to ensure that all integral types used by the code point to some fixed size type (e.g. an unsigned 8-bit integer). However, the previous implementation only allowed JPL style typedefs (i.e. U8) and ignored C standard integer types (i.e. uint8_t). This causes the query to false-positive when a typedef resolves to a C standard int type instead of the JPL type even though the spirit of the check has been met.

'bool' has also be allowed as part of the exclusions list as it represents distinct values 'true' and 'false' in C++ code.

Since this significantly reduces the false-positives on my project, I've labeled it "majorAnalysis" per: https://github.com/github/codeql/blob/main/docs/change-notes.md#query-pack-change-categories