### PR TITLE
JS: `got` package modeling

### DIFF
--- a/javascript/ql/lib/change-notes/2025-03-24-got-package.md
+++ b/javascript/ql/lib/change-notes/2025-03-24-got-package.md
@@ -1,0 +1,4 @@
+---
+category: minorAnalysis
+---
+* Improved support for `got` package with `Options`, `paginate()` and `extend()`

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -415,12 +415,20 @@ module ClientRequest {
   }
 
   /**
+   * Gets a reference to an instance of the `got` library, including instances
+   * created through chained `extend` calls.
+   */
+  private API::Node getAGotInstance() {
+    result = [API::moduleImport("got"), getAGotInstance().getMember("extend").getReturn()]
+  }
+
+  /**
    * A model of a URL request made using the `got` library.
    */
   class GotUrlRequest extends ClientRequest::Range {
     GotUrlRequest() {
       exists(API::Node callee, API::Node got | this = callee.getACall() |
-        got = [API::moduleImport("got"), API::moduleImport("got").getMember("extend").getReturn()] and
+        got = getAGotInstance() and
         callee = [got, got.getMember(["stream", "get", "post", "put", "patch", "head", "delete"])]
       )
     }

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -429,7 +429,11 @@ module ClientRequest {
     GotUrlRequest() {
       exists(API::Node callee, API::Node got | this = callee.getACall() |
         got = getAGotInstance() and
-        callee = [got, got.getMember(["stream", "get", "post", "put", "patch", "head", "delete"])]
+        callee =
+          [
+            got,
+            got.getMember(["stream", "get", "post", "put", "patch", "head", "delete", "paginate"])
+          ]
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -436,6 +436,13 @@ module ClientRequest {
     override DataFlow::Node getUrl() {
       result = this.getArgument(0) and
       not exists(this.getOptionArgument(1, "baseUrl"))
+      or
+      // Handle URL when passed as options
+      exists(API::InvokeNode optionsCall |
+        optionsCall = API::moduleImport("got").getMember("Options").getAnInvocation() and
+        optionsCall.getReturn().getAValueReachableFromSource() = this.getAnArgument() and
+        result = optionsCall.getParameter(0).getMember("url").asSink()
+      )
     }
 
     override DataFlow::Node getHost() {

--- a/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/ClientRequests.qll
@@ -437,7 +437,14 @@ module ClientRequest {
       result = this.getArgument(0) and
       not exists(this.getOptionArgument(1, "baseUrl"))
       or
-      // Handle URL when passed as options
+      // Handle URL from options passed to extend()
+      exists(API::CallNode extendCall |
+        extendCall = API::moduleImport("got").getMember("extend").getACall() and
+        result = extendCall.getParameter(0).getMember("url").asSink() and
+        not exists(this.getArgument(0))
+      )
+      or
+      // Handle URL from options passed as third argument when first arg is undefined/missing
       exists(API::InvokeNode optionsCall |
         optionsCall = API::moduleImport("got").getMember("Options").getAnInvocation() and
         optionsCall.getReturn().getAValueReachableFromSource() = this.getAnArgument() and

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -264,13 +264,10 @@ test_getUrl
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:9:328:17 | undefined |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:40:329:42 | url |
-| tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:336:41:336:43 | url |
-| tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:339:42:339:44 | url |
 | tst.js:334:5:334:25 | got.pag ... rl, {}) | tst.js:334:18:334:20 | url |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:336:41:336:43 | url |
-| tst.js:337:5:337:20 | jsonClient.get() | tst.js:339:42:339:44 | url |
-| tst.js:340:5:340:21 | jsonClient2.get() | tst.js:336:41:336:43 | url |
 | tst.js:340:5:340:21 | jsonClient2.get() | tst.js:339:42:339:44 | url |
+| tst.js:340:5:340:21 | jsonClient2.get() | tst.js:339:61:339:63 | url |
 test_getAResponseDataNode
 | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | json | true |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | json | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -98,7 +98,7 @@ test_ClientRequest
 | tst.js:320:5:320:23 | superagent.del(url) |
 | tst.js:321:5:321:32 | superag ... st(url) |
 | tst.js:328:5:328:38 | got(und ... ptions) |
-| tst.js:329:5:329:45 | got(und ... {url})) |
+| tst.js:329:5:329:49 | got(und ... {url})) |
 | tst.js:332:5:332:46 | got.ext ... ).get() |
 | tst.js:334:5:334:25 | got.pag ... rl, {}) |
 | tst.js:337:5:337:20 | jsonClient.get() |
@@ -262,8 +262,8 @@ test_getUrl
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:29:321:31 | url |
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:327:34:327:36 | url |
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:9:328:17 | undefined |
-| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
-| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:40:329:42 | url |
+| tst.js:329:5:329:49 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
+| tst.js:329:5:329:49 | got(und ... {url})) | tst.js:329:44:329:46 | url |
 | tst.js:334:5:334:25 | got.pag ... rl, {}) | tst.js:334:18:334:20 | url |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:336:41:336:43 | url |
 | tst.js:340:5:340:21 | jsonClient2.get() | tst.js:339:42:339:44 | url |
@@ -349,7 +349,7 @@ test_getAResponseDataNode
 | tst.js:320:5:320:23 | superagent.del(url) | tst.js:320:5:320:23 | superagent.del(url) | stream | true |
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:5:321:32 | superag ... st(url) | stream | true |
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:5:328:38 | got(und ... ptions) | text | true |
-| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:5:329:45 | got(und ... {url})) | text | true |
+| tst.js:329:5:329:49 | got(und ... {url})) | tst.js:329:5:329:49 | got(und ... {url})) | text | true |
 | tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:332:5:332:46 | got.ext ... ).get() | text | true |
 | tst.js:334:5:334:25 | got.pag ... rl, {}) | tst.js:334:5:334:25 | got.pag ... rl, {}) | text | true |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:337:5:337:20 | jsonClient.get() | text | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -97,6 +97,9 @@ test_ClientRequest
 | tst.js:319:5:319:26 | superag ... ', url) |
 | tst.js:320:5:320:23 | superagent.del(url) |
 | tst.js:321:5:321:32 | superag ... st(url) |
