### PR TITLE
Rust: Also resolve `crate` paths in non-source files

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -187,7 +187,12 @@ abstract class ItemNode extends Locatable {
     this = result.(ImplOrTraitItemNode).getAnItemInSelfScope()
     or
     name = "crate" and
-    this = result.(CrateItemNode).getASourceFile()
+    result =
+      any(CrateItemNode crate |
+        this = crate.getASourceFile()
+        or
+        this = crate.getModuleNode()
+      )
   }
 
   /** Gets the location of this item. */


### PR DESCRIPTION
Previously, we didn't extract `crate::...` paths for non-source code, but starting with https://github.com/github/codeql/pull/19113 we do. 