### PR TITLE
JS: Handle spread/rest in API graphs

### DIFF
--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -866,6 +866,14 @@ module API {
                   .getAReturn()
           )
           or
+          // Handle rest parameters escaping into external code. For example:
+          //
+          //   function foo(...rest) {
+          //     externalFunc(rest);
+          //   }
+          //
+          // Here, 'rest' reaches a def-node at the call to externalFunc, so we need to ensure
+          // the arguments passed to 'foo' are stored in the 'rest' array.
           exists(Function fun, DataFlow::InvokeNode invoke, int argIndex, Parameter rest |
             fun.getRestParameter() = rest and
             rest.flow() = pred and

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -1795,7 +1795,10 @@ module API {
         /** Gets the argument index at which the spread argument appears. */
         int getIndex() { result = index }
 
-        override string toString() { result = "getSpreadArgument(" + index + ")" }
+        override string toString() {
+          // Note: This refers to the internal edge that has no corresponding method on API::Node
+          result = "getSpreadArgument(" + index + ")"
+        }
       }
 
       /** A label for a function that is a wrapper around another function. */

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -955,12 +955,17 @@ module API {
       result = min(int i | expr.getArgument(i) instanceof SpreadElement)
     }
 
+    pragma[nomagic]
+    private InvokeExpr getAnInvocationWithSpread(DataFlow::SourceNode node, int i) {
+      result = node.getAnInvocation().asExpr() and
+      i = firstSpreadIndex(result)
+    }
+
     private predicate spreadArgumentPassing(TApiNode base, int i, DataFlow::Node spreadArray) {
       exists(DataFlow::Node use, DataFlow::SourceNode pred, int bound, InvokeExpr invoke |
         use(base, use) and
         pred = trackUseNode(use, _, bound, "") and
-        invoke = pred.getAnInvocation().asExpr() and
-        i = firstSpreadIndex(invoke) and
+        invoke = getAnInvocationWithSpread(pred, i) and
         spreadArray = invoke.getArgument(i - bound).(SpreadElement).getOperand().flow()
       )
     }

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -962,11 +962,14 @@ module API {
     }
 
     private predicate spreadArgumentPassing(TApiNode base, int i, DataFlow::Node spreadArray) {
-      exists(DataFlow::Node use, DataFlow::SourceNode pred, int bound, InvokeExpr invoke |
+      exists(
+        DataFlow::Node use, DataFlow::SourceNode pred, int bound, InvokeExpr invoke, int spreadPos
+      |
         use(base, use) and
         pred = trackUseNode(use, _, bound, "") and
-        invoke = getAnInvocationWithSpread(pred, i) and
-        spreadArray = invoke.getArgument(i - bound).(SpreadElement).getOperand().flow()
+        invoke = getAnInvocationWithSpread(pred, spreadPos) and
+        spreadArray = invoke.getArgument(spreadPos).(SpreadElement).getOperand().flow() and
+        i = bound + spreadPos
       )
     }
 

--- a/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/lib/semmle/javascript/ApiGraphs.qll
@@ -1792,7 +1792,7 @@ module API {
 
         LabelSpreadArgument() { this = MkLabelSpreadArgument(index) }
 
-        /** The argument index at which the spread argument appears. */
+        /** Gets the argument index at which the spread argument appears. */
         int getIndex() { result = index }
 
         override string toString() { result = "getSpreadArgument(" + index + ")" }

--- a/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Sources.qll
@@ -254,6 +254,12 @@ private module Cached {
   cached
   predicate invocation(DataFlow::SourceNode func, DataFlow::InvokeNode invoke) {
     hasLocalSource(invoke.getCalleeNode(), func)
+    or
+    exists(ClassDefinition cls, SuperCall call |
+      hasLocalSource(cls.getSuperClass().flow(), func) and
+      call.getBinder() = cls.getConstructor().getBody() and
+      invoke = call.flow()
+    )
   }
 
   /**

--- a/javascript/ql/test/ApiGraphs/spread/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/spread/VerifyAssertions.expected
@@ -1,2 +1,0 @@
-| tst.js:15:14:15:101 | /* def= ... r(0) */ | use moduleImport("something").getMember("exports").getMember("m2") has no outgoing edge labelled getParameter(0); it does have outgoing edges labelled getReceiver(), getReturn(). |
-| tst.js:16:14:16:101 | /* def= ... r(1) */ | use moduleImport("something").getMember("exports").getMember("m2") has no outgoing edge labelled getParameter(1); it does have outgoing edges labelled getReceiver(), getReturn(). |

--- a/javascript/ql/test/ApiGraphs/spread/VerifyAssertions.expected
+++ b/javascript/ql/test/ApiGraphs/spread/VerifyAssertions.expected
@@ -1,0 +1,2 @@
+| tst.js:15:14:15:101 | /* def= ... r(0) */ | use moduleImport("something").getMember("exports").getMember("m2") has no outgoing edge labelled getParameter(0); it does have outgoing edges labelled getReceiver(), getReturn(). |
+| tst.js:16:14:16:101 | /* def= ... r(1) */ | use moduleImport("something").getMember("exports").getMember("m2") has no outgoing edge labelled getParameter(1); it does have outgoing edges labelled getReceiver(), getReturn(). |

--- a/javascript/ql/test/ApiGraphs/spread/tst.js
+++ b/javascript/ql/test/ApiGraphs/spread/tst.js
@@ -18,3 +18,12 @@ function getArgs() {
 }
 
 lib.m2(...getArgs());
+
+function f3() {
+    return [
+        'x', /* def=moduleImport("something").getMember("exports").getMember("m3").getSpreadArgument(1).getArrayElement() */
+        'y', /* def=moduleImport("something").getMember("exports").getMember("m3").getSpreadArgument(1).getArrayElement() */
+    ]
+}
+
+lib.m3.bind(undefined, 1)(...f3());

--- a/javascript/ql/test/ApiGraphs/spread/tst.js
+++ b/javascript/ql/test/ApiGraphs/spread/tst.js
@@ -12,8 +12,8 @@ lib.m1({
 
 function getArgs() {
     return [
-        'x', /* def=moduleImport("something").getMember("exports").getMember("m2").getParameter(0) */
-        'y', /* def=moduleImport("something").getMember("exports").getMember("m2").getParameter(1) */
+        'x', /* def=moduleImport("something").getMember("exports").getMember("m2").getSpreadArgument(0).getArrayElement() */
+        'y', /* def=moduleImport("something").getMember("exports").getMember("m2").getSpreadArgument(0).getArrayElement() */
     ]
 }
 

--- a/javascript/ql/test/ApiGraphs/spread/tst.js
+++ b/javascript/ql/test/ApiGraphs/spread/tst.js
@@ -9,3 +9,12 @@ function f() {
 lib.m1({
     ...f()
 })
+
+function getArgs() {
+    return [
+        'x', /* def=moduleImport("something").getMember("exports").getMember("m2").getParameter(0) */
+        'y', /* def=moduleImport("something").getMember("exports").getMember("m2").getParameter(1) */
+    ]
+}
+
+lib.m2(...getArgs());

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -1,5 +1,6 @@
 #select
 | apollo.serverSide.ts:8:39:8:64 | get(fil ...  => {}) | apollo.serverSide.ts:7:36:7:44 | { files } | apollo.serverSide.ts:8:43:8:50 | file.url | The $@ of this request depends on a $@. | apollo.serverSide.ts:8:43:8:50 | file.url | URL | apollo.serverSide.ts:7:36:7:44 | { files } | user-provided value |
+| apollo.serverSide.ts:18:37:18:62 | get(fil ...  => {}) | apollo.serverSide.ts:17:34:17:42 | { files } | apollo.serverSide.ts:18:41:18:48 | file.url | The $@ of this request depends on a $@. | apollo.serverSide.ts:18:41:18:48 | file.url | URL | apollo.serverSide.ts:17:34:17:42 | { files } | user-provided value |
 | axiosInterceptors.serverSide.js:11:26:11:40 | userProvidedUrl | axiosInterceptors.serverSide.js:19:21:19:28 | req.body | axiosInterceptors.serverSide.js:11:26:11:40 | userProvidedUrl | The $@ of this request depends on a $@. | axiosInterceptors.serverSide.js:11:26:11:40 | userProvidedUrl | endpoint | axiosInterceptors.serverSide.js:19:21:19:28 | req.body | user-provided value |
 | serverSide.js:18:5:18:20 | request(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:18:13:18:19 | tainted | The $@ of this request depends on a $@. | serverSide.js:18:13:18:19 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
 | serverSide.js:20:5:20:24 | request.get(tainted) | serverSide.js:14:29:14:35 | req.url | serverSide.js:20:17:20:23 | tainted | The $@ of this request depends on a $@. | serverSide.js:20:17:20:23 | tainted | URL | serverSide.js:14:29:14:35 | req.url | user-provided value |
@@ -31,6 +32,11 @@ edges
 | apollo.serverSide.ts:8:13:8:17 | files | apollo.serverSide.ts:8:28:8:31 | file | provenance |  |
 | apollo.serverSide.ts:8:28:8:31 | file | apollo.serverSide.ts:8:43:8:46 | file | provenance |  |
 | apollo.serverSide.ts:8:43:8:46 | file | apollo.serverSide.ts:8:43:8:50 | file.url | provenance |  |
+| apollo.serverSide.ts:17:34:17:42 | files | apollo.serverSide.ts:18:11:18:15 | files | provenance |  |
+| apollo.serverSide.ts:17:34:17:42 | { files } | apollo.serverSide.ts:17:34:17:42 | files | provenance |  |
+| apollo.serverSide.ts:18:11:18:15 | files | apollo.serverSide.ts:18:26:18:29 | file | provenance |  |
+| apollo.serverSide.ts:18:26:18:29 | file | apollo.serverSide.ts:18:41:18:44 | file | provenance |  |
+| apollo.serverSide.ts:18:41:18:44 | file | apollo.serverSide.ts:18:41:18:48 | file.url | provenance |  |
 | axiosInterceptors.serverSide.js:19:11:19:17 | { url } | axiosInterceptors.serverSide.js:19:11:19:28 | url | provenance |  |
 | axiosInterceptors.serverSide.js:19:11:19:28 | url | axiosInterceptors.serverSide.js:20:23:20:25 | url | provenance |  |
 | axiosInterceptors.serverSide.js:19:21:19:28 | req.body | axiosInterceptors.serverSide.js:19:11:19:17 | { url } | provenance |  |
@@ -91,6 +97,12 @@ nodes
 | apollo.serverSide.ts:8:28:8:31 | file | semmle.label | file |
 | apollo.serverSide.ts:8:43:8:46 | file | semmle.label | file |
 | apollo.serverSide.ts:8:43:8:50 | file.url | semmle.label | file.url |
+| apollo.serverSide.ts:17:34:17:42 | files | semmle.label | files |
+| apollo.serverSide.ts:17:34:17:42 | { files } | semmle.label | { files } |
+| apollo.serverSide.ts:18:11:18:15 | files | semmle.label | files |
+| apollo.serverSide.ts:18:26:18:29 | file | semmle.label | file |
+| apollo.serverSide.ts:18:41:18:44 | file | semmle.label | file |
+| apollo.serverSide.ts:18:41:18:48 | file.url | semmle.label | file.url |
 | axiosInterceptors.serverSide.js:11:26:11:40 | userProvidedUrl | semmle.label | userProvidedUrl |
 | axiosInterceptors.serverSide.js:19:11:19:17 | { url } | semmle.label | { url } |
 | axiosInterceptors.serverSide.js:19:11:19:28 | url | semmle.label | url |

--- a/javascript/ql/test/query-tests/Security/CWE-918/apollo.serverSide.ts
+++ b/javascript/ql/test/query-tests/Security/CWE-918/apollo.serverSide.ts
@@ -14,8 +14,8 @@ function createApolloServer(typeDefs) {
 
     const resolvers2 = {
       Mutation: {
-        downloadFiles: async (_, { files }) => { // $ MISSING: Source[js/request-forgery]
-          files.forEach((file) => { get(file.url, (res) => {}); }); // $ MISSING: Alert[js/request-forgery] Sink[js/request-forgery]
+        downloadFiles: async (_, { files }) => { // $ Source[js/request-forgery]
+          files.forEach((file) => { get(file.url, (res) => {}); }); // $ Alert[js/request-forgery] Sink[js/request-forgery]
           return true;
         },
       },


### PR DESCRIPTION
Makes sure API graphs can look through spread/rest parameters. An important situation where this occurs is in default constructors, where spread/rest are inserted automatically.

For example, the class below
```js
import { ApolloServer } from "@apollo/server"

class CustomApollo extends ApolloServer {}
```
is desugared into this:
```js
class CustomApollo extends ApolloServer {
  constructor(...args) { super(...args) }
}
```

We have a model that looks for arguments passed to the `ApolloServer` constructor,
```yml
["@apollo/server", "Member[ApolloServer,ApolloServerBase].Argument[0].AnyMember.AnyMember.AnyMember.Parameter[1]", "remote"]
```
This ought to pick up on calls to `new CustomApollo` because the arguments are forwarded to `ApolloServer`:
```js
new CustomApollo({ ... })
```

But evaluation got stuck at `Argument[0]` because of two issues:
- the `super` call targeting the `ApolloServer` constructor was not being considered at all, and
- the rest parameter and spread argument `...args` were not understood by API graphs

This PR fixes the above two issues, and fixes the FN from the test case.