+| tst.js:328:5:328:38 | got(und ... ptions) |
+| tst.js:329:5:329:45 | got(und ... {url})) |
+| tst.js:337:5:337:20 | jsonClient.get() |
 test_getADataNode
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:15:18:15:55 | { 'Cont ... json' } |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:16:15:16:35 | {x: 'te ... 'test'} |
@@ -254,6 +257,8 @@ test_getUrl
 | tst.js:319:5:319:26 | superag ... ', url) | tst.js:319:23:319:25 | url |
 | tst.js:320:5:320:23 | superagent.del(url) | tst.js:320:20:320:22 | url |
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:29:321:31 | url |
+| tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:9:328:17 | undefined |
+| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
 test_getAResponseDataNode
 | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | json | true |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | json | true |
@@ -334,3 +339,6 @@ test_getAResponseDataNode
 | tst.js:319:5:319:26 | superag ... ', url) | tst.js:319:5:319:26 | superag ... ', url) | stream | true |
 | tst.js:320:5:320:23 | superagent.del(url) | tst.js:320:5:320:23 | superagent.del(url) | stream | true |
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:5:321:32 | superag ... st(url) | stream | true |
+| tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:5:328:38 | got(und ... ptions) | text | true |
+| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:5:329:45 | got(und ... {url})) | text | true |
+| tst.js:337:5:337:20 | jsonClient.get() | tst.js:337:5:337:20 | jsonClient.get() | text | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -263,6 +263,12 @@ test_getUrl
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:9:328:17 | undefined |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:40:329:42 | url |
+| tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:336:41:336:43 | url |
+| tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:339:42:339:44 | url |
+| tst.js:337:5:337:20 | jsonClient.get() | tst.js:336:41:336:43 | url |
+| tst.js:337:5:337:20 | jsonClient.get() | tst.js:339:42:339:44 | url |
+| tst.js:340:5:340:21 | jsonClient2.get() | tst.js:336:41:336:43 | url |
+| tst.js:340:5:340:21 | jsonClient2.get() | tst.js:339:42:339:44 | url |
 test_getAResponseDataNode
 | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | json | true |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | json | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -100,6 +100,7 @@ test_ClientRequest
 | tst.js:328:5:328:38 | got(und ... ptions) |
 | tst.js:329:5:329:45 | got(und ... {url})) |
 | tst.js:332:5:332:46 | got.ext ... ).get() |
