### PR TITLE
C#: Add cs/constant-condition to the CCR suite.

### DIFF
--- a/csharp/ql/src/codeql-suites/csharp-ccr.qls
+++ b/csharp/ql/src/codeql-suites/csharp-ccr.qls
@@ -9,3 +9,4 @@
       - cs/inefficient-containskey
       - cs/call-to-object-tostring
       - cs/local-not-disposed
+      - cs/constant-condition


### PR DESCRIPTION
In this PR we add the `cs/constant-condition` to the CCR suite.
A couple of improvements related to the accuracy was made prior to this change
- https://github.com/github/codeql/pull/18976
- https://github.com/github/codeql/pull/18932

The available autofix triage data for C# only had 3 results where 2 were FPs (which were fixed by the above improvements) and for the last data point autofix gave an almost correct suggestion (at least a good staring point).
I have tried to run autofix locally on our query test data files, which provided pretty good fix suggestions. Most of these cases are constructed examples, where the correct suggestion is to delete the code as nothing is done (which autofix correctly detects). Furthermore, it is also able to correctly detect the logic error in the `Max` method (and provide a good fix for the implementation).
Also ran autofix locally on the alerts for ASP.NET Core, which also provided good fix suggestions that could be directly applied.