### PR TITLE
JS: Fix bug in API graphs getPromised() missing async function returns

### DIFF
--- a/javascript/ql/test/ApiGraphs/async-await/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/async-await/VerifyAssertions.expected
@@ -1,0 +1,2 @@
+| wrap-async-in-thunk.js:5:25:5:137 | /* def= ... ed() */ | Node not found on this line (but there is one on line wrap-async-in-thunk.js:14). |
+| wrap-async-in-thunk.js:5:25:5:137 | /* def= ... ed() */ | Node not found on this line (but there is one on line wrap-async-in-thunk.js:24). |

--- a/javascript/ql/test/ApiGraphs/async-await/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/async-await/VerifyAssertions.expected
@@ -1,2 +1,0 @@
-| wrap-async-in-thunk.js:5:25:5:137 | /* def= ... ed() */ | Node not found on this line (but there is one on line wrap-async-in-thunk.js:14). |
-| wrap-async-in-thunk.js:5:25:5:137 | /* def= ... ed() */ | Node not found on this line (but there is one on line wrap-async-in-thunk.js:24). |

--- a/javascript/ql/test/ApiGraphs/async-await/wrap-async-in-thunk.js
+++ b/javascript/ql/test/ApiGraphs/async-await/wrap-async-in-thunk.js
@@ -1,0 +1,26 @@
+import * as t from "testlib";
+
+async function getData1() {
+    const data = await fetch("https://example.com/content");
+    return data.json(); /* def=moduleImport("testlib").getMember("exports").getMember("foo").getParameter(0).getReturn().getPromised() */
+}
+
+export function use1() {
+    t.foo(() => getData1());
+}
+
+async function getData2() {
+    const data = await fetch("https://example.com/content");
+    return data.json(); /* def=moduleImport("testlib").getMember("exports").getMember("foo").getParameter(0).getReturn().getPromised() */
+}
+
+export function use2() {
+    t.foo(getData2);
+}
+
+export function use3() {
+    t.foo(async () => {
+        const data = await fetch("https://example.com/content");
+        return data.json(); /* def=moduleImport("testlib").getMember("exports").getMember("foo").getParameter(0).getReturn().getPromised() */
+    });
+}


### PR DESCRIPTION
API graphs were missing a `getPromised()` step from the return value of an `async` function to the returned expression (i.e. from the promise object to the value it is being resolved with).

It is currently relying on `PromiseFlow::storeStep` to access promise-related steps, which means steps contributed by other means are not seen by API graphs. In general we want API graphs to use all type-tracking steps, including those induced by summaries, like in Ruby, but now I'm just fixing the bug by moving the relevant code into `PromiseFlow::storeStep`.