### PR TITLE
Java: fix comma splice in alert message

### DIFF
--- a/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
+++ b/java/ql/src/Security/CWE/CWE-327/MaybeBrokenCryptoAlgorithm.ql
@@ -23,5 +23,5 @@ where
   sink.getNode().asExpr() = c.getAlgoSpec() and
   InsecureCryptoFlow::flowPath(source, sink)
 select c, source, sink,
-  "Cryptographic algorithm $@ may not be secure, consider using a different algorithm.", source,
+  "Cryptographic algorithm $@ may not be secure. Consider using a different algorithm.", source,
   source.getNode().asExpr().(InsecureAlgorithm).getStringValue()

--- a/java/ql/test/query-tests/security/CWE-327/semmle/tests/MaybeBrokenCryptoAlgorithm.expected
+++ b/java/ql/test/query-tests/security/CWE-327/semmle/tests/MaybeBrokenCryptoAlgorithm.expected
@@ -6,7 +6,7 @@ nodes
 | WeakHashing.java:21:56:21:91 | getProperty(...) | semmle.label | getProperty(...) |
 subpaths
 #select
-| Test.java:34:21:34:53 | new SecretKeySpec(...) | Test.java:34:48:34:52 | "foo" | Test.java:34:48:34:52 | "foo" | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | Test.java:34:48:34:52 | "foo" | foo |
-| WeakHashing.java:15:29:15:84 | getInstance(...) | WeakHashing.java:15:55:15:83 | getProperty(...) | WeakHashing.java:15:55:15:83 | getProperty(...) | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | WeakHashing.java:15:55:15:83 | getProperty(...) | MD5 |
-| WeakHashing.java:18:30:18:96 | getInstance(...) | WeakHashing.java:18:56:18:95 | getProperty(...) | WeakHashing.java:18:56:18:95 | getProperty(...) | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | WeakHashing.java:18:56:18:95 | getProperty(...) | MD5 |
-| WeakHashing.java:21:30:21:92 | getInstance(...) | WeakHashing.java:21:56:21:91 | getProperty(...) | WeakHashing.java:21:56:21:91 | getProperty(...) | Cryptographic algorithm $@ may not be secure, consider using a different algorithm. | WeakHashing.java:21:56:21:91 | getProperty(...) | MD5 |
+| Test.java:34:21:34:53 | new SecretKeySpec(...) | Test.java:34:48:34:52 | "foo" | Test.java:34:48:34:52 | "foo" | Cryptographic algorithm $@ may not be secure. Consider using a different algorithm. | Test.java:34:48:34:52 | "foo" | foo |
+| WeakHashing.java:15:29:15:84 | getInstance(...) | WeakHashing.java:15:55:15:83 | getProperty(...) | WeakHashing.java:15:55:15:83 | getProperty(...) | Cryptographic algorithm $@ may not be secure. Consider using a different algorithm. | WeakHashing.java:15:55:15:83 | getProperty(...) | MD5 |
+| WeakHashing.java:18:30:18:96 | getInstance(...) | WeakHashing.java:18:56:18:95 | getProperty(...) | WeakHashing.java:18:56:18:95 | getProperty(...) | Cryptographic algorithm $@ may not be secure. Consider using a different algorithm. | WeakHashing.java:18:56:18:95 | getProperty(...) | MD5 |
+| WeakHashing.java:21:30:21:92 | getInstance(...) | WeakHashing.java:21:56:21:91 | getProperty(...) | WeakHashing.java:21:56:21:91 | getProperty(...) | Cryptographic algorithm $@ may not be secure. Consider using a different algorithm. | WeakHashing.java:21:56:21:91 | getProperty(...) | MD5 |


### PR DESCRIPTION
From https://en.wikipedia.org/wiki/Comma_splice:
> It is usually considered an error in English writing style.