### PR TITLE
Rust: Have CleartextTransmissionSink extend QuerySink::Range.

### DIFF
--- a/rust/ql/lib/codeql/rust/security/CleartextLoggingExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/CleartextLoggingExtensions.qll
@@ -37,7 +37,7 @@ module CleartextLogging {
   private class SensitiveDataAsSource extends Source instanceof SensitiveData { }
 
   /** A sink for logging from model data. */
-  private class ModelsAsDataSinks extends Sink {
-    ModelsAsDataSinks() { exists(string s | sinkNode(this, s) and s.matches("log-injection%")) }
+  private class ModelsAsDataSink extends Sink {
+    ModelsAsDataSink() { exists(string s | sinkNode(this, s) and s.matches("log-injection%")) }
   }
 }

--- a/rust/ql/lib/codeql/rust/security/CleartextTransmissionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/CleartextTransmissionExtensions.qll
@@ -10,32 +10,39 @@ private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowSink
 
 /**
- * A data flow sink for cleartext transmission vulnerabilities. That is,
- * a `DataFlow::Node` of something that is transmitted over a network.
+ * Provides default sources, sinks and barriers for detecting cleartext
+ * transmission vulnerabilities, as well as extension points for adding your
+ * own.
  */
-abstract class CleartextTransmissionSink extends QuerySink::Range {
-  override string getSinkType() { result = "CleartextTransmission" }
-}
-
-/**
- * A barrier for cleartext transmission vulnerabilities.
- */
-abstract class CleartextTransmissionBarrier extends DataFlow::Node { }
-
-/**
- * A unit class for adding additional flow steps.
- */
-class CleartextTransmissionAdditionalFlowStep extends Unit {
+module CleartextTransmission {
   /**
-   * Holds if the step from `node1` to `node2` should be considered a flow
-   * step for paths related to cleartext transmission vulnerabilities.
+   * A data flow sink for cleartext transmission vulnerabilities. That is,
+   * a `DataFlow::Node` of something that is transmitted over a network.
    */
-  abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
-}
+  abstract class Sink extends QuerySink::Range {
+    override string getSinkType() { result = "CleartextTransmission" }
+  }
 
-/**
- * A sink defined through MaD.
- */
-private class MadCleartextTransmissionSink extends CleartextTransmissionSink {
-  MadCleartextTransmissionSink() { sinkNode(this, "transmission") }
+  /**
+   * A barrier for cleartext transmission vulnerabilities.
+   */
+  abstract class Barrier extends DataFlow::Node { }
+
+  /**
+   * A unit class for adding additional flow steps.
+   */
+  class AdditionalFlowStep extends Unit {
+    /**
+     * Holds if the step from `node1` to `node2` should be considered a flow
+     * step for paths related to cleartext transmission vulnerabilities.
+     */
+    abstract predicate step(DataFlow::Node nodeFrom, DataFlow::Node nodeTo);
+  }
+
+  /**
+   * A sink defined through MaD.
+   */
+  private class ModelsAsDataSink extends Sink {
+    ModelsAsDataSink() { sinkNode(this, "transmission") }
+  }
 }

--- a/rust/ql/lib/codeql/rust/security/CleartextTransmissionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/CleartextTransmissionExtensions.qll
@@ -5,6 +5,7 @@
 
 private import codeql.util.Unit
 private import rust
+private import codeql.rust.Concepts
 private import codeql.rust.dataflow.DataFlow
 private import codeql.rust.dataflow.FlowSink
 
@@ -12,7 +13,9 @@ private import codeql.rust.dataflow.FlowSink
  * A data flow sink for cleartext transmission vulnerabilities. That is,
  * a `DataFlow::Node` of something that is transmitted over a network.
  */
-abstract class CleartextTransmissionSink extends DataFlow::Node { }
+abstract class CleartextTransmissionSink extends QuerySink::Range {
+  override string getSinkType() { result = "CleartextTransmission" }
+}
 
 /**
  * A barrier for cleartext transmission vulnerabilities.

--- a/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
+++ b/rust/ql/lib/codeql/rust/security/SqlInjectionExtensions.qll
@@ -52,7 +52,7 @@ module SqlInjection {
   }
 
   /** A sink for sql-injection from model data. */
-  private class ModelsAsDataSinks extends Sink {
-    ModelsAsDataSinks() { sinkNode(this, "sql-injection") }
+  private class ModelsAsDataSink extends Sink {
+    ModelsAsDataSink() { sinkNode(this, "sql-injection") }
   }
 }

--- a/rust/ql/src/queries/security/CWE-311/CleartextTransmission.ql
+++ b/rust/ql/src/queries/security/CWE-311/CleartextTransmission.ql
@@ -24,12 +24,12 @@ import codeql.rust.security.CleartextTransmissionExtensions
 module CleartextTransmissionConfig implements DataFlow::ConfigSig {
   predicate isSource(DataFlow::Node node) { node instanceof SensitiveData }
 
-  predicate isSink(DataFlow::Node node) { node instanceof CleartextTransmissionSink }
+  predicate isSink(DataFlow::Node node) { node instanceof CleartextTransmission::Sink }
 
-  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextTransmissionBarrier }
+  predicate isBarrier(DataFlow::Node barrier) { barrier instanceof CleartextTransmission::Barrier }
 
   predicate isAdditionalFlowStep(DataFlow::Node nodeFrom, DataFlow::Node nodeTo) {
-    any(CleartextTransmissionAdditionalFlowStep s).step(nodeFrom, nodeTo)
+    any(CleartextTransmission::AdditionalFlowStep s).step(nodeFrom, nodeTo)
   }
 
   predicate isBarrierIn(DataFlow::Node node) {


### PR DESCRIPTION
This fixes a semantic merge conflict between https://github.com/github/codeql/pull/18977 (second commit) and https://github.com/github/codeql/pull/19000 (and makes things a bit more consistent between query-associated `.qll`s).  The DCA run is expected to show sinks for the new query after this change.

This PR will also serve to test rumours that the test for ~this query~ the cleartext logging query is failing on CI (despite working locally).