### PR TITLE
Replace occurences of ubuntu-20 by ubuntu-22 in .github/workflows

### DIFF
--- a/.github/workflows/build-ripunzip.yml
+++ b/.github/workflows/build-ripunzip.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Moving the workflow to run on `ubuntu-22`, since `ubuntu-20` is going to be removed from actions-runners offering: https://github.com/actions/runner-images/issues/11101 
