### PR TITLE
Ssa: Refactor data flow integration to make the input signature simpler

### DIFF
--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -977,6 +977,8 @@ private module DataFlowIntegrationInput implements SsaImpl::DataFlowIntegrationI
     )
   }
 
+  predicate ssaDefHasSource(SsaImpl::WriteDefinition def) { none() }
+
   predicate ssaDefAssigns(SsaImpl::WriteDefinition def, Expr value) { none() }
 
   class Parameter extends Void {

--- a/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
+++ b/cpp/ql/lib/semmle/code/cpp/ir/dataflow/internal/SsaInternals.qll
@@ -956,8 +956,6 @@ class GlobalDef extends Definition {
 private module SsaImpl = SsaImplCommon::Make<Location, SsaInput>;
 
 private module DataFlowIntegrationInput implements SsaImpl::DataFlowIntegrationInputSig {
-  private import codeql.util.Void
-
   class Expr extends Instruction {
     Expr() {
       exists(IRBlock bb, int i |
@@ -978,14 +976,6 @@ private module DataFlowIntegrationInput implements SsaImpl::DataFlowIntegrationI
   }
 
   predicate ssaDefHasSource(SsaImpl::WriteDefinition def) { none() }
-
-  predicate ssaDefAssigns(SsaImpl::WriteDefinition def, Expr value) { none() }
-
-  class Parameter extends Void {
-    Location getLocation() { none() }
-  }
-
-  predicate ssaDefInitializesParam(SsaImpl::WriteDefinition def, Parameter p) { none() }
 
   predicate allowFlowIntoUncertainDef(SsaImpl::UncertainWriteDefinition def) { any() }
 

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -506,7 +506,7 @@ module SsaFlow {
     result.(Impl::ExprPostUpdateNode).getExpr() =
       n.(PostUpdateNode).getPreUpdateNode().(ExprNode).getControlFlowNode()
     or
-    result.(Impl::ParameterNode).getParameter() = n.(ExplicitParameterNode).getSsaDefinition()
+    result.(Impl::WriteDefSourceNode).getDefinition() = n.(ExplicitParameterNode).getSsaDefinition()
   }
 
   predicate localFlowStep(Ssa::SourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -1029,16 +1029,6 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
     def instanceof Ssa::ImplicitParameterDefinition
   }
 
-  predicate ssaDefAssigns(WriteDefinition def, Expr value) {
-    // exclude flow directly from RHS to SSA definition, as we instead want to
-    // go from RHS to matching assingnable definition, and from there to SSA definition
-    none()
-  }
-
-  class Parameter = Ssa::ImplicitParameterDefinition;
-
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { none() }
-
   /**
    * Allows for flow into uncertain defintions that are not call definitions,
    * as we, conservatively, consider such definitions to be certain.

--- a/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
+++ b/csharp/ql/lib/semmle/code/csharp/dataflow/internal/SsaImpl.qll
@@ -1023,6 +1023,12 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   Expr getARead(Definition def) { exists(getAReadAtNode(def, result)) }
 
+  predicate ssaDefHasSource(WriteDefinition def) {
+    // exclude flow directly from RHS to SSA definition, as we instead want to
+    // go from RHS to matching assignable definition, and from there to SSA definition
+    def instanceof Ssa::ImplicitParameterDefinition
+  }
+
   predicate ssaDefAssigns(WriteDefinition def, Expr value) {
     // exclude flow directly from RHS to SSA definition, as we instead want to
     // go from RHS to matching assingnable definition, and from there to SSA definition
@@ -1031,7 +1037,7 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   class Parameter = Ssa::ImplicitParameterDefinition;
 
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { def = p }
+  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { none() }
 
   /**
    * Allows for flow into uncertain defintions that are not call definitions,

--- a/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/DataFlowNodes.qll
@@ -26,6 +26,14 @@ private predicate deadcode(Expr e) {
 module SsaFlow {
   module Impl = SsaImpl::DataFlowIntegration;
 
+  private predicate ssaDefAssigns(SsaExplicitUpdate def, Expr value) {
+    exists(VariableUpdate upd | upd = def.getDefiningExpr() |
+      value = upd.(VariableAssign).getSource() or
+      value = upd.(AssignOp) or
+      value = upd.(RecordBindingVariableExpr)
+    )
+  }
+
   Impl::Node asNode(Node n) {
     n = TSsaNode(result)
     or
@@ -33,7 +41,12 @@ module SsaFlow {
     or
     result.(Impl::ExprPostUpdateNode).getExpr() = n.(PostUpdateNode).getPreUpdateNode().asExpr()
     or
-    TExplicitParameterNode(result.(Impl::ParameterNode).getParameter()) = n
+    exists(Parameter p |
+      n = TExplicitParameterNode(p) and
+      result.(Impl::WriteDefSourceNode).getDefinition().(SsaImplicitInit).isParameterDefinition(p)
+    )
+    or
+    ssaDefAssigns(result.(Impl::WriteDefSourceNode).getDefinition(), n.asExpr())
   }
 
   predicate localFlowStep(SsaSourceVariable v, Node nodeFrom, Node nodeTo, boolean isUseStep) {

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -647,15 +647,9 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   Expr getARead(Definition def) { result = getAUse(def) }
 
-  class Parameter = J::Parameter;
-
   predicate ssaDefHasSource(WriteDefinition def) {
     def instanceof SsaExplicitUpdate or def.(SsaImplicitInit).isParameterDefinition(_)
   }
-
-  predicate ssaDefAssigns(Impl::WriteDefinition def, Expr value) { none() }
-
-  predicate ssaDefInitializesParam(Impl::WriteDefinition def, Parameter p) { none() }
 
   predicate allowFlowIntoUncertainDef(UncertainWriteDefinition def) {
     def instanceof SsaUncertainImplicitUpdate

--- a/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
+++ b/java/ql/lib/semmle/code/java/dataflow/internal/SsaImpl.qll
@@ -649,21 +649,13 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   class Parameter = J::Parameter;
 
-  predicate ssaDefAssigns(Impl::WriteDefinition def, Expr value) {
-    exists(VariableUpdate upd | upd = def.(SsaExplicitUpdate).getDefiningExpr() |
-      value = upd.(VariableAssign).getSource() or
-      value = upd.(AssignOp) or
-      value = upd.(RecordBindingVariableExpr)
-    )
+  predicate ssaDefHasSource(WriteDefinition def) {
+    def instanceof SsaExplicitUpdate or def.(SsaImplicitInit).isParameterDefinition(_)
   }
 
-  predicate ssaDefInitializesParam(Impl::WriteDefinition def, Parameter p) {
-    def.(SsaImplicitInit).getSourceVariable() =
-      any(SsaSourceVariable v |
-        v.getVariable() = p and
-        v.getEnclosingCallable() = p.getCallable()
-      )
-  }
+  predicate ssaDefAssigns(Impl::WriteDefinition def, Expr value) { none() }
+
+  predicate ssaDefInitializesParam(Impl::WriteDefinition def, Parameter p) { none() }
 
   predicate allowFlowIntoUncertainDef(UncertainWriteDefinition def) {
     def instanceof SsaUncertainImplicitUpdate

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
@@ -56,6 +56,11 @@ module SsaDataflowInput implements DataFlowIntegrationInputSig {
     predicate hasCfgNode(js::BasicBlock bb, int i) { this = bb.getNode(i) }
   }
 
+  predicate ssaDefHasSource(WriteDefinition def) {
+    // This library only handles use-use flow after a post-update, there are no definitions, only uses.
+    none()
+  }
+
   predicate ssaDefAssigns(WriteDefinition def, Expr value) {
     // This library only handles use-use flow after a post-update, there are no definitions, only uses.
     none()

--- a/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/internal/sharedlib/Ssa.qll
@@ -61,18 +61,6 @@ module SsaDataflowInput implements DataFlowIntegrationInputSig {
     none()
   }
 
-  predicate ssaDefAssigns(WriteDefinition def, Expr value) {
-    // This library only handles use-use flow after a post-update, there are no definitions, only uses.
-    none()
-  }
-
-  class Parameter = js::Parameter;
-
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) {
-    // This library only handles use-use flow after a post-update, there are no definitions, only uses.
-    none()
-  }
-
   cached
   Expr getARead(Definition def) {
     // Copied from implementation so we can cache it here

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/DataFlowPrivate.qll
@@ -108,7 +108,12 @@ module SsaFlow {
     or
     result.(Impl::ExprPostUpdateNode).getExpr() = n.(PostUpdateNode).getPreUpdateNode().asExpr()
     or
-    n = toParameterNode(result.(Impl::ParameterNode).getParameter())
+    exists(SsaImpl::ParameterExt p |
+      n = toParameterNode(p) and
+      p.isInitializedBy(result.(Impl::WriteDefSourceNode).getDefinition())
+    )
+    or
+    result.(Impl::WriteDefSourceNode).getDefinition().(Ssa::WriteDefinition).assigns(n.asExpr())
   }
 
   predicate localFlowStep(

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -479,6 +479,10 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   Expr getARead(Definition def) { result = Cached::getARead(def) }
 
+  predicate ssaDefHasSource(WriteDefinition def) {
+    any(ParameterExt p).isInitializedBy(def) or def.(Ssa::WriteDefinition).assigns(_)
+  }
+
   class Guard extends Cfg::CfgNodes::AstCfgNode {
     /**
      * Holds if the control flow branching from `bb1` is dependent on this guard,

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -473,17 +473,11 @@ class ParameterExt extends TParameterExt {
 private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInputSig {
   private import codeql.ruby.controlflow.internal.Guards as Guards
 
-  class Parameter = ParameterExt;
-
   class Expr extends Cfg::CfgNodes::ExprCfgNode {
     predicate hasCfgNode(SsaInput::BasicBlock bb, int i) { this = bb.getNode(i) }
   }
 
   Expr getARead(Definition def) { result = Cached::getARead(def) }
-
-  predicate ssaDefAssigns(WriteDefinition def, Expr value) { none() }
-
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { none() }
 
   class Guard extends Cfg::CfgNodes::AstCfgNode {
     /**

--- a/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
+++ b/ruby/ql/lib/codeql/ruby/dataflow/internal/SsaImpl.qll
@@ -481,11 +481,9 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   Expr getARead(Definition def) { result = Cached::getARead(def) }
 
-  predicate ssaDefAssigns(WriteDefinition def, Expr value) {
-    def.(Ssa::WriteDefinition).assigns(value)
-  }
+  predicate ssaDefAssigns(WriteDefinition def, Expr value) { none() }
 
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { p.isInitializedBy(def) }
+  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) { none() }
 
   class Guard extends Cfg::CfgNodes::AstCfgNode {
     /**

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -172,10 +172,6 @@ predicate isArgumentForCall(ExprCfgNode arg, CallExprBaseCfgNode call, Parameter
 module SsaFlow {
   private module SsaFlow = SsaImpl::DataFlowIntegration;
 
-  private ParameterNode toParameterNode(ParamCfgNode p) {
-    result.(SourceParameterNode).getParameter() = p
-  }
-
   /** Converts a control flow node into an SSA control flow node. */
   SsaFlow::Node asNode(Node n) {
     n = TSsaNode(result)
@@ -183,8 +179,6 @@ module SsaFlow {
     result.(SsaFlow::ExprNode).getExpr() = n.asExpr()
     or
     result.(SsaFlow::ExprPostUpdateNode).getExpr() = n.(PostUpdateNode).getPreUpdateNode().asExpr()
-    or
-    n = toParameterNode(result.(SsaFlow::ParameterNode).getParameter())
   }
 
   predicate localFlowStep(

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -342,11 +342,6 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   predicate ssaDefHasSource(WriteDefinition def) { none() } // handled in `DataFlowImpl.qll` instead
 
-  /** Holds if SSA definition `def` assigns `value` to the underlying variable. */
-  predicate ssaDefAssigns(WriteDefinition def, Expr value) {
-    none() // handled in `DataFlowImpl.qll` instead
-  }
-
   private predicate isArg(CfgNodes::CallExprBaseCfgNode call, CfgNodes::ExprCfgNode e) {
     call.getArgument(_) = e
     or
@@ -364,13 +359,6 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
       mutablyBorrows(bb.getNode(i).getAstNode(), v) and
       isArg(call, bb.getNode(i))
     )
-  }
-
-  class Parameter = CfgNodes::ParamBaseCfgNode;
-
-  /** Holds if SSA definition `def` initializes parameter `p` at function entry. */
-  predicate ssaDefInitializesParam(WriteDefinition def, Parameter p) {
-    none() // handled in `DataFlowImpl.qll` instead
   }
 
   class Guard extends CfgNodes::AstCfgNode {

--- a/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/SsaImpl.qll
@@ -340,6 +340,8 @@ private module DataFlowIntegrationInput implements Impl::DataFlowIntegrationInpu
 
   Expr getARead(Definition def) { result = Cached::getARead(def) }
 
+  predicate ssaDefHasSource(WriteDefinition def) { none() } // handled in `DataFlowImpl.qll` instead
+
   /** Holds if SSA definition `def` assigns `value` to the underlying variable. */
   predicate ssaDefAssigns(WriteDefinition def, Expr value) {
     none() // handled in `DataFlowImpl.qll` instead

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1690,7 +1690,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       /** Gets the underlying definition. */
       WriteDefinition getDefinition() { result = def }
 
-      override string toString() { result = def.toString() }
+      override string toString() { result = "[source] " + def.toString() }
 
       override Location getLocation() { result = def.getLocation() }
     }


### PR DESCRIPTION
This replaces the two predicates, `ssaDefAssigns` and `ssaDefInitializesParam`, with a per-default synthesized input-value node that can then be mapped to the RHS of an assignment or the parameter as appropriate.

The changes are split into individual commits that can be reviewed one-by-one, but the combined changes are simple enough that it's possibly just as easy to just look at all the changes together.