### PR TITLE
Rust: Investigate test discrepancies for rust/cleartext-logging

### DIFF
--- a/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
+++ b/rust/ql/test/query-tests/security/CWE-312/CleartextLogging.expected
@@ -1,8 +1,33 @@
 #select
+| test_logging.rs:42:5:42:36 | ...::log | test_logging.rs:42:28:42:35 | password | test_logging.rs:42:5:42:36 | ...::log | This operation writes $@ to a log file. | test_logging.rs:42:28:42:35 | password | password |
+| test_logging.rs:43:5:43:36 | ...::log | test_logging.rs:43:28:43:35 | password | test_logging.rs:43:5:43:36 | ...::log | This operation writes $@ to a log file. | test_logging.rs:43:28:43:35 | password | password |
+| test_logging.rs:44:5:44:35 | ...::log | test_logging.rs:44:27:44:34 | password | test_logging.rs:44:5:44:35 | ...::log | This operation writes $@ to a log file. | test_logging.rs:44:27:44:34 | password | password |
+| test_logging.rs:45:5:45:36 | ...::log | test_logging.rs:45:28:45:35 | password | test_logging.rs:45:5:45:36 | ...::log | This operation writes $@ to a log file. | test_logging.rs:45:28:45:35 | password | password |
+| test_logging.rs:46:5:46:35 | ...::log | test_logging.rs:46:27:46:34 | password | test_logging.rs:46:5:46:35 | ...::log | This operation writes $@ to a log file. | test_logging.rs:46:27:46:34 | password | password |
+| test_logging.rs:47:5:47:48 | ...::log | test_logging.rs:47:40:47:47 | password | test_logging.rs:47:5:47:48 | ...::log | This operation writes $@ to a log file. | test_logging.rs:47:40:47:47 | password | password |
+| test_logging.rs:52:5:52:36 | ...::log | test_logging.rs:52:28:52:35 | password | test_logging.rs:52:5:52:36 | ...::log | This operation writes $@ to a log file. | test_logging.rs:52:28:52:35 | password | password |
+| test_logging.rs:54:5:54:49 | ...::log | test_logging.rs:54:41:54:48 | password | test_logging.rs:54:5:54:49 | ...::log | This operation writes $@ to a log file. | test_logging.rs:54:41:54:48 | password | password |
+| test_logging.rs:56:5:56:47 | ...::log | test_logging.rs:56:39:56:46 | password | test_logging.rs:56:5:56:47 | ...::log | This operation writes $@ to a log file. | test_logging.rs:56:39:56:46 | password | password |
+| test_logging.rs:57:5:57:34 | ...::log | test_logging.rs:57:24:57:31 | password | test_logging.rs:57:5:57:34 | ...::log | This operation writes $@ to a log file. | test_logging.rs:57:24:57:31 | password | password |
+| test_logging.rs:58:5:58:36 | ...::log | test_logging.rs:58:24:58:31 | password | test_logging.rs:58:5:58:36 | ...::log | This operation writes $@ to a log file. | test_logging.rs:58:24:58:31 | password | password |
+| test_logging.rs:60:5:60:54 | ...::log | test_logging.rs:60:46:60:53 | password | test_logging.rs:60:5:60:54 | ...::log | This operation writes $@ to a log file. | test_logging.rs:60:46:60:53 | password | password |
 | test_logging.rs:61:5:61:55 | ...::log | test_logging.rs:61:21:61:28 | password | test_logging.rs:61:5:61:55 | ...::log | This operation writes $@ to a log file. | test_logging.rs:61:21:61:28 | password | password |
+| test_logging.rs:65:5:65:48 | ...::log | test_logging.rs:65:40:65:47 | password | test_logging.rs:65:5:65:48 | ...::log | This operation writes $@ to a log file. | test_logging.rs:65:40:65:47 | password | password |
+| test_logging.rs:67:5:67:66 | ...::log | test_logging.rs:67:58:67:65 | password | test_logging.rs:67:5:67:66 | ...::log | This operation writes $@ to a log file. | test_logging.rs:67:58:67:65 | password | password |
 | test_logging.rs:68:5:68:67 | ...::log | test_logging.rs:68:19:68:26 | password | test_logging.rs:68:5:68:67 | ...::log | This operation writes $@ to a log file. | test_logging.rs:68:19:68:26 | password | password |
-| test_logging.rs:75:5:75:51 | ...::log | test_logging.rs:75:21:75:28 | password | test_logging.rs:75:5:75:51 | ...::log | This operation writes $@ to a log file. | test_logging.rs:75:21:75:28 | password | password |
-| test_logging.rs:85:5:85:48 | ...::log | test_logging.rs:85:21:85:28 | password | test_logging.rs:85:5:85:48 | ...::log | This operation writes $@ to a log file. | test_logging.rs:85:21:85:28 | password | password |
+| test_logging.rs:72:5:72:47 | ...::log::<...> | test_logging.rs:72:39:72:46 | password | test_logging.rs:72:5:72:47 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:72:39:72:46 | password | password |
+| test_logging.rs:74:5:74:65 | ...::log::<...> | test_logging.rs:74:57:74:64 | password | test_logging.rs:74:5:74:65 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:74:57:74:64 | password | password |
+| test_logging.rs:75:5:75:51 | ...::log::<...> | test_logging.rs:75:21:75:28 | password | test_logging.rs:75:5:75:51 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:75:21:75:28 | password | password |
+| test_logging.rs:76:5:76:47 | ...::log::<...> | test_logging.rs:76:39:76:46 | password | test_logging.rs:76:5:76:47 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:76:39:76:46 | password | password |
+| test_logging.rs:82:5:82:44 | ...::log::<...> | test_logging.rs:82:36:82:43 | password | test_logging.rs:82:5:82:44 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:82:36:82:43 | password | password |
+| test_logging.rs:84:5:84:62 | ...::log::<...> | test_logging.rs:84:54:84:61 | password | test_logging.rs:84:5:84:62 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:84:54:84:61 | password | password |
+| test_logging.rs:85:5:85:48 | ...::log::<...> | test_logging.rs:85:21:85:28 | password | test_logging.rs:85:5:85:48 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:85:21:85:28 | password | password |
+| test_logging.rs:86:5:86:44 | ...::log::<...> | test_logging.rs:86:36:86:43 | password | test_logging.rs:86:5:86:44 | ...::log::<...> | This operation writes $@ to a log file. | test_logging.rs:86:36:86:43 | password | password |
+| test_logging.rs:94:5:94:29 | ...::log | test_logging.rs:93:15:93:22 | password | test_logging.rs:94:5:94:29 | ...::log | This operation writes $@ to a log file. | test_logging.rs:93:15:93:22 | password | password |
+| test_logging.rs:97:5:97:19 | ...::log | test_logging.rs:96:42:96:49 | password | test_logging.rs:97:5:97:19 | ...::log | This operation writes $@ to a log file. | test_logging.rs:96:42:96:49 | password | password |
+| test_logging.rs:100:5:100:19 | ...::log | test_logging.rs:99:38:99:45 | password | test_logging.rs:100:5:100:19 | ...::log | This operation writes $@ to a log file. | test_logging.rs:99:38:99:45 | password | password |
+| test_logging.rs:118:5:118:42 | ...::log | test_logging.rs:118:28:118:41 | get_password(...) | test_logging.rs:118:5:118:42 | ...::log | This operation writes $@ to a log file. | test_logging.rs:118:28:118:41 | get_password(...) | get_password(...) |
+| test_logging.rs:131:5:131:32 | ...::log | test_logging.rs:129:25:129:32 | password | test_logging.rs:131:5:131:32 | ...::log | This operation writes $@ to a log file. | test_logging.rs:129:25:129:32 | password | password |
 | test_logging.rs:152:5:152:38 | ...::_print | test_logging.rs:152:30:152:37 | password | test_logging.rs:152:5:152:38 | ...::_print | This operation writes $@ to a log file. | test_logging.rs:152:30:152:37 | password | password |
 | test_logging.rs:153:5:153:38 | ...::_print | test_logging.rs:153:30:153:37 | password | test_logging.rs:153:5:153:38 | ...::_print | This operation writes $@ to a log file. | test_logging.rs:153:30:153:37 | password | password |
 | test_logging.rs:154:5:154:39 | ...::_eprint | test_logging.rs:154:31:154:38 | password | test_logging.rs:154:5:154:39 | ...::_eprint | This operation writes $@ to a log file. | test_logging.rs:154:31:154:38 | password | password |
@@ -23,42 +48,106 @@
 | test_logging.rs:178:9:178:13 | write | test_logging.rs:178:41:178:48 | password | test_logging.rs:178:9:178:13 | write | This operation writes $@ to a log file. | test_logging.rs:178:41:178:48 | password | password |
 | test_logging.rs:181:9:181:13 | write | test_logging.rs:181:41:181:48 | password | test_logging.rs:181:9:181:13 | write | This operation writes $@ to a log file. | test_logging.rs:181:41:181:48 | password | password |
 edges
-| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
+| test_logging.rs:42:12:42:35 | MacroExpr | test_logging.rs:42:5:42:36 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:42:28:42:35 | password | test_logging.rs:42:12:42:35 | MacroExpr | provenance |  |
+| test_logging.rs:43:12:43:35 | MacroExpr | test_logging.rs:43:5:43:36 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:43:28:43:35 | password | test_logging.rs:43:12:43:35 | MacroExpr | provenance |  |
+| test_logging.rs:44:11:44:34 | MacroExpr | test_logging.rs:44:5:44:35 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:44:27:44:34 | password | test_logging.rs:44:11:44:34 | MacroExpr | provenance |  |
+| test_logging.rs:45:12:45:35 | MacroExpr | test_logging.rs:45:5:45:36 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:45:28:45:35 | password | test_logging.rs:45:12:45:35 | MacroExpr | provenance |  |
+| test_logging.rs:46:11:46:34 | MacroExpr | test_logging.rs:46:5:46:35 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:46:27:46:34 | password | test_logging.rs:46:11:46:34 | MacroExpr | provenance |  |
+| test_logging.rs:47:24:47:47 | MacroExpr | test_logging.rs:47:5:47:48 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:47:40:47:47 | password | test_logging.rs:47:24:47:47 | MacroExpr | provenance |  |
+| test_logging.rs:52:12:52:35 | MacroExpr | test_logging.rs:52:5:52:36 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:52:28:52:35 | password | test_logging.rs:52:12:52:35 | MacroExpr | provenance |  |
+| test_logging.rs:54:12:54:48 | MacroExpr | test_logging.rs:54:5:54:49 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:54:41:54:48 | password | test_logging.rs:54:12:54:48 | MacroExpr | provenance |  |
+| test_logging.rs:56:12:56:46 | MacroExpr | test_logging.rs:56:5:56:47 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:56:39:56:46 | password | test_logging.rs:56:12:56:46 | MacroExpr | provenance |  |
+| test_logging.rs:57:12:57:33 | MacroExpr | test_logging.rs:57:5:57:34 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:57:24:57:31 | password | test_logging.rs:57:12:57:33 | MacroExpr | provenance |  |
+| test_logging.rs:58:12:58:35 | MacroExpr | test_logging.rs:58:5:58:36 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:58:24:58:31 | password | test_logging.rs:58:12:58:35 | MacroExpr | provenance |  |
+| test_logging.rs:60:30:60:53 | MacroExpr | test_logging.rs:60:5:60:54 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:60:46:60:53 | password | test_logging.rs:60:30:60:53 | MacroExpr | provenance |  |
+| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:61:20:61:28 | &... [&ref, tuple.0] | test_logging.rs:61:5:61:55 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
 | test_logging.rs:61:20:61:28 | &password | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0] | provenance |  |
 | test_logging.rs:61:20:61:28 | &password [&ref] | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0, &ref] | provenance |  |
 | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0, &ref] | test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | provenance |  |
 | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0] | test_logging.rs:61:20:61:28 | &... [&ref, tuple.0] | provenance |  |
 | test_logging.rs:61:21:61:28 | password | test_logging.rs:61:20:61:28 | &password | provenance | Config |
 | test_logging.rs:61:21:61:28 | password | test_logging.rs:61:20:61:28 | &password [&ref] | provenance |  |
-| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
+| test_logging.rs:65:24:65:47 | MacroExpr | test_logging.rs:65:5:65:48 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:65:40:65:47 | password | test_logging.rs:65:24:65:47 | MacroExpr | provenance |  |
+| test_logging.rs:67:42:67:65 | MacroExpr | test_logging.rs:67:5:67:66 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:67:58:67:65 | password | test_logging.rs:67:42:67:65 | MacroExpr | provenance |  |
+| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:68:18:68:26 | &... [&ref, tuple.0] | test_logging.rs:68:5:68:67 | ...::log | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
 | test_logging.rs:68:18:68:26 | &password | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0] | provenance |  |
 | test_logging.rs:68:18:68:26 | &password [&ref] | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0, &ref] | provenance |  |
 | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0, &ref] | test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | provenance |  |
 | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0] | test_logging.rs:68:18:68:26 | &... [&ref, tuple.0] | provenance |  |
 | test_logging.rs:68:19:68:26 | password | test_logging.rs:68:18:68:26 | &password | provenance | Config |
 | test_logging.rs:68:19:68:26 | password | test_logging.rs:68:18:68:26 | &password [&ref] | provenance |  |
-| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:75:5:75:51 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:75:5:75:51 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0] | test_logging.rs:75:5:75:51 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
+| test_logging.rs:72:23:72:46 | MacroExpr | test_logging.rs:72:5:72:47 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:72:39:72:46 | password | test_logging.rs:72:23:72:46 | MacroExpr | provenance |  |
+| test_logging.rs:74:41:74:64 | MacroExpr | test_logging.rs:74:5:74:65 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:74:57:74:64 | password | test_logging.rs:74:41:74:64 | MacroExpr | provenance |  |
+| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:75:5:75:51 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:75:5:75:51 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:75:20:75:28 | &... [&ref, tuple.0] | test_logging.rs:75:5:75:51 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
 | test_logging.rs:75:20:75:28 | &password | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0] | provenance |  |
 | test_logging.rs:75:20:75:28 | &password [&ref] | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0, &ref] | provenance |  |
 | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0, &ref] | test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | provenance |  |
 | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0] | test_logging.rs:75:20:75:28 | &... [&ref, tuple.0] | provenance |  |
 | test_logging.rs:75:21:75:28 | password | test_logging.rs:75:20:75:28 | &password | provenance | Config |
 | test_logging.rs:75:21:75:28 | password | test_logging.rs:75:20:75:28 | &password [&ref] | provenance |  |
-| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:85:5:85:48 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:85:5:85:48 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 Sink:MaD:9 |
-| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0] | test_logging.rs:85:5:85:48 | ...::log | provenance | MaD:9 Sink:MaD:9 Sink:MaD:9 |
+| test_logging.rs:76:23:76:46 | MacroExpr | test_logging.rs:76:5:76:47 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:76:39:76:46 | password | test_logging.rs:76:23:76:46 | MacroExpr | provenance |  |
+| test_logging.rs:82:20:82:43 | MacroExpr | test_logging.rs:82:5:82:44 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:82:36:82:43 | password | test_logging.rs:82:20:82:43 | MacroExpr | provenance |  |
+| test_logging.rs:84:38:84:61 | MacroExpr | test_logging.rs:84:5:84:62 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:84:54:84:61 | password | test_logging.rs:84:38:84:61 | MacroExpr | provenance |  |
+| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:85:5:85:48 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | test_logging.rs:85:5:85:48 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 Sink:MaD:10 |
+| test_logging.rs:85:20:85:28 | &... [&ref, tuple.0] | test_logging.rs:85:5:85:48 | ...::log::<...> | provenance | MaD:10 Sink:MaD:10 Sink:MaD:10 |
 | test_logging.rs:85:20:85:28 | &password | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0] | provenance |  |
 | test_logging.rs:85:20:85:28 | &password [&ref] | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0, &ref] | provenance |  |
 | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0, &ref] | test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | provenance |  |
 | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0] | test_logging.rs:85:20:85:28 | &... [&ref, tuple.0] | provenance |  |
 | test_logging.rs:85:21:85:28 | password | test_logging.rs:85:20:85:28 | &password | provenance | Config |
 | test_logging.rs:85:21:85:28 | password | test_logging.rs:85:20:85:28 | &password [&ref] | provenance |  |
+| test_logging.rs:86:20:86:43 | MacroExpr | test_logging.rs:86:5:86:44 | ...::log::<...> | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:86:36:86:43 | password | test_logging.rs:86:20:86:43 | MacroExpr | provenance |  |
+| test_logging.rs:93:9:93:10 | m1 | test_logging.rs:94:11:94:28 | MacroExpr | provenance |  |
+| test_logging.rs:93:14:93:22 | &password | test_logging.rs:93:9:93:10 | m1 | provenance |  |
+| test_logging.rs:93:15:93:22 | password | test_logging.rs:93:14:93:22 | &password | provenance | Config |
+| test_logging.rs:94:11:94:28 | MacroExpr | test_logging.rs:94:5:94:29 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:96:9:96:10 | m2 | test_logging.rs:97:11:97:18 | MacroExpr | provenance |  |
+| test_logging.rs:96:41:96:49 | &password | test_logging.rs:96:9:96:10 | m2 | provenance |  |
+| test_logging.rs:96:42:96:49 | password | test_logging.rs:96:41:96:49 | &password | provenance | Config |
+| test_logging.rs:97:11:97:18 | MacroExpr | test_logging.rs:97:5:97:19 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:99:9:99:10 | m3 | test_logging.rs:100:11:100:18 | MacroExpr | provenance |  |
+| test_logging.rs:99:14:99:46 | res | test_logging.rs:99:22:99:45 | { ... } | provenance |  |
+| test_logging.rs:99:22:99:45 | ...::format(...) | test_logging.rs:99:14:99:46 | res | provenance |  |
+| test_logging.rs:99:22:99:45 | ...::must_use(...) | test_logging.rs:99:9:99:10 | m3 | provenance |  |
+| test_logging.rs:99:22:99:45 | MacroExpr | test_logging.rs:99:22:99:45 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:99:22:99:45 | { ... } | test_logging.rs:99:22:99:45 | ...::must_use(...) | provenance | MaD:14 |
+| test_logging.rs:99:38:99:45 | password | test_logging.rs:99:22:99:45 | MacroExpr | provenance |  |
+| test_logging.rs:100:11:100:18 | MacroExpr | test_logging.rs:100:5:100:19 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:118:12:118:41 | MacroExpr | test_logging.rs:118:5:118:42 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:118:28:118:41 | get_password(...) | test_logging.rs:118:12:118:41 | MacroExpr | provenance |  |
+| test_logging.rs:129:9:129:10 | t1 [tuple.1] | test_logging.rs:131:28:131:29 | t1 [tuple.1] | provenance |  |
+| test_logging.rs:129:14:129:33 | TupleExpr [tuple.1] | test_logging.rs:129:9:129:10 | t1 [tuple.1] | provenance |  |
+| test_logging.rs:129:25:129:32 | password | test_logging.rs:129:14:129:33 | TupleExpr [tuple.1] | provenance |  |
+| test_logging.rs:131:12:131:31 | MacroExpr | test_logging.rs:131:5:131:32 | ...::log | provenance | MaD:9 Sink:MaD:9 |
+| test_logging.rs:131:28:131:29 | t1 [tuple.1] | test_logging.rs:131:28:131:31 | t1.1 | provenance |  |
+| test_logging.rs:131:28:131:31 | t1.1 | test_logging.rs:131:12:131:31 | MacroExpr | provenance |  |
 | test_logging.rs:152:12:152:37 | MacroExpr | test_logging.rs:152:5:152:38 | ...::_print | provenance | MaD:8 Sink:MaD:8 |
 | test_logging.rs:152:30:152:37 | password | test_logging.rs:152:12:152:37 | MacroExpr | provenance |  |
 | test_logging.rs:153:14:153:37 | MacroExpr | test_logging.rs:153:5:153:38 | ...::_print | provenance | MaD:8 Sink:MaD:8 |
@@ -94,37 +183,37 @@ edges
 | test_logging.rs:168:34:168:66 | res | test_logging.rs:168:42:168:65 | { ... } | provenance |  |
 | test_logging.rs:168:34:168:75 | ... .as_str(...) | test_logging.rs:168:27:168:32 | expect | provenance | MaD:1 Sink:MaD:1 |
 | test_logging.rs:168:42:168:65 | ...::format(...) | test_logging.rs:168:34:168:66 | res | provenance |  |
-| test_logging.rs:168:42:168:65 | ...::must_use(...) | test_logging.rs:168:34:168:75 | ... .as_str(...) | provenance | MaD:11 |
-| test_logging.rs:168:42:168:65 | MacroExpr | test_logging.rs:168:42:168:65 | ...::format(...) | provenance | MaD:12 |
-| test_logging.rs:168:42:168:65 | { ... } | test_logging.rs:168:42:168:65 | ...::must_use(...) | provenance | MaD:13 |
+| test_logging.rs:168:42:168:65 | ...::must_use(...) | test_logging.rs:168:34:168:75 | ... .as_str(...) | provenance | MaD:12 |
+| test_logging.rs:168:42:168:65 | MacroExpr | test_logging.rs:168:42:168:65 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:168:42:168:65 | { ... } | test_logging.rs:168:42:168:65 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:168:58:168:65 | password | test_logging.rs:168:42:168:65 | MacroExpr | provenance |  |
 | test_logging.rs:174:36:174:70 | res | test_logging.rs:174:44:174:69 | { ... } | provenance |  |
 | test_logging.rs:174:36:174:81 | ... .as_bytes(...) | test_logging.rs:174:30:174:34 | write | provenance | MaD:5 Sink:MaD:5 |
 | test_logging.rs:174:44:174:69 | ...::format(...) | test_logging.rs:174:36:174:70 | res | provenance |  |
-| test_logging.rs:174:44:174:69 | ...::must_use(...) | test_logging.rs:174:36:174:81 | ... .as_bytes(...) | provenance | MaD:10 |
-| test_logging.rs:174:44:174:69 | MacroExpr | test_logging.rs:174:44:174:69 | ...::format(...) | provenance | MaD:12 |
-| test_logging.rs:174:44:174:69 | { ... } | test_logging.rs:174:44:174:69 | ...::must_use(...) | provenance | MaD:13 |
+| test_logging.rs:174:44:174:69 | ...::must_use(...) | test_logging.rs:174:36:174:81 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:174:44:174:69 | MacroExpr | test_logging.rs:174:44:174:69 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:174:44:174:69 | { ... } | test_logging.rs:174:44:174:69 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:174:62:174:69 | password | test_logging.rs:174:44:174:69 | MacroExpr | provenance |  |
 | test_logging.rs:175:40:175:74 | res | test_logging.rs:175:48:175:73 | { ... } | provenance |  |
 | test_logging.rs:175:40:175:85 | ... .as_bytes(...) | test_logging.rs:175:30:175:38 | write_all | provenance | MaD:6 Sink:MaD:6 |
 | test_logging.rs:175:48:175:73 | ...::format(...) | test_logging.rs:175:40:175:74 | res | provenance |  |
-| test_logging.rs:175:48:175:73 | ...::must_use(...) | test_logging.rs:175:40:175:85 | ... .as_bytes(...) | provenance | MaD:10 |
-| test_logging.rs:175:48:175:73 | MacroExpr | test_logging.rs:175:48:175:73 | ...::format(...) | provenance | MaD:12 |
-| test_logging.rs:175:48:175:73 | { ... } | test_logging.rs:175:48:175:73 | ...::must_use(...) | provenance | MaD:13 |
+| test_logging.rs:175:48:175:73 | ...::must_use(...) | test_logging.rs:175:40:175:85 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:175:48:175:73 | MacroExpr | test_logging.rs:175:48:175:73 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:175:48:175:73 | { ... } | test_logging.rs:175:48:175:73 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:175:66:175:73 | password | test_logging.rs:175:48:175:73 | MacroExpr | provenance |  |
 | test_logging.rs:178:15:178:49 | res | test_logging.rs:178:23:178:48 | { ... } | provenance |  |
 | test_logging.rs:178:15:178:60 | ... .as_bytes(...) | test_logging.rs:178:9:178:13 | write | provenance | MaD:5 Sink:MaD:5 |
 | test_logging.rs:178:23:178:48 | ...::format(...) | test_logging.rs:178:15:178:49 | res | provenance |  |
-| test_logging.rs:178:23:178:48 | ...::must_use(...) | test_logging.rs:178:15:178:60 | ... .as_bytes(...) | provenance | MaD:10 |
-| test_logging.rs:178:23:178:48 | MacroExpr | test_logging.rs:178:23:178:48 | ...::format(...) | provenance | MaD:12 |
-| test_logging.rs:178:23:178:48 | { ... } | test_logging.rs:178:23:178:48 | ...::must_use(...) | provenance | MaD:13 |
+| test_logging.rs:178:23:178:48 | ...::must_use(...) | test_logging.rs:178:15:178:60 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:178:23:178:48 | MacroExpr | test_logging.rs:178:23:178:48 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:178:23:178:48 | { ... } | test_logging.rs:178:23:178:48 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:178:41:178:48 | password | test_logging.rs:178:23:178:48 | MacroExpr | provenance |  |
 | test_logging.rs:181:15:181:49 | res | test_logging.rs:181:23:181:48 | { ... } | provenance |  |
 | test_logging.rs:181:15:181:60 | ... .as_bytes(...) | test_logging.rs:181:9:181:13 | write | provenance | MaD:4 Sink:MaD:4 |
 | test_logging.rs:181:23:181:48 | ...::format(...) | test_logging.rs:181:15:181:49 | res | provenance |  |
-| test_logging.rs:181:23:181:48 | ...::must_use(...) | test_logging.rs:181:15:181:60 | ... .as_bytes(...) | provenance | MaD:10 |
-| test_logging.rs:181:23:181:48 | MacroExpr | test_logging.rs:181:23:181:48 | ...::format(...) | provenance | MaD:12 |
-| test_logging.rs:181:23:181:48 | { ... } | test_logging.rs:181:23:181:48 | ...::must_use(...) | provenance | MaD:13 |
+| test_logging.rs:181:23:181:48 | ...::must_use(...) | test_logging.rs:181:15:181:60 | ... .as_bytes(...) | provenance | MaD:11 |
+| test_logging.rs:181:23:181:48 | MacroExpr | test_logging.rs:181:23:181:48 | ...::format(...) | provenance | MaD:13 |
+| test_logging.rs:181:23:181:48 | { ... } | test_logging.rs:181:23:181:48 | ...::must_use(...) | provenance | MaD:14 |
 | test_logging.rs:181:41:181:48 | password | test_logging.rs:181:23:181:48 | MacroExpr | provenance |  |
 models
 | 1 | Sink: lang:core; <crate::option::Option>::expect; log-injection; Argument[0] |
@@ -135,12 +224,49 @@ models
 | 6 | Sink: lang:std; <crate::io::stdio::StdoutLock as crate::io::Write>::write_all; log-injection; Argument[0] |
 | 7 | Sink: lang:std; crate::io::stdio::_eprint; log-injection; Argument[0] |
 | 8 | Sink: lang:std; crate::io::stdio::_print; log-injection; Argument[0] |
-| 9 | Sink: repo:https://github.com/rust-lang/log:log; crate::__private_api::log; log-injection; Argument[3] |
-| 10 | Summary: lang:alloc; <crate::string::String>::as_bytes; Argument[self]; ReturnValue; taint |
-| 11 | Summary: lang:alloc; <crate::string::String>::as_str; Argument[self]; ReturnValue; taint |
-| 12 | Summary: lang:alloc; crate::fmt::format; Argument[0]; ReturnValue; taint |
-| 13 | Summary: lang:core; crate::hint::must_use; Argument[0]; ReturnValue; value |
+| 9 | Sink: repo:https://github.com/rust-lang/log:log; crate::__private_api::log; log-injection; Argument[0] |
+| 10 | Sink: repo:https://github.com/rust-lang/log:log; crate::__private_api::log; log-injection; Argument[2] |
+| 11 | Summary: lang:alloc; <crate::string::String>::as_bytes; Argument[self]; ReturnValue; taint |
+| 12 | Summary: lang:alloc; <crate::string::String>::as_str; Argument[self]; ReturnValue; taint |
+| 13 | Summary: lang:alloc; crate::fmt::format; Argument[0]; ReturnValue; taint |
+| 14 | Summary: lang:core; crate::hint::must_use; Argument[0]; ReturnValue; value |
 nodes
+| test_logging.rs:42:5:42:36 | ...::log | semmle.label | ...::log |
+| test_logging.rs:42:12:42:35 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:42:28:42:35 | password | semmle.label | password |
+| test_logging.rs:43:5:43:36 | ...::log | semmle.label | ...::log |
+| test_logging.rs:43:12:43:35 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:43:28:43:35 | password | semmle.label | password |
+| test_logging.rs:44:5:44:35 | ...::log | semmle.label | ...::log |
+| test_logging.rs:44:11:44:34 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:44:27:44:34 | password | semmle.label | password |
+| test_logging.rs:45:5:45:36 | ...::log | semmle.label | ...::log |
+| test_logging.rs:45:12:45:35 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:45:28:45:35 | password | semmle.label | password |
+| test_logging.rs:46:5:46:35 | ...::log | semmle.label | ...::log |
+| test_logging.rs:46:11:46:34 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:46:27:46:34 | password | semmle.label | password |
+| test_logging.rs:47:5:47:48 | ...::log | semmle.label | ...::log |
+| test_logging.rs:47:24:47:47 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:47:40:47:47 | password | semmle.label | password |
+| test_logging.rs:52:5:52:36 | ...::log | semmle.label | ...::log |
+| test_logging.rs:52:12:52:35 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:52:28:52:35 | password | semmle.label | password |
+| test_logging.rs:54:5:54:49 | ...::log | semmle.label | ...::log |
+| test_logging.rs:54:12:54:48 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:54:41:54:48 | password | semmle.label | password |
+| test_logging.rs:56:5:56:47 | ...::log | semmle.label | ...::log |
+| test_logging.rs:56:12:56:46 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:56:39:56:46 | password | semmle.label | password |
+| test_logging.rs:57:5:57:34 | ...::log | semmle.label | ...::log |
+| test_logging.rs:57:12:57:33 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:57:24:57:31 | password | semmle.label | password |
+| test_logging.rs:58:5:58:36 | ...::log | semmle.label | ...::log |
+| test_logging.rs:58:12:58:35 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:58:24:58:31 | password | semmle.label | password |
+| test_logging.rs:60:5:60:54 | ...::log | semmle.label | ...::log |
+| test_logging.rs:60:30:60:53 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:60:46:60:53 | password | semmle.label | password |
 | test_logging.rs:61:5:61:55 | ...::log | semmle.label | ...::log |
 | test_logging.rs:61:20:61:28 | &... [&ref, tuple.0, &ref] | semmle.label | &... [&ref, tuple.0, &ref] |
 | test_logging.rs:61:20:61:28 | &... [&ref, tuple.0] | semmle.label | &... [&ref, tuple.0] |
@@ -149,6 +275,12 @@ nodes
 | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0, &ref] | semmle.label | TupleExpr [tuple.0, &ref] |
 | test_logging.rs:61:20:61:28 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | test_logging.rs:61:21:61:28 | password | semmle.label | password |
+| test_logging.rs:65:5:65:48 | ...::log | semmle.label | ...::log |
+| test_logging.rs:65:24:65:47 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:65:40:65:47 | password | semmle.label | password |
+| test_logging.rs:67:5:67:66 | ...::log | semmle.label | ...::log |
+| test_logging.rs:67:42:67:65 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:67:58:67:65 | password | semmle.label | password |
 | test_logging.rs:68:5:68:67 | ...::log | semmle.label | ...::log |
 | test_logging.rs:68:18:68:26 | &... [&ref, tuple.0, &ref] | semmle.label | &... [&ref, tuple.0, &ref] |
 | test_logging.rs:68:18:68:26 | &... [&ref, tuple.0] | semmle.label | &... [&ref, tuple.0] |
@@ -157,7 +289,13 @@ nodes
 | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0, &ref] | semmle.label | TupleExpr [tuple.0, &ref] |
 | test_logging.rs:68:18:68:26 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | test_logging.rs:68:19:68:26 | password | semmle.label | password |
-| test_logging.rs:75:5:75:51 | ...::log | semmle.label | ...::log |
+| test_logging.rs:72:5:72:47 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:72:23:72:46 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:72:39:72:46 | password | semmle.label | password |
+| test_logging.rs:74:5:74:65 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:74:41:74:64 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:74:57:74:64 | password | semmle.label | password |
+| test_logging.rs:75:5:75:51 | ...::log::<...> | semmle.label | ...::log::<...> |
 | test_logging.rs:75:20:75:28 | &... [&ref, tuple.0, &ref] | semmle.label | &... [&ref, tuple.0, &ref] |
 | test_logging.rs:75:20:75:28 | &... [&ref, tuple.0] | semmle.label | &... [&ref, tuple.0] |
 | test_logging.rs:75:20:75:28 | &password | semmle.label | &password |
@@ -165,7 +303,16 @@ nodes
 | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0, &ref] | semmle.label | TupleExpr [tuple.0, &ref] |
 | test_logging.rs:75:20:75:28 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | test_logging.rs:75:21:75:28 | password | semmle.label | password |
-| test_logging.rs:85:5:85:48 | ...::log | semmle.label | ...::log |
+| test_logging.rs:76:5:76:47 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:76:23:76:46 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:76:39:76:46 | password | semmle.label | password |
+| test_logging.rs:82:5:82:44 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:82:20:82:43 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:82:36:82:43 | password | semmle.label | password |
+| test_logging.rs:84:5:84:62 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:84:38:84:61 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:84:54:84:61 | password | semmle.label | password |
+| test_logging.rs:85:5:85:48 | ...::log::<...> | semmle.label | ...::log::<...> |
 | test_logging.rs:85:20:85:28 | &... [&ref, tuple.0, &ref] | semmle.label | &... [&ref, tuple.0, &ref] |
 | test_logging.rs:85:20:85:28 | &... [&ref, tuple.0] | semmle.label | &... [&ref, tuple.0] |
 | test_logging.rs:85:20:85:28 | &password | semmle.label | &password |
@@ -173,6 +320,38 @@ nodes
 | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0, &ref] | semmle.label | TupleExpr [tuple.0, &ref] |
 | test_logging.rs:85:20:85:28 | TupleExpr [tuple.0] | semmle.label | TupleExpr [tuple.0] |
 | test_logging.rs:85:21:85:28 | password | semmle.label | password |
+| test_logging.rs:86:5:86:44 | ...::log::<...> | semmle.label | ...::log::<...> |
+| test_logging.rs:86:20:86:43 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:86:36:86:43 | password | semmle.label | password |
+| test_logging.rs:93:9:93:10 | m1 | semmle.label | m1 |
+| test_logging.rs:93:14:93:22 | &password | semmle.label | &password |
+| test_logging.rs:93:15:93:22 | password | semmle.label | password |
+| test_logging.rs:94:5:94:29 | ...::log | semmle.label | ...::log |
+| test_logging.rs:94:11:94:28 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:96:9:96:10 | m2 | semmle.label | m2 |
+| test_logging.rs:96:41:96:49 | &password | semmle.label | &password |
+| test_logging.rs:96:42:96:49 | password | semmle.label | password |
+| test_logging.rs:97:5:97:19 | ...::log | semmle.label | ...::log |
+| test_logging.rs:97:11:97:18 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:99:9:99:10 | m3 | semmle.label | m3 |
+| test_logging.rs:99:14:99:46 | res | semmle.label | res |
+| test_logging.rs:99:22:99:45 | ...::format(...) | semmle.label | ...::format(...) |
+| test_logging.rs:99:22:99:45 | ...::must_use(...) | semmle.label | ...::must_use(...) |
+| test_logging.rs:99:22:99:45 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:99:22:99:45 | { ... } | semmle.label | { ... } |
+| test_logging.rs:99:38:99:45 | password | semmle.label | password |
+| test_logging.rs:100:5:100:19 | ...::log | semmle.label | ...::log |
+| test_logging.rs:100:11:100:18 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:118:5:118:42 | ...::log | semmle.label | ...::log |
+| test_logging.rs:118:12:118:41 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:118:28:118:41 | get_password(...) | semmle.label | get_password(...) |
+| test_logging.rs:129:9:129:10 | t1 [tuple.1] | semmle.label | t1 [tuple.1] |
+| test_logging.rs:129:14:129:33 | TupleExpr [tuple.1] | semmle.label | TupleExpr [tuple.1] |
+| test_logging.rs:129:25:129:32 | password | semmle.label | password |
+| test_logging.rs:131:5:131:32 | ...::log | semmle.label | ...::log |
+| test_logging.rs:131:12:131:31 | MacroExpr | semmle.label | MacroExpr |
+| test_logging.rs:131:28:131:29 | t1 [tuple.1] | semmle.label | t1 [tuple.1] |
+| test_logging.rs:131:28:131:31 | t1.1 | semmle.label | t1.1 |
 | test_logging.rs:152:5:152:38 | ...::_print | semmle.label | ...::_print |
 | test_logging.rs:152:12:152:37 | MacroExpr | semmle.label | MacroExpr |
 | test_logging.rs:152:30:152:37 | password | semmle.label | password |
@@ -260,33 +439,3 @@ nodes
 | test_logging.rs:181:23:181:48 | { ... } | semmle.label | { ... } |
 | test_logging.rs:181:41:181:48 | password | semmle.label | password |
 subpaths
-testFailures
-| test_logging.rs:42:39:42:72 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:43:39:43:72 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:44:38:44:71 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:45:39:45:72 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:46:38:46:71 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:47:51:47:84 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:52:39:52:72 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:54:52:54:85 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:56:50:56:83 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:57:37:57:70 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:58:39:58:72 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:60:57:60:90 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:65:51:65:84 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:67:69:67:102 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:72:50:72:83 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:74:68:74:101 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:76:50:76:83 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:82:47:82:80 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:84:65:84:98 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:86:47:86:80 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:93:25:93:38 | //... | Missing result: Source=m1 |
-| test_logging.rs:94:32:94:68 | //... | Missing result: Alert[rust/cleartext-logging]=m1 |
-| test_logging.rs:96:52:96:65 | //... | Missing result: Source=m2 |
-| test_logging.rs:97:22:97:58 | //... | Missing result: Alert[rust/cleartext-logging]=m2 |
-| test_logging.rs:99:49:99:62 | //... | Missing result: Source=m3 |
-| test_logging.rs:100:22:100:59 | //... | Missing result: Alert[rust/cleartext-logging]=m3 |
-| test_logging.rs:118:45:118:78 | //... | Missing result: Alert[rust/cleartext-logging] |
-| test_logging.rs:129:36:129:49 | //... | Missing result: Source=t1 |
-| test_logging.rs:131:35:131:71 | //... | Missing result: Alert[rust/cleartext-logging]=t1 |

--- a/rust/ql/test/query-tests/security/CWE-312/debug.expected
+++ b/rust/ql/test/query-tests/security/CWE-312/debug.expected
@@ -1,0 +1,12876 @@
+| test_logging.rs:1:1:189:2 | SourceFile | 1 | SourceFile |  |
+| test_logging.rs:2:1:2:55 | Use | 2 | Use |  |
+| test_logging.rs:2:5:2:7 | log | 2 | IdentPath |  |
+| test_logging.rs:2:5:2:7 | log | 2 | NameRef |  |
+| test_logging.rs:2:5:2:7 | log | 2 | PathSegment |  |
+| test_logging.rs:2:5:2:54 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:10:2:54 | UseTreeList | 2 | UseTreeList |  |
+| test_logging.rs:2:11:2:15 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:11:2:15 | debug | 2 | IdentPath |  |
+| test_logging.rs:2:11:2:15 | debug | 2 | NameRef |  |
+| test_logging.rs:2:11:2:15 | debug | 2 | PathSegment |  |
+| test_logging.rs:2:18:2:22 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:18:2:22 | error | 2 | IdentPath |  |
+| test_logging.rs:2:18:2:22 | error | 2 | NameRef |  |
+| test_logging.rs:2:18:2:22 | error | 2 | PathSegment |  |
+| test_logging.rs:2:25:2:28 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:25:2:28 | info | 2 | IdentPath |  |
+| test_logging.rs:2:25:2:28 | info | 2 | NameRef |  |
+| test_logging.rs:2:25:2:28 | info | 2 | PathSegment |  |
+| test_logging.rs:2:31:2:35 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:31:2:35 | trace | 2 | IdentPath |  |
+| test_logging.rs:2:31:2:35 | trace | 2 | NameRef |  |
+| test_logging.rs:2:31:2:35 | trace | 2 | PathSegment |  |
+| test_logging.rs:2:38:2:41 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:38:2:41 | warn | 2 | IdentPath |  |
+| test_logging.rs:2:38:2:41 | warn | 2 | NameRef |  |
+| test_logging.rs:2:38:2:41 | warn | 2 | PathSegment |  |
+| test_logging.rs:2:44:2:46 | UseTree | 2 | UseTree |  |
+| test_logging.rs:2:44:2:46 | log | 2 | IdentPath |  |
+| test_logging.rs:2:44:2:46 | log | 2 | NameRef |  |
+| test_logging.rs:2:44:2:46 | log | 2 | PathSegment |  |
+| test_logging.rs:2:49:2:53 | Level | 2 | IdentPath |  |
+| test_logging.rs:2:49:2:53 | Level | 2 | NameRef |  |
+| test_logging.rs:2:49:2:53 | Level | 2 | PathSegment |  |
+| test_logging.rs:2:49:2:53 | UseTree | 2 | UseTree |  |
+| test_logging.rs:3:1:3:24 | Use | 3 | Use |  |
+| test_logging.rs:3:5:3:7 | std | 3 | IdentPath |  |
+| test_logging.rs:3:5:3:7 | std | 3 | NameRef |  |
+| test_logging.rs:3:5:3:7 | std | 3 | PathSegment |  |
+| test_logging.rs:3:5:3:11 | ...::io | 3 | Path |  |
+| test_logging.rs:3:5:3:18 | ...::Write | 3 | Path |  |
+| test_logging.rs:3:5:3:23 | UseTree | 3 | UseTree |  |
+| test_logging.rs:3:10:3:11 | io | 3 | NameRef |  |
+| test_logging.rs:3:10:3:11 | io | 3 | PathSegment |  |
+| test_logging.rs:3:14:3:18 | Write | 3 | NameRef |  |
+| test_logging.rs:3:14:3:18 | Write | 3 | PathSegment |  |
+| test_logging.rs:3:20:3:23 | Rename | 3 | Rename |  |
+| test_logging.rs:4:1:4:25 | Use | 4 | Use |  |
+| test_logging.rs:4:5:4:7 | std | 4 | IdentPath |  |
+| test_logging.rs:4:5:4:7 | std | 4 | NameRef |  |
+| test_logging.rs:4:5:4:7 | std | 4 | PathSegment |  |
+| test_logging.rs:4:5:4:12 | ...::fmt | 4 | Path |  |
+| test_logging.rs:4:5:4:19 | ...::Write | 4 | Path |  |
+| test_logging.rs:4:5:4:24 | UseTree | 4 | UseTree |  |
+| test_logging.rs:4:10:4:12 | fmt | 4 | NameRef |  |
+| test_logging.rs:4:10:4:12 | fmt | 4 | PathSegment |  |
+| test_logging.rs:4:15:4:19 | Write | 4 | NameRef |  |
+| test_logging.rs:4:15:4:19 | Write | 4 | PathSegment |  |
+| test_logging.rs:4:21:4:24 | Rename | 4 | Rename |  |
+| test_logging.rs:6:1:6:16 | //... | 6 | Comment |  |
+| test_logging.rs:8:1:10:1 | fn get_password | 8 | Function |  |
+| test_logging.rs:8:4:8:15 | get_password | 8 | Name |  |
+| test_logging.rs:8:16:8:17 | ParamList | 8 | ParamList |  |
+| test_logging.rs:8:19:8:27 | RetTypeRepr | 8 | RetTypeRepr |  |
+| test_logging.rs:8:22:8:27 | String | 8 | IdentPath |  |
+| test_logging.rs:8:22:8:27 | String | 8 | NameRef |  |
+| test_logging.rs:8:22:8:27 | String | 8 | PathSegment |  |
+| test_logging.rs:8:22:8:27 | String | 8 | PathTypeRepr |  |
+| test_logging.rs:8:29:10:1 | StmtList | 8 | StmtList |  |
+| test_logging.rs:8:29:10:1 | { ... } | 8 | BlockExpr |  |
+| test_logging.rs:9:5:9:12 | "123456" | 9 | LiteralExpr |  |
+| test_logging.rs:9:5:9:24 | "123456".to_string(...) | 9 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:9:14:9:22 | to_string | 9 | NameRef |  |
+| test_logging.rs:9:23:9:24 | ArgList | 9 | ArgList |  |
+| test_logging.rs:12:1:14:1 | fn use_password | 12 | Function |  |
+| test_logging.rs:12:4:12:15 | use_password | 12 | Name |  |
+| test_logging.rs:12:16:12:34 | ParamList | 12 | ParamList |  |
+| test_logging.rs:12:17:12:24 | password | 12 | IdentPat |  |
+| test_logging.rs:12:17:12:24 | password | 12 | Name |  |
+| test_logging.rs:12:17:12:33 | ...: ... | 12 | Param |  |
+| test_logging.rs:12:27:12:33 | RefTypeRepr | 12 | RefTypeRepr |  |
+| test_logging.rs:12:28:12:33 | String | 12 | IdentPath |  |
+| test_logging.rs:12:28:12:33 | String | 12 | NameRef |  |
+| test_logging.rs:12:28:12:33 | String | 12 | PathSegment |  |
+| test_logging.rs:12:28:12:33 | String | 12 | PathTypeRepr |  |
+| test_logging.rs:12:36:14:1 | StmtList | 12 | StmtList |  |
+| test_logging.rs:12:36:14:1 | { ... } | 12 | BlockExpr |  |
+| test_logging.rs:13:5:13:10 | //... | 13 | Comment |  |
+| test_logging.rs:16:1:16:16 | Attr | 16 | Attr |  |
+| test_logging.rs:16:1:20:1 | struct MyStruct1 | 16 | Struct |  |
+| test_logging.rs:16:3:16:8 | derive | 16 | IdentPath |  |
+| test_logging.rs:16:3:16:8 | derive | 16 | NameRef |  |
+| test_logging.rs:16:3:16:8 | derive | 16 | PathSegment |  |
+| test_logging.rs:16:3:16:15 | Meta | 16 | Meta |  |
+| test_logging.rs:16:9:16:15 | TokenTree | 16 | TokenTree |  |
+| test_logging.rs:17:8:17:16 | MyStruct1 | 17 | Name |  |
+| test_logging.rs:17:18:20:1 | RecordFieldList | 17 | RecordFieldList |  |
+| test_logging.rs:18:5:18:12 | harmless | 18 | Name |  |
+| test_logging.rs:18:5:18:20 | StructField | 18 | StructField |  |
+| test_logging.rs:18:15:18:20 | String | 18 | IdentPath |  |
+| test_logging.rs:18:15:18:20 | String | 18 | NameRef |  |
+| test_logging.rs:18:15:18:20 | String | 18 | PathSegment |  |
+| test_logging.rs:18:15:18:20 | String | 18 | PathTypeRepr |  |
+| test_logging.rs:19:5:19:12 | password | 19 | Name |  |
+| test_logging.rs:19:5:19:20 | StructField | 19 | StructField |  |
+| test_logging.rs:19:15:19:20 | String | 19 | IdentPath |  |
+| test_logging.rs:19:15:19:20 | String | 19 | NameRef |  |
+| test_logging.rs:19:15:19:20 | String | 19 | PathSegment |  |
+| test_logging.rs:19:15:19:20 | String | 19 | PathTypeRepr |  |
+| test_logging.rs:22:1:26:1 | impl ...::Display for MyStruct1 { ... } | 22 | Impl |  |
+| test_logging.rs:22:6:22:8 | std | 22 | IdentPath |  |
+| test_logging.rs:22:6:22:8 | std | 22 | NameRef |  |
+| test_logging.rs:22:6:22:8 | std | 22 | PathSegment |  |
+| test_logging.rs:22:6:22:13 | ...::fmt | 22 | Path |  |
+| test_logging.rs:22:6:22:22 | ...::Display | 22 | Path |  |
+| test_logging.rs:22:6:22:22 | ...::Display | 22 | PathTypeRepr |  |
+| test_logging.rs:22:11:22:13 | fmt | 22 | NameRef |  |
+| test_logging.rs:22:11:22:13 | fmt | 22 | PathSegment |  |
+| test_logging.rs:22:16:22:22 | Display | 22 | NameRef |  |
+| test_logging.rs:22:16:22:22 | Display | 22 | PathSegment |  |
+| test_logging.rs:22:28:22:36 | MyStruct1 | 22 | IdentPath |  |
+| test_logging.rs:22:28:22:36 | MyStruct1 | 22 | NameRef |  |
+| test_logging.rs:22:28:22:36 | MyStruct1 | 22 | PathSegment |  |
+| test_logging.rs:22:28:22:36 | MyStruct1 | 22 | PathTypeRepr |  |
+| test_logging.rs:22:38:26:1 | AssocItemList | 22 | AssocItemList |  |
+| test_logging.rs:23:5:25:5 | fn fmt | 23 | Function |  |
+| test_logging.rs:23:8:23:10 | fmt | 23 | Name |  |
+| test_logging.rs:23:11:23:46 | ParamList | 23 | ParamList |  |
+| test_logging.rs:23:12:23:16 | SelfParam | 23 | SelfParam |  |
+| test_logging.rs:23:13:23:16 | self | 23 | Name |  |
+| test_logging.rs:23:19:23:19 | f | 23 | IdentPat |  |
+| test_logging.rs:23:19:23:19 | f | 23 | Name |  |
+| test_logging.rs:23:19:23:45 | ...: ... | 23 | Param |  |
+| test_logging.rs:23:22:23:45 | RefTypeRepr | 23 | RefTypeRepr |  |
+| test_logging.rs:23:27:23:29 | std | 23 | IdentPath |  |
+| test_logging.rs:23:27:23:29 | std | 23 | NameRef |  |
+| test_logging.rs:23:27:23:29 | std | 23 | PathSegment |  |
+| test_logging.rs:23:27:23:34 | ...::fmt | 23 | Path |  |
+| test_logging.rs:23:27:23:45 | ...::Formatter | 23 | Path |  |
+| test_logging.rs:23:27:23:45 | ...::Formatter | 23 | PathTypeRepr |  |
+| test_logging.rs:23:32:23:34 | fmt | 23 | NameRef |  |
+| test_logging.rs:23:32:23:34 | fmt | 23 | PathSegment |  |
+| test_logging.rs:23:37:23:45 | Formatter | 23 | NameRef |  |
+| test_logging.rs:23:37:23:45 | Formatter | 23 | PathSegment |  |
+| test_logging.rs:23:48:23:66 | RetTypeRepr | 23 | RetTypeRepr |  |
+| test_logging.rs:23:51:23:53 | std | 23 | IdentPath |  |
+| test_logging.rs:23:51:23:53 | std | 23 | NameRef |  |
+| test_logging.rs:23:51:23:53 | std | 23 | PathSegment |  |
+| test_logging.rs:23:51:23:58 | ...::fmt | 23 | Path |  |
+| test_logging.rs:23:51:23:66 | ...::Result | 23 | Path |  |
+| test_logging.rs:23:51:23:66 | ...::Result | 23 | PathTypeRepr |  |
+| test_logging.rs:23:56:23:58 | fmt | 23 | NameRef |  |
+| test_logging.rs:23:56:23:58 | fmt | 23 | PathSegment |  |
+| test_logging.rs:23:61:23:66 | Result | 23 | NameRef |  |
+| test_logging.rs:23:61:23:66 | Result | 23 | PathSegment |  |
+| test_logging.rs:23:68:25:5 | StmtList | 23 | StmtList |  |
+| test_logging.rs:23:68:25:5 | { ... } | 23 | BlockExpr |  |
+| test_logging.rs:24:9:24:13 | write | 24 | IdentPath |  |
+| test_logging.rs:24:9:24:13 | write | 24 | NameRef |  |
+| test_logging.rs:24:9:24:13 | write | 24 | PathSegment |  |
+| test_logging.rs:24:9:24:56 | $crate | 24 | IdentPath |  |
+| test_logging.rs:24:9:24:56 | $crate | 24 | NameRef |  |
+| test_logging.rs:24:9:24:56 | $crate | 24 | PathSegment |  |
+| test_logging.rs:24:9:24:56 | ...::format_args | 24 | Path |  |
+| test_logging.rs:24:9:24:56 | MacroExpr | 24 | MacroExpr |  |
+| test_logging.rs:24:9:24:56 | format_args | 24 | NameRef |  |
+| test_logging.rs:24:9:24:56 | format_args | 24 | PathSegment |  |
+| test_logging.rs:24:9:24:56 | write!... | 24 | MacroCall |  |
+| test_logging.rs:24:9:24:56 | write_fmt | 24 | NameRef |  |
+| test_logging.rs:24:15:24:56 | TokenTree | 24 | TokenTree |  |
+| test_logging.rs:24:16:24:16 | f | 24 | IdentPath |  |
+| test_logging.rs:24:16:24:16 | f | 24 | NameRef |  |
+| test_logging.rs:24:16:24:16 | f | 24 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:24:16:24:16 | f | 24 | PathSegment |  |
+| test_logging.rs:24:16:24:55 | MacroStmts | 24 | MacroStmts |  |
+| test_logging.rs:24:16:24:55 | f.write_fmt(...) | 24 | MethodCallExpr | method-origin:lang:core, method-path:<crate::fmt::Formatter>::write_fmt |
+| test_logging.rs:24:19:24:25 | "{} {}" | 24 | LiteralExpr |  |
+| test_logging.rs:24:19:24:55 | ...::format_args!... | 24 | MacroCall |  |
+| test_logging.rs:24:19:24:55 | ArgList | 24 | ArgList |  |
+| test_logging.rs:24:19:24:55 | FormatArgsExpr | 24 | FormatArgsExpr |  |
+| test_logging.rs:24:19:24:55 | MacroExpr | 24 | MacroExpr |  |
+| test_logging.rs:24:19:24:55 | TokenTree | 24 | TokenTree |  |
+| test_logging.rs:24:20:24:21 | {} | 24 | FormatSynthLocationImpl |  |
+| test_logging.rs:24:23:24:24 | {} | 24 | FormatSynthLocationImpl |  |
+| test_logging.rs:24:28:24:31 | self | 24 | IdentPath |  |
+| test_logging.rs:24:28:24:31 | self | 24 | NameRef |  |
+| test_logging.rs:24:28:24:31 | self | 24 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:24:28:24:31 | self | 24 | PathSegment |  |
+| test_logging.rs:24:28:24:40 | FormatArgsArg | 24 | FormatArgsArg |  |
+| test_logging.rs:24:28:24:40 | self.harmless | 24 | FieldExpr |  |
+| test_logging.rs:24:33:24:40 | harmless | 24 | NameRef |  |
+| test_logging.rs:24:43:24:46 | self | 24 | IdentPath |  |
+| test_logging.rs:24:43:24:46 | self | 24 | NameRef |  |
+| test_logging.rs:24:43:24:46 | self | 24 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:24:43:24:46 | self | 24 | PathSegment |  |
+| test_logging.rs:24:43:24:55 | FormatArgsArg | 24 | FormatArgsArg |  |
+| test_logging.rs:24:43:24:55 | self.password | 24 | FieldExpr |  |
+| test_logging.rs:24:48:24:55 | password | 24 | NameRef |  |
+| test_logging.rs:28:1:28:16 | Attr | 28 | Attr |  |
+| test_logging.rs:28:1:32:1 | struct MyStruct2 | 28 | Struct |  |
+| test_logging.rs:28:3:28:8 | derive | 28 | IdentPath |  |
+| test_logging.rs:28:3:28:8 | derive | 28 | NameRef |  |
+| test_logging.rs:28:3:28:8 | derive | 28 | PathSegment |  |
+| test_logging.rs:28:3:28:15 | Meta | 28 | Meta |  |
+| test_logging.rs:28:9:28:15 | TokenTree | 28 | TokenTree |  |
+| test_logging.rs:29:8:29:16 | MyStruct2 | 29 | Name |  |
+| test_logging.rs:29:18:32:1 | RecordFieldList | 29 | RecordFieldList |  |
+| test_logging.rs:30:5:30:12 | harmless | 30 | Name |  |
+| test_logging.rs:30:5:30:20 | StructField | 30 | StructField |  |
+| test_logging.rs:30:15:30:20 | String | 30 | IdentPath |  |
+| test_logging.rs:30:15:30:20 | String | 30 | NameRef |  |
+| test_logging.rs:30:15:30:20 | String | 30 | PathSegment |  |
+| test_logging.rs:30:15:30:20 | String | 30 | PathTypeRepr |  |
+| test_logging.rs:31:5:31:12 | password | 31 | Name |  |
+| test_logging.rs:31:5:31:20 | StructField | 31 | StructField |  |
+| test_logging.rs:31:15:31:20 | String | 31 | IdentPath |  |
+| test_logging.rs:31:15:31:20 | String | 31 | NameRef |  |
+| test_logging.rs:31:15:31:20 | String | 31 | PathSegment |  |
+| test_logging.rs:31:15:31:20 | String | 31 | PathTypeRepr |  |
+| test_logging.rs:34:1:38:1 | impl ...::Display for MyStruct2 { ... } | 34 | Impl |  |
+| test_logging.rs:34:6:34:8 | std | 34 | IdentPath |  |
+| test_logging.rs:34:6:34:8 | std | 34 | NameRef |  |
+| test_logging.rs:34:6:34:8 | std | 34 | PathSegment |  |
+| test_logging.rs:34:6:34:13 | ...::fmt | 34 | Path |  |
+| test_logging.rs:34:6:34:22 | ...::Display | 34 | Path |  |
+| test_logging.rs:34:6:34:22 | ...::Display | 34 | PathTypeRepr |  |
+| test_logging.rs:34:11:34:13 | fmt | 34 | NameRef |  |
+| test_logging.rs:34:11:34:13 | fmt | 34 | PathSegment |  |
+| test_logging.rs:34:16:34:22 | Display | 34 | NameRef |  |
+| test_logging.rs:34:16:34:22 | Display | 34 | PathSegment |  |
+| test_logging.rs:34:28:34:36 | MyStruct2 | 34 | IdentPath |  |
+| test_logging.rs:34:28:34:36 | MyStruct2 | 34 | NameRef |  |
+| test_logging.rs:34:28:34:36 | MyStruct2 | 34 | PathSegment |  |
+| test_logging.rs:34:28:34:36 | MyStruct2 | 34 | PathTypeRepr |  |
+| test_logging.rs:34:38:38:1 | AssocItemList | 34 | AssocItemList |  |
+| test_logging.rs:35:5:37:5 | fn fmt | 35 | Function |  |
+| test_logging.rs:35:8:35:10 | fmt | 35 | Name |  |
+| test_logging.rs:35:11:35:46 | ParamList | 35 | ParamList |  |
+| test_logging.rs:35:12:35:16 | SelfParam | 35 | SelfParam |  |
+| test_logging.rs:35:13:35:16 | self | 35 | Name |  |
+| test_logging.rs:35:19:35:19 | f | 35 | IdentPat |  |
+| test_logging.rs:35:19:35:19 | f | 35 | Name |  |
+| test_logging.rs:35:19:35:45 | ...: ... | 35 | Param |  |
+| test_logging.rs:35:22:35:45 | RefTypeRepr | 35 | RefTypeRepr |  |
+| test_logging.rs:35:27:35:29 | std | 35 | IdentPath |  |
+| test_logging.rs:35:27:35:29 | std | 35 | NameRef |  |
+| test_logging.rs:35:27:35:29 | std | 35 | PathSegment |  |
+| test_logging.rs:35:27:35:34 | ...::fmt | 35 | Path |  |
+| test_logging.rs:35:27:35:45 | ...::Formatter | 35 | Path |  |
+| test_logging.rs:35:27:35:45 | ...::Formatter | 35 | PathTypeRepr |  |
+| test_logging.rs:35:32:35:34 | fmt | 35 | NameRef |  |
+| test_logging.rs:35:32:35:34 | fmt | 35 | PathSegment |  |
+| test_logging.rs:35:37:35:45 | Formatter | 35 | NameRef |  |
+| test_logging.rs:35:37:35:45 | Formatter | 35 | PathSegment |  |
+| test_logging.rs:35:48:35:66 | RetTypeRepr | 35 | RetTypeRepr |  |
+| test_logging.rs:35:51:35:53 | std | 35 | IdentPath |  |
+| test_logging.rs:35:51:35:53 | std | 35 | NameRef |  |
+| test_logging.rs:35:51:35:53 | std | 35 | PathSegment |  |
+| test_logging.rs:35:51:35:58 | ...::fmt | 35 | Path |  |
+| test_logging.rs:35:51:35:66 | ...::Result | 35 | Path |  |
+| test_logging.rs:35:51:35:66 | ...::Result | 35 | PathTypeRepr |  |
+| test_logging.rs:35:56:35:58 | fmt | 35 | NameRef |  |
+| test_logging.rs:35:56:35:58 | fmt | 35 | PathSegment |  |
+| test_logging.rs:35:61:35:66 | Result | 35 | NameRef |  |
+| test_logging.rs:35:61:35:66 | Result | 35 | PathSegment |  |
+| test_logging.rs:35:68:37:5 | StmtList | 35 | StmtList |  |
+| test_logging.rs:35:68:37:5 | { ... } | 35 | BlockExpr |  |
+| test_logging.rs:36:9:36:13 | write | 36 | IdentPath |  |
+| test_logging.rs:36:9:36:13 | write | 36 | NameRef |  |
+| test_logging.rs:36:9:36:13 | write | 36 | PathSegment |  |
+| test_logging.rs:36:9:36:49 | $crate | 36 | IdentPath |  |
+| test_logging.rs:36:9:36:49 | $crate | 36 | NameRef |  |
+| test_logging.rs:36:9:36:49 | $crate | 36 | PathSegment |  |
+| test_logging.rs:36:9:36:49 | ...::format_args | 36 | Path |  |
+| test_logging.rs:36:9:36:49 | MacroExpr | 36 | MacroExpr |  |
+| test_logging.rs:36:9:36:49 | format_args | 36 | NameRef |  |
+| test_logging.rs:36:9:36:49 | format_args | 36 | PathSegment |  |
+| test_logging.rs:36:9:36:49 | write!... | 36 | MacroCall |  |
+| test_logging.rs:36:9:36:49 | write_fmt | 36 | NameRef |  |
+| test_logging.rs:36:15:36:49 | TokenTree | 36 | TokenTree |  |
+| test_logging.rs:36:16:36:16 | f | 36 | IdentPath |  |
+| test_logging.rs:36:16:36:16 | f | 36 | NameRef |  |
+| test_logging.rs:36:16:36:16 | f | 36 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:36:16:36:16 | f | 36 | PathSegment |  |
+| test_logging.rs:36:16:36:48 | MacroStmts | 36 | MacroStmts |  |
+| test_logging.rs:36:16:36:48 | f.write_fmt(...) | 36 | MethodCallExpr | method-origin:lang:core, method-path:<crate::fmt::Formatter>::write_fmt |
+| test_logging.rs:36:19:36:33 | "{} [REDACTED]" | 36 | LiteralExpr |  |
+| test_logging.rs:36:19:36:48 | ...::format_args!... | 36 | MacroCall |  |
+| test_logging.rs:36:19:36:48 | ArgList | 36 | ArgList |  |
+| test_logging.rs:36:19:36:48 | FormatArgsExpr | 36 | FormatArgsExpr |  |
+| test_logging.rs:36:19:36:48 | MacroExpr | 36 | MacroExpr |  |
+| test_logging.rs:36:19:36:48 | TokenTree | 36 | TokenTree |  |
+| test_logging.rs:36:20:36:21 | {} | 36 | FormatSynthLocationImpl |  |
+| test_logging.rs:36:36:36:39 | self | 36 | IdentPath |  |
+| test_logging.rs:36:36:36:39 | self | 36 | NameRef |  |
+| test_logging.rs:36:36:36:39 | self | 36 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:36:36:36:39 | self | 36 | PathSegment |  |
+| test_logging.rs:36:36:36:48 | FormatArgsArg | 36 | FormatArgsArg |  |
+| test_logging.rs:36:36:36:48 | self.harmless | 36 | FieldExpr |  |
+| test_logging.rs:36:41:36:48 | harmless | 36 | NameRef |  |
+| test_logging.rs:36:51:36:76 | //... | 36 | Comment |  |
+| test_logging.rs:40:1:149:1 | fn test_log | 40 | Function |  |
+| test_logging.rs:40:4:40:11 | test_log | 40 | Name |  |
+| test_logging.rs:40:12:40:75 | ParamList | 40 | ParamList |  |
+| test_logging.rs:40:13:40:20 | harmless | 40 | IdentPat |  |
+| test_logging.rs:40:13:40:20 | harmless | 40 | Name |  |
+| test_logging.rs:40:13:40:28 | ...: String | 40 | Param |  |
+| test_logging.rs:40:23:40:28 | String | 40 | IdentPath |  |
+| test_logging.rs:40:23:40:28 | String | 40 | NameRef |  |
+| test_logging.rs:40:23:40:28 | String | 40 | PathSegment |  |
+| test_logging.rs:40:23:40:28 | String | 40 | PathTypeRepr |  |
+| test_logging.rs:40:31:40:38 | password | 40 | IdentPat |  |
+| test_logging.rs:40:31:40:38 | password | 40 | Name |  |
+| test_logging.rs:40:31:40:46 | ...: String | 40 | Param |  |
+| test_logging.rs:40:41:40:46 | String | 40 | IdentPath |  |
+| test_logging.rs:40:41:40:46 | String | 40 | NameRef |  |
+| test_logging.rs:40:41:40:46 | String | 40 | PathSegment |  |
+| test_logging.rs:40:41:40:46 | String | 40 | PathTypeRepr |  |
+| test_logging.rs:40:49:40:66 | encrypted_password | 40 | IdentPat |  |
+| test_logging.rs:40:49:40:66 | encrypted_password | 40 | Name |  |
+| test_logging.rs:40:49:40:74 | ...: String | 40 | Param |  |
+| test_logging.rs:40:69:40:74 | String | 40 | IdentPath |  |
+| test_logging.rs:40:69:40:74 | String | 40 | NameRef |  |
+| test_logging.rs:40:69:40:74 | String | 40 | PathSegment |  |
+| test_logging.rs:40:69:40:74 | String | 40 | PathTypeRepr |  |
+| test_logging.rs:40:77:149:1 | StmtList | 40 | StmtList |  |
+| test_logging.rs:40:77:149:1 | { ... } | 40 | BlockExpr |  |
+| test_logging.rs:41:5:41:21 | //... | 41 | Comment |  |
+| test_logging.rs:42:5:42:9 | debug | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:9 | debug | 42 | NameRef |  |
+| test_logging.rs:42:5:42:9 | debug | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | "module::path" | 42 | LiteralExpr |  |
+| test_logging.rs:42:5:42:36 | "module::path" | 42 | LiteralExpr |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | $crate | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | &... | 42 | RefExpr |  |
+| test_logging.rs:42:5:42:36 | (...) | 42 | ParenExpr |  |
+| test_logging.rs:42:5:42:36 | (...::Debug) | 42 | ParenExpr |  |
+| test_logging.rs:42:5:42:36 | ... && ... | 42 | BinaryExpr |  |
+| test_logging.rs:42:5:42:36 | ... <= ... | 42 | BinaryExpr |  |
+| test_logging.rs:42:5:42:36 | ... <= ... | 42 | BinaryExpr |  |
+| test_logging.rs:42:5:42:36 | ...::Debug | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::Debug | 42 | PathExpr |  |
+| test_logging.rs:42:5:42:36 | ...::Level | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::STATIC_MAX_LEVEL | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::STATIC_MAX_LEVEL | 42 | PathExpr |  |
+| test_logging.rs:42:5:42:36 | ...::__private_api | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::__private_api | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::__private_api | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::__private_api | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::__private_api | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::format_args | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::loc | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::loc | 42 | PathExpr |  |
+| test_logging.rs:42:5:42:36 | ...::loc(...) | 42 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:42:5:42:36 | ...::log | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::log | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::log | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::log | 42 | PathExpr |  |
+| test_logging.rs:42:5:42:36 | ...::max_level | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::max_level | 42 | PathExpr |  |
+| test_logging.rs:42:5:42:36 | ...::max_level(...) | 42 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:42:5:42:36 | ...::module_path | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::module_path | 42 | Path |  |
+| test_logging.rs:42:5:42:36 | ...::module_path!... | 42 | MacroCall |  |
+| test_logging.rs:42:5:42:36 | ...::module_path!... | 42 | MacroCall |  |
+| test_logging.rs:42:5:42:36 | ArgList | 42 | ArgList |  |
+| test_logging.rs:42:5:42:36 | ArgList | 42 | ArgList |  |
+| test_logging.rs:42:5:42:36 | Debug | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | Debug | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | Level | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | Level | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:5:42:36 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:5:42:36 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:5:42:36 | STATIC_MAX_LEVEL | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | STATIC_MAX_LEVEL | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:5:42:36 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:5:42:36 | TupleExpr | 42 | TupleExpr |  |
+| test_logging.rs:42:5:42:36 | TupleExpr | 42 | TupleExpr |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | __private_api | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | debug!... | 42 | MacroCall |  |
+| test_logging.rs:42:5:42:36 | format_args | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | format_args | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | let ... = ... | 42 | LetStmt |  |
+| test_logging.rs:42:5:42:36 | loc | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | loc | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | log | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | log | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | log | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | log | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | log | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | log | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | IdentPat |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | IdentPath |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | Name |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | lvl | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | max_level | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | max_level | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | module_path | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | module_path | 42 | NameRef |  |
+| test_logging.rs:42:5:42:36 | module_path | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:36 | module_path | 42 | PathSegment |  |
+| test_logging.rs:42:5:42:37 | ExprStmt | 42 | ExprStmt |  |
+| test_logging.rs:42:11:42:36 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:12:42:25 | "message = {}" | 42 | LiteralExpr |  |
+| test_logging.rs:42:12:42:35 | ...::format_args!... | 42 | MacroCall |  |
+| test_logging.rs:42:12:42:35 | ...::log!... | 42 | MacroCall |  |
+| test_logging.rs:42:12:42:35 | ...::log!... | 42 | MacroCall |  |
+| test_logging.rs:42:12:42:35 | ...::log(...) | 42 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:42:12:42:35 | ArgList | 42 | ArgList |  |
+| test_logging.rs:42:12:42:35 | ExprStmt | 42 | ExprStmt |  |
+| test_logging.rs:42:12:42:35 | FormatArgsExpr | 42 | FormatArgsExpr |  |
+| test_logging.rs:42:12:42:35 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:12:42:35 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:12:42:35 | MacroExpr | 42 | MacroExpr |  |
+| test_logging.rs:42:12:42:35 | MacroStmts | 42 | MacroStmts |  |
+| test_logging.rs:42:12:42:35 | MacroStmts | 42 | MacroStmts |  |
+| test_logging.rs:42:12:42:35 | MacroStmts | 42 | MacroStmts |  |
+| test_logging.rs:42:12:42:35 | StmtList | 42 | StmtList |  |
+| test_logging.rs:42:12:42:35 | StmtList | 42 | StmtList |  |
+| test_logging.rs:42:12:42:35 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:12:42:35 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:12:42:35 | TokenTree | 42 | TokenTree |  |
+| test_logging.rs:42:12:42:35 | if ... {...} | 42 | IfExpr |  |
+| test_logging.rs:42:12:42:35 | { ... } | 42 | BlockExpr |  |
+| test_logging.rs:42:12:42:35 | { ... } | 42 | BlockExpr |  |
+| test_logging.rs:42:23:42:24 | {} | 42 | FormatSynthLocationImpl |  |
+| test_logging.rs:42:28:42:35 | FormatArgsArg | 42 | FormatArgsArg |  |
+| test_logging.rs:42:28:42:35 | password | 42 | IdentPath |  |
+| test_logging.rs:42:28:42:35 | password | 42 | NameRef |  |
+| test_logging.rs:42:28:42:35 | password | 42 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:42:28:42:35 | password | 42 | PathSegment |  |
+| test_logging.rs:42:39:42:72 | //... | 42 | Comment |  |
+| test_logging.rs:43:5:43:9 | error | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:9 | error | 43 | NameRef |  |
+| test_logging.rs:43:5:43:9 | error | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | "module::path" | 43 | LiteralExpr |  |
+| test_logging.rs:43:5:43:36 | "module::path" | 43 | LiteralExpr |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | $crate | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | &... | 43 | RefExpr |  |
+| test_logging.rs:43:5:43:36 | (...) | 43 | ParenExpr |  |
+| test_logging.rs:43:5:43:36 | (...::Error) | 43 | ParenExpr |  |
+| test_logging.rs:43:5:43:36 | ... && ... | 43 | BinaryExpr |  |
+| test_logging.rs:43:5:43:36 | ... <= ... | 43 | BinaryExpr |  |
+| test_logging.rs:43:5:43:36 | ... <= ... | 43 | BinaryExpr |  |
+| test_logging.rs:43:5:43:36 | ...::Error | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::Error | 43 | PathExpr |  |
+| test_logging.rs:43:5:43:36 | ...::Level | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::STATIC_MAX_LEVEL | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::STATIC_MAX_LEVEL | 43 | PathExpr |  |
+| test_logging.rs:43:5:43:36 | ...::__private_api | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::__private_api | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::__private_api | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::__private_api | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::__private_api | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::format_args | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::loc | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::loc | 43 | PathExpr |  |
+| test_logging.rs:43:5:43:36 | ...::loc(...) | 43 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:43:5:43:36 | ...::log | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::log | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::log | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::log | 43 | PathExpr |  |
+| test_logging.rs:43:5:43:36 | ...::max_level | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::max_level | 43 | PathExpr |  |
+| test_logging.rs:43:5:43:36 | ...::max_level(...) | 43 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:43:5:43:36 | ...::module_path | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::module_path | 43 | Path |  |
+| test_logging.rs:43:5:43:36 | ...::module_path!... | 43 | MacroCall |  |
+| test_logging.rs:43:5:43:36 | ...::module_path!... | 43 | MacroCall |  |
+| test_logging.rs:43:5:43:36 | ArgList | 43 | ArgList |  |
+| test_logging.rs:43:5:43:36 | ArgList | 43 | ArgList |  |
+| test_logging.rs:43:5:43:36 | Error | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | Error | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | Level | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | Level | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:5:43:36 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:5:43:36 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:5:43:36 | STATIC_MAX_LEVEL | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | STATIC_MAX_LEVEL | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:5:43:36 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:5:43:36 | TupleExpr | 43 | TupleExpr |  |
+| test_logging.rs:43:5:43:36 | TupleExpr | 43 | TupleExpr |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | __private_api | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | error!... | 43 | MacroCall |  |
+| test_logging.rs:43:5:43:36 | format_args | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | format_args | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | let ... = ... | 43 | LetStmt |  |
+| test_logging.rs:43:5:43:36 | loc | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | loc | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | log | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | log | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | log | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | log | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | log | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | log | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | IdentPat |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | IdentPath |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | Name |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | lvl | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | max_level | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | max_level | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | module_path | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | module_path | 43 | NameRef |  |
+| test_logging.rs:43:5:43:36 | module_path | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:36 | module_path | 43 | PathSegment |  |
+| test_logging.rs:43:5:43:37 | ExprStmt | 43 | ExprStmt |  |
+| test_logging.rs:43:11:43:36 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:12:43:25 | "message = {}" | 43 | LiteralExpr |  |
+| test_logging.rs:43:12:43:35 | ...::format_args!... | 43 | MacroCall |  |
+| test_logging.rs:43:12:43:35 | ...::log!... | 43 | MacroCall |  |
+| test_logging.rs:43:12:43:35 | ...::log!... | 43 | MacroCall |  |
+| test_logging.rs:43:12:43:35 | ...::log(...) | 43 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:43:12:43:35 | ArgList | 43 | ArgList |  |
+| test_logging.rs:43:12:43:35 | ExprStmt | 43 | ExprStmt |  |
+| test_logging.rs:43:12:43:35 | FormatArgsExpr | 43 | FormatArgsExpr |  |
+| test_logging.rs:43:12:43:35 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:12:43:35 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:12:43:35 | MacroExpr | 43 | MacroExpr |  |
+| test_logging.rs:43:12:43:35 | MacroStmts | 43 | MacroStmts |  |
+| test_logging.rs:43:12:43:35 | MacroStmts | 43 | MacroStmts |  |
+| test_logging.rs:43:12:43:35 | MacroStmts | 43 | MacroStmts |  |
+| test_logging.rs:43:12:43:35 | StmtList | 43 | StmtList |  |
+| test_logging.rs:43:12:43:35 | StmtList | 43 | StmtList |  |
+| test_logging.rs:43:12:43:35 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:12:43:35 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:12:43:35 | TokenTree | 43 | TokenTree |  |
+| test_logging.rs:43:12:43:35 | if ... {...} | 43 | IfExpr |  |
+| test_logging.rs:43:12:43:35 | { ... } | 43 | BlockExpr |  |
+| test_logging.rs:43:12:43:35 | { ... } | 43 | BlockExpr |  |
+| test_logging.rs:43:23:43:24 | {} | 43 | FormatSynthLocationImpl |  |
+| test_logging.rs:43:28:43:35 | FormatArgsArg | 43 | FormatArgsArg |  |
+| test_logging.rs:43:28:43:35 | password | 43 | IdentPath |  |
+| test_logging.rs:43:28:43:35 | password | 43 | NameRef |  |
+| test_logging.rs:43:28:43:35 | password | 43 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:43:28:43:35 | password | 43 | PathSegment |  |
+| test_logging.rs:43:39:43:72 | //... | 43 | Comment |  |
+| test_logging.rs:44:5:44:8 | info | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:8 | info | 44 | NameRef |  |
+| test_logging.rs:44:5:44:8 | info | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | "module::path" | 44 | LiteralExpr |  |
+| test_logging.rs:44:5:44:35 | "module::path" | 44 | LiteralExpr |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | $crate | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | &... | 44 | RefExpr |  |
+| test_logging.rs:44:5:44:35 | (...) | 44 | ParenExpr |  |
+| test_logging.rs:44:5:44:35 | (...::Info) | 44 | ParenExpr |  |
+| test_logging.rs:44:5:44:35 | ... && ... | 44 | BinaryExpr |  |
+| test_logging.rs:44:5:44:35 | ... <= ... | 44 | BinaryExpr |  |
+| test_logging.rs:44:5:44:35 | ... <= ... | 44 | BinaryExpr |  |
+| test_logging.rs:44:5:44:35 | ...::Info | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::Info | 44 | PathExpr |  |
+| test_logging.rs:44:5:44:35 | ...::Level | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::STATIC_MAX_LEVEL | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::STATIC_MAX_LEVEL | 44 | PathExpr |  |
+| test_logging.rs:44:5:44:35 | ...::__private_api | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::__private_api | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::__private_api | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::__private_api | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::__private_api | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::format_args | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::loc | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::loc | 44 | PathExpr |  |
+| test_logging.rs:44:5:44:35 | ...::loc(...) | 44 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:44:5:44:35 | ...::log | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::log | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::log | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::log | 44 | PathExpr |  |
+| test_logging.rs:44:5:44:35 | ...::max_level | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::max_level | 44 | PathExpr |  |
+| test_logging.rs:44:5:44:35 | ...::max_level(...) | 44 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:44:5:44:35 | ...::module_path | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::module_path | 44 | Path |  |
+| test_logging.rs:44:5:44:35 | ...::module_path!... | 44 | MacroCall |  |
+| test_logging.rs:44:5:44:35 | ...::module_path!... | 44 | MacroCall |  |
+| test_logging.rs:44:5:44:35 | ArgList | 44 | ArgList |  |
+| test_logging.rs:44:5:44:35 | ArgList | 44 | ArgList |  |
+| test_logging.rs:44:5:44:35 | Info | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | Info | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | Level | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | Level | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:5:44:35 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:5:44:35 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:5:44:35 | STATIC_MAX_LEVEL | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | STATIC_MAX_LEVEL | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:5:44:35 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:5:44:35 | TupleExpr | 44 | TupleExpr |  |
+| test_logging.rs:44:5:44:35 | TupleExpr | 44 | TupleExpr |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | __private_api | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | format_args | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | format_args | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | info!... | 44 | MacroCall |  |
+| test_logging.rs:44:5:44:35 | let ... = ... | 44 | LetStmt |  |
+| test_logging.rs:44:5:44:35 | loc | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | loc | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | log | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | log | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | log | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | log | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | log | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | log | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | IdentPat |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | IdentPath |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | Name |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | lvl | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | max_level | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | max_level | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | module_path | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | module_path | 44 | NameRef |  |
+| test_logging.rs:44:5:44:35 | module_path | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:35 | module_path | 44 | PathSegment |  |
+| test_logging.rs:44:5:44:36 | ExprStmt | 44 | ExprStmt |  |
+| test_logging.rs:44:10:44:35 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:11:44:24 | "message = {}" | 44 | LiteralExpr |  |
+| test_logging.rs:44:11:44:34 | ...::format_args!... | 44 | MacroCall |  |
+| test_logging.rs:44:11:44:34 | ...::log!... | 44 | MacroCall |  |
+| test_logging.rs:44:11:44:34 | ...::log!... | 44 | MacroCall |  |
+| test_logging.rs:44:11:44:34 | ...::log(...) | 44 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:44:11:44:34 | ArgList | 44 | ArgList |  |
+| test_logging.rs:44:11:44:34 | ExprStmt | 44 | ExprStmt |  |
+| test_logging.rs:44:11:44:34 | FormatArgsExpr | 44 | FormatArgsExpr |  |
+| test_logging.rs:44:11:44:34 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:11:44:34 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:11:44:34 | MacroExpr | 44 | MacroExpr |  |
+| test_logging.rs:44:11:44:34 | MacroStmts | 44 | MacroStmts |  |
+| test_logging.rs:44:11:44:34 | MacroStmts | 44 | MacroStmts |  |
+| test_logging.rs:44:11:44:34 | MacroStmts | 44 | MacroStmts |  |
+| test_logging.rs:44:11:44:34 | StmtList | 44 | StmtList |  |
+| test_logging.rs:44:11:44:34 | StmtList | 44 | StmtList |  |
+| test_logging.rs:44:11:44:34 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:11:44:34 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:11:44:34 | TokenTree | 44 | TokenTree |  |
+| test_logging.rs:44:11:44:34 | if ... {...} | 44 | IfExpr |  |
+| test_logging.rs:44:11:44:34 | { ... } | 44 | BlockExpr |  |
+| test_logging.rs:44:11:44:34 | { ... } | 44 | BlockExpr |  |
+| test_logging.rs:44:22:44:23 | {} | 44 | FormatSynthLocationImpl |  |
+| test_logging.rs:44:27:44:34 | FormatArgsArg | 44 | FormatArgsArg |  |
+| test_logging.rs:44:27:44:34 | password | 44 | IdentPath |  |
+| test_logging.rs:44:27:44:34 | password | 44 | NameRef |  |
+| test_logging.rs:44:27:44:34 | password | 44 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:44:27:44:34 | password | 44 | PathSegment |  |
+| test_logging.rs:44:38:44:71 | //... | 44 | Comment |  |
+| test_logging.rs:45:5:45:9 | trace | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:9 | trace | 45 | NameRef |  |
+| test_logging.rs:45:5:45:9 | trace | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | "module::path" | 45 | LiteralExpr |  |
+| test_logging.rs:45:5:45:36 | "module::path" | 45 | LiteralExpr |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | $crate | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | &... | 45 | RefExpr |  |
+| test_logging.rs:45:5:45:36 | (...) | 45 | ParenExpr |  |
+| test_logging.rs:45:5:45:36 | (...::Trace) | 45 | ParenExpr |  |
+| test_logging.rs:45:5:45:36 | ... && ... | 45 | BinaryExpr |  |
+| test_logging.rs:45:5:45:36 | ... <= ... | 45 | BinaryExpr |  |
+| test_logging.rs:45:5:45:36 | ... <= ... | 45 | BinaryExpr |  |
+| test_logging.rs:45:5:45:36 | ...::Level | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::STATIC_MAX_LEVEL | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::STATIC_MAX_LEVEL | 45 | PathExpr |  |
+| test_logging.rs:45:5:45:36 | ...::Trace | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::Trace | 45 | PathExpr |  |
+| test_logging.rs:45:5:45:36 | ...::__private_api | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::__private_api | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::__private_api | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::__private_api | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::__private_api | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::format_args | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::loc | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::loc | 45 | PathExpr |  |
+| test_logging.rs:45:5:45:36 | ...::loc(...) | 45 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:45:5:45:36 | ...::log | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::log | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::log | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::log | 45 | PathExpr |  |
+| test_logging.rs:45:5:45:36 | ...::max_level | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::max_level | 45 | PathExpr |  |
+| test_logging.rs:45:5:45:36 | ...::max_level(...) | 45 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:45:5:45:36 | ...::module_path | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::module_path | 45 | Path |  |
+| test_logging.rs:45:5:45:36 | ...::module_path!... | 45 | MacroCall |  |
+| test_logging.rs:45:5:45:36 | ...::module_path!... | 45 | MacroCall |  |
+| test_logging.rs:45:5:45:36 | ArgList | 45 | ArgList |  |
+| test_logging.rs:45:5:45:36 | ArgList | 45 | ArgList |  |
+| test_logging.rs:45:5:45:36 | Level | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | Level | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:5:45:36 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:5:45:36 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:5:45:36 | STATIC_MAX_LEVEL | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | STATIC_MAX_LEVEL | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:5:45:36 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:5:45:36 | Trace | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | Trace | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | TupleExpr | 45 | TupleExpr |  |
+| test_logging.rs:45:5:45:36 | TupleExpr | 45 | TupleExpr |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | __private_api | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | format_args | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | format_args | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | let ... = ... | 45 | LetStmt |  |
+| test_logging.rs:45:5:45:36 | loc | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | loc | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | log | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | log | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | log | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | log | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | log | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | log | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | IdentPat |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | IdentPath |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | Name |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | lvl | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | max_level | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | max_level | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | module_path | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | module_path | 45 | NameRef |  |
+| test_logging.rs:45:5:45:36 | module_path | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | module_path | 45 | PathSegment |  |
+| test_logging.rs:45:5:45:36 | trace!... | 45 | MacroCall |  |
+| test_logging.rs:45:5:45:37 | ExprStmt | 45 | ExprStmt |  |
+| test_logging.rs:45:11:45:36 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:12:45:25 | "message = {}" | 45 | LiteralExpr |  |
+| test_logging.rs:45:12:45:35 | ...::format_args!... | 45 | MacroCall |  |
+| test_logging.rs:45:12:45:35 | ...::log!... | 45 | MacroCall |  |
+| test_logging.rs:45:12:45:35 | ...::log!... | 45 | MacroCall |  |
+| test_logging.rs:45:12:45:35 | ...::log(...) | 45 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:45:12:45:35 | ArgList | 45 | ArgList |  |
+| test_logging.rs:45:12:45:35 | ExprStmt | 45 | ExprStmt |  |
+| test_logging.rs:45:12:45:35 | FormatArgsExpr | 45 | FormatArgsExpr |  |
+| test_logging.rs:45:12:45:35 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:12:45:35 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:12:45:35 | MacroExpr | 45 | MacroExpr |  |
+| test_logging.rs:45:12:45:35 | MacroStmts | 45 | MacroStmts |  |
+| test_logging.rs:45:12:45:35 | MacroStmts | 45 | MacroStmts |  |
+| test_logging.rs:45:12:45:35 | MacroStmts | 45 | MacroStmts |  |
+| test_logging.rs:45:12:45:35 | StmtList | 45 | StmtList |  |
+| test_logging.rs:45:12:45:35 | StmtList | 45 | StmtList |  |
+| test_logging.rs:45:12:45:35 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:12:45:35 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:12:45:35 | TokenTree | 45 | TokenTree |  |
+| test_logging.rs:45:12:45:35 | if ... {...} | 45 | IfExpr |  |
+| test_logging.rs:45:12:45:35 | { ... } | 45 | BlockExpr |  |
+| test_logging.rs:45:12:45:35 | { ... } | 45 | BlockExpr |  |
+| test_logging.rs:45:23:45:24 | {} | 45 | FormatSynthLocationImpl |  |
+| test_logging.rs:45:28:45:35 | FormatArgsArg | 45 | FormatArgsArg |  |
+| test_logging.rs:45:28:45:35 | password | 45 | IdentPath |  |
+| test_logging.rs:45:28:45:35 | password | 45 | NameRef |  |
+| test_logging.rs:45:28:45:35 | password | 45 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:45:28:45:35 | password | 45 | PathSegment |  |
+| test_logging.rs:45:39:45:72 | //... | 45 | Comment |  |
+| test_logging.rs:46:5:46:8 | warn | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:8 | warn | 46 | NameRef |  |
+| test_logging.rs:46:5:46:8 | warn | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | "module::path" | 46 | LiteralExpr |  |
+| test_logging.rs:46:5:46:35 | "module::path" | 46 | LiteralExpr |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | $crate | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | &... | 46 | RefExpr |  |
+| test_logging.rs:46:5:46:35 | (...) | 46 | ParenExpr |  |
+| test_logging.rs:46:5:46:35 | (...::Warn) | 46 | ParenExpr |  |
+| test_logging.rs:46:5:46:35 | ... && ... | 46 | BinaryExpr |  |
+| test_logging.rs:46:5:46:35 | ... <= ... | 46 | BinaryExpr |  |
+| test_logging.rs:46:5:46:35 | ... <= ... | 46 | BinaryExpr |  |
+| test_logging.rs:46:5:46:35 | ...::Level | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::STATIC_MAX_LEVEL | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::STATIC_MAX_LEVEL | 46 | PathExpr |  |
+| test_logging.rs:46:5:46:35 | ...::Warn | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::Warn | 46 | PathExpr |  |
+| test_logging.rs:46:5:46:35 | ...::__private_api | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::__private_api | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::__private_api | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::__private_api | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::__private_api | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::format_args | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::loc | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::loc | 46 | PathExpr |  |
+| test_logging.rs:46:5:46:35 | ...::loc(...) | 46 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:46:5:46:35 | ...::log | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::log | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::log | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::log | 46 | PathExpr |  |
+| test_logging.rs:46:5:46:35 | ...::max_level | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::max_level | 46 | PathExpr |  |
+| test_logging.rs:46:5:46:35 | ...::max_level(...) | 46 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:46:5:46:35 | ...::module_path | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::module_path | 46 | Path |  |
+| test_logging.rs:46:5:46:35 | ...::module_path!... | 46 | MacroCall |  |
+| test_logging.rs:46:5:46:35 | ...::module_path!... | 46 | MacroCall |  |
+| test_logging.rs:46:5:46:35 | ArgList | 46 | ArgList |  |
+| test_logging.rs:46:5:46:35 | ArgList | 46 | ArgList |  |
+| test_logging.rs:46:5:46:35 | Level | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | Level | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:5:46:35 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:5:46:35 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:5:46:35 | STATIC_MAX_LEVEL | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | STATIC_MAX_LEVEL | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:5:46:35 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:5:46:35 | TupleExpr | 46 | TupleExpr |  |
+| test_logging.rs:46:5:46:35 | TupleExpr | 46 | TupleExpr |  |
+| test_logging.rs:46:5:46:35 | Warn | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | Warn | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | __private_api | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | format_args | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | format_args | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | let ... = ... | 46 | LetStmt |  |
+| test_logging.rs:46:5:46:35 | loc | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | loc | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | log | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | log | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | log | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | log | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | log | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | log | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | IdentPat |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | IdentPath |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | Name |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | lvl | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | max_level | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | max_level | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | module_path | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | module_path | 46 | NameRef |  |
+| test_logging.rs:46:5:46:35 | module_path | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | module_path | 46 | PathSegment |  |
+| test_logging.rs:46:5:46:35 | warn!... | 46 | MacroCall |  |
+| test_logging.rs:46:5:46:36 | ExprStmt | 46 | ExprStmt |  |
+| test_logging.rs:46:10:46:35 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:11:46:24 | "message = {}" | 46 | LiteralExpr |  |
+| test_logging.rs:46:11:46:34 | ...::format_args!... | 46 | MacroCall |  |
+| test_logging.rs:46:11:46:34 | ...::log!... | 46 | MacroCall |  |
+| test_logging.rs:46:11:46:34 | ...::log!... | 46 | MacroCall |  |
+| test_logging.rs:46:11:46:34 | ...::log(...) | 46 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:46:11:46:34 | ArgList | 46 | ArgList |  |
+| test_logging.rs:46:11:46:34 | ExprStmt | 46 | ExprStmt |  |
+| test_logging.rs:46:11:46:34 | FormatArgsExpr | 46 | FormatArgsExpr |  |
+| test_logging.rs:46:11:46:34 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:11:46:34 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:11:46:34 | MacroExpr | 46 | MacroExpr |  |
+| test_logging.rs:46:11:46:34 | MacroStmts | 46 | MacroStmts |  |
+| test_logging.rs:46:11:46:34 | MacroStmts | 46 | MacroStmts |  |
+| test_logging.rs:46:11:46:34 | MacroStmts | 46 | MacroStmts |  |
+| test_logging.rs:46:11:46:34 | StmtList | 46 | StmtList |  |
+| test_logging.rs:46:11:46:34 | StmtList | 46 | StmtList |  |
+| test_logging.rs:46:11:46:34 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:11:46:34 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:11:46:34 | TokenTree | 46 | TokenTree |  |
+| test_logging.rs:46:11:46:34 | if ... {...} | 46 | IfExpr |  |
+| test_logging.rs:46:11:46:34 | { ... } | 46 | BlockExpr |  |
+| test_logging.rs:46:11:46:34 | { ... } | 46 | BlockExpr |  |
+| test_logging.rs:46:22:46:23 | {} | 46 | FormatSynthLocationImpl |  |
+| test_logging.rs:46:27:46:34 | FormatArgsArg | 46 | FormatArgsArg |  |
+| test_logging.rs:46:27:46:34 | password | 46 | IdentPath |  |
+| test_logging.rs:46:27:46:34 | password | 46 | NameRef |  |
+| test_logging.rs:46:27:46:34 | password | 46 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:46:27:46:34 | password | 46 | PathSegment |  |
+| test_logging.rs:46:38:46:71 | //... | 46 | Comment |  |
+| test_logging.rs:47:5:47:7 | log | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:7 | log | 47 | NameRef |  |
+| test_logging.rs:47:5:47:7 | log | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | "module::path" | 47 | LiteralExpr |  |
+| test_logging.rs:47:5:47:48 | "module::path" | 47 | LiteralExpr |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | $crate | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | &... | 47 | RefExpr |  |
+| test_logging.rs:47:5:47:48 | (...) | 47 | ParenExpr |  |
+| test_logging.rs:47:5:47:48 | ... && ... | 47 | BinaryExpr |  |
+| test_logging.rs:47:5:47:48 | ... <= ... | 47 | BinaryExpr |  |
+| test_logging.rs:47:5:47:48 | ... <= ... | 47 | BinaryExpr |  |
+| test_logging.rs:47:5:47:48 | ...::STATIC_MAX_LEVEL | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::STATIC_MAX_LEVEL | 47 | PathExpr |  |
+| test_logging.rs:47:5:47:48 | ...::__private_api | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::__private_api | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::__private_api | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::__private_api | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::__private_api | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::format_args | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::loc | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::loc | 47 | PathExpr |  |
+| test_logging.rs:47:5:47:48 | ...::loc(...) | 47 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:47:5:47:48 | ...::log | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::log | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::log | 47 | PathExpr |  |
+| test_logging.rs:47:5:47:48 | ...::max_level | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::max_level | 47 | PathExpr |  |
+| test_logging.rs:47:5:47:48 | ...::max_level(...) | 47 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:47:5:47:48 | ...::module_path | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::module_path | 47 | Path |  |
+| test_logging.rs:47:5:47:48 | ...::module_path!... | 47 | MacroCall |  |
+| test_logging.rs:47:5:47:48 | ...::module_path!... | 47 | MacroCall |  |
+| test_logging.rs:47:5:47:48 | ArgList | 47 | ArgList |  |
+| test_logging.rs:47:5:47:48 | ArgList | 47 | ArgList |  |
+| test_logging.rs:47:5:47:48 | MacroExpr | 47 | MacroExpr |  |
+| test_logging.rs:47:5:47:48 | MacroExpr | 47 | MacroExpr |  |
+| test_logging.rs:47:5:47:48 | MacroExpr | 47 | MacroExpr |  |
+| test_logging.rs:47:5:47:48 | STATIC_MAX_LEVEL | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | STATIC_MAX_LEVEL | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | TokenTree | 47 | TokenTree |  |
+| test_logging.rs:47:5:47:48 | TokenTree | 47 | TokenTree |  |
+| test_logging.rs:47:5:47:48 | TupleExpr | 47 | TupleExpr |  |
+| test_logging.rs:47:5:47:48 | TupleExpr | 47 | TupleExpr |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | __private_api | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | format_args | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | format_args | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | loc | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | loc | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | log | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | log | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | log | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | log | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | log!... | 47 | MacroCall |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | IdentPat |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | IdentPath |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | Name |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | lvl | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | max_level | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | max_level | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | module_path | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | module_path | 47 | NameRef |  |
+| test_logging.rs:47:5:47:48 | module_path | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:48 | module_path | 47 | PathSegment |  |
+| test_logging.rs:47:5:47:49 | ExprStmt | 47 | ExprStmt |  |
+| test_logging.rs:47:9:47:48 | TokenTree | 47 | TokenTree |  |
+| test_logging.rs:47:10:47:14 | Level | 47 | IdentPath |  |
+| test_logging.rs:47:10:47:14 | Level | 47 | NameRef |  |
+| test_logging.rs:47:10:47:14 | Level | 47 | PathSegment |  |
+| test_logging.rs:47:10:47:21 | (...::Error) | 47 | ParenExpr |  |
+| test_logging.rs:47:10:47:21 | ...::Error | 47 | Path |  |
+| test_logging.rs:47:10:47:21 | ...::Error | 47 | PathExpr |  |
+| test_logging.rs:47:10:47:21 | let ... = ... | 47 | LetStmt |  |
+| test_logging.rs:47:10:47:47 | ...::log!... | 47 | MacroCall |  |
+| test_logging.rs:47:10:47:47 | MacroExpr | 47 | MacroExpr |  |
+| test_logging.rs:47:10:47:47 | MacroStmts | 47 | MacroStmts |  |
+| test_logging.rs:47:10:47:47 | MacroStmts | 47 | MacroStmts |  |
+| test_logging.rs:47:10:47:47 | StmtList | 47 | StmtList |  |
+| test_logging.rs:47:10:47:47 | TokenTree | 47 | TokenTree |  |
+| test_logging.rs:47:10:47:47 | { ... } | 47 | BlockExpr |  |
+| test_logging.rs:47:17:47:21 | Error | 47 | NameRef |  |
+| test_logging.rs:47:17:47:21 | Error | 47 | PathSegment |  |
+| test_logging.rs:47:24:47:37 | "message = {}" | 47 | LiteralExpr |  |
+| test_logging.rs:47:24:47:47 | ...::format_args!... | 47 | MacroCall |  |
+| test_logging.rs:47:24:47:47 | ...::log(...) | 47 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:47:24:47:47 | ArgList | 47 | ArgList |  |
+| test_logging.rs:47:24:47:47 | ExprStmt | 47 | ExprStmt |  |
+| test_logging.rs:47:24:47:47 | FormatArgsExpr | 47 | FormatArgsExpr |  |
+| test_logging.rs:47:24:47:47 | MacroExpr | 47 | MacroExpr |  |
+| test_logging.rs:47:24:47:47 | StmtList | 47 | StmtList |  |
+| test_logging.rs:47:24:47:47 | TokenTree | 47 | TokenTree |  |
+| test_logging.rs:47:24:47:47 | if ... {...} | 47 | IfExpr |  |
+| test_logging.rs:47:24:47:47 | { ... } | 47 | BlockExpr |  |
+| test_logging.rs:47:35:47:36 | {} | 47 | FormatSynthLocationImpl |  |
+| test_logging.rs:47:40:47:47 | FormatArgsArg | 47 | FormatArgsArg |  |
+| test_logging.rs:47:40:47:47 | password | 47 | IdentPath |  |
+| test_logging.rs:47:40:47:47 | password | 47 | NameRef |  |
+| test_logging.rs:47:40:47:47 | password | 47 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:47:40:47:47 | password | 47 | PathSegment |  |
+| test_logging.rs:47:51:47:84 | //... | 47 | Comment |  |
+| test_logging.rs:49:5:49:39 | //... | 49 | Comment |  |
+| test_logging.rs:50:5:50:9 | debug | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:9 | debug | 50 | NameRef |  |
+| test_logging.rs:50:5:50:9 | debug | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | "module::path" | 50 | LiteralExpr |  |
+| test_logging.rs:50:5:50:21 | "module::path" | 50 | LiteralExpr |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | $crate | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | &... | 50 | RefExpr |  |
+| test_logging.rs:50:5:50:21 | (...) | 50 | ParenExpr |  |
+| test_logging.rs:50:5:50:21 | (...::Debug) | 50 | ParenExpr |  |
+| test_logging.rs:50:5:50:21 | ... && ... | 50 | BinaryExpr |  |
+| test_logging.rs:50:5:50:21 | ... <= ... | 50 | BinaryExpr |  |
+| test_logging.rs:50:5:50:21 | ... <= ... | 50 | BinaryExpr |  |
+| test_logging.rs:50:5:50:21 | ...::Debug | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::Debug | 50 | PathExpr |  |
+| test_logging.rs:50:5:50:21 | ...::Level | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::STATIC_MAX_LEVEL | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::STATIC_MAX_LEVEL | 50 | PathExpr |  |
+| test_logging.rs:50:5:50:21 | ...::__private_api | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::__private_api | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::__private_api | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::__private_api | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::__private_api | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::format_args | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::loc | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::loc | 50 | PathExpr |  |
+| test_logging.rs:50:5:50:21 | ...::loc(...) | 50 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:50:5:50:21 | ...::log | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::log | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::log | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::log | 50 | PathExpr |  |
+| test_logging.rs:50:5:50:21 | ...::max_level | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::max_level | 50 | PathExpr |  |
+| test_logging.rs:50:5:50:21 | ...::max_level(...) | 50 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:50:5:50:21 | ...::module_path | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::module_path | 50 | Path |  |
+| test_logging.rs:50:5:50:21 | ...::module_path!... | 50 | MacroCall |  |
+| test_logging.rs:50:5:50:21 | ...::module_path!... | 50 | MacroCall |  |
+| test_logging.rs:50:5:50:21 | ArgList | 50 | ArgList |  |
+| test_logging.rs:50:5:50:21 | ArgList | 50 | ArgList |  |
+| test_logging.rs:50:5:50:21 | Debug | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | Debug | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | Level | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | Level | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:5:50:21 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:5:50:21 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:5:50:21 | STATIC_MAX_LEVEL | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | STATIC_MAX_LEVEL | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:5:50:21 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:5:50:21 | TupleExpr | 50 | TupleExpr |  |
+| test_logging.rs:50:5:50:21 | TupleExpr | 50 | TupleExpr |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | __private_api | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | debug!... | 50 | MacroCall |  |
+| test_logging.rs:50:5:50:21 | format_args | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | format_args | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | let ... = ... | 50 | LetStmt |  |
+| test_logging.rs:50:5:50:21 | loc | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | loc | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | log | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | log | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | log | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | log | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | log | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | log | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | IdentPat |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | IdentPath |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | Name |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | lvl | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | max_level | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | max_level | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | module_path | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | module_path | 50 | NameRef |  |
+| test_logging.rs:50:5:50:21 | module_path | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:21 | module_path | 50 | PathSegment |  |
+| test_logging.rs:50:5:50:22 | ExprStmt | 50 | ExprStmt |  |
+| test_logging.rs:50:11:50:21 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:12:50:20 | "message" | 50 | LiteralExpr |  |
+| test_logging.rs:50:12:50:20 | ...::format_args!... | 50 | MacroCall |  |
+| test_logging.rs:50:12:50:20 | ...::log!... | 50 | MacroCall |  |
+| test_logging.rs:50:12:50:20 | ...::log!... | 50 | MacroCall |  |
+| test_logging.rs:50:12:50:20 | ...::log(...) | 50 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:50:12:50:20 | ArgList | 50 | ArgList |  |
+| test_logging.rs:50:12:50:20 | ExprStmt | 50 | ExprStmt |  |
+| test_logging.rs:50:12:50:20 | FormatArgsExpr | 50 | FormatArgsExpr |  |
+| test_logging.rs:50:12:50:20 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:12:50:20 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:12:50:20 | MacroExpr | 50 | MacroExpr |  |
+| test_logging.rs:50:12:50:20 | MacroStmts | 50 | MacroStmts |  |
+| test_logging.rs:50:12:50:20 | MacroStmts | 50 | MacroStmts |  |
+| test_logging.rs:50:12:50:20 | MacroStmts | 50 | MacroStmts |  |
+| test_logging.rs:50:12:50:20 | StmtList | 50 | StmtList |  |
+| test_logging.rs:50:12:50:20 | StmtList | 50 | StmtList |  |
+| test_logging.rs:50:12:50:20 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:12:50:20 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:12:50:20 | TokenTree | 50 | TokenTree |  |
+| test_logging.rs:50:12:50:20 | if ... {...} | 50 | IfExpr |  |
+| test_logging.rs:50:12:50:20 | { ... } | 50 | BlockExpr |  |
+| test_logging.rs:50:12:50:20 | { ... } | 50 | BlockExpr |  |
+| test_logging.rs:51:5:51:9 | debug | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:9 | debug | 51 | NameRef |  |
+| test_logging.rs:51:5:51:9 | debug | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | "module::path" | 51 | LiteralExpr |  |
+| test_logging.rs:51:5:51:36 | "module::path" | 51 | LiteralExpr |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | $crate | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | &... | 51 | RefExpr |  |
+| test_logging.rs:51:5:51:36 | (...) | 51 | ParenExpr |  |
+| test_logging.rs:51:5:51:36 | (...::Debug) | 51 | ParenExpr |  |
+| test_logging.rs:51:5:51:36 | ... && ... | 51 | BinaryExpr |  |
+| test_logging.rs:51:5:51:36 | ... <= ... | 51 | BinaryExpr |  |
+| test_logging.rs:51:5:51:36 | ... <= ... | 51 | BinaryExpr |  |
+| test_logging.rs:51:5:51:36 | ...::Debug | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::Debug | 51 | PathExpr |  |
+| test_logging.rs:51:5:51:36 | ...::Level | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::STATIC_MAX_LEVEL | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::STATIC_MAX_LEVEL | 51 | PathExpr |  |
+| test_logging.rs:51:5:51:36 | ...::__private_api | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::__private_api | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::__private_api | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::__private_api | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::__private_api | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::format_args | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::loc | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::loc | 51 | PathExpr |  |
+| test_logging.rs:51:5:51:36 | ...::loc(...) | 51 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:51:5:51:36 | ...::log | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::log | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::log | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::log | 51 | PathExpr |  |
+| test_logging.rs:51:5:51:36 | ...::max_level | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::max_level | 51 | PathExpr |  |
+| test_logging.rs:51:5:51:36 | ...::max_level(...) | 51 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:51:5:51:36 | ...::module_path | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::module_path | 51 | Path |  |
+| test_logging.rs:51:5:51:36 | ...::module_path!... | 51 | MacroCall |  |
+| test_logging.rs:51:5:51:36 | ...::module_path!... | 51 | MacroCall |  |
+| test_logging.rs:51:5:51:36 | ArgList | 51 | ArgList |  |
+| test_logging.rs:51:5:51:36 | ArgList | 51 | ArgList |  |
+| test_logging.rs:51:5:51:36 | Debug | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | Debug | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | Level | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | Level | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:5:51:36 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:5:51:36 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:5:51:36 | STATIC_MAX_LEVEL | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | STATIC_MAX_LEVEL | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:5:51:36 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:5:51:36 | TupleExpr | 51 | TupleExpr |  |
+| test_logging.rs:51:5:51:36 | TupleExpr | 51 | TupleExpr |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | __private_api | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | debug!... | 51 | MacroCall |  |
+| test_logging.rs:51:5:51:36 | format_args | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | format_args | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | let ... = ... | 51 | LetStmt |  |
+| test_logging.rs:51:5:51:36 | loc | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | loc | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | log | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | log | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | log | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | log | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | log | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | log | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | IdentPat |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | IdentPath |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | Name |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | lvl | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | max_level | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | max_level | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | module_path | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | module_path | 51 | NameRef |  |
+| test_logging.rs:51:5:51:36 | module_path | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:36 | module_path | 51 | PathSegment |  |
+| test_logging.rs:51:5:51:37 | ExprStmt | 51 | ExprStmt |  |
+| test_logging.rs:51:11:51:36 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:12:51:25 | "message = {}" | 51 | LiteralExpr |  |
+| test_logging.rs:51:12:51:35 | ...::format_args!... | 51 | MacroCall |  |
+| test_logging.rs:51:12:51:35 | ...::log!... | 51 | MacroCall |  |
+| test_logging.rs:51:12:51:35 | ...::log!... | 51 | MacroCall |  |
+| test_logging.rs:51:12:51:35 | ...::log(...) | 51 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:51:12:51:35 | ArgList | 51 | ArgList |  |
+| test_logging.rs:51:12:51:35 | ExprStmt | 51 | ExprStmt |  |
+| test_logging.rs:51:12:51:35 | FormatArgsExpr | 51 | FormatArgsExpr |  |
+| test_logging.rs:51:12:51:35 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:12:51:35 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:12:51:35 | MacroExpr | 51 | MacroExpr |  |
+| test_logging.rs:51:12:51:35 | MacroStmts | 51 | MacroStmts |  |
+| test_logging.rs:51:12:51:35 | MacroStmts | 51 | MacroStmts |  |
+| test_logging.rs:51:12:51:35 | MacroStmts | 51 | MacroStmts |  |
+| test_logging.rs:51:12:51:35 | StmtList | 51 | StmtList |  |
+| test_logging.rs:51:12:51:35 | StmtList | 51 | StmtList |  |
+| test_logging.rs:51:12:51:35 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:12:51:35 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:12:51:35 | TokenTree | 51 | TokenTree |  |
+| test_logging.rs:51:12:51:35 | if ... {...} | 51 | IfExpr |  |
+| test_logging.rs:51:12:51:35 | { ... } | 51 | BlockExpr |  |
+| test_logging.rs:51:12:51:35 | { ... } | 51 | BlockExpr |  |
+| test_logging.rs:51:23:51:24 | {} | 51 | FormatSynthLocationImpl |  |
+| test_logging.rs:51:28:51:35 | FormatArgsArg | 51 | FormatArgsArg |  |
+| test_logging.rs:51:28:51:35 | harmless | 51 | IdentPath |  |
+| test_logging.rs:51:28:51:35 | harmless | 51 | NameRef |  |
+| test_logging.rs:51:28:51:35 | harmless | 51 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:51:28:51:35 | harmless | 51 | PathSegment |  |
+| test_logging.rs:52:5:52:9 | debug | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:9 | debug | 52 | NameRef |  |
+| test_logging.rs:52:5:52:9 | debug | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | "module::path" | 52 | LiteralExpr |  |
+| test_logging.rs:52:5:52:36 | "module::path" | 52 | LiteralExpr |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | $crate | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | &... | 52 | RefExpr |  |
+| test_logging.rs:52:5:52:36 | (...) | 52 | ParenExpr |  |
+| test_logging.rs:52:5:52:36 | (...::Debug) | 52 | ParenExpr |  |
+| test_logging.rs:52:5:52:36 | ... && ... | 52 | BinaryExpr |  |
+| test_logging.rs:52:5:52:36 | ... <= ... | 52 | BinaryExpr |  |
+| test_logging.rs:52:5:52:36 | ... <= ... | 52 | BinaryExpr |  |
+| test_logging.rs:52:5:52:36 | ...::Debug | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::Debug | 52 | PathExpr |  |
+| test_logging.rs:52:5:52:36 | ...::Level | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::STATIC_MAX_LEVEL | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::STATIC_MAX_LEVEL | 52 | PathExpr |  |
+| test_logging.rs:52:5:52:36 | ...::__private_api | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::__private_api | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::__private_api | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::__private_api | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::__private_api | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::format_args | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::loc | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::loc | 52 | PathExpr |  |
+| test_logging.rs:52:5:52:36 | ...::loc(...) | 52 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:52:5:52:36 | ...::log | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::log | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::log | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::log | 52 | PathExpr |  |
+| test_logging.rs:52:5:52:36 | ...::max_level | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::max_level | 52 | PathExpr |  |
+| test_logging.rs:52:5:52:36 | ...::max_level(...) | 52 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:52:5:52:36 | ...::module_path | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::module_path | 52 | Path |  |
+| test_logging.rs:52:5:52:36 | ...::module_path!... | 52 | MacroCall |  |
+| test_logging.rs:52:5:52:36 | ...::module_path!... | 52 | MacroCall |  |
+| test_logging.rs:52:5:52:36 | ArgList | 52 | ArgList |  |
+| test_logging.rs:52:5:52:36 | ArgList | 52 | ArgList |  |
+| test_logging.rs:52:5:52:36 | Debug | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | Debug | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | Level | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | Level | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:5:52:36 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:5:52:36 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:5:52:36 | STATIC_MAX_LEVEL | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | STATIC_MAX_LEVEL | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:5:52:36 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:5:52:36 | TupleExpr | 52 | TupleExpr |  |
+| test_logging.rs:52:5:52:36 | TupleExpr | 52 | TupleExpr |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | __private_api | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | debug!... | 52 | MacroCall |  |
+| test_logging.rs:52:5:52:36 | format_args | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | format_args | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | let ... = ... | 52 | LetStmt |  |
+| test_logging.rs:52:5:52:36 | loc | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | loc | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | log | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | log | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | log | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | log | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | log | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | log | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | IdentPat |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | IdentPath |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | Name |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | lvl | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | max_level | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | max_level | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | module_path | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | module_path | 52 | NameRef |  |
+| test_logging.rs:52:5:52:36 | module_path | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:36 | module_path | 52 | PathSegment |  |
+| test_logging.rs:52:5:52:37 | ExprStmt | 52 | ExprStmt |  |
+| test_logging.rs:52:11:52:36 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:12:52:25 | "message = {}" | 52 | LiteralExpr |  |
+| test_logging.rs:52:12:52:35 | ...::format_args!... | 52 | MacroCall |  |
+| test_logging.rs:52:12:52:35 | ...::log!... | 52 | MacroCall |  |
+| test_logging.rs:52:12:52:35 | ...::log!... | 52 | MacroCall |  |
+| test_logging.rs:52:12:52:35 | ...::log(...) | 52 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:52:12:52:35 | ArgList | 52 | ArgList |  |
+| test_logging.rs:52:12:52:35 | ExprStmt | 52 | ExprStmt |  |
+| test_logging.rs:52:12:52:35 | FormatArgsExpr | 52 | FormatArgsExpr |  |
+| test_logging.rs:52:12:52:35 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:12:52:35 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:12:52:35 | MacroExpr | 52 | MacroExpr |  |
+| test_logging.rs:52:12:52:35 | MacroStmts | 52 | MacroStmts |  |
+| test_logging.rs:52:12:52:35 | MacroStmts | 52 | MacroStmts |  |
+| test_logging.rs:52:12:52:35 | MacroStmts | 52 | MacroStmts |  |
+| test_logging.rs:52:12:52:35 | StmtList | 52 | StmtList |  |
+| test_logging.rs:52:12:52:35 | StmtList | 52 | StmtList |  |
+| test_logging.rs:52:12:52:35 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:12:52:35 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:12:52:35 | TokenTree | 52 | TokenTree |  |
+| test_logging.rs:52:12:52:35 | if ... {...} | 52 | IfExpr |  |
+| test_logging.rs:52:12:52:35 | { ... } | 52 | BlockExpr |  |
+| test_logging.rs:52:12:52:35 | { ... } | 52 | BlockExpr |  |
+| test_logging.rs:52:23:52:24 | {} | 52 | FormatSynthLocationImpl |  |
+| test_logging.rs:52:28:52:35 | FormatArgsArg | 52 | FormatArgsArg |  |
+| test_logging.rs:52:28:52:35 | password | 52 | IdentPath |  |
+| test_logging.rs:52:28:52:35 | password | 52 | NameRef |  |
+| test_logging.rs:52:28:52:35 | password | 52 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:52:28:52:35 | password | 52 | PathSegment |  |
+| test_logging.rs:52:39:52:72 | //... | 52 | Comment |  |
+| test_logging.rs:53:5:53:9 | debug | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:9 | debug | 53 | NameRef |  |
+| test_logging.rs:53:5:53:9 | debug | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | "module::path" | 53 | LiteralExpr |  |
+| test_logging.rs:53:5:53:46 | "module::path" | 53 | LiteralExpr |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | $crate | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | &... | 53 | RefExpr |  |
+| test_logging.rs:53:5:53:46 | (...) | 53 | ParenExpr |  |
+| test_logging.rs:53:5:53:46 | (...::Debug) | 53 | ParenExpr |  |
+| test_logging.rs:53:5:53:46 | ... && ... | 53 | BinaryExpr |  |
+| test_logging.rs:53:5:53:46 | ... <= ... | 53 | BinaryExpr |  |
+| test_logging.rs:53:5:53:46 | ... <= ... | 53 | BinaryExpr |  |
+| test_logging.rs:53:5:53:46 | ...::Debug | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::Debug | 53 | PathExpr |  |
+| test_logging.rs:53:5:53:46 | ...::Level | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::STATIC_MAX_LEVEL | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::STATIC_MAX_LEVEL | 53 | PathExpr |  |
+| test_logging.rs:53:5:53:46 | ...::__private_api | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::__private_api | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::__private_api | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::__private_api | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::__private_api | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::format_args | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::loc | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::loc | 53 | PathExpr |  |
+| test_logging.rs:53:5:53:46 | ...::loc(...) | 53 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:53:5:53:46 | ...::log | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::log | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::log | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::log | 53 | PathExpr |  |
+| test_logging.rs:53:5:53:46 | ...::max_level | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::max_level | 53 | PathExpr |  |
+| test_logging.rs:53:5:53:46 | ...::max_level(...) | 53 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:53:5:53:46 | ...::module_path | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::module_path | 53 | Path |  |
+| test_logging.rs:53:5:53:46 | ...::module_path!... | 53 | MacroCall |  |
+| test_logging.rs:53:5:53:46 | ...::module_path!... | 53 | MacroCall |  |
+| test_logging.rs:53:5:53:46 | ArgList | 53 | ArgList |  |
+| test_logging.rs:53:5:53:46 | ArgList | 53 | ArgList |  |
+| test_logging.rs:53:5:53:46 | Debug | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | Debug | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | Level | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | Level | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:5:53:46 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:5:53:46 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:5:53:46 | STATIC_MAX_LEVEL | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | STATIC_MAX_LEVEL | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:5:53:46 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:5:53:46 | TupleExpr | 53 | TupleExpr |  |
+| test_logging.rs:53:5:53:46 | TupleExpr | 53 | TupleExpr |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | __private_api | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | debug!... | 53 | MacroCall |  |
+| test_logging.rs:53:5:53:46 | format_args | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | format_args | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | let ... = ... | 53 | LetStmt |  |
+| test_logging.rs:53:5:53:46 | loc | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | loc | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | log | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | log | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | log | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | log | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | log | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | log | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | IdentPat |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | IdentPath |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | Name |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | lvl | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | max_level | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | max_level | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | module_path | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | module_path | 53 | NameRef |  |
+| test_logging.rs:53:5:53:46 | module_path | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:46 | module_path | 53 | PathSegment |  |
+| test_logging.rs:53:5:53:47 | ExprStmt | 53 | ExprStmt |  |
+| test_logging.rs:53:11:53:46 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:12:53:25 | "message = {}" | 53 | LiteralExpr |  |
+| test_logging.rs:53:12:53:45 | ...::format_args!... | 53 | MacroCall |  |
+| test_logging.rs:53:12:53:45 | ...::log!... | 53 | MacroCall |  |
+| test_logging.rs:53:12:53:45 | ...::log!... | 53 | MacroCall |  |
+| test_logging.rs:53:12:53:45 | ...::log(...) | 53 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:53:12:53:45 | ArgList | 53 | ArgList |  |
+| test_logging.rs:53:12:53:45 | ExprStmt | 53 | ExprStmt |  |
+| test_logging.rs:53:12:53:45 | FormatArgsExpr | 53 | FormatArgsExpr |  |
+| test_logging.rs:53:12:53:45 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:12:53:45 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:12:53:45 | MacroExpr | 53 | MacroExpr |  |
+| test_logging.rs:53:12:53:45 | MacroStmts | 53 | MacroStmts |  |
+| test_logging.rs:53:12:53:45 | MacroStmts | 53 | MacroStmts |  |
+| test_logging.rs:53:12:53:45 | MacroStmts | 53 | MacroStmts |  |
+| test_logging.rs:53:12:53:45 | StmtList | 53 | StmtList |  |
+| test_logging.rs:53:12:53:45 | StmtList | 53 | StmtList |  |
+| test_logging.rs:53:12:53:45 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:12:53:45 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:12:53:45 | TokenTree | 53 | TokenTree |  |
+| test_logging.rs:53:12:53:45 | if ... {...} | 53 | IfExpr |  |
+| test_logging.rs:53:12:53:45 | { ... } | 53 | BlockExpr |  |
+| test_logging.rs:53:12:53:45 | { ... } | 53 | BlockExpr |  |
+| test_logging.rs:53:23:53:24 | {} | 53 | FormatSynthLocationImpl |  |
+| test_logging.rs:53:28:53:45 | FormatArgsArg | 53 | FormatArgsArg |  |
+| test_logging.rs:53:28:53:45 | encrypted_password | 53 | IdentPath |  |
+| test_logging.rs:53:28:53:45 | encrypted_password | 53 | NameRef |  |
+| test_logging.rs:53:28:53:45 | encrypted_password | 53 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:53:28:53:45 | encrypted_password | 53 | PathSegment |  |
+| test_logging.rs:54:5:54:9 | debug | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:9 | debug | 54 | NameRef |  |
+| test_logging.rs:54:5:54:9 | debug | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | "module::path" | 54 | LiteralExpr |  |
+| test_logging.rs:54:5:54:49 | "module::path" | 54 | LiteralExpr |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | $crate | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | &... | 54 | RefExpr |  |
+| test_logging.rs:54:5:54:49 | (...) | 54 | ParenExpr |  |
+| test_logging.rs:54:5:54:49 | (...::Debug) | 54 | ParenExpr |  |
+| test_logging.rs:54:5:54:49 | ... && ... | 54 | BinaryExpr |  |
+| test_logging.rs:54:5:54:49 | ... <= ... | 54 | BinaryExpr |  |
+| test_logging.rs:54:5:54:49 | ... <= ... | 54 | BinaryExpr |  |
+| test_logging.rs:54:5:54:49 | ...::Debug | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::Debug | 54 | PathExpr |  |
+| test_logging.rs:54:5:54:49 | ...::Level | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::STATIC_MAX_LEVEL | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::STATIC_MAX_LEVEL | 54 | PathExpr |  |
+| test_logging.rs:54:5:54:49 | ...::__private_api | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::__private_api | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::__private_api | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::__private_api | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::__private_api | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::format_args | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::loc | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::loc | 54 | PathExpr |  |
+| test_logging.rs:54:5:54:49 | ...::loc(...) | 54 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:54:5:54:49 | ...::log | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::log | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::log | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::log | 54 | PathExpr |  |
+| test_logging.rs:54:5:54:49 | ...::max_level | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::max_level | 54 | PathExpr |  |
+| test_logging.rs:54:5:54:49 | ...::max_level(...) | 54 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:54:5:54:49 | ...::module_path | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::module_path | 54 | Path |  |
+| test_logging.rs:54:5:54:49 | ...::module_path!... | 54 | MacroCall |  |
+| test_logging.rs:54:5:54:49 | ...::module_path!... | 54 | MacroCall |  |
+| test_logging.rs:54:5:54:49 | ArgList | 54 | ArgList |  |
+| test_logging.rs:54:5:54:49 | ArgList | 54 | ArgList |  |
+| test_logging.rs:54:5:54:49 | Debug | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | Debug | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | Level | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | Level | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:5:54:49 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:5:54:49 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:5:54:49 | STATIC_MAX_LEVEL | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | STATIC_MAX_LEVEL | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:5:54:49 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:5:54:49 | TupleExpr | 54 | TupleExpr |  |
+| test_logging.rs:54:5:54:49 | TupleExpr | 54 | TupleExpr |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | __private_api | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | debug!... | 54 | MacroCall |  |
+| test_logging.rs:54:5:54:49 | format_args | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | format_args | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | let ... = ... | 54 | LetStmt |  |
+| test_logging.rs:54:5:54:49 | loc | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | loc | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | log | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | log | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | log | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | log | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | log | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | log | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | IdentPat |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | IdentPath |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | Name |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | lvl | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | max_level | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | max_level | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | module_path | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | module_path | 54 | NameRef |  |
+| test_logging.rs:54:5:54:49 | module_path | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:49 | module_path | 54 | PathSegment |  |
+| test_logging.rs:54:5:54:50 | ExprStmt | 54 | ExprStmt |  |
+| test_logging.rs:54:11:54:49 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:12:54:28 | "message = {} {}" | 54 | LiteralExpr |  |
+| test_logging.rs:54:12:54:48 | ...::format_args!... | 54 | MacroCall |  |
+| test_logging.rs:54:12:54:48 | ...::log!... | 54 | MacroCall |  |
+| test_logging.rs:54:12:54:48 | ...::log!... | 54 | MacroCall |  |
+| test_logging.rs:54:12:54:48 | ...::log(...) | 54 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:54:12:54:48 | ArgList | 54 | ArgList |  |
+| test_logging.rs:54:12:54:48 | ExprStmt | 54 | ExprStmt |  |
+| test_logging.rs:54:12:54:48 | FormatArgsExpr | 54 | FormatArgsExpr |  |
+| test_logging.rs:54:12:54:48 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:12:54:48 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:12:54:48 | MacroExpr | 54 | MacroExpr |  |
+| test_logging.rs:54:12:54:48 | MacroStmts | 54 | MacroStmts |  |
+| test_logging.rs:54:12:54:48 | MacroStmts | 54 | MacroStmts |  |
+| test_logging.rs:54:12:54:48 | MacroStmts | 54 | MacroStmts |  |
+| test_logging.rs:54:12:54:48 | StmtList | 54 | StmtList |  |
+| test_logging.rs:54:12:54:48 | StmtList | 54 | StmtList |  |
+| test_logging.rs:54:12:54:48 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:12:54:48 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:12:54:48 | TokenTree | 54 | TokenTree |  |
+| test_logging.rs:54:12:54:48 | if ... {...} | 54 | IfExpr |  |
+| test_logging.rs:54:12:54:48 | { ... } | 54 | BlockExpr |  |
+| test_logging.rs:54:12:54:48 | { ... } | 54 | BlockExpr |  |
+| test_logging.rs:54:23:54:24 | {} | 54 | FormatSynthLocationImpl |  |
+| test_logging.rs:54:26:54:27 | {} | 54 | FormatSynthLocationImpl |  |
+| test_logging.rs:54:31:54:38 | FormatArgsArg | 54 | FormatArgsArg |  |
+| test_logging.rs:54:31:54:38 | harmless | 54 | IdentPath |  |
+| test_logging.rs:54:31:54:38 | harmless | 54 | NameRef |  |
+| test_logging.rs:54:31:54:38 | harmless | 54 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:54:31:54:38 | harmless | 54 | PathSegment |  |
+| test_logging.rs:54:41:54:48 | FormatArgsArg | 54 | FormatArgsArg |  |
+| test_logging.rs:54:41:54:48 | password | 54 | IdentPath |  |
+| test_logging.rs:54:41:54:48 | password | 54 | NameRef |  |
+| test_logging.rs:54:41:54:48 | password | 54 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:54:41:54:48 | password | 54 | PathSegment |  |
+| test_logging.rs:54:52:54:85 | //... | 54 | Comment |  |
+| test_logging.rs:55:5:55:9 | debug | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:9 | debug | 55 | NameRef |  |
+| test_logging.rs:55:5:55:9 | debug | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | "module::path" | 55 | LiteralExpr |  |
+| test_logging.rs:55:5:55:34 | "module::path" | 55 | LiteralExpr |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | $crate | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | &... | 55 | RefExpr |  |
+| test_logging.rs:55:5:55:34 | (...) | 55 | ParenExpr |  |
+| test_logging.rs:55:5:55:34 | (...::Debug) | 55 | ParenExpr |  |
+| test_logging.rs:55:5:55:34 | ... && ... | 55 | BinaryExpr |  |
+| test_logging.rs:55:5:55:34 | ... <= ... | 55 | BinaryExpr |  |
+| test_logging.rs:55:5:55:34 | ... <= ... | 55 | BinaryExpr |  |
+| test_logging.rs:55:5:55:34 | ...::Debug | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::Debug | 55 | PathExpr |  |
+| test_logging.rs:55:5:55:34 | ...::Level | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::STATIC_MAX_LEVEL | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::STATIC_MAX_LEVEL | 55 | PathExpr |  |
+| test_logging.rs:55:5:55:34 | ...::__private_api | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::__private_api | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::__private_api | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::__private_api | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::__private_api | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::format_args | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::loc | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::loc | 55 | PathExpr |  |
+| test_logging.rs:55:5:55:34 | ...::loc(...) | 55 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:55:5:55:34 | ...::log | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::log | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::log | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::log | 55 | PathExpr |  |
+| test_logging.rs:55:5:55:34 | ...::max_level | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::max_level | 55 | PathExpr |  |
+| test_logging.rs:55:5:55:34 | ...::max_level(...) | 55 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:55:5:55:34 | ...::module_path | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::module_path | 55 | Path |  |
+| test_logging.rs:55:5:55:34 | ...::module_path!... | 55 | MacroCall |  |
+| test_logging.rs:55:5:55:34 | ...::module_path!... | 55 | MacroCall |  |
+| test_logging.rs:55:5:55:34 | ArgList | 55 | ArgList |  |
+| test_logging.rs:55:5:55:34 | ArgList | 55 | ArgList |  |
+| test_logging.rs:55:5:55:34 | Debug | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | Debug | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | Level | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | Level | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:5:55:34 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:5:55:34 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:5:55:34 | STATIC_MAX_LEVEL | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | STATIC_MAX_LEVEL | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:5:55:34 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:5:55:34 | TupleExpr | 55 | TupleExpr |  |
+| test_logging.rs:55:5:55:34 | TupleExpr | 55 | TupleExpr |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | __private_api | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | debug!... | 55 | MacroCall |  |
+| test_logging.rs:55:5:55:34 | format_args | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | format_args | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | let ... = ... | 55 | LetStmt |  |
+| test_logging.rs:55:5:55:34 | loc | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | loc | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | log | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | log | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | log | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | log | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | log | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | log | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | IdentPat |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | IdentPath |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | Name |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | lvl | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | max_level | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | max_level | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | module_path | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | module_path | 55 | NameRef |  |
+| test_logging.rs:55:5:55:34 | module_path | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:34 | module_path | 55 | PathSegment |  |
+| test_logging.rs:55:5:55:35 | ExprStmt | 55 | ExprStmt |  |
+| test_logging.rs:55:11:55:34 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:12:55:33 | "message = {harmless}" | 55 | LiteralExpr |  |
+| test_logging.rs:55:12:55:33 | ...::format_args!... | 55 | MacroCall |  |
+| test_logging.rs:55:12:55:33 | ...::log!... | 55 | MacroCall |  |
+| test_logging.rs:55:12:55:33 | ...::log!... | 55 | MacroCall |  |
+| test_logging.rs:55:12:55:33 | ...::log(...) | 55 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:55:12:55:33 | ArgList | 55 | ArgList |  |
+| test_logging.rs:55:12:55:33 | ExprStmt | 55 | ExprStmt |  |
+| test_logging.rs:55:12:55:33 | FormatArgsExpr | 55 | FormatArgsExpr |  |
+| test_logging.rs:55:12:55:33 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:12:55:33 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:12:55:33 | MacroExpr | 55 | MacroExpr |  |
+| test_logging.rs:55:12:55:33 | MacroStmts | 55 | MacroStmts |  |
+| test_logging.rs:55:12:55:33 | MacroStmts | 55 | MacroStmts |  |
+| test_logging.rs:55:12:55:33 | MacroStmts | 55 | MacroStmts |  |
+| test_logging.rs:55:12:55:33 | StmtList | 55 | StmtList |  |
+| test_logging.rs:55:12:55:33 | StmtList | 55 | StmtList |  |
+| test_logging.rs:55:12:55:33 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:12:55:33 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:12:55:33 | TokenTree | 55 | TokenTree |  |
+| test_logging.rs:55:12:55:33 | if ... {...} | 55 | IfExpr |  |
+| test_logging.rs:55:12:55:33 | { ... } | 55 | BlockExpr |  |
+| test_logging.rs:55:12:55:33 | { ... } | 55 | BlockExpr |  |
+| test_logging.rs:55:23:55:32 | {harmless} | 55 | FormatSynthLocationImpl |  |
+| test_logging.rs:55:24:55:31 | harmless | 55 | FormatSynthLocationImpl, NamedFormatArgument |  |
+| test_logging.rs:55:24:55:31 | harmless | 55 | FormatTemplateVariableAccess, VariableReadAccess |  |
+| test_logging.rs:56:5:56:9 | debug | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:9 | debug | 56 | NameRef |  |
+| test_logging.rs:56:5:56:9 | debug | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | "module::path" | 56 | LiteralExpr |  |
+| test_logging.rs:56:5:56:47 | "module::path" | 56 | LiteralExpr |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | $crate | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | &... | 56 | RefExpr |  |
+| test_logging.rs:56:5:56:47 | (...) | 56 | ParenExpr |  |
+| test_logging.rs:56:5:56:47 | (...::Debug) | 56 | ParenExpr |  |
+| test_logging.rs:56:5:56:47 | ... && ... | 56 | BinaryExpr |  |
+| test_logging.rs:56:5:56:47 | ... <= ... | 56 | BinaryExpr |  |
+| test_logging.rs:56:5:56:47 | ... <= ... | 56 | BinaryExpr |  |
+| test_logging.rs:56:5:56:47 | ...::Debug | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::Debug | 56 | PathExpr |  |
+| test_logging.rs:56:5:56:47 | ...::Level | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::STATIC_MAX_LEVEL | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::STATIC_MAX_LEVEL | 56 | PathExpr |  |
+| test_logging.rs:56:5:56:47 | ...::__private_api | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::__private_api | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::__private_api | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::__private_api | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::__private_api | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::format_args | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::loc | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::loc | 56 | PathExpr |  |
+| test_logging.rs:56:5:56:47 | ...::loc(...) | 56 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:56:5:56:47 | ...::log | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::log | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::log | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::log | 56 | PathExpr |  |
+| test_logging.rs:56:5:56:47 | ...::max_level | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::max_level | 56 | PathExpr |  |
+| test_logging.rs:56:5:56:47 | ...::max_level(...) | 56 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:56:5:56:47 | ...::module_path | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::module_path | 56 | Path |  |
+| test_logging.rs:56:5:56:47 | ...::module_path!... | 56 | MacroCall |  |
+| test_logging.rs:56:5:56:47 | ...::module_path!... | 56 | MacroCall |  |
+| test_logging.rs:56:5:56:47 | ArgList | 56 | ArgList |  |
+| test_logging.rs:56:5:56:47 | ArgList | 56 | ArgList |  |
+| test_logging.rs:56:5:56:47 | Debug | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | Debug | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | Level | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | Level | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:5:56:47 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:5:56:47 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:5:56:47 | STATIC_MAX_LEVEL | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | STATIC_MAX_LEVEL | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:5:56:47 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:5:56:47 | TupleExpr | 56 | TupleExpr |  |
+| test_logging.rs:56:5:56:47 | TupleExpr | 56 | TupleExpr |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | __private_api | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | debug!... | 56 | MacroCall |  |
+| test_logging.rs:56:5:56:47 | format_args | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | format_args | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | let ... = ... | 56 | LetStmt |  |
+| test_logging.rs:56:5:56:47 | loc | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | loc | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | log | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | log | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | log | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | log | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | log | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | log | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | IdentPat |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | IdentPath |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | Name |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | lvl | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | max_level | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | max_level | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | module_path | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | module_path | 56 | NameRef |  |
+| test_logging.rs:56:5:56:47 | module_path | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:47 | module_path | 56 | PathSegment |  |
+| test_logging.rs:56:5:56:48 | ExprStmt | 56 | ExprStmt |  |
+| test_logging.rs:56:11:56:47 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:12:56:36 | "message = {harmless} {}" | 56 | LiteralExpr |  |
+| test_logging.rs:56:12:56:46 | ...::format_args!... | 56 | MacroCall |  |
+| test_logging.rs:56:12:56:46 | ...::log!... | 56 | MacroCall |  |
+| test_logging.rs:56:12:56:46 | ...::log!... | 56 | MacroCall |  |
+| test_logging.rs:56:12:56:46 | ...::log(...) | 56 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:56:12:56:46 | ArgList | 56 | ArgList |  |
+| test_logging.rs:56:12:56:46 | ExprStmt | 56 | ExprStmt |  |
+| test_logging.rs:56:12:56:46 | FormatArgsExpr | 56 | FormatArgsExpr |  |
+| test_logging.rs:56:12:56:46 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:12:56:46 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:12:56:46 | MacroExpr | 56 | MacroExpr |  |
+| test_logging.rs:56:12:56:46 | MacroStmts | 56 | MacroStmts |  |
+| test_logging.rs:56:12:56:46 | MacroStmts | 56 | MacroStmts |  |
+| test_logging.rs:56:12:56:46 | MacroStmts | 56 | MacroStmts |  |
+| test_logging.rs:56:12:56:46 | StmtList | 56 | StmtList |  |
+| test_logging.rs:56:12:56:46 | StmtList | 56 | StmtList |  |
+| test_logging.rs:56:12:56:46 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:12:56:46 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:12:56:46 | TokenTree | 56 | TokenTree |  |
+| test_logging.rs:56:12:56:46 | if ... {...} | 56 | IfExpr |  |
+| test_logging.rs:56:12:56:46 | { ... } | 56 | BlockExpr |  |
+| test_logging.rs:56:12:56:46 | { ... } | 56 | BlockExpr |  |
+| test_logging.rs:56:23:56:32 | {harmless} | 56 | FormatSynthLocationImpl |  |
+| test_logging.rs:56:24:56:31 | harmless | 56 | FormatSynthLocationImpl, NamedFormatArgument |  |
+| test_logging.rs:56:24:56:31 | harmless | 56 | FormatTemplateVariableAccess, VariableReadAccess |  |
+| test_logging.rs:56:34:56:35 | {} | 56 | FormatSynthLocationImpl |  |
+| test_logging.rs:56:39:56:46 | FormatArgsArg | 56 | FormatArgsArg |  |
+| test_logging.rs:56:39:56:46 | password | 56 | IdentPath |  |
+| test_logging.rs:56:39:56:46 | password | 56 | NameRef |  |
+| test_logging.rs:56:39:56:46 | password | 56 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:56:39:56:46 | password | 56 | PathSegment |  |
+| test_logging.rs:56:50:56:83 | //... | 56 | Comment |  |
+| test_logging.rs:57:5:57:9 | debug | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:9 | debug | 57 | NameRef |  |
+| test_logging.rs:57:5:57:9 | debug | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | "module::path" | 57 | LiteralExpr |  |
+| test_logging.rs:57:5:57:34 | "module::path" | 57 | LiteralExpr |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | $crate | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | &... | 57 | RefExpr |  |
+| test_logging.rs:57:5:57:34 | (...) | 57 | ParenExpr |  |
+| test_logging.rs:57:5:57:34 | (...::Debug) | 57 | ParenExpr |  |
+| test_logging.rs:57:5:57:34 | ... && ... | 57 | BinaryExpr |  |
+| test_logging.rs:57:5:57:34 | ... <= ... | 57 | BinaryExpr |  |
+| test_logging.rs:57:5:57:34 | ... <= ... | 57 | BinaryExpr |  |
+| test_logging.rs:57:5:57:34 | ...::Debug | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::Debug | 57 | PathExpr |  |
+| test_logging.rs:57:5:57:34 | ...::Level | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::STATIC_MAX_LEVEL | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::STATIC_MAX_LEVEL | 57 | PathExpr |  |
+| test_logging.rs:57:5:57:34 | ...::__private_api | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::__private_api | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::__private_api | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::__private_api | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::__private_api | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::format_args | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::loc | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::loc | 57 | PathExpr |  |
+| test_logging.rs:57:5:57:34 | ...::loc(...) | 57 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:57:5:57:34 | ...::log | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::log | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::log | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::log | 57 | PathExpr |  |
+| test_logging.rs:57:5:57:34 | ...::max_level | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::max_level | 57 | PathExpr |  |
+| test_logging.rs:57:5:57:34 | ...::max_level(...) | 57 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:57:5:57:34 | ...::module_path | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::module_path | 57 | Path |  |
+| test_logging.rs:57:5:57:34 | ...::module_path!... | 57 | MacroCall |  |
+| test_logging.rs:57:5:57:34 | ...::module_path!... | 57 | MacroCall |  |
+| test_logging.rs:57:5:57:34 | ArgList | 57 | ArgList |  |
+| test_logging.rs:57:5:57:34 | ArgList | 57 | ArgList |  |
+| test_logging.rs:57:5:57:34 | Debug | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | Debug | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | Level | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | Level | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:5:57:34 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:5:57:34 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:5:57:34 | STATIC_MAX_LEVEL | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | STATIC_MAX_LEVEL | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:5:57:34 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:5:57:34 | TupleExpr | 57 | TupleExpr |  |
+| test_logging.rs:57:5:57:34 | TupleExpr | 57 | TupleExpr |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | __private_api | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | debug!... | 57 | MacroCall |  |
+| test_logging.rs:57:5:57:34 | format_args | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | format_args | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | let ... = ... | 57 | LetStmt |  |
+| test_logging.rs:57:5:57:34 | loc | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | loc | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | log | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | log | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | log | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | log | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | log | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | log | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | IdentPat |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | IdentPath |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | Name |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | lvl | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | max_level | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | max_level | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | module_path | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | module_path | 57 | NameRef |  |
+| test_logging.rs:57:5:57:34 | module_path | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:34 | module_path | 57 | PathSegment |  |
+| test_logging.rs:57:5:57:35 | ExprStmt | 57 | ExprStmt |  |
+| test_logging.rs:57:11:57:34 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:12:57:33 | "message = {password}" | 57 | LiteralExpr |  |
+| test_logging.rs:57:12:57:33 | ...::format_args!... | 57 | MacroCall |  |
+| test_logging.rs:57:12:57:33 | ...::log!... | 57 | MacroCall |  |
+| test_logging.rs:57:12:57:33 | ...::log!... | 57 | MacroCall |  |
+| test_logging.rs:57:12:57:33 | ...::log(...) | 57 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:57:12:57:33 | ArgList | 57 | ArgList |  |
+| test_logging.rs:57:12:57:33 | ExprStmt | 57 | ExprStmt |  |
+| test_logging.rs:57:12:57:33 | FormatArgsExpr | 57 | FormatArgsExpr |  |
+| test_logging.rs:57:12:57:33 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:12:57:33 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:12:57:33 | MacroExpr | 57 | MacroExpr |  |
+| test_logging.rs:57:12:57:33 | MacroStmts | 57 | MacroStmts |  |
+| test_logging.rs:57:12:57:33 | MacroStmts | 57 | MacroStmts |  |
+| test_logging.rs:57:12:57:33 | MacroStmts | 57 | MacroStmts |  |
+| test_logging.rs:57:12:57:33 | StmtList | 57 | StmtList |  |
+| test_logging.rs:57:12:57:33 | StmtList | 57 | StmtList |  |
+| test_logging.rs:57:12:57:33 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:12:57:33 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:12:57:33 | TokenTree | 57 | TokenTree |  |
+| test_logging.rs:57:12:57:33 | if ... {...} | 57 | IfExpr |  |
+| test_logging.rs:57:12:57:33 | { ... } | 57 | BlockExpr |  |
+| test_logging.rs:57:12:57:33 | { ... } | 57 | BlockExpr |  |
+| test_logging.rs:57:23:57:32 | {password} | 57 | FormatSynthLocationImpl |  |
+| test_logging.rs:57:24:57:31 | password | 57 | FormatSynthLocationImpl, NamedFormatArgument |  |
+| test_logging.rs:57:24:57:31 | password | 57 | FormatTemplateVariableAccess, VariableReadAccess |  |
+| test_logging.rs:57:37:57:70 | //... | 57 | Comment |  |
+| test_logging.rs:58:5:58:9 | debug | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:9 | debug | 58 | NameRef |  |
+| test_logging.rs:58:5:58:9 | debug | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | "module::path" | 58 | LiteralExpr |  |
+| test_logging.rs:58:5:58:36 | "module::path" | 58 | LiteralExpr |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | $crate | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | &... | 58 | RefExpr |  |
+| test_logging.rs:58:5:58:36 | (...) | 58 | ParenExpr |  |
+| test_logging.rs:58:5:58:36 | (...::Debug) | 58 | ParenExpr |  |
+| test_logging.rs:58:5:58:36 | ... && ... | 58 | BinaryExpr |  |
+| test_logging.rs:58:5:58:36 | ... <= ... | 58 | BinaryExpr |  |
+| test_logging.rs:58:5:58:36 | ... <= ... | 58 | BinaryExpr |  |
+| test_logging.rs:58:5:58:36 | ...::Debug | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::Debug | 58 | PathExpr |  |
+| test_logging.rs:58:5:58:36 | ...::Level | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::STATIC_MAX_LEVEL | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::STATIC_MAX_LEVEL | 58 | PathExpr |  |
+| test_logging.rs:58:5:58:36 | ...::__private_api | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::__private_api | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::__private_api | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::__private_api | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::__private_api | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::format_args | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::loc | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::loc | 58 | PathExpr |  |
+| test_logging.rs:58:5:58:36 | ...::loc(...) | 58 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:58:5:58:36 | ...::log | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::log | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::log | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::log | 58 | PathExpr |  |
+| test_logging.rs:58:5:58:36 | ...::max_level | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::max_level | 58 | PathExpr |  |
+| test_logging.rs:58:5:58:36 | ...::max_level(...) | 58 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:58:5:58:36 | ...::module_path | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::module_path | 58 | Path |  |
+| test_logging.rs:58:5:58:36 | ...::module_path!... | 58 | MacroCall |  |
+| test_logging.rs:58:5:58:36 | ...::module_path!... | 58 | MacroCall |  |
+| test_logging.rs:58:5:58:36 | ArgList | 58 | ArgList |  |
+| test_logging.rs:58:5:58:36 | ArgList | 58 | ArgList |  |
+| test_logging.rs:58:5:58:36 | Debug | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | Debug | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | Level | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | Level | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:5:58:36 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:5:58:36 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:5:58:36 | STATIC_MAX_LEVEL | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | STATIC_MAX_LEVEL | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:5:58:36 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:5:58:36 | TupleExpr | 58 | TupleExpr |  |
+| test_logging.rs:58:5:58:36 | TupleExpr | 58 | TupleExpr |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | __private_api | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | debug!... | 58 | MacroCall |  |
+| test_logging.rs:58:5:58:36 | format_args | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | format_args | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | let ... = ... | 58 | LetStmt |  |
+| test_logging.rs:58:5:58:36 | loc | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | loc | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | log | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | log | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | log | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | log | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | log | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | log | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | IdentPat |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | IdentPath |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | Name |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | lvl | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | max_level | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | max_level | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | module_path | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | module_path | 58 | NameRef |  |
+| test_logging.rs:58:5:58:36 | module_path | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:36 | module_path | 58 | PathSegment |  |
+| test_logging.rs:58:5:58:37 | ExprStmt | 58 | ExprStmt |  |
+| test_logging.rs:58:11:58:36 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:12:58:35 | "message = {password:?}" | 58 | LiteralExpr |  |
+| test_logging.rs:58:12:58:35 | ...::format_args!... | 58 | MacroCall |  |
+| test_logging.rs:58:12:58:35 | ...::log!... | 58 | MacroCall |  |
+| test_logging.rs:58:12:58:35 | ...::log!... | 58 | MacroCall |  |
+| test_logging.rs:58:12:58:35 | ...::log(...) | 58 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:58:12:58:35 | ArgList | 58 | ArgList |  |
+| test_logging.rs:58:12:58:35 | ExprStmt | 58 | ExprStmt |  |
+| test_logging.rs:58:12:58:35 | FormatArgsExpr | 58 | FormatArgsExpr |  |
+| test_logging.rs:58:12:58:35 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:12:58:35 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:12:58:35 | MacroExpr | 58 | MacroExpr |  |
+| test_logging.rs:58:12:58:35 | MacroStmts | 58 | MacroStmts |  |
+| test_logging.rs:58:12:58:35 | MacroStmts | 58 | MacroStmts |  |
+| test_logging.rs:58:12:58:35 | MacroStmts | 58 | MacroStmts |  |
+| test_logging.rs:58:12:58:35 | StmtList | 58 | StmtList |  |
+| test_logging.rs:58:12:58:35 | StmtList | 58 | StmtList |  |
+| test_logging.rs:58:12:58:35 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:12:58:35 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:12:58:35 | TokenTree | 58 | TokenTree |  |
+| test_logging.rs:58:12:58:35 | if ... {...} | 58 | IfExpr |  |
+| test_logging.rs:58:12:58:35 | { ... } | 58 | BlockExpr |  |
+| test_logging.rs:58:12:58:35 | { ... } | 58 | BlockExpr |  |
+| test_logging.rs:58:23:58:34 | {password:?} | 58 | FormatSynthLocationImpl |  |
+| test_logging.rs:58:24:58:31 | password | 58 | FormatSynthLocationImpl, NamedFormatArgument |  |
+| test_logging.rs:58:24:58:31 | password | 58 | FormatTemplateVariableAccess, VariableReadAccess |  |
+| test_logging.rs:58:39:58:72 | //... | 58 | Comment |  |
+| test_logging.rs:59:5:59:9 | debug | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:9 | debug | 59 | NameRef |  |
+| test_logging.rs:59:5:59:9 | debug | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | "module::path" | 59 | LiteralExpr |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | $crate | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | (...::Debug) | 59 | ParenExpr |  |
+| test_logging.rs:59:5:59:54 | ... && ... | 59 | BinaryExpr |  |
+| test_logging.rs:59:5:59:54 | ... <= ... | 59 | BinaryExpr |  |
+| test_logging.rs:59:5:59:54 | ... <= ... | 59 | BinaryExpr |  |
+| test_logging.rs:59:5:59:54 | ...::Debug | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::Debug | 59 | PathExpr |  |
+| test_logging.rs:59:5:59:54 | ...::Level | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::STATIC_MAX_LEVEL | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::STATIC_MAX_LEVEL | 59 | PathExpr |  |
+| test_logging.rs:59:5:59:54 | ...::__private_api | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::__private_api | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::__private_api | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::__private_api | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::format_args | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::loc | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::loc | 59 | PathExpr |  |
+| test_logging.rs:59:5:59:54 | ...::loc(...) | 59 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:59:5:59:54 | ...::log | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::log | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::log | 59 | PathExpr |  |
+| test_logging.rs:59:5:59:54 | ...::max_level | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::max_level | 59 | PathExpr |  |
+| test_logging.rs:59:5:59:54 | ...::max_level(...) | 59 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:59:5:59:54 | ...::module_path | 59 | Path |  |
+| test_logging.rs:59:5:59:54 | ...::module_path!... | 59 | MacroCall |  |
+| test_logging.rs:59:5:59:54 | ArgList | 59 | ArgList |  |
+| test_logging.rs:59:5:59:54 | ArgList | 59 | ArgList |  |
+| test_logging.rs:59:5:59:54 | Debug | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | Debug | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | Level | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | Level | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | MacroExpr | 59 | MacroExpr |  |
+| test_logging.rs:59:5:59:54 | MacroExpr | 59 | MacroExpr |  |
+| test_logging.rs:59:5:59:54 | STATIC_MAX_LEVEL | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | STATIC_MAX_LEVEL | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | TokenTree | 59 | TokenTree |  |
+| test_logging.rs:59:5:59:54 | TupleExpr | 59 | TupleExpr |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | __private_api | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | debug!... | 59 | MacroCall |  |
+| test_logging.rs:59:5:59:54 | format_args | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | format_args | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | let ... = ... | 59 | LetStmt |  |
+| test_logging.rs:59:5:59:54 | loc | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | loc | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | log | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | log | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | log | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | log | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | IdentPat |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | IdentPath |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | Name |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | lvl | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | max_level | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | max_level | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:54 | module_path | 59 | NameRef |  |
+| test_logging.rs:59:5:59:54 | module_path | 59 | PathSegment |  |
+| test_logging.rs:59:5:59:55 | ExprStmt | 59 | ExprStmt |  |
+| test_logging.rs:59:11:59:54 | TokenTree | 59 | TokenTree |  |
+| test_logging.rs:59:20:59:27 | "target" | 59 | LiteralExpr |  |
+| test_logging.rs:59:20:59:27 | &... | 59 | RefExpr |  |
+| test_logging.rs:59:20:59:27 | TupleExpr | 59 | TupleExpr |  |
+| test_logging.rs:59:20:59:53 | ...::log!... | 59 | MacroCall |  |
+| test_logging.rs:59:20:59:53 | ...::log(...) | 59 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:59:20:59:53 | ArgList | 59 | ArgList |  |
+| test_logging.rs:59:20:59:53 | ExprStmt | 59 | ExprStmt |  |
+| test_logging.rs:59:20:59:53 | MacroExpr | 59 | MacroExpr |  |
+| test_logging.rs:59:20:59:53 | MacroStmts | 59 | MacroStmts |  |
+| test_logging.rs:59:20:59:53 | MacroStmts | 59 | MacroStmts |  |
+| test_logging.rs:59:20:59:53 | StmtList | 59 | StmtList |  |
+| test_logging.rs:59:20:59:53 | StmtList | 59 | StmtList |  |
+| test_logging.rs:59:20:59:53 | TokenTree | 59 | TokenTree |  |
+| test_logging.rs:59:20:59:53 | if ... {...} | 59 | IfExpr |  |
+| test_logging.rs:59:20:59:53 | { ... } | 59 | BlockExpr |  |
+| test_logging.rs:59:20:59:53 | { ... } | 59 | BlockExpr |  |
+| test_logging.rs:59:30:59:43 | "message = {}" | 59 | LiteralExpr |  |
+| test_logging.rs:59:30:59:53 | ...::format_args!... | 59 | MacroCall |  |
+| test_logging.rs:59:30:59:53 | FormatArgsExpr | 59 | FormatArgsExpr |  |
+| test_logging.rs:59:30:59:53 | MacroExpr | 59 | MacroExpr |  |
+| test_logging.rs:59:30:59:53 | TokenTree | 59 | TokenTree |  |
+| test_logging.rs:59:41:59:42 | {} | 59 | FormatSynthLocationImpl |  |
+| test_logging.rs:59:46:59:53 | FormatArgsArg | 59 | FormatArgsArg |  |
+| test_logging.rs:59:46:59:53 | harmless | 59 | IdentPath |  |
+| test_logging.rs:59:46:59:53 | harmless | 59 | NameRef |  |
+| test_logging.rs:59:46:59:53 | harmless | 59 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:59:46:59:53 | harmless | 59 | PathSegment |  |
+| test_logging.rs:60:5:60:9 | debug | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:9 | debug | 60 | NameRef |  |
+| test_logging.rs:60:5:60:9 | debug | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | "module::path" | 60 | LiteralExpr |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | $crate | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | (...::Debug) | 60 | ParenExpr |  |
+| test_logging.rs:60:5:60:54 | ... && ... | 60 | BinaryExpr |  |
+| test_logging.rs:60:5:60:54 | ... <= ... | 60 | BinaryExpr |  |
+| test_logging.rs:60:5:60:54 | ... <= ... | 60 | BinaryExpr |  |
+| test_logging.rs:60:5:60:54 | ...::Debug | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::Debug | 60 | PathExpr |  |
+| test_logging.rs:60:5:60:54 | ...::Level | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::STATIC_MAX_LEVEL | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::STATIC_MAX_LEVEL | 60 | PathExpr |  |
+| test_logging.rs:60:5:60:54 | ...::__private_api | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::__private_api | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::__private_api | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::__private_api | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::format_args | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::loc | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::loc | 60 | PathExpr |  |
+| test_logging.rs:60:5:60:54 | ...::loc(...) | 60 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:60:5:60:54 | ...::log | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::log | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::log | 60 | PathExpr |  |
+| test_logging.rs:60:5:60:54 | ...::max_level | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::max_level | 60 | PathExpr |  |
+| test_logging.rs:60:5:60:54 | ...::max_level(...) | 60 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:60:5:60:54 | ...::module_path | 60 | Path |  |
+| test_logging.rs:60:5:60:54 | ...::module_path!... | 60 | MacroCall |  |
+| test_logging.rs:60:5:60:54 | ArgList | 60 | ArgList |  |
+| test_logging.rs:60:5:60:54 | ArgList | 60 | ArgList |  |
+| test_logging.rs:60:5:60:54 | Debug | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | Debug | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | Level | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | Level | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | MacroExpr | 60 | MacroExpr |  |
+| test_logging.rs:60:5:60:54 | MacroExpr | 60 | MacroExpr |  |
+| test_logging.rs:60:5:60:54 | STATIC_MAX_LEVEL | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | STATIC_MAX_LEVEL | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | TokenTree | 60 | TokenTree |  |
+| test_logging.rs:60:5:60:54 | TupleExpr | 60 | TupleExpr |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | __private_api | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | debug!... | 60 | MacroCall |  |
+| test_logging.rs:60:5:60:54 | format_args | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | format_args | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | let ... = ... | 60 | LetStmt |  |
+| test_logging.rs:60:5:60:54 | loc | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | loc | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | log | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | log | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | log | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | log | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | IdentPat |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | IdentPath |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | Name |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | lvl | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | max_level | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | max_level | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:54 | module_path | 60 | NameRef |  |
+| test_logging.rs:60:5:60:54 | module_path | 60 | PathSegment |  |
+| test_logging.rs:60:5:60:55 | ExprStmt | 60 | ExprStmt |  |
+| test_logging.rs:60:11:60:54 | TokenTree | 60 | TokenTree |  |
+| test_logging.rs:60:20:60:27 | "target" | 60 | LiteralExpr |  |
+| test_logging.rs:60:20:60:27 | &... | 60 | RefExpr |  |
+| test_logging.rs:60:20:60:27 | TupleExpr | 60 | TupleExpr |  |
+| test_logging.rs:60:20:60:53 | ...::log!... | 60 | MacroCall |  |
+| test_logging.rs:60:20:60:53 | ...::log(...) | 60 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:60:20:60:53 | ArgList | 60 | ArgList |  |
+| test_logging.rs:60:20:60:53 | ExprStmt | 60 | ExprStmt |  |
+| test_logging.rs:60:20:60:53 | MacroExpr | 60 | MacroExpr |  |
+| test_logging.rs:60:20:60:53 | MacroStmts | 60 | MacroStmts |  |
+| test_logging.rs:60:20:60:53 | MacroStmts | 60 | MacroStmts |  |
+| test_logging.rs:60:20:60:53 | StmtList | 60 | StmtList |  |
+| test_logging.rs:60:20:60:53 | StmtList | 60 | StmtList |  |
+| test_logging.rs:60:20:60:53 | TokenTree | 60 | TokenTree |  |
+| test_logging.rs:60:20:60:53 | if ... {...} | 60 | IfExpr |  |
+| test_logging.rs:60:20:60:53 | { ... } | 60 | BlockExpr |  |
+| test_logging.rs:60:20:60:53 | { ... } | 60 | BlockExpr |  |
+| test_logging.rs:60:30:60:43 | "message = {}" | 60 | LiteralExpr |  |
+| test_logging.rs:60:30:60:53 | ...::format_args!... | 60 | MacroCall |  |
+| test_logging.rs:60:30:60:53 | FormatArgsExpr | 60 | FormatArgsExpr |  |
+| test_logging.rs:60:30:60:53 | MacroExpr | 60 | MacroExpr |  |
+| test_logging.rs:60:30:60:53 | TokenTree | 60 | TokenTree |  |
+| test_logging.rs:60:41:60:42 | {} | 60 | FormatSynthLocationImpl |  |
+| test_logging.rs:60:46:60:53 | FormatArgsArg | 60 | FormatArgsArg |  |
+| test_logging.rs:60:46:60:53 | password | 60 | IdentPath |  |
+| test_logging.rs:60:46:60:53 | password | 60 | NameRef |  |
+| test_logging.rs:60:46:60:53 | password | 60 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:60:46:60:53 | password | 60 | PathSegment |  |
+| test_logging.rs:60:57:60:90 | //... | 60 | Comment |  |
+| test_logging.rs:61:5:61:9 | debug | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:9 | debug | 61 | NameRef |  |
+| test_logging.rs:61:5:61:9 | debug | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | "module::path" | 61 | LiteralExpr |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | $crate | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | (...::Debug) | 61 | ParenExpr |  |
+| test_logging.rs:61:5:61:55 | ... && ... | 61 | BinaryExpr |  |
+| test_logging.rs:61:5:61:55 | ... <= ... | 61 | BinaryExpr |  |
+| test_logging.rs:61:5:61:55 | ... <= ... | 61 | BinaryExpr |  |
+| test_logging.rs:61:5:61:55 | ...::Debug | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::Debug | 61 | PathExpr |  |
+| test_logging.rs:61:5:61:55 | ...::Level | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::STATIC_MAX_LEVEL | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::STATIC_MAX_LEVEL | 61 | PathExpr |  |
+| test_logging.rs:61:5:61:55 | ...::__private_api | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::__private_api | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::__private_api | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::__private_api | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::format_args | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::loc | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::loc | 61 | PathExpr |  |
+| test_logging.rs:61:5:61:55 | ...::loc(...) | 61 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:61:5:61:55 | ...::log | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::log | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::log | 61 | PathExpr |  |
+| test_logging.rs:61:5:61:55 | ...::max_level | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::max_level | 61 | PathExpr |  |
+| test_logging.rs:61:5:61:55 | ...::max_level(...) | 61 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:61:5:61:55 | ...::module_path | 61 | Path |  |
+| test_logging.rs:61:5:61:55 | ...::module_path!... | 61 | MacroCall |  |
+| test_logging.rs:61:5:61:55 | ArgList | 61 | ArgList |  |
+| test_logging.rs:61:5:61:55 | ArgList | 61 | ArgList |  |
+| test_logging.rs:61:5:61:55 | Debug | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | Debug | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | Level | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | Level | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | MacroExpr | 61 | MacroExpr |  |
+| test_logging.rs:61:5:61:55 | MacroExpr | 61 | MacroExpr |  |
+| test_logging.rs:61:5:61:55 | STATIC_MAX_LEVEL | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | STATIC_MAX_LEVEL | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | TokenTree | 61 | TokenTree |  |
+| test_logging.rs:61:5:61:55 | TupleExpr | 61 | TupleExpr |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | __private_api | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | debug!... | 61 | MacroCall |  |
+| test_logging.rs:61:5:61:55 | format_args | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | format_args | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | let ... = ... | 61 | LetStmt |  |
+| test_logging.rs:61:5:61:55 | loc | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | loc | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | log | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | log | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | log | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | log | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | IdentPat |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | IdentPath |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | Name |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | lvl | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | max_level | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | max_level | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:55 | module_path | 61 | NameRef |  |
+| test_logging.rs:61:5:61:55 | module_path | 61 | PathSegment |  |
+| test_logging.rs:61:5:61:56 | ExprStmt | 61 | ExprStmt |  |
+| test_logging.rs:61:11:61:55 | TokenTree | 61 | TokenTree |  |
+| test_logging.rs:61:20:61:28 | &... | 61 | RefExpr |  |
+| test_logging.rs:61:20:61:28 | &password | 61 | RefExpr |  |
+| test_logging.rs:61:20:61:28 | (...) | 61 | ParenExpr |  |
+| test_logging.rs:61:20:61:28 | TupleExpr | 61 | TupleExpr |  |
+| test_logging.rs:61:20:61:54 | ...::log!... | 61 | MacroCall |  |
+| test_logging.rs:61:20:61:54 | ...::log(...) | 61 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:61:20:61:54 | ArgList | 61 | ArgList |  |
+| test_logging.rs:61:20:61:54 | ExprStmt | 61 | ExprStmt |  |
+| test_logging.rs:61:20:61:54 | MacroExpr | 61 | MacroExpr |  |
+| test_logging.rs:61:20:61:54 | MacroStmts | 61 | MacroStmts |  |
+| test_logging.rs:61:20:61:54 | MacroStmts | 61 | MacroStmts |  |
+| test_logging.rs:61:20:61:54 | StmtList | 61 | StmtList |  |
+| test_logging.rs:61:20:61:54 | StmtList | 61 | StmtList |  |
+| test_logging.rs:61:20:61:54 | TokenTree | 61 | TokenTree |  |
+| test_logging.rs:61:20:61:54 | if ... {...} | 61 | IfExpr |  |
+| test_logging.rs:61:20:61:54 | { ... } | 61 | BlockExpr |  |
+| test_logging.rs:61:20:61:54 | { ... } | 61 | BlockExpr |  |
+| test_logging.rs:61:21:61:28 | password | 61 | IdentPath |  |
+| test_logging.rs:61:21:61:28 | password | 61 | NameRef |  |
+| test_logging.rs:61:21:61:28 | password | 61 | PathExpr, VariableAccess |  |
+| test_logging.rs:61:21:61:28 | password | 61 | PathSegment |  |
+| test_logging.rs:61:31:61:44 | "message = {}" | 61 | LiteralExpr |  |
+| test_logging.rs:61:31:61:54 | ...::format_args!... | 61 | MacroCall |  |
+| test_logging.rs:61:31:61:54 | FormatArgsExpr | 61 | FormatArgsExpr |  |
+| test_logging.rs:61:31:61:54 | MacroExpr | 61 | MacroExpr |  |
+| test_logging.rs:61:31:61:54 | TokenTree | 61 | TokenTree |  |
+| test_logging.rs:61:42:61:43 | {} | 61 | FormatSynthLocationImpl |  |
+| test_logging.rs:61:47:61:54 | FormatArgsArg | 61 | FormatArgsArg |  |
+| test_logging.rs:61:47:61:54 | harmless | 61 | IdentPath |  |
+| test_logging.rs:61:47:61:54 | harmless | 61 | NameRef |  |
+| test_logging.rs:61:47:61:54 | harmless | 61 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:61:47:61:54 | harmless | 61 | PathSegment |  |
+| test_logging.rs:61:58:61:91 | //... | 61 | Comment |  |
+| test_logging.rs:63:5:63:37 | //... | 63 | Comment |  |
+| test_logging.rs:64:5:64:7 | log | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:7 | log | 64 | NameRef |  |
+| test_logging.rs:64:5:64:7 | log | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | "module::path" | 64 | LiteralExpr |  |
+| test_logging.rs:64:5:64:48 | "module::path" | 64 | LiteralExpr |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | $crate | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | &... | 64 | RefExpr |  |
+| test_logging.rs:64:5:64:48 | (...) | 64 | ParenExpr |  |
+| test_logging.rs:64:5:64:48 | ... && ... | 64 | BinaryExpr |  |
+| test_logging.rs:64:5:64:48 | ... <= ... | 64 | BinaryExpr |  |
+| test_logging.rs:64:5:64:48 | ... <= ... | 64 | BinaryExpr |  |
+| test_logging.rs:64:5:64:48 | ...::STATIC_MAX_LEVEL | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::STATIC_MAX_LEVEL | 64 | PathExpr |  |
+| test_logging.rs:64:5:64:48 | ...::__private_api | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::__private_api | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::__private_api | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::__private_api | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::__private_api | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::format_args | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::loc | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::loc | 64 | PathExpr |  |
+| test_logging.rs:64:5:64:48 | ...::loc(...) | 64 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:64:5:64:48 | ...::log | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::log | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::log | 64 | PathExpr |  |
+| test_logging.rs:64:5:64:48 | ...::max_level | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::max_level | 64 | PathExpr |  |
+| test_logging.rs:64:5:64:48 | ...::max_level(...) | 64 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:64:5:64:48 | ...::module_path | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::module_path | 64 | Path |  |
+| test_logging.rs:64:5:64:48 | ...::module_path!... | 64 | MacroCall |  |
+| test_logging.rs:64:5:64:48 | ...::module_path!... | 64 | MacroCall |  |
+| test_logging.rs:64:5:64:48 | ArgList | 64 | ArgList |  |
+| test_logging.rs:64:5:64:48 | ArgList | 64 | ArgList |  |
+| test_logging.rs:64:5:64:48 | MacroExpr | 64 | MacroExpr |  |
+| test_logging.rs:64:5:64:48 | MacroExpr | 64 | MacroExpr |  |
+| test_logging.rs:64:5:64:48 | MacroExpr | 64 | MacroExpr |  |
+| test_logging.rs:64:5:64:48 | STATIC_MAX_LEVEL | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | STATIC_MAX_LEVEL | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | TokenTree | 64 | TokenTree |  |
+| test_logging.rs:64:5:64:48 | TokenTree | 64 | TokenTree |  |
+| test_logging.rs:64:5:64:48 | TupleExpr | 64 | TupleExpr |  |
+| test_logging.rs:64:5:64:48 | TupleExpr | 64 | TupleExpr |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | __private_api | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | format_args | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | format_args | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | loc | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | loc | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | log | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | log | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | log | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | log | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | log!... | 64 | MacroCall |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | IdentPat |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | IdentPath |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | Name |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | lvl | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | max_level | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | max_level | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | module_path | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | module_path | 64 | NameRef |  |
+| test_logging.rs:64:5:64:48 | module_path | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:48 | module_path | 64 | PathSegment |  |
+| test_logging.rs:64:5:64:49 | ExprStmt | 64 | ExprStmt |  |
+| test_logging.rs:64:9:64:48 | TokenTree | 64 | TokenTree |  |
+| test_logging.rs:64:10:64:14 | Level | 64 | IdentPath |  |
+| test_logging.rs:64:10:64:14 | Level | 64 | NameRef |  |
+| test_logging.rs:64:10:64:14 | Level | 64 | PathSegment |  |
+| test_logging.rs:64:10:64:21 | (...::Error) | 64 | ParenExpr |  |
+| test_logging.rs:64:10:64:21 | ...::Error | 64 | Path |  |
+| test_logging.rs:64:10:64:21 | ...::Error | 64 | PathExpr |  |
+| test_logging.rs:64:10:64:21 | let ... = ... | 64 | LetStmt |  |
+| test_logging.rs:64:10:64:47 | ...::log!... | 64 | MacroCall |  |
+| test_logging.rs:64:10:64:47 | MacroExpr | 64 | MacroExpr |  |
+| test_logging.rs:64:10:64:47 | MacroStmts | 64 | MacroStmts |  |
+| test_logging.rs:64:10:64:47 | MacroStmts | 64 | MacroStmts |  |
+| test_logging.rs:64:10:64:47 | StmtList | 64 | StmtList |  |
+| test_logging.rs:64:10:64:47 | TokenTree | 64 | TokenTree |  |
+| test_logging.rs:64:10:64:47 | { ... } | 64 | BlockExpr |  |
+| test_logging.rs:64:17:64:21 | Error | 64 | NameRef |  |
+| test_logging.rs:64:17:64:21 | Error | 64 | PathSegment |  |
+| test_logging.rs:64:24:64:37 | "message = {}" | 64 | LiteralExpr |  |
+| test_logging.rs:64:24:64:47 | ...::format_args!... | 64 | MacroCall |  |
+| test_logging.rs:64:24:64:47 | ...::log(...) | 64 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:64:24:64:47 | ArgList | 64 | ArgList |  |
+| test_logging.rs:64:24:64:47 | ExprStmt | 64 | ExprStmt |  |
+| test_logging.rs:64:24:64:47 | FormatArgsExpr | 64 | FormatArgsExpr |  |
+| test_logging.rs:64:24:64:47 | MacroExpr | 64 | MacroExpr |  |
+| test_logging.rs:64:24:64:47 | StmtList | 64 | StmtList |  |
+| test_logging.rs:64:24:64:47 | TokenTree | 64 | TokenTree |  |
+| test_logging.rs:64:24:64:47 | if ... {...} | 64 | IfExpr |  |
+| test_logging.rs:64:24:64:47 | { ... } | 64 | BlockExpr |  |
+| test_logging.rs:64:35:64:36 | {} | 64 | FormatSynthLocationImpl |  |
+| test_logging.rs:64:40:64:47 | FormatArgsArg | 64 | FormatArgsArg |  |
+| test_logging.rs:64:40:64:47 | harmless | 64 | IdentPath |  |
+| test_logging.rs:64:40:64:47 | harmless | 64 | NameRef |  |
+| test_logging.rs:64:40:64:47 | harmless | 64 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:64:40:64:47 | harmless | 64 | PathSegment |  |
+| test_logging.rs:65:5:65:7 | log | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:7 | log | 65 | NameRef |  |
+| test_logging.rs:65:5:65:7 | log | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | "module::path" | 65 | LiteralExpr |  |
+| test_logging.rs:65:5:65:48 | "module::path" | 65 | LiteralExpr |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | $crate | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | &... | 65 | RefExpr |  |
+| test_logging.rs:65:5:65:48 | (...) | 65 | ParenExpr |  |
+| test_logging.rs:65:5:65:48 | ... && ... | 65 | BinaryExpr |  |
+| test_logging.rs:65:5:65:48 | ... <= ... | 65 | BinaryExpr |  |
+| test_logging.rs:65:5:65:48 | ... <= ... | 65 | BinaryExpr |  |
+| test_logging.rs:65:5:65:48 | ...::STATIC_MAX_LEVEL | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::STATIC_MAX_LEVEL | 65 | PathExpr |  |
+| test_logging.rs:65:5:65:48 | ...::__private_api | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::__private_api | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::__private_api | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::__private_api | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::__private_api | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::format_args | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::loc | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::loc | 65 | PathExpr |  |
+| test_logging.rs:65:5:65:48 | ...::loc(...) | 65 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:65:5:65:48 | ...::log | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::log | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::log | 65 | PathExpr |  |
+| test_logging.rs:65:5:65:48 | ...::max_level | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::max_level | 65 | PathExpr |  |
+| test_logging.rs:65:5:65:48 | ...::max_level(...) | 65 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:65:5:65:48 | ...::module_path | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::module_path | 65 | Path |  |
+| test_logging.rs:65:5:65:48 | ...::module_path!... | 65 | MacroCall |  |
+| test_logging.rs:65:5:65:48 | ...::module_path!... | 65 | MacroCall |  |
+| test_logging.rs:65:5:65:48 | ArgList | 65 | ArgList |  |
+| test_logging.rs:65:5:65:48 | ArgList | 65 | ArgList |  |
+| test_logging.rs:65:5:65:48 | MacroExpr | 65 | MacroExpr |  |
+| test_logging.rs:65:5:65:48 | MacroExpr | 65 | MacroExpr |  |
+| test_logging.rs:65:5:65:48 | MacroExpr | 65 | MacroExpr |  |
+| test_logging.rs:65:5:65:48 | STATIC_MAX_LEVEL | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | STATIC_MAX_LEVEL | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | TokenTree | 65 | TokenTree |  |
+| test_logging.rs:65:5:65:48 | TokenTree | 65 | TokenTree |  |
+| test_logging.rs:65:5:65:48 | TupleExpr | 65 | TupleExpr |  |
+| test_logging.rs:65:5:65:48 | TupleExpr | 65 | TupleExpr |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | __private_api | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | format_args | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | format_args | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | loc | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | loc | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | log | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | log | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | log | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | log | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | log!... | 65 | MacroCall |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | IdentPat |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | IdentPath |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | Name |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | lvl | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | max_level | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | max_level | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | module_path | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | module_path | 65 | NameRef |  |
+| test_logging.rs:65:5:65:48 | module_path | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:48 | module_path | 65 | PathSegment |  |
+| test_logging.rs:65:5:65:49 | ExprStmt | 65 | ExprStmt |  |
+| test_logging.rs:65:9:65:48 | TokenTree | 65 | TokenTree |  |
+| test_logging.rs:65:10:65:14 | Level | 65 | IdentPath |  |
+| test_logging.rs:65:10:65:14 | Level | 65 | NameRef |  |
+| test_logging.rs:65:10:65:14 | Level | 65 | PathSegment |  |
+| test_logging.rs:65:10:65:21 | (...::Error) | 65 | ParenExpr |  |
+| test_logging.rs:65:10:65:21 | ...::Error | 65 | Path |  |
+| test_logging.rs:65:10:65:21 | ...::Error | 65 | PathExpr |  |
+| test_logging.rs:65:10:65:21 | let ... = ... | 65 | LetStmt |  |
+| test_logging.rs:65:10:65:47 | ...::log!... | 65 | MacroCall |  |
+| test_logging.rs:65:10:65:47 | MacroExpr | 65 | MacroExpr |  |
+| test_logging.rs:65:10:65:47 | MacroStmts | 65 | MacroStmts |  |
+| test_logging.rs:65:10:65:47 | MacroStmts | 65 | MacroStmts |  |
+| test_logging.rs:65:10:65:47 | StmtList | 65 | StmtList |  |
+| test_logging.rs:65:10:65:47 | TokenTree | 65 | TokenTree |  |
+| test_logging.rs:65:10:65:47 | { ... } | 65 | BlockExpr |  |
+| test_logging.rs:65:17:65:21 | Error | 65 | NameRef |  |
+| test_logging.rs:65:17:65:21 | Error | 65 | PathSegment |  |
+| test_logging.rs:65:24:65:37 | "message = {}" | 65 | LiteralExpr |  |
+| test_logging.rs:65:24:65:47 | ...::format_args!... | 65 | MacroCall |  |
+| test_logging.rs:65:24:65:47 | ...::log(...) | 65 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:65:24:65:47 | ArgList | 65 | ArgList |  |
+| test_logging.rs:65:24:65:47 | ExprStmt | 65 | ExprStmt |  |
+| test_logging.rs:65:24:65:47 | FormatArgsExpr | 65 | FormatArgsExpr |  |
+| test_logging.rs:65:24:65:47 | MacroExpr | 65 | MacroExpr |  |
+| test_logging.rs:65:24:65:47 | StmtList | 65 | StmtList |  |
+| test_logging.rs:65:24:65:47 | TokenTree | 65 | TokenTree |  |
+| test_logging.rs:65:24:65:47 | if ... {...} | 65 | IfExpr |  |
+| test_logging.rs:65:24:65:47 | { ... } | 65 | BlockExpr |  |
+| test_logging.rs:65:35:65:36 | {} | 65 | FormatSynthLocationImpl |  |
+| test_logging.rs:65:40:65:47 | FormatArgsArg | 65 | FormatArgsArg |  |
+| test_logging.rs:65:40:65:47 | password | 65 | IdentPath |  |
+| test_logging.rs:65:40:65:47 | password | 65 | NameRef |  |
+| test_logging.rs:65:40:65:47 | password | 65 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:65:40:65:47 | password | 65 | PathSegment |  |
+| test_logging.rs:65:51:65:84 | //... | 65 | Comment |  |
+| test_logging.rs:66:5:66:7 | log | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:7 | log | 66 | NameRef |  |
+| test_logging.rs:66:5:66:7 | log | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | "module::path" | 66 | LiteralExpr |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | $crate | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | ... && ... | 66 | BinaryExpr |  |
+| test_logging.rs:66:5:66:66 | ... <= ... | 66 | BinaryExpr |  |
+| test_logging.rs:66:5:66:66 | ... <= ... | 66 | BinaryExpr |  |
+| test_logging.rs:66:5:66:66 | ...::STATIC_MAX_LEVEL | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::STATIC_MAX_LEVEL | 66 | PathExpr |  |
+| test_logging.rs:66:5:66:66 | ...::__private_api | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::__private_api | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::__private_api | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::__private_api | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::format_args | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::loc | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::loc | 66 | PathExpr |  |
+| test_logging.rs:66:5:66:66 | ...::loc(...) | 66 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:66:5:66:66 | ...::log | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::log | 66 | PathExpr |  |
+| test_logging.rs:66:5:66:66 | ...::max_level | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::max_level | 66 | PathExpr |  |
+| test_logging.rs:66:5:66:66 | ...::max_level(...) | 66 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:66:5:66:66 | ...::module_path | 66 | Path |  |
+| test_logging.rs:66:5:66:66 | ...::module_path!... | 66 | MacroCall |  |
+| test_logging.rs:66:5:66:66 | ArgList | 66 | ArgList |  |
+| test_logging.rs:66:5:66:66 | ArgList | 66 | ArgList |  |
+| test_logging.rs:66:5:66:66 | MacroExpr | 66 | MacroExpr |  |
+| test_logging.rs:66:5:66:66 | MacroExpr | 66 | MacroExpr |  |
+| test_logging.rs:66:5:66:66 | STATIC_MAX_LEVEL | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | STATIC_MAX_LEVEL | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | TokenTree | 66 | TokenTree |  |
+| test_logging.rs:66:5:66:66 | TupleExpr | 66 | TupleExpr |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | __private_api | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | format_args | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | format_args | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | loc | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | loc | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | log | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | log | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | log!... | 66 | MacroCall |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | IdentPat |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | IdentPath |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | Name |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | lvl | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | max_level | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | max_level | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:66 | module_path | 66 | NameRef |  |
+| test_logging.rs:66:5:66:66 | module_path | 66 | PathSegment |  |
+| test_logging.rs:66:5:66:67 | ExprStmt | 66 | ExprStmt |  |
+| test_logging.rs:66:9:66:66 | TokenTree | 66 | TokenTree |  |
+| test_logging.rs:66:18:66:25 | "target" | 66 | LiteralExpr |  |
+| test_logging.rs:66:18:66:25 | &... | 66 | RefExpr |  |
+| test_logging.rs:66:18:66:25 | TupleExpr | 66 | TupleExpr |  |
+| test_logging.rs:66:18:66:65 | ...::log(...) | 66 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:66:18:66:65 | ArgList | 66 | ArgList |  |
+| test_logging.rs:66:18:66:65 | ExprStmt | 66 | ExprStmt |  |
+| test_logging.rs:66:18:66:65 | MacroStmts | 66 | MacroStmts |  |
+| test_logging.rs:66:18:66:65 | StmtList | 66 | StmtList |  |
+| test_logging.rs:66:18:66:65 | StmtList | 66 | StmtList |  |
+| test_logging.rs:66:18:66:65 | if ... {...} | 66 | IfExpr |  |
+| test_logging.rs:66:18:66:65 | { ... } | 66 | BlockExpr |  |
+| test_logging.rs:66:18:66:65 | { ... } | 66 | BlockExpr |  |
+| test_logging.rs:66:28:66:32 | Level | 66 | IdentPath |  |
+| test_logging.rs:66:28:66:32 | Level | 66 | NameRef |  |
+| test_logging.rs:66:28:66:32 | Level | 66 | PathSegment |  |
+| test_logging.rs:66:28:66:39 | (...::Error) | 66 | ParenExpr |  |
+| test_logging.rs:66:28:66:39 | ...::Error | 66 | Path |  |
+| test_logging.rs:66:28:66:39 | ...::Error | 66 | PathExpr |  |
+| test_logging.rs:66:28:66:39 | let ... = ... | 66 | LetStmt |  |
+| test_logging.rs:66:35:66:39 | Error | 66 | NameRef |  |
+| test_logging.rs:66:35:66:39 | Error | 66 | PathSegment |  |
+| test_logging.rs:66:42:66:55 | "message = {}" | 66 | LiteralExpr |  |
+| test_logging.rs:66:42:66:65 | ...::format_args!... | 66 | MacroCall |  |
+| test_logging.rs:66:42:66:65 | FormatArgsExpr | 66 | FormatArgsExpr |  |
+| test_logging.rs:66:42:66:65 | MacroExpr | 66 | MacroExpr |  |
+| test_logging.rs:66:42:66:65 | TokenTree | 66 | TokenTree |  |
+| test_logging.rs:66:53:66:54 | {} | 66 | FormatSynthLocationImpl |  |
+| test_logging.rs:66:58:66:65 | FormatArgsArg | 66 | FormatArgsArg |  |
+| test_logging.rs:66:58:66:65 | harmless | 66 | IdentPath |  |
+| test_logging.rs:66:58:66:65 | harmless | 66 | NameRef |  |
+| test_logging.rs:66:58:66:65 | harmless | 66 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:66:58:66:65 | harmless | 66 | PathSegment |  |
+| test_logging.rs:67:5:67:7 | log | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:7 | log | 67 | NameRef |  |
+| test_logging.rs:67:5:67:7 | log | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | "module::path" | 67 | LiteralExpr |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | $crate | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | ... && ... | 67 | BinaryExpr |  |
+| test_logging.rs:67:5:67:66 | ... <= ... | 67 | BinaryExpr |  |
+| test_logging.rs:67:5:67:66 | ... <= ... | 67 | BinaryExpr |  |
+| test_logging.rs:67:5:67:66 | ...::STATIC_MAX_LEVEL | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::STATIC_MAX_LEVEL | 67 | PathExpr |  |
+| test_logging.rs:67:5:67:66 | ...::__private_api | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::__private_api | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::__private_api | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::__private_api | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::format_args | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::loc | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::loc | 67 | PathExpr |  |
+| test_logging.rs:67:5:67:66 | ...::loc(...) | 67 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:67:5:67:66 | ...::log | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::log | 67 | PathExpr |  |
+| test_logging.rs:67:5:67:66 | ...::max_level | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::max_level | 67 | PathExpr |  |
+| test_logging.rs:67:5:67:66 | ...::max_level(...) | 67 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:67:5:67:66 | ...::module_path | 67 | Path |  |
+| test_logging.rs:67:5:67:66 | ...::module_path!... | 67 | MacroCall |  |
+| test_logging.rs:67:5:67:66 | ArgList | 67 | ArgList |  |
+| test_logging.rs:67:5:67:66 | ArgList | 67 | ArgList |  |
+| test_logging.rs:67:5:67:66 | MacroExpr | 67 | MacroExpr |  |
+| test_logging.rs:67:5:67:66 | MacroExpr | 67 | MacroExpr |  |
+| test_logging.rs:67:5:67:66 | STATIC_MAX_LEVEL | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | STATIC_MAX_LEVEL | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | TokenTree | 67 | TokenTree |  |
+| test_logging.rs:67:5:67:66 | TupleExpr | 67 | TupleExpr |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | __private_api | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | format_args | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | format_args | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | loc | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | loc | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | log | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | log | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | log!... | 67 | MacroCall |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | IdentPat |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | IdentPath |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | Name |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | lvl | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | max_level | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | max_level | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:66 | module_path | 67 | NameRef |  |
+| test_logging.rs:67:5:67:66 | module_path | 67 | PathSegment |  |
+| test_logging.rs:67:5:67:67 | ExprStmt | 67 | ExprStmt |  |
+| test_logging.rs:67:9:67:66 | TokenTree | 67 | TokenTree |  |
+| test_logging.rs:67:18:67:25 | "target" | 67 | LiteralExpr |  |
+| test_logging.rs:67:18:67:25 | &... | 67 | RefExpr |  |
+| test_logging.rs:67:18:67:25 | TupleExpr | 67 | TupleExpr |  |
+| test_logging.rs:67:18:67:65 | ...::log(...) | 67 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:67:18:67:65 | ArgList | 67 | ArgList |  |
+| test_logging.rs:67:18:67:65 | ExprStmt | 67 | ExprStmt |  |
+| test_logging.rs:67:18:67:65 | MacroStmts | 67 | MacroStmts |  |
+| test_logging.rs:67:18:67:65 | StmtList | 67 | StmtList |  |
+| test_logging.rs:67:18:67:65 | StmtList | 67 | StmtList |  |
+| test_logging.rs:67:18:67:65 | if ... {...} | 67 | IfExpr |  |
+| test_logging.rs:67:18:67:65 | { ... } | 67 | BlockExpr |  |
+| test_logging.rs:67:18:67:65 | { ... } | 67 | BlockExpr |  |
+| test_logging.rs:67:28:67:32 | Level | 67 | IdentPath |  |
+| test_logging.rs:67:28:67:32 | Level | 67 | NameRef |  |
+| test_logging.rs:67:28:67:32 | Level | 67 | PathSegment |  |
+| test_logging.rs:67:28:67:39 | (...::Error) | 67 | ParenExpr |  |
+| test_logging.rs:67:28:67:39 | ...::Error | 67 | Path |  |
+| test_logging.rs:67:28:67:39 | ...::Error | 67 | PathExpr |  |
+| test_logging.rs:67:28:67:39 | let ... = ... | 67 | LetStmt |  |
+| test_logging.rs:67:35:67:39 | Error | 67 | NameRef |  |
+| test_logging.rs:67:35:67:39 | Error | 67 | PathSegment |  |
+| test_logging.rs:67:42:67:55 | "message = {}" | 67 | LiteralExpr |  |
+| test_logging.rs:67:42:67:65 | ...::format_args!... | 67 | MacroCall |  |
+| test_logging.rs:67:42:67:65 | FormatArgsExpr | 67 | FormatArgsExpr |  |
+| test_logging.rs:67:42:67:65 | MacroExpr | 67 | MacroExpr |  |
+| test_logging.rs:67:42:67:65 | TokenTree | 67 | TokenTree |  |
+| test_logging.rs:67:53:67:54 | {} | 67 | FormatSynthLocationImpl |  |
+| test_logging.rs:67:58:67:65 | FormatArgsArg | 67 | FormatArgsArg |  |
+| test_logging.rs:67:58:67:65 | password | 67 | IdentPath |  |
+| test_logging.rs:67:58:67:65 | password | 67 | NameRef |  |
+| test_logging.rs:67:58:67:65 | password | 67 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:67:58:67:65 | password | 67 | PathSegment |  |
+| test_logging.rs:67:69:67:102 | //... | 67 | Comment |  |
+| test_logging.rs:68:5:68:7 | log | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:7 | log | 68 | NameRef |  |
+| test_logging.rs:68:5:68:7 | log | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | "module::path" | 68 | LiteralExpr |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | $crate | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | ... && ... | 68 | BinaryExpr |  |
+| test_logging.rs:68:5:68:67 | ... <= ... | 68 | BinaryExpr |  |
+| test_logging.rs:68:5:68:67 | ... <= ... | 68 | BinaryExpr |  |
+| test_logging.rs:68:5:68:67 | ...::STATIC_MAX_LEVEL | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::STATIC_MAX_LEVEL | 68 | PathExpr |  |
+| test_logging.rs:68:5:68:67 | ...::__private_api | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::__private_api | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::__private_api | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::__private_api | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::format_args | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::loc | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::loc | 68 | PathExpr |  |
+| test_logging.rs:68:5:68:67 | ...::loc(...) | 68 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:68:5:68:67 | ...::log | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::log | 68 | PathExpr |  |
+| test_logging.rs:68:5:68:67 | ...::max_level | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::max_level | 68 | PathExpr |  |
+| test_logging.rs:68:5:68:67 | ...::max_level(...) | 68 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:68:5:68:67 | ...::module_path | 68 | Path |  |
+| test_logging.rs:68:5:68:67 | ...::module_path!... | 68 | MacroCall |  |
+| test_logging.rs:68:5:68:67 | ArgList | 68 | ArgList |  |
+| test_logging.rs:68:5:68:67 | ArgList | 68 | ArgList |  |
+| test_logging.rs:68:5:68:67 | MacroExpr | 68 | MacroExpr |  |
+| test_logging.rs:68:5:68:67 | MacroExpr | 68 | MacroExpr |  |
+| test_logging.rs:68:5:68:67 | STATIC_MAX_LEVEL | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | STATIC_MAX_LEVEL | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | TokenTree | 68 | TokenTree |  |
+| test_logging.rs:68:5:68:67 | TupleExpr | 68 | TupleExpr |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | __private_api | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | format_args | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | format_args | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | loc | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | loc | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | log | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | log | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | log!... | 68 | MacroCall |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | IdentPat |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | IdentPath |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | Name |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | lvl | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | max_level | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | max_level | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:67 | module_path | 68 | NameRef |  |
+| test_logging.rs:68:5:68:67 | module_path | 68 | PathSegment |  |
+| test_logging.rs:68:5:68:68 | ExprStmt | 68 | ExprStmt |  |
+| test_logging.rs:68:9:68:67 | TokenTree | 68 | TokenTree |  |
+| test_logging.rs:68:18:68:26 | &... | 68 | RefExpr |  |
+| test_logging.rs:68:18:68:26 | &password | 68 | RefExpr |  |
+| test_logging.rs:68:18:68:26 | (...) | 68 | ParenExpr |  |
+| test_logging.rs:68:18:68:26 | TupleExpr | 68 | TupleExpr |  |
+| test_logging.rs:68:18:68:66 | ...::log(...) | 68 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:68:18:68:66 | ArgList | 68 | ArgList |  |
+| test_logging.rs:68:18:68:66 | ExprStmt | 68 | ExprStmt |  |
+| test_logging.rs:68:18:68:66 | MacroStmts | 68 | MacroStmts |  |
+| test_logging.rs:68:18:68:66 | StmtList | 68 | StmtList |  |
+| test_logging.rs:68:18:68:66 | StmtList | 68 | StmtList |  |
+| test_logging.rs:68:18:68:66 | if ... {...} | 68 | IfExpr |  |
+| test_logging.rs:68:18:68:66 | { ... } | 68 | BlockExpr |  |
+| test_logging.rs:68:18:68:66 | { ... } | 68 | BlockExpr |  |
+| test_logging.rs:68:19:68:26 | password | 68 | IdentPath |  |
+| test_logging.rs:68:19:68:26 | password | 68 | NameRef |  |
+| test_logging.rs:68:19:68:26 | password | 68 | PathExpr, VariableAccess |  |
+| test_logging.rs:68:19:68:26 | password | 68 | PathSegment |  |
+| test_logging.rs:68:29:68:33 | Level | 68 | IdentPath |  |
+| test_logging.rs:68:29:68:33 | Level | 68 | NameRef |  |
+| test_logging.rs:68:29:68:33 | Level | 68 | PathSegment |  |
+| test_logging.rs:68:29:68:40 | (...::Error) | 68 | ParenExpr |  |
+| test_logging.rs:68:29:68:40 | ...::Error | 68 | Path |  |
+| test_logging.rs:68:29:68:40 | ...::Error | 68 | PathExpr |  |
+| test_logging.rs:68:29:68:40 | let ... = ... | 68 | LetStmt |  |
+| test_logging.rs:68:36:68:40 | Error | 68 | NameRef |  |
+| test_logging.rs:68:36:68:40 | Error | 68 | PathSegment |  |
+| test_logging.rs:68:43:68:56 | "message = {}" | 68 | LiteralExpr |  |
+| test_logging.rs:68:43:68:66 | ...::format_args!... | 68 | MacroCall |  |
+| test_logging.rs:68:43:68:66 | FormatArgsExpr | 68 | FormatArgsExpr |  |
+| test_logging.rs:68:43:68:66 | MacroExpr | 68 | MacroExpr |  |
+| test_logging.rs:68:43:68:66 | TokenTree | 68 | TokenTree |  |
+| test_logging.rs:68:54:68:55 | {} | 68 | FormatSynthLocationImpl |  |
+| test_logging.rs:68:59:68:66 | FormatArgsArg | 68 | FormatArgsArg |  |
+| test_logging.rs:68:59:68:66 | harmless | 68 | IdentPath |  |
+| test_logging.rs:68:59:68:66 | harmless | 68 | NameRef |  |
+| test_logging.rs:68:59:68:66 | harmless | 68 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:68:59:68:66 | harmless | 68 | PathSegment |  |
+| test_logging.rs:68:70:68:103 | //... | 68 | Comment |  |
+| test_logging.rs:70:5:70:25 | //... | 70 | Comment |  |
+| test_logging.rs:71:5:71:9 | error | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:9 | error | 71 | NameRef |  |
+| test_logging.rs:71:5:71:9 | error | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | "module::path" | 71 | LiteralExpr |  |
+| test_logging.rs:71:5:71:47 | "module::path" | 71 | LiteralExpr |  |
+| test_logging.rs:71:5:71:47 | "value" | 71 | LiteralExpr |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | $crate | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | &... | 71 | RefExpr |  |
+| test_logging.rs:71:5:71:47 | (...) | 71 | ParenExpr |  |
+| test_logging.rs:71:5:71:47 | (...::Error) | 71 | ParenExpr |  |
+| test_logging.rs:71:5:71:47 | ... && ... | 71 | BinaryExpr |  |
+| test_logging.rs:71:5:71:47 | ... <= ... | 71 | BinaryExpr |  |
+| test_logging.rs:71:5:71:47 | ... <= ... | 71 | BinaryExpr |  |
+| test_logging.rs:71:5:71:47 | ...::Error | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::Error | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::Level | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::STATIC_MAX_LEVEL | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::STATIC_MAX_LEVEL | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::__log_key | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__log_value | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__log_value | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::__private_api | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::capture_to_value | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::capture_to_value | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::format_args | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::loc | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::loc | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::loc(...) | 71 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:71:5:71:47 | ...::log | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::log | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::log::<...> | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::log::<...> | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::max_level | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::max_level | 71 | PathExpr |  |
+| test_logging.rs:71:5:71:47 | ...::max_level(...) | 71 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:71:5:71:47 | ...::module_path | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::module_path | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | ...::module_path!... | 71 | MacroCall |  |
+| test_logging.rs:71:5:71:47 | ...::module_path!... | 71 | MacroCall |  |
+| test_logging.rs:71:5:71:47 | ...::stringify | 71 | Path |  |
+| test_logging.rs:71:5:71:47 | <...> | 71 | GenericArgList |  |
+| test_logging.rs:71:5:71:47 | ArgList | 71 | ArgList |  |
+| test_logging.rs:71:5:71:47 | ArgList | 71 | ArgList |  |
+| test_logging.rs:71:5:71:47 | Error | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | Error | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | Level | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | Level | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:5:71:47 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:5:71:47 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:5:71:47 | RefTypeRepr | 71 | RefTypeRepr |  |
+| test_logging.rs:71:5:71:47 | STATIC_MAX_LEVEL | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | STATIC_MAX_LEVEL | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:5:71:47 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:5:71:47 | TupleExpr | 71 | TupleExpr |  |
+| test_logging.rs:71:5:71:47 | TypeArg | 71 | TypeArg |  |
+| test_logging.rs:71:5:71:47 | _ | 71 | InferTypeRepr |  |
+| test_logging.rs:71:5:71:47 | __log_key | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __log_key | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __log_value | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __log_value | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __log_value | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __log_value | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | __private_api | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | capture_to_value | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | capture_to_value | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | error!... | 71 | MacroCall |  |
+| test_logging.rs:71:5:71:47 | format_args | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | format_args | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | let ... = ... | 71 | LetStmt |  |
+| test_logging.rs:71:5:71:47 | loc | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | loc | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | log | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | log | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | log | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | log | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | log | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | log::<...> | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | IdentPat |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | IdentPath |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | Name |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | lvl | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | max_level | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | max_level | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | module_path | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | module_path | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | module_path | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | module_path | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:47 | stringify | 71 | NameRef |  |
+| test_logging.rs:71:5:71:47 | stringify | 71 | PathSegment |  |
+| test_logging.rs:71:5:71:48 | ExprStmt | 71 | ExprStmt |  |
+| test_logging.rs:71:11:71:47 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:16 | ...::__log_key!... | 71 | MacroCall |  |
+| test_logging.rs:71:12:71:16 | ...::stringify!... | 71 | MacroCall |  |
+| test_logging.rs:71:12:71:16 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:12:71:16 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:12:71:16 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:16 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:20 | &... | 71 | RefExpr |  |
+| test_logging.rs:71:12:71:20 | ...::__log_value!... | 71 | MacroCall |  |
+| test_logging.rs:71:12:71:20 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:12:71:20 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:20 | TupleExpr | 71 | TupleExpr |  |
+| test_logging.rs:71:12:71:20 | [...] | 71 | ArrayListExpr |  |
+| test_logging.rs:71:12:71:46 | ...::log!... | 71 | MacroCall |  |
+| test_logging.rs:71:12:71:46 | ...::log!... | 71 | MacroCall |  |
+| test_logging.rs:71:12:71:46 | ...::log::<...>(...) | 71 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:71:12:71:46 | ArgList | 71 | ArgList |  |
+| test_logging.rs:71:12:71:46 | ExprStmt | 71 | ExprStmt |  |
+| test_logging.rs:71:12:71:46 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:12:71:46 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:12:71:46 | MacroStmts | 71 | MacroStmts |  |
+| test_logging.rs:71:12:71:46 | MacroStmts | 71 | MacroStmts |  |
+| test_logging.rs:71:12:71:46 | MacroStmts | 71 | MacroStmts |  |
+| test_logging.rs:71:12:71:46 | StmtList | 71 | StmtList |  |
+| test_logging.rs:71:12:71:46 | StmtList | 71 | StmtList |  |
+| test_logging.rs:71:12:71:46 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:46 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:12:71:46 | if ... {...} | 71 | IfExpr |  |
+| test_logging.rs:71:12:71:46 | { ... } | 71 | BlockExpr |  |
+| test_logging.rs:71:12:71:46 | { ... } | 71 | BlockExpr |  |
+| test_logging.rs:71:20:71:20 | 1 | 71 | LiteralExpr |  |
+| test_logging.rs:71:20:71:20 | &1 | 71 | RefExpr |  |
+| test_logging.rs:71:20:71:20 | &... | 71 | RefExpr |  |
+| test_logging.rs:71:20:71:20 | ...::__log_value!... | 71 | MacroCall |  |
+| test_logging.rs:71:20:71:20 | ...::capture_to_value(...) | 71 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:71:20:71:20 | ArgList | 71 | ArgList |  |
+| test_logging.rs:71:20:71:20 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:20:71:20 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:23:71:36 | "message = {}" | 71 | LiteralExpr |  |
+| test_logging.rs:71:23:71:46 | ...::format_args!... | 71 | MacroCall |  |
+| test_logging.rs:71:23:71:46 | FormatArgsExpr | 71 | FormatArgsExpr |  |
+| test_logging.rs:71:23:71:46 | MacroExpr | 71 | MacroExpr |  |
+| test_logging.rs:71:23:71:46 | TokenTree | 71 | TokenTree |  |
+| test_logging.rs:71:34:71:35 | {} | 71 | FormatSynthLocationImpl |  |
+| test_logging.rs:71:39:71:46 | FormatArgsArg | 71 | FormatArgsArg |  |
+| test_logging.rs:71:39:71:46 | harmless | 71 | IdentPath |  |
+| test_logging.rs:71:39:71:46 | harmless | 71 | NameRef |  |
+| test_logging.rs:71:39:71:46 | harmless | 71 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:71:39:71:46 | harmless | 71 | PathSegment |  |
+| test_logging.rs:72:5:72:9 | error | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:9 | error | 72 | NameRef |  |
+| test_logging.rs:72:5:72:9 | error | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | "module::path" | 72 | LiteralExpr |  |
+| test_logging.rs:72:5:72:47 | "module::path" | 72 | LiteralExpr |  |
+| test_logging.rs:72:5:72:47 | "value" | 72 | LiteralExpr |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | $crate | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | &... | 72 | RefExpr |  |
+| test_logging.rs:72:5:72:47 | (...) | 72 | ParenExpr |  |
+| test_logging.rs:72:5:72:47 | (...::Error) | 72 | ParenExpr |  |
+| test_logging.rs:72:5:72:47 | ... && ... | 72 | BinaryExpr |  |
+| test_logging.rs:72:5:72:47 | ... <= ... | 72 | BinaryExpr |  |
+| test_logging.rs:72:5:72:47 | ... <= ... | 72 | BinaryExpr |  |
+| test_logging.rs:72:5:72:47 | ...::Error | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::Error | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::Level | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::STATIC_MAX_LEVEL | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::STATIC_MAX_LEVEL | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::__log_key | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__log_value | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__log_value | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::__private_api | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::capture_to_value | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::capture_to_value | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::format_args | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::loc | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::loc | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::loc(...) | 72 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:72:5:72:47 | ...::log | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::log | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::log::<...> | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::log::<...> | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::max_level | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::max_level | 72 | PathExpr |  |
+| test_logging.rs:72:5:72:47 | ...::max_level(...) | 72 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:72:5:72:47 | ...::module_path | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::module_path | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | ...::module_path!... | 72 | MacroCall |  |
+| test_logging.rs:72:5:72:47 | ...::module_path!... | 72 | MacroCall |  |
+| test_logging.rs:72:5:72:47 | ...::stringify | 72 | Path |  |
+| test_logging.rs:72:5:72:47 | <...> | 72 | GenericArgList |  |
+| test_logging.rs:72:5:72:47 | ArgList | 72 | ArgList |  |
+| test_logging.rs:72:5:72:47 | ArgList | 72 | ArgList |  |
+| test_logging.rs:72:5:72:47 | Error | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | Error | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | Level | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | Level | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:5:72:47 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:5:72:47 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:5:72:47 | RefTypeRepr | 72 | RefTypeRepr |  |
+| test_logging.rs:72:5:72:47 | STATIC_MAX_LEVEL | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | STATIC_MAX_LEVEL | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:5:72:47 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:5:72:47 | TupleExpr | 72 | TupleExpr |  |
+| test_logging.rs:72:5:72:47 | TypeArg | 72 | TypeArg |  |
+| test_logging.rs:72:5:72:47 | _ | 72 | InferTypeRepr |  |
+| test_logging.rs:72:5:72:47 | __log_key | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __log_key | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __log_value | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __log_value | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __log_value | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __log_value | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | __private_api | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | capture_to_value | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | capture_to_value | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | error!... | 72 | MacroCall |  |
+| test_logging.rs:72:5:72:47 | format_args | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | format_args | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | let ... = ... | 72 | LetStmt |  |
+| test_logging.rs:72:5:72:47 | loc | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | loc | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | log | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | log | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | log | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | log | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | log | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | log::<...> | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | IdentPat |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | IdentPath |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | Name |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | lvl | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | max_level | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | max_level | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | module_path | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | module_path | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | module_path | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | module_path | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:47 | stringify | 72 | NameRef |  |
+| test_logging.rs:72:5:72:47 | stringify | 72 | PathSegment |  |
+| test_logging.rs:72:5:72:48 | ExprStmt | 72 | ExprStmt |  |
+| test_logging.rs:72:11:72:47 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:16 | ...::__log_key!... | 72 | MacroCall |  |
+| test_logging.rs:72:12:72:16 | ...::stringify!... | 72 | MacroCall |  |
+| test_logging.rs:72:12:72:16 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:12:72:16 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:12:72:16 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:16 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:20 | &... | 72 | RefExpr |  |
+| test_logging.rs:72:12:72:20 | ...::__log_value!... | 72 | MacroCall |  |
+| test_logging.rs:72:12:72:20 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:12:72:20 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:20 | TupleExpr | 72 | TupleExpr |  |
+| test_logging.rs:72:12:72:20 | [...] | 72 | ArrayListExpr |  |
+| test_logging.rs:72:12:72:46 | ...::log!... | 72 | MacroCall |  |
+| test_logging.rs:72:12:72:46 | ...::log!... | 72 | MacroCall |  |
+| test_logging.rs:72:12:72:46 | ...::log::<...>(...) | 72 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:72:12:72:46 | ArgList | 72 | ArgList |  |
+| test_logging.rs:72:12:72:46 | ExprStmt | 72 | ExprStmt |  |
+| test_logging.rs:72:12:72:46 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:12:72:46 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:12:72:46 | MacroStmts | 72 | MacroStmts |  |
+| test_logging.rs:72:12:72:46 | MacroStmts | 72 | MacroStmts |  |
+| test_logging.rs:72:12:72:46 | MacroStmts | 72 | MacroStmts |  |
+| test_logging.rs:72:12:72:46 | StmtList | 72 | StmtList |  |
+| test_logging.rs:72:12:72:46 | StmtList | 72 | StmtList |  |
+| test_logging.rs:72:12:72:46 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:46 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:12:72:46 | if ... {...} | 72 | IfExpr |  |
+| test_logging.rs:72:12:72:46 | { ... } | 72 | BlockExpr |  |
+| test_logging.rs:72:12:72:46 | { ... } | 72 | BlockExpr |  |
+| test_logging.rs:72:20:72:20 | 1 | 72 | LiteralExpr |  |
+| test_logging.rs:72:20:72:20 | &1 | 72 | RefExpr |  |
+| test_logging.rs:72:20:72:20 | &... | 72 | RefExpr |  |
+| test_logging.rs:72:20:72:20 | ...::__log_value!... | 72 | MacroCall |  |
+| test_logging.rs:72:20:72:20 | ...::capture_to_value(...) | 72 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:72:20:72:20 | ArgList | 72 | ArgList |  |
+| test_logging.rs:72:20:72:20 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:20:72:20 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:23:72:36 | "message = {}" | 72 | LiteralExpr |  |
+| test_logging.rs:72:23:72:46 | ...::format_args!... | 72 | MacroCall |  |
+| test_logging.rs:72:23:72:46 | FormatArgsExpr | 72 | FormatArgsExpr |  |
+| test_logging.rs:72:23:72:46 | MacroExpr | 72 | MacroExpr |  |
+| test_logging.rs:72:23:72:46 | TokenTree | 72 | TokenTree |  |
+| test_logging.rs:72:34:72:35 | {} | 72 | FormatSynthLocationImpl |  |
+| test_logging.rs:72:39:72:46 | FormatArgsArg | 72 | FormatArgsArg |  |
+| test_logging.rs:72:39:72:46 | password | 72 | IdentPath |  |
+| test_logging.rs:72:39:72:46 | password | 72 | NameRef |  |
+| test_logging.rs:72:39:72:46 | password | 72 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:72:39:72:46 | password | 72 | PathSegment |  |
+| test_logging.rs:72:50:72:83 | //... | 72 | Comment |  |
+| test_logging.rs:73:5:73:9 | error | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:9 | error | 73 | NameRef |  |
+| test_logging.rs:73:5:73:9 | error | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | "module::path" | 73 | LiteralExpr |  |
+| test_logging.rs:73:5:73:50 | "value" | 73 | LiteralExpr |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | $crate | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | (...::Error) | 73 | ParenExpr |  |
+| test_logging.rs:73:5:73:50 | ... && ... | 73 | BinaryExpr |  |
+| test_logging.rs:73:5:73:50 | ... <= ... | 73 | BinaryExpr |  |
+| test_logging.rs:73:5:73:50 | ... <= ... | 73 | BinaryExpr |  |
+| test_logging.rs:73:5:73:50 | ...::Error | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::Error | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::Level | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::STATIC_MAX_LEVEL | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::STATIC_MAX_LEVEL | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::__log_key | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__log_value | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__log_value | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::__private_api | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::capture_to_value | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::capture_to_value | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::format_args | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::loc | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::loc | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::loc(...) | 73 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:73:5:73:50 | ...::log | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::log::<...> | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::log::<...> | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::max_level | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::max_level | 73 | PathExpr |  |
+| test_logging.rs:73:5:73:50 | ...::max_level(...) | 73 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:73:5:73:50 | ...::module_path | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | ...::module_path!... | 73 | MacroCall |  |
+| test_logging.rs:73:5:73:50 | ...::stringify | 73 | Path |  |
+| test_logging.rs:73:5:73:50 | <...> | 73 | GenericArgList |  |
+| test_logging.rs:73:5:73:50 | ArgList | 73 | ArgList |  |
+| test_logging.rs:73:5:73:50 | ArgList | 73 | ArgList |  |
+| test_logging.rs:73:5:73:50 | Error | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | Error | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | Level | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | Level | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:5:73:50 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:5:73:50 | RefTypeRepr | 73 | RefTypeRepr |  |
+| test_logging.rs:73:5:73:50 | STATIC_MAX_LEVEL | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | STATIC_MAX_LEVEL | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:5:73:50 | TypeArg | 73 | TypeArg |  |
+| test_logging.rs:73:5:73:50 | _ | 73 | InferTypeRepr |  |
+| test_logging.rs:73:5:73:50 | __log_key | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __log_key | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __log_value | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __log_value | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __log_value | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __log_value | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | __private_api | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | capture_to_value | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | capture_to_value | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | error!... | 73 | MacroCall |  |
+| test_logging.rs:73:5:73:50 | format_args | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | format_args | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | let ... = ... | 73 | LetStmt |  |
+| test_logging.rs:73:5:73:50 | loc | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | loc | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | log | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | log | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | log | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | log::<...> | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | IdentPat |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | IdentPath |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | Name |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | lvl | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | max_level | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | max_level | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | module_path | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | module_path | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:50 | stringify | 73 | NameRef |  |
+| test_logging.rs:73:5:73:50 | stringify | 73 | PathSegment |  |
+| test_logging.rs:73:5:73:51 | ExprStmt | 73 | ExprStmt |  |
+| test_logging.rs:73:11:73:50 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:20:73:27 | "target" | 73 | LiteralExpr |  |
+| test_logging.rs:73:20:73:27 | &... | 73 | RefExpr |  |
+| test_logging.rs:73:20:73:27 | TupleExpr | 73 | TupleExpr |  |
+| test_logging.rs:73:20:73:49 | ...::log!... | 73 | MacroCall |  |
+| test_logging.rs:73:20:73:49 | ...::log::<...>(...) | 73 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:73:20:73:49 | ArgList | 73 | ArgList |  |
+| test_logging.rs:73:20:73:49 | ExprStmt | 73 | ExprStmt |  |
+| test_logging.rs:73:20:73:49 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:20:73:49 | MacroStmts | 73 | MacroStmts |  |
+| test_logging.rs:73:20:73:49 | MacroStmts | 73 | MacroStmts |  |
+| test_logging.rs:73:20:73:49 | StmtList | 73 | StmtList |  |
+| test_logging.rs:73:20:73:49 | StmtList | 73 | StmtList |  |
+| test_logging.rs:73:20:73:49 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:20:73:49 | if ... {...} | 73 | IfExpr |  |
+| test_logging.rs:73:20:73:49 | { ... } | 73 | BlockExpr |  |
+| test_logging.rs:73:20:73:49 | { ... } | 73 | BlockExpr |  |
+| test_logging.rs:73:30:73:34 | ...::__log_key!... | 73 | MacroCall |  |
+| test_logging.rs:73:30:73:34 | ...::stringify!... | 73 | MacroCall |  |
+| test_logging.rs:73:30:73:34 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:30:73:34 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:30:73:34 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:30:73:34 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:30:73:38 | &... | 73 | RefExpr |  |
+| test_logging.rs:73:30:73:38 | ...::__log_value!... | 73 | MacroCall |  |
+| test_logging.rs:73:30:73:38 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:30:73:38 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:30:73:38 | TupleExpr | 73 | TupleExpr |  |
+| test_logging.rs:73:30:73:38 | [...] | 73 | ArrayListExpr |  |
+| test_logging.rs:73:38:73:38 | 1 | 73 | LiteralExpr |  |
+| test_logging.rs:73:38:73:38 | &1 | 73 | RefExpr |  |
+| test_logging.rs:73:38:73:38 | &... | 73 | RefExpr |  |
+| test_logging.rs:73:38:73:38 | ...::__log_value!... | 73 | MacroCall |  |
+| test_logging.rs:73:38:73:38 | ...::capture_to_value(...) | 73 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:73:38:73:38 | ArgList | 73 | ArgList |  |
+| test_logging.rs:73:38:73:38 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:38:73:38 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:73:41:73:49 | "message" | 73 | LiteralExpr |  |
+| test_logging.rs:73:41:73:49 | ...::format_args!... | 73 | MacroCall |  |
+| test_logging.rs:73:41:73:49 | FormatArgsExpr | 73 | FormatArgsExpr |  |
+| test_logging.rs:73:41:73:49 | MacroExpr | 73 | MacroExpr |  |
+| test_logging.rs:73:41:73:49 | TokenTree | 73 | TokenTree |  |
+| test_logging.rs:74:5:74:9 | error | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:9 | error | 74 | NameRef |  |
+| test_logging.rs:74:5:74:9 | error | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | "module::path" | 74 | LiteralExpr |  |
+| test_logging.rs:74:5:74:65 | "value" | 74 | LiteralExpr |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | $crate | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | (...::Error) | 74 | ParenExpr |  |
+| test_logging.rs:74:5:74:65 | ... && ... | 74 | BinaryExpr |  |
+| test_logging.rs:74:5:74:65 | ... <= ... | 74 | BinaryExpr |  |
+| test_logging.rs:74:5:74:65 | ... <= ... | 74 | BinaryExpr |  |
+| test_logging.rs:74:5:74:65 | ...::Error | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::Error | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::Level | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::STATIC_MAX_LEVEL | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::STATIC_MAX_LEVEL | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::__log_key | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__log_value | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__log_value | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::__private_api | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::capture_to_value | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::capture_to_value | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::format_args | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::loc | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::loc | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::loc(...) | 74 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:74:5:74:65 | ...::log | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::log::<...> | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::log::<...> | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::max_level | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::max_level | 74 | PathExpr |  |
+| test_logging.rs:74:5:74:65 | ...::max_level(...) | 74 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:74:5:74:65 | ...::module_path | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | ...::module_path!... | 74 | MacroCall |  |
+| test_logging.rs:74:5:74:65 | ...::stringify | 74 | Path |  |
+| test_logging.rs:74:5:74:65 | <...> | 74 | GenericArgList |  |
+| test_logging.rs:74:5:74:65 | ArgList | 74 | ArgList |  |
+| test_logging.rs:74:5:74:65 | ArgList | 74 | ArgList |  |
+| test_logging.rs:74:5:74:65 | Error | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | Error | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | Level | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | Level | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:5:74:65 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:5:74:65 | RefTypeRepr | 74 | RefTypeRepr |  |
+| test_logging.rs:74:5:74:65 | STATIC_MAX_LEVEL | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | STATIC_MAX_LEVEL | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:5:74:65 | TypeArg | 74 | TypeArg |  |
+| test_logging.rs:74:5:74:65 | _ | 74 | InferTypeRepr |  |
+| test_logging.rs:74:5:74:65 | __log_key | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __log_key | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __log_value | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __log_value | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __log_value | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __log_value | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | __private_api | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | capture_to_value | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | capture_to_value | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | error!... | 74 | MacroCall |  |
+| test_logging.rs:74:5:74:65 | format_args | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | format_args | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | let ... = ... | 74 | LetStmt |  |
+| test_logging.rs:74:5:74:65 | loc | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | loc | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | log | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | log | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | log | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | log::<...> | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | IdentPat |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | IdentPath |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | Name |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | lvl | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | max_level | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | max_level | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | module_path | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | module_path | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:65 | stringify | 74 | NameRef |  |
+| test_logging.rs:74:5:74:65 | stringify | 74 | PathSegment |  |
+| test_logging.rs:74:5:74:66 | ExprStmt | 74 | ExprStmt |  |
+| test_logging.rs:74:11:74:65 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:20:74:27 | "target" | 74 | LiteralExpr |  |
+| test_logging.rs:74:20:74:27 | &... | 74 | RefExpr |  |
+| test_logging.rs:74:20:74:27 | TupleExpr | 74 | TupleExpr |  |
+| test_logging.rs:74:20:74:64 | ...::log!... | 74 | MacroCall |  |
+| test_logging.rs:74:20:74:64 | ...::log::<...>(...) | 74 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:74:20:74:64 | ArgList | 74 | ArgList |  |
+| test_logging.rs:74:20:74:64 | ExprStmt | 74 | ExprStmt |  |
+| test_logging.rs:74:20:74:64 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:20:74:64 | MacroStmts | 74 | MacroStmts |  |
+| test_logging.rs:74:20:74:64 | MacroStmts | 74 | MacroStmts |  |
+| test_logging.rs:74:20:74:64 | StmtList | 74 | StmtList |  |
+| test_logging.rs:74:20:74:64 | StmtList | 74 | StmtList |  |
+| test_logging.rs:74:20:74:64 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:20:74:64 | if ... {...} | 74 | IfExpr |  |
+| test_logging.rs:74:20:74:64 | { ... } | 74 | BlockExpr |  |
+| test_logging.rs:74:20:74:64 | { ... } | 74 | BlockExpr |  |
+| test_logging.rs:74:30:74:34 | ...::__log_key!... | 74 | MacroCall |  |
+| test_logging.rs:74:30:74:34 | ...::stringify!... | 74 | MacroCall |  |
+| test_logging.rs:74:30:74:34 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:30:74:34 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:30:74:34 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:30:74:34 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:30:74:38 | &... | 74 | RefExpr |  |
+| test_logging.rs:74:30:74:38 | ...::__log_value!... | 74 | MacroCall |  |
+| test_logging.rs:74:30:74:38 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:30:74:38 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:30:74:38 | TupleExpr | 74 | TupleExpr |  |
+| test_logging.rs:74:30:74:38 | [...] | 74 | ArrayListExpr |  |
+| test_logging.rs:74:38:74:38 | 1 | 74 | LiteralExpr |  |
+| test_logging.rs:74:38:74:38 | &1 | 74 | RefExpr |  |
+| test_logging.rs:74:38:74:38 | &... | 74 | RefExpr |  |
+| test_logging.rs:74:38:74:38 | ...::__log_value!... | 74 | MacroCall |  |
+| test_logging.rs:74:38:74:38 | ...::capture_to_value(...) | 74 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:74:38:74:38 | ArgList | 74 | ArgList |  |
+| test_logging.rs:74:38:74:38 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:38:74:38 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:41:74:54 | "message = {}" | 74 | LiteralExpr |  |
+| test_logging.rs:74:41:74:64 | ...::format_args!... | 74 | MacroCall |  |
+| test_logging.rs:74:41:74:64 | FormatArgsExpr | 74 | FormatArgsExpr |  |
+| test_logging.rs:74:41:74:64 | MacroExpr | 74 | MacroExpr |  |
+| test_logging.rs:74:41:74:64 | TokenTree | 74 | TokenTree |  |
+| test_logging.rs:74:52:74:53 | {} | 74 | FormatSynthLocationImpl |  |
+| test_logging.rs:74:57:74:64 | FormatArgsArg | 74 | FormatArgsArg |  |
+| test_logging.rs:74:57:74:64 | password | 74 | IdentPath |  |
+| test_logging.rs:74:57:74:64 | password | 74 | NameRef |  |
+| test_logging.rs:74:57:74:64 | password | 74 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:74:57:74:64 | password | 74 | PathSegment |  |
+| test_logging.rs:74:68:74:101 | //... | 74 | Comment |  |
+| test_logging.rs:75:5:75:9 | error | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:9 | error | 75 | NameRef |  |
+| test_logging.rs:75:5:75:9 | error | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | "module::path" | 75 | LiteralExpr |  |
+| test_logging.rs:75:5:75:51 | "value" | 75 | LiteralExpr |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | $crate | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | (...::Error) | 75 | ParenExpr |  |
+| test_logging.rs:75:5:75:51 | ... && ... | 75 | BinaryExpr |  |
+| test_logging.rs:75:5:75:51 | ... <= ... | 75 | BinaryExpr |  |
+| test_logging.rs:75:5:75:51 | ... <= ... | 75 | BinaryExpr |  |
+| test_logging.rs:75:5:75:51 | ...::Error | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::Error | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::Level | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::STATIC_MAX_LEVEL | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::STATIC_MAX_LEVEL | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::__log_key | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__log_value | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__log_value | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::__private_api | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::capture_to_value | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::capture_to_value | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::format_args | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::loc | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::loc | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::loc(...) | 75 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:75:5:75:51 | ...::log | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::log::<...> | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::log::<...> | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::max_level | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::max_level | 75 | PathExpr |  |
+| test_logging.rs:75:5:75:51 | ...::max_level(...) | 75 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:75:5:75:51 | ...::module_path | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | ...::module_path!... | 75 | MacroCall |  |
+| test_logging.rs:75:5:75:51 | ...::stringify | 75 | Path |  |
+| test_logging.rs:75:5:75:51 | <...> | 75 | GenericArgList |  |
+| test_logging.rs:75:5:75:51 | ArgList | 75 | ArgList |  |
+| test_logging.rs:75:5:75:51 | ArgList | 75 | ArgList |  |
+| test_logging.rs:75:5:75:51 | Error | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | Error | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | Level | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | Level | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:5:75:51 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:5:75:51 | RefTypeRepr | 75 | RefTypeRepr |  |
+| test_logging.rs:75:5:75:51 | STATIC_MAX_LEVEL | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | STATIC_MAX_LEVEL | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:5:75:51 | TypeArg | 75 | TypeArg |  |
+| test_logging.rs:75:5:75:51 | _ | 75 | InferTypeRepr |  |
+| test_logging.rs:75:5:75:51 | __log_key | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __log_key | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __log_value | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __log_value | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __log_value | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __log_value | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | __private_api | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | capture_to_value | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | capture_to_value | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | error!... | 75 | MacroCall |  |
+| test_logging.rs:75:5:75:51 | format_args | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | format_args | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | let ... = ... | 75 | LetStmt |  |
+| test_logging.rs:75:5:75:51 | loc | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | loc | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | log | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | log | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | log | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | log::<...> | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | IdentPat |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | IdentPath |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | Name |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | lvl | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | max_level | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | max_level | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | module_path | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | module_path | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:51 | stringify | 75 | NameRef |  |
+| test_logging.rs:75:5:75:51 | stringify | 75 | PathSegment |  |
+| test_logging.rs:75:5:75:52 | ExprStmt | 75 | ExprStmt |  |
+| test_logging.rs:75:11:75:51 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:20:75:28 | &... | 75 | RefExpr |  |
+| test_logging.rs:75:20:75:28 | &password | 75 | RefExpr |  |
+| test_logging.rs:75:20:75:28 | (...) | 75 | ParenExpr |  |
+| test_logging.rs:75:20:75:28 | TupleExpr | 75 | TupleExpr |  |
+| test_logging.rs:75:20:75:50 | ...::log!... | 75 | MacroCall |  |
+| test_logging.rs:75:20:75:50 | ...::log::<...>(...) | 75 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:75:20:75:50 | ArgList | 75 | ArgList |  |
+| test_logging.rs:75:20:75:50 | ExprStmt | 75 | ExprStmt |  |
+| test_logging.rs:75:20:75:50 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:20:75:50 | MacroStmts | 75 | MacroStmts |  |
+| test_logging.rs:75:20:75:50 | MacroStmts | 75 | MacroStmts |  |
+| test_logging.rs:75:20:75:50 | StmtList | 75 | StmtList |  |
+| test_logging.rs:75:20:75:50 | StmtList | 75 | StmtList |  |
+| test_logging.rs:75:20:75:50 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:20:75:50 | if ... {...} | 75 | IfExpr |  |
+| test_logging.rs:75:20:75:50 | { ... } | 75 | BlockExpr |  |
+| test_logging.rs:75:20:75:50 | { ... } | 75 | BlockExpr |  |
+| test_logging.rs:75:21:75:28 | password | 75 | IdentPath |  |
+| test_logging.rs:75:21:75:28 | password | 75 | NameRef |  |
+| test_logging.rs:75:21:75:28 | password | 75 | PathExpr, VariableAccess |  |
+| test_logging.rs:75:21:75:28 | password | 75 | PathSegment |  |
+| test_logging.rs:75:31:75:35 | ...::__log_key!... | 75 | MacroCall |  |
+| test_logging.rs:75:31:75:35 | ...::stringify!... | 75 | MacroCall |  |
+| test_logging.rs:75:31:75:35 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:31:75:35 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:31:75:35 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:31:75:35 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:31:75:39 | &... | 75 | RefExpr |  |
+| test_logging.rs:75:31:75:39 | ...::__log_value!... | 75 | MacroCall |  |
+| test_logging.rs:75:31:75:39 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:31:75:39 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:31:75:39 | TupleExpr | 75 | TupleExpr |  |
+| test_logging.rs:75:31:75:39 | [...] | 75 | ArrayListExpr |  |
+| test_logging.rs:75:39:75:39 | 1 | 75 | LiteralExpr |  |
+| test_logging.rs:75:39:75:39 | &1 | 75 | RefExpr |  |
+| test_logging.rs:75:39:75:39 | &... | 75 | RefExpr |  |
+| test_logging.rs:75:39:75:39 | ...::__log_value!... | 75 | MacroCall |  |
+| test_logging.rs:75:39:75:39 | ...::capture_to_value(...) | 75 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:75:39:75:39 | ArgList | 75 | ArgList |  |
+| test_logging.rs:75:39:75:39 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:39:75:39 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:42:75:50 | "message" | 75 | LiteralExpr |  |
+| test_logging.rs:75:42:75:50 | ...::format_args!... | 75 | MacroCall |  |
+| test_logging.rs:75:42:75:50 | FormatArgsExpr | 75 | FormatArgsExpr |  |
+| test_logging.rs:75:42:75:50 | MacroExpr | 75 | MacroExpr |  |
+| test_logging.rs:75:42:75:50 | TokenTree | 75 | TokenTree |  |
+| test_logging.rs:75:54:75:87 | //... | 75 | Comment |  |
+| test_logging.rs:76:5:76:9 | error | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:9 | error | 76 | NameRef |  |
+| test_logging.rs:76:5:76:9 | error | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | "module::path" | 76 | LiteralExpr |  |
+| test_logging.rs:76:5:76:47 | "module::path" | 76 | LiteralExpr |  |
+| test_logging.rs:76:5:76:47 | "value" | 76 | LiteralExpr |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | $crate | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | &... | 76 | RefExpr |  |
+| test_logging.rs:76:5:76:47 | (...) | 76 | ParenExpr |  |
+| test_logging.rs:76:5:76:47 | (...::Error) | 76 | ParenExpr |  |
+| test_logging.rs:76:5:76:47 | ... && ... | 76 | BinaryExpr |  |
+| test_logging.rs:76:5:76:47 | ... <= ... | 76 | BinaryExpr |  |
+| test_logging.rs:76:5:76:47 | ... <= ... | 76 | BinaryExpr |  |
+| test_logging.rs:76:5:76:47 | ...::Error | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::Error | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::Level | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::STATIC_MAX_LEVEL | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::STATIC_MAX_LEVEL | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::__log_key | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__log_value | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__log_value | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::__private_api | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::capture_to_value | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::capture_to_value | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::format_args | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::loc | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::loc | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::loc(...) | 76 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:76:5:76:47 | ...::log | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::log | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::log::<...> | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::log::<...> | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::max_level | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::max_level | 76 | PathExpr |  |
+| test_logging.rs:76:5:76:47 | ...::max_level(...) | 76 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:76:5:76:47 | ...::module_path | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::module_path | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | ...::module_path!... | 76 | MacroCall |  |
+| test_logging.rs:76:5:76:47 | ...::module_path!... | 76 | MacroCall |  |
+| test_logging.rs:76:5:76:47 | ...::stringify | 76 | Path |  |
+| test_logging.rs:76:5:76:47 | <...> | 76 | GenericArgList |  |
+| test_logging.rs:76:5:76:47 | ArgList | 76 | ArgList |  |
+| test_logging.rs:76:5:76:47 | ArgList | 76 | ArgList |  |
+| test_logging.rs:76:5:76:47 | Error | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | Error | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | Level | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | Level | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:5:76:47 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:5:76:47 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:5:76:47 | RefTypeRepr | 76 | RefTypeRepr |  |
+| test_logging.rs:76:5:76:47 | STATIC_MAX_LEVEL | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | STATIC_MAX_LEVEL | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:5:76:47 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:5:76:47 | TupleExpr | 76 | TupleExpr |  |
+| test_logging.rs:76:5:76:47 | TypeArg | 76 | TypeArg |  |
+| test_logging.rs:76:5:76:47 | _ | 76 | InferTypeRepr |  |
+| test_logging.rs:76:5:76:47 | __log_key | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __log_key | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __log_value | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __log_value | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __log_value | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __log_value | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | __private_api | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | capture_to_value | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | capture_to_value | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | error!... | 76 | MacroCall |  |
+| test_logging.rs:76:5:76:47 | format_args | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | format_args | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | let ... = ... | 76 | LetStmt |  |
+| test_logging.rs:76:5:76:47 | loc | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | loc | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | log | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | log | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | log | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | log | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | log | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | log::<...> | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | IdentPat |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | IdentPath |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | Name |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | lvl | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | max_level | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | max_level | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | module_path | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | module_path | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | module_path | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | module_path | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:47 | stringify | 76 | NameRef |  |
+| test_logging.rs:76:5:76:47 | stringify | 76 | PathSegment |  |
+| test_logging.rs:76:5:76:48 | ExprStmt | 76 | ExprStmt |  |
+| test_logging.rs:76:11:76:47 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:16 | ...::__log_key!... | 76 | MacroCall |  |
+| test_logging.rs:76:12:76:16 | ...::stringify!... | 76 | MacroCall |  |
+| test_logging.rs:76:12:76:16 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:12:76:16 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:12:76:16 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:16 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:20 | &... | 76 | RefExpr |  |
+| test_logging.rs:76:12:76:20 | ...::__log_value!... | 76 | MacroCall |  |
+| test_logging.rs:76:12:76:20 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:12:76:20 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:20 | TupleExpr | 76 | TupleExpr |  |
+| test_logging.rs:76:12:76:20 | [...] | 76 | ArrayListExpr |  |
+| test_logging.rs:76:12:76:46 | ...::log!... | 76 | MacroCall |  |
+| test_logging.rs:76:12:76:46 | ...::log!... | 76 | MacroCall |  |
+| test_logging.rs:76:12:76:46 | ...::log::<...>(...) | 76 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:76:12:76:46 | ArgList | 76 | ArgList |  |
+| test_logging.rs:76:12:76:46 | ExprStmt | 76 | ExprStmt |  |
+| test_logging.rs:76:12:76:46 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:12:76:46 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:12:76:46 | MacroStmts | 76 | MacroStmts |  |
+| test_logging.rs:76:12:76:46 | MacroStmts | 76 | MacroStmts |  |
+| test_logging.rs:76:12:76:46 | MacroStmts | 76 | MacroStmts |  |
+| test_logging.rs:76:12:76:46 | StmtList | 76 | StmtList |  |
+| test_logging.rs:76:12:76:46 | StmtList | 76 | StmtList |  |
+| test_logging.rs:76:12:76:46 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:46 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:12:76:46 | if ... {...} | 76 | IfExpr |  |
+| test_logging.rs:76:12:76:46 | { ... } | 76 | BlockExpr |  |
+| test_logging.rs:76:12:76:46 | { ... } | 76 | BlockExpr |  |
+| test_logging.rs:76:20:76:20 | 1 | 76 | LiteralExpr |  |
+| test_logging.rs:76:20:76:20 | &1 | 76 | RefExpr |  |
+| test_logging.rs:76:20:76:20 | &... | 76 | RefExpr |  |
+| test_logging.rs:76:20:76:20 | ...::__log_value!... | 76 | MacroCall |  |
+| test_logging.rs:76:20:76:20 | ...::capture_to_value(...) | 76 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:76:20:76:20 | ArgList | 76 | ArgList |  |
+| test_logging.rs:76:20:76:20 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:20:76:20 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:23:76:36 | "message = {}" | 76 | LiteralExpr |  |
+| test_logging.rs:76:23:76:46 | ...::format_args!... | 76 | MacroCall |  |
+| test_logging.rs:76:23:76:46 | FormatArgsExpr | 76 | FormatArgsExpr |  |
+| test_logging.rs:76:23:76:46 | MacroExpr | 76 | MacroExpr |  |
+| test_logging.rs:76:23:76:46 | TokenTree | 76 | TokenTree |  |
+| test_logging.rs:76:34:76:35 | {} | 76 | FormatSynthLocationImpl |  |
+| test_logging.rs:76:39:76:46 | FormatArgsArg | 76 | FormatArgsArg |  |
+| test_logging.rs:76:39:76:46 | password | 76 | IdentPath |  |
+| test_logging.rs:76:39:76:46 | password | 76 | NameRef |  |
+| test_logging.rs:76:39:76:46 | password | 76 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:76:39:76:46 | password | 76 | PathSegment |  |
+| test_logging.rs:76:50:76:83 | //... | 76 | Comment |  |
+| test_logging.rs:77:5:77:9 | error | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:9 | error | 77 | NameRef |  |
+| test_logging.rs:77:5:77:9 | error | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | "module::path" | 77 | LiteralExpr |  |
+| test_logging.rs:77:5:77:48 | "module::path" | 77 | LiteralExpr |  |
+| test_logging.rs:77:5:77:48 | "value" | 77 | LiteralExpr |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | $crate | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | &... | 77 | RefExpr |  |
+| test_logging.rs:77:5:77:48 | (...) | 77 | ParenExpr |  |
+| test_logging.rs:77:5:77:48 | (...::Error) | 77 | ParenExpr |  |
+| test_logging.rs:77:5:77:48 | ... && ... | 77 | BinaryExpr |  |
+| test_logging.rs:77:5:77:48 | ... <= ... | 77 | BinaryExpr |  |
+| test_logging.rs:77:5:77:48 | ... <= ... | 77 | BinaryExpr |  |
+| test_logging.rs:77:5:77:48 | ...::Error | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::Error | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::Level | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::STATIC_MAX_LEVEL | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::STATIC_MAX_LEVEL | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::__log_key | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__log_value | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__log_value | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::__private_api | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::capture_to_value | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::capture_to_value | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::format_args | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::loc | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::loc | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::loc(...) | 77 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:77:5:77:48 | ...::log | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::log | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::log::<...> | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::log::<...> | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::max_level | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::max_level | 77 | PathExpr |  |
+| test_logging.rs:77:5:77:48 | ...::max_level(...) | 77 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:77:5:77:48 | ...::module_path | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::module_path | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | ...::module_path!... | 77 | MacroCall |  |
+| test_logging.rs:77:5:77:48 | ...::module_path!... | 77 | MacroCall |  |
+| test_logging.rs:77:5:77:48 | ...::stringify | 77 | Path |  |
+| test_logging.rs:77:5:77:48 | <...> | 77 | GenericArgList |  |
+| test_logging.rs:77:5:77:48 | ArgList | 77 | ArgList |  |
+| test_logging.rs:77:5:77:48 | ArgList | 77 | ArgList |  |
+| test_logging.rs:77:5:77:48 | Error | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | Error | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | Level | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | Level | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:5:77:48 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:5:77:48 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:5:77:48 | RefTypeRepr | 77 | RefTypeRepr |  |
+| test_logging.rs:77:5:77:48 | STATIC_MAX_LEVEL | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | STATIC_MAX_LEVEL | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:5:77:48 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:5:77:48 | TupleExpr | 77 | TupleExpr |  |
+| test_logging.rs:77:5:77:48 | TypeArg | 77 | TypeArg |  |
+| test_logging.rs:77:5:77:48 | _ | 77 | InferTypeRepr |  |
+| test_logging.rs:77:5:77:48 | __log_key | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __log_key | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __log_value | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __log_value | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __log_value | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __log_value | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | __private_api | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | capture_to_value | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | capture_to_value | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | error!... | 77 | MacroCall |  |
+| test_logging.rs:77:5:77:48 | format_args | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | format_args | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | let ... = ... | 77 | LetStmt |  |
+| test_logging.rs:77:5:77:48 | loc | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | loc | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | log | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | log | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | log | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | log | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | log | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | log::<...> | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | IdentPat |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | IdentPath |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | Name |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | lvl | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | max_level | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | max_level | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | module_path | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | module_path | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | module_path | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | module_path | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:48 | stringify | 77 | NameRef |  |
+| test_logging.rs:77:5:77:48 | stringify | 77 | PathSegment |  |
+| test_logging.rs:77:5:77:49 | ExprStmt | 77 | ExprStmt |  |
+| test_logging.rs:77:11:77:48 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:16 | ...::__log_key!... | 77 | MacroCall |  |
+| test_logging.rs:77:12:77:16 | ...::stringify!... | 77 | MacroCall |  |
+| test_logging.rs:77:12:77:16 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:12:77:16 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:12:77:16 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:16 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:36 | &... | 77 | RefExpr |  |
+| test_logging.rs:77:12:77:36 | ...::__log_value!... | 77 | MacroCall |  |
+| test_logging.rs:77:12:77:36 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:12:77:36 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:36 | TupleExpr | 77 | TupleExpr |  |
+| test_logging.rs:77:12:77:36 | [...] | 77 | ArrayListExpr |  |
+| test_logging.rs:77:12:77:47 | ...::log!... | 77 | MacroCall |  |
+| test_logging.rs:77:12:77:47 | ...::log!... | 77 | MacroCall |  |
+| test_logging.rs:77:12:77:47 | ...::log::<...>(...) | 77 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:77:12:77:47 | ArgList | 77 | ArgList |  |
+| test_logging.rs:77:12:77:47 | ExprStmt | 77 | ExprStmt |  |
+| test_logging.rs:77:12:77:47 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:12:77:47 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:12:77:47 | MacroStmts | 77 | MacroStmts |  |
+| test_logging.rs:77:12:77:47 | MacroStmts | 77 | MacroStmts |  |
+| test_logging.rs:77:12:77:47 | MacroStmts | 77 | MacroStmts |  |
+| test_logging.rs:77:12:77:47 | StmtList | 77 | StmtList |  |
+| test_logging.rs:77:12:77:47 | StmtList | 77 | StmtList |  |
+| test_logging.rs:77:12:77:47 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:47 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:12:77:47 | if ... {...} | 77 | IfExpr |  |
+| test_logging.rs:77:12:77:47 | { ... } | 77 | BlockExpr |  |
+| test_logging.rs:77:12:77:47 | { ... } | 77 | BlockExpr |  |
+| test_logging.rs:77:20:77:27 | password | 77 | IdentPath |  |
+| test_logging.rs:77:20:77:27 | password | 77 | NameRef |  |
+| test_logging.rs:77:20:77:27 | password | 77 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:77:20:77:27 | password | 77 | PathSegment |  |
+| test_logging.rs:77:20:77:36 | &... | 77 | RefExpr |  |
+| test_logging.rs:77:20:77:36 | &... | 77 | RefExpr |  |
+| test_logging.rs:77:20:77:36 | (...) | 77 | ParenExpr |  |
+| test_logging.rs:77:20:77:36 | ...::__log_value!... | 77 | MacroCall |  |
+| test_logging.rs:77:20:77:36 | ...::capture_to_value(...) | 77 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:77:20:77:36 | ArgList | 77 | ArgList |  |
+| test_logging.rs:77:20:77:36 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:20:77:36 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:20:77:36 | password.as_str(...) | 77 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_str |
+| test_logging.rs:77:29:77:34 | as_str | 77 | NameRef |  |
+| test_logging.rs:77:35:77:36 | ArgList | 77 | ArgList |  |
+| test_logging.rs:77:39:77:47 | "message" | 77 | LiteralExpr |  |
+| test_logging.rs:77:39:77:47 | ...::format_args!... | 77 | MacroCall |  |
+| test_logging.rs:77:39:77:47 | FormatArgsExpr | 77 | FormatArgsExpr |  |
+| test_logging.rs:77:39:77:47 | MacroExpr | 77 | MacroExpr |  |
+| test_logging.rs:77:39:77:47 | TokenTree | 77 | TokenTree |  |
+| test_logging.rs:77:51:77:93 | //... | 77 | Comment |  |
+| test_logging.rs:78:5:78:9 | error | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:9 | error | 78 | NameRef |  |
+| test_logging.rs:78:5:78:9 | error | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | "module::path" | 78 | LiteralExpr |  |
+| test_logging.rs:78:5:78:50 | "module::path" | 78 | LiteralExpr |  |
+| test_logging.rs:78:5:78:50 | "value" | 78 | LiteralExpr |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | $crate | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | &... | 78 | RefExpr |  |
+| test_logging.rs:78:5:78:50 | (...) | 78 | ParenExpr |  |
+| test_logging.rs:78:5:78:50 | (...::Error) | 78 | ParenExpr |  |
+| test_logging.rs:78:5:78:50 | ... && ... | 78 | BinaryExpr |  |
+| test_logging.rs:78:5:78:50 | ... <= ... | 78 | BinaryExpr |  |
+| test_logging.rs:78:5:78:50 | ... <= ... | 78 | BinaryExpr |  |
+| test_logging.rs:78:5:78:50 | ...::Error | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::Error | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::Level | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::STATIC_MAX_LEVEL | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::STATIC_MAX_LEVEL | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::__log_key | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__log_value | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__log_value | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::__private_api | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::capture_debug | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::capture_debug | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::format_args | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::loc | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::loc | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::loc(...) | 78 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:78:5:78:50 | ...::log | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::log | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::log::<...> | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::log::<...> | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::max_level | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::max_level | 78 | PathExpr |  |
+| test_logging.rs:78:5:78:50 | ...::max_level(...) | 78 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:78:5:78:50 | ...::module_path | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::module_path | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | ...::module_path!... | 78 | MacroCall |  |
+| test_logging.rs:78:5:78:50 | ...::module_path!... | 78 | MacroCall |  |
+| test_logging.rs:78:5:78:50 | ...::stringify | 78 | Path |  |
+| test_logging.rs:78:5:78:50 | <...> | 78 | GenericArgList |  |
+| test_logging.rs:78:5:78:50 | ArgList | 78 | ArgList |  |
+| test_logging.rs:78:5:78:50 | ArgList | 78 | ArgList |  |
+| test_logging.rs:78:5:78:50 | Error | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | Error | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | Level | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | Level | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:5:78:50 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:5:78:50 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:5:78:50 | RefTypeRepr | 78 | RefTypeRepr |  |
+| test_logging.rs:78:5:78:50 | STATIC_MAX_LEVEL | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | STATIC_MAX_LEVEL | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:5:78:50 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:5:78:50 | TupleExpr | 78 | TupleExpr |  |
+| test_logging.rs:78:5:78:50 | TypeArg | 78 | TypeArg |  |
+| test_logging.rs:78:5:78:50 | _ | 78 | InferTypeRepr |  |
+| test_logging.rs:78:5:78:50 | __log_key | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __log_key | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __log_value | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __log_value | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __log_value | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __log_value | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | __private_api | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | capture_debug | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | capture_debug | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | error!... | 78 | MacroCall |  |
+| test_logging.rs:78:5:78:50 | format_args | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | format_args | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | let ... = ... | 78 | LetStmt |  |
+| test_logging.rs:78:5:78:50 | loc | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | loc | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | log | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | log | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | log | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | log | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | log | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | log::<...> | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | IdentPat |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | IdentPath |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | Name |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | lvl | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | max_level | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | max_level | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | module_path | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | module_path | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | module_path | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | module_path | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:50 | stringify | 78 | NameRef |  |
+| test_logging.rs:78:5:78:50 | stringify | 78 | PathSegment |  |
+| test_logging.rs:78:5:78:51 | ExprStmt | 78 | ExprStmt |  |
+| test_logging.rs:78:11:78:50 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:16 | ...::__log_key!... | 78 | MacroCall |  |
+| test_logging.rs:78:12:78:16 | ...::stringify!... | 78 | MacroCall |  |
+| test_logging.rs:78:12:78:16 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:12:78:16 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:12:78:16 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:16 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:38 | &... | 78 | RefExpr |  |
+| test_logging.rs:78:12:78:38 | ...::__log_value!... | 78 | MacroCall |  |
+| test_logging.rs:78:12:78:38 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:12:78:38 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:38 | TupleExpr | 78 | TupleExpr |  |
+| test_logging.rs:78:12:78:38 | [...] | 78 | ArrayListExpr |  |
+| test_logging.rs:78:12:78:49 | ...::log!... | 78 | MacroCall |  |
+| test_logging.rs:78:12:78:49 | ...::log!... | 78 | MacroCall |  |
+| test_logging.rs:78:12:78:49 | ...::log::<...>(...) | 78 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:78:12:78:49 | ArgList | 78 | ArgList |  |
+| test_logging.rs:78:12:78:49 | ExprStmt | 78 | ExprStmt |  |
+| test_logging.rs:78:12:78:49 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:12:78:49 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:12:78:49 | MacroStmts | 78 | MacroStmts |  |
+| test_logging.rs:78:12:78:49 | MacroStmts | 78 | MacroStmts |  |
+| test_logging.rs:78:12:78:49 | MacroStmts | 78 | MacroStmts |  |
+| test_logging.rs:78:12:78:49 | StmtList | 78 | StmtList |  |
+| test_logging.rs:78:12:78:49 | StmtList | 78 | StmtList |  |
+| test_logging.rs:78:12:78:49 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:49 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:12:78:49 | if ... {...} | 78 | IfExpr |  |
+| test_logging.rs:78:12:78:49 | { ... } | 78 | BlockExpr |  |
+| test_logging.rs:78:12:78:49 | { ... } | 78 | BlockExpr |  |
+| test_logging.rs:78:18:78:38 | ...::__log_value!... | 78 | MacroCall |  |
+| test_logging.rs:78:18:78:38 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:18:78:38 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:22:78:29 | password | 78 | IdentPath |  |
+| test_logging.rs:78:22:78:29 | password | 78 | NameRef |  |
+| test_logging.rs:78:22:78:29 | password | 78 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:78:22:78:29 | password | 78 | PathSegment |  |
+| test_logging.rs:78:22:78:38 | &... | 78 | RefExpr |  |
+| test_logging.rs:78:22:78:38 | &... | 78 | RefExpr |  |
+| test_logging.rs:78:22:78:38 | (...) | 78 | ParenExpr |  |
+| test_logging.rs:78:22:78:38 | ...::capture_debug(...) | 78 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_debug, target:PathExpr |
+| test_logging.rs:78:22:78:38 | ArgList | 78 | ArgList |  |
+| test_logging.rs:78:22:78:38 | password.as_str(...) | 78 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_str |
+| test_logging.rs:78:31:78:36 | as_str | 78 | NameRef |  |
+| test_logging.rs:78:37:78:38 | ArgList | 78 | ArgList |  |
+| test_logging.rs:78:41:78:49 | "message" | 78 | LiteralExpr |  |
+| test_logging.rs:78:41:78:49 | ...::format_args!... | 78 | MacroCall |  |
+| test_logging.rs:78:41:78:49 | FormatArgsExpr | 78 | FormatArgsExpr |  |
+| test_logging.rs:78:41:78:49 | MacroExpr | 78 | MacroExpr |  |
+| test_logging.rs:78:41:78:49 | TokenTree | 78 | TokenTree |  |
+| test_logging.rs:78:53:78:95 | //... | 78 | Comment |  |
+| test_logging.rs:80:5:80:19 | let ... = 1 | 80 | LetStmt |  |
+| test_logging.rs:80:9:80:14 | value1 | 80 | IdentPat |  |
+| test_logging.rs:80:9:80:14 | value1 | 80 | Name |  |
+| test_logging.rs:80:18:80:18 | 1 | 80 | LiteralExpr |  |
+| test_logging.rs:81:5:81:9 | error | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:9 | error | 81 | NameRef |  |
+| test_logging.rs:81:5:81:9 | error | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | "module::path" | 81 | LiteralExpr |  |
+| test_logging.rs:81:5:81:44 | "module::path" | 81 | LiteralExpr |  |
+| test_logging.rs:81:5:81:44 | "value1" | 81 | LiteralExpr |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | $crate | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | &... | 81 | RefExpr |  |
+| test_logging.rs:81:5:81:44 | (...) | 81 | ParenExpr |  |
+| test_logging.rs:81:5:81:44 | (...::Error) | 81 | ParenExpr |  |
+| test_logging.rs:81:5:81:44 | ... && ... | 81 | BinaryExpr |  |
+| test_logging.rs:81:5:81:44 | ... <= ... | 81 | BinaryExpr |  |
+| test_logging.rs:81:5:81:44 | ... <= ... | 81 | BinaryExpr |  |
+| test_logging.rs:81:5:81:44 | ...::Error | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::Error | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::Level | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::STATIC_MAX_LEVEL | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::STATIC_MAX_LEVEL | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::__log_key | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__log_value | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__log_value | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::__private_api | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::capture_to_value | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::capture_to_value | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::format_args | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::loc | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::loc | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::loc(...) | 81 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:81:5:81:44 | ...::log | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::log | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::log::<...> | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::log::<...> | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::max_level | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::max_level | 81 | PathExpr |  |
+| test_logging.rs:81:5:81:44 | ...::max_level(...) | 81 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:81:5:81:44 | ...::module_path | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::module_path | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | ...::module_path!... | 81 | MacroCall |  |
+| test_logging.rs:81:5:81:44 | ...::module_path!... | 81 | MacroCall |  |
+| test_logging.rs:81:5:81:44 | ...::stringify | 81 | Path |  |
+| test_logging.rs:81:5:81:44 | <...> | 81 | GenericArgList |  |
+| test_logging.rs:81:5:81:44 | ArgList | 81 | ArgList |  |
+| test_logging.rs:81:5:81:44 | ArgList | 81 | ArgList |  |
+| test_logging.rs:81:5:81:44 | Error | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | Error | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | Level | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | Level | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:5:81:44 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:5:81:44 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:5:81:44 | RefTypeRepr | 81 | RefTypeRepr |  |
+| test_logging.rs:81:5:81:44 | STATIC_MAX_LEVEL | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | STATIC_MAX_LEVEL | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:5:81:44 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:5:81:44 | TupleExpr | 81 | TupleExpr |  |
+| test_logging.rs:81:5:81:44 | TypeArg | 81 | TypeArg |  |
+| test_logging.rs:81:5:81:44 | _ | 81 | InferTypeRepr |  |
+| test_logging.rs:81:5:81:44 | __log_key | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __log_key | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __log_value | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __log_value | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __log_value | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __log_value | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | __private_api | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | capture_to_value | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | capture_to_value | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | error!... | 81 | MacroCall |  |
+| test_logging.rs:81:5:81:44 | format_args | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | format_args | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | let ... = ... | 81 | LetStmt |  |
+| test_logging.rs:81:5:81:44 | loc | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | loc | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | log | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | log | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | log | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | log | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | log | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | log::<...> | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | IdentPat |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | IdentPath |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | Name |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | lvl | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | max_level | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | max_level | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | module_path | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | module_path | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | module_path | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | module_path | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:44 | stringify | 81 | NameRef |  |
+| test_logging.rs:81:5:81:44 | stringify | 81 | PathSegment |  |
+| test_logging.rs:81:5:81:45 | ExprStmt | 81 | ExprStmt |  |
+| test_logging.rs:81:11:81:44 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:17 | &... | 81 | RefExpr |  |
+| test_logging.rs:81:12:81:17 | &... | 81 | RefExpr |  |
+| test_logging.rs:81:12:81:17 | &value1 | 81 | RefExpr |  |
+| test_logging.rs:81:12:81:17 | ...::__log_key!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:17 | ...::__log_value!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:17 | ...::__log_value!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:17 | ...::capture_to_value(...) | 81 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:81:12:81:17 | ...::stringify!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:17 | ArgList | 81 | ArgList |  |
+| test_logging.rs:81:12:81:17 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:17 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:17 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:17 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:17 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:17 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:17 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:17 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:17 | TupleExpr | 81 | TupleExpr |  |
+| test_logging.rs:81:12:81:17 | [...] | 81 | ArrayListExpr |  |
+| test_logging.rs:81:12:81:17 | value1 | 81 | IdentPath |  |
+| test_logging.rs:81:12:81:17 | value1 | 81 | NameRef |  |
+| test_logging.rs:81:12:81:17 | value1 | 81 | PathExpr, VariableAccess |  |
+| test_logging.rs:81:12:81:17 | value1 | 81 | PathSegment |  |
+| test_logging.rs:81:12:81:43 | ...::log!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:43 | ...::log!... | 81 | MacroCall |  |
+| test_logging.rs:81:12:81:43 | ...::log::<...>(...) | 81 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:81:12:81:43 | ArgList | 81 | ArgList |  |
+| test_logging.rs:81:12:81:43 | ExprStmt | 81 | ExprStmt |  |
+| test_logging.rs:81:12:81:43 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:43 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:12:81:43 | MacroStmts | 81 | MacroStmts |  |
+| test_logging.rs:81:12:81:43 | MacroStmts | 81 | MacroStmts |  |
+| test_logging.rs:81:12:81:43 | MacroStmts | 81 | MacroStmts |  |
+| test_logging.rs:81:12:81:43 | StmtList | 81 | StmtList |  |
+| test_logging.rs:81:12:81:43 | StmtList | 81 | StmtList |  |
+| test_logging.rs:81:12:81:43 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:43 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:12:81:43 | if ... {...} | 81 | IfExpr |  |
+| test_logging.rs:81:12:81:43 | { ... } | 81 | BlockExpr |  |
+| test_logging.rs:81:12:81:43 | { ... } | 81 | BlockExpr |  |
+| test_logging.rs:81:20:81:33 | "message = {}" | 81 | LiteralExpr |  |
+| test_logging.rs:81:20:81:43 | ...::format_args!... | 81 | MacroCall |  |
+| test_logging.rs:81:20:81:43 | FormatArgsExpr | 81 | FormatArgsExpr |  |
+| test_logging.rs:81:20:81:43 | MacroExpr | 81 | MacroExpr |  |
+| test_logging.rs:81:20:81:43 | TokenTree | 81 | TokenTree |  |
+| test_logging.rs:81:31:81:32 | {} | 81 | FormatSynthLocationImpl |  |
+| test_logging.rs:81:36:81:43 | FormatArgsArg | 81 | FormatArgsArg |  |
+| test_logging.rs:81:36:81:43 | harmless | 81 | IdentPath |  |
+| test_logging.rs:81:36:81:43 | harmless | 81 | NameRef |  |
+| test_logging.rs:81:36:81:43 | harmless | 81 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:81:36:81:43 | harmless | 81 | PathSegment |  |
+| test_logging.rs:82:5:82:9 | error | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:9 | error | 82 | NameRef |  |
+| test_logging.rs:82:5:82:9 | error | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | "module::path" | 82 | LiteralExpr |  |
+| test_logging.rs:82:5:82:44 | "module::path" | 82 | LiteralExpr |  |
+| test_logging.rs:82:5:82:44 | "value1" | 82 | LiteralExpr |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | $crate | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | &... | 82 | RefExpr |  |
+| test_logging.rs:82:5:82:44 | (...) | 82 | ParenExpr |  |
+| test_logging.rs:82:5:82:44 | (...::Error) | 82 | ParenExpr |  |
+| test_logging.rs:82:5:82:44 | ... && ... | 82 | BinaryExpr |  |
+| test_logging.rs:82:5:82:44 | ... <= ... | 82 | BinaryExpr |  |
+| test_logging.rs:82:5:82:44 | ... <= ... | 82 | BinaryExpr |  |
+| test_logging.rs:82:5:82:44 | ...::Error | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::Error | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::Level | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::STATIC_MAX_LEVEL | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::STATIC_MAX_LEVEL | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::__log_key | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__log_value | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__log_value | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::__private_api | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::capture_to_value | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::capture_to_value | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::format_args | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::loc | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::loc | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::loc(...) | 82 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:82:5:82:44 | ...::log | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::log | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::log::<...> | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::log::<...> | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::max_level | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::max_level | 82 | PathExpr |  |
+| test_logging.rs:82:5:82:44 | ...::max_level(...) | 82 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:82:5:82:44 | ...::module_path | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::module_path | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | ...::module_path!... | 82 | MacroCall |  |
+| test_logging.rs:82:5:82:44 | ...::module_path!... | 82 | MacroCall |  |
+| test_logging.rs:82:5:82:44 | ...::stringify | 82 | Path |  |
+| test_logging.rs:82:5:82:44 | <...> | 82 | GenericArgList |  |
+| test_logging.rs:82:5:82:44 | ArgList | 82 | ArgList |  |
+| test_logging.rs:82:5:82:44 | ArgList | 82 | ArgList |  |
+| test_logging.rs:82:5:82:44 | Error | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | Error | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | Level | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | Level | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:5:82:44 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:5:82:44 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:5:82:44 | RefTypeRepr | 82 | RefTypeRepr |  |
+| test_logging.rs:82:5:82:44 | STATIC_MAX_LEVEL | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | STATIC_MAX_LEVEL | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:5:82:44 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:5:82:44 | TupleExpr | 82 | TupleExpr |  |
+| test_logging.rs:82:5:82:44 | TypeArg | 82 | TypeArg |  |
+| test_logging.rs:82:5:82:44 | _ | 82 | InferTypeRepr |  |
+| test_logging.rs:82:5:82:44 | __log_key | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __log_key | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __log_value | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __log_value | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __log_value | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __log_value | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | __private_api | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | capture_to_value | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | capture_to_value | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | error!... | 82 | MacroCall |  |
+| test_logging.rs:82:5:82:44 | format_args | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | format_args | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | let ... = ... | 82 | LetStmt |  |
+| test_logging.rs:82:5:82:44 | loc | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | loc | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | log | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | log | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | log | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | log | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | log | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | log::<...> | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | IdentPat |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | IdentPath |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | Name |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | lvl | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | max_level | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | max_level | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | module_path | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | module_path | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | module_path | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | module_path | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:44 | stringify | 82 | NameRef |  |
+| test_logging.rs:82:5:82:44 | stringify | 82 | PathSegment |  |
+| test_logging.rs:82:5:82:45 | ExprStmt | 82 | ExprStmt |  |
+| test_logging.rs:82:11:82:44 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:17 | &... | 82 | RefExpr |  |
+| test_logging.rs:82:12:82:17 | &... | 82 | RefExpr |  |
+| test_logging.rs:82:12:82:17 | &value1 | 82 | RefExpr |  |
+| test_logging.rs:82:12:82:17 | ...::__log_key!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:17 | ...::__log_value!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:17 | ...::__log_value!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:17 | ...::capture_to_value(...) | 82 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:82:12:82:17 | ...::stringify!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:17 | ArgList | 82 | ArgList |  |
+| test_logging.rs:82:12:82:17 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:17 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:17 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:17 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:17 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:17 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:17 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:17 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:17 | TupleExpr | 82 | TupleExpr |  |
+| test_logging.rs:82:12:82:17 | [...] | 82 | ArrayListExpr |  |
+| test_logging.rs:82:12:82:17 | value1 | 82 | IdentPath |  |
+| test_logging.rs:82:12:82:17 | value1 | 82 | NameRef |  |
+| test_logging.rs:82:12:82:17 | value1 | 82 | PathExpr, VariableAccess |  |
+| test_logging.rs:82:12:82:17 | value1 | 82 | PathSegment |  |
+| test_logging.rs:82:12:82:43 | ...::log!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:43 | ...::log!... | 82 | MacroCall |  |
+| test_logging.rs:82:12:82:43 | ...::log::<...>(...) | 82 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:82:12:82:43 | ArgList | 82 | ArgList |  |
+| test_logging.rs:82:12:82:43 | ExprStmt | 82 | ExprStmt |  |
+| test_logging.rs:82:12:82:43 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:43 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:12:82:43 | MacroStmts | 82 | MacroStmts |  |
+| test_logging.rs:82:12:82:43 | MacroStmts | 82 | MacroStmts |  |
+| test_logging.rs:82:12:82:43 | MacroStmts | 82 | MacroStmts |  |
+| test_logging.rs:82:12:82:43 | StmtList | 82 | StmtList |  |
+| test_logging.rs:82:12:82:43 | StmtList | 82 | StmtList |  |
+| test_logging.rs:82:12:82:43 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:43 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:12:82:43 | if ... {...} | 82 | IfExpr |  |
+| test_logging.rs:82:12:82:43 | { ... } | 82 | BlockExpr |  |
+| test_logging.rs:82:12:82:43 | { ... } | 82 | BlockExpr |  |
+| test_logging.rs:82:20:82:33 | "message = {}" | 82 | LiteralExpr |  |
+| test_logging.rs:82:20:82:43 | ...::format_args!... | 82 | MacroCall |  |
+| test_logging.rs:82:20:82:43 | FormatArgsExpr | 82 | FormatArgsExpr |  |
+| test_logging.rs:82:20:82:43 | MacroExpr | 82 | MacroExpr |  |
+| test_logging.rs:82:20:82:43 | TokenTree | 82 | TokenTree |  |
+| test_logging.rs:82:31:82:32 | {} | 82 | FormatSynthLocationImpl |  |
+| test_logging.rs:82:36:82:43 | FormatArgsArg | 82 | FormatArgsArg |  |
+| test_logging.rs:82:36:82:43 | password | 82 | IdentPath |  |
+| test_logging.rs:82:36:82:43 | password | 82 | NameRef |  |
+| test_logging.rs:82:36:82:43 | password | 82 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:82:36:82:43 | password | 82 | PathSegment |  |
+| test_logging.rs:82:47:82:80 | //... | 82 | Comment |  |
+| test_logging.rs:83:5:83:9 | error | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:9 | error | 83 | NameRef |  |
+| test_logging.rs:83:5:83:9 | error | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | "module::path" | 83 | LiteralExpr |  |
+| test_logging.rs:83:5:83:47 | "value1" | 83 | LiteralExpr |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | $crate | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | (...::Error) | 83 | ParenExpr |  |
+| test_logging.rs:83:5:83:47 | ... && ... | 83 | BinaryExpr |  |
+| test_logging.rs:83:5:83:47 | ... <= ... | 83 | BinaryExpr |  |
+| test_logging.rs:83:5:83:47 | ... <= ... | 83 | BinaryExpr |  |
+| test_logging.rs:83:5:83:47 | ...::Error | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::Error | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::Level | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::STATIC_MAX_LEVEL | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::STATIC_MAX_LEVEL | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::__log_key | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__log_value | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__log_value | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::__private_api | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::capture_to_value | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::capture_to_value | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::format_args | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::loc | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::loc | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::loc(...) | 83 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:83:5:83:47 | ...::log | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::log::<...> | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::log::<...> | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::max_level | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::max_level | 83 | PathExpr |  |
+| test_logging.rs:83:5:83:47 | ...::max_level(...) | 83 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:83:5:83:47 | ...::module_path | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | ...::module_path!... | 83 | MacroCall |  |
+| test_logging.rs:83:5:83:47 | ...::stringify | 83 | Path |  |
+| test_logging.rs:83:5:83:47 | <...> | 83 | GenericArgList |  |
+| test_logging.rs:83:5:83:47 | ArgList | 83 | ArgList |  |
+| test_logging.rs:83:5:83:47 | ArgList | 83 | ArgList |  |
+| test_logging.rs:83:5:83:47 | Error | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | Error | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | Level | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | Level | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:5:83:47 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:5:83:47 | RefTypeRepr | 83 | RefTypeRepr |  |
+| test_logging.rs:83:5:83:47 | STATIC_MAX_LEVEL | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | STATIC_MAX_LEVEL | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:5:83:47 | TypeArg | 83 | TypeArg |  |
+| test_logging.rs:83:5:83:47 | _ | 83 | InferTypeRepr |  |
+| test_logging.rs:83:5:83:47 | __log_key | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __log_key | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __log_value | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __log_value | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __log_value | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __log_value | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | __private_api | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | capture_to_value | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | capture_to_value | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | error!... | 83 | MacroCall |  |
+| test_logging.rs:83:5:83:47 | format_args | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | format_args | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | let ... = ... | 83 | LetStmt |  |
+| test_logging.rs:83:5:83:47 | loc | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | loc | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | log | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | log | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | log | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | log::<...> | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | IdentPat |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | IdentPath |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | Name |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | lvl | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | max_level | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | max_level | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | module_path | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | module_path | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:47 | stringify | 83 | NameRef |  |
+| test_logging.rs:83:5:83:47 | stringify | 83 | PathSegment |  |
+| test_logging.rs:83:5:83:48 | ExprStmt | 83 | ExprStmt |  |
+| test_logging.rs:83:11:83:47 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:20:83:27 | "target" | 83 | LiteralExpr |  |
+| test_logging.rs:83:20:83:27 | &... | 83 | RefExpr |  |
+| test_logging.rs:83:20:83:27 | TupleExpr | 83 | TupleExpr |  |
+| test_logging.rs:83:20:83:46 | ...::log!... | 83 | MacroCall |  |
+| test_logging.rs:83:20:83:46 | ...::log::<...>(...) | 83 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:83:20:83:46 | ArgList | 83 | ArgList |  |
+| test_logging.rs:83:20:83:46 | ExprStmt | 83 | ExprStmt |  |
+| test_logging.rs:83:20:83:46 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:20:83:46 | MacroStmts | 83 | MacroStmts |  |
+| test_logging.rs:83:20:83:46 | MacroStmts | 83 | MacroStmts |  |
+| test_logging.rs:83:20:83:46 | StmtList | 83 | StmtList |  |
+| test_logging.rs:83:20:83:46 | StmtList | 83 | StmtList |  |
+| test_logging.rs:83:20:83:46 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:20:83:46 | if ... {...} | 83 | IfExpr |  |
+| test_logging.rs:83:20:83:46 | { ... } | 83 | BlockExpr |  |
+| test_logging.rs:83:20:83:46 | { ... } | 83 | BlockExpr |  |
+| test_logging.rs:83:30:83:35 | &... | 83 | RefExpr |  |
+| test_logging.rs:83:30:83:35 | &... | 83 | RefExpr |  |
+| test_logging.rs:83:30:83:35 | &value1 | 83 | RefExpr |  |
+| test_logging.rs:83:30:83:35 | ...::__log_key!... | 83 | MacroCall |  |
+| test_logging.rs:83:30:83:35 | ...::__log_value!... | 83 | MacroCall |  |
+| test_logging.rs:83:30:83:35 | ...::__log_value!... | 83 | MacroCall |  |
+| test_logging.rs:83:30:83:35 | ...::capture_to_value(...) | 83 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:83:30:83:35 | ...::stringify!... | 83 | MacroCall |  |
+| test_logging.rs:83:30:83:35 | ArgList | 83 | ArgList |  |
+| test_logging.rs:83:30:83:35 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:30:83:35 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:30:83:35 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:30:83:35 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:30:83:35 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:30:83:35 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:30:83:35 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:30:83:35 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:83:30:83:35 | TupleExpr | 83 | TupleExpr |  |
+| test_logging.rs:83:30:83:35 | [...] | 83 | ArrayListExpr |  |
+| test_logging.rs:83:30:83:35 | value1 | 83 | IdentPath |  |
+| test_logging.rs:83:30:83:35 | value1 | 83 | NameRef |  |
+| test_logging.rs:83:30:83:35 | value1 | 83 | PathExpr, VariableAccess |  |
+| test_logging.rs:83:30:83:35 | value1 | 83 | PathSegment |  |
+| test_logging.rs:83:38:83:46 | "message" | 83 | LiteralExpr |  |
+| test_logging.rs:83:38:83:46 | ...::format_args!... | 83 | MacroCall |  |
+| test_logging.rs:83:38:83:46 | FormatArgsExpr | 83 | FormatArgsExpr |  |
+| test_logging.rs:83:38:83:46 | MacroExpr | 83 | MacroExpr |  |
+| test_logging.rs:83:38:83:46 | TokenTree | 83 | TokenTree |  |
+| test_logging.rs:84:5:84:9 | error | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:9 | error | 84 | NameRef |  |
+| test_logging.rs:84:5:84:9 | error | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | "module::path" | 84 | LiteralExpr |  |
+| test_logging.rs:84:5:84:62 | "value1" | 84 | LiteralExpr |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | $crate | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | (...::Error) | 84 | ParenExpr |  |
+| test_logging.rs:84:5:84:62 | ... && ... | 84 | BinaryExpr |  |
+| test_logging.rs:84:5:84:62 | ... <= ... | 84 | BinaryExpr |  |
+| test_logging.rs:84:5:84:62 | ... <= ... | 84 | BinaryExpr |  |
+| test_logging.rs:84:5:84:62 | ...::Error | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::Error | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::Level | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::STATIC_MAX_LEVEL | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::STATIC_MAX_LEVEL | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::__log_key | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__log_value | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__log_value | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::__private_api | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::capture_to_value | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::capture_to_value | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::format_args | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::loc | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::loc | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::loc(...) | 84 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:84:5:84:62 | ...::log | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::log::<...> | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::log::<...> | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::max_level | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::max_level | 84 | PathExpr |  |
+| test_logging.rs:84:5:84:62 | ...::max_level(...) | 84 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:84:5:84:62 | ...::module_path | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | ...::module_path!... | 84 | MacroCall |  |
+| test_logging.rs:84:5:84:62 | ...::stringify | 84 | Path |  |
+| test_logging.rs:84:5:84:62 | <...> | 84 | GenericArgList |  |
+| test_logging.rs:84:5:84:62 | ArgList | 84 | ArgList |  |
+| test_logging.rs:84:5:84:62 | ArgList | 84 | ArgList |  |
+| test_logging.rs:84:5:84:62 | Error | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | Error | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | Level | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | Level | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:5:84:62 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:5:84:62 | RefTypeRepr | 84 | RefTypeRepr |  |
+| test_logging.rs:84:5:84:62 | STATIC_MAX_LEVEL | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | STATIC_MAX_LEVEL | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:5:84:62 | TypeArg | 84 | TypeArg |  |
+| test_logging.rs:84:5:84:62 | _ | 84 | InferTypeRepr |  |
+| test_logging.rs:84:5:84:62 | __log_key | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __log_key | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __log_value | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __log_value | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __log_value | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __log_value | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | __private_api | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | capture_to_value | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | capture_to_value | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | error!... | 84 | MacroCall |  |
+| test_logging.rs:84:5:84:62 | format_args | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | format_args | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | let ... = ... | 84 | LetStmt |  |
+| test_logging.rs:84:5:84:62 | loc | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | loc | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | log | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | log | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | log | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | log::<...> | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | IdentPat |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | IdentPath |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | Name |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | lvl | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | max_level | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | max_level | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | module_path | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | module_path | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:62 | stringify | 84 | NameRef |  |
+| test_logging.rs:84:5:84:62 | stringify | 84 | PathSegment |  |
+| test_logging.rs:84:5:84:63 | ExprStmt | 84 | ExprStmt |  |
+| test_logging.rs:84:11:84:62 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:20:84:27 | "target" | 84 | LiteralExpr |  |
+| test_logging.rs:84:20:84:27 | &... | 84 | RefExpr |  |
+| test_logging.rs:84:20:84:27 | TupleExpr | 84 | TupleExpr |  |
+| test_logging.rs:84:20:84:61 | ...::log!... | 84 | MacroCall |  |
+| test_logging.rs:84:20:84:61 | ...::log::<...>(...) | 84 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:84:20:84:61 | ArgList | 84 | ArgList |  |
+| test_logging.rs:84:20:84:61 | ExprStmt | 84 | ExprStmt |  |
+| test_logging.rs:84:20:84:61 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:20:84:61 | MacroStmts | 84 | MacroStmts |  |
+| test_logging.rs:84:20:84:61 | MacroStmts | 84 | MacroStmts |  |
+| test_logging.rs:84:20:84:61 | StmtList | 84 | StmtList |  |
+| test_logging.rs:84:20:84:61 | StmtList | 84 | StmtList |  |
+| test_logging.rs:84:20:84:61 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:20:84:61 | if ... {...} | 84 | IfExpr |  |
+| test_logging.rs:84:20:84:61 | { ... } | 84 | BlockExpr |  |
+| test_logging.rs:84:20:84:61 | { ... } | 84 | BlockExpr |  |
+| test_logging.rs:84:30:84:35 | &... | 84 | RefExpr |  |
+| test_logging.rs:84:30:84:35 | &... | 84 | RefExpr |  |
+| test_logging.rs:84:30:84:35 | &value1 | 84 | RefExpr |  |
+| test_logging.rs:84:30:84:35 | ...::__log_key!... | 84 | MacroCall |  |
+| test_logging.rs:84:30:84:35 | ...::__log_value!... | 84 | MacroCall |  |
+| test_logging.rs:84:30:84:35 | ...::__log_value!... | 84 | MacroCall |  |
+| test_logging.rs:84:30:84:35 | ...::capture_to_value(...) | 84 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:84:30:84:35 | ...::stringify!... | 84 | MacroCall |  |
+| test_logging.rs:84:30:84:35 | ArgList | 84 | ArgList |  |
+| test_logging.rs:84:30:84:35 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:30:84:35 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:30:84:35 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:30:84:35 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:30:84:35 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:30:84:35 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:30:84:35 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:30:84:35 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:30:84:35 | TupleExpr | 84 | TupleExpr |  |
+| test_logging.rs:84:30:84:35 | [...] | 84 | ArrayListExpr |  |
+| test_logging.rs:84:30:84:35 | value1 | 84 | IdentPath |  |
+| test_logging.rs:84:30:84:35 | value1 | 84 | NameRef |  |
+| test_logging.rs:84:30:84:35 | value1 | 84 | PathExpr, VariableAccess |  |
+| test_logging.rs:84:30:84:35 | value1 | 84 | PathSegment |  |
+| test_logging.rs:84:38:84:51 | "message = {}" | 84 | LiteralExpr |  |
+| test_logging.rs:84:38:84:61 | ...::format_args!... | 84 | MacroCall |  |
+| test_logging.rs:84:38:84:61 | FormatArgsExpr | 84 | FormatArgsExpr |  |
+| test_logging.rs:84:38:84:61 | MacroExpr | 84 | MacroExpr |  |
+| test_logging.rs:84:38:84:61 | TokenTree | 84 | TokenTree |  |
+| test_logging.rs:84:49:84:50 | {} | 84 | FormatSynthLocationImpl |  |
+| test_logging.rs:84:54:84:61 | FormatArgsArg | 84 | FormatArgsArg |  |
+| test_logging.rs:84:54:84:61 | password | 84 | IdentPath |  |
+| test_logging.rs:84:54:84:61 | password | 84 | NameRef |  |
+| test_logging.rs:84:54:84:61 | password | 84 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:84:54:84:61 | password | 84 | PathSegment |  |
+| test_logging.rs:84:65:84:98 | //... | 84 | Comment |  |
+| test_logging.rs:85:5:85:9 | error | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:9 | error | 85 | NameRef |  |
+| test_logging.rs:85:5:85:9 | error | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | "module::path" | 85 | LiteralExpr |  |
+| test_logging.rs:85:5:85:48 | "value1" | 85 | LiteralExpr |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | $crate | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | (...::Error) | 85 | ParenExpr |  |
+| test_logging.rs:85:5:85:48 | ... && ... | 85 | BinaryExpr |  |
+| test_logging.rs:85:5:85:48 | ... <= ... | 85 | BinaryExpr |  |
+| test_logging.rs:85:5:85:48 | ... <= ... | 85 | BinaryExpr |  |
+| test_logging.rs:85:5:85:48 | ...::Error | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::Error | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::Level | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::STATIC_MAX_LEVEL | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::STATIC_MAX_LEVEL | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::__log_key | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__log_value | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__log_value | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::__private_api | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::capture_to_value | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::capture_to_value | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::format_args | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::loc | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::loc | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::loc(...) | 85 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:85:5:85:48 | ...::log | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::log::<...> | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::log::<...> | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::max_level | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::max_level | 85 | PathExpr |  |
+| test_logging.rs:85:5:85:48 | ...::max_level(...) | 85 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:85:5:85:48 | ...::module_path | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | ...::module_path!... | 85 | MacroCall |  |
+| test_logging.rs:85:5:85:48 | ...::stringify | 85 | Path |  |
+| test_logging.rs:85:5:85:48 | <...> | 85 | GenericArgList |  |
+| test_logging.rs:85:5:85:48 | ArgList | 85 | ArgList |  |
+| test_logging.rs:85:5:85:48 | ArgList | 85 | ArgList |  |
+| test_logging.rs:85:5:85:48 | Error | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | Error | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | Level | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | Level | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:5:85:48 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:5:85:48 | RefTypeRepr | 85 | RefTypeRepr |  |
+| test_logging.rs:85:5:85:48 | STATIC_MAX_LEVEL | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | STATIC_MAX_LEVEL | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:5:85:48 | TypeArg | 85 | TypeArg |  |
+| test_logging.rs:85:5:85:48 | _ | 85 | InferTypeRepr |  |
+| test_logging.rs:85:5:85:48 | __log_key | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __log_key | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __log_value | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __log_value | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __log_value | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __log_value | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | __private_api | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | capture_to_value | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | capture_to_value | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | error!... | 85 | MacroCall |  |
+| test_logging.rs:85:5:85:48 | format_args | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | format_args | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | let ... = ... | 85 | LetStmt |  |
+| test_logging.rs:85:5:85:48 | loc | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | loc | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | log | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | log | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | log | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | log::<...> | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | IdentPat |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | IdentPath |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | Name |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | lvl | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | max_level | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | max_level | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | module_path | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | module_path | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:48 | stringify | 85 | NameRef |  |
+| test_logging.rs:85:5:85:48 | stringify | 85 | PathSegment |  |
+| test_logging.rs:85:5:85:49 | ExprStmt | 85 | ExprStmt |  |
+| test_logging.rs:85:11:85:48 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:20:85:28 | &... | 85 | RefExpr |  |
+| test_logging.rs:85:20:85:28 | &password | 85 | RefExpr |  |
+| test_logging.rs:85:20:85:28 | (...) | 85 | ParenExpr |  |
+| test_logging.rs:85:20:85:28 | TupleExpr | 85 | TupleExpr |  |
+| test_logging.rs:85:20:85:47 | ...::log!... | 85 | MacroCall |  |
+| test_logging.rs:85:20:85:47 | ...::log::<...>(...) | 85 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:85:20:85:47 | ArgList | 85 | ArgList |  |
+| test_logging.rs:85:20:85:47 | ExprStmt | 85 | ExprStmt |  |
+| test_logging.rs:85:20:85:47 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:20:85:47 | MacroStmts | 85 | MacroStmts |  |
+| test_logging.rs:85:20:85:47 | MacroStmts | 85 | MacroStmts |  |
+| test_logging.rs:85:20:85:47 | StmtList | 85 | StmtList |  |
+| test_logging.rs:85:20:85:47 | StmtList | 85 | StmtList |  |
+| test_logging.rs:85:20:85:47 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:20:85:47 | if ... {...} | 85 | IfExpr |  |
+| test_logging.rs:85:20:85:47 | { ... } | 85 | BlockExpr |  |
+| test_logging.rs:85:20:85:47 | { ... } | 85 | BlockExpr |  |
+| test_logging.rs:85:21:85:28 | password | 85 | IdentPath |  |
+| test_logging.rs:85:21:85:28 | password | 85 | NameRef |  |
+| test_logging.rs:85:21:85:28 | password | 85 | PathExpr, VariableAccess |  |
+| test_logging.rs:85:21:85:28 | password | 85 | PathSegment |  |
+| test_logging.rs:85:31:85:36 | &... | 85 | RefExpr |  |
+| test_logging.rs:85:31:85:36 | &... | 85 | RefExpr |  |
+| test_logging.rs:85:31:85:36 | &value1 | 85 | RefExpr |  |
+| test_logging.rs:85:31:85:36 | ...::__log_key!... | 85 | MacroCall |  |
+| test_logging.rs:85:31:85:36 | ...::__log_value!... | 85 | MacroCall |  |
+| test_logging.rs:85:31:85:36 | ...::__log_value!... | 85 | MacroCall |  |
+| test_logging.rs:85:31:85:36 | ...::capture_to_value(...) | 85 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:85:31:85:36 | ...::stringify!... | 85 | MacroCall |  |
+| test_logging.rs:85:31:85:36 | ArgList | 85 | ArgList |  |
+| test_logging.rs:85:31:85:36 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:31:85:36 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:31:85:36 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:31:85:36 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:31:85:36 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:31:85:36 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:31:85:36 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:31:85:36 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:31:85:36 | TupleExpr | 85 | TupleExpr |  |
+| test_logging.rs:85:31:85:36 | [...] | 85 | ArrayListExpr |  |
+| test_logging.rs:85:31:85:36 | value1 | 85 | IdentPath |  |
+| test_logging.rs:85:31:85:36 | value1 | 85 | NameRef |  |
+| test_logging.rs:85:31:85:36 | value1 | 85 | PathExpr, VariableAccess |  |
+| test_logging.rs:85:31:85:36 | value1 | 85 | PathSegment |  |
+| test_logging.rs:85:39:85:47 | "message" | 85 | LiteralExpr |  |
+| test_logging.rs:85:39:85:47 | ...::format_args!... | 85 | MacroCall |  |
+| test_logging.rs:85:39:85:47 | FormatArgsExpr | 85 | FormatArgsExpr |  |
+| test_logging.rs:85:39:85:47 | MacroExpr | 85 | MacroExpr |  |
+| test_logging.rs:85:39:85:47 | TokenTree | 85 | TokenTree |  |
+| test_logging.rs:85:51:85:84 | //... | 85 | Comment |  |
+| test_logging.rs:86:5:86:9 | error | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:9 | error | 86 | NameRef |  |
+| test_logging.rs:86:5:86:9 | error | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | "module::path" | 86 | LiteralExpr |  |
+| test_logging.rs:86:5:86:44 | "module::path" | 86 | LiteralExpr |  |
+| test_logging.rs:86:5:86:44 | "value1" | 86 | LiteralExpr |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | $crate | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | &... | 86 | RefExpr |  |
+| test_logging.rs:86:5:86:44 | (...) | 86 | ParenExpr |  |
+| test_logging.rs:86:5:86:44 | (...::Error) | 86 | ParenExpr |  |
+| test_logging.rs:86:5:86:44 | ... && ... | 86 | BinaryExpr |  |
+| test_logging.rs:86:5:86:44 | ... <= ... | 86 | BinaryExpr |  |
+| test_logging.rs:86:5:86:44 | ... <= ... | 86 | BinaryExpr |  |
+| test_logging.rs:86:5:86:44 | ...::Error | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::Error | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::Level | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::STATIC_MAX_LEVEL | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::STATIC_MAX_LEVEL | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::__log_key | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__log_value | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__log_value | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::__private_api | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::capture_to_value | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::capture_to_value | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::format_args | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::loc | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::loc | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::loc(...) | 86 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:86:5:86:44 | ...::log | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::log | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::log::<...> | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::log::<...> | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::max_level | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::max_level | 86 | PathExpr |  |
+| test_logging.rs:86:5:86:44 | ...::max_level(...) | 86 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:86:5:86:44 | ...::module_path | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::module_path | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | ...::module_path!... | 86 | MacroCall |  |
+| test_logging.rs:86:5:86:44 | ...::module_path!... | 86 | MacroCall |  |
+| test_logging.rs:86:5:86:44 | ...::stringify | 86 | Path |  |
+| test_logging.rs:86:5:86:44 | <...> | 86 | GenericArgList |  |
+| test_logging.rs:86:5:86:44 | ArgList | 86 | ArgList |  |
+| test_logging.rs:86:5:86:44 | ArgList | 86 | ArgList |  |
+| test_logging.rs:86:5:86:44 | Error | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | Error | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | Level | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | Level | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:5:86:44 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:5:86:44 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:5:86:44 | RefTypeRepr | 86 | RefTypeRepr |  |
+| test_logging.rs:86:5:86:44 | STATIC_MAX_LEVEL | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | STATIC_MAX_LEVEL | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:5:86:44 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:5:86:44 | TupleExpr | 86 | TupleExpr |  |
+| test_logging.rs:86:5:86:44 | TypeArg | 86 | TypeArg |  |
+| test_logging.rs:86:5:86:44 | _ | 86 | InferTypeRepr |  |
+| test_logging.rs:86:5:86:44 | __log_key | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __log_key | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __log_value | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __log_value | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __log_value | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __log_value | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | __private_api | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | capture_to_value | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | capture_to_value | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | error!... | 86 | MacroCall |  |
+| test_logging.rs:86:5:86:44 | format_args | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | format_args | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | let ... = ... | 86 | LetStmt |  |
+| test_logging.rs:86:5:86:44 | loc | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | loc | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | log | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | log | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | log | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | log | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | log | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | log::<...> | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | IdentPat |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | IdentPath |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | Name |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | lvl | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | max_level | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | max_level | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | module_path | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | module_path | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | module_path | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | module_path | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:44 | stringify | 86 | NameRef |  |
+| test_logging.rs:86:5:86:44 | stringify | 86 | PathSegment |  |
+| test_logging.rs:86:5:86:45 | ExprStmt | 86 | ExprStmt |  |
+| test_logging.rs:86:11:86:44 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:17 | &... | 86 | RefExpr |  |
+| test_logging.rs:86:12:86:17 | &... | 86 | RefExpr |  |
+| test_logging.rs:86:12:86:17 | &value1 | 86 | RefExpr |  |
+| test_logging.rs:86:12:86:17 | ...::__log_key!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:17 | ...::__log_value!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:17 | ...::__log_value!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:17 | ...::capture_to_value(...) | 86 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:86:12:86:17 | ...::stringify!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:17 | ArgList | 86 | ArgList |  |
+| test_logging.rs:86:12:86:17 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:17 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:17 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:17 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:17 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:17 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:17 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:17 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:17 | TupleExpr | 86 | TupleExpr |  |
+| test_logging.rs:86:12:86:17 | [...] | 86 | ArrayListExpr |  |
+| test_logging.rs:86:12:86:17 | value1 | 86 | IdentPath |  |
+| test_logging.rs:86:12:86:17 | value1 | 86 | NameRef |  |
+| test_logging.rs:86:12:86:17 | value1 | 86 | PathExpr, VariableAccess |  |
+| test_logging.rs:86:12:86:17 | value1 | 86 | PathSegment |  |
+| test_logging.rs:86:12:86:43 | ...::log!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:43 | ...::log!... | 86 | MacroCall |  |
+| test_logging.rs:86:12:86:43 | ...::log::<...>(...) | 86 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:86:12:86:43 | ArgList | 86 | ArgList |  |
+| test_logging.rs:86:12:86:43 | ExprStmt | 86 | ExprStmt |  |
+| test_logging.rs:86:12:86:43 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:43 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:12:86:43 | MacroStmts | 86 | MacroStmts |  |
+| test_logging.rs:86:12:86:43 | MacroStmts | 86 | MacroStmts |  |
+| test_logging.rs:86:12:86:43 | MacroStmts | 86 | MacroStmts |  |
+| test_logging.rs:86:12:86:43 | StmtList | 86 | StmtList |  |
+| test_logging.rs:86:12:86:43 | StmtList | 86 | StmtList |  |
+| test_logging.rs:86:12:86:43 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:43 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:12:86:43 | if ... {...} | 86 | IfExpr |  |
+| test_logging.rs:86:12:86:43 | { ... } | 86 | BlockExpr |  |
+| test_logging.rs:86:12:86:43 | { ... } | 86 | BlockExpr |  |
+| test_logging.rs:86:20:86:33 | "message = {}" | 86 | LiteralExpr |  |
+| test_logging.rs:86:20:86:43 | ...::format_args!... | 86 | MacroCall |  |
+| test_logging.rs:86:20:86:43 | FormatArgsExpr | 86 | FormatArgsExpr |  |
+| test_logging.rs:86:20:86:43 | MacroExpr | 86 | MacroExpr |  |
+| test_logging.rs:86:20:86:43 | TokenTree | 86 | TokenTree |  |
+| test_logging.rs:86:31:86:32 | {} | 86 | FormatSynthLocationImpl |  |
+| test_logging.rs:86:36:86:43 | FormatArgsArg | 86 | FormatArgsArg |  |
+| test_logging.rs:86:36:86:43 | password | 86 | IdentPath |  |
+| test_logging.rs:86:36:86:43 | password | 86 | NameRef |  |
+| test_logging.rs:86:36:86:43 | password | 86 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:86:36:86:43 | password | 86 | PathSegment |  |
+| test_logging.rs:86:47:86:80 | //... | 86 | Comment |  |
+| test_logging.rs:88:5:88:35 | let ... = ... | 88 | LetStmt |  |
+| test_logging.rs:88:9:88:14 | value2 | 88 | IdentPat |  |
+| test_logging.rs:88:9:88:14 | value2 | 88 | Name |  |
+| test_logging.rs:88:18:88:25 | password | 88 | IdentPath |  |
+| test_logging.rs:88:18:88:25 | password | 88 | NameRef |  |
+| test_logging.rs:88:18:88:25 | password | 88 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:88:18:88:25 | password | 88 | PathSegment |  |
+| test_logging.rs:88:18:88:34 | password.as_str(...) | 88 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_str |
+| test_logging.rs:88:27:88:32 | as_str | 88 | NameRef |  |
+| test_logging.rs:88:33:88:34 | ArgList | 88 | ArgList |  |
+| test_logging.rs:89:5:89:9 | error | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:9 | error | 89 | NameRef |  |
+| test_logging.rs:89:5:89:9 | error | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | "module::path" | 89 | LiteralExpr |  |
+| test_logging.rs:89:5:89:29 | "module::path" | 89 | LiteralExpr |  |
+| test_logging.rs:89:5:89:29 | "value2" | 89 | LiteralExpr |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | $crate | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | &... | 89 | RefExpr |  |
+| test_logging.rs:89:5:89:29 | (...) | 89 | ParenExpr |  |
+| test_logging.rs:89:5:89:29 | (...::Error) | 89 | ParenExpr |  |
+| test_logging.rs:89:5:89:29 | ... && ... | 89 | BinaryExpr |  |
+| test_logging.rs:89:5:89:29 | ... <= ... | 89 | BinaryExpr |  |
+| test_logging.rs:89:5:89:29 | ... <= ... | 89 | BinaryExpr |  |
+| test_logging.rs:89:5:89:29 | ...::Error | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::Error | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::Level | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::STATIC_MAX_LEVEL | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::STATIC_MAX_LEVEL | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::__log_key | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__log_value | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__log_value | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::__private_api | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::capture_to_value | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::capture_to_value | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::format_args | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::loc | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::loc | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::loc(...) | 89 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:89:5:89:29 | ...::log | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::log | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::log::<...> | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::log::<...> | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::max_level | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::max_level | 89 | PathExpr |  |
+| test_logging.rs:89:5:89:29 | ...::max_level(...) | 89 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:89:5:89:29 | ...::module_path | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::module_path | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | ...::module_path!... | 89 | MacroCall |  |
+| test_logging.rs:89:5:89:29 | ...::module_path!... | 89 | MacroCall |  |
+| test_logging.rs:89:5:89:29 | ...::stringify | 89 | Path |  |
+| test_logging.rs:89:5:89:29 | <...> | 89 | GenericArgList |  |
+| test_logging.rs:89:5:89:29 | ArgList | 89 | ArgList |  |
+| test_logging.rs:89:5:89:29 | ArgList | 89 | ArgList |  |
+| test_logging.rs:89:5:89:29 | Error | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | Error | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | Level | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | Level | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:5:89:29 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:5:89:29 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:5:89:29 | RefTypeRepr | 89 | RefTypeRepr |  |
+| test_logging.rs:89:5:89:29 | STATIC_MAX_LEVEL | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | STATIC_MAX_LEVEL | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:5:89:29 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:5:89:29 | TupleExpr | 89 | TupleExpr |  |
+| test_logging.rs:89:5:89:29 | TypeArg | 89 | TypeArg |  |
+| test_logging.rs:89:5:89:29 | _ | 89 | InferTypeRepr |  |
+| test_logging.rs:89:5:89:29 | __log_key | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __log_key | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __log_value | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __log_value | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __log_value | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __log_value | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | __private_api | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | capture_to_value | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | capture_to_value | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | error!... | 89 | MacroCall |  |
+| test_logging.rs:89:5:89:29 | format_args | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | format_args | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | let ... = ... | 89 | LetStmt |  |
+| test_logging.rs:89:5:89:29 | loc | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | loc | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | log | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | log | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | log | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | log | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | log | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | log::<...> | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | IdentPat |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | IdentPath |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | Name |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | lvl | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | max_level | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | max_level | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | module_path | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | module_path | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | module_path | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | module_path | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:29 | stringify | 89 | NameRef |  |
+| test_logging.rs:89:5:89:29 | stringify | 89 | PathSegment |  |
+| test_logging.rs:89:5:89:30 | ExprStmt | 89 | ExprStmt |  |
+| test_logging.rs:89:11:89:29 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:17 | &... | 89 | RefExpr |  |
+| test_logging.rs:89:12:89:17 | &... | 89 | RefExpr |  |
+| test_logging.rs:89:12:89:17 | &value2 | 89 | RefExpr |  |
+| test_logging.rs:89:12:89:17 | ...::__log_key!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:17 | ...::__log_value!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:17 | ...::__log_value!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:17 | ...::capture_to_value(...) | 89 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::kv_support::capture_to_value, target:PathExpr |
+| test_logging.rs:89:12:89:17 | ...::stringify!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:17 | ArgList | 89 | ArgList |  |
+| test_logging.rs:89:12:89:17 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:17 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:17 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:17 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:17 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:17 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:17 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:17 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:17 | TupleExpr | 89 | TupleExpr |  |
+| test_logging.rs:89:12:89:17 | [...] | 89 | ArrayListExpr |  |
+| test_logging.rs:89:12:89:17 | value2 | 89 | IdentPath |  |
+| test_logging.rs:89:12:89:17 | value2 | 89 | NameRef |  |
+| test_logging.rs:89:12:89:17 | value2 | 89 | PathExpr, VariableAccess |  |
+| test_logging.rs:89:12:89:17 | value2 | 89 | PathSegment |  |
+| test_logging.rs:89:12:89:28 | ...::log!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:28 | ...::log!... | 89 | MacroCall |  |
+| test_logging.rs:89:12:89:28 | ...::log::<...>(...) | 89 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:89:12:89:28 | ArgList | 89 | ArgList |  |
+| test_logging.rs:89:12:89:28 | ExprStmt | 89 | ExprStmt |  |
+| test_logging.rs:89:12:89:28 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:28 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:12:89:28 | MacroStmts | 89 | MacroStmts |  |
+| test_logging.rs:89:12:89:28 | MacroStmts | 89 | MacroStmts |  |
+| test_logging.rs:89:12:89:28 | MacroStmts | 89 | MacroStmts |  |
+| test_logging.rs:89:12:89:28 | StmtList | 89 | StmtList |  |
+| test_logging.rs:89:12:89:28 | StmtList | 89 | StmtList |  |
+| test_logging.rs:89:12:89:28 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:28 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:12:89:28 | if ... {...} | 89 | IfExpr |  |
+| test_logging.rs:89:12:89:28 | { ... } | 89 | BlockExpr |  |
+| test_logging.rs:89:12:89:28 | { ... } | 89 | BlockExpr |  |
+| test_logging.rs:89:20:89:28 | "message" | 89 | LiteralExpr |  |
+| test_logging.rs:89:20:89:28 | ...::format_args!... | 89 | MacroCall |  |
+| test_logging.rs:89:20:89:28 | FormatArgsExpr | 89 | FormatArgsExpr |  |
+| test_logging.rs:89:20:89:28 | MacroExpr | 89 | MacroExpr |  |
+| test_logging.rs:89:20:89:28 | TokenTree | 89 | TokenTree |  |
+| test_logging.rs:89:32:89:74 | //... | 89 | Comment |  |
+| test_logging.rs:90:5:90:9 | error | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:9 | error | 90 | NameRef |  |
+| test_logging.rs:90:5:90:9 | error | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | "module::path" | 90 | LiteralExpr |  |
+| test_logging.rs:90:5:90:31 | "module::path" | 90 | LiteralExpr |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | $crate | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | &... | 90 | RefExpr |  |
+| test_logging.rs:90:5:90:31 | (...) | 90 | ParenExpr |  |
+| test_logging.rs:90:5:90:31 | (...::Error) | 90 | ParenExpr |  |
+| test_logging.rs:90:5:90:31 | ... && ... | 90 | BinaryExpr |  |
+| test_logging.rs:90:5:90:31 | ... <= ... | 90 | BinaryExpr |  |
+| test_logging.rs:90:5:90:31 | ... <= ... | 90 | BinaryExpr |  |
+| test_logging.rs:90:5:90:31 | ...::Error | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::Error | 90 | PathExpr |  |
+| test_logging.rs:90:5:90:31 | ...::Level | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::STATIC_MAX_LEVEL | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::STATIC_MAX_LEVEL | 90 | PathExpr |  |
+| test_logging.rs:90:5:90:31 | ...::__private_api | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::__private_api | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::__private_api | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::__private_api | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::__private_api | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::format_args | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::loc | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::loc | 90 | PathExpr |  |
+| test_logging.rs:90:5:90:31 | ...::loc(...) | 90 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:90:5:90:31 | ...::log | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::log | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::log | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::log | 90 | PathExpr |  |
+| test_logging.rs:90:5:90:31 | ...::max_level | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::max_level | 90 | PathExpr |  |
+| test_logging.rs:90:5:90:31 | ...::max_level(...) | 90 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:90:5:90:31 | ...::module_path | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::module_path | 90 | Path |  |
+| test_logging.rs:90:5:90:31 | ...::module_path!... | 90 | MacroCall |  |
+| test_logging.rs:90:5:90:31 | ...::module_path!... | 90 | MacroCall |  |
+| test_logging.rs:90:5:90:31 | ArgList | 90 | ArgList |  |
+| test_logging.rs:90:5:90:31 | ArgList | 90 | ArgList |  |
+| test_logging.rs:90:5:90:31 | Error | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | Error | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | Level | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | Level | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:5:90:31 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:5:90:31 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:5:90:31 | STATIC_MAX_LEVEL | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | STATIC_MAX_LEVEL | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:5:90:31 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:5:90:31 | TupleExpr | 90 | TupleExpr |  |
+| test_logging.rs:90:5:90:31 | TupleExpr | 90 | TupleExpr |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | __private_api | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | error!... | 90 | MacroCall |  |
+| test_logging.rs:90:5:90:31 | format_args | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | format_args | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | let ... = ... | 90 | LetStmt |  |
+| test_logging.rs:90:5:90:31 | loc | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | loc | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | log | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | log | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | log | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | log | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | log | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | log | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | IdentPat |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | IdentPath |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | Name |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | lvl | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | max_level | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | max_level | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | module_path | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | module_path | 90 | NameRef |  |
+| test_logging.rs:90:5:90:31 | module_path | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:31 | module_path | 90 | PathSegment |  |
+| test_logging.rs:90:5:90:32 | ExprStmt | 90 | ExprStmt |  |
+| test_logging.rs:90:11:90:31 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:12:90:30 | ...::format_args!... | 90 | MacroCall |  |
+| test_logging.rs:90:12:90:30 | ...::log!... | 90 | MacroCall |  |
+| test_logging.rs:90:12:90:30 | ...::log!... | 90 | MacroCall |  |
+| test_logging.rs:90:12:90:30 | ...::log(...) | 90 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:90:12:90:30 | ArgList | 90 | ArgList |  |
+| test_logging.rs:90:12:90:30 | ExprStmt | 90 | ExprStmt |  |
+| test_logging.rs:90:12:90:30 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:12:90:30 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:12:90:30 | MacroExpr | 90 | MacroExpr |  |
+| test_logging.rs:90:12:90:30 | MacroStmts | 90 | MacroStmts |  |
+| test_logging.rs:90:12:90:30 | MacroStmts | 90 | MacroStmts |  |
+| test_logging.rs:90:12:90:30 | MacroStmts | 90 | MacroStmts |  |
+| test_logging.rs:90:12:90:30 | StmtList | 90 | StmtList |  |
+| test_logging.rs:90:12:90:30 | StmtList | 90 | StmtList |  |
+| test_logging.rs:90:12:90:30 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:12:90:30 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:12:90:30 | TokenTree | 90 | TokenTree |  |
+| test_logging.rs:90:12:90:30 | if ... {...} | 90 | IfExpr |  |
+| test_logging.rs:90:12:90:30 | { ... } | 90 | BlockExpr |  |
+| test_logging.rs:90:12:90:30 | { ... } | 90 | BlockExpr |  |
+| test_logging.rs:90:34:90:76 | //... | 90 | Comment |  |
+| test_logging.rs:92:5:92:20 | //... | 92 | Comment |  |
+| test_logging.rs:93:5:93:23 | let ... = ... | 93 | LetStmt |  |
+| test_logging.rs:93:9:93:10 | m1 | 93 | IdentPat |  |
+| test_logging.rs:93:9:93:10 | m1 | 93 | Name |  |
+| test_logging.rs:93:14:93:22 | &password | 93 | RefExpr |  |
+| test_logging.rs:93:15:93:22 | password | 93 | IdentPath |  |
+| test_logging.rs:93:15:93:22 | password | 93 | NameRef |  |
+| test_logging.rs:93:15:93:22 | password | 93 | PathExpr, VariableAccess |  |
+| test_logging.rs:93:15:93:22 | password | 93 | PathSegment |  |
+| test_logging.rs:93:25:93:38 | //... | 93 | Comment |  |
+| test_logging.rs:94:5:94:8 | info | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:8 | info | 94 | NameRef |  |
+| test_logging.rs:94:5:94:8 | info | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | "module::path" | 94 | LiteralExpr |  |
+| test_logging.rs:94:5:94:29 | "module::path" | 94 | LiteralExpr |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | $crate | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | &... | 94 | RefExpr |  |
+| test_logging.rs:94:5:94:29 | (...) | 94 | ParenExpr |  |
+| test_logging.rs:94:5:94:29 | (...::Info) | 94 | ParenExpr |  |
+| test_logging.rs:94:5:94:29 | ... && ... | 94 | BinaryExpr |  |
+| test_logging.rs:94:5:94:29 | ... <= ... | 94 | BinaryExpr |  |
+| test_logging.rs:94:5:94:29 | ... <= ... | 94 | BinaryExpr |  |
+| test_logging.rs:94:5:94:29 | ...::Info | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::Info | 94 | PathExpr |  |
+| test_logging.rs:94:5:94:29 | ...::Level | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::STATIC_MAX_LEVEL | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::STATIC_MAX_LEVEL | 94 | PathExpr |  |
+| test_logging.rs:94:5:94:29 | ...::__private_api | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::__private_api | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::__private_api | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::__private_api | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::__private_api | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::format_args | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::loc | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::loc | 94 | PathExpr |  |
+| test_logging.rs:94:5:94:29 | ...::loc(...) | 94 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:94:5:94:29 | ...::log | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::log | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::log | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::log | 94 | PathExpr |  |
+| test_logging.rs:94:5:94:29 | ...::max_level | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::max_level | 94 | PathExpr |  |
+| test_logging.rs:94:5:94:29 | ...::max_level(...) | 94 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:94:5:94:29 | ...::module_path | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::module_path | 94 | Path |  |
+| test_logging.rs:94:5:94:29 | ...::module_path!... | 94 | MacroCall |  |
+| test_logging.rs:94:5:94:29 | ...::module_path!... | 94 | MacroCall |  |
+| test_logging.rs:94:5:94:29 | ArgList | 94 | ArgList |  |
+| test_logging.rs:94:5:94:29 | ArgList | 94 | ArgList |  |
+| test_logging.rs:94:5:94:29 | Info | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | Info | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | Level | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | Level | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:5:94:29 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:5:94:29 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:5:94:29 | STATIC_MAX_LEVEL | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | STATIC_MAX_LEVEL | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:5:94:29 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:5:94:29 | TupleExpr | 94 | TupleExpr |  |
+| test_logging.rs:94:5:94:29 | TupleExpr | 94 | TupleExpr |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | __private_api | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | format_args | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | format_args | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | info!... | 94 | MacroCall |  |
+| test_logging.rs:94:5:94:29 | let ... = ... | 94 | LetStmt |  |
+| test_logging.rs:94:5:94:29 | loc | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | loc | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | log | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | log | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | log | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | log | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | log | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | log | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | IdentPat |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | IdentPath |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | Name |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | lvl | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | max_level | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | max_level | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | module_path | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | module_path | 94 | NameRef |  |
+| test_logging.rs:94:5:94:29 | module_path | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:29 | module_path | 94 | PathSegment |  |
+| test_logging.rs:94:5:94:30 | ExprStmt | 94 | ExprStmt |  |
+| test_logging.rs:94:10:94:29 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:11:94:24 | "message = {}" | 94 | LiteralExpr |  |
+| test_logging.rs:94:11:94:28 | ...::format_args!... | 94 | MacroCall |  |
+| test_logging.rs:94:11:94:28 | ...::log!... | 94 | MacroCall |  |
+| test_logging.rs:94:11:94:28 | ...::log!... | 94 | MacroCall |  |
+| test_logging.rs:94:11:94:28 | ...::log(...) | 94 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:94:11:94:28 | ArgList | 94 | ArgList |  |
+| test_logging.rs:94:11:94:28 | ExprStmt | 94 | ExprStmt |  |
+| test_logging.rs:94:11:94:28 | FormatArgsExpr | 94 | FormatArgsExpr |  |
+| test_logging.rs:94:11:94:28 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:11:94:28 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:11:94:28 | MacroExpr | 94 | MacroExpr |  |
+| test_logging.rs:94:11:94:28 | MacroStmts | 94 | MacroStmts |  |
+| test_logging.rs:94:11:94:28 | MacroStmts | 94 | MacroStmts |  |
+| test_logging.rs:94:11:94:28 | MacroStmts | 94 | MacroStmts |  |
+| test_logging.rs:94:11:94:28 | StmtList | 94 | StmtList |  |
+| test_logging.rs:94:11:94:28 | StmtList | 94 | StmtList |  |
+| test_logging.rs:94:11:94:28 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:11:94:28 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:11:94:28 | TokenTree | 94 | TokenTree |  |
+| test_logging.rs:94:11:94:28 | if ... {...} | 94 | IfExpr |  |
+| test_logging.rs:94:11:94:28 | { ... } | 94 | BlockExpr |  |
+| test_logging.rs:94:11:94:28 | { ... } | 94 | BlockExpr |  |
+| test_logging.rs:94:22:94:23 | {} | 94 | FormatSynthLocationImpl |  |
+| test_logging.rs:94:27:94:28 | FormatArgsArg | 94 | FormatArgsArg |  |
+| test_logging.rs:94:27:94:28 | m1 | 94 | IdentPath |  |
+| test_logging.rs:94:27:94:28 | m1 | 94 | NameRef |  |
+| test_logging.rs:94:27:94:28 | m1 | 94 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:94:27:94:28 | m1 | 94 | PathSegment |  |
+| test_logging.rs:94:32:94:68 | //... | 94 | Comment |  |
+| test_logging.rs:96:5:96:50 | let ... = ... | 96 | LetStmt |  |
+| test_logging.rs:96:9:96:10 | m2 | 96 | IdentPat |  |
+| test_logging.rs:96:9:96:10 | m2 | 96 | Name |  |
+| test_logging.rs:96:14:96:25 | "message = " | 96 | LiteralExpr |  |
+| test_logging.rs:96:14:96:37 | "message = ".to_string(...) | 96 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:96:14:96:49 | ... + ... | 96 | BinaryExpr |  |
+| test_logging.rs:96:27:96:35 | to_string | 96 | NameRef |  |
+| test_logging.rs:96:36:96:37 | ArgList | 96 | ArgList |  |
+| test_logging.rs:96:41:96:49 | &password | 96 | RefExpr |  |
+| test_logging.rs:96:42:96:49 | password | 96 | IdentPath |  |
+| test_logging.rs:96:42:96:49 | password | 96 | NameRef |  |
+| test_logging.rs:96:42:96:49 | password | 96 | PathExpr, VariableAccess |  |
+| test_logging.rs:96:42:96:49 | password | 96 | PathSegment |  |
+| test_logging.rs:96:52:96:65 | //... | 96 | Comment |  |
+| test_logging.rs:97:5:97:8 | info | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:8 | info | 97 | NameRef |  |
+| test_logging.rs:97:5:97:8 | info | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | "module::path" | 97 | LiteralExpr |  |
+| test_logging.rs:97:5:97:19 | "module::path" | 97 | LiteralExpr |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | $crate | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | &... | 97 | RefExpr |  |
+| test_logging.rs:97:5:97:19 | (...) | 97 | ParenExpr |  |
+| test_logging.rs:97:5:97:19 | (...::Info) | 97 | ParenExpr |  |
+| test_logging.rs:97:5:97:19 | ... && ... | 97 | BinaryExpr |  |
+| test_logging.rs:97:5:97:19 | ... <= ... | 97 | BinaryExpr |  |
+| test_logging.rs:97:5:97:19 | ... <= ... | 97 | BinaryExpr |  |
+| test_logging.rs:97:5:97:19 | ...::Info | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::Info | 97 | PathExpr |  |
+| test_logging.rs:97:5:97:19 | ...::Level | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::STATIC_MAX_LEVEL | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::STATIC_MAX_LEVEL | 97 | PathExpr |  |
+| test_logging.rs:97:5:97:19 | ...::__private_api | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::__private_api | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::__private_api | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::__private_api | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::__private_api | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::format_args | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::loc | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::loc | 97 | PathExpr |  |
+| test_logging.rs:97:5:97:19 | ...::loc(...) | 97 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:97:5:97:19 | ...::log | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::log | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::log | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::log | 97 | PathExpr |  |
+| test_logging.rs:97:5:97:19 | ...::max_level | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::max_level | 97 | PathExpr |  |
+| test_logging.rs:97:5:97:19 | ...::max_level(...) | 97 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:97:5:97:19 | ...::module_path | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::module_path | 97 | Path |  |
+| test_logging.rs:97:5:97:19 | ...::module_path!... | 97 | MacroCall |  |
+| test_logging.rs:97:5:97:19 | ...::module_path!... | 97 | MacroCall |  |
+| test_logging.rs:97:5:97:19 | ArgList | 97 | ArgList |  |
+| test_logging.rs:97:5:97:19 | ArgList | 97 | ArgList |  |
+| test_logging.rs:97:5:97:19 | Info | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | Info | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | Level | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | Level | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:5:97:19 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:5:97:19 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:5:97:19 | STATIC_MAX_LEVEL | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | STATIC_MAX_LEVEL | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:5:97:19 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:5:97:19 | TupleExpr | 97 | TupleExpr |  |
+| test_logging.rs:97:5:97:19 | TupleExpr | 97 | TupleExpr |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | __private_api | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | format_args | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | format_args | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | info!... | 97 | MacroCall |  |
+| test_logging.rs:97:5:97:19 | let ... = ... | 97 | LetStmt |  |
+| test_logging.rs:97:5:97:19 | loc | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | loc | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | log | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | log | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | log | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | log | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | log | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | log | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | IdentPat |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | IdentPath |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | Name |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | lvl | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | max_level | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | max_level | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | module_path | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | module_path | 97 | NameRef |  |
+| test_logging.rs:97:5:97:19 | module_path | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:19 | module_path | 97 | PathSegment |  |
+| test_logging.rs:97:5:97:20 | ExprStmt | 97 | ExprStmt |  |
+| test_logging.rs:97:10:97:19 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:11:97:14 | "{}" | 97 | LiteralExpr |  |
+| test_logging.rs:97:11:97:18 | ...::format_args!... | 97 | MacroCall |  |
+| test_logging.rs:97:11:97:18 | ...::log!... | 97 | MacroCall |  |
+| test_logging.rs:97:11:97:18 | ...::log!... | 97 | MacroCall |  |
+| test_logging.rs:97:11:97:18 | ...::log(...) | 97 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:97:11:97:18 | ArgList | 97 | ArgList |  |
+| test_logging.rs:97:11:97:18 | ExprStmt | 97 | ExprStmt |  |
+| test_logging.rs:97:11:97:18 | FormatArgsExpr | 97 | FormatArgsExpr |  |
+| test_logging.rs:97:11:97:18 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:11:97:18 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:11:97:18 | MacroExpr | 97 | MacroExpr |  |
+| test_logging.rs:97:11:97:18 | MacroStmts | 97 | MacroStmts |  |
+| test_logging.rs:97:11:97:18 | MacroStmts | 97 | MacroStmts |  |
+| test_logging.rs:97:11:97:18 | MacroStmts | 97 | MacroStmts |  |
+| test_logging.rs:97:11:97:18 | StmtList | 97 | StmtList |  |
+| test_logging.rs:97:11:97:18 | StmtList | 97 | StmtList |  |
+| test_logging.rs:97:11:97:18 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:11:97:18 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:11:97:18 | TokenTree | 97 | TokenTree |  |
+| test_logging.rs:97:11:97:18 | if ... {...} | 97 | IfExpr |  |
+| test_logging.rs:97:11:97:18 | { ... } | 97 | BlockExpr |  |
+| test_logging.rs:97:11:97:18 | { ... } | 97 | BlockExpr |  |
+| test_logging.rs:97:12:97:13 | {} | 97 | FormatSynthLocationImpl |  |
+| test_logging.rs:97:17:97:18 | FormatArgsArg | 97 | FormatArgsArg |  |
+| test_logging.rs:97:17:97:18 | m2 | 97 | IdentPath |  |
+| test_logging.rs:97:17:97:18 | m2 | 97 | NameRef |  |
+| test_logging.rs:97:17:97:18 | m2 | 97 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:97:17:97:18 | m2 | 97 | PathSegment |  |
+| test_logging.rs:97:22:97:58 | //... | 97 | Comment |  |
+| test_logging.rs:99:5:99:47 | let ... = ... | 99 | LetStmt |  |
+| test_logging.rs:99:9:99:10 | m3 | 99 | IdentPat |  |
+| test_logging.rs:99:9:99:10 | m3 | 99 | Name |  |
+| test_logging.rs:99:14:99:19 | format | 99 | IdentPath |  |
+| test_logging.rs:99:14:99:19 | format | 99 | NameRef |  |
+| test_logging.rs:99:14:99:19 | format | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | IdentPath |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | IdentPath |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | IdentPath |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | $crate | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | ...::__export | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::__export | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::fmt | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::format | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::format | 99 | PathExpr |  |
+| test_logging.rs:99:14:99:46 | ...::format_args | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::must_use | 99 | Path |  |
+| test_logging.rs:99:14:99:46 | ...::must_use | 99 | PathExpr |  |
+| test_logging.rs:99:14:99:46 | MacroExpr | 99 | MacroExpr |  |
+| test_logging.rs:99:14:99:46 | __export | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | __export | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | __export | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | __export | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | fmt | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | fmt | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | format | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | format | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | format!... | 99 | MacroCall |  |
+| test_logging.rs:99:14:99:46 | format_args | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | format_args | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | must_use | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | must_use | 99 | PathSegment |  |
+| test_logging.rs:99:14:99:46 | res | 99 | IdentPat |  |
+| test_logging.rs:99:14:99:46 | res | 99 | IdentPath |  |
+| test_logging.rs:99:14:99:46 | res | 99 | Name |  |
+| test_logging.rs:99:14:99:46 | res | 99 | NameRef |  |
+| test_logging.rs:99:14:99:46 | res | 99 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:99:14:99:46 | res | 99 | PathSegment |  |
+| test_logging.rs:99:21:99:46 | TokenTree | 99 | TokenTree |  |
+| test_logging.rs:99:22:99:35 | "message = {}" | 99 | LiteralExpr |  |
+| test_logging.rs:99:22:99:45 | ...::format(...) | 99 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:99:22:99:45 | ...::format_args!... | 99 | MacroCall |  |
+| test_logging.rs:99:22:99:45 | ...::must_use(...) | 99 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:99:22:99:45 | ArgList | 99 | ArgList |  |
+| test_logging.rs:99:22:99:45 | ArgList | 99 | ArgList |  |
+| test_logging.rs:99:22:99:45 | FormatArgsExpr | 99 | FormatArgsExpr |  |
+| test_logging.rs:99:22:99:45 | MacroExpr | 99 | MacroExpr |  |
+| test_logging.rs:99:22:99:45 | StmtList | 99 | StmtList |  |
+| test_logging.rs:99:22:99:45 | TokenTree | 99 | TokenTree |  |
+| test_logging.rs:99:22:99:45 | let ... = ... | 99 | LetStmt |  |
+| test_logging.rs:99:22:99:45 | { ... } | 99 | BlockExpr |  |
+| test_logging.rs:99:33:99:34 | {} | 99 | FormatSynthLocationImpl |  |
+| test_logging.rs:99:38:99:45 | FormatArgsArg | 99 | FormatArgsArg |  |
+| test_logging.rs:99:38:99:45 | password | 99 | IdentPath |  |
+| test_logging.rs:99:38:99:45 | password | 99 | NameRef |  |
+| test_logging.rs:99:38:99:45 | password | 99 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:99:38:99:45 | password | 99 | PathSegment |  |
+| test_logging.rs:99:49:99:62 | //... | 99 | Comment |  |
+| test_logging.rs:100:5:100:8 | info | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:8 | info | 100 | NameRef |  |
+| test_logging.rs:100:5:100:8 | info | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | "module::path" | 100 | LiteralExpr |  |
+| test_logging.rs:100:5:100:19 | "module::path" | 100 | LiteralExpr |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | $crate | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | &... | 100 | RefExpr |  |
+| test_logging.rs:100:5:100:19 | (...) | 100 | ParenExpr |  |
+| test_logging.rs:100:5:100:19 | (...::Info) | 100 | ParenExpr |  |
+| test_logging.rs:100:5:100:19 | ... && ... | 100 | BinaryExpr |  |
+| test_logging.rs:100:5:100:19 | ... <= ... | 100 | BinaryExpr |  |
+| test_logging.rs:100:5:100:19 | ... <= ... | 100 | BinaryExpr |  |
+| test_logging.rs:100:5:100:19 | ...::Info | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::Info | 100 | PathExpr |  |
+| test_logging.rs:100:5:100:19 | ...::Level | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::STATIC_MAX_LEVEL | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::STATIC_MAX_LEVEL | 100 | PathExpr |  |
+| test_logging.rs:100:5:100:19 | ...::__private_api | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::__private_api | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::__private_api | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::__private_api | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::__private_api | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::format_args | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::loc | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::loc | 100 | PathExpr |  |
+| test_logging.rs:100:5:100:19 | ...::loc(...) | 100 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:100:5:100:19 | ...::log | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::log | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::log | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::log | 100 | PathExpr |  |
+| test_logging.rs:100:5:100:19 | ...::max_level | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::max_level | 100 | PathExpr |  |
+| test_logging.rs:100:5:100:19 | ...::max_level(...) | 100 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:100:5:100:19 | ...::module_path | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::module_path | 100 | Path |  |
+| test_logging.rs:100:5:100:19 | ...::module_path!... | 100 | MacroCall |  |
+| test_logging.rs:100:5:100:19 | ...::module_path!... | 100 | MacroCall |  |
+| test_logging.rs:100:5:100:19 | ArgList | 100 | ArgList |  |
+| test_logging.rs:100:5:100:19 | ArgList | 100 | ArgList |  |
+| test_logging.rs:100:5:100:19 | Info | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | Info | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | Level | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | Level | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:5:100:19 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:5:100:19 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:5:100:19 | STATIC_MAX_LEVEL | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | STATIC_MAX_LEVEL | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:5:100:19 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:5:100:19 | TupleExpr | 100 | TupleExpr |  |
+| test_logging.rs:100:5:100:19 | TupleExpr | 100 | TupleExpr |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | __private_api | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | format_args | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | format_args | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | info!... | 100 | MacroCall |  |
+| test_logging.rs:100:5:100:19 | let ... = ... | 100 | LetStmt |  |
+| test_logging.rs:100:5:100:19 | loc | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | loc | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | log | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | log | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | log | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | log | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | log | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | log | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | IdentPat |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | IdentPath |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | Name |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | lvl | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | max_level | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | max_level | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | module_path | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | module_path | 100 | NameRef |  |
+| test_logging.rs:100:5:100:19 | module_path | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:19 | module_path | 100 | PathSegment |  |
+| test_logging.rs:100:5:100:20 | ExprStmt | 100 | ExprStmt |  |
+| test_logging.rs:100:10:100:19 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:11:100:14 | "{}" | 100 | LiteralExpr |  |
+| test_logging.rs:100:11:100:18 | ...::format_args!... | 100 | MacroCall |  |
+| test_logging.rs:100:11:100:18 | ...::log!... | 100 | MacroCall |  |
+| test_logging.rs:100:11:100:18 | ...::log!... | 100 | MacroCall |  |
+| test_logging.rs:100:11:100:18 | ...::log(...) | 100 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:100:11:100:18 | ArgList | 100 | ArgList |  |
+| test_logging.rs:100:11:100:18 | ExprStmt | 100 | ExprStmt |  |
+| test_logging.rs:100:11:100:18 | FormatArgsExpr | 100 | FormatArgsExpr |  |
+| test_logging.rs:100:11:100:18 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:11:100:18 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:11:100:18 | MacroExpr | 100 | MacroExpr |  |
+| test_logging.rs:100:11:100:18 | MacroStmts | 100 | MacroStmts |  |
+| test_logging.rs:100:11:100:18 | MacroStmts | 100 | MacroStmts |  |
+| test_logging.rs:100:11:100:18 | MacroStmts | 100 | MacroStmts |  |
+| test_logging.rs:100:11:100:18 | StmtList | 100 | StmtList |  |
+| test_logging.rs:100:11:100:18 | StmtList | 100 | StmtList |  |
+| test_logging.rs:100:11:100:18 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:11:100:18 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:11:100:18 | TokenTree | 100 | TokenTree |  |
+| test_logging.rs:100:11:100:18 | if ... {...} | 100 | IfExpr |  |
+| test_logging.rs:100:11:100:18 | { ... } | 100 | BlockExpr |  |
+| test_logging.rs:100:11:100:18 | { ... } | 100 | BlockExpr |  |
+| test_logging.rs:100:12:100:13 | {} | 100 | FormatSynthLocationImpl |  |
+| test_logging.rs:100:17:100:18 | FormatArgsArg | 100 | FormatArgsArg |  |
+| test_logging.rs:100:17:100:18 | m3 | 100 | IdentPath |  |
+| test_logging.rs:100:17:100:18 | m3 | 100 | NameRef |  |
+| test_logging.rs:100:17:100:18 | m3 | 100 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:100:17:100:18 | m3 | 100 | PathSegment |  |
+| test_logging.rs:100:22:100:59 | //... | 100 | Comment |  |
+| test_logging.rs:102:5:102:31 | let ... = ... | 102 | LetStmt |  |
+| test_logging.rs:102:9:102:14 | mut m4 | 102 | IdentPat |  |
+| test_logging.rs:102:13:102:14 | m4 | 102 | Name |  |
+| test_logging.rs:102:18:102:23 | String | 102 | IdentPath |  |
+| test_logging.rs:102:18:102:23 | String | 102 | NameRef |  |
+| test_logging.rs:102:18:102:23 | String | 102 | PathSegment |  |
+| test_logging.rs:102:18:102:28 | ...::new | 102 | Path |  |
+| test_logging.rs:102:18:102:28 | ...::new | 102 | PathExpr |  |
+| test_logging.rs:102:18:102:30 | ...::new(...) | 102 | CallExpr | target-origin:lang:alloc, target-path:<crate::string::String>::new, target:PathExpr |
+| test_logging.rs:102:26:102:28 | new | 102 | NameRef |  |
+| test_logging.rs:102:26:102:28 | new | 102 | PathSegment |  |
+| test_logging.rs:102:29:102:30 | ArgList | 102 | ArgList |  |
+| test_logging.rs:103:5:103:9 | write | 103 | IdentPath |  |
+| test_logging.rs:103:5:103:9 | write | 103 | NameRef |  |
+| test_logging.rs:103:5:103:9 | write | 103 | PathSegment |  |
+| test_logging.rs:103:5:103:45 | $crate | 103 | IdentPath |  |
+| test_logging.rs:103:5:103:45 | $crate | 103 | NameRef |  |
+| test_logging.rs:103:5:103:45 | $crate | 103 | PathSegment |  |
+| test_logging.rs:103:5:103:45 | ...::format_args | 103 | Path |  |
+| test_logging.rs:103:5:103:45 | MacroExpr | 103 | MacroExpr |  |
+| test_logging.rs:103:5:103:45 | format_args | 103 | NameRef |  |
+| test_logging.rs:103:5:103:45 | format_args | 103 | PathSegment |  |
+| test_logging.rs:103:5:103:45 | write!... | 103 | MacroCall |  |
+| test_logging.rs:103:5:103:45 | write_fmt | 103 | NameRef |  |
+| test_logging.rs:103:5:103:46 | ExprStmt | 103 | ExprStmt |  |
+| test_logging.rs:103:11:103:45 | TokenTree | 103 | TokenTree |  |
+| test_logging.rs:103:12:103:18 | &mut m4 | 103 | RefExpr |  |
+| test_logging.rs:103:12:103:18 | (...) | 103 | ParenExpr |  |
+| test_logging.rs:103:12:103:44 | ... .write_fmt(...) | 103 | MethodCallExpr | method-origin:lang:core, method-path:crate::fmt::Write::write_fmt |
+| test_logging.rs:103:12:103:44 | MacroStmts | 103 | MacroStmts |  |
+| test_logging.rs:103:17:103:18 | m4 | 103 | IdentPath |  |
+| test_logging.rs:103:17:103:18 | m4 | 103 | NameRef |  |
+| test_logging.rs:103:17:103:18 | m4 | 103 | PathExpr, VariableAccess |  |
+| test_logging.rs:103:17:103:18 | m4 | 103 | PathSegment |  |
+| test_logging.rs:103:21:103:34 | "message = {}" | 103 | LiteralExpr |  |
+| test_logging.rs:103:21:103:44 | ...::format_args!... | 103 | MacroCall |  |
+| test_logging.rs:103:21:103:44 | ArgList | 103 | ArgList |  |
+| test_logging.rs:103:21:103:44 | FormatArgsExpr | 103 | FormatArgsExpr |  |
+| test_logging.rs:103:21:103:44 | MacroExpr | 103 | MacroExpr |  |
+| test_logging.rs:103:21:103:44 | TokenTree | 103 | TokenTree |  |
+| test_logging.rs:103:32:103:33 | {} | 103 | FormatSynthLocationImpl |  |
+| test_logging.rs:103:37:103:44 | FormatArgsArg | 103 | FormatArgsArg |  |
+| test_logging.rs:103:37:103:44 | password | 103 | IdentPath |  |
+| test_logging.rs:103:37:103:44 | password | 103 | NameRef |  |
+| test_logging.rs:103:37:103:44 | password | 103 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:103:37:103:44 | password | 103 | PathSegment |  |
+| test_logging.rs:103:48:103:70 | //... | 103 | Comment |  |
+| test_logging.rs:104:5:104:8 | info | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:8 | info | 104 | NameRef |  |
+| test_logging.rs:104:5:104:8 | info | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | "module::path" | 104 | LiteralExpr |  |
+| test_logging.rs:104:5:104:19 | "module::path" | 104 | LiteralExpr |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | $crate | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | &... | 104 | RefExpr |  |
+| test_logging.rs:104:5:104:19 | (...) | 104 | ParenExpr |  |
+| test_logging.rs:104:5:104:19 | (...::Info) | 104 | ParenExpr |  |
+| test_logging.rs:104:5:104:19 | ... && ... | 104 | BinaryExpr |  |
+| test_logging.rs:104:5:104:19 | ... <= ... | 104 | BinaryExpr |  |
+| test_logging.rs:104:5:104:19 | ... <= ... | 104 | BinaryExpr |  |
+| test_logging.rs:104:5:104:19 | ...::Info | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::Info | 104 | PathExpr |  |
+| test_logging.rs:104:5:104:19 | ...::Level | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::STATIC_MAX_LEVEL | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::STATIC_MAX_LEVEL | 104 | PathExpr |  |
+| test_logging.rs:104:5:104:19 | ...::__private_api | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::__private_api | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::__private_api | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::__private_api | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::__private_api | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::format_args | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::loc | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::loc | 104 | PathExpr |  |
+| test_logging.rs:104:5:104:19 | ...::loc(...) | 104 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:104:5:104:19 | ...::log | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::log | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::log | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::log | 104 | PathExpr |  |
+| test_logging.rs:104:5:104:19 | ...::max_level | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::max_level | 104 | PathExpr |  |
+| test_logging.rs:104:5:104:19 | ...::max_level(...) | 104 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:104:5:104:19 | ...::module_path | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::module_path | 104 | Path |  |
+| test_logging.rs:104:5:104:19 | ...::module_path!... | 104 | MacroCall |  |
+| test_logging.rs:104:5:104:19 | ...::module_path!... | 104 | MacroCall |  |
+| test_logging.rs:104:5:104:19 | ArgList | 104 | ArgList |  |
+| test_logging.rs:104:5:104:19 | ArgList | 104 | ArgList |  |
+| test_logging.rs:104:5:104:19 | Info | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | Info | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | Level | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | Level | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:5:104:19 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:5:104:19 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:5:104:19 | STATIC_MAX_LEVEL | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | STATIC_MAX_LEVEL | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:5:104:19 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:5:104:19 | TupleExpr | 104 | TupleExpr |  |
+| test_logging.rs:104:5:104:19 | TupleExpr | 104 | TupleExpr |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | __private_api | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | format_args | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | format_args | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | info!... | 104 | MacroCall |  |
+| test_logging.rs:104:5:104:19 | let ... = ... | 104 | LetStmt |  |
+| test_logging.rs:104:5:104:19 | loc | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | loc | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | log | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | log | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | log | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | log | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | log | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | log | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | IdentPat |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | IdentPath |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | Name |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | lvl | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | max_level | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | max_level | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | module_path | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | module_path | 104 | NameRef |  |
+| test_logging.rs:104:5:104:19 | module_path | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:19 | module_path | 104 | PathSegment |  |
+| test_logging.rs:104:5:104:20 | ExprStmt | 104 | ExprStmt |  |
+| test_logging.rs:104:10:104:19 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:11:104:14 | "{}" | 104 | LiteralExpr |  |
+| test_logging.rs:104:11:104:18 | ...::format_args!... | 104 | MacroCall |  |
+| test_logging.rs:104:11:104:18 | ...::log!... | 104 | MacroCall |  |
+| test_logging.rs:104:11:104:18 | ...::log!... | 104 | MacroCall |  |
+| test_logging.rs:104:11:104:18 | ...::log(...) | 104 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:104:11:104:18 | ArgList | 104 | ArgList |  |
+| test_logging.rs:104:11:104:18 | ExprStmt | 104 | ExprStmt |  |
+| test_logging.rs:104:11:104:18 | FormatArgsExpr | 104 | FormatArgsExpr |  |
+| test_logging.rs:104:11:104:18 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:11:104:18 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:11:104:18 | MacroExpr | 104 | MacroExpr |  |
+| test_logging.rs:104:11:104:18 | MacroStmts | 104 | MacroStmts |  |
+| test_logging.rs:104:11:104:18 | MacroStmts | 104 | MacroStmts |  |
+| test_logging.rs:104:11:104:18 | MacroStmts | 104 | MacroStmts |  |
+| test_logging.rs:104:11:104:18 | StmtList | 104 | StmtList |  |
+| test_logging.rs:104:11:104:18 | StmtList | 104 | StmtList |  |
+| test_logging.rs:104:11:104:18 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:11:104:18 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:11:104:18 | TokenTree | 104 | TokenTree |  |
+| test_logging.rs:104:11:104:18 | if ... {...} | 104 | IfExpr |  |
+| test_logging.rs:104:11:104:18 | { ... } | 104 | BlockExpr |  |
+| test_logging.rs:104:11:104:18 | { ... } | 104 | BlockExpr |  |
+| test_logging.rs:104:12:104:13 | {} | 104 | FormatSynthLocationImpl |  |
+| test_logging.rs:104:17:104:18 | FormatArgsArg | 104 | FormatArgsArg |  |
+| test_logging.rs:104:17:104:18 | m4 | 104 | IdentPath |  |
+| test_logging.rs:104:17:104:18 | m4 | 104 | NameRef |  |
+| test_logging.rs:104:17:104:18 | m4 | 104 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:104:17:104:18 | m4 | 104 | PathSegment |  |
+| test_logging.rs:104:22:104:67 | //... | 104 | Comment |  |
+| test_logging.rs:106:5:106:31 | let ... = ... | 106 | LetStmt |  |
+| test_logging.rs:106:9:106:14 | mut m5 | 106 | IdentPat |  |
+| test_logging.rs:106:13:106:14 | m5 | 106 | Name |  |
+| test_logging.rs:106:18:106:23 | String | 106 | IdentPath |  |
+| test_logging.rs:106:18:106:23 | String | 106 | NameRef |  |
+| test_logging.rs:106:18:106:23 | String | 106 | PathSegment |  |
+| test_logging.rs:106:18:106:28 | ...::new | 106 | Path |  |
+| test_logging.rs:106:18:106:28 | ...::new | 106 | PathExpr |  |
+| test_logging.rs:106:18:106:30 | ...::new(...) | 106 | CallExpr | target-origin:lang:alloc, target-path:<crate::string::String>::new, target:PathExpr |
+| test_logging.rs:106:26:106:28 | new | 106 | NameRef |  |
+| test_logging.rs:106:26:106:28 | new | 106 | PathSegment |  |
+| test_logging.rs:106:29:106:30 | ArgList | 106 | ArgList |  |
+| test_logging.rs:107:5:107:11 | writeln | 107 | IdentPath |  |
+| test_logging.rs:107:5:107:11 | writeln | 107 | NameRef |  |
+| test_logging.rs:107:5:107:11 | writeln | 107 | PathSegment |  |
+| test_logging.rs:107:5:107:47 | $crate | 107 | IdentPath |  |
+| test_logging.rs:107:5:107:47 | $crate | 107 | NameRef |  |
+| test_logging.rs:107:5:107:47 | $crate | 107 | PathSegment |  |
+| test_logging.rs:107:5:107:47 | ...::format_args_nl | 107 | Path |  |
+| test_logging.rs:107:5:107:47 | MacroExpr | 107 | MacroExpr |  |
+| test_logging.rs:107:5:107:47 | format_args_nl | 107 | NameRef |  |
+| test_logging.rs:107:5:107:47 | format_args_nl | 107 | PathSegment |  |
+| test_logging.rs:107:5:107:47 | write_fmt | 107 | NameRef |  |
+| test_logging.rs:107:5:107:47 | writeln!... | 107 | MacroCall |  |
+| test_logging.rs:107:5:107:48 | ExprStmt | 107 | ExprStmt |  |
+| test_logging.rs:107:13:107:47 | TokenTree | 107 | TokenTree |  |
+| test_logging.rs:107:14:107:20 | &mut m5 | 107 | RefExpr |  |
+| test_logging.rs:107:14:107:20 | (...) | 107 | ParenExpr |  |
+| test_logging.rs:107:14:107:46 | ... .write_fmt(...) | 107 | MethodCallExpr | method-origin:lang:core, method-path:crate::fmt::Write::write_fmt |
+| test_logging.rs:107:14:107:46 | MacroStmts | 107 | MacroStmts |  |
+| test_logging.rs:107:19:107:20 | m5 | 107 | IdentPath |  |
+| test_logging.rs:107:19:107:20 | m5 | 107 | NameRef |  |
+| test_logging.rs:107:19:107:20 | m5 | 107 | PathExpr, VariableAccess |  |
+| test_logging.rs:107:19:107:20 | m5 | 107 | PathSegment |  |
+| test_logging.rs:107:23:107:36 | "message = {}\\n" | 107 | LiteralExpr |  |
+| test_logging.rs:107:23:107:46 | ...::format_args_nl!... | 107 | MacroCall |  |
+| test_logging.rs:107:23:107:46 | ArgList | 107 | ArgList |  |
+| test_logging.rs:107:23:107:46 | FormatArgsExpr | 107 | FormatArgsExpr |  |
+| test_logging.rs:107:23:107:46 | MacroExpr | 107 | MacroExpr |  |
+| test_logging.rs:107:23:107:46 | TokenTree | 107 | TokenTree |  |
+| test_logging.rs:107:34:107:35 | {} | 107 | FormatSynthLocationImpl |  |
+| test_logging.rs:107:39:107:46 | FormatArgsArg | 107 | FormatArgsArg |  |
+| test_logging.rs:107:39:107:46 | password | 107 | IdentPath |  |
+| test_logging.rs:107:39:107:46 | password | 107 | NameRef |  |
+| test_logging.rs:107:39:107:46 | password | 107 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:107:39:107:46 | password | 107 | PathSegment |  |
+| test_logging.rs:107:50:107:72 | //... | 107 | Comment |  |
+| test_logging.rs:108:5:108:8 | info | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:8 | info | 108 | NameRef |  |
+| test_logging.rs:108:5:108:8 | info | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | "module::path" | 108 | LiteralExpr |  |
+| test_logging.rs:108:5:108:19 | "module::path" | 108 | LiteralExpr |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | $crate | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | &... | 108 | RefExpr |  |
+| test_logging.rs:108:5:108:19 | (...) | 108 | ParenExpr |  |
+| test_logging.rs:108:5:108:19 | (...::Info) | 108 | ParenExpr |  |
+| test_logging.rs:108:5:108:19 | ... && ... | 108 | BinaryExpr |  |
+| test_logging.rs:108:5:108:19 | ... <= ... | 108 | BinaryExpr |  |
+| test_logging.rs:108:5:108:19 | ... <= ... | 108 | BinaryExpr |  |
+| test_logging.rs:108:5:108:19 | ...::Info | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::Info | 108 | PathExpr |  |
+| test_logging.rs:108:5:108:19 | ...::Level | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::STATIC_MAX_LEVEL | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::STATIC_MAX_LEVEL | 108 | PathExpr |  |
+| test_logging.rs:108:5:108:19 | ...::__private_api | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::__private_api | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::__private_api | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::__private_api | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::__private_api | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::format_args | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::loc | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::loc | 108 | PathExpr |  |
+| test_logging.rs:108:5:108:19 | ...::loc(...) | 108 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:108:5:108:19 | ...::log | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::log | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::log | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::log | 108 | PathExpr |  |
+| test_logging.rs:108:5:108:19 | ...::max_level | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::max_level | 108 | PathExpr |  |
+| test_logging.rs:108:5:108:19 | ...::max_level(...) | 108 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:108:5:108:19 | ...::module_path | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::module_path | 108 | Path |  |
+| test_logging.rs:108:5:108:19 | ...::module_path!... | 108 | MacroCall |  |
+| test_logging.rs:108:5:108:19 | ...::module_path!... | 108 | MacroCall |  |
+| test_logging.rs:108:5:108:19 | ArgList | 108 | ArgList |  |
+| test_logging.rs:108:5:108:19 | ArgList | 108 | ArgList |  |
+| test_logging.rs:108:5:108:19 | Info | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | Info | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | Level | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | Level | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:5:108:19 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:5:108:19 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:5:108:19 | STATIC_MAX_LEVEL | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | STATIC_MAX_LEVEL | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:5:108:19 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:5:108:19 | TupleExpr | 108 | TupleExpr |  |
+| test_logging.rs:108:5:108:19 | TupleExpr | 108 | TupleExpr |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | __private_api | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | format_args | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | format_args | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | info!... | 108 | MacroCall |  |
+| test_logging.rs:108:5:108:19 | let ... = ... | 108 | LetStmt |  |
+| test_logging.rs:108:5:108:19 | loc | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | loc | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | log | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | log | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | log | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | log | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | log | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | log | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | IdentPat |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | IdentPath |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | Name |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | lvl | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | max_level | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | max_level | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | module_path | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | module_path | 108 | NameRef |  |
+| test_logging.rs:108:5:108:19 | module_path | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:19 | module_path | 108 | PathSegment |  |
+| test_logging.rs:108:5:108:20 | ExprStmt | 108 | ExprStmt |  |
+| test_logging.rs:108:10:108:19 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:11:108:14 | "{}" | 108 | LiteralExpr |  |
+| test_logging.rs:108:11:108:18 | ...::format_args!... | 108 | MacroCall |  |
+| test_logging.rs:108:11:108:18 | ...::log!... | 108 | MacroCall |  |
+| test_logging.rs:108:11:108:18 | ...::log!... | 108 | MacroCall |  |
+| test_logging.rs:108:11:108:18 | ...::log(...) | 108 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:108:11:108:18 | ArgList | 108 | ArgList |  |
+| test_logging.rs:108:11:108:18 | ExprStmt | 108 | ExprStmt |  |
+| test_logging.rs:108:11:108:18 | FormatArgsExpr | 108 | FormatArgsExpr |  |
+| test_logging.rs:108:11:108:18 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:11:108:18 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:11:108:18 | MacroExpr | 108 | MacroExpr |  |
+| test_logging.rs:108:11:108:18 | MacroStmts | 108 | MacroStmts |  |
+| test_logging.rs:108:11:108:18 | MacroStmts | 108 | MacroStmts |  |
+| test_logging.rs:108:11:108:18 | MacroStmts | 108 | MacroStmts |  |
+| test_logging.rs:108:11:108:18 | StmtList | 108 | StmtList |  |
+| test_logging.rs:108:11:108:18 | StmtList | 108 | StmtList |  |
+| test_logging.rs:108:11:108:18 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:11:108:18 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:11:108:18 | TokenTree | 108 | TokenTree |  |
+| test_logging.rs:108:11:108:18 | if ... {...} | 108 | IfExpr |  |
+| test_logging.rs:108:11:108:18 | { ... } | 108 | BlockExpr |  |
+| test_logging.rs:108:11:108:18 | { ... } | 108 | BlockExpr |  |
+| test_logging.rs:108:12:108:13 | {} | 108 | FormatSynthLocationImpl |  |
+| test_logging.rs:108:17:108:18 | FormatArgsArg | 108 | FormatArgsArg |  |
+| test_logging.rs:108:17:108:18 | m5 | 108 | IdentPath |  |
+| test_logging.rs:108:17:108:18 | m5 | 108 | NameRef |  |
+| test_logging.rs:108:17:108:18 | m5 | 108 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:108:17:108:18 | m5 | 108 | PathSegment |  |
+| test_logging.rs:108:22:108:67 | //... | 108 | Comment |  |
+| test_logging.rs:110:5:110:28 | let ... = ... | 110 | LetStmt |  |
+| test_logging.rs:110:9:110:14 | mut m6 | 110 | IdentPat |  |
+| test_logging.rs:110:13:110:14 | m6 | 110 | Name |  |
+| test_logging.rs:110:18:110:20 | Vec | 110 | IdentPath |  |
+| test_logging.rs:110:18:110:20 | Vec | 110 | NameRef |  |
+| test_logging.rs:110:18:110:20 | Vec | 110 | PathSegment |  |
+| test_logging.rs:110:18:110:25 | ...::new | 110 | Path |  |
+| test_logging.rs:110:18:110:25 | ...::new | 110 | PathExpr |  |
+| test_logging.rs:110:18:110:27 | ...::new(...) | 110 | CallExpr | target-origin:lang:alloc, target-path:<crate::vec::Vec>::new, target:PathExpr |
+| test_logging.rs:110:23:110:25 | new | 110 | NameRef |  |
+| test_logging.rs:110:23:110:25 | new | 110 | PathSegment |  |
+| test_logging.rs:110:26:110:27 | ArgList | 110 | ArgList |  |
+| test_logging.rs:111:5:111:9 | write | 111 | IdentPath |  |
+| test_logging.rs:111:5:111:9 | write | 111 | NameRef |  |
+| test_logging.rs:111:5:111:9 | write | 111 | PathSegment |  |
+| test_logging.rs:111:5:111:45 | $crate | 111 | IdentPath |  |
+| test_logging.rs:111:5:111:45 | $crate | 111 | NameRef |  |
+| test_logging.rs:111:5:111:45 | $crate | 111 | PathSegment |  |
+| test_logging.rs:111:5:111:45 | ...::format_args | 111 | Path |  |
+| test_logging.rs:111:5:111:45 | MacroExpr | 111 | MacroExpr |  |
+| test_logging.rs:111:5:111:45 | format_args | 111 | NameRef |  |
+| test_logging.rs:111:5:111:45 | format_args | 111 | PathSegment |  |
+| test_logging.rs:111:5:111:45 | write!... | 111 | MacroCall |  |
+| test_logging.rs:111:5:111:45 | write_fmt | 111 | NameRef |  |
+| test_logging.rs:111:5:111:46 | ExprStmt | 111 | ExprStmt |  |
+| test_logging.rs:111:11:111:45 | TokenTree | 111 | TokenTree |  |
+| test_logging.rs:111:12:111:18 | &mut m6 | 111 | RefExpr |  |
+| test_logging.rs:111:12:111:18 | (...) | 111 | ParenExpr |  |
+| test_logging.rs:111:12:111:44 | ... .write_fmt(...) | 111 | MethodCallExpr | method-origin:lang:std, method-path:crate::io::Write::write_fmt |
+| test_logging.rs:111:12:111:44 | MacroStmts | 111 | MacroStmts |  |
+| test_logging.rs:111:17:111:18 | m6 | 111 | IdentPath |  |
+| test_logging.rs:111:17:111:18 | m6 | 111 | NameRef |  |
+| test_logging.rs:111:17:111:18 | m6 | 111 | PathExpr, VariableAccess |  |
+| test_logging.rs:111:17:111:18 | m6 | 111 | PathSegment |  |
+| test_logging.rs:111:21:111:34 | "message = {}" | 111 | LiteralExpr |  |
+| test_logging.rs:111:21:111:44 | ...::format_args!... | 111 | MacroCall |  |
+| test_logging.rs:111:21:111:44 | ArgList | 111 | ArgList |  |
+| test_logging.rs:111:21:111:44 | FormatArgsExpr | 111 | FormatArgsExpr |  |
+| test_logging.rs:111:21:111:44 | MacroExpr | 111 | MacroExpr |  |
+| test_logging.rs:111:21:111:44 | TokenTree | 111 | TokenTree |  |
+| test_logging.rs:111:32:111:33 | {} | 111 | FormatSynthLocationImpl |  |
+| test_logging.rs:111:37:111:44 | FormatArgsArg | 111 | FormatArgsArg |  |
+| test_logging.rs:111:37:111:44 | password | 111 | IdentPath |  |
+| test_logging.rs:111:37:111:44 | password | 111 | NameRef |  |
+| test_logging.rs:111:37:111:44 | password | 111 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:111:37:111:44 | password | 111 | PathSegment |  |
+| test_logging.rs:111:48:111:70 | //... | 111 | Comment |  |
+| test_logging.rs:112:5:112:8 | info | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:8 | info | 112 | NameRef |  |
+| test_logging.rs:112:5:112:8 | info | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | "module::path" | 112 | LiteralExpr |  |
+| test_logging.rs:112:5:112:50 | "module::path" | 112 | LiteralExpr |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | $crate | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | &... | 112 | RefExpr |  |
+| test_logging.rs:112:5:112:50 | (...) | 112 | ParenExpr |  |
+| test_logging.rs:112:5:112:50 | (...::Info) | 112 | ParenExpr |  |
+| test_logging.rs:112:5:112:50 | ... && ... | 112 | BinaryExpr |  |
+| test_logging.rs:112:5:112:50 | ... <= ... | 112 | BinaryExpr |  |
+| test_logging.rs:112:5:112:50 | ... <= ... | 112 | BinaryExpr |  |
+| test_logging.rs:112:5:112:50 | ...::Info | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::Info | 112 | PathExpr |  |
+| test_logging.rs:112:5:112:50 | ...::Level | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::STATIC_MAX_LEVEL | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::STATIC_MAX_LEVEL | 112 | PathExpr |  |
+| test_logging.rs:112:5:112:50 | ...::__private_api | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::__private_api | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::__private_api | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::__private_api | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::__private_api | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::format_args | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::loc | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::loc | 112 | PathExpr |  |
+| test_logging.rs:112:5:112:50 | ...::loc(...) | 112 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:112:5:112:50 | ...::log | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::log | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::log | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::log | 112 | PathExpr |  |
+| test_logging.rs:112:5:112:50 | ...::max_level | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::max_level | 112 | PathExpr |  |
+| test_logging.rs:112:5:112:50 | ...::max_level(...) | 112 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:112:5:112:50 | ...::module_path | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::module_path | 112 | Path |  |
+| test_logging.rs:112:5:112:50 | ...::module_path!... | 112 | MacroCall |  |
+| test_logging.rs:112:5:112:50 | ...::module_path!... | 112 | MacroCall |  |
+| test_logging.rs:112:5:112:50 | ArgList | 112 | ArgList |  |
+| test_logging.rs:112:5:112:50 | ArgList | 112 | ArgList |  |
+| test_logging.rs:112:5:112:50 | Info | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | Info | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | Level | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | Level | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:5:112:50 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:5:112:50 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:5:112:50 | STATIC_MAX_LEVEL | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | STATIC_MAX_LEVEL | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:5:112:50 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:5:112:50 | TupleExpr | 112 | TupleExpr |  |
+| test_logging.rs:112:5:112:50 | TupleExpr | 112 | TupleExpr |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | __private_api | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | format_args | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | format_args | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | info!... | 112 | MacroCall |  |
+| test_logging.rs:112:5:112:50 | let ... = ... | 112 | LetStmt |  |
+| test_logging.rs:112:5:112:50 | loc | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | loc | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | log | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | log | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | log | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | log | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | log | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | log | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | IdentPat |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | IdentPath |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | Name |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | lvl | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | max_level | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | max_level | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | module_path | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | module_path | 112 | NameRef |  |
+| test_logging.rs:112:5:112:50 | module_path | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:50 | module_path | 112 | PathSegment |  |
+| test_logging.rs:112:5:112:51 | ExprStmt | 112 | ExprStmt |  |
+| test_logging.rs:112:10:112:50 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:11:112:14 | "{}" | 112 | LiteralExpr |  |
+| test_logging.rs:112:11:112:49 | ...::format_args!... | 112 | MacroCall |  |
+| test_logging.rs:112:11:112:49 | ...::log!... | 112 | MacroCall |  |
+| test_logging.rs:112:11:112:49 | ...::log!... | 112 | MacroCall |  |
+| test_logging.rs:112:11:112:49 | ...::log(...) | 112 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:112:11:112:49 | ArgList | 112 | ArgList |  |
+| test_logging.rs:112:11:112:49 | ExprStmt | 112 | ExprStmt |  |
+| test_logging.rs:112:11:112:49 | FormatArgsExpr | 112 | FormatArgsExpr |  |
+| test_logging.rs:112:11:112:49 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:11:112:49 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:11:112:49 | MacroExpr | 112 | MacroExpr |  |
+| test_logging.rs:112:11:112:49 | MacroStmts | 112 | MacroStmts |  |
+| test_logging.rs:112:11:112:49 | MacroStmts | 112 | MacroStmts |  |
+| test_logging.rs:112:11:112:49 | MacroStmts | 112 | MacroStmts |  |
+| test_logging.rs:112:11:112:49 | StmtList | 112 | StmtList |  |
+| test_logging.rs:112:11:112:49 | StmtList | 112 | StmtList |  |
+| test_logging.rs:112:11:112:49 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:11:112:49 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:11:112:49 | TokenTree | 112 | TokenTree |  |
+| test_logging.rs:112:11:112:49 | if ... {...} | 112 | IfExpr |  |
+| test_logging.rs:112:11:112:49 | { ... } | 112 | BlockExpr |  |
+| test_logging.rs:112:11:112:49 | { ... } | 112 | BlockExpr |  |
+| test_logging.rs:112:12:112:13 | {} | 112 | FormatSynthLocationImpl |  |
+| test_logging.rs:112:17:112:19 | std | 112 | IdentPath |  |
+| test_logging.rs:112:17:112:19 | std | 112 | NameRef |  |
+| test_logging.rs:112:17:112:19 | std | 112 | PathSegment |  |
+| test_logging.rs:112:17:112:24 | ...::str | 112 | Path |  |
+| test_logging.rs:112:17:112:35 | ...::from_utf8 | 112 | Path |  |
+| test_logging.rs:112:17:112:35 | ...::from_utf8 | 112 | PathExpr |  |
+| test_logging.rs:112:17:112:40 | ...::from_utf8(...) | 112 | CallExpr | target-origin:lang:core, target-path:crate::str::converts::from_utf8, target:PathExpr |
+| test_logging.rs:112:17:112:49 | ... .unwrap(...) | 112 | MethodCallExpr | method-origin:lang:core, method-path:<crate::result::Result>::unwrap |
+| test_logging.rs:112:17:112:49 | FormatArgsArg | 112 | FormatArgsArg |  |
+| test_logging.rs:112:22:112:24 | str | 112 | NameRef |  |
+| test_logging.rs:112:22:112:24 | str | 112 | PathSegment |  |
+| test_logging.rs:112:27:112:35 | from_utf8 | 112 | NameRef |  |
+| test_logging.rs:112:27:112:35 | from_utf8 | 112 | PathSegment |  |
+| test_logging.rs:112:36:112:40 | ArgList | 112 | ArgList |  |
+| test_logging.rs:112:37:112:39 | &m6 | 112 | RefExpr |  |
+| test_logging.rs:112:38:112:39 | m6 | 112 | IdentPath |  |
+| test_logging.rs:112:38:112:39 | m6 | 112 | NameRef |  |
+| test_logging.rs:112:38:112:39 | m6 | 112 | PathExpr, VariableAccess |  |
+| test_logging.rs:112:38:112:39 | m6 | 112 | PathSegment |  |
+| test_logging.rs:112:42:112:47 | unwrap | 112 | NameRef |  |
+| test_logging.rs:112:48:112:49 | ArgList | 112 | ArgList |  |
+| test_logging.rs:112:53:112:98 | //... | 112 | Comment |  |
+| test_logging.rs:113:5:115:5 | ExprStmt | 113 | ExprStmt |  |
+| test_logging.rs:113:5:115:5 | { ... } | 113 | BlockExpr |  |
+| test_logging.rs:113:12:115:5 | StmtList | 113 | StmtList |  |
+| test_logging.rs:114:9:114:12 | info | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:12 | info | 114 | NameRef |  |
+| test_logging.rs:114:9:114:12 | info | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | "module::path" | 114 | LiteralExpr |  |
+| test_logging.rs:114:9:114:55 | "module::path" | 114 | LiteralExpr |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | $crate | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | &... | 114 | RefExpr |  |
+| test_logging.rs:114:9:114:55 | (...) | 114 | ParenExpr |  |
+| test_logging.rs:114:9:114:55 | (...::Info) | 114 | ParenExpr |  |
+| test_logging.rs:114:9:114:55 | ... && ... | 114 | BinaryExpr |  |
+| test_logging.rs:114:9:114:55 | ... <= ... | 114 | BinaryExpr |  |
+| test_logging.rs:114:9:114:55 | ... <= ... | 114 | BinaryExpr |  |
+| test_logging.rs:114:9:114:55 | ...::Info | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::Info | 114 | PathExpr |  |
+| test_logging.rs:114:9:114:55 | ...::Level | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::STATIC_MAX_LEVEL | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::STATIC_MAX_LEVEL | 114 | PathExpr |  |
+| test_logging.rs:114:9:114:55 | ...::__private_api | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::__private_api | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::__private_api | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::__private_api | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::__private_api | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::format_args | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::loc | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::loc | 114 | PathExpr |  |
+| test_logging.rs:114:9:114:55 | ...::loc(...) | 114 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:114:9:114:55 | ...::log | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::log | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::log | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::log | 114 | PathExpr |  |
+| test_logging.rs:114:9:114:55 | ...::max_level | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::max_level | 114 | PathExpr |  |
+| test_logging.rs:114:9:114:55 | ...::max_level(...) | 114 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:114:9:114:55 | ...::module_path | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::module_path | 114 | Path |  |
+| test_logging.rs:114:9:114:55 | ...::module_path!... | 114 | MacroCall |  |
+| test_logging.rs:114:9:114:55 | ...::module_path!... | 114 | MacroCall |  |
+| test_logging.rs:114:9:114:55 | ArgList | 114 | ArgList |  |
+| test_logging.rs:114:9:114:55 | ArgList | 114 | ArgList |  |
+| test_logging.rs:114:9:114:55 | Info | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | Info | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | Level | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | Level | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:9:114:55 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:9:114:55 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:9:114:55 | STATIC_MAX_LEVEL | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | STATIC_MAX_LEVEL | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:9:114:55 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:9:114:55 | TupleExpr | 114 | TupleExpr |  |
+| test_logging.rs:114:9:114:55 | TupleExpr | 114 | TupleExpr |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | __private_api | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | format_args | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | format_args | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | info!... | 114 | MacroCall |  |
+| test_logging.rs:114:9:114:55 | let ... = ... | 114 | LetStmt |  |
+| test_logging.rs:114:9:114:55 | loc | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | loc | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | log | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | log | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | log | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | log | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | log | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | log | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | IdentPat |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | IdentPath |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | Name |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | lvl | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | max_level | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | max_level | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | module_path | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | module_path | 114 | NameRef |  |
+| test_logging.rs:114:9:114:55 | module_path | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:55 | module_path | 114 | PathSegment |  |
+| test_logging.rs:114:9:114:56 | ExprStmt | 114 | ExprStmt |  |
+| test_logging.rs:114:14:114:55 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:15:114:18 | "{}" | 114 | LiteralExpr |  |
+| test_logging.rs:114:15:114:54 | ...::format_args!... | 114 | MacroCall |  |
+| test_logging.rs:114:15:114:54 | ...::log!... | 114 | MacroCall |  |
+| test_logging.rs:114:15:114:54 | ...::log!... | 114 | MacroCall |  |
+| test_logging.rs:114:15:114:54 | ...::log(...) | 114 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:114:15:114:54 | ArgList | 114 | ArgList |  |
+| test_logging.rs:114:15:114:54 | ExprStmt | 114 | ExprStmt |  |
+| test_logging.rs:114:15:114:54 | FormatArgsExpr | 114 | FormatArgsExpr |  |
+| test_logging.rs:114:15:114:54 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:15:114:54 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:15:114:54 | MacroExpr | 114 | MacroExpr |  |
+| test_logging.rs:114:15:114:54 | MacroStmts | 114 | MacroStmts |  |
+| test_logging.rs:114:15:114:54 | MacroStmts | 114 | MacroStmts |  |
+| test_logging.rs:114:15:114:54 | MacroStmts | 114 | MacroStmts |  |
+| test_logging.rs:114:15:114:54 | StmtList | 114 | StmtList |  |
+| test_logging.rs:114:15:114:54 | StmtList | 114 | StmtList |  |
+| test_logging.rs:114:15:114:54 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:15:114:54 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:15:114:54 | TokenTree | 114 | TokenTree |  |
+| test_logging.rs:114:15:114:54 | if ... {...} | 114 | IfExpr |  |
+| test_logging.rs:114:15:114:54 | { ... } | 114 | BlockExpr |  |
+| test_logging.rs:114:15:114:54 | { ... } | 114 | BlockExpr |  |
+| test_logging.rs:114:16:114:17 | {} | 114 | FormatSynthLocationImpl |  |
+| test_logging.rs:114:21:114:23 | std | 114 | IdentPath |  |
+| test_logging.rs:114:21:114:23 | std | 114 | NameRef |  |
+| test_logging.rs:114:21:114:23 | std | 114 | PathSegment |  |
+| test_logging.rs:114:21:114:28 | ...::str | 114 | Path |  |
+| test_logging.rs:114:21:114:49 | ...::from_utf8_unchecked | 114 | Path |  |
+| test_logging.rs:114:21:114:49 | ...::from_utf8_unchecked | 114 | PathExpr |  |
+| test_logging.rs:114:21:114:54 | ...::from_utf8_unchecked(...) | 114 | CallExpr | target-origin:lang:core, target-path:crate::str::converts::from_utf8_unchecked, target:PathExpr |
+| test_logging.rs:114:21:114:54 | FormatArgsArg | 114 | FormatArgsArg |  |
+| test_logging.rs:114:26:114:28 | str | 114 | NameRef |  |
+| test_logging.rs:114:26:114:28 | str | 114 | PathSegment |  |
+| test_logging.rs:114:31:114:49 | from_utf8_unchecked | 114 | NameRef |  |
+| test_logging.rs:114:31:114:49 | from_utf8_unchecked | 114 | PathSegment |  |
+| test_logging.rs:114:50:114:54 | ArgList | 114 | ArgList |  |
+| test_logging.rs:114:51:114:53 | &m6 | 114 | RefExpr |  |
+| test_logging.rs:114:52:114:53 | m6 | 114 | IdentPath |  |
+| test_logging.rs:114:52:114:53 | m6 | 114 | NameRef |  |
+| test_logging.rs:114:52:114:53 | m6 | 114 | PathExpr, VariableAccess |  |
+| test_logging.rs:114:52:114:53 | m6 | 114 | PathSegment |  |
+| test_logging.rs:114:58:114:103 | //... | 114 | Comment |  |
+| test_logging.rs:117:5:117:26 | //... | 117 | Comment |  |
+| test_logging.rs:118:5:118:9 | trace | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:9 | trace | 118 | NameRef |  |
+| test_logging.rs:118:5:118:9 | trace | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | "module::path" | 118 | LiteralExpr |  |
+| test_logging.rs:118:5:118:42 | "module::path" | 118 | LiteralExpr |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | $crate | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | &... | 118 | RefExpr |  |
+| test_logging.rs:118:5:118:42 | (...) | 118 | ParenExpr |  |
+| test_logging.rs:118:5:118:42 | (...::Trace) | 118 | ParenExpr |  |
+| test_logging.rs:118:5:118:42 | ... && ... | 118 | BinaryExpr |  |
+| test_logging.rs:118:5:118:42 | ... <= ... | 118 | BinaryExpr |  |
+| test_logging.rs:118:5:118:42 | ... <= ... | 118 | BinaryExpr |  |
+| test_logging.rs:118:5:118:42 | ...::Level | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::STATIC_MAX_LEVEL | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::STATIC_MAX_LEVEL | 118 | PathExpr |  |
+| test_logging.rs:118:5:118:42 | ...::Trace | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::Trace | 118 | PathExpr |  |
+| test_logging.rs:118:5:118:42 | ...::__private_api | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::__private_api | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::__private_api | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::__private_api | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::__private_api | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::format_args | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::loc | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::loc | 118 | PathExpr |  |
+| test_logging.rs:118:5:118:42 | ...::loc(...) | 118 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:118:5:118:42 | ...::log | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::log | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::log | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::log | 118 | PathExpr |  |
+| test_logging.rs:118:5:118:42 | ...::max_level | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::max_level | 118 | PathExpr |  |
+| test_logging.rs:118:5:118:42 | ...::max_level(...) | 118 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:118:5:118:42 | ...::module_path | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::module_path | 118 | Path |  |
+| test_logging.rs:118:5:118:42 | ...::module_path!... | 118 | MacroCall |  |
+| test_logging.rs:118:5:118:42 | ...::module_path!... | 118 | MacroCall |  |
+| test_logging.rs:118:5:118:42 | ArgList | 118 | ArgList |  |
+| test_logging.rs:118:5:118:42 | ArgList | 118 | ArgList |  |
+| test_logging.rs:118:5:118:42 | Level | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | Level | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:5:118:42 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:5:118:42 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:5:118:42 | STATIC_MAX_LEVEL | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | STATIC_MAX_LEVEL | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:5:118:42 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:5:118:42 | Trace | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | Trace | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | TupleExpr | 118 | TupleExpr |  |
+| test_logging.rs:118:5:118:42 | TupleExpr | 118 | TupleExpr |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | __private_api | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | format_args | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | format_args | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | let ... = ... | 118 | LetStmt |  |
+| test_logging.rs:118:5:118:42 | loc | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | loc | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | log | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | log | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | log | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | log | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | log | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | log | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | IdentPat |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | IdentPath |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | Name |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | lvl | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | max_level | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | max_level | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | module_path | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | module_path | 118 | NameRef |  |
+| test_logging.rs:118:5:118:42 | module_path | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | module_path | 118 | PathSegment |  |
+| test_logging.rs:118:5:118:42 | trace!... | 118 | MacroCall |  |
+| test_logging.rs:118:5:118:43 | ExprStmt | 118 | ExprStmt |  |
+| test_logging.rs:118:11:118:42 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:12:118:25 | "message = {}" | 118 | LiteralExpr |  |
+| test_logging.rs:118:12:118:41 | ...::format_args!... | 118 | MacroCall |  |
+| test_logging.rs:118:12:118:41 | ...::log!... | 118 | MacroCall |  |
+| test_logging.rs:118:12:118:41 | ...::log!... | 118 | MacroCall |  |
+| test_logging.rs:118:12:118:41 | ...::log(...) | 118 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:118:12:118:41 | ArgList | 118 | ArgList |  |
+| test_logging.rs:118:12:118:41 | ExprStmt | 118 | ExprStmt |  |
+| test_logging.rs:118:12:118:41 | FormatArgsExpr | 118 | FormatArgsExpr |  |
+| test_logging.rs:118:12:118:41 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:12:118:41 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:12:118:41 | MacroExpr | 118 | MacroExpr |  |
+| test_logging.rs:118:12:118:41 | MacroStmts | 118 | MacroStmts |  |
+| test_logging.rs:118:12:118:41 | MacroStmts | 118 | MacroStmts |  |
+| test_logging.rs:118:12:118:41 | MacroStmts | 118 | MacroStmts |  |
+| test_logging.rs:118:12:118:41 | StmtList | 118 | StmtList |  |
+| test_logging.rs:118:12:118:41 | StmtList | 118 | StmtList |  |
+| test_logging.rs:118:12:118:41 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:12:118:41 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:12:118:41 | TokenTree | 118 | TokenTree |  |
+| test_logging.rs:118:12:118:41 | if ... {...} | 118 | IfExpr |  |
+| test_logging.rs:118:12:118:41 | { ... } | 118 | BlockExpr |  |
+| test_logging.rs:118:12:118:41 | { ... } | 118 | BlockExpr |  |
+| test_logging.rs:118:23:118:24 | {} | 118 | FormatSynthLocationImpl |  |
+| test_logging.rs:118:28:118:39 | get_password | 118 | IdentPath |  |
+| test_logging.rs:118:28:118:39 | get_password | 118 | NameRef |  |
+| test_logging.rs:118:28:118:39 | get_password | 118 | PathExpr |  |
+| test_logging.rs:118:28:118:39 | get_password | 118 | PathSegment |  |
+| test_logging.rs:118:28:118:41 | FormatArgsArg | 118 | FormatArgsArg |  |
+| test_logging.rs:118:28:118:41 | get_password(...) | 118 | CallExpr | static-target:Function, target-origin:repo::test, target-path:crate::test_logging::get_password, target:PathExpr |
+| test_logging.rs:118:40:118:41 | ArgList | 118 | ArgList |  |
+| test_logging.rs:118:45:118:78 | //... | 118 | Comment |  |
+| test_logging.rs:120:5:120:36 | let ... = ... | 120 | LetStmt |  |
+| test_logging.rs:120:9:120:12 | str1 | 120 | IdentPat |  |
+| test_logging.rs:120:9:120:12 | str1 | 120 | Name |  |
+| test_logging.rs:120:16:120:23 | "123456" | 120 | LiteralExpr |  |
+| test_logging.rs:120:16:120:35 | "123456".to_string(...) | 120 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:120:25:120:33 | to_string | 120 | NameRef |  |
+| test_logging.rs:120:34:120:35 | ArgList | 120 | ArgList |  |
+| test_logging.rs:121:5:121:9 | trace | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:9 | trace | 121 | NameRef |  |
+| test_logging.rs:121:5:121:9 | trace | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | "module::path" | 121 | LiteralExpr |  |
+| test_logging.rs:121:5:121:33 | "module::path" | 121 | LiteralExpr |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | $crate | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | &... | 121 | RefExpr |  |
+| test_logging.rs:121:5:121:33 | (...) | 121 | ParenExpr |  |
+| test_logging.rs:121:5:121:33 | (...::Trace) | 121 | ParenExpr |  |
+| test_logging.rs:121:5:121:33 | ... && ... | 121 | BinaryExpr |  |
+| test_logging.rs:121:5:121:33 | ... <= ... | 121 | BinaryExpr |  |
+| test_logging.rs:121:5:121:33 | ... <= ... | 121 | BinaryExpr |  |
+| test_logging.rs:121:5:121:33 | ...::Level | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::STATIC_MAX_LEVEL | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::STATIC_MAX_LEVEL | 121 | PathExpr |  |
+| test_logging.rs:121:5:121:33 | ...::Trace | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::Trace | 121 | PathExpr |  |
+| test_logging.rs:121:5:121:33 | ...::__private_api | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::__private_api | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::__private_api | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::__private_api | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::__private_api | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::format_args | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::loc | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::loc | 121 | PathExpr |  |
+| test_logging.rs:121:5:121:33 | ...::loc(...) | 121 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:121:5:121:33 | ...::log | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::log | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::log | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::log | 121 | PathExpr |  |
+| test_logging.rs:121:5:121:33 | ...::max_level | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::max_level | 121 | PathExpr |  |
+| test_logging.rs:121:5:121:33 | ...::max_level(...) | 121 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:121:5:121:33 | ...::module_path | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::module_path | 121 | Path |  |
+| test_logging.rs:121:5:121:33 | ...::module_path!... | 121 | MacroCall |  |
+| test_logging.rs:121:5:121:33 | ...::module_path!... | 121 | MacroCall |  |
+| test_logging.rs:121:5:121:33 | ArgList | 121 | ArgList |  |
+| test_logging.rs:121:5:121:33 | ArgList | 121 | ArgList |  |
+| test_logging.rs:121:5:121:33 | Level | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | Level | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:5:121:33 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:5:121:33 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:5:121:33 | STATIC_MAX_LEVEL | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | STATIC_MAX_LEVEL | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:5:121:33 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:5:121:33 | Trace | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | Trace | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | TupleExpr | 121 | TupleExpr |  |
+| test_logging.rs:121:5:121:33 | TupleExpr | 121 | TupleExpr |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | __private_api | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | format_args | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | format_args | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | let ... = ... | 121 | LetStmt |  |
+| test_logging.rs:121:5:121:33 | loc | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | loc | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | log | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | log | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | log | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | log | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | log | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | log | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | IdentPat |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | IdentPath |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | Name |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | lvl | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | max_level | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | max_level | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | module_path | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | module_path | 121 | NameRef |  |
+| test_logging.rs:121:5:121:33 | module_path | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | module_path | 121 | PathSegment |  |
+| test_logging.rs:121:5:121:33 | trace!... | 121 | MacroCall |  |
+| test_logging.rs:121:5:121:34 | ExprStmt | 121 | ExprStmt |  |
+| test_logging.rs:121:11:121:33 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:12:121:25 | "message = {}" | 121 | LiteralExpr |  |
+| test_logging.rs:121:12:121:32 | ...::format_args!... | 121 | MacroCall |  |
+| test_logging.rs:121:12:121:32 | ...::log!... | 121 | MacroCall |  |
+| test_logging.rs:121:12:121:32 | ...::log!... | 121 | MacroCall |  |
+| test_logging.rs:121:12:121:32 | ...::log(...) | 121 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:121:12:121:32 | ArgList | 121 | ArgList |  |
+| test_logging.rs:121:12:121:32 | ExprStmt | 121 | ExprStmt |  |
+| test_logging.rs:121:12:121:32 | FormatArgsExpr | 121 | FormatArgsExpr |  |
+| test_logging.rs:121:12:121:32 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:12:121:32 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:12:121:32 | MacroExpr | 121 | MacroExpr |  |
+| test_logging.rs:121:12:121:32 | MacroStmts | 121 | MacroStmts |  |
+| test_logging.rs:121:12:121:32 | MacroStmts | 121 | MacroStmts |  |
+| test_logging.rs:121:12:121:32 | MacroStmts | 121 | MacroStmts |  |
+| test_logging.rs:121:12:121:32 | StmtList | 121 | StmtList |  |
+| test_logging.rs:121:12:121:32 | StmtList | 121 | StmtList |  |
+| test_logging.rs:121:12:121:32 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:12:121:32 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:12:121:32 | TokenTree | 121 | TokenTree |  |
+| test_logging.rs:121:12:121:32 | if ... {...} | 121 | IfExpr |  |
+| test_logging.rs:121:12:121:32 | { ... } | 121 | BlockExpr |  |
+| test_logging.rs:121:12:121:32 | { ... } | 121 | BlockExpr |  |
+| test_logging.rs:121:23:121:24 | {} | 121 | FormatSynthLocationImpl |  |
+| test_logging.rs:121:28:121:32 | &str1 | 121 | RefExpr |  |
+| test_logging.rs:121:28:121:32 | FormatArgsArg | 121 | FormatArgsArg |  |
+| test_logging.rs:121:29:121:32 | str1 | 121 | IdentPath |  |
+| test_logging.rs:121:29:121:32 | str1 | 121 | NameRef |  |
+| test_logging.rs:121:29:121:32 | str1 | 121 | PathExpr, VariableAccess |  |
+| test_logging.rs:121:29:121:32 | str1 | 121 | PathSegment |  |
+| test_logging.rs:121:36:121:78 | //... | 121 | Comment |  |
+| test_logging.rs:122:5:122:16 | use_password | 122 | IdentPath |  |
+| test_logging.rs:122:5:122:16 | use_password | 122 | NameRef |  |
+| test_logging.rs:122:5:122:16 | use_password | 122 | PathExpr |  |
+| test_logging.rs:122:5:122:16 | use_password | 122 | PathSegment |  |
+| test_logging.rs:122:5:122:23 | use_password(...) | 122 | CallExpr | static-target:Function, target-origin:repo::test, target-path:crate::test_logging::use_password, target:PathExpr |
+| test_logging.rs:122:5:122:24 | ExprStmt | 122 | ExprStmt |  |
+| test_logging.rs:122:17:122:23 | ArgList | 122 | ArgList |  |
+| test_logging.rs:122:18:122:22 | &str1 | 122 | RefExpr |  |
+| test_logging.rs:122:19:122:22 | str1 | 122 | IdentPath |  |
+| test_logging.rs:122:19:122:22 | str1 | 122 | NameRef |  |
+| test_logging.rs:122:19:122:22 | str1 | 122 | PathExpr, VariableAccess |  |
+| test_logging.rs:122:19:122:22 | str1 | 122 | PathSegment |  |
+| test_logging.rs:122:26:122:62 | //... | 122 | Comment |  |
+| test_logging.rs:123:5:123:9 | trace | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:9 | trace | 123 | NameRef |  |
+| test_logging.rs:123:5:123:9 | trace | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | "module::path" | 123 | LiteralExpr |  |
+| test_logging.rs:123:5:123:33 | "module::path" | 123 | LiteralExpr |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | $crate | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | &... | 123 | RefExpr |  |
+| test_logging.rs:123:5:123:33 | (...) | 123 | ParenExpr |  |
+| test_logging.rs:123:5:123:33 | (...::Trace) | 123 | ParenExpr |  |
+| test_logging.rs:123:5:123:33 | ... && ... | 123 | BinaryExpr |  |
+| test_logging.rs:123:5:123:33 | ... <= ... | 123 | BinaryExpr |  |
+| test_logging.rs:123:5:123:33 | ... <= ... | 123 | BinaryExpr |  |
+| test_logging.rs:123:5:123:33 | ...::Level | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::STATIC_MAX_LEVEL | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::STATIC_MAX_LEVEL | 123 | PathExpr |  |
+| test_logging.rs:123:5:123:33 | ...::Trace | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::Trace | 123 | PathExpr |  |
+| test_logging.rs:123:5:123:33 | ...::__private_api | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::__private_api | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::__private_api | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::__private_api | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::__private_api | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::format_args | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::loc | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::loc | 123 | PathExpr |  |
+| test_logging.rs:123:5:123:33 | ...::loc(...) | 123 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:123:5:123:33 | ...::log | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::log | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::log | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::log | 123 | PathExpr |  |
+| test_logging.rs:123:5:123:33 | ...::max_level | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::max_level | 123 | PathExpr |  |
+| test_logging.rs:123:5:123:33 | ...::max_level(...) | 123 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:123:5:123:33 | ...::module_path | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::module_path | 123 | Path |  |
+| test_logging.rs:123:5:123:33 | ...::module_path!... | 123 | MacroCall |  |
+| test_logging.rs:123:5:123:33 | ...::module_path!... | 123 | MacroCall |  |
+| test_logging.rs:123:5:123:33 | ArgList | 123 | ArgList |  |
+| test_logging.rs:123:5:123:33 | ArgList | 123 | ArgList |  |
+| test_logging.rs:123:5:123:33 | Level | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | Level | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:5:123:33 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:5:123:33 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:5:123:33 | STATIC_MAX_LEVEL | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | STATIC_MAX_LEVEL | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:5:123:33 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:5:123:33 | Trace | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | Trace | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | TupleExpr | 123 | TupleExpr |  |
+| test_logging.rs:123:5:123:33 | TupleExpr | 123 | TupleExpr |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | __private_api | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | format_args | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | format_args | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | let ... = ... | 123 | LetStmt |  |
+| test_logging.rs:123:5:123:33 | loc | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | loc | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | log | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | log | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | log | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | log | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | log | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | log | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | IdentPat |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | IdentPath |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | Name |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | lvl | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | max_level | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | max_level | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | module_path | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | module_path | 123 | NameRef |  |
+| test_logging.rs:123:5:123:33 | module_path | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | module_path | 123 | PathSegment |  |
+| test_logging.rs:123:5:123:33 | trace!... | 123 | MacroCall |  |
+| test_logging.rs:123:5:123:34 | ExprStmt | 123 | ExprStmt |  |
+| test_logging.rs:123:11:123:33 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:12:123:25 | "message = {}" | 123 | LiteralExpr |  |
+| test_logging.rs:123:12:123:32 | ...::format_args!... | 123 | MacroCall |  |
+| test_logging.rs:123:12:123:32 | ...::log!... | 123 | MacroCall |  |
+| test_logging.rs:123:12:123:32 | ...::log!... | 123 | MacroCall |  |
+| test_logging.rs:123:12:123:32 | ...::log(...) | 123 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:123:12:123:32 | ArgList | 123 | ArgList |  |
+| test_logging.rs:123:12:123:32 | ExprStmt | 123 | ExprStmt |  |
+| test_logging.rs:123:12:123:32 | FormatArgsExpr | 123 | FormatArgsExpr |  |
+| test_logging.rs:123:12:123:32 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:12:123:32 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:12:123:32 | MacroExpr | 123 | MacroExpr |  |
+| test_logging.rs:123:12:123:32 | MacroStmts | 123 | MacroStmts |  |
+| test_logging.rs:123:12:123:32 | MacroStmts | 123 | MacroStmts |  |
+| test_logging.rs:123:12:123:32 | MacroStmts | 123 | MacroStmts |  |
+| test_logging.rs:123:12:123:32 | StmtList | 123 | StmtList |  |
+| test_logging.rs:123:12:123:32 | StmtList | 123 | StmtList |  |
+| test_logging.rs:123:12:123:32 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:12:123:32 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:12:123:32 | TokenTree | 123 | TokenTree |  |
+| test_logging.rs:123:12:123:32 | if ... {...} | 123 | IfExpr |  |
+| test_logging.rs:123:12:123:32 | { ... } | 123 | BlockExpr |  |
+| test_logging.rs:123:12:123:32 | { ... } | 123 | BlockExpr |  |
+| test_logging.rs:123:23:123:24 | {} | 123 | FormatSynthLocationImpl |  |
+| test_logging.rs:123:28:123:32 | &str1 | 123 | RefExpr |  |
+| test_logging.rs:123:28:123:32 | FormatArgsArg | 123 | FormatArgsArg |  |
+| test_logging.rs:123:29:123:32 | str1 | 123 | IdentPath |  |
+| test_logging.rs:123:29:123:32 | str1 | 123 | NameRef |  |
+| test_logging.rs:123:29:123:32 | str1 | 123 | PathExpr, VariableAccess |  |
+| test_logging.rs:123:29:123:32 | str1 | 123 | PathSegment |  |
+| test_logging.rs:123:36:123:78 | //... | 123 | Comment |  |
+| test_logging.rs:125:5:125:36 | let ... = ... | 125 | LetStmt |  |
+| test_logging.rs:125:9:125:12 | str2 | 125 | IdentPat |  |
+| test_logging.rs:125:9:125:12 | str2 | 125 | Name |  |
+| test_logging.rs:125:16:125:23 | "123456" | 125 | LiteralExpr |  |
+| test_logging.rs:125:16:125:35 | "123456".to_string(...) | 125 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:125:25:125:33 | to_string | 125 | NameRef |  |
+| test_logging.rs:125:34:125:35 | ArgList | 125 | ArgList |  |
+| test_logging.rs:126:5:126:9 | trace | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:9 | trace | 126 | NameRef |  |
+| test_logging.rs:126:5:126:9 | trace | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | "module::path" | 126 | LiteralExpr |  |
+| test_logging.rs:126:5:126:33 | "module::path" | 126 | LiteralExpr |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | $crate | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | &... | 126 | RefExpr |  |
+| test_logging.rs:126:5:126:33 | (...) | 126 | ParenExpr |  |
+| test_logging.rs:126:5:126:33 | (...::Trace) | 126 | ParenExpr |  |
+| test_logging.rs:126:5:126:33 | ... && ... | 126 | BinaryExpr |  |
+| test_logging.rs:126:5:126:33 | ... <= ... | 126 | BinaryExpr |  |
+| test_logging.rs:126:5:126:33 | ... <= ... | 126 | BinaryExpr |  |
+| test_logging.rs:126:5:126:33 | ...::Level | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::STATIC_MAX_LEVEL | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::STATIC_MAX_LEVEL | 126 | PathExpr |  |
+| test_logging.rs:126:5:126:33 | ...::Trace | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::Trace | 126 | PathExpr |  |
+| test_logging.rs:126:5:126:33 | ...::__private_api | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::__private_api | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::__private_api | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::__private_api | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::__private_api | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::format_args | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::loc | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::loc | 126 | PathExpr |  |
+| test_logging.rs:126:5:126:33 | ...::loc(...) | 126 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:126:5:126:33 | ...::log | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::log | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::log | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::log | 126 | PathExpr |  |
+| test_logging.rs:126:5:126:33 | ...::max_level | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::max_level | 126 | PathExpr |  |
+| test_logging.rs:126:5:126:33 | ...::max_level(...) | 126 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:126:5:126:33 | ...::module_path | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::module_path | 126 | Path |  |
+| test_logging.rs:126:5:126:33 | ...::module_path!... | 126 | MacroCall |  |
+| test_logging.rs:126:5:126:33 | ...::module_path!... | 126 | MacroCall |  |
+| test_logging.rs:126:5:126:33 | ArgList | 126 | ArgList |  |
+| test_logging.rs:126:5:126:33 | ArgList | 126 | ArgList |  |
+| test_logging.rs:126:5:126:33 | Level | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | Level | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:5:126:33 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:5:126:33 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:5:126:33 | STATIC_MAX_LEVEL | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | STATIC_MAX_LEVEL | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:5:126:33 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:5:126:33 | Trace | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | Trace | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | TupleExpr | 126 | TupleExpr |  |
+| test_logging.rs:126:5:126:33 | TupleExpr | 126 | TupleExpr |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | __private_api | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | format_args | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | format_args | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | let ... = ... | 126 | LetStmt |  |
+| test_logging.rs:126:5:126:33 | loc | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | loc | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | log | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | log | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | log | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | log | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | log | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | log | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | IdentPat |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | IdentPath |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | Name |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | lvl | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | max_level | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | max_level | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | module_path | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | module_path | 126 | NameRef |  |
+| test_logging.rs:126:5:126:33 | module_path | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | module_path | 126 | PathSegment |  |
+| test_logging.rs:126:5:126:33 | trace!... | 126 | MacroCall |  |
+| test_logging.rs:126:5:126:34 | ExprStmt | 126 | ExprStmt |  |
+| test_logging.rs:126:11:126:33 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:12:126:25 | "message = {}" | 126 | LiteralExpr |  |
+| test_logging.rs:126:12:126:32 | ...::format_args!... | 126 | MacroCall |  |
+| test_logging.rs:126:12:126:32 | ...::log!... | 126 | MacroCall |  |
+| test_logging.rs:126:12:126:32 | ...::log!... | 126 | MacroCall |  |
+| test_logging.rs:126:12:126:32 | ...::log(...) | 126 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:126:12:126:32 | ArgList | 126 | ArgList |  |
+| test_logging.rs:126:12:126:32 | ExprStmt | 126 | ExprStmt |  |
+| test_logging.rs:126:12:126:32 | FormatArgsExpr | 126 | FormatArgsExpr |  |
+| test_logging.rs:126:12:126:32 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:12:126:32 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:12:126:32 | MacroExpr | 126 | MacroExpr |  |
+| test_logging.rs:126:12:126:32 | MacroStmts | 126 | MacroStmts |  |
+| test_logging.rs:126:12:126:32 | MacroStmts | 126 | MacroStmts |  |
+| test_logging.rs:126:12:126:32 | MacroStmts | 126 | MacroStmts |  |
+| test_logging.rs:126:12:126:32 | StmtList | 126 | StmtList |  |
+| test_logging.rs:126:12:126:32 | StmtList | 126 | StmtList |  |
+| test_logging.rs:126:12:126:32 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:12:126:32 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:12:126:32 | TokenTree | 126 | TokenTree |  |
+| test_logging.rs:126:12:126:32 | if ... {...} | 126 | IfExpr |  |
+| test_logging.rs:126:12:126:32 | { ... } | 126 | BlockExpr |  |
+| test_logging.rs:126:12:126:32 | { ... } | 126 | BlockExpr |  |
+| test_logging.rs:126:23:126:24 | {} | 126 | FormatSynthLocationImpl |  |
+| test_logging.rs:126:28:126:32 | &str2 | 126 | RefExpr |  |
+| test_logging.rs:126:28:126:32 | FormatArgsArg | 126 | FormatArgsArg |  |
+| test_logging.rs:126:29:126:32 | str2 | 126 | IdentPath |  |
+| test_logging.rs:126:29:126:32 | str2 | 126 | NameRef |  |
+| test_logging.rs:126:29:126:32 | str2 | 126 | PathExpr, VariableAccess |  |
+| test_logging.rs:126:29:126:32 | str2 | 126 | PathSegment |  |
+| test_logging.rs:128:5:128:27 | //... | 128 | Comment |  |
+| test_logging.rs:129:5:129:34 | let ... = ... | 129 | LetStmt |  |
+| test_logging.rs:129:9:129:10 | t1 | 129 | IdentPat |  |
+| test_logging.rs:129:9:129:10 | t1 | 129 | Name |  |
+| test_logging.rs:129:14:129:33 | TupleExpr | 129 | TupleExpr |  |
+| test_logging.rs:129:15:129:22 | harmless | 129 | IdentPath |  |
+| test_logging.rs:129:15:129:22 | harmless | 129 | NameRef |  |
+| test_logging.rs:129:15:129:22 | harmless | 129 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:129:15:129:22 | harmless | 129 | PathSegment |  |
+| test_logging.rs:129:25:129:32 | password | 129 | IdentPath |  |
+| test_logging.rs:129:25:129:32 | password | 129 | NameRef |  |
+| test_logging.rs:129:25:129:32 | password | 129 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:129:25:129:32 | password | 129 | PathSegment |  |
+| test_logging.rs:129:36:129:49 | //... | 129 | Comment |  |
+| test_logging.rs:130:5:130:9 | trace | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:9 | trace | 130 | NameRef |  |
+| test_logging.rs:130:5:130:9 | trace | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | "module::path" | 130 | LiteralExpr |  |
+| test_logging.rs:130:5:130:32 | "module::path" | 130 | LiteralExpr |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | $crate | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | &... | 130 | RefExpr |  |
+| test_logging.rs:130:5:130:32 | (...) | 130 | ParenExpr |  |
+| test_logging.rs:130:5:130:32 | (...::Trace) | 130 | ParenExpr |  |
+| test_logging.rs:130:5:130:32 | ... && ... | 130 | BinaryExpr |  |
+| test_logging.rs:130:5:130:32 | ... <= ... | 130 | BinaryExpr |  |
+| test_logging.rs:130:5:130:32 | ... <= ... | 130 | BinaryExpr |  |
+| test_logging.rs:130:5:130:32 | ...::Level | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::STATIC_MAX_LEVEL | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::STATIC_MAX_LEVEL | 130 | PathExpr |  |
+| test_logging.rs:130:5:130:32 | ...::Trace | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::Trace | 130 | PathExpr |  |
+| test_logging.rs:130:5:130:32 | ...::__private_api | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::__private_api | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::__private_api | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::__private_api | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::__private_api | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::format_args | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::loc | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::loc | 130 | PathExpr |  |
+| test_logging.rs:130:5:130:32 | ...::loc(...) | 130 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:130:5:130:32 | ...::log | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::log | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::log | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::log | 130 | PathExpr |  |
+| test_logging.rs:130:5:130:32 | ...::max_level | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::max_level | 130 | PathExpr |  |
+| test_logging.rs:130:5:130:32 | ...::max_level(...) | 130 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:130:5:130:32 | ...::module_path | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::module_path | 130 | Path |  |
+| test_logging.rs:130:5:130:32 | ...::module_path!... | 130 | MacroCall |  |
+| test_logging.rs:130:5:130:32 | ...::module_path!... | 130 | MacroCall |  |
+| test_logging.rs:130:5:130:32 | ArgList | 130 | ArgList |  |
+| test_logging.rs:130:5:130:32 | ArgList | 130 | ArgList |  |
+| test_logging.rs:130:5:130:32 | Level | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | Level | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:5:130:32 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:5:130:32 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:5:130:32 | STATIC_MAX_LEVEL | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | STATIC_MAX_LEVEL | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:5:130:32 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:5:130:32 | Trace | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | Trace | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | TupleExpr | 130 | TupleExpr |  |
+| test_logging.rs:130:5:130:32 | TupleExpr | 130 | TupleExpr |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | __private_api | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | format_args | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | format_args | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | let ... = ... | 130 | LetStmt |  |
+| test_logging.rs:130:5:130:32 | loc | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | loc | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | log | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | log | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | log | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | log | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | log | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | log | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | IdentPat |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | IdentPath |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | Name |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | lvl | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | max_level | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | max_level | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | module_path | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | module_path | 130 | NameRef |  |
+| test_logging.rs:130:5:130:32 | module_path | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | module_path | 130 | PathSegment |  |
+| test_logging.rs:130:5:130:32 | trace!... | 130 | MacroCall |  |
+| test_logging.rs:130:5:130:33 | ExprStmt | 130 | ExprStmt |  |
+| test_logging.rs:130:11:130:32 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:12:130:25 | "message = {}" | 130 | LiteralExpr |  |
+| test_logging.rs:130:12:130:31 | ...::format_args!... | 130 | MacroCall |  |
+| test_logging.rs:130:12:130:31 | ...::log!... | 130 | MacroCall |  |
+| test_logging.rs:130:12:130:31 | ...::log!... | 130 | MacroCall |  |
+| test_logging.rs:130:12:130:31 | ...::log(...) | 130 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:130:12:130:31 | ArgList | 130 | ArgList |  |
+| test_logging.rs:130:12:130:31 | ExprStmt | 130 | ExprStmt |  |
+| test_logging.rs:130:12:130:31 | FormatArgsExpr | 130 | FormatArgsExpr |  |
+| test_logging.rs:130:12:130:31 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:12:130:31 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:12:130:31 | MacroExpr | 130 | MacroExpr |  |
+| test_logging.rs:130:12:130:31 | MacroStmts | 130 | MacroStmts |  |
+| test_logging.rs:130:12:130:31 | MacroStmts | 130 | MacroStmts |  |
+| test_logging.rs:130:12:130:31 | MacroStmts | 130 | MacroStmts |  |
+| test_logging.rs:130:12:130:31 | StmtList | 130 | StmtList |  |
+| test_logging.rs:130:12:130:31 | StmtList | 130 | StmtList |  |
+| test_logging.rs:130:12:130:31 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:12:130:31 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:12:130:31 | TokenTree | 130 | TokenTree |  |
+| test_logging.rs:130:12:130:31 | if ... {...} | 130 | IfExpr |  |
+| test_logging.rs:130:12:130:31 | { ... } | 130 | BlockExpr |  |
+| test_logging.rs:130:12:130:31 | { ... } | 130 | BlockExpr |  |
+| test_logging.rs:130:23:130:24 | {} | 130 | FormatSynthLocationImpl |  |
+| test_logging.rs:130:28:130:29 | t1 | 130 | IdentPath |  |
+| test_logging.rs:130:28:130:29 | t1 | 130 | NameRef |  |
+| test_logging.rs:130:28:130:29 | t1 | 130 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:130:28:130:29 | t1 | 130 | PathSegment |  |
+| test_logging.rs:130:28:130:31 | FormatArgsArg | 130 | FormatArgsArg |  |
+| test_logging.rs:130:28:130:31 | t1.0 | 130 | FieldExpr |  |
+| test_logging.rs:130:31:130:31 | 0 | 130 | NameRef |  |
+| test_logging.rs:131:5:131:9 | trace | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:9 | trace | 131 | NameRef |  |
+| test_logging.rs:131:5:131:9 | trace | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | "module::path" | 131 | LiteralExpr |  |
+| test_logging.rs:131:5:131:32 | "module::path" | 131 | LiteralExpr |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | $crate | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | &... | 131 | RefExpr |  |
+| test_logging.rs:131:5:131:32 | (...) | 131 | ParenExpr |  |
+| test_logging.rs:131:5:131:32 | (...::Trace) | 131 | ParenExpr |  |
+| test_logging.rs:131:5:131:32 | ... && ... | 131 | BinaryExpr |  |
+| test_logging.rs:131:5:131:32 | ... <= ... | 131 | BinaryExpr |  |
+| test_logging.rs:131:5:131:32 | ... <= ... | 131 | BinaryExpr |  |
+| test_logging.rs:131:5:131:32 | ...::Level | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::STATIC_MAX_LEVEL | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::STATIC_MAX_LEVEL | 131 | PathExpr |  |
+| test_logging.rs:131:5:131:32 | ...::Trace | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::Trace | 131 | PathExpr |  |
+| test_logging.rs:131:5:131:32 | ...::__private_api | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::__private_api | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::__private_api | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::__private_api | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::__private_api | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::format_args | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::loc | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::loc | 131 | PathExpr |  |
+| test_logging.rs:131:5:131:32 | ...::loc(...) | 131 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:131:5:131:32 | ...::log | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::log | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::log | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::log | 131 | PathExpr |  |
+| test_logging.rs:131:5:131:32 | ...::max_level | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::max_level | 131 | PathExpr |  |
+| test_logging.rs:131:5:131:32 | ...::max_level(...) | 131 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:131:5:131:32 | ...::module_path | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::module_path | 131 | Path |  |
+| test_logging.rs:131:5:131:32 | ...::module_path!... | 131 | MacroCall |  |
+| test_logging.rs:131:5:131:32 | ...::module_path!... | 131 | MacroCall |  |
+| test_logging.rs:131:5:131:32 | ArgList | 131 | ArgList |  |
+| test_logging.rs:131:5:131:32 | ArgList | 131 | ArgList |  |
+| test_logging.rs:131:5:131:32 | Level | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | Level | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:5:131:32 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:5:131:32 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:5:131:32 | STATIC_MAX_LEVEL | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | STATIC_MAX_LEVEL | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:5:131:32 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:5:131:32 | Trace | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | Trace | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | TupleExpr | 131 | TupleExpr |  |
+| test_logging.rs:131:5:131:32 | TupleExpr | 131 | TupleExpr |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | __private_api | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | format_args | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | format_args | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | let ... = ... | 131 | LetStmt |  |
+| test_logging.rs:131:5:131:32 | loc | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | loc | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | log | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | log | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | log | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | log | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | log | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | log | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | IdentPat |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | IdentPath |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | Name |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | lvl | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | max_level | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | max_level | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | module_path | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | module_path | 131 | NameRef |  |
+| test_logging.rs:131:5:131:32 | module_path | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | module_path | 131 | PathSegment |  |
+| test_logging.rs:131:5:131:32 | trace!... | 131 | MacroCall |  |
+| test_logging.rs:131:5:131:33 | ExprStmt | 131 | ExprStmt |  |
+| test_logging.rs:131:11:131:32 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:12:131:25 | "message = {}" | 131 | LiteralExpr |  |
+| test_logging.rs:131:12:131:31 | ...::format_args!... | 131 | MacroCall |  |
+| test_logging.rs:131:12:131:31 | ...::log!... | 131 | MacroCall |  |
+| test_logging.rs:131:12:131:31 | ...::log!... | 131 | MacroCall |  |
+| test_logging.rs:131:12:131:31 | ...::log(...) | 131 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:131:12:131:31 | ArgList | 131 | ArgList |  |
+| test_logging.rs:131:12:131:31 | ExprStmt | 131 | ExprStmt |  |
+| test_logging.rs:131:12:131:31 | FormatArgsExpr | 131 | FormatArgsExpr |  |
+| test_logging.rs:131:12:131:31 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:12:131:31 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:12:131:31 | MacroExpr | 131 | MacroExpr |  |
+| test_logging.rs:131:12:131:31 | MacroStmts | 131 | MacroStmts |  |
+| test_logging.rs:131:12:131:31 | MacroStmts | 131 | MacroStmts |  |
+| test_logging.rs:131:12:131:31 | MacroStmts | 131 | MacroStmts |  |
+| test_logging.rs:131:12:131:31 | StmtList | 131 | StmtList |  |
+| test_logging.rs:131:12:131:31 | StmtList | 131 | StmtList |  |
+| test_logging.rs:131:12:131:31 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:12:131:31 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:12:131:31 | TokenTree | 131 | TokenTree |  |
+| test_logging.rs:131:12:131:31 | if ... {...} | 131 | IfExpr |  |
+| test_logging.rs:131:12:131:31 | { ... } | 131 | BlockExpr |  |
+| test_logging.rs:131:12:131:31 | { ... } | 131 | BlockExpr |  |
+| test_logging.rs:131:23:131:24 | {} | 131 | FormatSynthLocationImpl |  |
+| test_logging.rs:131:28:131:29 | t1 | 131 | IdentPath |  |
+| test_logging.rs:131:28:131:29 | t1 | 131 | NameRef |  |
+| test_logging.rs:131:28:131:29 | t1 | 131 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:131:28:131:29 | t1 | 131 | PathSegment |  |
+| test_logging.rs:131:28:131:31 | FormatArgsArg | 131 | FormatArgsArg |  |
+| test_logging.rs:131:28:131:31 | t1.1 | 131 | FieldExpr |  |
+| test_logging.rs:131:31:131:31 | 1 | 131 | NameRef |  |
+| test_logging.rs:131:35:131:71 | //... | 131 | Comment |  |
+| test_logging.rs:132:5:132:9 | trace | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:9 | trace | 132 | NameRef |  |
+| test_logging.rs:132:5:132:9 | trace | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | "module::path" | 132 | LiteralExpr |  |
+| test_logging.rs:132:5:132:32 | "module::path" | 132 | LiteralExpr |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | $crate | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | &... | 132 | RefExpr |  |
+| test_logging.rs:132:5:132:32 | (...) | 132 | ParenExpr |  |
+| test_logging.rs:132:5:132:32 | (...::Trace) | 132 | ParenExpr |  |
+| test_logging.rs:132:5:132:32 | ... && ... | 132 | BinaryExpr |  |
+| test_logging.rs:132:5:132:32 | ... <= ... | 132 | BinaryExpr |  |
+| test_logging.rs:132:5:132:32 | ... <= ... | 132 | BinaryExpr |  |
+| test_logging.rs:132:5:132:32 | ...::Level | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::STATIC_MAX_LEVEL | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::STATIC_MAX_LEVEL | 132 | PathExpr |  |
+| test_logging.rs:132:5:132:32 | ...::Trace | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::Trace | 132 | PathExpr |  |
+| test_logging.rs:132:5:132:32 | ...::__private_api | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::__private_api | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::__private_api | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::__private_api | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::__private_api | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::format_args | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::loc | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::loc | 132 | PathExpr |  |
+| test_logging.rs:132:5:132:32 | ...::loc(...) | 132 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:132:5:132:32 | ...::log | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::log | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::log | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::log | 132 | PathExpr |  |
+| test_logging.rs:132:5:132:32 | ...::max_level | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::max_level | 132 | PathExpr |  |
+| test_logging.rs:132:5:132:32 | ...::max_level(...) | 132 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:132:5:132:32 | ...::module_path | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::module_path | 132 | Path |  |
+| test_logging.rs:132:5:132:32 | ...::module_path!... | 132 | MacroCall |  |
+| test_logging.rs:132:5:132:32 | ...::module_path!... | 132 | MacroCall |  |
+| test_logging.rs:132:5:132:32 | ArgList | 132 | ArgList |  |
+| test_logging.rs:132:5:132:32 | ArgList | 132 | ArgList |  |
+| test_logging.rs:132:5:132:32 | Level | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | Level | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:5:132:32 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:5:132:32 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:5:132:32 | STATIC_MAX_LEVEL | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | STATIC_MAX_LEVEL | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:5:132:32 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:5:132:32 | Trace | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | Trace | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | TupleExpr | 132 | TupleExpr |  |
+| test_logging.rs:132:5:132:32 | TupleExpr | 132 | TupleExpr |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | __private_api | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | format_args | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | format_args | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | let ... = ... | 132 | LetStmt |  |
+| test_logging.rs:132:5:132:32 | loc | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | loc | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | log | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | log | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | log | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | log | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | log | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | log | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | IdentPat |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | IdentPath |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | Name |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | lvl | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | max_level | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | max_level | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | module_path | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | module_path | 132 | NameRef |  |
+| test_logging.rs:132:5:132:32 | module_path | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | module_path | 132 | PathSegment |  |
+| test_logging.rs:132:5:132:32 | trace!... | 132 | MacroCall |  |
+| test_logging.rs:132:5:132:33 | ExprStmt | 132 | ExprStmt |  |
+| test_logging.rs:132:11:132:32 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:12:132:27 | "message = {:?}" | 132 | LiteralExpr |  |
+| test_logging.rs:132:12:132:31 | ...::format_args!... | 132 | MacroCall |  |
+| test_logging.rs:132:12:132:31 | ...::log!... | 132 | MacroCall |  |
+| test_logging.rs:132:12:132:31 | ...::log!... | 132 | MacroCall |  |
+| test_logging.rs:132:12:132:31 | ...::log(...) | 132 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:132:12:132:31 | ArgList | 132 | ArgList |  |
+| test_logging.rs:132:12:132:31 | ExprStmt | 132 | ExprStmt |  |
+| test_logging.rs:132:12:132:31 | FormatArgsExpr | 132 | FormatArgsExpr |  |
+| test_logging.rs:132:12:132:31 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:12:132:31 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:12:132:31 | MacroExpr | 132 | MacroExpr |  |
+| test_logging.rs:132:12:132:31 | MacroStmts | 132 | MacroStmts |  |
+| test_logging.rs:132:12:132:31 | MacroStmts | 132 | MacroStmts |  |
+| test_logging.rs:132:12:132:31 | MacroStmts | 132 | MacroStmts |  |
+| test_logging.rs:132:12:132:31 | StmtList | 132 | StmtList |  |
+| test_logging.rs:132:12:132:31 | StmtList | 132 | StmtList |  |
+| test_logging.rs:132:12:132:31 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:12:132:31 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:12:132:31 | TokenTree | 132 | TokenTree |  |
+| test_logging.rs:132:12:132:31 | if ... {...} | 132 | IfExpr |  |
+| test_logging.rs:132:12:132:31 | { ... } | 132 | BlockExpr |  |
+| test_logging.rs:132:12:132:31 | { ... } | 132 | BlockExpr |  |
+| test_logging.rs:132:23:132:26 | {:?} | 132 | FormatSynthLocationImpl |  |
+| test_logging.rs:132:30:132:31 | FormatArgsArg | 132 | FormatArgsArg |  |
+| test_logging.rs:132:30:132:31 | t1 | 132 | IdentPath |  |
+| test_logging.rs:132:30:132:31 | t1 | 132 | NameRef |  |
+| test_logging.rs:132:30:132:31 | t1 | 132 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:132:30:132:31 | t1 | 132 | PathSegment |  |
+| test_logging.rs:132:35:132:80 | //... | 132 | Comment |  |
+| test_logging.rs:133:5:133:9 | trace | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:9 | trace | 133 | NameRef |  |
+| test_logging.rs:133:5:133:9 | trace | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | "module::path" | 133 | LiteralExpr |  |
+| test_logging.rs:133:5:133:33 | "module::path" | 133 | LiteralExpr |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | $crate | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | &... | 133 | RefExpr |  |
+| test_logging.rs:133:5:133:33 | (...) | 133 | ParenExpr |  |
+| test_logging.rs:133:5:133:33 | (...::Trace) | 133 | ParenExpr |  |
+| test_logging.rs:133:5:133:33 | ... && ... | 133 | BinaryExpr |  |
+| test_logging.rs:133:5:133:33 | ... <= ... | 133 | BinaryExpr |  |
+| test_logging.rs:133:5:133:33 | ... <= ... | 133 | BinaryExpr |  |
+| test_logging.rs:133:5:133:33 | ...::Level | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::STATIC_MAX_LEVEL | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::STATIC_MAX_LEVEL | 133 | PathExpr |  |
+| test_logging.rs:133:5:133:33 | ...::Trace | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::Trace | 133 | PathExpr |  |
+| test_logging.rs:133:5:133:33 | ...::__private_api | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::__private_api | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::__private_api | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::__private_api | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::__private_api | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::format_args | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::loc | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::loc | 133 | PathExpr |  |
+| test_logging.rs:133:5:133:33 | ...::loc(...) | 133 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:133:5:133:33 | ...::log | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::log | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::log | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::log | 133 | PathExpr |  |
+| test_logging.rs:133:5:133:33 | ...::max_level | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::max_level | 133 | PathExpr |  |
+| test_logging.rs:133:5:133:33 | ...::max_level(...) | 133 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:133:5:133:33 | ...::module_path | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::module_path | 133 | Path |  |
+| test_logging.rs:133:5:133:33 | ...::module_path!... | 133 | MacroCall |  |
+| test_logging.rs:133:5:133:33 | ...::module_path!... | 133 | MacroCall |  |
+| test_logging.rs:133:5:133:33 | ArgList | 133 | ArgList |  |
+| test_logging.rs:133:5:133:33 | ArgList | 133 | ArgList |  |
+| test_logging.rs:133:5:133:33 | Level | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | Level | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:5:133:33 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:5:133:33 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:5:133:33 | STATIC_MAX_LEVEL | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | STATIC_MAX_LEVEL | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:5:133:33 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:5:133:33 | Trace | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | Trace | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | TupleExpr | 133 | TupleExpr |  |
+| test_logging.rs:133:5:133:33 | TupleExpr | 133 | TupleExpr |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | __private_api | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | format_args | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | format_args | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | let ... = ... | 133 | LetStmt |  |
+| test_logging.rs:133:5:133:33 | loc | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | loc | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | log | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | log | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | log | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | log | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | log | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | log | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | IdentPat |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | IdentPath |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | Name |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | lvl | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | max_level | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | max_level | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | module_path | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | module_path | 133 | NameRef |  |
+| test_logging.rs:133:5:133:33 | module_path | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | module_path | 133 | PathSegment |  |
+| test_logging.rs:133:5:133:33 | trace!... | 133 | MacroCall |  |
+| test_logging.rs:133:5:133:34 | ExprStmt | 133 | ExprStmt |  |
+| test_logging.rs:133:11:133:33 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:12:133:28 | "message = {:#?}" | 133 | LiteralExpr |  |
+| test_logging.rs:133:12:133:32 | ...::format_args!... | 133 | MacroCall |  |
+| test_logging.rs:133:12:133:32 | ...::log!... | 133 | MacroCall |  |
+| test_logging.rs:133:12:133:32 | ...::log!... | 133 | MacroCall |  |
+| test_logging.rs:133:12:133:32 | ...::log(...) | 133 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:133:12:133:32 | ArgList | 133 | ArgList |  |
+| test_logging.rs:133:12:133:32 | ExprStmt | 133 | ExprStmt |  |
+| test_logging.rs:133:12:133:32 | FormatArgsExpr | 133 | FormatArgsExpr |  |
+| test_logging.rs:133:12:133:32 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:12:133:32 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:12:133:32 | MacroExpr | 133 | MacroExpr |  |
+| test_logging.rs:133:12:133:32 | MacroStmts | 133 | MacroStmts |  |
+| test_logging.rs:133:12:133:32 | MacroStmts | 133 | MacroStmts |  |
+| test_logging.rs:133:12:133:32 | MacroStmts | 133 | MacroStmts |  |
+| test_logging.rs:133:12:133:32 | StmtList | 133 | StmtList |  |
+| test_logging.rs:133:12:133:32 | StmtList | 133 | StmtList |  |
+| test_logging.rs:133:12:133:32 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:12:133:32 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:12:133:32 | TokenTree | 133 | TokenTree |  |
+| test_logging.rs:133:12:133:32 | if ... {...} | 133 | IfExpr |  |
+| test_logging.rs:133:12:133:32 | { ... } | 133 | BlockExpr |  |
+| test_logging.rs:133:12:133:32 | { ... } | 133 | BlockExpr |  |
+| test_logging.rs:133:23:133:27 | {:#?} | 133 | FormatSynthLocationImpl |  |
+| test_logging.rs:133:31:133:32 | FormatArgsArg | 133 | FormatArgsArg |  |
+| test_logging.rs:133:31:133:32 | t1 | 133 | IdentPath |  |
+| test_logging.rs:133:31:133:32 | t1 | 133 | NameRef |  |
+| test_logging.rs:133:31:133:32 | t1 | 133 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:133:31:133:32 | t1 | 133 | PathSegment |  |
+| test_logging.rs:133:36:133:81 | //... | 133 | Comment |  |
+| test_logging.rs:135:5:135:28 | //... | 135 | Comment |  |
+| test_logging.rs:136:5:136:87 | let ... = ... | 136 | LetStmt |  |
+| test_logging.rs:136:9:136:10 | s1 | 136 | IdentPat |  |
+| test_logging.rs:136:9:136:10 | s1 | 136 | Name |  |
+| test_logging.rs:136:14:136:22 | MyStruct1 | 136 | IdentPath |  |
+| test_logging.rs:136:14:136:22 | MyStruct1 | 136 | NameRef |  |
+| test_logging.rs:136:14:136:22 | MyStruct1 | 136 | PathSegment |  |
+| test_logging.rs:136:14:136:86 | MyStruct1 {...} | 136 | StructExpr |  |
+| test_logging.rs:136:24:136:86 | StructExprFieldList | 136 | StructExprFieldList |  |
+| test_logging.rs:136:26:136:33 | harmless | 136 | NameRef |  |
+| test_logging.rs:136:26:136:52 | harmless: ... | 136 | StructExprField |  |
+| test_logging.rs:136:36:136:40 | "foo" | 136 | LiteralExpr |  |
+| test_logging.rs:136:36:136:52 | "foo".to_string(...) | 136 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:136:42:136:50 | to_string | 136 | NameRef |  |
+| test_logging.rs:136:51:136:52 | ArgList | 136 | ArgList |  |
+| test_logging.rs:136:55:136:62 | password | 136 | NameRef |  |
+| test_logging.rs:136:55:136:84 | password: ... | 136 | StructExprField |  |
+| test_logging.rs:136:65:136:72 | "123456" | 136 | LiteralExpr |  |
+| test_logging.rs:136:65:136:84 | "123456".to_string(...) | 136 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:136:74:136:82 | to_string | 136 | NameRef |  |
+| test_logging.rs:136:83:136:84 | ArgList | 136 | ArgList |  |
+| test_logging.rs:136:89:136:111 | //... | 136 | Comment |  |
+| test_logging.rs:137:5:137:8 | warn | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:8 | warn | 137 | NameRef |  |
+| test_logging.rs:137:5:137:8 | warn | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | "module::path" | 137 | LiteralExpr |  |
+| test_logging.rs:137:5:137:38 | "module::path" | 137 | LiteralExpr |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | $crate | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | &... | 137 | RefExpr |  |
+| test_logging.rs:137:5:137:38 | (...) | 137 | ParenExpr |  |
+| test_logging.rs:137:5:137:38 | (...::Warn) | 137 | ParenExpr |  |
+| test_logging.rs:137:5:137:38 | ... && ... | 137 | BinaryExpr |  |
+| test_logging.rs:137:5:137:38 | ... <= ... | 137 | BinaryExpr |  |
+| test_logging.rs:137:5:137:38 | ... <= ... | 137 | BinaryExpr |  |
+| test_logging.rs:137:5:137:38 | ...::Level | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::STATIC_MAX_LEVEL | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::STATIC_MAX_LEVEL | 137 | PathExpr |  |
+| test_logging.rs:137:5:137:38 | ...::Warn | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::Warn | 137 | PathExpr |  |
+| test_logging.rs:137:5:137:38 | ...::__private_api | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::__private_api | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::__private_api | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::__private_api | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::__private_api | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::format_args | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::loc | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::loc | 137 | PathExpr |  |
+| test_logging.rs:137:5:137:38 | ...::loc(...) | 137 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:137:5:137:38 | ...::log | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::log | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::log | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::log | 137 | PathExpr |  |
+| test_logging.rs:137:5:137:38 | ...::max_level | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::max_level | 137 | PathExpr |  |
+| test_logging.rs:137:5:137:38 | ...::max_level(...) | 137 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:137:5:137:38 | ...::module_path | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::module_path | 137 | Path |  |
+| test_logging.rs:137:5:137:38 | ...::module_path!... | 137 | MacroCall |  |
+| test_logging.rs:137:5:137:38 | ...::module_path!... | 137 | MacroCall |  |
+| test_logging.rs:137:5:137:38 | ArgList | 137 | ArgList |  |
+| test_logging.rs:137:5:137:38 | ArgList | 137 | ArgList |  |
+| test_logging.rs:137:5:137:38 | Level | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | Level | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:5:137:38 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:5:137:38 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:5:137:38 | STATIC_MAX_LEVEL | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | STATIC_MAX_LEVEL | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:5:137:38 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:5:137:38 | TupleExpr | 137 | TupleExpr |  |
+| test_logging.rs:137:5:137:38 | TupleExpr | 137 | TupleExpr |  |
+| test_logging.rs:137:5:137:38 | Warn | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | Warn | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | __private_api | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | format_args | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | format_args | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | let ... = ... | 137 | LetStmt |  |
+| test_logging.rs:137:5:137:38 | loc | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | loc | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | log | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | log | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | log | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | log | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | log | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | log | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | IdentPat |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | IdentPath |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | Name |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | lvl | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | max_level | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | max_level | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | module_path | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | module_path | 137 | NameRef |  |
+| test_logging.rs:137:5:137:38 | module_path | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | module_path | 137 | PathSegment |  |
+| test_logging.rs:137:5:137:38 | warn!... | 137 | MacroCall |  |
+| test_logging.rs:137:5:137:39 | ExprStmt | 137 | ExprStmt |  |
+| test_logging.rs:137:10:137:38 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:11:137:24 | "message = {}" | 137 | LiteralExpr |  |
+| test_logging.rs:137:11:137:37 | ...::format_args!... | 137 | MacroCall |  |
+| test_logging.rs:137:11:137:37 | ...::log!... | 137 | MacroCall |  |
+| test_logging.rs:137:11:137:37 | ...::log!... | 137 | MacroCall |  |
+| test_logging.rs:137:11:137:37 | ...::log(...) | 137 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:137:11:137:37 | ArgList | 137 | ArgList |  |
+| test_logging.rs:137:11:137:37 | ExprStmt | 137 | ExprStmt |  |
+| test_logging.rs:137:11:137:37 | FormatArgsExpr | 137 | FormatArgsExpr |  |
+| test_logging.rs:137:11:137:37 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:11:137:37 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:11:137:37 | MacroExpr | 137 | MacroExpr |  |
+| test_logging.rs:137:11:137:37 | MacroStmts | 137 | MacroStmts |  |
+| test_logging.rs:137:11:137:37 | MacroStmts | 137 | MacroStmts |  |
+| test_logging.rs:137:11:137:37 | MacroStmts | 137 | MacroStmts |  |
+| test_logging.rs:137:11:137:37 | StmtList | 137 | StmtList |  |
+| test_logging.rs:137:11:137:37 | StmtList | 137 | StmtList |  |
+| test_logging.rs:137:11:137:37 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:11:137:37 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:11:137:37 | TokenTree | 137 | TokenTree |  |
+| test_logging.rs:137:11:137:37 | if ... {...} | 137 | IfExpr |  |
+| test_logging.rs:137:11:137:37 | { ... } | 137 | BlockExpr |  |
+| test_logging.rs:137:11:137:37 | { ... } | 137 | BlockExpr |  |
+| test_logging.rs:137:22:137:23 | {} | 137 | FormatSynthLocationImpl |  |
+| test_logging.rs:137:27:137:28 | s1 | 137 | IdentPath |  |
+| test_logging.rs:137:27:137:28 | s1 | 137 | NameRef |  |
+| test_logging.rs:137:27:137:28 | s1 | 137 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:137:27:137:28 | s1 | 137 | PathSegment |  |
+| test_logging.rs:137:27:137:37 | FormatArgsArg | 137 | FormatArgsArg |  |
+| test_logging.rs:137:27:137:37 | s1.harmless | 137 | FieldExpr |  |
+| test_logging.rs:137:30:137:37 | harmless | 137 | NameRef |  |
+| test_logging.rs:138:5:138:8 | warn | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:8 | warn | 138 | NameRef |  |
+| test_logging.rs:138:5:138:8 | warn | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | "module::path" | 138 | LiteralExpr |  |
+| test_logging.rs:138:5:138:38 | "module::path" | 138 | LiteralExpr |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | $crate | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | &... | 138 | RefExpr |  |
+| test_logging.rs:138:5:138:38 | (...) | 138 | ParenExpr |  |
+| test_logging.rs:138:5:138:38 | (...::Warn) | 138 | ParenExpr |  |
+| test_logging.rs:138:5:138:38 | ... && ... | 138 | BinaryExpr |  |
+| test_logging.rs:138:5:138:38 | ... <= ... | 138 | BinaryExpr |  |
+| test_logging.rs:138:5:138:38 | ... <= ... | 138 | BinaryExpr |  |
+| test_logging.rs:138:5:138:38 | ...::Level | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::STATIC_MAX_LEVEL | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::STATIC_MAX_LEVEL | 138 | PathExpr |  |
+| test_logging.rs:138:5:138:38 | ...::Warn | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::Warn | 138 | PathExpr |  |
+| test_logging.rs:138:5:138:38 | ...::__private_api | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::__private_api | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::__private_api | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::__private_api | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::__private_api | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::format_args | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::loc | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::loc | 138 | PathExpr |  |
+| test_logging.rs:138:5:138:38 | ...::loc(...) | 138 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:138:5:138:38 | ...::log | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::log | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::log | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::log | 138 | PathExpr |  |
+| test_logging.rs:138:5:138:38 | ...::max_level | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::max_level | 138 | PathExpr |  |
+| test_logging.rs:138:5:138:38 | ...::max_level(...) | 138 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:138:5:138:38 | ...::module_path | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::module_path | 138 | Path |  |
+| test_logging.rs:138:5:138:38 | ...::module_path!... | 138 | MacroCall |  |
+| test_logging.rs:138:5:138:38 | ...::module_path!... | 138 | MacroCall |  |
+| test_logging.rs:138:5:138:38 | ArgList | 138 | ArgList |  |
+| test_logging.rs:138:5:138:38 | ArgList | 138 | ArgList |  |
+| test_logging.rs:138:5:138:38 | Level | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | Level | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:5:138:38 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:5:138:38 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:5:138:38 | STATIC_MAX_LEVEL | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | STATIC_MAX_LEVEL | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:5:138:38 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:5:138:38 | TupleExpr | 138 | TupleExpr |  |
+| test_logging.rs:138:5:138:38 | TupleExpr | 138 | TupleExpr |  |
+| test_logging.rs:138:5:138:38 | Warn | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | Warn | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | __private_api | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | format_args | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | format_args | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | let ... = ... | 138 | LetStmt |  |
+| test_logging.rs:138:5:138:38 | loc | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | loc | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | log | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | log | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | log | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | log | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | log | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | log | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | IdentPat |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | IdentPath |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | Name |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | lvl | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | max_level | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | max_level | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | module_path | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | module_path | 138 | NameRef |  |
+| test_logging.rs:138:5:138:38 | module_path | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | module_path | 138 | PathSegment |  |
+| test_logging.rs:138:5:138:38 | warn!... | 138 | MacroCall |  |
+| test_logging.rs:138:5:138:39 | ExprStmt | 138 | ExprStmt |  |
+| test_logging.rs:138:10:138:38 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:11:138:24 | "message = {}" | 138 | LiteralExpr |  |
+| test_logging.rs:138:11:138:37 | ...::format_args!... | 138 | MacroCall |  |
+| test_logging.rs:138:11:138:37 | ...::log!... | 138 | MacroCall |  |
+| test_logging.rs:138:11:138:37 | ...::log!... | 138 | MacroCall |  |
+| test_logging.rs:138:11:138:37 | ...::log(...) | 138 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:138:11:138:37 | ArgList | 138 | ArgList |  |
+| test_logging.rs:138:11:138:37 | ExprStmt | 138 | ExprStmt |  |
+| test_logging.rs:138:11:138:37 | FormatArgsExpr | 138 | FormatArgsExpr |  |
+| test_logging.rs:138:11:138:37 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:11:138:37 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:11:138:37 | MacroExpr | 138 | MacroExpr |  |
+| test_logging.rs:138:11:138:37 | MacroStmts | 138 | MacroStmts |  |
+| test_logging.rs:138:11:138:37 | MacroStmts | 138 | MacroStmts |  |
+| test_logging.rs:138:11:138:37 | MacroStmts | 138 | MacroStmts |  |
+| test_logging.rs:138:11:138:37 | StmtList | 138 | StmtList |  |
+| test_logging.rs:138:11:138:37 | StmtList | 138 | StmtList |  |
+| test_logging.rs:138:11:138:37 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:11:138:37 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:11:138:37 | TokenTree | 138 | TokenTree |  |
+| test_logging.rs:138:11:138:37 | if ... {...} | 138 | IfExpr |  |
+| test_logging.rs:138:11:138:37 | { ... } | 138 | BlockExpr |  |
+| test_logging.rs:138:11:138:37 | { ... } | 138 | BlockExpr |  |
+| test_logging.rs:138:22:138:23 | {} | 138 | FormatSynthLocationImpl |  |
+| test_logging.rs:138:27:138:28 | s1 | 138 | IdentPath |  |
+| test_logging.rs:138:27:138:28 | s1 | 138 | NameRef |  |
+| test_logging.rs:138:27:138:28 | s1 | 138 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:138:27:138:28 | s1 | 138 | PathSegment |  |
+| test_logging.rs:138:27:138:37 | FormatArgsArg | 138 | FormatArgsArg |  |
+| test_logging.rs:138:27:138:37 | s1.password | 138 | FieldExpr |  |
+| test_logging.rs:138:30:138:37 | password | 138 | NameRef |  |
+| test_logging.rs:138:41:138:83 | //... | 138 | Comment |  |
+| test_logging.rs:139:5:139:8 | warn | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:8 | warn | 139 | NameRef |  |
+| test_logging.rs:139:5:139:8 | warn | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | "module::path" | 139 | LiteralExpr |  |
+| test_logging.rs:139:5:139:29 | "module::path" | 139 | LiteralExpr |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | $crate | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | &... | 139 | RefExpr |  |
+| test_logging.rs:139:5:139:29 | (...) | 139 | ParenExpr |  |
+| test_logging.rs:139:5:139:29 | (...::Warn) | 139 | ParenExpr |  |
+| test_logging.rs:139:5:139:29 | ... && ... | 139 | BinaryExpr |  |
+| test_logging.rs:139:5:139:29 | ... <= ... | 139 | BinaryExpr |  |
+| test_logging.rs:139:5:139:29 | ... <= ... | 139 | BinaryExpr |  |
+| test_logging.rs:139:5:139:29 | ...::Level | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::STATIC_MAX_LEVEL | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::STATIC_MAX_LEVEL | 139 | PathExpr |  |
+| test_logging.rs:139:5:139:29 | ...::Warn | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::Warn | 139 | PathExpr |  |
+| test_logging.rs:139:5:139:29 | ...::__private_api | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::__private_api | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::__private_api | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::__private_api | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::__private_api | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::format_args | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::loc | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::loc | 139 | PathExpr |  |
+| test_logging.rs:139:5:139:29 | ...::loc(...) | 139 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:139:5:139:29 | ...::log | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::log | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::log | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::log | 139 | PathExpr |  |
+| test_logging.rs:139:5:139:29 | ...::max_level | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::max_level | 139 | PathExpr |  |
+| test_logging.rs:139:5:139:29 | ...::max_level(...) | 139 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:139:5:139:29 | ...::module_path | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::module_path | 139 | Path |  |
+| test_logging.rs:139:5:139:29 | ...::module_path!... | 139 | MacroCall |  |
+| test_logging.rs:139:5:139:29 | ...::module_path!... | 139 | MacroCall |  |
+| test_logging.rs:139:5:139:29 | ArgList | 139 | ArgList |  |
+| test_logging.rs:139:5:139:29 | ArgList | 139 | ArgList |  |
+| test_logging.rs:139:5:139:29 | Level | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | Level | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:5:139:29 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:5:139:29 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:5:139:29 | STATIC_MAX_LEVEL | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | STATIC_MAX_LEVEL | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:5:139:29 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:5:139:29 | TupleExpr | 139 | TupleExpr |  |
+| test_logging.rs:139:5:139:29 | TupleExpr | 139 | TupleExpr |  |
+| test_logging.rs:139:5:139:29 | Warn | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | Warn | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | __private_api | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | format_args | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | format_args | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | let ... = ... | 139 | LetStmt |  |
+| test_logging.rs:139:5:139:29 | loc | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | loc | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | log | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | log | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | log | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | log | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | log | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | log | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | IdentPat |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | IdentPath |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | Name |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | lvl | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | max_level | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | max_level | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | module_path | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | module_path | 139 | NameRef |  |
+| test_logging.rs:139:5:139:29 | module_path | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | module_path | 139 | PathSegment |  |
+| test_logging.rs:139:5:139:29 | warn!... | 139 | MacroCall |  |
+| test_logging.rs:139:5:139:30 | ExprStmt | 139 | ExprStmt |  |
+| test_logging.rs:139:10:139:29 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:11:139:24 | "message = {}" | 139 | LiteralExpr |  |
+| test_logging.rs:139:11:139:28 | ...::format_args!... | 139 | MacroCall |  |
+| test_logging.rs:139:11:139:28 | ...::log!... | 139 | MacroCall |  |
+| test_logging.rs:139:11:139:28 | ...::log!... | 139 | MacroCall |  |
+| test_logging.rs:139:11:139:28 | ...::log(...) | 139 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:139:11:139:28 | ArgList | 139 | ArgList |  |
+| test_logging.rs:139:11:139:28 | ExprStmt | 139 | ExprStmt |  |
+| test_logging.rs:139:11:139:28 | FormatArgsExpr | 139 | FormatArgsExpr |  |
+| test_logging.rs:139:11:139:28 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:11:139:28 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:11:139:28 | MacroExpr | 139 | MacroExpr |  |
+| test_logging.rs:139:11:139:28 | MacroStmts | 139 | MacroStmts |  |
+| test_logging.rs:139:11:139:28 | MacroStmts | 139 | MacroStmts |  |
+| test_logging.rs:139:11:139:28 | MacroStmts | 139 | MacroStmts |  |
+| test_logging.rs:139:11:139:28 | StmtList | 139 | StmtList |  |
+| test_logging.rs:139:11:139:28 | StmtList | 139 | StmtList |  |
+| test_logging.rs:139:11:139:28 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:11:139:28 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:11:139:28 | TokenTree | 139 | TokenTree |  |
+| test_logging.rs:139:11:139:28 | if ... {...} | 139 | IfExpr |  |
+| test_logging.rs:139:11:139:28 | { ... } | 139 | BlockExpr |  |
+| test_logging.rs:139:11:139:28 | { ... } | 139 | BlockExpr |  |
+| test_logging.rs:139:22:139:23 | {} | 139 | FormatSynthLocationImpl |  |
+| test_logging.rs:139:27:139:28 | FormatArgsArg | 139 | FormatArgsArg |  |
+| test_logging.rs:139:27:139:28 | s1 | 139 | IdentPath |  |
+| test_logging.rs:139:27:139:28 | s1 | 139 | NameRef |  |
+| test_logging.rs:139:27:139:28 | s1 | 139 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:139:27:139:28 | s1 | 139 | PathSegment |  |
+| test_logging.rs:139:32:139:77 | //... | 139 | Comment |  |
+| test_logging.rs:140:5:140:8 | warn | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:8 | warn | 140 | NameRef |  |
+| test_logging.rs:140:5:140:8 | warn | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | "module::path" | 140 | LiteralExpr |  |
+| test_logging.rs:140:5:140:31 | "module::path" | 140 | LiteralExpr |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | $crate | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | &... | 140 | RefExpr |  |
+| test_logging.rs:140:5:140:31 | (...) | 140 | ParenExpr |  |
+| test_logging.rs:140:5:140:31 | (...::Warn) | 140 | ParenExpr |  |
+| test_logging.rs:140:5:140:31 | ... && ... | 140 | BinaryExpr |  |
+| test_logging.rs:140:5:140:31 | ... <= ... | 140 | BinaryExpr |  |
+| test_logging.rs:140:5:140:31 | ... <= ... | 140 | BinaryExpr |  |
+| test_logging.rs:140:5:140:31 | ...::Level | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::STATIC_MAX_LEVEL | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::STATIC_MAX_LEVEL | 140 | PathExpr |  |
+| test_logging.rs:140:5:140:31 | ...::Warn | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::Warn | 140 | PathExpr |  |
+| test_logging.rs:140:5:140:31 | ...::__private_api | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::__private_api | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::__private_api | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::__private_api | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::__private_api | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::format_args | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::loc | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::loc | 140 | PathExpr |  |
+| test_logging.rs:140:5:140:31 | ...::loc(...) | 140 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:140:5:140:31 | ...::log | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::log | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::log | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::log | 140 | PathExpr |  |
+| test_logging.rs:140:5:140:31 | ...::max_level | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::max_level | 140 | PathExpr |  |
+| test_logging.rs:140:5:140:31 | ...::max_level(...) | 140 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:140:5:140:31 | ...::module_path | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::module_path | 140 | Path |  |
+| test_logging.rs:140:5:140:31 | ...::module_path!... | 140 | MacroCall |  |
+| test_logging.rs:140:5:140:31 | ...::module_path!... | 140 | MacroCall |  |
+| test_logging.rs:140:5:140:31 | ArgList | 140 | ArgList |  |
+| test_logging.rs:140:5:140:31 | ArgList | 140 | ArgList |  |
+| test_logging.rs:140:5:140:31 | Level | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | Level | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:5:140:31 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:5:140:31 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:5:140:31 | STATIC_MAX_LEVEL | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | STATIC_MAX_LEVEL | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:5:140:31 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:5:140:31 | TupleExpr | 140 | TupleExpr |  |
+| test_logging.rs:140:5:140:31 | TupleExpr | 140 | TupleExpr |  |
+| test_logging.rs:140:5:140:31 | Warn | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | Warn | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | __private_api | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | format_args | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | format_args | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | let ... = ... | 140 | LetStmt |  |
+| test_logging.rs:140:5:140:31 | loc | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | loc | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | log | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | log | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | log | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | log | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | log | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | log | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | IdentPat |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | IdentPath |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | Name |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | lvl | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | max_level | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | max_level | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | module_path | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | module_path | 140 | NameRef |  |
+| test_logging.rs:140:5:140:31 | module_path | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | module_path | 140 | PathSegment |  |
+| test_logging.rs:140:5:140:31 | warn!... | 140 | MacroCall |  |
+| test_logging.rs:140:5:140:32 | ExprStmt | 140 | ExprStmt |  |
+| test_logging.rs:140:10:140:31 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:11:140:26 | "message = {:?}" | 140 | LiteralExpr |  |
+| test_logging.rs:140:11:140:30 | ...::format_args!... | 140 | MacroCall |  |
+| test_logging.rs:140:11:140:30 | ...::log!... | 140 | MacroCall |  |
+| test_logging.rs:140:11:140:30 | ...::log!... | 140 | MacroCall |  |
+| test_logging.rs:140:11:140:30 | ...::log(...) | 140 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:140:11:140:30 | ArgList | 140 | ArgList |  |
+| test_logging.rs:140:11:140:30 | ExprStmt | 140 | ExprStmt |  |
+| test_logging.rs:140:11:140:30 | FormatArgsExpr | 140 | FormatArgsExpr |  |
+| test_logging.rs:140:11:140:30 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:11:140:30 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:11:140:30 | MacroExpr | 140 | MacroExpr |  |
+| test_logging.rs:140:11:140:30 | MacroStmts | 140 | MacroStmts |  |
+| test_logging.rs:140:11:140:30 | MacroStmts | 140 | MacroStmts |  |
+| test_logging.rs:140:11:140:30 | MacroStmts | 140 | MacroStmts |  |
+| test_logging.rs:140:11:140:30 | StmtList | 140 | StmtList |  |
+| test_logging.rs:140:11:140:30 | StmtList | 140 | StmtList |  |
+| test_logging.rs:140:11:140:30 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:11:140:30 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:11:140:30 | TokenTree | 140 | TokenTree |  |
+| test_logging.rs:140:11:140:30 | if ... {...} | 140 | IfExpr |  |
+| test_logging.rs:140:11:140:30 | { ... } | 140 | BlockExpr |  |
+| test_logging.rs:140:11:140:30 | { ... } | 140 | BlockExpr |  |
+| test_logging.rs:140:22:140:25 | {:?} | 140 | FormatSynthLocationImpl |  |
+| test_logging.rs:140:29:140:30 | FormatArgsArg | 140 | FormatArgsArg |  |
+| test_logging.rs:140:29:140:30 | s1 | 140 | IdentPath |  |
+| test_logging.rs:140:29:140:30 | s1 | 140 | NameRef |  |
+| test_logging.rs:140:29:140:30 | s1 | 140 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:140:29:140:30 | s1 | 140 | PathSegment |  |
+| test_logging.rs:140:34:140:79 | //... | 140 | Comment |  |
+| test_logging.rs:141:5:141:8 | warn | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:8 | warn | 141 | NameRef |  |
+| test_logging.rs:141:5:141:8 | warn | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | "module::path" | 141 | LiteralExpr |  |
+| test_logging.rs:141:5:141:32 | "module::path" | 141 | LiteralExpr |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | $crate | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | &... | 141 | RefExpr |  |
+| test_logging.rs:141:5:141:32 | (...) | 141 | ParenExpr |  |
+| test_logging.rs:141:5:141:32 | (...::Warn) | 141 | ParenExpr |  |
+| test_logging.rs:141:5:141:32 | ... && ... | 141 | BinaryExpr |  |
+| test_logging.rs:141:5:141:32 | ... <= ... | 141 | BinaryExpr |  |
+| test_logging.rs:141:5:141:32 | ... <= ... | 141 | BinaryExpr |  |
+| test_logging.rs:141:5:141:32 | ...::Level | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::STATIC_MAX_LEVEL | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::STATIC_MAX_LEVEL | 141 | PathExpr |  |
+| test_logging.rs:141:5:141:32 | ...::Warn | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::Warn | 141 | PathExpr |  |
+| test_logging.rs:141:5:141:32 | ...::__private_api | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::__private_api | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::__private_api | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::__private_api | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::__private_api | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::format_args | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::loc | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::loc | 141 | PathExpr |  |
+| test_logging.rs:141:5:141:32 | ...::loc(...) | 141 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:141:5:141:32 | ...::log | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::log | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::log | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::log | 141 | PathExpr |  |
+| test_logging.rs:141:5:141:32 | ...::max_level | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::max_level | 141 | PathExpr |  |
+| test_logging.rs:141:5:141:32 | ...::max_level(...) | 141 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:141:5:141:32 | ...::module_path | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::module_path | 141 | Path |  |
+| test_logging.rs:141:5:141:32 | ...::module_path!... | 141 | MacroCall |  |
+| test_logging.rs:141:5:141:32 | ...::module_path!... | 141 | MacroCall |  |
+| test_logging.rs:141:5:141:32 | ArgList | 141 | ArgList |  |
+| test_logging.rs:141:5:141:32 | ArgList | 141 | ArgList |  |
+| test_logging.rs:141:5:141:32 | Level | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | Level | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:5:141:32 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:5:141:32 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:5:141:32 | STATIC_MAX_LEVEL | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | STATIC_MAX_LEVEL | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:5:141:32 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:5:141:32 | TupleExpr | 141 | TupleExpr |  |
+| test_logging.rs:141:5:141:32 | TupleExpr | 141 | TupleExpr |  |
+| test_logging.rs:141:5:141:32 | Warn | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | Warn | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | __private_api | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | format_args | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | format_args | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | let ... = ... | 141 | LetStmt |  |
+| test_logging.rs:141:5:141:32 | loc | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | loc | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | log | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | log | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | log | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | log | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | log | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | log | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | IdentPat |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | IdentPath |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | Name |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | lvl | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | max_level | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | max_level | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | module_path | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | module_path | 141 | NameRef |  |
+| test_logging.rs:141:5:141:32 | module_path | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | module_path | 141 | PathSegment |  |
+| test_logging.rs:141:5:141:32 | warn!... | 141 | MacroCall |  |
+| test_logging.rs:141:5:141:33 | ExprStmt | 141 | ExprStmt |  |
+| test_logging.rs:141:10:141:32 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:11:141:27 | "message = {:#?}" | 141 | LiteralExpr |  |
+| test_logging.rs:141:11:141:31 | ...::format_args!... | 141 | MacroCall |  |
+| test_logging.rs:141:11:141:31 | ...::log!... | 141 | MacroCall |  |
+| test_logging.rs:141:11:141:31 | ...::log!... | 141 | MacroCall |  |
+| test_logging.rs:141:11:141:31 | ...::log(...) | 141 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:141:11:141:31 | ArgList | 141 | ArgList |  |
+| test_logging.rs:141:11:141:31 | ExprStmt | 141 | ExprStmt |  |
+| test_logging.rs:141:11:141:31 | FormatArgsExpr | 141 | FormatArgsExpr |  |
+| test_logging.rs:141:11:141:31 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:11:141:31 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:11:141:31 | MacroExpr | 141 | MacroExpr |  |
+| test_logging.rs:141:11:141:31 | MacroStmts | 141 | MacroStmts |  |
+| test_logging.rs:141:11:141:31 | MacroStmts | 141 | MacroStmts |  |
+| test_logging.rs:141:11:141:31 | MacroStmts | 141 | MacroStmts |  |
+| test_logging.rs:141:11:141:31 | StmtList | 141 | StmtList |  |
+| test_logging.rs:141:11:141:31 | StmtList | 141 | StmtList |  |
+| test_logging.rs:141:11:141:31 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:11:141:31 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:11:141:31 | TokenTree | 141 | TokenTree |  |
+| test_logging.rs:141:11:141:31 | if ... {...} | 141 | IfExpr |  |
+| test_logging.rs:141:11:141:31 | { ... } | 141 | BlockExpr |  |
+| test_logging.rs:141:11:141:31 | { ... } | 141 | BlockExpr |  |
+| test_logging.rs:141:22:141:26 | {:#?} | 141 | FormatSynthLocationImpl |  |
+| test_logging.rs:141:30:141:31 | FormatArgsArg | 141 | FormatArgsArg |  |
+| test_logging.rs:141:30:141:31 | s1 | 141 | IdentPath |  |
+| test_logging.rs:141:30:141:31 | s1 | 141 | NameRef |  |
+| test_logging.rs:141:30:141:31 | s1 | 141 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:141:30:141:31 | s1 | 141 | PathSegment |  |
+| test_logging.rs:141:35:141:80 | //... | 141 | Comment |  |
+| test_logging.rs:143:5:143:87 | let ... = ... | 143 | LetStmt |  |
+| test_logging.rs:143:9:143:10 | s2 | 143 | IdentPat |  |
+| test_logging.rs:143:9:143:10 | s2 | 143 | Name |  |
+| test_logging.rs:143:14:143:22 | MyStruct2 | 143 | IdentPath |  |
+| test_logging.rs:143:14:143:22 | MyStruct2 | 143 | NameRef |  |
+| test_logging.rs:143:14:143:22 | MyStruct2 | 143 | PathSegment |  |
+| test_logging.rs:143:14:143:86 | MyStruct2 {...} | 143 | StructExpr |  |
+| test_logging.rs:143:24:143:86 | StructExprFieldList | 143 | StructExprFieldList |  |
+| test_logging.rs:143:26:143:33 | harmless | 143 | NameRef |  |
+| test_logging.rs:143:26:143:52 | harmless: ... | 143 | StructExprField |  |
+| test_logging.rs:143:36:143:40 | "foo" | 143 | LiteralExpr |  |
+| test_logging.rs:143:36:143:52 | "foo".to_string(...) | 143 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:143:42:143:50 | to_string | 143 | NameRef |  |
+| test_logging.rs:143:51:143:52 | ArgList | 143 | ArgList |  |
+| test_logging.rs:143:55:143:62 | password | 143 | NameRef |  |
+| test_logging.rs:143:55:143:84 | password: ... | 143 | StructExprField |  |
+| test_logging.rs:143:65:143:72 | "123456" | 143 | LiteralExpr |  |
+| test_logging.rs:143:65:143:84 | "123456".to_string(...) | 143 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:143:74:143:82 | to_string | 143 | NameRef |  |
+| test_logging.rs:143:83:143:84 | ArgList | 143 | ArgList |  |
+| test_logging.rs:143:89:143:111 | //... | 143 | Comment |  |
+| test_logging.rs:144:5:144:8 | warn | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:8 | warn | 144 | NameRef |  |
+| test_logging.rs:144:5:144:8 | warn | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | "module::path" | 144 | LiteralExpr |  |
+| test_logging.rs:144:5:144:38 | "module::path" | 144 | LiteralExpr |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | $crate | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | &... | 144 | RefExpr |  |
+| test_logging.rs:144:5:144:38 | (...) | 144 | ParenExpr |  |
+| test_logging.rs:144:5:144:38 | (...::Warn) | 144 | ParenExpr |  |
+| test_logging.rs:144:5:144:38 | ... && ... | 144 | BinaryExpr |  |
+| test_logging.rs:144:5:144:38 | ... <= ... | 144 | BinaryExpr |  |
+| test_logging.rs:144:5:144:38 | ... <= ... | 144 | BinaryExpr |  |
+| test_logging.rs:144:5:144:38 | ...::Level | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::STATIC_MAX_LEVEL | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::STATIC_MAX_LEVEL | 144 | PathExpr |  |
+| test_logging.rs:144:5:144:38 | ...::Warn | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::Warn | 144 | PathExpr |  |
+| test_logging.rs:144:5:144:38 | ...::__private_api | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::__private_api | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::__private_api | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::__private_api | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::__private_api | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::format_args | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::loc | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::loc | 144 | PathExpr |  |
+| test_logging.rs:144:5:144:38 | ...::loc(...) | 144 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:144:5:144:38 | ...::log | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::log | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::log | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::log | 144 | PathExpr |  |
+| test_logging.rs:144:5:144:38 | ...::max_level | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::max_level | 144 | PathExpr |  |
+| test_logging.rs:144:5:144:38 | ...::max_level(...) | 144 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:144:5:144:38 | ...::module_path | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::module_path | 144 | Path |  |
+| test_logging.rs:144:5:144:38 | ...::module_path!... | 144 | MacroCall |  |
+| test_logging.rs:144:5:144:38 | ...::module_path!... | 144 | MacroCall |  |
+| test_logging.rs:144:5:144:38 | ArgList | 144 | ArgList |  |
+| test_logging.rs:144:5:144:38 | ArgList | 144 | ArgList |  |
+| test_logging.rs:144:5:144:38 | Level | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | Level | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:5:144:38 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:5:144:38 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:5:144:38 | STATIC_MAX_LEVEL | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | STATIC_MAX_LEVEL | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:5:144:38 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:5:144:38 | TupleExpr | 144 | TupleExpr |  |
+| test_logging.rs:144:5:144:38 | TupleExpr | 144 | TupleExpr |  |
+| test_logging.rs:144:5:144:38 | Warn | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | Warn | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | __private_api | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | format_args | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | format_args | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | let ... = ... | 144 | LetStmt |  |
+| test_logging.rs:144:5:144:38 | loc | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | loc | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | log | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | log | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | log | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | log | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | log | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | log | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | IdentPat |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | IdentPath |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | Name |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | lvl | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | max_level | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | max_level | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | module_path | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | module_path | 144 | NameRef |  |
+| test_logging.rs:144:5:144:38 | module_path | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | module_path | 144 | PathSegment |  |
+| test_logging.rs:144:5:144:38 | warn!... | 144 | MacroCall |  |
+| test_logging.rs:144:5:144:39 | ExprStmt | 144 | ExprStmt |  |
+| test_logging.rs:144:10:144:38 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:11:144:24 | "message = {}" | 144 | LiteralExpr |  |
+| test_logging.rs:144:11:144:37 | ...::format_args!... | 144 | MacroCall |  |
+| test_logging.rs:144:11:144:37 | ...::log!... | 144 | MacroCall |  |
+| test_logging.rs:144:11:144:37 | ...::log!... | 144 | MacroCall |  |
+| test_logging.rs:144:11:144:37 | ...::log(...) | 144 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:144:11:144:37 | ArgList | 144 | ArgList |  |
+| test_logging.rs:144:11:144:37 | ExprStmt | 144 | ExprStmt |  |
+| test_logging.rs:144:11:144:37 | FormatArgsExpr | 144 | FormatArgsExpr |  |
+| test_logging.rs:144:11:144:37 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:11:144:37 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:11:144:37 | MacroExpr | 144 | MacroExpr |  |
+| test_logging.rs:144:11:144:37 | MacroStmts | 144 | MacroStmts |  |
+| test_logging.rs:144:11:144:37 | MacroStmts | 144 | MacroStmts |  |
+| test_logging.rs:144:11:144:37 | MacroStmts | 144 | MacroStmts |  |
+| test_logging.rs:144:11:144:37 | StmtList | 144 | StmtList |  |
+| test_logging.rs:144:11:144:37 | StmtList | 144 | StmtList |  |
+| test_logging.rs:144:11:144:37 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:11:144:37 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:11:144:37 | TokenTree | 144 | TokenTree |  |
+| test_logging.rs:144:11:144:37 | if ... {...} | 144 | IfExpr |  |
+| test_logging.rs:144:11:144:37 | { ... } | 144 | BlockExpr |  |
+| test_logging.rs:144:11:144:37 | { ... } | 144 | BlockExpr |  |
+| test_logging.rs:144:22:144:23 | {} | 144 | FormatSynthLocationImpl |  |
+| test_logging.rs:144:27:144:28 | s2 | 144 | IdentPath |  |
+| test_logging.rs:144:27:144:28 | s2 | 144 | NameRef |  |
+| test_logging.rs:144:27:144:28 | s2 | 144 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:144:27:144:28 | s2 | 144 | PathSegment |  |
+| test_logging.rs:144:27:144:37 | FormatArgsArg | 144 | FormatArgsArg |  |
+| test_logging.rs:144:27:144:37 | s2.harmless | 144 | FieldExpr |  |
+| test_logging.rs:144:30:144:37 | harmless | 144 | NameRef |  |
+| test_logging.rs:145:5:145:8 | warn | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:8 | warn | 145 | NameRef |  |
+| test_logging.rs:145:5:145:8 | warn | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | "module::path" | 145 | LiteralExpr |  |
+| test_logging.rs:145:5:145:38 | "module::path" | 145 | LiteralExpr |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | $crate | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | &... | 145 | RefExpr |  |
+| test_logging.rs:145:5:145:38 | (...) | 145 | ParenExpr |  |
+| test_logging.rs:145:5:145:38 | (...::Warn) | 145 | ParenExpr |  |
+| test_logging.rs:145:5:145:38 | ... && ... | 145 | BinaryExpr |  |
+| test_logging.rs:145:5:145:38 | ... <= ... | 145 | BinaryExpr |  |
+| test_logging.rs:145:5:145:38 | ... <= ... | 145 | BinaryExpr |  |
+| test_logging.rs:145:5:145:38 | ...::Level | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::STATIC_MAX_LEVEL | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::STATIC_MAX_LEVEL | 145 | PathExpr |  |
+| test_logging.rs:145:5:145:38 | ...::Warn | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::Warn | 145 | PathExpr |  |
+| test_logging.rs:145:5:145:38 | ...::__private_api | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::__private_api | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::__private_api | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::__private_api | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::__private_api | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::format_args | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::loc | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::loc | 145 | PathExpr |  |
+| test_logging.rs:145:5:145:38 | ...::loc(...) | 145 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:145:5:145:38 | ...::log | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::log | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::log | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::log | 145 | PathExpr |  |
+| test_logging.rs:145:5:145:38 | ...::max_level | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::max_level | 145 | PathExpr |  |
+| test_logging.rs:145:5:145:38 | ...::max_level(...) | 145 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:145:5:145:38 | ...::module_path | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::module_path | 145 | Path |  |
+| test_logging.rs:145:5:145:38 | ...::module_path!... | 145 | MacroCall |  |
+| test_logging.rs:145:5:145:38 | ...::module_path!... | 145 | MacroCall |  |
+| test_logging.rs:145:5:145:38 | ArgList | 145 | ArgList |  |
+| test_logging.rs:145:5:145:38 | ArgList | 145 | ArgList |  |
+| test_logging.rs:145:5:145:38 | Level | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | Level | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:5:145:38 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:5:145:38 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:5:145:38 | STATIC_MAX_LEVEL | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | STATIC_MAX_LEVEL | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:5:145:38 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:5:145:38 | TupleExpr | 145 | TupleExpr |  |
+| test_logging.rs:145:5:145:38 | TupleExpr | 145 | TupleExpr |  |
+| test_logging.rs:145:5:145:38 | Warn | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | Warn | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | __private_api | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | format_args | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | format_args | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | let ... = ... | 145 | LetStmt |  |
+| test_logging.rs:145:5:145:38 | loc | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | loc | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | log | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | log | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | log | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | log | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | log | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | log | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | IdentPat |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | IdentPath |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | Name |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | lvl | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | max_level | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | max_level | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | module_path | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | module_path | 145 | NameRef |  |
+| test_logging.rs:145:5:145:38 | module_path | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | module_path | 145 | PathSegment |  |
+| test_logging.rs:145:5:145:38 | warn!... | 145 | MacroCall |  |
+| test_logging.rs:145:5:145:39 | ExprStmt | 145 | ExprStmt |  |
+| test_logging.rs:145:10:145:38 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:11:145:24 | "message = {}" | 145 | LiteralExpr |  |
+| test_logging.rs:145:11:145:37 | ...::format_args!... | 145 | MacroCall |  |
+| test_logging.rs:145:11:145:37 | ...::log!... | 145 | MacroCall |  |
+| test_logging.rs:145:11:145:37 | ...::log!... | 145 | MacroCall |  |
+| test_logging.rs:145:11:145:37 | ...::log(...) | 145 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:145:11:145:37 | ArgList | 145 | ArgList |  |
+| test_logging.rs:145:11:145:37 | ExprStmt | 145 | ExprStmt |  |
+| test_logging.rs:145:11:145:37 | FormatArgsExpr | 145 | FormatArgsExpr |  |
+| test_logging.rs:145:11:145:37 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:11:145:37 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:11:145:37 | MacroExpr | 145 | MacroExpr |  |
+| test_logging.rs:145:11:145:37 | MacroStmts | 145 | MacroStmts |  |
+| test_logging.rs:145:11:145:37 | MacroStmts | 145 | MacroStmts |  |
+| test_logging.rs:145:11:145:37 | MacroStmts | 145 | MacroStmts |  |
+| test_logging.rs:145:11:145:37 | StmtList | 145 | StmtList |  |
+| test_logging.rs:145:11:145:37 | StmtList | 145 | StmtList |  |
+| test_logging.rs:145:11:145:37 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:11:145:37 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:11:145:37 | TokenTree | 145 | TokenTree |  |
+| test_logging.rs:145:11:145:37 | if ... {...} | 145 | IfExpr |  |
+| test_logging.rs:145:11:145:37 | { ... } | 145 | BlockExpr |  |
+| test_logging.rs:145:11:145:37 | { ... } | 145 | BlockExpr |  |
+| test_logging.rs:145:22:145:23 | {} | 145 | FormatSynthLocationImpl |  |
+| test_logging.rs:145:27:145:28 | s2 | 145 | IdentPath |  |
+| test_logging.rs:145:27:145:28 | s2 | 145 | NameRef |  |
+| test_logging.rs:145:27:145:28 | s2 | 145 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:145:27:145:28 | s2 | 145 | PathSegment |  |
+| test_logging.rs:145:27:145:37 | FormatArgsArg | 145 | FormatArgsArg |  |
+| test_logging.rs:145:27:145:37 | s2.password | 145 | FieldExpr |  |
+| test_logging.rs:145:30:145:37 | password | 145 | NameRef |  |
+| test_logging.rs:145:41:145:83 | //... | 145 | Comment |  |
+| test_logging.rs:146:5:146:8 | warn | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:8 | warn | 146 | NameRef |  |
+| test_logging.rs:146:5:146:8 | warn | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | "module::path" | 146 | LiteralExpr |  |
+| test_logging.rs:146:5:146:29 | "module::path" | 146 | LiteralExpr |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | $crate | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | &... | 146 | RefExpr |  |
+| test_logging.rs:146:5:146:29 | (...) | 146 | ParenExpr |  |
+| test_logging.rs:146:5:146:29 | (...::Warn) | 146 | ParenExpr |  |
+| test_logging.rs:146:5:146:29 | ... && ... | 146 | BinaryExpr |  |
+| test_logging.rs:146:5:146:29 | ... <= ... | 146 | BinaryExpr |  |
+| test_logging.rs:146:5:146:29 | ... <= ... | 146 | BinaryExpr |  |
+| test_logging.rs:146:5:146:29 | ...::Level | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::STATIC_MAX_LEVEL | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::STATIC_MAX_LEVEL | 146 | PathExpr |  |
+| test_logging.rs:146:5:146:29 | ...::Warn | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::Warn | 146 | PathExpr |  |
+| test_logging.rs:146:5:146:29 | ...::__private_api | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::__private_api | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::__private_api | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::__private_api | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::__private_api | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::format_args | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::loc | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::loc | 146 | PathExpr |  |
+| test_logging.rs:146:5:146:29 | ...::loc(...) | 146 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:146:5:146:29 | ...::log | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::log | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::log | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::log | 146 | PathExpr |  |
+| test_logging.rs:146:5:146:29 | ...::max_level | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::max_level | 146 | PathExpr |  |
+| test_logging.rs:146:5:146:29 | ...::max_level(...) | 146 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:146:5:146:29 | ...::module_path | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::module_path | 146 | Path |  |
+| test_logging.rs:146:5:146:29 | ...::module_path!... | 146 | MacroCall |  |
+| test_logging.rs:146:5:146:29 | ...::module_path!... | 146 | MacroCall |  |
+| test_logging.rs:146:5:146:29 | ArgList | 146 | ArgList |  |
+| test_logging.rs:146:5:146:29 | ArgList | 146 | ArgList |  |
+| test_logging.rs:146:5:146:29 | Level | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | Level | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:5:146:29 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:5:146:29 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:5:146:29 | STATIC_MAX_LEVEL | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | STATIC_MAX_LEVEL | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:5:146:29 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:5:146:29 | TupleExpr | 146 | TupleExpr |  |
+| test_logging.rs:146:5:146:29 | TupleExpr | 146 | TupleExpr |  |
+| test_logging.rs:146:5:146:29 | Warn | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | Warn | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | __private_api | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | format_args | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | format_args | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | let ... = ... | 146 | LetStmt |  |
+| test_logging.rs:146:5:146:29 | loc | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | loc | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | log | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | log | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | log | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | log | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | log | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | log | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | IdentPat |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | IdentPath |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | Name |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | lvl | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | max_level | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | max_level | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | module_path | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | module_path | 146 | NameRef |  |
+| test_logging.rs:146:5:146:29 | module_path | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | module_path | 146 | PathSegment |  |
+| test_logging.rs:146:5:146:29 | warn!... | 146 | MacroCall |  |
+| test_logging.rs:146:5:146:30 | ExprStmt | 146 | ExprStmt |  |
+| test_logging.rs:146:10:146:29 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:11:146:24 | "message = {}" | 146 | LiteralExpr |  |
+| test_logging.rs:146:11:146:28 | ...::format_args!... | 146 | MacroCall |  |
+| test_logging.rs:146:11:146:28 | ...::log!... | 146 | MacroCall |  |
+| test_logging.rs:146:11:146:28 | ...::log!... | 146 | MacroCall |  |
+| test_logging.rs:146:11:146:28 | ...::log(...) | 146 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:146:11:146:28 | ArgList | 146 | ArgList |  |
+| test_logging.rs:146:11:146:28 | ExprStmt | 146 | ExprStmt |  |
+| test_logging.rs:146:11:146:28 | FormatArgsExpr | 146 | FormatArgsExpr |  |
+| test_logging.rs:146:11:146:28 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:11:146:28 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:11:146:28 | MacroExpr | 146 | MacroExpr |  |
+| test_logging.rs:146:11:146:28 | MacroStmts | 146 | MacroStmts |  |
+| test_logging.rs:146:11:146:28 | MacroStmts | 146 | MacroStmts |  |
+| test_logging.rs:146:11:146:28 | MacroStmts | 146 | MacroStmts |  |
+| test_logging.rs:146:11:146:28 | StmtList | 146 | StmtList |  |
+| test_logging.rs:146:11:146:28 | StmtList | 146 | StmtList |  |
+| test_logging.rs:146:11:146:28 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:11:146:28 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:11:146:28 | TokenTree | 146 | TokenTree |  |
+| test_logging.rs:146:11:146:28 | if ... {...} | 146 | IfExpr |  |
+| test_logging.rs:146:11:146:28 | { ... } | 146 | BlockExpr |  |
+| test_logging.rs:146:11:146:28 | { ... } | 146 | BlockExpr |  |
+| test_logging.rs:146:22:146:23 | {} | 146 | FormatSynthLocationImpl |  |
+| test_logging.rs:146:27:146:28 | FormatArgsArg | 146 | FormatArgsArg |  |
+| test_logging.rs:146:27:146:28 | s2 | 146 | IdentPath |  |
+| test_logging.rs:146:27:146:28 | s2 | 146 | NameRef |  |
+| test_logging.rs:146:27:146:28 | s2 | 146 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:146:27:146:28 | s2 | 146 | PathSegment |  |
+| test_logging.rs:146:32:146:90 | //... | 146 | Comment |  |
+| test_logging.rs:147:5:147:8 | warn | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:8 | warn | 147 | NameRef |  |
+| test_logging.rs:147:5:147:8 | warn | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | "module::path" | 147 | LiteralExpr |  |
+| test_logging.rs:147:5:147:31 | "module::path" | 147 | LiteralExpr |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | $crate | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | &... | 147 | RefExpr |  |
+| test_logging.rs:147:5:147:31 | (...) | 147 | ParenExpr |  |
+| test_logging.rs:147:5:147:31 | (...::Warn) | 147 | ParenExpr |  |
+| test_logging.rs:147:5:147:31 | ... && ... | 147 | BinaryExpr |  |
+| test_logging.rs:147:5:147:31 | ... <= ... | 147 | BinaryExpr |  |
+| test_logging.rs:147:5:147:31 | ... <= ... | 147 | BinaryExpr |  |
+| test_logging.rs:147:5:147:31 | ...::Level | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::STATIC_MAX_LEVEL | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::STATIC_MAX_LEVEL | 147 | PathExpr |  |
+| test_logging.rs:147:5:147:31 | ...::Warn | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::Warn | 147 | PathExpr |  |
+| test_logging.rs:147:5:147:31 | ...::__private_api | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::__private_api | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::__private_api | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::__private_api | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::__private_api | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::format_args | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::loc | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::loc | 147 | PathExpr |  |
+| test_logging.rs:147:5:147:31 | ...::loc(...) | 147 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:147:5:147:31 | ...::log | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::log | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::log | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::log | 147 | PathExpr |  |
+| test_logging.rs:147:5:147:31 | ...::max_level | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::max_level | 147 | PathExpr |  |
+| test_logging.rs:147:5:147:31 | ...::max_level(...) | 147 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:147:5:147:31 | ...::module_path | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::module_path | 147 | Path |  |
+| test_logging.rs:147:5:147:31 | ...::module_path!... | 147 | MacroCall |  |
+| test_logging.rs:147:5:147:31 | ...::module_path!... | 147 | MacroCall |  |
+| test_logging.rs:147:5:147:31 | ArgList | 147 | ArgList |  |
+| test_logging.rs:147:5:147:31 | ArgList | 147 | ArgList |  |
+| test_logging.rs:147:5:147:31 | Level | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | Level | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:5:147:31 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:5:147:31 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:5:147:31 | STATIC_MAX_LEVEL | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | STATIC_MAX_LEVEL | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:5:147:31 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:5:147:31 | TupleExpr | 147 | TupleExpr |  |
+| test_logging.rs:147:5:147:31 | TupleExpr | 147 | TupleExpr |  |
+| test_logging.rs:147:5:147:31 | Warn | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | Warn | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | __private_api | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | format_args | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | format_args | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | let ... = ... | 147 | LetStmt |  |
+| test_logging.rs:147:5:147:31 | loc | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | loc | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | log | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | log | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | log | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | log | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | log | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | log | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | IdentPat |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | IdentPath |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | Name |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | lvl | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | max_level | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | max_level | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | module_path | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | module_path | 147 | NameRef |  |
+| test_logging.rs:147:5:147:31 | module_path | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | module_path | 147 | PathSegment |  |
+| test_logging.rs:147:5:147:31 | warn!... | 147 | MacroCall |  |
+| test_logging.rs:147:5:147:32 | ExprStmt | 147 | ExprStmt |  |
+| test_logging.rs:147:10:147:31 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:11:147:26 | "message = {:?}" | 147 | LiteralExpr |  |
+| test_logging.rs:147:11:147:30 | ...::format_args!... | 147 | MacroCall |  |
+| test_logging.rs:147:11:147:30 | ...::log!... | 147 | MacroCall |  |
+| test_logging.rs:147:11:147:30 | ...::log!... | 147 | MacroCall |  |
+| test_logging.rs:147:11:147:30 | ...::log(...) | 147 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:147:11:147:30 | ArgList | 147 | ArgList |  |
+| test_logging.rs:147:11:147:30 | ExprStmt | 147 | ExprStmt |  |
+| test_logging.rs:147:11:147:30 | FormatArgsExpr | 147 | FormatArgsExpr |  |
+| test_logging.rs:147:11:147:30 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:11:147:30 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:11:147:30 | MacroExpr | 147 | MacroExpr |  |
+| test_logging.rs:147:11:147:30 | MacroStmts | 147 | MacroStmts |  |
+| test_logging.rs:147:11:147:30 | MacroStmts | 147 | MacroStmts |  |
+| test_logging.rs:147:11:147:30 | MacroStmts | 147 | MacroStmts |  |
+| test_logging.rs:147:11:147:30 | StmtList | 147 | StmtList |  |
+| test_logging.rs:147:11:147:30 | StmtList | 147 | StmtList |  |
+| test_logging.rs:147:11:147:30 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:11:147:30 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:11:147:30 | TokenTree | 147 | TokenTree |  |
+| test_logging.rs:147:11:147:30 | if ... {...} | 147 | IfExpr |  |
+| test_logging.rs:147:11:147:30 | { ... } | 147 | BlockExpr |  |
+| test_logging.rs:147:11:147:30 | { ... } | 147 | BlockExpr |  |
+| test_logging.rs:147:22:147:25 | {:?} | 147 | FormatSynthLocationImpl |  |
+| test_logging.rs:147:29:147:30 | FormatArgsArg | 147 | FormatArgsArg |  |
+| test_logging.rs:147:29:147:30 | s2 | 147 | IdentPath |  |
+| test_logging.rs:147:29:147:30 | s2 | 147 | NameRef |  |
+| test_logging.rs:147:29:147:30 | s2 | 147 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:147:29:147:30 | s2 | 147 | PathSegment |  |
+| test_logging.rs:147:34:147:79 | //... | 147 | Comment |  |
+| test_logging.rs:148:5:148:8 | warn | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:8 | warn | 148 | NameRef |  |
+| test_logging.rs:148:5:148:8 | warn | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | "module::path" | 148 | LiteralExpr |  |
+| test_logging.rs:148:5:148:32 | "module::path" | 148 | LiteralExpr |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | $crate | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | &... | 148 | RefExpr |  |
+| test_logging.rs:148:5:148:32 | (...) | 148 | ParenExpr |  |
+| test_logging.rs:148:5:148:32 | (...::Warn) | 148 | ParenExpr |  |
+| test_logging.rs:148:5:148:32 | ... && ... | 148 | BinaryExpr |  |
+| test_logging.rs:148:5:148:32 | ... <= ... | 148 | BinaryExpr |  |
+| test_logging.rs:148:5:148:32 | ... <= ... | 148 | BinaryExpr |  |
+| test_logging.rs:148:5:148:32 | ...::Level | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::STATIC_MAX_LEVEL | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::STATIC_MAX_LEVEL | 148 | PathExpr |  |
+| test_logging.rs:148:5:148:32 | ...::Warn | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::Warn | 148 | PathExpr |  |
+| test_logging.rs:148:5:148:32 | ...::__private_api | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::__private_api | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::__private_api | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::__private_api | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::__private_api | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::format_args | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::loc | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::loc | 148 | PathExpr |  |
+| test_logging.rs:148:5:148:32 | ...::loc(...) | 148 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::loc, target:PathExpr |
+| test_logging.rs:148:5:148:32 | ...::log | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::log | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::log | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::log | 148 | PathExpr |  |
+| test_logging.rs:148:5:148:32 | ...::max_level | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::max_level | 148 | PathExpr |  |
+| test_logging.rs:148:5:148:32 | ...::max_level(...) | 148 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::max_level, target:PathExpr |
+| test_logging.rs:148:5:148:32 | ...::module_path | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::module_path | 148 | Path |  |
+| test_logging.rs:148:5:148:32 | ...::module_path!... | 148 | MacroCall |  |
+| test_logging.rs:148:5:148:32 | ...::module_path!... | 148 | MacroCall |  |
+| test_logging.rs:148:5:148:32 | ArgList | 148 | ArgList |  |
+| test_logging.rs:148:5:148:32 | ArgList | 148 | ArgList |  |
+| test_logging.rs:148:5:148:32 | Level | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | Level | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:5:148:32 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:5:148:32 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:5:148:32 | STATIC_MAX_LEVEL | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | STATIC_MAX_LEVEL | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:5:148:32 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:5:148:32 | TupleExpr | 148 | TupleExpr |  |
+| test_logging.rs:148:5:148:32 | TupleExpr | 148 | TupleExpr |  |
+| test_logging.rs:148:5:148:32 | Warn | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | Warn | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | __private_api | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | format_args | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | format_args | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | let ... = ... | 148 | LetStmt |  |
+| test_logging.rs:148:5:148:32 | loc | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | loc | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | log | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | log | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | log | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | log | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | log | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | log | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | IdentPat |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | IdentPath |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | Name |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | lvl | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | max_level | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | max_level | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | module_path | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | module_path | 148 | NameRef |  |
+| test_logging.rs:148:5:148:32 | module_path | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | module_path | 148 | PathSegment |  |
+| test_logging.rs:148:5:148:32 | warn!... | 148 | MacroCall |  |
+| test_logging.rs:148:5:148:33 | ExprStmt | 148 | ExprStmt |  |
+| test_logging.rs:148:10:148:32 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:11:148:27 | "message = {:#?}" | 148 | LiteralExpr |  |
+| test_logging.rs:148:11:148:31 | ...::format_args!... | 148 | MacroCall |  |
+| test_logging.rs:148:11:148:31 | ...::log!... | 148 | MacroCall |  |
+| test_logging.rs:148:11:148:31 | ...::log!... | 148 | MacroCall |  |
+| test_logging.rs:148:11:148:31 | ...::log(...) | 148 | CallExpr | target-origin:repo:https://github.com/rust-lang/log:log, target-path:crate::__private_api::log, target:PathExpr |
+| test_logging.rs:148:11:148:31 | ArgList | 148 | ArgList |  |
+| test_logging.rs:148:11:148:31 | ExprStmt | 148 | ExprStmt |  |
+| test_logging.rs:148:11:148:31 | FormatArgsExpr | 148 | FormatArgsExpr |  |
+| test_logging.rs:148:11:148:31 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:11:148:31 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:11:148:31 | MacroExpr | 148 | MacroExpr |  |
+| test_logging.rs:148:11:148:31 | MacroStmts | 148 | MacroStmts |  |
+| test_logging.rs:148:11:148:31 | MacroStmts | 148 | MacroStmts |  |
+| test_logging.rs:148:11:148:31 | MacroStmts | 148 | MacroStmts |  |
+| test_logging.rs:148:11:148:31 | StmtList | 148 | StmtList |  |
+| test_logging.rs:148:11:148:31 | StmtList | 148 | StmtList |  |
+| test_logging.rs:148:11:148:31 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:11:148:31 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:11:148:31 | TokenTree | 148 | TokenTree |  |
+| test_logging.rs:148:11:148:31 | if ... {...} | 148 | IfExpr |  |
+| test_logging.rs:148:11:148:31 | { ... } | 148 | BlockExpr |  |
+| test_logging.rs:148:11:148:31 | { ... } | 148 | BlockExpr |  |
+| test_logging.rs:148:22:148:26 | {:#?} | 148 | FormatSynthLocationImpl |  |
+| test_logging.rs:148:30:148:31 | FormatArgsArg | 148 | FormatArgsArg |  |
+| test_logging.rs:148:30:148:31 | s2 | 148 | IdentPath |  |
+| test_logging.rs:148:30:148:31 | s2 | 148 | NameRef |  |
+| test_logging.rs:148:30:148:31 | s2 | 148 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:148:30:148:31 | s2 | 148 | PathSegment |  |
+| test_logging.rs:148:35:148:80 | //... | 148 | Comment |  |
+| test_logging.rs:151:1:182:1 | fn test_std | 151 | Function |  |
+| test_logging.rs:151:4:151:11 | test_std | 151 | Name |  |
+| test_logging.rs:151:12:151:57 | ParamList | 151 | ParamList |  |
+| test_logging.rs:151:13:151:20 | password | 151 | IdentPat |  |
+| test_logging.rs:151:13:151:20 | password | 151 | Name |  |
+| test_logging.rs:151:13:151:28 | ...: String | 151 | Param |  |
+| test_logging.rs:151:23:151:28 | String | 151 | IdentPath |  |
+| test_logging.rs:151:23:151:28 | String | 151 | NameRef |  |
+| test_logging.rs:151:23:151:28 | String | 151 | PathSegment |  |
+| test_logging.rs:151:23:151:28 | String | 151 | PathTypeRepr |  |
+| test_logging.rs:151:31:151:31 | i | 151 | IdentPat |  |
+| test_logging.rs:151:31:151:31 | i | 151 | Name |  |
+| test_logging.rs:151:31:151:36 | ...: i32 | 151 | Param |  |
+| test_logging.rs:151:34:151:36 | i32 | 151 | IdentPath |  |
+| test_logging.rs:151:34:151:36 | i32 | 151 | NameRef |  |
+| test_logging.rs:151:34:151:36 | i32 | 151 | PathSegment |  |
+| test_logging.rs:151:34:151:36 | i32 | 151 | PathTypeRepr |  |
+| test_logging.rs:151:39:151:43 | opt_i | 151 | IdentPat |  |
+| test_logging.rs:151:39:151:43 | opt_i | 151 | Name |  |
+| test_logging.rs:151:39:151:56 | ...: Option::<...> | 151 | Param |  |
+| test_logging.rs:151:46:151:51 | Option | 151 | NameRef |  |
+| test_logging.rs:151:46:151:56 | Option::<...> | 151 | Path |  |
+| test_logging.rs:151:46:151:56 | Option::<...> | 151 | PathSegment |  |
+| test_logging.rs:151:46:151:56 | Option::<...> | 151 | PathTypeRepr |  |
+| test_logging.rs:151:52:151:56 | <...> | 151 | GenericArgList |  |
+| test_logging.rs:151:53:151:55 | TypeArg | 151 | TypeArg |  |
+| test_logging.rs:151:53:151:55 | i32 | 151 | IdentPath |  |
+| test_logging.rs:151:53:151:55 | i32 | 151 | NameRef |  |
+| test_logging.rs:151:53:151:55 | i32 | 151 | PathSegment |  |
+| test_logging.rs:151:53:151:55 | i32 | 151 | PathTypeRepr |  |
+| test_logging.rs:151:59:182:1 | StmtList | 151 | StmtList |  |
+| test_logging.rs:151:59:182:1 | { ... } | 151 | BlockExpr |  |
+| test_logging.rs:152:5:152:9 | print | 152 | IdentPath |  |
+| test_logging.rs:152:5:152:9 | print | 152 | NameRef |  |
+| test_logging.rs:152:5:152:9 | print | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | IdentPath |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | IdentPath |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | NameRef |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | NameRef |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | $crate | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | ...::_print | 152 | Path |  |
+| test_logging.rs:152:5:152:38 | ...::_print | 152 | PathExpr |  |
+| test_logging.rs:152:5:152:38 | ...::format_args | 152 | Path |  |
+| test_logging.rs:152:5:152:38 | ...::io | 152 | Path |  |
+| test_logging.rs:152:5:152:38 | MacroExpr | 152 | MacroExpr |  |
+| test_logging.rs:152:5:152:38 | _print | 152 | NameRef |  |
+| test_logging.rs:152:5:152:38 | _print | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | format_args | 152 | NameRef |  |
+| test_logging.rs:152:5:152:38 | format_args | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | io | 152 | NameRef |  |
+| test_logging.rs:152:5:152:38 | io | 152 | PathSegment |  |
+| test_logging.rs:152:5:152:38 | print!... | 152 | MacroCall |  |
+| test_logging.rs:152:5:152:39 | ExprStmt | 152 | ExprStmt |  |
+| test_logging.rs:152:11:152:38 | TokenTree | 152 | TokenTree |  |
+| test_logging.rs:152:12:152:27 | "message = {}\\n" | 152 | LiteralExpr |  |
+| test_logging.rs:152:12:152:37 | ...::_print(...) | 152 | CallExpr | target-origin:lang:std, target-path:crate::io::stdio::_print, target:PathExpr |
+| test_logging.rs:152:12:152:37 | ...::format_args!... | 152 | MacroCall |  |
+| test_logging.rs:152:12:152:37 | ArgList | 152 | ArgList |  |
+| test_logging.rs:152:12:152:37 | ExprStmt | 152 | ExprStmt |  |
+| test_logging.rs:152:12:152:37 | FormatArgsExpr | 152 | FormatArgsExpr |  |
+| test_logging.rs:152:12:152:37 | MacroExpr | 152 | MacroExpr |  |
+| test_logging.rs:152:12:152:37 | MacroStmts | 152 | MacroStmts |  |
+| test_logging.rs:152:12:152:37 | StmtList | 152 | StmtList |  |
+| test_logging.rs:152:12:152:37 | TokenTree | 152 | TokenTree |  |
+| test_logging.rs:152:12:152:37 | { ... } | 152 | BlockExpr |  |
+| test_logging.rs:152:23:152:24 | {} | 152 | FormatSynthLocationImpl |  |
+| test_logging.rs:152:30:152:37 | FormatArgsArg | 152 | FormatArgsArg |  |
+| test_logging.rs:152:30:152:37 | password | 152 | IdentPath |  |
+| test_logging.rs:152:30:152:37 | password | 152 | NameRef |  |
+| test_logging.rs:152:30:152:37 | password | 152 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:152:30:152:37 | password | 152 | PathSegment |  |
+| test_logging.rs:152:41:152:74 | //... | 152 | Comment |  |
+| test_logging.rs:153:5:153:11 | println | 153 | IdentPath |  |
+| test_logging.rs:153:5:153:11 | println | 153 | NameRef |  |
+| test_logging.rs:153:5:153:11 | println | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | IdentPath |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | IdentPath |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | NameRef |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | NameRef |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | $crate | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | ...::_print | 153 | Path |  |
+| test_logging.rs:153:5:153:38 | ...::_print | 153 | PathExpr |  |
+| test_logging.rs:153:5:153:38 | ...::format_args_nl | 153 | Path |  |
+| test_logging.rs:153:5:153:38 | ...::io | 153 | Path |  |
+| test_logging.rs:153:5:153:38 | MacroExpr | 153 | MacroExpr |  |
+| test_logging.rs:153:5:153:38 | _print | 153 | NameRef |  |
+| test_logging.rs:153:5:153:38 | _print | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | format_args_nl | 153 | NameRef |  |
+| test_logging.rs:153:5:153:38 | format_args_nl | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | io | 153 | NameRef |  |
+| test_logging.rs:153:5:153:38 | io | 153 | PathSegment |  |
+| test_logging.rs:153:5:153:38 | println!... | 153 | MacroCall |  |
+| test_logging.rs:153:5:153:39 | ExprStmt | 153 | ExprStmt |  |
+| test_logging.rs:153:13:153:38 | TokenTree | 153 | TokenTree |  |
+| test_logging.rs:153:14:153:27 | "message = {}\\n" | 153 | LiteralExpr |  |
+| test_logging.rs:153:14:153:37 | ...::_print(...) | 153 | CallExpr | target-origin:lang:std, target-path:crate::io::stdio::_print, target:PathExpr |
+| test_logging.rs:153:14:153:37 | ...::format_args_nl!... | 153 | MacroCall |  |
+| test_logging.rs:153:14:153:37 | ArgList | 153 | ArgList |  |
+| test_logging.rs:153:14:153:37 | ExprStmt | 153 | ExprStmt |  |
+| test_logging.rs:153:14:153:37 | FormatArgsExpr | 153 | FormatArgsExpr |  |
+| test_logging.rs:153:14:153:37 | MacroExpr | 153 | MacroExpr |  |
+| test_logging.rs:153:14:153:37 | MacroStmts | 153 | MacroStmts |  |
+| test_logging.rs:153:14:153:37 | StmtList | 153 | StmtList |  |
+| test_logging.rs:153:14:153:37 | TokenTree | 153 | TokenTree |  |
+| test_logging.rs:153:14:153:37 | { ... } | 153 | BlockExpr |  |
+| test_logging.rs:153:25:153:26 | {} | 153 | FormatSynthLocationImpl |  |
+| test_logging.rs:153:30:153:37 | FormatArgsArg | 153 | FormatArgsArg |  |
+| test_logging.rs:153:30:153:37 | password | 153 | IdentPath |  |
+| test_logging.rs:153:30:153:37 | password | 153 | NameRef |  |
+| test_logging.rs:153:30:153:37 | password | 153 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:153:30:153:37 | password | 153 | PathSegment |  |
+| test_logging.rs:153:41:153:74 | //... | 153 | Comment |  |
+| test_logging.rs:154:5:154:10 | eprint | 154 | IdentPath |  |
+| test_logging.rs:154:5:154:10 | eprint | 154 | NameRef |  |
+| test_logging.rs:154:5:154:10 | eprint | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | IdentPath |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | IdentPath |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | NameRef |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | NameRef |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:39 | $crate | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:39 | ...::_eprint | 154 | Path |  |
+| test_logging.rs:154:5:154:39 | ...::_eprint | 154 | PathExpr |  |
+| test_logging.rs:154:5:154:39 | ...::format_args | 154 | Path |  |
+| test_logging.rs:154:5:154:39 | ...::io | 154 | Path |  |
+| test_logging.rs:154:5:154:39 | MacroExpr | 154 | MacroExpr |  |
+| test_logging.rs:154:5:154:39 | _eprint | 154 | NameRef |  |
+| test_logging.rs:154:5:154:39 | _eprint | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:39 | eprint!... | 154 | MacroCall |  |
+| test_logging.rs:154:5:154:39 | format_args | 154 | NameRef |  |
+| test_logging.rs:154:5:154:39 | format_args | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:39 | io | 154 | NameRef |  |
+| test_logging.rs:154:5:154:39 | io | 154 | PathSegment |  |
+| test_logging.rs:154:5:154:40 | ExprStmt | 154 | ExprStmt |  |
+| test_logging.rs:154:12:154:39 | TokenTree | 154 | TokenTree |  |
+| test_logging.rs:154:13:154:28 | "message = {}\\n" | 154 | LiteralExpr |  |
+| test_logging.rs:154:13:154:38 | ...::_eprint(...) | 154 | CallExpr | target-origin:lang:std, target-path:crate::io::stdio::_eprint, target:PathExpr |
+| test_logging.rs:154:13:154:38 | ...::format_args!... | 154 | MacroCall |  |
+| test_logging.rs:154:13:154:38 | ArgList | 154 | ArgList |  |
+| test_logging.rs:154:13:154:38 | ExprStmt | 154 | ExprStmt |  |
+| test_logging.rs:154:13:154:38 | FormatArgsExpr | 154 | FormatArgsExpr |  |
+| test_logging.rs:154:13:154:38 | MacroExpr | 154 | MacroExpr |  |
+| test_logging.rs:154:13:154:38 | MacroStmts | 154 | MacroStmts |  |
+| test_logging.rs:154:13:154:38 | StmtList | 154 | StmtList |  |
+| test_logging.rs:154:13:154:38 | TokenTree | 154 | TokenTree |  |
+| test_logging.rs:154:13:154:38 | { ... } | 154 | BlockExpr |  |
+| test_logging.rs:154:24:154:25 | {} | 154 | FormatSynthLocationImpl |  |
+| test_logging.rs:154:31:154:38 | FormatArgsArg | 154 | FormatArgsArg |  |
+| test_logging.rs:154:31:154:38 | password | 154 | IdentPath |  |
+| test_logging.rs:154:31:154:38 | password | 154 | NameRef |  |
+| test_logging.rs:154:31:154:38 | password | 154 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:154:31:154:38 | password | 154 | PathSegment |  |
+| test_logging.rs:154:42:154:75 | //... | 154 | Comment |  |
+| test_logging.rs:155:5:155:12 | eprintln | 155 | IdentPath |  |
+| test_logging.rs:155:5:155:12 | eprintln | 155 | NameRef |  |
+| test_logging.rs:155:5:155:12 | eprintln | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | IdentPath |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | IdentPath |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | NameRef |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | NameRef |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:39 | $crate | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:39 | ...::_eprint | 155 | Path |  |
+| test_logging.rs:155:5:155:39 | ...::_eprint | 155 | PathExpr |  |
+| test_logging.rs:155:5:155:39 | ...::format_args_nl | 155 | Path |  |
+| test_logging.rs:155:5:155:39 | ...::io | 155 | Path |  |
+| test_logging.rs:155:5:155:39 | MacroExpr | 155 | MacroExpr |  |
+| test_logging.rs:155:5:155:39 | _eprint | 155 | NameRef |  |
+| test_logging.rs:155:5:155:39 | _eprint | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:39 | eprintln!... | 155 | MacroCall |  |
+| test_logging.rs:155:5:155:39 | format_args_nl | 155 | NameRef |  |
+| test_logging.rs:155:5:155:39 | format_args_nl | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:39 | io | 155 | NameRef |  |
+| test_logging.rs:155:5:155:39 | io | 155 | PathSegment |  |
+| test_logging.rs:155:5:155:40 | ExprStmt | 155 | ExprStmt |  |
+| test_logging.rs:155:14:155:39 | TokenTree | 155 | TokenTree |  |
+| test_logging.rs:155:15:155:28 | "message = {}\\n" | 155 | LiteralExpr |  |
+| test_logging.rs:155:15:155:38 | ...::_eprint(...) | 155 | CallExpr | target-origin:lang:std, target-path:crate::io::stdio::_eprint, target:PathExpr |
+| test_logging.rs:155:15:155:38 | ...::format_args_nl!... | 155 | MacroCall |  |
+| test_logging.rs:155:15:155:38 | ArgList | 155 | ArgList |  |
+| test_logging.rs:155:15:155:38 | ExprStmt | 155 | ExprStmt |  |
+| test_logging.rs:155:15:155:38 | FormatArgsExpr | 155 | FormatArgsExpr |  |
+| test_logging.rs:155:15:155:38 | MacroExpr | 155 | MacroExpr |  |
+| test_logging.rs:155:15:155:38 | MacroStmts | 155 | MacroStmts |  |
+| test_logging.rs:155:15:155:38 | StmtList | 155 | StmtList |  |
+| test_logging.rs:155:15:155:38 | TokenTree | 155 | TokenTree |  |
+| test_logging.rs:155:15:155:38 | { ... } | 155 | BlockExpr |  |
+| test_logging.rs:155:26:155:27 | {} | 155 | FormatSynthLocationImpl |  |
+| test_logging.rs:155:31:155:38 | FormatArgsArg | 155 | FormatArgsArg |  |
+| test_logging.rs:155:31:155:38 | password | 155 | IdentPath |  |
+| test_logging.rs:155:31:155:38 | password | 155 | NameRef |  |
+| test_logging.rs:155:31:155:38 | password | 155 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:155:31:155:38 | password | 155 | PathSegment |  |
+| test_logging.rs:155:42:155:75 | //... | 155 | Comment |  |
+| test_logging.rs:157:5:170:5 | ExprStmt | 157 | ExprStmt |  |
+| test_logging.rs:157:5:170:5 | match i { ... } | 157 | MatchExpr |  |
+| test_logging.rs:157:11:157:11 | i | 157 | IdentPath |  |
+| test_logging.rs:157:11:157:11 | i | 157 | NameRef |  |
+| test_logging.rs:157:11:157:11 | i | 157 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:157:11:157:11 | i | 157 | PathSegment |  |
+| test_logging.rs:157:13:170:5 | MatchArmList | 157 | MatchArmList |  |
+| test_logging.rs:158:9:158:9 | 1 | 158 | LiteralExpr |  |
+| test_logging.rs:158:9:158:9 | 1 | 158 | LiteralPat |  |
+| test_logging.rs:158:9:158:50 | 1 => ... | 158 | MatchArm |  |
+| test_logging.rs:158:14:158:50 | StmtList | 158 | StmtList |  |
+| test_logging.rs:158:14:158:50 | { ... } | 158 | BlockExpr |  |
+| test_logging.rs:158:16:158:20 | panic | 158 | IdentPath |  |
+| test_logging.rs:158:16:158:20 | panic | 158 | NameRef |  |
+| test_logging.rs:158:16:158:20 | panic | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | IdentPath |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | IdentPath |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | IdentPath |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | $crate | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | ...::const_format_args | 158 | Path |  |
+| test_logging.rs:158:16:158:47 | ...::panic | 158 | Path |  |
+| test_logging.rs:158:16:158:47 | ...::panic_2021 | 158 | Path |  |
+| test_logging.rs:158:16:158:47 | ...::panic_fmt | 158 | Path |  |
+| test_logging.rs:158:16:158:47 | ...::panic_fmt | 158 | PathExpr |  |
+| test_logging.rs:158:16:158:47 | ...::panicking | 158 | Path |  |
+| test_logging.rs:158:16:158:47 | MacroExpr | 158 | MacroExpr |  |
+| test_logging.rs:158:16:158:47 | const_format_args | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | const_format_args | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | panic | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | panic | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | panic!... | 158 | MacroCall |  |
+| test_logging.rs:158:16:158:47 | panic_2021 | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | panic_2021 | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | panic_fmt | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | panic_fmt | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:47 | panicking | 158 | NameRef |  |
+| test_logging.rs:158:16:158:47 | panicking | 158 | PathSegment |  |
+| test_logging.rs:158:16:158:48 | ExprStmt | 158 | ExprStmt |  |
+| test_logging.rs:158:22:158:47 | TokenTree | 158 | TokenTree |  |
+| test_logging.rs:158:23:158:36 | "message = {}" | 158 | LiteralExpr |  |
+| test_logging.rs:158:23:158:46 | ...::const_format_args!... | 158 | MacroCall |  |
+| test_logging.rs:158:23:158:46 | ...::panic_2021!... | 158 | MacroCall |  |
+| test_logging.rs:158:23:158:46 | ...::panic_fmt(...) | 158 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:158:23:158:46 | ArgList | 158 | ArgList |  |
+| test_logging.rs:158:23:158:46 | ExprStmt | 158 | ExprStmt |  |
+| test_logging.rs:158:23:158:46 | FormatArgsExpr | 158 | FormatArgsExpr |  |
+| test_logging.rs:158:23:158:46 | MacroExpr | 158 | MacroExpr |  |
+| test_logging.rs:158:23:158:46 | MacroExpr | 158 | MacroExpr |  |
+| test_logging.rs:158:23:158:46 | MacroStmts | 158 | MacroStmts |  |
+| test_logging.rs:158:23:158:46 | MacroStmts | 158 | MacroStmts |  |
+| test_logging.rs:158:23:158:46 | StmtList | 158 | StmtList |  |
+| test_logging.rs:158:23:158:46 | TokenTree | 158 | TokenTree |  |
+| test_logging.rs:158:23:158:46 | TokenTree | 158 | TokenTree |  |
+| test_logging.rs:158:23:158:46 | { ... } | 158 | BlockExpr |  |
+| test_logging.rs:158:34:158:35 | {} | 158 | FormatSynthLocationImpl |  |
+| test_logging.rs:158:39:158:46 | FormatArgsArg | 158 | FormatArgsArg |  |
+| test_logging.rs:158:39:158:46 | password | 158 | IdentPath |  |
+| test_logging.rs:158:39:158:46 | password | 158 | NameRef |  |
+| test_logging.rs:158:39:158:46 | password | 158 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:158:39:158:46 | password | 158 | PathSegment |  |
+| test_logging.rs:158:52:158:85 | //... | 158 | Comment |  |
+| test_logging.rs:159:9:159:9 | 2 | 159 | LiteralExpr |  |
+| test_logging.rs:159:9:159:9 | 2 | 159 | LiteralPat |  |
+| test_logging.rs:159:9:159:49 | 2 => ... | 159 | MatchArm |  |
+| test_logging.rs:159:14:159:49 | StmtList | 159 | StmtList |  |
+| test_logging.rs:159:14:159:49 | { ... } | 159 | BlockExpr |  |
+| test_logging.rs:159:16:159:19 | todo | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:19 | todo | 159 | NameRef |  |
+| test_logging.rs:159:16:159:19 | todo | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | "not yet implemented: {}" | 159 | LiteralExpr |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | IdentPath |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | $crate | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | ...::const_format_args | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::format_args | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::panic | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::panic | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::panic_2021 | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::panic_fmt | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | ...::panic_fmt | 159 | PathExpr |  |
+| test_logging.rs:159:16:159:46 | ...::panicking | 159 | Path |  |
+| test_logging.rs:159:16:159:46 | MacroExpr | 159 | MacroExpr |  |
+| test_logging.rs:159:16:159:46 | const_format_args | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | const_format_args | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | format_args | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | format_args | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | panic | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | panic | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | panic | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | panic | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | panic_2021 | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | panic_2021 | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | panic_fmt | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | panic_fmt | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | panicking | 159 | NameRef |  |
+| test_logging.rs:159:16:159:46 | panicking | 159 | PathSegment |  |
+| test_logging.rs:159:16:159:46 | todo!... | 159 | MacroCall |  |
+| test_logging.rs:159:16:159:47 | ExprStmt | 159 | ExprStmt |  |
+| test_logging.rs:159:21:159:46 | TokenTree | 159 | TokenTree |  |
+| test_logging.rs:159:22:159:35 | "message = {}" | 159 | LiteralExpr |  |
+| test_logging.rs:159:22:159:45 | ...::const_format_args!... | 159 | MacroCall |  |
+| test_logging.rs:159:22:159:45 | ...::format_args!... | 159 | MacroCall |  |
+| test_logging.rs:159:22:159:45 | ...::panic!... | 159 | MacroCall |  |
+| test_logging.rs:159:22:159:45 | ...::panic_2021!... | 159 | MacroCall |  |
+| test_logging.rs:159:22:159:45 | ...::panic_fmt(...) | 159 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:159:22:159:45 | ArgList | 159 | ArgList |  |
+| test_logging.rs:159:22:159:45 | ExprStmt | 159 | ExprStmt |  |
+| test_logging.rs:159:22:159:45 | FormatArgsArg | 159 | FormatArgsArg |  |
+| test_logging.rs:159:22:159:45 | FormatArgsExpr | 159 | FormatArgsExpr |  |
+| test_logging.rs:159:22:159:45 | FormatArgsExpr | 159 | FormatArgsExpr |  |
+| test_logging.rs:159:22:159:45 | MacroExpr | 159 | MacroExpr |  |
+| test_logging.rs:159:22:159:45 | MacroExpr | 159 | MacroExpr |  |
+| test_logging.rs:159:22:159:45 | MacroExpr | 159 | MacroExpr |  |
+| test_logging.rs:159:22:159:45 | MacroExpr | 159 | MacroExpr |  |
+| test_logging.rs:159:22:159:45 | MacroStmts | 159 | MacroStmts |  |
+| test_logging.rs:159:22:159:45 | MacroStmts | 159 | MacroStmts |  |
+| test_logging.rs:159:22:159:45 | MacroStmts | 159 | MacroStmts |  |
+| test_logging.rs:159:22:159:45 | StmtList | 159 | StmtList |  |
+| test_logging.rs:159:22:159:45 | TokenTree | 159 | TokenTree |  |
+| test_logging.rs:159:22:159:45 | TokenTree | 159 | TokenTree |  |
+| test_logging.rs:159:22:159:45 | TokenTree | 159 | TokenTree |  |
+| test_logging.rs:159:22:159:45 | TokenTree | 159 | TokenTree |  |
+| test_logging.rs:159:22:159:45 | { ... } | 159 | BlockExpr |  |
+| test_logging.rs:159:33:159:34 | {} | 159 | FormatSynthLocationImpl |  |
+| test_logging.rs:159:38:159:39 | {} | 159 | FormatSynthLocationImpl |  |
+| test_logging.rs:159:38:159:45 | FormatArgsArg | 159 | FormatArgsArg |  |
+| test_logging.rs:159:38:159:45 | password | 159 | IdentPath |  |
+| test_logging.rs:159:38:159:45 | password | 159 | NameRef |  |
+| test_logging.rs:159:38:159:45 | password | 159 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:159:38:159:45 | password | 159 | PathSegment |  |
+| test_logging.rs:159:51:159:84 | //... | 159 | Comment |  |
+| test_logging.rs:160:9:160:9 | 3 | 160 | LiteralExpr |  |
+| test_logging.rs:160:9:160:9 | 3 | 160 | LiteralPat |  |
+| test_logging.rs:160:9:160:58 | 3 => ... | 160 | MatchArm |  |
+| test_logging.rs:160:14:160:58 | StmtList | 160 | StmtList |  |
+| test_logging.rs:160:14:160:58 | { ... } | 160 | BlockExpr |  |
+| test_logging.rs:160:16:160:28 | unimplemented | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:28 | unimplemented | 160 | NameRef |  |
+| test_logging.rs:160:16:160:28 | unimplemented | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | "not implemented: {}" | 160 | LiteralExpr |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | IdentPath |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | $crate | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | ...::const_format_args | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::format_args | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::panic | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::panic | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::panic_2021 | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::panic_fmt | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | ...::panic_fmt | 160 | PathExpr |  |
+| test_logging.rs:160:16:160:55 | ...::panicking | 160 | Path |  |
+| test_logging.rs:160:16:160:55 | MacroExpr | 160 | MacroExpr |  |
+| test_logging.rs:160:16:160:55 | const_format_args | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | const_format_args | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | format_args | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | format_args | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | panic | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | panic | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | panic | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | panic | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | panic_2021 | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | panic_2021 | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | panic_fmt | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | panic_fmt | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | panicking | 160 | NameRef |  |
+| test_logging.rs:160:16:160:55 | panicking | 160 | PathSegment |  |
+| test_logging.rs:160:16:160:55 | unimplemented!... | 160 | MacroCall |  |
+| test_logging.rs:160:16:160:56 | ExprStmt | 160 | ExprStmt |  |
+| test_logging.rs:160:30:160:55 | TokenTree | 160 | TokenTree |  |
+| test_logging.rs:160:31:160:44 | "message = {}" | 160 | LiteralExpr |  |
+| test_logging.rs:160:31:160:54 | ...::const_format_args!... | 160 | MacroCall |  |
+| test_logging.rs:160:31:160:54 | ...::format_args!... | 160 | MacroCall |  |
+| test_logging.rs:160:31:160:54 | ...::panic!... | 160 | MacroCall |  |
+| test_logging.rs:160:31:160:54 | ...::panic_2021!... | 160 | MacroCall |  |
+| test_logging.rs:160:31:160:54 | ...::panic_fmt(...) | 160 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:160:31:160:54 | ArgList | 160 | ArgList |  |
+| test_logging.rs:160:31:160:54 | ExprStmt | 160 | ExprStmt |  |
+| test_logging.rs:160:31:160:54 | FormatArgsArg | 160 | FormatArgsArg |  |
+| test_logging.rs:160:31:160:54 | FormatArgsExpr | 160 | FormatArgsExpr |  |
+| test_logging.rs:160:31:160:54 | FormatArgsExpr | 160 | FormatArgsExpr |  |
+| test_logging.rs:160:31:160:54 | MacroExpr | 160 | MacroExpr |  |
+| test_logging.rs:160:31:160:54 | MacroExpr | 160 | MacroExpr |  |
+| test_logging.rs:160:31:160:54 | MacroExpr | 160 | MacroExpr |  |
+| test_logging.rs:160:31:160:54 | MacroExpr | 160 | MacroExpr |  |
+| test_logging.rs:160:31:160:54 | MacroStmts | 160 | MacroStmts |  |
+| test_logging.rs:160:31:160:54 | MacroStmts | 160 | MacroStmts |  |
+| test_logging.rs:160:31:160:54 | MacroStmts | 160 | MacroStmts |  |
+| test_logging.rs:160:31:160:54 | StmtList | 160 | StmtList |  |
+| test_logging.rs:160:31:160:54 | TokenTree | 160 | TokenTree |  |
+| test_logging.rs:160:31:160:54 | TokenTree | 160 | TokenTree |  |
+| test_logging.rs:160:31:160:54 | TokenTree | 160 | TokenTree |  |
+| test_logging.rs:160:31:160:54 | TokenTree | 160 | TokenTree |  |
+| test_logging.rs:160:31:160:54 | { ... } | 160 | BlockExpr |  |
+| test_logging.rs:160:34:160:35 | {} | 160 | FormatSynthLocationImpl |  |
+| test_logging.rs:160:42:160:43 | {} | 160 | FormatSynthLocationImpl |  |
+| test_logging.rs:160:47:160:54 | FormatArgsArg | 160 | FormatArgsArg |  |
+| test_logging.rs:160:47:160:54 | password | 160 | IdentPath |  |
+| test_logging.rs:160:47:160:54 | password | 160 | NameRef |  |
+| test_logging.rs:160:47:160:54 | password | 160 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:160:47:160:54 | password | 160 | PathSegment |  |
+| test_logging.rs:160:60:160:93 | //... | 160 | Comment |  |
+| test_logging.rs:161:9:161:9 | 4 | 161 | LiteralExpr |  |
+| test_logging.rs:161:9:161:9 | 4 | 161 | LiteralPat |  |
+| test_logging.rs:161:9:161:56 | 4 => ... | 161 | MatchArm |  |
+| test_logging.rs:161:14:161:56 | StmtList | 161 | StmtList |  |
+| test_logging.rs:161:14:161:56 | { ... } | 161 | BlockExpr |  |
+| test_logging.rs:161:16:161:26 | unreachable | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:26 | unreachable | 161 | NameRef |  |
+| test_logging.rs:161:16:161:26 | unreachable | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | "internal error: entered unrea... | 161 | LiteralExpr |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | IdentPath |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | $crate | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | ...::const_format_args | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::format_args | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic_2021 | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic_fmt | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::panic_fmt | 161 | PathExpr |  |
+| test_logging.rs:161:16:161:53 | ...::panicking | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | ...::unreachable_2021 | 161 | Path |  |
+| test_logging.rs:161:16:161:53 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:16:161:53 | const_format_args | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | const_format_args | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | format_args | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | format_args | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panic | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panic_2021 | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panic_2021 | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panic_fmt | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panic_fmt | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | panicking | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | panicking | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:53 | unreachable!... | 161 | MacroCall |  |
+| test_logging.rs:161:16:161:53 | unreachable_2021 | 161 | NameRef |  |
+| test_logging.rs:161:16:161:53 | unreachable_2021 | 161 | PathSegment |  |
+| test_logging.rs:161:16:161:54 | ExprStmt | 161 | ExprStmt |  |
+| test_logging.rs:161:28:161:53 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:42 | "message = {}" | 161 | LiteralExpr |  |
+| test_logging.rs:161:29:161:52 | ...::const_format_args!... | 161 | MacroCall |  |
+| test_logging.rs:161:29:161:52 | ...::format_args!... | 161 | MacroCall |  |
+| test_logging.rs:161:29:161:52 | ...::panic!... | 161 | MacroCall |  |
+| test_logging.rs:161:29:161:52 | ...::panic_2021!... | 161 | MacroCall |  |
+| test_logging.rs:161:29:161:52 | ...::panic_fmt(...) | 161 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:161:29:161:52 | ...::unreachable_2021!... | 161 | MacroCall |  |
+| test_logging.rs:161:29:161:52 | ArgList | 161 | ArgList |  |
+| test_logging.rs:161:29:161:52 | ExprStmt | 161 | ExprStmt |  |
+| test_logging.rs:161:29:161:52 | FormatArgsArg | 161 | FormatArgsArg |  |
+| test_logging.rs:161:29:161:52 | FormatArgsExpr | 161 | FormatArgsExpr |  |
+| test_logging.rs:161:29:161:52 | FormatArgsExpr | 161 | FormatArgsExpr |  |
+| test_logging.rs:161:29:161:52 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:29:161:52 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:29:161:52 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:29:161:52 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:29:161:52 | MacroExpr | 161 | MacroExpr |  |
+| test_logging.rs:161:29:161:52 | MacroStmts | 161 | MacroStmts |  |
+| test_logging.rs:161:29:161:52 | MacroStmts | 161 | MacroStmts |  |
+| test_logging.rs:161:29:161:52 | MacroStmts | 161 | MacroStmts |  |
+| test_logging.rs:161:29:161:52 | MacroStmts | 161 | MacroStmts |  |
+| test_logging.rs:161:29:161:52 | StmtList | 161 | StmtList |  |
+| test_logging.rs:161:29:161:52 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:52 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:52 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:52 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:52 | TokenTree | 161 | TokenTree |  |
+| test_logging.rs:161:29:161:52 | { ... } | 161 | BlockExpr |  |
+| test_logging.rs:161:40:161:41 | {} | 161 | FormatSynthLocationImpl |  |
+| test_logging.rs:161:45:161:52 | FormatArgsArg | 161 | FormatArgsArg |  |
+| test_logging.rs:161:45:161:52 | password | 161 | IdentPath |  |
+| test_logging.rs:161:45:161:52 | password | 161 | NameRef |  |
+| test_logging.rs:161:45:161:52 | password | 161 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:161:45:161:52 | password | 161 | PathSegment |  |
+| test_logging.rs:161:58:161:91 | //... | 161 | Comment |  |
+| test_logging.rs:161:59:161:60 | {} | 161 | FormatSynthLocationImpl |  |
+| test_logging.rs:162:9:162:9 | 5 | 162 | LiteralExpr |  |
+| test_logging.rs:162:9:162:9 | 5 | 162 | LiteralPat |  |
+| test_logging.rs:162:9:162:58 | 5 => ... | 162 | MatchArm |  |
+| test_logging.rs:162:14:162:58 | StmtList | 162 | StmtList |  |
+| test_logging.rs:162:14:162:58 | { ... } | 162 | BlockExpr |  |
+| test_logging.rs:162:16:162:21 | assert | 162 | IdentPath |  |
+| test_logging.rs:162:16:162:21 | assert | 162 | NameRef |  |
+| test_logging.rs:162:16:162:21 | assert | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | IdentPath |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | IdentPath |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | IdentPath |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | $crate | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | ...::const_format_args | 162 | Path |  |
+| test_logging.rs:162:16:162:55 | ...::panic | 162 | Path |  |
+| test_logging.rs:162:16:162:55 | ...::panic_2021 | 162 | Path |  |
+| test_logging.rs:162:16:162:55 | ...::panic_fmt | 162 | Path |  |
+| test_logging.rs:162:16:162:55 | ...::panic_fmt | 162 | PathExpr |  |
+| test_logging.rs:162:16:162:55 | ...::panicking | 162 | Path |  |
+| test_logging.rs:162:16:162:55 | MacroExpr | 162 | MacroExpr |  |
+| test_logging.rs:162:16:162:55 | assert!... | 162 | MacroCall |  |
+| test_logging.rs:162:16:162:55 | const_format_args | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | const_format_args | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | panic | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | panic | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | panic_2021 | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | panic_2021 | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | panic_fmt | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | panic_fmt | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:55 | panicking | 162 | NameRef |  |
+| test_logging.rs:162:16:162:55 | panicking | 162 | PathSegment |  |
+| test_logging.rs:162:16:162:56 | ExprStmt | 162 | ExprStmt |  |
+| test_logging.rs:162:23:162:55 | TokenTree | 162 | TokenTree |  |
+| test_logging.rs:162:24:162:28 | ! ... | 162 | PrefixExpr |  |
+| test_logging.rs:162:24:162:28 | (false) | 162 | ParenExpr |  |
+| test_logging.rs:162:24:162:28 | false | 162 | LiteralExpr |  |
+| test_logging.rs:162:24:162:54 | MacroStmts | 162 | MacroStmts |  |
+| test_logging.rs:162:24:162:54 | StmtList | 162 | StmtList |  |
+| test_logging.rs:162:24:162:54 | if ... {...} | 162 | IfExpr |  |
+| test_logging.rs:162:24:162:54 | { ... } | 162 | BlockExpr |  |
+| test_logging.rs:162:31:162:44 | "message = {}" | 162 | LiteralExpr |  |
+| test_logging.rs:162:31:162:54 | ...::const_format_args!... | 162 | MacroCall |  |
+| test_logging.rs:162:31:162:54 | ...::panic_2021!... | 162 | MacroCall |  |
+| test_logging.rs:162:31:162:54 | ...::panic_fmt(...) | 162 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:162:31:162:54 | ArgList | 162 | ArgList |  |
+| test_logging.rs:162:31:162:54 | ExprStmt | 162 | ExprStmt |  |
+| test_logging.rs:162:31:162:54 | ExprStmt | 162 | ExprStmt |  |
+| test_logging.rs:162:31:162:54 | FormatArgsExpr | 162 | FormatArgsExpr |  |
+| test_logging.rs:162:31:162:54 | MacroExpr | 162 | MacroExpr |  |
+| test_logging.rs:162:31:162:54 | MacroExpr | 162 | MacroExpr |  |
+| test_logging.rs:162:31:162:54 | MacroStmts | 162 | MacroStmts |  |
+| test_logging.rs:162:31:162:54 | StmtList | 162 | StmtList |  |
+| test_logging.rs:162:31:162:54 | StmtList | 162 | StmtList |  |
+| test_logging.rs:162:31:162:54 | TokenTree | 162 | TokenTree |  |
+| test_logging.rs:162:31:162:54 | TokenTree | 162 | TokenTree |  |
+| test_logging.rs:162:31:162:54 | { ... } | 162 | BlockExpr |  |
+| test_logging.rs:162:31:162:54 | { ... } | 162 | BlockExpr |  |
+| test_logging.rs:162:42:162:43 | {} | 162 | FormatSynthLocationImpl |  |
+| test_logging.rs:162:47:162:54 | FormatArgsArg | 162 | FormatArgsArg |  |
+| test_logging.rs:162:47:162:54 | password | 162 | IdentPath |  |
+| test_logging.rs:162:47:162:54 | password | 162 | NameRef |  |
+| test_logging.rs:162:47:162:54 | password | 162 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:162:47:162:54 | password | 162 | PathSegment |  |
+| test_logging.rs:162:60:162:93 | //... | 162 | Comment |  |
+| test_logging.rs:163:9:163:9 | 6 | 163 | LiteralExpr |  |
+| test_logging.rs:163:9:163:9 | 6 | 163 | LiteralPat |  |
+| test_logging.rs:163:9:163:60 | 6 => ... | 163 | MatchArm |  |
+| test_logging.rs:163:14:163:60 | StmtList | 163 | StmtList |  |
+| test_logging.rs:163:14:163:60 | { ... } | 163 | BlockExpr |  |
+| test_logging.rs:163:16:163:24 | assert_eq | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:24 | assert_eq | 163 | NameRef |  |
+| test_logging.rs:163:16:163:24 | assert_eq | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | ! ... | 163 | PrefixExpr |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | $crate | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | &... | 163 | RefExpr |  |
+| test_logging.rs:163:16:163:57 | &... | 163 | RefExpr |  |
+| test_logging.rs:163:16:163:57 | (...) | 163 | ParenExpr |  |
+| test_logging.rs:163:16:163:57 | * ... | 163 | PrefixExpr |  |
+| test_logging.rs:163:16:163:57 | * ... | 163 | PrefixExpr |  |
+| test_logging.rs:163:16:163:57 | * ... | 163 | PrefixExpr |  |
+| test_logging.rs:163:16:163:57 | * ... | 163 | PrefixExpr |  |
+| test_logging.rs:163:16:163:57 | ... == ... | 163 | BinaryExpr |  |
+| test_logging.rs:163:16:163:57 | ...::AssertKind | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::Eq | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::Eq | 163 | PathExpr |  |
+| test_logging.rs:163:16:163:57 | ...::Option | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::Some | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::Some | 163 | PathExpr |  |
+| test_logging.rs:163:16:163:57 | ...::assert_failed | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::assert_failed | 163 | PathExpr |  |
+| test_logging.rs:163:16:163:57 | ...::format_args | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::option | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::panicking | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | ...::panicking | 163 | Path |  |
+| test_logging.rs:163:16:163:57 | AssertKind | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | AssertKind | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | Eq | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | Eq | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | MacroExpr | 163 | MacroExpr |  |
+| test_logging.rs:163:16:163:57 | Option | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | Option | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | Some | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | Some | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | TuplePat | 163 | TuplePat |  |
+| test_logging.rs:163:16:163:57 | assert_eq!... | 163 | MacroCall |  |
+| test_logging.rs:163:16:163:57 | assert_failed | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | assert_failed | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | format_args | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | format_args | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | IdentPat |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | Name |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:16:163:57 | kind | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | IdentPat |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | Name |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | left_val | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | let ... = ...::Eq | 163 | LetStmt |  |
+| test_logging.rs:163:16:163:57 | option | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | option | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | panicking | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | panicking | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | panicking | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | panicking | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | IdentPat |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | IdentPath |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | Name |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | NameRef |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:57 | right_val | 163 | PathSegment |  |
+| test_logging.rs:163:16:163:58 | ExprStmt | 163 | ExprStmt |  |
+| test_logging.rs:163:26:163:57 | TokenTree | 163 | TokenTree |  |
+| test_logging.rs:163:27:163:27 | 1 | 163 | LiteralExpr |  |
+| test_logging.rs:163:27:163:27 | &1 | 163 | RefExpr |  |
+| test_logging.rs:163:27:163:30 | TupleExpr | 163 | TupleExpr |  |
+| test_logging.rs:163:27:163:56 | MacroStmts | 163 | MacroStmts |  |
+| test_logging.rs:163:27:163:56 | match ... { ... } | 163 | MatchExpr |  |
+| test_logging.rs:163:30:163:30 | 2 | 163 | LiteralExpr |  |
+| test_logging.rs:163:30:163:30 | &2 | 163 | RefExpr |  |
+| test_logging.rs:163:33:163:46 | "message = {}" | 163 | LiteralExpr |  |
+| test_logging.rs:163:33:163:56 | ... => ... | 163 | MatchArm |  |
+| test_logging.rs:163:33:163:56 | ...::Some(...) | 163 | CallExpr | target-origin:lang:core, target-path:crate::option::Option::Some, target:PathExpr |
+| test_logging.rs:163:33:163:56 | ...::assert_failed(...) | 163 | CallExpr | target-origin:lang:core, target-path:crate::panicking::assert_failed, target:PathExpr |
+| test_logging.rs:163:33:163:56 | ...::format_args!... | 163 | MacroCall |  |
+| test_logging.rs:163:33:163:56 | ArgList | 163 | ArgList |  |
+| test_logging.rs:163:33:163:56 | ArgList | 163 | ArgList |  |
+| test_logging.rs:163:33:163:56 | ExprStmt | 163 | ExprStmt |  |
+| test_logging.rs:163:33:163:56 | FormatArgsExpr | 163 | FormatArgsExpr |  |
+| test_logging.rs:163:33:163:56 | MacroExpr | 163 | MacroExpr |  |
+| test_logging.rs:163:33:163:56 | MatchArmList | 163 | MatchArmList |  |
+| test_logging.rs:163:33:163:56 | StmtList | 163 | StmtList |  |
+| test_logging.rs:163:33:163:56 | StmtList | 163 | StmtList |  |
+| test_logging.rs:163:33:163:56 | TokenTree | 163 | TokenTree |  |
+| test_logging.rs:163:33:163:56 | if ... {...} | 163 | IfExpr |  |
+| test_logging.rs:163:33:163:56 | { ... } | 163 | BlockExpr |  |
+| test_logging.rs:163:33:163:56 | { ... } | 163 | BlockExpr |  |
+| test_logging.rs:163:44:163:45 | {} | 163 | FormatSynthLocationImpl |  |
+| test_logging.rs:163:49:163:56 | FormatArgsArg | 163 | FormatArgsArg |  |
+| test_logging.rs:163:49:163:56 | password | 163 | IdentPath |  |
+| test_logging.rs:163:49:163:56 | password | 163 | NameRef |  |
+| test_logging.rs:163:49:163:56 | password | 163 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:163:49:163:56 | password | 163 | PathSegment |  |
+| test_logging.rs:163:62:163:95 | //... | 163 | Comment |  |
+| test_logging.rs:164:9:164:9 | 7 | 164 | LiteralExpr |  |
+| test_logging.rs:164:9:164:9 | 7 | 164 | LiteralPat |  |
+| test_logging.rs:164:9:164:60 | 7 => ... | 164 | MatchArm |  |
+| test_logging.rs:164:14:164:60 | StmtList | 164 | StmtList |  |
+| test_logging.rs:164:14:164:60 | { ... } | 164 | BlockExpr |  |
+| test_logging.rs:164:16:164:24 | assert_ne | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:24 | assert_ne | 164 | NameRef |  |
+| test_logging.rs:164:16:164:24 | assert_ne | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | $crate | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | &... | 164 | RefExpr |  |
+| test_logging.rs:164:16:164:57 | &... | 164 | RefExpr |  |
+| test_logging.rs:164:16:164:57 | * ... | 164 | PrefixExpr |  |
+| test_logging.rs:164:16:164:57 | * ... | 164 | PrefixExpr |  |
+| test_logging.rs:164:16:164:57 | * ... | 164 | PrefixExpr |  |
+| test_logging.rs:164:16:164:57 | * ... | 164 | PrefixExpr |  |
+| test_logging.rs:164:16:164:57 | ... == ... | 164 | BinaryExpr |  |
+| test_logging.rs:164:16:164:57 | ...::AssertKind | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::Ne | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::Ne | 164 | PathExpr |  |
+| test_logging.rs:164:16:164:57 | ...::Option | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::Some | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::Some | 164 | PathExpr |  |
+| test_logging.rs:164:16:164:57 | ...::assert_failed | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::assert_failed | 164 | PathExpr |  |
+| test_logging.rs:164:16:164:57 | ...::format_args | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::option | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::panicking | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | ...::panicking | 164 | Path |  |
+| test_logging.rs:164:16:164:57 | AssertKind | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | AssertKind | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | MacroExpr | 164 | MacroExpr |  |
+| test_logging.rs:164:16:164:57 | Ne | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | Ne | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | Option | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | Option | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | Some | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | Some | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | TuplePat | 164 | TuplePat |  |
+| test_logging.rs:164:16:164:57 | assert_failed | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | assert_failed | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | assert_ne!... | 164 | MacroCall |  |
+| test_logging.rs:164:16:164:57 | format_args | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | format_args | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | IdentPat |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | Name |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:16:164:57 | kind | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | IdentPat |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | Name |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | left_val | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | let ... = ...::Ne | 164 | LetStmt |  |
+| test_logging.rs:164:16:164:57 | option | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | option | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | panicking | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | panicking | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | panicking | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | panicking | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | IdentPat |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | IdentPath |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | Name |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | NameRef |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:57 | right_val | 164 | PathSegment |  |
+| test_logging.rs:164:16:164:58 | ExprStmt | 164 | ExprStmt |  |
+| test_logging.rs:164:26:164:57 | TokenTree | 164 | TokenTree |  |
+| test_logging.rs:164:27:164:27 | 1 | 164 | LiteralExpr |  |
+| test_logging.rs:164:27:164:27 | &... | 164 | RefExpr |  |
+| test_logging.rs:164:27:164:27 | (1) | 164 | ParenExpr |  |
+| test_logging.rs:164:27:164:30 | TupleExpr | 164 | TupleExpr |  |
+| test_logging.rs:164:27:164:56 | MacroStmts | 164 | MacroStmts |  |
+| test_logging.rs:164:27:164:56 | match ... { ... } | 164 | MatchExpr |  |
+| test_logging.rs:164:30:164:30 | 1 | 164 | LiteralExpr |  |
+| test_logging.rs:164:30:164:30 | &... | 164 | RefExpr |  |
+| test_logging.rs:164:30:164:30 | (1) | 164 | ParenExpr |  |
+| test_logging.rs:164:33:164:46 | "message = {}" | 164 | LiteralExpr |  |
+| test_logging.rs:164:33:164:56 | ... => ... | 164 | MatchArm |  |
+| test_logging.rs:164:33:164:56 | ...::Some(...) | 164 | CallExpr | target-origin:lang:core, target-path:crate::option::Option::Some, target:PathExpr |
+| test_logging.rs:164:33:164:56 | ...::assert_failed(...) | 164 | CallExpr | target-origin:lang:core, target-path:crate::panicking::assert_failed, target:PathExpr |
+| test_logging.rs:164:33:164:56 | ...::format_args!... | 164 | MacroCall |  |
+| test_logging.rs:164:33:164:56 | ArgList | 164 | ArgList |  |
+| test_logging.rs:164:33:164:56 | ArgList | 164 | ArgList |  |
+| test_logging.rs:164:33:164:56 | ExprStmt | 164 | ExprStmt |  |
+| test_logging.rs:164:33:164:56 | FormatArgsExpr | 164 | FormatArgsExpr |  |
+| test_logging.rs:164:33:164:56 | MacroExpr | 164 | MacroExpr |  |
+| test_logging.rs:164:33:164:56 | MatchArmList | 164 | MatchArmList |  |
+| test_logging.rs:164:33:164:56 | StmtList | 164 | StmtList |  |
+| test_logging.rs:164:33:164:56 | StmtList | 164 | StmtList |  |
+| test_logging.rs:164:33:164:56 | TokenTree | 164 | TokenTree |  |
+| test_logging.rs:164:33:164:56 | if ... {...} | 164 | IfExpr |  |
+| test_logging.rs:164:33:164:56 | { ... } | 164 | BlockExpr |  |
+| test_logging.rs:164:33:164:56 | { ... } | 164 | BlockExpr |  |
+| test_logging.rs:164:44:164:45 | {} | 164 | FormatSynthLocationImpl |  |
+| test_logging.rs:164:49:164:56 | FormatArgsArg | 164 | FormatArgsArg |  |
+| test_logging.rs:164:49:164:56 | password | 164 | IdentPath |  |
+| test_logging.rs:164:49:164:56 | password | 164 | NameRef |  |
+| test_logging.rs:164:49:164:56 | password | 164 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:164:49:164:56 | password | 164 | PathSegment |  |
+| test_logging.rs:164:62:164:95 | //... | 164 | Comment |  |
+| test_logging.rs:165:9:165:9 | 8 | 165 | LiteralExpr |  |
+| test_logging.rs:165:9:165:9 | 8 | 165 | LiteralPat |  |
+| test_logging.rs:165:9:165:64 | 8 => ... | 165 | MatchArm |  |
+| test_logging.rs:165:14:165:64 | StmtList | 165 | StmtList |  |
+| test_logging.rs:165:14:165:64 | { ... } | 165 | BlockExpr |  |
+| test_logging.rs:165:16:165:27 | debug_assert | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:27 | debug_assert | 165 | NameRef |  |
+| test_logging.rs:165:16:165:27 | debug_assert | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | IdentPath |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | $crate | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | ...::assert | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::cfg | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::cfg!... | 165 | MacroCall |  |
+| test_logging.rs:165:16:165:61 | ...::const_format_args | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::panic | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::panic_2021 | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::panic_fmt | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | ...::panic_fmt | 165 | PathExpr |  |
+| test_logging.rs:165:16:165:61 | ...::panicking | 165 | Path |  |
+| test_logging.rs:165:16:165:61 | MacroExpr | 165 | MacroExpr |  |
+| test_logging.rs:165:16:165:61 | MacroExpr | 165 | MacroExpr |  |
+| test_logging.rs:165:16:165:61 | TokenTree | 165 | TokenTree |  |
+| test_logging.rs:165:16:165:61 | assert | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | assert | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | cfg | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | cfg | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | const_format_args | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | const_format_args | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | debug_assert!... | 165 | MacroCall |  |
+| test_logging.rs:165:16:165:61 | false | 165 | LiteralExpr |  |
+| test_logging.rs:165:16:165:61 | panic | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | panic | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | panic_2021 | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | panic_2021 | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | panic_fmt | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | panic_fmt | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:61 | panicking | 165 | NameRef |  |
+| test_logging.rs:165:16:165:61 | panicking | 165 | PathSegment |  |
+| test_logging.rs:165:16:165:62 | ExprStmt | 165 | ExprStmt |  |
+| test_logging.rs:165:29:165:61 | TokenTree | 165 | TokenTree |  |
+| test_logging.rs:165:30:165:34 | ! ... | 165 | PrefixExpr |  |
+| test_logging.rs:165:30:165:34 | (false) | 165 | ParenExpr |  |
+| test_logging.rs:165:30:165:34 | false | 165 | LiteralExpr |  |
+| test_logging.rs:165:30:165:60 | ...::assert!... | 165 | MacroCall |  |
+| test_logging.rs:165:30:165:60 | ExprStmt | 165 | ExprStmt |  |
+| test_logging.rs:165:30:165:60 | MacroExpr | 165 | MacroExpr |  |
+| test_logging.rs:165:30:165:60 | MacroStmts | 165 | MacroStmts |  |
+| test_logging.rs:165:30:165:60 | MacroStmts | 165 | MacroStmts |  |
+| test_logging.rs:165:30:165:60 | StmtList | 165 | StmtList |  |
+| test_logging.rs:165:30:165:60 | StmtList | 165 | StmtList |  |
+| test_logging.rs:165:30:165:60 | TokenTree | 165 | TokenTree |  |
+| test_logging.rs:165:30:165:60 | if ... {...} | 165 | IfExpr |  |
+| test_logging.rs:165:30:165:60 | if ... {...} | 165 | IfExpr |  |
+| test_logging.rs:165:30:165:60 | { ... } | 165 | BlockExpr |  |
+| test_logging.rs:165:30:165:60 | { ... } | 165 | BlockExpr |  |
+| test_logging.rs:165:37:165:50 | "message = {}" | 165 | LiteralExpr |  |
+| test_logging.rs:165:37:165:60 | ...::const_format_args!... | 165 | MacroCall |  |
+| test_logging.rs:165:37:165:60 | ...::panic_2021!... | 165 | MacroCall |  |
+| test_logging.rs:165:37:165:60 | ...::panic_fmt(...) | 165 | CallExpr | target-origin:lang:core, target-path:crate::panicking::panic_fmt, target:PathExpr |
+| test_logging.rs:165:37:165:60 | ArgList | 165 | ArgList |  |
+| test_logging.rs:165:37:165:60 | ExprStmt | 165 | ExprStmt |  |
+| test_logging.rs:165:37:165:60 | ExprStmt | 165 | ExprStmt |  |
+| test_logging.rs:165:37:165:60 | FormatArgsExpr | 165 | FormatArgsExpr |  |
+| test_logging.rs:165:37:165:60 | MacroExpr | 165 | MacroExpr |  |
+| test_logging.rs:165:37:165:60 | MacroExpr | 165 | MacroExpr |  |
+| test_logging.rs:165:37:165:60 | MacroStmts | 165 | MacroStmts |  |
+| test_logging.rs:165:37:165:60 | StmtList | 165 | StmtList |  |
+| test_logging.rs:165:37:165:60 | StmtList | 165 | StmtList |  |
+| test_logging.rs:165:37:165:60 | TokenTree | 165 | TokenTree |  |
+| test_logging.rs:165:37:165:60 | TokenTree | 165 | TokenTree |  |
+| test_logging.rs:165:37:165:60 | { ... } | 165 | BlockExpr |  |
+| test_logging.rs:165:37:165:60 | { ... } | 165 | BlockExpr |  |
+| test_logging.rs:165:48:165:49 | {} | 165 | FormatSynthLocationImpl |  |
+| test_logging.rs:165:53:165:60 | FormatArgsArg | 165 | FormatArgsArg |  |
+| test_logging.rs:165:53:165:60 | password | 165 | IdentPath |  |
+| test_logging.rs:165:53:165:60 | password | 165 | NameRef |  |
+| test_logging.rs:165:53:165:60 | password | 165 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:165:53:165:60 | password | 165 | PathSegment |  |
+| test_logging.rs:165:66:165:99 | //... | 165 | Comment |  |
+| test_logging.rs:166:9:166:9 | 9 | 166 | LiteralExpr |  |
+| test_logging.rs:166:9:166:9 | 9 | 166 | LiteralPat |  |
+| test_logging.rs:166:9:166:66 | 9 => ... | 166 | MatchArm |  |
+| test_logging.rs:166:14:166:66 | StmtList | 166 | StmtList |  |
+| test_logging.rs:166:14:166:66 | { ... } | 166 | BlockExpr |  |
+| test_logging.rs:166:16:166:30 | debug_assert_eq | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:30 | debug_assert_eq | 166 | NameRef |  |
+| test_logging.rs:166:16:166:30 | debug_assert_eq | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | ! ... | 166 | PrefixExpr |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | $crate | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | &... | 166 | RefExpr |  |
+| test_logging.rs:166:16:166:63 | &... | 166 | RefExpr |  |
+| test_logging.rs:166:16:166:63 | (...) | 166 | ParenExpr |  |
+| test_logging.rs:166:16:166:63 | * ... | 166 | PrefixExpr |  |
+| test_logging.rs:166:16:166:63 | * ... | 166 | PrefixExpr |  |
+| test_logging.rs:166:16:166:63 | * ... | 166 | PrefixExpr |  |
+| test_logging.rs:166:16:166:63 | * ... | 166 | PrefixExpr |  |
+| test_logging.rs:166:16:166:63 | ... == ... | 166 | BinaryExpr |  |
+| test_logging.rs:166:16:166:63 | ...::AssertKind | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::Eq | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::Eq | 166 | PathExpr |  |
+| test_logging.rs:166:16:166:63 | ...::Option | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::Some | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::Some | 166 | PathExpr |  |
+| test_logging.rs:166:16:166:63 | ...::assert_eq | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::assert_failed | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::assert_failed | 166 | PathExpr |  |
+| test_logging.rs:166:16:166:63 | ...::cfg | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::cfg!... | 166 | MacroCall |  |
+| test_logging.rs:166:16:166:63 | ...::format_args | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::option | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::panicking | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | ...::panicking | 166 | Path |  |
+| test_logging.rs:166:16:166:63 | AssertKind | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | AssertKind | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | Eq | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | Eq | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | MacroExpr | 166 | MacroExpr |  |
+| test_logging.rs:166:16:166:63 | MacroExpr | 166 | MacroExpr |  |
+| test_logging.rs:166:16:166:63 | Option | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | Option | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | Some | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | Some | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | TokenTree | 166 | TokenTree |  |
+| test_logging.rs:166:16:166:63 | TuplePat | 166 | TuplePat |  |
+| test_logging.rs:166:16:166:63 | assert_eq | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | assert_eq | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | assert_failed | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | assert_failed | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | cfg | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | cfg | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | debug_assert_eq!... | 166 | MacroCall |  |
+| test_logging.rs:166:16:166:63 | false | 166 | LiteralExpr |  |
+| test_logging.rs:166:16:166:63 | format_args | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | format_args | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | IdentPat |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | Name |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:16:166:63 | kind | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | IdentPat |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | Name |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | left_val | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | let ... = ...::Eq | 166 | LetStmt |  |
+| test_logging.rs:166:16:166:63 | option | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | option | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | panicking | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | panicking | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | panicking | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | panicking | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | IdentPat |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | IdentPath |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | Name |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | NameRef |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:63 | right_val | 166 | PathSegment |  |
+| test_logging.rs:166:16:166:64 | ExprStmt | 166 | ExprStmt |  |
+| test_logging.rs:166:32:166:63 | TokenTree | 166 | TokenTree |  |
+| test_logging.rs:166:33:166:33 | 1 | 166 | LiteralExpr |  |
+| test_logging.rs:166:33:166:33 | &1 | 166 | RefExpr |  |
+| test_logging.rs:166:33:166:36 | TupleExpr | 166 | TupleExpr |  |
+| test_logging.rs:166:33:166:62 | ...::assert_eq!... | 166 | MacroCall |  |
+| test_logging.rs:166:33:166:62 | ExprStmt | 166 | ExprStmt |  |
+| test_logging.rs:166:33:166:62 | MacroExpr | 166 | MacroExpr |  |
+| test_logging.rs:166:33:166:62 | MacroStmts | 166 | MacroStmts |  |
+| test_logging.rs:166:33:166:62 | MacroStmts | 166 | MacroStmts |  |
+| test_logging.rs:166:33:166:62 | StmtList | 166 | StmtList |  |
+| test_logging.rs:166:33:166:62 | TokenTree | 166 | TokenTree |  |
+| test_logging.rs:166:33:166:62 | if ... {...} | 166 | IfExpr |  |
+| test_logging.rs:166:33:166:62 | match ... { ... } | 166 | MatchExpr |  |
+| test_logging.rs:166:33:166:62 | { ... } | 166 | BlockExpr |  |
+| test_logging.rs:166:36:166:36 | 2 | 166 | LiteralExpr |  |
+| test_logging.rs:166:36:166:36 | &2 | 166 | RefExpr |  |
+| test_logging.rs:166:39:166:52 | "message = {}" | 166 | LiteralExpr |  |
+| test_logging.rs:166:39:166:62 | ... => ... | 166 | MatchArm |  |
+| test_logging.rs:166:39:166:62 | ...::Some(...) | 166 | CallExpr | target-origin:lang:core, target-path:crate::option::Option::Some, target:PathExpr |
+| test_logging.rs:166:39:166:62 | ...::assert_failed(...) | 166 | CallExpr | target-origin:lang:core, target-path:crate::panicking::assert_failed, target:PathExpr |
+| test_logging.rs:166:39:166:62 | ...::format_args!... | 166 | MacroCall |  |
+| test_logging.rs:166:39:166:62 | ArgList | 166 | ArgList |  |
+| test_logging.rs:166:39:166:62 | ArgList | 166 | ArgList |  |
+| test_logging.rs:166:39:166:62 | ExprStmt | 166 | ExprStmt |  |
+| test_logging.rs:166:39:166:62 | FormatArgsExpr | 166 | FormatArgsExpr |  |
+| test_logging.rs:166:39:166:62 | MacroExpr | 166 | MacroExpr |  |
+| test_logging.rs:166:39:166:62 | MatchArmList | 166 | MatchArmList |  |
+| test_logging.rs:166:39:166:62 | StmtList | 166 | StmtList |  |
+| test_logging.rs:166:39:166:62 | StmtList | 166 | StmtList |  |
+| test_logging.rs:166:39:166:62 | TokenTree | 166 | TokenTree |  |
+| test_logging.rs:166:39:166:62 | if ... {...} | 166 | IfExpr |  |
+| test_logging.rs:166:39:166:62 | { ... } | 166 | BlockExpr |  |
+| test_logging.rs:166:39:166:62 | { ... } | 166 | BlockExpr |  |
+| test_logging.rs:166:50:166:51 | {} | 166 | FormatSynthLocationImpl |  |
+| test_logging.rs:166:55:166:62 | FormatArgsArg | 166 | FormatArgsArg |  |
+| test_logging.rs:166:55:166:62 | password | 166 | IdentPath |  |
+| test_logging.rs:166:55:166:62 | password | 166 | NameRef |  |
+| test_logging.rs:166:55:166:62 | password | 166 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:166:55:166:62 | password | 166 | PathSegment |  |
+| test_logging.rs:166:68:166:101 | //... | 166 | Comment |  |
+| test_logging.rs:167:9:167:10 | 10 | 167 | LiteralExpr |  |
+| test_logging.rs:167:9:167:10 | 10 | 167 | LiteralPat |  |
+| test_logging.rs:167:9:167:67 | 10 => ... | 167 | MatchArm |  |
+| test_logging.rs:167:15:167:67 | StmtList | 167 | StmtList |  |
+| test_logging.rs:167:15:167:67 | { ... } | 167 | BlockExpr |  |
+| test_logging.rs:167:17:167:31 | debug_assert_ne | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:31 | debug_assert_ne | 167 | NameRef |  |
+| test_logging.rs:167:17:167:31 | debug_assert_ne | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | $crate | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | &... | 167 | RefExpr |  |
+| test_logging.rs:167:17:167:64 | &... | 167 | RefExpr |  |
+| test_logging.rs:167:17:167:64 | * ... | 167 | PrefixExpr |  |
+| test_logging.rs:167:17:167:64 | * ... | 167 | PrefixExpr |  |
+| test_logging.rs:167:17:167:64 | * ... | 167 | PrefixExpr |  |
+| test_logging.rs:167:17:167:64 | * ... | 167 | PrefixExpr |  |
+| test_logging.rs:167:17:167:64 | ... == ... | 167 | BinaryExpr |  |
+| test_logging.rs:167:17:167:64 | ...::AssertKind | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::Ne | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::Ne | 167 | PathExpr |  |
+| test_logging.rs:167:17:167:64 | ...::Option | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::Some | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::Some | 167 | PathExpr |  |
+| test_logging.rs:167:17:167:64 | ...::assert_failed | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::assert_failed | 167 | PathExpr |  |
+| test_logging.rs:167:17:167:64 | ...::assert_ne | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::cfg | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::cfg!... | 167 | MacroCall |  |
+| test_logging.rs:167:17:167:64 | ...::format_args | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::option | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::panicking | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | ...::panicking | 167 | Path |  |
+| test_logging.rs:167:17:167:64 | AssertKind | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | AssertKind | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | MacroExpr | 167 | MacroExpr |  |
+| test_logging.rs:167:17:167:64 | MacroExpr | 167 | MacroExpr |  |
+| test_logging.rs:167:17:167:64 | Ne | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | Ne | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | Option | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | Option | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | Some | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | Some | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | TokenTree | 167 | TokenTree |  |
+| test_logging.rs:167:17:167:64 | TuplePat | 167 | TuplePat |  |
+| test_logging.rs:167:17:167:64 | assert_failed | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | assert_failed | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | assert_ne | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | assert_ne | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | cfg | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | cfg | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | debug_assert_ne!... | 167 | MacroCall |  |
+| test_logging.rs:167:17:167:64 | false | 167 | LiteralExpr |  |
+| test_logging.rs:167:17:167:64 | format_args | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | format_args | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | IdentPat |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | Name |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:17:167:64 | kind | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | IdentPat |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | Name |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | left_val | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | let ... = ...::Ne | 167 | LetStmt |  |
+| test_logging.rs:167:17:167:64 | option | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | option | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | panicking | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | panicking | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | panicking | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | panicking | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | IdentPat |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | IdentPath |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | Name |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | NameRef |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:64 | right_val | 167 | PathSegment |  |
+| test_logging.rs:167:17:167:65 | ExprStmt | 167 | ExprStmt |  |
+| test_logging.rs:167:33:167:64 | TokenTree | 167 | TokenTree |  |
+| test_logging.rs:167:34:167:34 | 1 | 167 | LiteralExpr |  |
+| test_logging.rs:167:34:167:34 | &... | 167 | RefExpr |  |
+| test_logging.rs:167:34:167:34 | (1) | 167 | ParenExpr |  |
+| test_logging.rs:167:34:167:37 | TupleExpr | 167 | TupleExpr |  |
+| test_logging.rs:167:34:167:63 | ...::assert_ne!... | 167 | MacroCall |  |
+| test_logging.rs:167:34:167:63 | ExprStmt | 167 | ExprStmt |  |
+| test_logging.rs:167:34:167:63 | MacroExpr | 167 | MacroExpr |  |
+| test_logging.rs:167:34:167:63 | MacroStmts | 167 | MacroStmts |  |
+| test_logging.rs:167:34:167:63 | MacroStmts | 167 | MacroStmts |  |
+| test_logging.rs:167:34:167:63 | StmtList | 167 | StmtList |  |
+| test_logging.rs:167:34:167:63 | TokenTree | 167 | TokenTree |  |
+| test_logging.rs:167:34:167:63 | if ... {...} | 167 | IfExpr |  |
+| test_logging.rs:167:34:167:63 | match ... { ... } | 167 | MatchExpr |  |
+| test_logging.rs:167:34:167:63 | { ... } | 167 | BlockExpr |  |
+| test_logging.rs:167:37:167:37 | 1 | 167 | LiteralExpr |  |
+| test_logging.rs:167:37:167:37 | &... | 167 | RefExpr |  |
+| test_logging.rs:167:37:167:37 | (1) | 167 | ParenExpr |  |
+| test_logging.rs:167:40:167:53 | "message = {}" | 167 | LiteralExpr |  |
+| test_logging.rs:167:40:167:63 | ... => ... | 167 | MatchArm |  |
+| test_logging.rs:167:40:167:63 | ...::Some(...) | 167 | CallExpr | target-origin:lang:core, target-path:crate::option::Option::Some, target:PathExpr |
+| test_logging.rs:167:40:167:63 | ...::assert_failed(...) | 167 | CallExpr | target-origin:lang:core, target-path:crate::panicking::assert_failed, target:PathExpr |
+| test_logging.rs:167:40:167:63 | ...::format_args!... | 167 | MacroCall |  |
+| test_logging.rs:167:40:167:63 | ArgList | 167 | ArgList |  |
+| test_logging.rs:167:40:167:63 | ArgList | 167 | ArgList |  |
+| test_logging.rs:167:40:167:63 | ExprStmt | 167 | ExprStmt |  |
+| test_logging.rs:167:40:167:63 | FormatArgsExpr | 167 | FormatArgsExpr |  |
+| test_logging.rs:167:40:167:63 | MacroExpr | 167 | MacroExpr |  |
+| test_logging.rs:167:40:167:63 | MatchArmList | 167 | MatchArmList |  |
+| test_logging.rs:167:40:167:63 | StmtList | 167 | StmtList |  |
+| test_logging.rs:167:40:167:63 | StmtList | 167 | StmtList |  |
+| test_logging.rs:167:40:167:63 | TokenTree | 167 | TokenTree |  |
+| test_logging.rs:167:40:167:63 | if ... {...} | 167 | IfExpr |  |
+| test_logging.rs:167:40:167:63 | { ... } | 167 | BlockExpr |  |
+| test_logging.rs:167:40:167:63 | { ... } | 167 | BlockExpr |  |
+| test_logging.rs:167:51:167:52 | {} | 167 | FormatSynthLocationImpl |  |
+| test_logging.rs:167:56:167:63 | FormatArgsArg | 167 | FormatArgsArg |  |
+| test_logging.rs:167:56:167:63 | password | 167 | IdentPath |  |
+| test_logging.rs:167:56:167:63 | password | 167 | NameRef |  |
+| test_logging.rs:167:56:167:63 | password | 167 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:167:56:167:63 | password | 167 | PathSegment |  |
+| test_logging.rs:167:69:167:102 | //... | 167 | Comment |  |
+| test_logging.rs:168:9:168:10 | 11 | 168 | LiteralExpr |  |
+| test_logging.rs:168:9:168:10 | 11 | 168 | LiteralPat |  |
+| test_logging.rs:168:9:168:79 | 11 => ... | 168 | MatchArm |  |
+| test_logging.rs:168:15:168:79 | StmtList | 168 | StmtList |  |
+| test_logging.rs:168:15:168:79 | { ... } | 168 | BlockExpr |  |
+| test_logging.rs:168:17:168:17 | _ | 168 | UnderscoreExpr |  |
+| test_logging.rs:168:17:168:76 | ... = ... | 168 | AssignmentExpr |  |
+| test_logging.rs:168:17:168:77 | ExprStmt | 168 | ExprStmt |  |
+| test_logging.rs:168:21:168:25 | opt_i | 168 | IdentPath |  |
+| test_logging.rs:168:21:168:25 | opt_i | 168 | NameRef |  |
+| test_logging.rs:168:21:168:25 | opt_i | 168 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:168:21:168:25 | opt_i | 168 | PathSegment |  |
+| test_logging.rs:168:21:168:76 | opt_i.expect(...) | 168 | MethodCallExpr | method-origin:lang:core, method-path:<crate::option::Option>::expect |
+| test_logging.rs:168:27:168:32 | expect | 168 | NameRef |  |
+| test_logging.rs:168:33:168:76 | ArgList | 168 | ArgList |  |
+| test_logging.rs:168:34:168:39 | format | 168 | IdentPath |  |
+| test_logging.rs:168:34:168:39 | format | 168 | NameRef |  |
+| test_logging.rs:168:34:168:39 | format | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | IdentPath |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | IdentPath |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | IdentPath |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | $crate | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | ...::__export | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::__export | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::fmt | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::format | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::format | 168 | PathExpr |  |
+| test_logging.rs:168:34:168:66 | ...::format_args | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::must_use | 168 | Path |  |
+| test_logging.rs:168:34:168:66 | ...::must_use | 168 | PathExpr |  |
+| test_logging.rs:168:34:168:66 | MacroExpr | 168 | MacroExpr |  |
+| test_logging.rs:168:34:168:66 | __export | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | __export | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | __export | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | __export | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | fmt | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | fmt | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | format | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | format | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | format!... | 168 | MacroCall |  |
+| test_logging.rs:168:34:168:66 | format_args | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | format_args | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | must_use | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | must_use | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:66 | res | 168 | IdentPat |  |
+| test_logging.rs:168:34:168:66 | res | 168 | IdentPath |  |
+| test_logging.rs:168:34:168:66 | res | 168 | Name |  |
+| test_logging.rs:168:34:168:66 | res | 168 | NameRef |  |
+| test_logging.rs:168:34:168:66 | res | 168 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:168:34:168:66 | res | 168 | PathSegment |  |
+| test_logging.rs:168:34:168:75 | ... .as_str(...) | 168 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_str |
+| test_logging.rs:168:41:168:66 | TokenTree | 168 | TokenTree |  |
+| test_logging.rs:168:42:168:55 | "message = {}" | 168 | LiteralExpr |  |
+| test_logging.rs:168:42:168:65 | ...::format(...) | 168 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:168:42:168:65 | ...::format_args!... | 168 | MacroCall |  |
+| test_logging.rs:168:42:168:65 | ...::must_use(...) | 168 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:168:42:168:65 | ArgList | 168 | ArgList |  |
+| test_logging.rs:168:42:168:65 | ArgList | 168 | ArgList |  |
+| test_logging.rs:168:42:168:65 | FormatArgsExpr | 168 | FormatArgsExpr |  |
+| test_logging.rs:168:42:168:65 | MacroExpr | 168 | MacroExpr |  |
+| test_logging.rs:168:42:168:65 | StmtList | 168 | StmtList |  |
+| test_logging.rs:168:42:168:65 | TokenTree | 168 | TokenTree |  |
+| test_logging.rs:168:42:168:65 | let ... = ... | 168 | LetStmt |  |
+| test_logging.rs:168:42:168:65 | { ... } | 168 | BlockExpr |  |
+| test_logging.rs:168:53:168:54 | {} | 168 | FormatSynthLocationImpl |  |
+| test_logging.rs:168:58:168:65 | FormatArgsArg | 168 | FormatArgsArg |  |
+| test_logging.rs:168:58:168:65 | password | 168 | IdentPath |  |
+| test_logging.rs:168:58:168:65 | password | 168 | NameRef |  |
+| test_logging.rs:168:58:168:65 | password | 168 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:168:58:168:65 | password | 168 | PathSegment |  |
+| test_logging.rs:168:68:168:73 | as_str | 168 | NameRef |  |
+| test_logging.rs:168:74:168:75 | ArgList | 168 | ArgList |  |
+| test_logging.rs:168:81:168:114 | //... | 168 | Comment |  |
+| test_logging.rs:169:9:169:9 | _ | 169 | WildcardPat |  |
+| test_logging.rs:169:9:169:15 | _ => ... | 169 | MatchArm |  |
+| test_logging.rs:169:14:169:15 | StmtList | 169 | StmtList |  |
+| test_logging.rs:169:14:169:15 | { ... } | 169 | BlockExpr |  |
+| test_logging.rs:172:5:172:7 | std | 172 | IdentPath |  |
+| test_logging.rs:172:5:172:7 | std | 172 | NameRef |  |
+| test_logging.rs:172:5:172:7 | std | 172 | PathSegment |  |
+| test_logging.rs:172:5:172:11 | ...::io | 172 | Path |  |
+| test_logging.rs:172:5:172:19 | ...::stdout | 172 | Path |  |
+| test_logging.rs:172:5:172:19 | ...::stdout | 172 | PathExpr |  |
+| test_logging.rs:172:5:172:21 | ...::stdout(...) | 172 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stdout, target:PathExpr |
+| test_logging.rs:172:5:172:28 | ... .lock(...) | 172 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stdout>::lock |
+| test_logging.rs:172:5:172:80 | ... .write_fmt(...) | 172 | MethodCallExpr | method-origin:lang:std, method-path:crate::io::Write::write_fmt |
+| test_logging.rs:172:5:172:81 | ExprStmt | 172 | ExprStmt |  |
+| test_logging.rs:172:10:172:11 | io | 172 | NameRef |  |
+| test_logging.rs:172:10:172:11 | io | 172 | PathSegment |  |
+| test_logging.rs:172:14:172:19 | stdout | 172 | NameRef |  |
+| test_logging.rs:172:14:172:19 | stdout | 172 | PathSegment |  |
+| test_logging.rs:172:20:172:21 | ArgList | 172 | ArgList |  |
+| test_logging.rs:172:23:172:26 | lock | 172 | NameRef |  |
+| test_logging.rs:172:27:172:28 | ArgList | 172 | ArgList |  |
+| test_logging.rs:172:30:172:38 | write_fmt | 172 | NameRef |  |
+| test_logging.rs:172:39:172:80 | ArgList | 172 | ArgList |  |
+| test_logging.rs:172:40:172:50 | format_args | 172 | IdentPath |  |
+| test_logging.rs:172:40:172:50 | format_args | 172 | NameRef |  |
+| test_logging.rs:172:40:172:50 | format_args | 172 | PathSegment |  |
+| test_logging.rs:172:40:172:79 | MacroExpr | 172 | MacroExpr |  |
+| test_logging.rs:172:40:172:79 | format_args!... | 172 | MacroCall |  |
+| test_logging.rs:172:52:172:79 | FormatArgsExpr | 172 | FormatArgsExpr |  |
+| test_logging.rs:172:52:172:79 | TokenTree | 172 | TokenTree |  |
+| test_logging.rs:172:53:172:68 | "message = {}\\n" | 172 | LiteralExpr |  |
+| test_logging.rs:172:64:172:65 | {} | 172 | FormatSynthLocationImpl |  |
+| test_logging.rs:172:71:172:78 | FormatArgsArg | 172 | FormatArgsArg |  |
+| test_logging.rs:172:71:172:78 | password | 172 | IdentPath |  |
+| test_logging.rs:172:71:172:78 | password | 172 | NameRef |  |
+| test_logging.rs:172:71:172:78 | password | 172 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:172:71:172:78 | password | 172 | PathSegment |  |
+| test_logging.rs:172:83:172:125 | //... | 172 | Comment |  |
+| test_logging.rs:173:5:173:7 | std | 173 | IdentPath |  |
+| test_logging.rs:173:5:173:7 | std | 173 | NameRef |  |
+| test_logging.rs:173:5:173:7 | std | 173 | PathSegment |  |
+| test_logging.rs:173:5:173:11 | ...::io | 173 | Path |  |
+| test_logging.rs:173:5:173:19 | ...::stderr | 173 | Path |  |
+| test_logging.rs:173:5:173:19 | ...::stderr | 173 | PathExpr |  |
+| test_logging.rs:173:5:173:21 | ...::stderr(...) | 173 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stderr, target:PathExpr |
+| test_logging.rs:173:5:173:28 | ... .lock(...) | 173 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stderr>::lock |
+| test_logging.rs:173:5:173:80 | ... .write_fmt(...) | 173 | MethodCallExpr | method-origin:lang:std, method-path:crate::io::Write::write_fmt |
+| test_logging.rs:173:5:173:81 | ExprStmt | 173 | ExprStmt |  |
+| test_logging.rs:173:10:173:11 | io | 173 | NameRef |  |
+| test_logging.rs:173:10:173:11 | io | 173 | PathSegment |  |
+| test_logging.rs:173:14:173:19 | stderr | 173 | NameRef |  |
+| test_logging.rs:173:14:173:19 | stderr | 173 | PathSegment |  |
+| test_logging.rs:173:20:173:21 | ArgList | 173 | ArgList |  |
+| test_logging.rs:173:23:173:26 | lock | 173 | NameRef |  |
+| test_logging.rs:173:27:173:28 | ArgList | 173 | ArgList |  |
+| test_logging.rs:173:30:173:38 | write_fmt | 173 | NameRef |  |
+| test_logging.rs:173:39:173:80 | ArgList | 173 | ArgList |  |
+| test_logging.rs:173:40:173:50 | format_args | 173 | IdentPath |  |
+| test_logging.rs:173:40:173:50 | format_args | 173 | NameRef |  |
+| test_logging.rs:173:40:173:50 | format_args | 173 | PathSegment |  |
+| test_logging.rs:173:40:173:79 | MacroExpr | 173 | MacroExpr |  |
+| test_logging.rs:173:40:173:79 | format_args!... | 173 | MacroCall |  |
+| test_logging.rs:173:52:173:79 | FormatArgsExpr | 173 | FormatArgsExpr |  |
+| test_logging.rs:173:52:173:79 | TokenTree | 173 | TokenTree |  |
+| test_logging.rs:173:53:173:68 | "message = {}\\n" | 173 | LiteralExpr |  |
+| test_logging.rs:173:64:173:65 | {} | 173 | FormatSynthLocationImpl |  |
+| test_logging.rs:173:71:173:78 | FormatArgsArg | 173 | FormatArgsArg |  |
+| test_logging.rs:173:71:173:78 | password | 173 | IdentPath |  |
+| test_logging.rs:173:71:173:78 | password | 173 | NameRef |  |
+| test_logging.rs:173:71:173:78 | password | 173 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:173:71:173:78 | password | 173 | PathSegment |  |
+| test_logging.rs:173:83:173:125 | //... | 173 | Comment |  |
+| test_logging.rs:174:5:174:7 | std | 174 | IdentPath |  |
+| test_logging.rs:174:5:174:7 | std | 174 | NameRef |  |
+| test_logging.rs:174:5:174:7 | std | 174 | PathSegment |  |
+| test_logging.rs:174:5:174:11 | ...::io | 174 | Path |  |
+| test_logging.rs:174:5:174:19 | ...::stdout | 174 | Path |  |
+| test_logging.rs:174:5:174:19 | ...::stdout | 174 | PathExpr |  |
+| test_logging.rs:174:5:174:21 | ...::stdout(...) | 174 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stdout, target:PathExpr |
+| test_logging.rs:174:5:174:28 | ... .lock(...) | 174 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stdout>::lock |
+| test_logging.rs:174:5:174:82 | ... .write(...) | 174 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::StdoutLock as crate::io::Write>::write |
+| test_logging.rs:174:5:174:83 | ExprStmt | 174 | ExprStmt |  |
+| test_logging.rs:174:10:174:11 | io | 174 | NameRef |  |
+| test_logging.rs:174:10:174:11 | io | 174 | PathSegment |  |
+| test_logging.rs:174:14:174:19 | stdout | 174 | NameRef |  |
+| test_logging.rs:174:14:174:19 | stdout | 174 | PathSegment |  |
+| test_logging.rs:174:20:174:21 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:23:174:26 | lock | 174 | NameRef |  |
+| test_logging.rs:174:27:174:28 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:30:174:34 | write | 174 | NameRef |  |
+| test_logging.rs:174:35:174:82 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:36:174:41 | format | 174 | IdentPath |  |
+| test_logging.rs:174:36:174:41 | format | 174 | NameRef |  |
+| test_logging.rs:174:36:174:41 | format | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | IdentPath |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | IdentPath |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | IdentPath |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | $crate | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | ...::__export | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::__export | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::fmt | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::format | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::format | 174 | PathExpr |  |
+| test_logging.rs:174:36:174:70 | ...::format_args | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::must_use | 174 | Path |  |
+| test_logging.rs:174:36:174:70 | ...::must_use | 174 | PathExpr |  |
+| test_logging.rs:174:36:174:70 | MacroExpr | 174 | MacroExpr |  |
+| test_logging.rs:174:36:174:70 | __export | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | __export | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | __export | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | __export | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | fmt | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | fmt | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | format | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | format | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | format!... | 174 | MacroCall |  |
+| test_logging.rs:174:36:174:70 | format_args | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | format_args | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | must_use | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | must_use | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:70 | res | 174 | IdentPat |  |
+| test_logging.rs:174:36:174:70 | res | 174 | IdentPath |  |
+| test_logging.rs:174:36:174:70 | res | 174 | Name |  |
+| test_logging.rs:174:36:174:70 | res | 174 | NameRef |  |
+| test_logging.rs:174:36:174:70 | res | 174 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:174:36:174:70 | res | 174 | PathSegment |  |
+| test_logging.rs:174:36:174:81 | ... .as_bytes(...) | 174 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_bytes |
+| test_logging.rs:174:43:174:70 | TokenTree | 174 | TokenTree |  |
+| test_logging.rs:174:44:174:59 | "message = {}\\n" | 174 | LiteralExpr |  |
+| test_logging.rs:174:44:174:69 | ...::format(...) | 174 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:174:44:174:69 | ...::format_args!... | 174 | MacroCall |  |
+| test_logging.rs:174:44:174:69 | ...::must_use(...) | 174 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:174:44:174:69 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:44:174:69 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:44:174:69 | FormatArgsExpr | 174 | FormatArgsExpr |  |
+| test_logging.rs:174:44:174:69 | MacroExpr | 174 | MacroExpr |  |
+| test_logging.rs:174:44:174:69 | StmtList | 174 | StmtList |  |
+| test_logging.rs:174:44:174:69 | TokenTree | 174 | TokenTree |  |
+| test_logging.rs:174:44:174:69 | let ... = ... | 174 | LetStmt |  |
+| test_logging.rs:174:44:174:69 | { ... } | 174 | BlockExpr |  |
+| test_logging.rs:174:55:174:56 | {} | 174 | FormatSynthLocationImpl |  |
+| test_logging.rs:174:62:174:69 | FormatArgsArg | 174 | FormatArgsArg |  |
+| test_logging.rs:174:62:174:69 | password | 174 | IdentPath |  |
+| test_logging.rs:174:62:174:69 | password | 174 | NameRef |  |
+| test_logging.rs:174:62:174:69 | password | 174 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:174:62:174:69 | password | 174 | PathSegment |  |
+| test_logging.rs:174:72:174:79 | as_bytes | 174 | NameRef |  |
+| test_logging.rs:174:80:174:81 | ArgList | 174 | ArgList |  |
+| test_logging.rs:174:85:174:118 | //... | 174 | Comment |  |
+| test_logging.rs:175:5:175:7 | std | 175 | IdentPath |  |
+| test_logging.rs:175:5:175:7 | std | 175 | NameRef |  |
+| test_logging.rs:175:5:175:7 | std | 175 | PathSegment |  |
+| test_logging.rs:175:5:175:11 | ...::io | 175 | Path |  |
+| test_logging.rs:175:5:175:19 | ...::stdout | 175 | Path |  |
+| test_logging.rs:175:5:175:19 | ...::stdout | 175 | PathExpr |  |
+| test_logging.rs:175:5:175:21 | ...::stdout(...) | 175 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stdout, target:PathExpr |
+| test_logging.rs:175:5:175:28 | ... .lock(...) | 175 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stdout>::lock |
+| test_logging.rs:175:5:175:86 | ... .write_all(...) | 175 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::StdoutLock as crate::io::Write>::write_all |
+| test_logging.rs:175:5:175:87 | ExprStmt | 175 | ExprStmt |  |
+| test_logging.rs:175:10:175:11 | io | 175 | NameRef |  |
+| test_logging.rs:175:10:175:11 | io | 175 | PathSegment |  |
+| test_logging.rs:175:14:175:19 | stdout | 175 | NameRef |  |
+| test_logging.rs:175:14:175:19 | stdout | 175 | PathSegment |  |
+| test_logging.rs:175:20:175:21 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:23:175:26 | lock | 175 | NameRef |  |
+| test_logging.rs:175:27:175:28 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:30:175:38 | write_all | 175 | NameRef |  |
+| test_logging.rs:175:39:175:86 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:40:175:45 | format | 175 | IdentPath |  |
+| test_logging.rs:175:40:175:45 | format | 175 | NameRef |  |
+| test_logging.rs:175:40:175:45 | format | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | IdentPath |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | IdentPath |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | IdentPath |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | $crate | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | ...::__export | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::__export | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::fmt | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::format | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::format | 175 | PathExpr |  |
+| test_logging.rs:175:40:175:74 | ...::format_args | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::must_use | 175 | Path |  |
+| test_logging.rs:175:40:175:74 | ...::must_use | 175 | PathExpr |  |
+| test_logging.rs:175:40:175:74 | MacroExpr | 175 | MacroExpr |  |
+| test_logging.rs:175:40:175:74 | __export | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | __export | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | __export | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | __export | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | fmt | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | fmt | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | format | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | format | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | format!... | 175 | MacroCall |  |
+| test_logging.rs:175:40:175:74 | format_args | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | format_args | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | must_use | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | must_use | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:74 | res | 175 | IdentPat |  |
+| test_logging.rs:175:40:175:74 | res | 175 | IdentPath |  |
+| test_logging.rs:175:40:175:74 | res | 175 | Name |  |
+| test_logging.rs:175:40:175:74 | res | 175 | NameRef |  |
+| test_logging.rs:175:40:175:74 | res | 175 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:175:40:175:74 | res | 175 | PathSegment |  |
+| test_logging.rs:175:40:175:85 | ... .as_bytes(...) | 175 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_bytes |
+| test_logging.rs:175:47:175:74 | TokenTree | 175 | TokenTree |  |
+| test_logging.rs:175:48:175:63 | "message = {}\\n" | 175 | LiteralExpr |  |
+| test_logging.rs:175:48:175:73 | ...::format(...) | 175 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:175:48:175:73 | ...::format_args!... | 175 | MacroCall |  |
+| test_logging.rs:175:48:175:73 | ...::must_use(...) | 175 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:175:48:175:73 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:48:175:73 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:48:175:73 | FormatArgsExpr | 175 | FormatArgsExpr |  |
+| test_logging.rs:175:48:175:73 | MacroExpr | 175 | MacroExpr |  |
+| test_logging.rs:175:48:175:73 | StmtList | 175 | StmtList |  |
+| test_logging.rs:175:48:175:73 | TokenTree | 175 | TokenTree |  |
+| test_logging.rs:175:48:175:73 | let ... = ... | 175 | LetStmt |  |
+| test_logging.rs:175:48:175:73 | { ... } | 175 | BlockExpr |  |
+| test_logging.rs:175:59:175:60 | {} | 175 | FormatSynthLocationImpl |  |
+| test_logging.rs:175:66:175:73 | FormatArgsArg | 175 | FormatArgsArg |  |
+| test_logging.rs:175:66:175:73 | password | 175 | IdentPath |  |
+| test_logging.rs:175:66:175:73 | password | 175 | NameRef |  |
+| test_logging.rs:175:66:175:73 | password | 175 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:175:66:175:73 | password | 175 | PathSegment |  |
+| test_logging.rs:175:76:175:83 | as_bytes | 175 | NameRef |  |
+| test_logging.rs:175:84:175:85 | ArgList | 175 | ArgList |  |
+| test_logging.rs:175:89:175:122 | //... | 175 | Comment |  |
+| test_logging.rs:177:5:177:43 | let ... = ... | 177 | LetStmt |  |
+| test_logging.rs:177:9:177:15 | mut out | 177 | IdentPat |  |
+| test_logging.rs:177:13:177:15 | out | 177 | Name |  |
+| test_logging.rs:177:19:177:21 | std | 177 | IdentPath |  |
+| test_logging.rs:177:19:177:21 | std | 177 | NameRef |  |
+| test_logging.rs:177:19:177:21 | std | 177 | PathSegment |  |
+| test_logging.rs:177:19:177:25 | ...::io | 177 | Path |  |
+| test_logging.rs:177:19:177:33 | ...::stdout | 177 | Path |  |
+| test_logging.rs:177:19:177:33 | ...::stdout | 177 | PathExpr |  |
+| test_logging.rs:177:19:177:35 | ...::stdout(...) | 177 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stdout, target:PathExpr |
+| test_logging.rs:177:19:177:42 | ... .lock(...) | 177 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stdout>::lock |
+| test_logging.rs:177:24:177:25 | io | 177 | NameRef |  |
+| test_logging.rs:177:24:177:25 | io | 177 | PathSegment |  |
+| test_logging.rs:177:28:177:33 | stdout | 177 | NameRef |  |
+| test_logging.rs:177:28:177:33 | stdout | 177 | PathSegment |  |
+| test_logging.rs:177:34:177:35 | ArgList | 177 | ArgList |  |
+| test_logging.rs:177:37:177:40 | lock | 177 | NameRef |  |
+| test_logging.rs:177:41:177:42 | ArgList | 177 | ArgList |  |
+| test_logging.rs:178:5:178:7 | out | 178 | IdentPath |  |
+| test_logging.rs:178:5:178:7 | out | 178 | NameRef |  |
+| test_logging.rs:178:5:178:7 | out | 178 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:178:5:178:7 | out | 178 | PathSegment |  |
+| test_logging.rs:178:5:178:61 | out.write(...) | 178 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::StdoutLock as crate::io::Write>::write |
+| test_logging.rs:178:5:178:62 | ExprStmt | 178 | ExprStmt |  |
+| test_logging.rs:178:9:178:13 | write | 178 | NameRef |  |
+| test_logging.rs:178:14:178:61 | ArgList | 178 | ArgList |  |
+| test_logging.rs:178:15:178:20 | format | 178 | IdentPath |  |
+| test_logging.rs:178:15:178:20 | format | 178 | NameRef |  |
+| test_logging.rs:178:15:178:20 | format | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | IdentPath |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | IdentPath |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | IdentPath |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | $crate | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | ...::__export | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::__export | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::fmt | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::format | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::format | 178 | PathExpr |  |
+| test_logging.rs:178:15:178:49 | ...::format_args | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::must_use | 178 | Path |  |
+| test_logging.rs:178:15:178:49 | ...::must_use | 178 | PathExpr |  |
+| test_logging.rs:178:15:178:49 | MacroExpr | 178 | MacroExpr |  |
+| test_logging.rs:178:15:178:49 | __export | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | __export | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | __export | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | __export | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | fmt | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | fmt | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | format | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | format | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | format!... | 178 | MacroCall |  |
+| test_logging.rs:178:15:178:49 | format_args | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | format_args | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | must_use | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | must_use | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:49 | res | 178 | IdentPat |  |
+| test_logging.rs:178:15:178:49 | res | 178 | IdentPath |  |
+| test_logging.rs:178:15:178:49 | res | 178 | Name |  |
+| test_logging.rs:178:15:178:49 | res | 178 | NameRef |  |
+| test_logging.rs:178:15:178:49 | res | 178 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:178:15:178:49 | res | 178 | PathSegment |  |
+| test_logging.rs:178:15:178:60 | ... .as_bytes(...) | 178 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_bytes |
+| test_logging.rs:178:22:178:49 | TokenTree | 178 | TokenTree |  |
+| test_logging.rs:178:23:178:38 | "message = {}\\n" | 178 | LiteralExpr |  |
+| test_logging.rs:178:23:178:48 | ...::format(...) | 178 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:178:23:178:48 | ...::format_args!... | 178 | MacroCall |  |
+| test_logging.rs:178:23:178:48 | ...::must_use(...) | 178 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:178:23:178:48 | ArgList | 178 | ArgList |  |
+| test_logging.rs:178:23:178:48 | ArgList | 178 | ArgList |  |
+| test_logging.rs:178:23:178:48 | FormatArgsExpr | 178 | FormatArgsExpr |  |
+| test_logging.rs:178:23:178:48 | MacroExpr | 178 | MacroExpr |  |
+| test_logging.rs:178:23:178:48 | StmtList | 178 | StmtList |  |
+| test_logging.rs:178:23:178:48 | TokenTree | 178 | TokenTree |  |
+| test_logging.rs:178:23:178:48 | let ... = ... | 178 | LetStmt |  |
+| test_logging.rs:178:23:178:48 | { ... } | 178 | BlockExpr |  |
+| test_logging.rs:178:34:178:35 | {} | 178 | FormatSynthLocationImpl |  |
+| test_logging.rs:178:41:178:48 | FormatArgsArg | 178 | FormatArgsArg |  |
+| test_logging.rs:178:41:178:48 | password | 178 | IdentPath |  |
+| test_logging.rs:178:41:178:48 | password | 178 | NameRef |  |
+| test_logging.rs:178:41:178:48 | password | 178 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:178:41:178:48 | password | 178 | PathSegment |  |
+| test_logging.rs:178:51:178:58 | as_bytes | 178 | NameRef |  |
+| test_logging.rs:178:59:178:60 | ArgList | 178 | ArgList |  |
+| test_logging.rs:178:64:178:97 | //... | 178 | Comment |  |
+| test_logging.rs:180:5:180:43 | let ... = ... | 180 | LetStmt |  |
+| test_logging.rs:180:9:180:15 | mut err | 180 | IdentPat |  |
+| test_logging.rs:180:13:180:15 | err | 180 | Name |  |
+| test_logging.rs:180:19:180:21 | std | 180 | IdentPath |  |
+| test_logging.rs:180:19:180:21 | std | 180 | NameRef |  |
+| test_logging.rs:180:19:180:21 | std | 180 | PathSegment |  |
+| test_logging.rs:180:19:180:25 | ...::io | 180 | Path |  |
+| test_logging.rs:180:19:180:33 | ...::stderr | 180 | Path |  |
+| test_logging.rs:180:19:180:33 | ...::stderr | 180 | PathExpr |  |
+| test_logging.rs:180:19:180:35 | ...::stderr(...) | 180 | CallExpr | static-target:Function, target-origin:lang:std, target-path:crate::io::stdio::stderr, target:PathExpr |
+| test_logging.rs:180:19:180:42 | ... .lock(...) | 180 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::Stderr>::lock |
+| test_logging.rs:180:24:180:25 | io | 180 | NameRef |  |
+| test_logging.rs:180:24:180:25 | io | 180 | PathSegment |  |
+| test_logging.rs:180:28:180:33 | stderr | 180 | NameRef |  |
+| test_logging.rs:180:28:180:33 | stderr | 180 | PathSegment |  |
+| test_logging.rs:180:34:180:35 | ArgList | 180 | ArgList |  |
+| test_logging.rs:180:37:180:40 | lock | 180 | NameRef |  |
+| test_logging.rs:180:41:180:42 | ArgList | 180 | ArgList |  |
+| test_logging.rs:181:5:181:7 | err | 181 | IdentPath |  |
+| test_logging.rs:181:5:181:7 | err | 181 | NameRef |  |
+| test_logging.rs:181:5:181:7 | err | 181 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:181:5:181:7 | err | 181 | PathSegment |  |
+| test_logging.rs:181:5:181:61 | err.write(...) | 181 | MethodCallExpr | method-origin:lang:std, method-path:<crate::io::stdio::StderrLock as crate::io::Write>::write |
+| test_logging.rs:181:5:181:62 | ExprStmt | 181 | ExprStmt |  |
+| test_logging.rs:181:9:181:13 | write | 181 | NameRef |  |
+| test_logging.rs:181:14:181:61 | ArgList | 181 | ArgList |  |
+| test_logging.rs:181:15:181:20 | format | 181 | IdentPath |  |
+| test_logging.rs:181:15:181:20 | format | 181 | NameRef |  |
+| test_logging.rs:181:15:181:20 | format | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | IdentPath |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | IdentPath |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | IdentPath |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | $crate | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | ...::__export | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::__export | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::fmt | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::format | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::format | 181 | PathExpr |  |
+| test_logging.rs:181:15:181:49 | ...::format_args | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::must_use | 181 | Path |  |
+| test_logging.rs:181:15:181:49 | ...::must_use | 181 | PathExpr |  |
+| test_logging.rs:181:15:181:49 | MacroExpr | 181 | MacroExpr |  |
+| test_logging.rs:181:15:181:49 | __export | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | __export | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | __export | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | __export | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | fmt | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | fmt | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | format | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | format | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | format!... | 181 | MacroCall |  |
+| test_logging.rs:181:15:181:49 | format_args | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | format_args | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | must_use | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | must_use | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:49 | res | 181 | IdentPat |  |
+| test_logging.rs:181:15:181:49 | res | 181 | IdentPath |  |
+| test_logging.rs:181:15:181:49 | res | 181 | Name |  |
+| test_logging.rs:181:15:181:49 | res | 181 | NameRef |  |
+| test_logging.rs:181:15:181:49 | res | 181 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:181:15:181:49 | res | 181 | PathSegment |  |
+| test_logging.rs:181:15:181:60 | ... .as_bytes(...) | 181 | MethodCallExpr | method-origin:lang:alloc, method-path:<crate::string::String>::as_bytes |
+| test_logging.rs:181:22:181:49 | TokenTree | 181 | TokenTree |  |
+| test_logging.rs:181:23:181:38 | "message = {}\\n" | 181 | LiteralExpr |  |
+| test_logging.rs:181:23:181:48 | ...::format(...) | 181 | CallExpr | target-origin:lang:alloc, target-path:crate::fmt::format, target:PathExpr |
+| test_logging.rs:181:23:181:48 | ...::format_args!... | 181 | MacroCall |  |
+| test_logging.rs:181:23:181:48 | ...::must_use(...) | 181 | CallExpr | target-origin:lang:core, target-path:crate::hint::must_use, target:PathExpr |
+| test_logging.rs:181:23:181:48 | ArgList | 181 | ArgList |  |
+| test_logging.rs:181:23:181:48 | ArgList | 181 | ArgList |  |
+| test_logging.rs:181:23:181:48 | FormatArgsExpr | 181 | FormatArgsExpr |  |
+| test_logging.rs:181:23:181:48 | MacroExpr | 181 | MacroExpr |  |
+| test_logging.rs:181:23:181:48 | StmtList | 181 | StmtList |  |
+| test_logging.rs:181:23:181:48 | TokenTree | 181 | TokenTree |  |
+| test_logging.rs:181:23:181:48 | let ... = ... | 181 | LetStmt |  |
+| test_logging.rs:181:23:181:48 | { ... } | 181 | BlockExpr |  |
+| test_logging.rs:181:34:181:35 | {} | 181 | FormatSynthLocationImpl |  |
+| test_logging.rs:181:41:181:48 | FormatArgsArg | 181 | FormatArgsArg |  |
+| test_logging.rs:181:41:181:48 | password | 181 | IdentPath |  |
+| test_logging.rs:181:41:181:48 | password | 181 | NameRef |  |
+| test_logging.rs:181:41:181:48 | password | 181 | PathExpr, VariableReadAccess |  |
+| test_logging.rs:181:41:181:48 | password | 181 | PathSegment |  |
+| test_logging.rs:181:51:181:58 | as_bytes | 181 | NameRef |  |
+| test_logging.rs:181:59:181:60 | ArgList | 181 | ArgList |  |
+| test_logging.rs:181:64:181:97 | //... | 181 | Comment |  |
+| test_logging.rs:184:1:189:1 | fn main | 184 | Function |  |
+| test_logging.rs:184:4:184:7 | main | 184 | Name |  |
+| test_logging.rs:184:8:184:9 | ParamList | 184 | ParamList |  |
+| test_logging.rs:184:11:189:1 | StmtList | 184 | StmtList |  |
+| test_logging.rs:184:11:189:1 | { ... } | 184 | BlockExpr |  |
+| test_logging.rs:185:5:185:17 | simple_logger | 185 | IdentPath |  |
+| test_logging.rs:185:5:185:17 | simple_logger | 185 | NameRef |  |
+| test_logging.rs:185:5:185:17 | simple_logger | 185 | PathSegment |  |
+| test_logging.rs:185:5:185:31 | ...::SimpleLogger | 185 | Path |  |
+| test_logging.rs:185:5:185:36 | ...::new | 185 | Path |  |
+| test_logging.rs:185:5:185:36 | ...::new | 185 | PathExpr |  |
+| test_logging.rs:185:5:185:38 | ...::new(...) | 185 | CallExpr | target-origin:repo:https://github.com/borntyping/rust-simple_logger:simple_logger, target-path:<crate::SimpleLogger>::new, target:PathExpr |
+| test_logging.rs:185:5:185:45 | ... .init(...) | 185 | MethodCallExpr | method-origin:repo:https://github.com/borntyping/rust-simple_logger:simple_logger, method-path:<crate::SimpleLogger>::init |
+| test_logging.rs:185:5:185:54 | ... .unwrap(...) | 185 | MethodCallExpr | method-origin:lang:core, method-path:<crate::result::Result>::unwrap |
+| test_logging.rs:185:5:185:55 | ExprStmt | 185 | ExprStmt |  |
+| test_logging.rs:185:20:185:31 | SimpleLogger | 185 | NameRef |  |
+| test_logging.rs:185:20:185:31 | SimpleLogger | 185 | PathSegment |  |
+| test_logging.rs:185:34:185:36 | new | 185 | NameRef |  |
+| test_logging.rs:185:34:185:36 | new | 185 | PathSegment |  |
+| test_logging.rs:185:37:185:38 | ArgList | 185 | ArgList |  |
+| test_logging.rs:185:40:185:43 | init | 185 | NameRef |  |
+| test_logging.rs:185:44:185:45 | ArgList | 185 | ArgList |  |
+| test_logging.rs:185:47:185:52 | unwrap | 185 | NameRef |  |
+| test_logging.rs:185:53:185:54 | ArgList | 185 | ArgList |  |
+| test_logging.rs:187:5:187:12 | test_log | 187 | IdentPath |  |
+| test_logging.rs:187:5:187:12 | test_log | 187 | NameRef |  |
+| test_logging.rs:187:5:187:12 | test_log | 187 | PathExpr |  |
+| test_logging.rs:187:5:187:12 | test_log | 187 | PathSegment |  |
+| test_logging.rs:187:5:187:85 | test_log(...) | 187 | CallExpr | static-target:Function, target-origin:repo::test, target-path:crate::test_logging::test_log, target:PathExpr |
+| test_logging.rs:187:5:187:86 | ExprStmt | 187 | ExprStmt |  |
+| test_logging.rs:187:13:187:85 | ArgList | 187 | ArgList |  |
+| test_logging.rs:187:14:187:23 | "harmless" | 187 | LiteralExpr |  |
+| test_logging.rs:187:14:187:35 | "harmless".to_string(...) | 187 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:187:25:187:33 | to_string | 187 | NameRef |  |
+| test_logging.rs:187:34:187:35 | ArgList | 187 | ArgList |  |
+| test_logging.rs:187:38:187:45 | "123456" | 187 | LiteralExpr |  |
+| test_logging.rs:187:38:187:57 | "123456".to_string(...) | 187 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:187:47:187:55 | to_string | 187 | NameRef |  |
+| test_logging.rs:187:56:187:57 | ArgList | 187 | ArgList |  |
+| test_logging.rs:187:60:187:72 | "[encrypted]" | 187 | LiteralExpr |  |
+| test_logging.rs:187:60:187:84 | "[encrypted]".to_string(...) | 187 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:187:74:187:82 | to_string | 187 | NameRef |  |
+| test_logging.rs:187:83:187:84 | ArgList | 187 | ArgList |  |
+| test_logging.rs:188:5:188:12 | test_std | 188 | IdentPath |  |
+| test_logging.rs:188:5:188:12 | test_std | 188 | NameRef |  |
+| test_logging.rs:188:5:188:12 | test_std | 188 | PathExpr |  |
+| test_logging.rs:188:5:188:12 | test_std | 188 | PathSegment |  |
+| test_logging.rs:188:5:188:43 | test_std(...) | 188 | CallExpr | static-target:Function, target-origin:repo::test, target-path:crate::test_logging::test_std, target:PathExpr |
+| test_logging.rs:188:5:188:44 | ExprStmt | 188 | ExprStmt |  |
+| test_logging.rs:188:13:188:43 | ArgList | 188 | ArgList |  |
+| test_logging.rs:188:14:188:21 | "123456" | 188 | LiteralExpr |  |
+| test_logging.rs:188:14:188:33 | "123456".to_string(...) | 188 | MethodCallExpr | method-origin:lang:alloc, method-path:<_ as crate::string::ToString>::to_string |
+| test_logging.rs:188:23:188:31 | to_string | 188 | NameRef |  |
+| test_logging.rs:188:32:188:33 | ArgList | 188 | ArgList |  |
+| test_logging.rs:188:36:188:36 | 0 | 188 | LiteralExpr |  |
+| test_logging.rs:188:39:188:42 | None | 188 | IdentPath |  |
+| test_logging.rs:188:39:188:42 | None | 188 | NameRef |  |
+| test_logging.rs:188:39:188:42 | None | 188 | PathExpr |  |
+| test_logging.rs:188:39:188:42 | None | 188 | PathSegment |  |

--- a/rust/ql/test/query-tests/security/CWE-312/debug.ql
+++ b/rust/ql/test/query-tests/security/CWE-312/debug.ql
@@ -1,0 +1,19 @@
+import rust
+
+string describe(Locatable l) {
+    result = "target:" + l.(CallExpr).getFunction().getAQlClass()
+    or
+    result = "target-path:" + l.(CallExpr).getFunction().(PathExpr).getResolvedPath()
+    or
+    result = "target-origin:" + l.(CallExpr).getFunction().(PathExpr).getResolvedCrateOrigin()
+    or
+    result = "method-path:" + l.(MethodCallExpr).getResolvedPath()
+    or
+    result = "method-origin:" + l.(MethodCallExpr).getResolvedCrateOrigin()
+    or
+    result = "static-target:" + l.(CallExprBase).getStaticTarget().getAQlClass() // resolved call
+}
+
+from Locatable l
+where l.getFile().getBaseName() = "test_logging.rs"
+select l, l.getLocation().getStartLine(), concat(l.getAQlClass(), ", "), concat(describe(l), ", ")


### PR DESCRIPTION
Investigate test discrepancies for `rust/cleartext-logging`.  These tests recently started failing on CI, but the results didn't change on local developer machines.  This PR is intended to trigger CI and give us more information about what's different there.  Not intended to be merged.