+| tst.js:334:5:334:25 | got.pag ... rl, {}) |
 | tst.js:337:5:337:20 | jsonClient.get() |
 | tst.js:340:5:340:21 | jsonClient2.get() |
 test_getADataNode
@@ -265,6 +266,7 @@ test_getUrl
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:40:329:42 | url |
 | tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:336:41:336:43 | url |
 | tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:339:42:339:44 | url |
+| tst.js:334:5:334:25 | got.pag ... rl, {}) | tst.js:334:18:334:20 | url |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:336:41:336:43 | url |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:339:42:339:44 | url |
 | tst.js:340:5:340:21 | jsonClient2.get() | tst.js:336:41:336:43 | url |
@@ -352,5 +354,6 @@ test_getAResponseDataNode
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:5:328:38 | got(und ... ptions) | text | true |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:5:329:45 | got(und ... {url})) | text | true |
 | tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:332:5:332:46 | got.ext ... ).get() | text | true |
+| tst.js:334:5:334:25 | got.pag ... rl, {}) | tst.js:334:5:334:25 | got.pag ... rl, {}) | text | true |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:337:5:337:20 | jsonClient.get() | text | true |
 | tst.js:340:5:340:21 | jsonClient2.get() | tst.js:340:5:340:21 | jsonClient2.get() | text | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/ClientRequests.expected
@@ -99,7 +99,9 @@ test_ClientRequest
 | tst.js:321:5:321:32 | superag ... st(url) |
 | tst.js:328:5:328:38 | got(und ... ptions) |
 | tst.js:329:5:329:45 | got(und ... {url})) |
+| tst.js:332:5:332:46 | got.ext ... ).get() |
 | tst.js:337:5:337:20 | jsonClient.get() |
+| tst.js:340:5:340:21 | jsonClient2.get() |
 test_getADataNode
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:15:18:15:55 | { 'Cont ... json' } |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:16:15:16:35 | {x: 'te ... 'test'} |
@@ -257,8 +259,10 @@ test_getUrl
 | tst.js:319:5:319:26 | superag ... ', url) | tst.js:319:23:319:25 | url |
 | tst.js:320:5:320:23 | superagent.del(url) | tst.js:320:20:320:22 | url |
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:29:321:31 | url |
+| tst.js:328:5:328:38 | got(und ... ptions) | tst.js:327:34:327:36 | url |
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:9:328:17 | undefined |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:9:329:17 | undefined |
+| tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:40:329:42 | url |
 test_getAResponseDataNode
 | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | axiosTest.js:4:5:7:6 | axios({ ... \\n    }) | json | true |
 | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | axiosTest.js:12:5:17:6 | axios({ ... \\n    }) | json | true |
@@ -341,4 +345,6 @@ test_getAResponseDataNode
 | tst.js:321:5:321:32 | superag ... st(url) | tst.js:321:5:321:32 | superag ... st(url) | stream | true |
 | tst.js:328:5:328:38 | got(und ... ptions) | tst.js:328:5:328:38 | got(und ... ptions) | text | true |
 | tst.js:329:5:329:45 | got(und ... {url})) | tst.js:329:5:329:45 | got(und ... {url})) | text | true |
