### PR TITLE
Rust: fix `qltest.sh` for some versions of macOS

### DIFF
--- a/rust/tools/qltest.sh
+++ b/rust/tools/qltest.sh
@@ -4,19 +4,18 @@ set -eu
 set -o pipefail
 
 export RUST_BACKTRACE=full
-QLTEST_LOG="$CODEQL_EXTRACTOR_RUST_LOG_DIR"/qltest.log
-mkdir -p "$CODEQL_EXTRACTOR_RUST_SCRATCH_DIR"
-TMP_OUT="$(mktemp --tmpdir="$CODEQL_EXTRACTOR_RUST_SCRATCH_DIR" qltest-XXXXXX.log))"
-trap 'rm -f "$TMP_OUT"' EXIT
+QLTEST_LOG="$CODEQL_EXTRACTOR_RUST_LOG_DIR/qltest.log"
+QLTEST_COLORED_LOG="$CODEQL_EXTRACTOR_RUST_SCRATCH_DIR/qltest.log"
+dirname "$QLTEST_LOG" "$QLTEST_COLORED_LOG" | xargs mkdir -p
 # put full-color output on the side, but remove the color codes from the log file
 # also, print (colored) output only in case of failure
 if ! "$CODEQL_EXTRACTOR_RUST_ROOT/tools/$CODEQL_PLATFORM/extractor" \
      --qltest \
      --logging-verbosity=progress+ \
      2>&1 \
-     | tee "$TMP_OUT" \
+     | tee "$QLTEST_COLORED_LOG" \
      | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' \
      > "$QLTEST_LOG"; then
-  cat "$TMP_OUT"
+  cat "$QLTEST_COLORED_LOG"
   exit 1
 fi


### PR DESCRIPTION
Turns out some version of macOS do not support the way `mktemp` was being used. In any case it wasn't really necessary, see https://github.com/github/codeql/pull/18918#discussion_r1979444850 (which I forgot to follow up on at the time after approval).