### PR TITLE
Update actions query suites

### DIFF
--- a/actions/ql/src/codeql-suites/actions-security-and-quality.qls
+++ b/actions/ql/src/codeql-suites/actions-security-and-quality.qls
@@ -1,2 +1,4 @@
 - description: Security-and-quality queries for GitHub Actions
-- import: codeql-suites/actions-security-extended.qls
+- queries: .
+- apply: security-and-quality-selectors.yml
+  from: codeql/suite-helpers

--- a/actions/ql/src/codeql-suites/actions-security-experimental.qls
+++ b/actions/ql/src/codeql-suites/actions-security-experimental.qls
@@ -1,2 +1,4 @@
 - description: Extended and experimental security queries for GitHub Actions
-- import: codeql-suites/actions-code-scanning.qls
+- queries: .
+- apply: security-experimental-selectors.yml
+  from: codeql/suite-helpers


### PR DESCRIPTION
Previously, the `actions-security-and-quality.qls` and `actions-security-experimental.qls`suites were not using the proper selectors. Now they are the same as in other languages.