### PR TITLE
Code scanning config: Exclude actions test directory

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,6 +4,7 @@ queries:
   - uses: security-and-quality
 
 paths-ignore:
+  - '/actions/ql/test'
   - '/cpp/'
   - '/java/'
   - '/python/'


### PR DESCRIPTION
These are test cases for the GitHub Actions analysis. Exclude them when running code scanning against this repo, to avoid noisy alerts.

Test workflow files in this directory are safe from execution, because Actions only executes workflows that live directly in the `.github/workflows` top-level directory.

`action.yml` files in this directory can in theory be executed as a step in a workflow; for now exclude them.