### PR TITLE
Avoid CodeQL alert against integration test

### DIFF
--- a/java/ql/integration-tests/java/buildless-inherit-trust-store/server.py
+++ b/java/ql/integration-tests/java/buildless-inherit-trust-store/server.py
@@ -4,7 +4,8 @@ import ssl
 
 httpd = HTTPServer(('localhost', 4443), SimpleHTTPRequestHandler)
 
-sslctx = ssl.SSLContext()
+sslctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+sslctx.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
 sslctx.load_cert_chain(certfile="../cert.pem", keyfile="../key.pem")
 
 httpd.socket = sslctx.wrap_socket (httpd.socket, server_side=True)


### PR DESCRIPTION
This doesn't really matter since it's a dummy test server, but it's simpler to fix than to dismiss.