### PR TITLE
C#: Increase precision of `cs/useless-gethashcode-call`.

### DIFF
--- a/csharp/ql/src/Useless code/IntGetHashCode.ql
+++ b/csharp/ql/src/Useless code/IntGetHashCode.ql
@@ -16,5 +16,12 @@ import semmle.code.csharp.frameworks.System
 from MethodCall mc, IntegralType t
 where
   mc.getTarget() instanceof GetHashCodeMethod and
-  t = mc.getQualifier().getType()
+  t = mc.getQualifier().getType() and
+  (
+    t instanceof ByteType or
+    t instanceof SByteType or
+    t instanceof ShortType or
+    t instanceof UShortType or
+    t instanceof IntType
+  )
 select mc, "Calling GetHashCode() on type " + t.toStringWithTypes() + " is redundant."

--- a/csharp/ql/src/change-notes/2025-03-13-useless-gethashcode-call.md
+++ b/csharp/ql/src/change-notes/2025-03-13-useless-gethashcode-call.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Increase query precision for `cs/useless-gethashcode-call` by not flagging calls to `GetHashCode` on `uint`, `long` and `ulong`.

--- a/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.cs
+++ b/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.cs
@@ -3,14 +3,14 @@ class IntGetHashCode
     void Test()
     {
         // These are all bad:
-        default(uint).GetHashCode();
-        default(int).GetHashCode();
-        default(long).GetHashCode();
-        default(ulong).GetHashCode();
-        default(short).GetHashCode();
-        default(ushort).GetHashCode();
-        default(byte).GetHashCode();
-        default(sbyte).GetHashCode();
+        default(uint).GetHashCode(); // $ Alert
+        default(int).GetHashCode(); // $ Alert
+        default(long).GetHashCode(); // $ Alert
+        default(ulong).GetHashCode(); // $ Alert
+        default(short).GetHashCode(); // $ Alert
+        default(ushort).GetHashCode(); // $ Alert
+        default(byte).GetHashCode(); // $ Alert
+        default(sbyte).GetHashCode(); // $ Alert
 
         // These are all good:
         default(double).GetHashCode();

--- a/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.cs
+++ b/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.cs
@@ -3,16 +3,16 @@ class IntGetHashCode
     void Test()
     {
         // These are all bad:
-        default(uint).GetHashCode(); // $ Alert
         default(int).GetHashCode(); // $ Alert
-        default(long).GetHashCode(); // $ Alert
-        default(ulong).GetHashCode(); // $ Alert
         default(short).GetHashCode(); // $ Alert
         default(ushort).GetHashCode(); // $ Alert
         default(byte).GetHashCode(); // $ Alert
         default(sbyte).GetHashCode(); // $ Alert
 
         // These are all good:
+        default(uint).GetHashCode();
+        default(long).GetHashCode();
+        default(ulong).GetHashCode();
         default(double).GetHashCode();
         default(float).GetHashCode();
         default(char).GetHashCode();

--- a/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.expected
+++ b/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.expected
@@ -1,8 +1,5 @@
-| IntGetHashCode.cs:6:9:6:35 | call to method GetHashCode | Calling GetHashCode() on type uint is redundant. |
-| IntGetHashCode.cs:7:9:7:34 | call to method GetHashCode | Calling GetHashCode() on type int is redundant. |
-| IntGetHashCode.cs:8:9:8:35 | call to method GetHashCode | Calling GetHashCode() on type long is redundant. |
-| IntGetHashCode.cs:9:9:9:36 | call to method GetHashCode | Calling GetHashCode() on type ulong is redundant. |
-| IntGetHashCode.cs:10:9:10:36 | call to method GetHashCode | Calling GetHashCode() on type short is redundant. |
-| IntGetHashCode.cs:11:9:11:37 | call to method GetHashCode | Calling GetHashCode() on type ushort is redundant. |
-| IntGetHashCode.cs:12:9:12:35 | call to method GetHashCode | Calling GetHashCode() on type byte is redundant. |
-| IntGetHashCode.cs:13:9:13:36 | call to method GetHashCode | Calling GetHashCode() on type sbyte is redundant. |
+| IntGetHashCode.cs:6:9:6:34 | call to method GetHashCode | Calling GetHashCode() on type int is redundant. |
+| IntGetHashCode.cs:7:9:7:36 | call to method GetHashCode | Calling GetHashCode() on type short is redundant. |
+| IntGetHashCode.cs:8:9:8:37 | call to method GetHashCode | Calling GetHashCode() on type ushort is redundant. |
+| IntGetHashCode.cs:9:9:9:35 | call to method GetHashCode | Calling GetHashCode() on type byte is redundant. |
+| IntGetHashCode.cs:10:9:10:36 | call to method GetHashCode | Calling GetHashCode() on type sbyte is redundant. |

--- a/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.qlref
+++ b/csharp/ql/test/query-tests/Useless Code/IntGetHashCode/IntGetHashCode.qlref
@@ -1,1 +1,2 @@
-Useless code/IntGetHashCode.ql
+query: Useless code/IntGetHashCode.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql


### PR DESCRIPTION
As [this](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types) table indicates, only `byte`, `sbyte`, `short`, `ushort` and `int` can use the identity function for `GetHashCode` (and they indeed do so) as the return type of `GetHashCode` is `int`.
In this PR we update the `cs/useless-gethashcode-call` to exclude calls to `GetHashCode` on `uint`, `long` and `ulong` and convert the tests to inline tests.