### PR TITLE
Add paths to codeql-config.yml to avoid codeql analysis errors

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -10,4 +10,6 @@ paths-ignore:
   - '/javascript/ql/test'
   - '/javascript/ql/integration-tests'
   - '/javascript/extractor/tests'
+  - '/javascript/extractor/parser-tests'
+  - '/javascript/ql/src/'
   - '/rust/ql'


### PR DESCRIPTION
Actions language analysis is hitting some errors while analysing some JS files: https://github.com/github/codeql/actions/runs/13839086154/job/38721621923 

This PR adds those paths to the exceptions in codeql config, to avoid that