### PR TITLE
JS: Use StringBuilder when building up type name in JSDoc

### DIFF
--- a/javascript/extractor/src/com/semmle/js/parser/JSDocParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/JSDocParser.java
@@ -561,7 +561,8 @@ public class JSDocParser {
     private Token scanTypeName() {
       char ch, ch2;
 
-      value = new String(Character.toChars(advance()));
+      StringBuilder sb = new StringBuilder();
+      sb.append((char)advance());
       while (index < endIndex && isTypeName(source.charAt(index))) {
         ch = source.charAt(index);
         if (ch == '.') {
@@ -572,8 +573,9 @@ public class JSDocParser {
             }
           }
         }
-        value += new String(Character.toChars(advance()));
+        sb.append((char)advance());
       }
+      value = sb.toString();
       return Token.NAME;
     }
 


### PR DESCRIPTION
This code was a bit of a performance cringe. It copied every character into a temporary array, copied that into a String, and slow-appended that onto another String.

Note that the call to Characters.toChars is redundant here as advance() doesn't return a code point; it returns -1 or a UTF-16 char. The -1 case is checked for before reaching the call, so we can just cast it to a char and use it directly.

We use a StringBuilder to accumulate the string. Normally it's faster to track the start/end indices and do a substring(), but that won't work in the JSDoc extractor because of the star-skipping logic in advance().