### PR TITLE
CI: Add RTJO tests for Go and Ruby

### DIFF
--- a/.github/workflows/go-tests-rtjo.yml
+++ b/.github/workflows/go-tests-rtjo.yml
@@ -1,0 +1,22 @@
+name: "Go: Run RTJO Tests"
+on:
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  contents: read
+
+jobs:
+  test-linux:
+    if: "github.repository_owner == 'github' && github.event.label.name == 'Run: RTJO Language Tests'"
+    name: RTJO Test Linux (Ubuntu)
+    runs-on: ubuntu-latest-xl
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run tests
+        uses: ./go/actions/test
+        with:
+          run-code-checks: true
+          dynamic-join-order-mode: all

--- a/.github/workflows/ruby-qltest-rtjo.yml
+++ b/.github/workflows/ruby-qltest-rtjo.yml
@@ -1,0 +1,40 @@
+name: "Ruby: Run RTJO Language Tests"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+env:
+  CARGO_TERM_COLOR: always
+
+defaults:
+  run:
+    working-directory: ruby
+
+permissions:
+  contents: read
+
+jobs:
+  qltest-rtjo:
+    if: "github.repository_owner == 'github' && github.event.label.name == 'Run: RTJO Language Tests'"
+    runs-on: ubuntu-latest-xl
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/fetch-codeql
+      - uses: ./ruby/actions/create-extractor-pack
+      - name: Cache compilation cache
+        id: query-cache
+        uses: ./.github/actions/cache-query-compilation
+        with:
+          key: ruby-qltest
+      - name: Run QL tests
+        run: |
+          codeql test run --dynamic-join-order-mode=all --threads=0 --ram 50000 --search-path "${{ github.workspace }}" --check-databases --check-undefined-labels --check-unused-labels --check-repeated-labels --check-redefined-labels --check-use-before-definition --consistency-queries ql/consistency-queries ql/test --compilation-cache "${{ steps.query-cache.outputs.cache-dir }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/go/Makefile
+++ b/go/Makefile
@@ -52,9 +52,9 @@ ql/lib/go.dbscheme.stats: ql/lib/go.dbscheme build/stats/src.stamp extractor
 	codeql dataset measure -o $@ build/stats/database/db-go
 
 test: all build/testdb/check-upgrade-path
-	codeql test run -j0 ql/test --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache)
+	codeql test run -j0 ql/test --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache) --dynamic-join-order-mode=$(rtjo)
 #	use GOOS=linux because GOOS=darwin GOARCH=386 is no longer supported
-	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache)
+	env GOOS=linux GOARCH=386 codeql$(EXE) test run -j0 ql/test/query-tests/Security/CWE-681 --search-path .. --consistency-queries ql/test/consistency --compilation-cache=$(cache) --dynamic-join-order-mode=$(rtjo)
 	cd extractor; $(BAZEL) test ...
 	bash extractor-smoke-test/test.sh || (echo "Extractor smoke test FAILED"; exit 1)
 

--- a/go/actions/test/action.yml
+++ b/go/actions/test/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Whether to run formatting, code and qhelp generation checks
     required: false
     default: false
+  dynamic-join-order-mode:
+    description: Value of the --dynamic-join-order-mode flag to pass to the codeql test command
+    required: false
+    default: "none"
 runs:
   using: composite
   steps:
@@ -74,4 +78,4 @@ runs:
       shell: bash
       run: |
         cd go
-        make test cache="${{ steps.query-cache.outputs.cache-dir }}"
+        make test cache="${{ steps.query-cache.outputs.cache-dir }}" rtjo=${{ inputs.dynamic-join-order-mode }}


### PR DESCRIPTION
Add new QL language test CI jobs next to the existing ones in this repo, using run-time join ordering (`--dynamic-join-order-mode=all`), to be triggered by adding the "Run: RTJO Language Tests" label.