+| tst.js:332:5:332:46 | got.ext ... ).get() | tst.js:332:5:332:46 | got.ext ... ).get() | text | true |
 | tst.js:337:5:337:20 | jsonClient.get() | tst.js:337:5:337:20 | jsonClient.get() | text | true |
+| tst.js:340:5:340:21 | jsonClient2.get() | tst.js:340:5:340:21 | jsonClient2.get() | text | true |

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -325,8 +325,8 @@ import { Options } from 'got';
 
 function gotTests(url){
     const options = new Options({url});
-    got(undefined, undefined, options); // undefined is flagged, but should be url from options
-    got(undefined, undefined, Options({url})); // undefined is flagged, but should be url from options
+    got(undefined, undefined, options);
+    got(undefined, undefined, Options({url}));
 
     const options2 = new Options({url});
     got.extend(options2).extend(options).get(); // call flagged not the actual url flow

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -326,7 +326,7 @@ import { Options } from 'got';
 function gotTests(url){
     const options = new Options({url});
     got(undefined, undefined, options);
-    got(undefined, undefined, Options({url}));
+    got(undefined, undefined, new Options({url}));
 
     const options2 = new Options({url});
     got.extend(options2).extend(options).get();

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -329,7 +329,7 @@ function gotTests(url){
     got(undefined, undefined, Options({url})); // undefined is flagged, but should be url from options
 
     const options2 = new Options({url});
-    got.extend(options2).extend(options).get(); // not flagged
+    got.extend(options2).extend(options).get(); // call flagged not the actual url flow
 
     got.paginate(url, {}); // not flagged 
 
@@ -337,5 +337,5 @@ function gotTests(url){
     jsonClient.get(); // call flagged not the actual url flow
 
     const jsonClient2 = got.extend({url: url}).extend({url: url});
-    jsonClient2.get(); // not flagged
+    jsonClient2.get(); // call flagged not the actual url flow
 }

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -329,13 +329,13 @@ function gotTests(url){
     got(undefined, undefined, Options({url}));
 
     const options2 = new Options({url});
-    got.extend(options2).extend(options).get(); // call flagged not the actual url flow
+    got.extend(options2).extend(options).get();
 
     got.paginate(url, {}); // not flagged 
 
     const jsonClient = got.extend({url: url});
-    jsonClient.get(); // call flagged not the actual url flow
+    jsonClient.get();
 
     const jsonClient2 = got.extend({url: url}).extend({url: url});
-    jsonClient2.get(); // call flagged not the actual url flow
+    jsonClient2.get();
 }

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -331,7 +331,7 @@ function gotTests(url){
     const options2 = new Options({url});
     got.extend(options2).extend(options).get();
 
-    got.paginate(url, {}); // not flagged 
+    got.paginate(url, {});
 
     const jsonClient = got.extend({url: url});
     jsonClient.get();

--- a/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/ClientRequests/tst.js
@@ -320,3 +320,22 @@ function useSuperagent(url){
     superagent.del(url);
     superagent.agent().post(url).send(data);
 }
+
+import { Options } from 'got';
+
+function gotTests(url){
+    const options = new Options({url});
+    got(undefined, undefined, options); // undefined is flagged, but should be url from options
+    got(undefined, undefined, Options({url})); // undefined is flagged, but should be url from options
+
+    const options2 = new Options({url});
+    got.extend(options2).extend(options).get(); // not flagged
+
+    got.paginate(url, {}); // not flagged 
+
+    const jsonClient = got.extend({url: url});
+    jsonClient.get(); // call flagged not the actual url flow
+
+    const jsonClient2 = got.extend({url: url}).extend({url: url});
+    jsonClient2.get(); // not flagged
+}


### PR DESCRIPTION
This PR models got's `Options` type, `paginate()`, and `extend()` functions, modeling their behavior.