### PR TITLE
Python: Modernize `py/mixed-tuple-returns`

### DIFF
--- a/python/ql/src/change-notes/2025-03-27-modernize-mixed-tuple-returns-query.md
+++ b/python/ql/src/change-notes/2025-03-27-modernize-mixed-tuple-returns-query.md
@@ -1,0 +1,5 @@
+---
+category: minorAnalysis
+---
+
+- The `py/mixed-tuple-returns` query no longer flags instances where the tuple is passed into the function as an argument, as this lead to too many false positives.

--- a/python/ql/src/change-notes/2025-03-27-modernize-mixed-tuple-returns-query.md
+++ b/python/ql/src/change-notes/2025-03-27-modernize-mixed-tuple-returns-query.md
@@ -2,4 +2,4 @@
 category: minorAnalysis
 ---
 
-- The `py/mixed-tuple-returns` query no longer flags instances where the tuple is passed into the function as an argument, as this lead to too many false positives.
+- The `py/mixed-tuple-returns` query no longer flags instances where the tuple is passed into the function as an argument, as this led to too many false positives.

--- a/python/ql/test/query-tests/Functions/return_values/ReturnConsistentTupleSizes.expected
+++ b/python/ql/test/query-tests/Functions/return_values/ReturnConsistentTupleSizes.expected
@@ -1,2 +1,1 @@
 | functions_test.py:306:1:306:39 | Function returning_different_tuple_sizes | returning_different_tuple_sizes returns $@ and $@. | functions_test.py:308:16:308:18 | Tuple | tuple of size 2 | functions_test.py:310:16:310:20 | Tuple | tuple of size 3 |
-| functions_test.py:324:1:324:50 | Function indirectly_returning_different_tuple_sizes | indirectly_returning_different_tuple_sizes returns $@ and $@. | functions_test.py:319:12:319:14 | Tuple | tuple of size 2 | functions_test.py:322:12:322:16 | Tuple | tuple of size 3 |

--- a/python/ql/test/query-tests/Functions/return_values/functions_test.py
+++ b/python/ql/test/query-tests/Functions/return_values/functions_test.py
@@ -321,7 +321,7 @@ def function_returning_2_tuple():
 def function_returning_3_tuple():
     return 1,2,3
 
-def indirectly_returning_different_tuple_sizes(x):
+def indirectly_returning_different_tuple_sizes(x): # OK, since we only look at local tuple returns
     if x:
         return function_returning_2_tuple()
     else:
@@ -347,3 +347,9 @@ def ok_match2(x):  # FP
             return 0
         case _:
             return 1
+
+def ok_tuple_returns_captured_in_type(x: bool) -> tuple[int, ...]: # OK because there is a type annotation present
+    if x:
+        return 1, 2
+    else:
+        return 1, 2, 3


### PR DESCRIPTION
Removes the dependence on points-to in favour of an approach based on (local) data-flow.

I first tried a version that used type tracking, as this more accurately mimics the behaviour of the old query. However, I soon discovered that there were _many_ false positives in this setup. The main bad pattern I saw was a helper function somewhere deep inside the code that both receives and returns an argument that can be tuples with different sizes and origins. In this case, global flow produces something akin to a cartesian product of "n-tuples that flow into the function" and "m-tuples that flow into the function" where m < n.

To combat this, I decided to instead focus on only flow _within_ a given function (and so local data-flow was sufficient).

Additionally, another class of false positives I saw was cases where the return type actually witnessed that the function in question could return tuples of varying sizes. In this case it seems reasonable to not flag these instances, since they are already (presumably) being checked by a type checker.

More generally, if you've annotated the return type of the function with anything (not just `Tuple[...]`), then there's probably little need to flag it.