### PR TITLE
Ruby: Make module graph queries avoid relying on evalaution order.

### DIFF
--- a/ruby/ql/test/library-tests/modules/ancestors.expected
+++ b/ruby/ql/test/library-tests/modules/ancestors.expected
@@ -1,24 +1,20 @@
+#-----| BasicObject
+
 #-----| Class
 #-----| super -> Module
 
-#-----| EsotericInstanceMethods
-
-#-----| MyStruct
-
-#-----| Struct
-
-#-----| UnresolvedNamespace
-
-#-----| BasicObject
-
 #-----| Complex
 #-----| super -> Numeric
+
+#-----| EsotericInstanceMethods
 
 #-----| FalseClass
 #-----| super -> Object
 
 #-----| Float
 #-----| super -> Numeric
+
+#-----| MyStruct
 
 #-----| NilClass
 #-----| super -> Object
@@ -31,10 +27,14 @@
 #-----| Rational
 #-----| super -> Numeric
 
+#-----| Struct
+
 #-----| Symbol
 
 #-----| TrueClass
 #-----| super -> Object
+
+#-----| UnresolvedNamespace
 
 #-----| UnresolvedNamespace::X1
 

--- a/ruby/ql/test/library-tests/modules/ancestors.ql
+++ b/ruby/ql/test/library-tests/modules/ancestors.ql
@@ -5,22 +5,33 @@
 
 import codeql.ruby.AST
 
+int locationModuleRank(Module node) {
+  node =
+    rank[result](Module m, Location l |
+      l = m.getLocation()
+    |
+      m
+      order by
+        l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+        l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
+    )
+}
+
+int stringModuleRank(Module node) {
+  node = rank[result](Module m | not exists(locationModuleRank(m)) | m order by m.toString())
+}
+
+int moduleRank(Module node) {
+  result = locationModuleRank(node) + max(stringModuleRank(_))
+  or
+  result = stringModuleRank(node)
+}
+
 query predicate nodes(Module node, string key, string value) {
   key = "semmle.label" and value = node.toString()
   or
   key = "semmle.order" and
-  value =
-    any(int i |
-      node =
-        rank[i](Module m, Location l |
-          l = m.getLocation()
-        |
-          m
-          order by
-            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
-        )
-    ).toString()
+  value = moduleRank(node).toString()
 }
 
 Module getATarget(Module source, string value) {

--- a/ruby/ql/test/library-tests/modules/superclasses.expected
+++ b/ruby/ql/test/library-tests/modules/superclasses.expected
@@ -1,24 +1,20 @@
+#-----| BasicObject
+
 #-----| Class
 #-----|  -> Module
 
-#-----| EsotericInstanceMethods
-
-#-----| MyStruct
-
-#-----| Struct
-
-#-----| UnresolvedNamespace
-
-#-----| BasicObject
-
 #-----| Complex
 #-----|  -> Numeric
+
+#-----| EsotericInstanceMethods
 
 #-----| FalseClass
 #-----|  -> Object
 
 #-----| Float
 #-----|  -> Numeric
+
+#-----| MyStruct
 
 #-----| NilClass
 #-----|  -> Object
@@ -31,10 +27,14 @@
 #-----| Rational
 #-----|  -> Numeric
 
+#-----| Struct
+
 #-----| Symbol
 
 #-----| TrueClass
 #-----|  -> Object
+
+#-----| UnresolvedNamespace
 
 #-----| UnresolvedNamespace::X1
 

--- a/ruby/ql/test/library-tests/modules/superclasses.ql
+++ b/ruby/ql/test/library-tests/modules/superclasses.ql
@@ -5,22 +5,33 @@
 
 import codeql.ruby.AST
 
+int locationModuleRank(Module node) {
+  node =
+    rank[result](Module m, Location l |
+      l = m.getLocation()
+    |
+      m
+      order by
+        l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
+        l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
+    )
+}
+
+int stringModuleRank(Module node) {
+  node = rank[result](Module m | not exists(locationModuleRank(m)) | m order by m.toString())
+}
+
+int moduleRank(Module node) {
+  result = locationModuleRank(node) + max(stringModuleRank(_))
+  or
+  result = stringModuleRank(node)
+}
+
 query predicate nodes(Module node, string key, string value) {
   key = "semmle.label" and value = node.toString()
   or
   key = "semmle.order" and
-  value =
-    any(int i |
-      node =
-        rank[i](Module m, Location l |
-          l = m.getLocation()
-        |
-          m
-          order by
-            l.getFile().getBaseName(), l.getFile().getAbsolutePath(), l.getStartLine(),
-            l.getStartColumn(), l.getEndLine(), l.getEndColumn(), m.toString()
-        )
-    ).toString()
+  value = moduleRank(node).toString()
 }
 
 query predicate edges(Module source, Module target, string key, string value) {


### PR DESCRIPTION
Graphs use the internal id if `semmle.order` is not good enough. However the internal id of a `newtype` depends on evaluation order (and in this case whether `TResolved` or `TUnresolved` is evaluated first). It seems the current evaluator is very consistent but RTJO changes it. In theory though the current evaluator could get the wrong result as multiple threads can change scheduling order.

I am looking into making the graph code use the label as an intermediate order. However we end up still needing us to make this test deterministic as the change would break this test.

This just adds the `toString` as an order when the location is not defined, I have put these first in the order as that matches the existing results better (if `semmle.order` is not defined then it is treated 0).

I have duplicated this code as it is already duplicated but I am happy to put this in a `qll` instead as this code has grown in size.