### PR TITLE
Rust: Make trait a base type mention of the self type parameter

### DIFF
--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -16,7 +16,7 @@ newtype TType =
   TRefType() or // todo: add mut?
   TTypeParamTypeParameter(TypeParam t) or
   TRefTypeParameter() or
-  TSelfTypeParameter()
+  TSelfTypeParameter(Trait t)
 
 /**
  * A type without type arguments.
@@ -144,9 +144,6 @@ class TraitType extends Type, TTrait {
 
   override TypeParameter getTypeParameter(int i) {
     result = TTypeParamTypeParameter(trait.getGenericParamList().getTypeParam(i))
-    or
-    result = TSelfTypeParameter() and
-    i = -1
   }
 
   pragma[nomagic]
@@ -226,11 +223,9 @@ class ImplType extends Type, TImpl {
 
   override TypeParameter getTypeParameter(int i) {
     result = TTypeParamTypeParameter(impl.getGenericParamList().getTypeParam(i))
-    or
-    result = TSelfTypeParameter() and
-    i = -1
   }
 
+  /** Get the trait implemented by this `impl` block, if any. */
   override TypeMention getABaseTypeMention() { result = impl.getTrait() }
 
   override string toString() { result = impl.toString() }
@@ -334,11 +329,29 @@ class RefTypeParameter extends TypeParameter, TRefTypeParameter {
   override Location getLocation() { result instanceof EmptyLocation }
 }
 
-/** An implicit `Self` type parameter. */
+/**
+ * The implicit `Self` type parameter of a trait, that refers to the
+ * implementing type of the trait.
+ *
+ * The Rust Reference on the implicit `Self` parameter:
+ * https://doc.rust-lang.org/reference/items/traits.html#r-items.traits.self-param
+ */
 class SelfTypeParameter extends TypeParameter, TSelfTypeParameter {
-  override Function getMethod(string name) { none() }
+  private Trait trait;
 
-  override string toString() { result = "(Self)" }
+  SelfTypeParameter() { this = TSelfTypeParameter(trait) }
 
-  override Location getLocation() { result instanceof EmptyLocation }
+  Trait getTrait() { result = trait }
+
+  override TypeMention getABaseTypeMention() { result = trait }
+
+  override Function getMethod(string name) {
+    // The `Self` type parameter is an implementation of the trait, so it has
+    // all the trait's methods.
+    result = trait.(ItemNode).getASuccessor(name)
+  }
+
+  override string toString() { result = "Self [" + trait.toString() + "]" }
+
+  override Location getLocation() { result = trait.getLocation() }
 }

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -69,9 +69,12 @@ private module Input1 implements InputSig1<Location> {
     apos.asMethodTypeArgumentPosition() = ppos.asTypeParam().getPosition()
   }
 
-  private predicate id(Raw::AstNode x, Raw::AstNode y) { x = y }
+  /** A raw AST node that might correspond to a type parameter. */
+  private class RawTypeParameter = @type_param or @trait;
 
-  private predicate idOfRaw(Raw::AstNode x, int y) = equivalenceRelation(id/2)(x, y)
+  private predicate id(RawTypeParameter x, RawTypeParameter y) { x = y }
+
+  private predicate idOfRaw(RawTypeParameter x, int y) = equivalenceRelation(id/2)(x, y)
 
   private int idOf(AstNode node) { idOfRaw(Synth::convertAstNodeToRaw(node), result) }
 

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -38,21 +38,42 @@ private module Input1 implements InputSig1<Location> {
     }
   }
 
-  class TypeParameterPosition = TypeParam;
+  private newtype TTypeParameterPosition =
+    TTypeParamTypeParameterPosition(TypeParam tp) or
+    TSelfTypeParameterPosition()
+
+  class TypeParameterPosition extends TTypeParameterPosition {
+    TypeParam asTypeParam() { this = TTypeParamTypeParameterPosition(result) }
+
+    predicate isSelf() { this = TSelfTypeParameterPosition() }
+
+    string toString() {
+      result = this.asTypeParam().toString()
+      or
+      result = "Self" and this.isSelf()
+    }
+  }
+
+  /** Holds if `typeParam`, `param` and `ppos` all concern the same `TypeParam`. */
+  additional predicate typeParamMatchPosition(
+    TypeParam typeParam, TypeParamTypeParameter param, TypeParameterPosition ppos
+  ) {
+    typeParam = param.getTypeParam() and typeParam = ppos.asTypeParam()
+  }
 
   bindingset[apos]
   bindingset[ppos]
   predicate typeArgumentParameterPositionMatch(TypeArgumentPosition apos, TypeParameterPosition ppos) {
-    apos.asTypeParam() = ppos
+    apos.asTypeParam() = ppos.asTypeParam()
     or
-    apos.asMethodTypeArgumentPosition() = ppos.getPosition()
+    apos.asMethodTypeArgumentPosition() = ppos.asTypeParam().getPosition()
   }
 
-  private predicate id(Raw::TypeParam x, Raw::TypeParam y) { x = y }
+  private predicate id(Raw::AstNode x, Raw::AstNode y) { x = y }
 
-  private predicate idOfRaw(Raw::TypeParam x, int y) = equivalenceRelation(id/2)(x, y)
+  private predicate idOfRaw(Raw::AstNode x, int y) = equivalenceRelation(id/2)(x, y)
 
-  private int idOf(TypeParam node) { idOfRaw(Synth::convertAstNodeToRaw(node), result) }
+  private int idOf(AstNode node) { idOfRaw(Synth::convertAstNodeToRaw(node), result) }
 
   int getTypeParameterId(TypeParameter tp) {
     tp =
@@ -61,12 +82,11 @@ private module Input1 implements InputSig1<Location> {
         kind = 0 and
         id = 0
         or
-        tp0 instanceof SelfTypeParameter and
-        kind = 0 and
-        id = 1
-        or
-        id = idOf(tp0.(TypeParamTypeParameter).getTypeParam()) and
-        kind = 1
+        kind = 1 and
+        exists(AstNode node | id = idOf(node) |
+          node = tp0.(TypeParamTypeParameter).getTypeParam() or
+          node = tp0.(SelfTypeParameter).getTrait()
+        )
       |
         tp0 order by kind, id
       )
@@ -211,15 +231,6 @@ private Type inferImplSelfType(Impl i, TypePath path) {
   result = i.getSelfTy().(TypeReprMention).resolveTypeAt(path)
 }
 
-pragma[nomagic]
-private Type inferTraitSelfType(Trait t, TypePath path) {
-  result = TTrait(t) and
-  path.isEmpty()
-  or
-  result = TTypeParamTypeParameter(t.getGenericParamList().getATypeParam()) and
-  path = TypePath::singleton(result)
-}
-
 /** Gets the type at `path` of the implicitly typed `self` parameter. */
 pragma[nomagic]
 private Type inferImplicitSelfType(SelfParam self, TypePath path) {
@@ -230,7 +241,7 @@ private Type inferImplicitSelfType(SelfParam self, TypePath path) {
   |
     t = inferImplSelfType(i, suffix)
     or
-    t = inferTraitSelfType(i, suffix)
+    t = TSelfTypeParameter(i) and suffix.isEmpty()
   )
 }
 
@@ -273,8 +284,7 @@ private module StructExprMatchingInput implements MatchingInputSig {
     abstract TypeParam getATypeParam();
 
     final TypeParameter getTypeParameter(TypeParameterPosition ppos) {
-      result.(TypeParamTypeParameter).getTypeParam() = ppos and
-      ppos = this.getATypeParam()
+      typeParamMatchPosition(this.getATypeParam(), result, ppos)
     }
 
     abstract StructField getField(string name);
@@ -417,12 +427,7 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
   }
 
   abstract class Declaration extends AstNode {
-    abstract TypeParam getATypeParam();
-
-    final TypeParameter getTypeParameter(TypeParameterPosition ppos) {
-      result.(TypeParamTypeParameter).getTypeParam() = ppos and
-      ppos = this.getATypeParam()
-    }
+    abstract TypeParameter getTypeParameter(TypeParameterPosition ppos);
 
     pragma[nomagic]
     abstract Type getParameterType(DeclarationPosition dpos, TypePath path);
@@ -440,7 +445,9 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
   private class TupleStructDecl extends Declaration, Struct {
     TupleStructDecl() { this.isTuple() }
 
-    override TypeParam getATypeParam() { result = this.getGenericParamList().getATypeParam() }
+    override TypeParameter getTypeParameter(TypeParameterPosition ppos) {
+      typeParamMatchPosition(this.getGenericParamList().getATypeParam(), result, ppos)
+    }
 
     override Type getParameterType(DeclarationPosition dpos, TypePath path) {
       exists(int pos |
@@ -461,8 +468,8 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
   private class TupleVariantDecl extends Declaration, Variant {
     TupleVariantDecl() { this.isTuple() }
 
-    override TypeParam getATypeParam() {
-      result = this.getEnum().getGenericParamList().getATypeParam()
+    override TypeParameter getTypeParameter(TypeParameterPosition ppos) {
+      typeParamMatchPosition(this.getEnum().getGenericParamList().getATypeParam(), result, ppos)
     }
 
     override Type getParameterType(DeclarationPosition dpos, TypePath path) {
@@ -483,38 +490,36 @@ private module CallExprBaseMatchingInput implements MatchingInputSig {
     }
   }
 
-  pragma[nomagic]
-  private Type inferAnnotatedTypeInclSelf(AstNode n, TypePath path) {
-    result = getTypeAnnotation(n).resolveTypeAtInclSelf(path)
-  }
-
   private class FunctionDecl extends Declaration, Function {
-    override TypeParam getATypeParam() { result = this.getGenericParamList().getATypeParam() }
+    override TypeParameter getTypeParameter(TypeParameterPosition ppos) {
+      typeParamMatchPosition(this.getGenericParamList().getATypeParam(), result, ppos)
+      or
+      exists(TraitItemNode trait | this = trait.getAnAssocItem() |
+        typeParamMatchPosition(trait.getTypeParam(_), result, ppos)
+        or
+        ppos.isSelf() and result = TSelfTypeParameter(trait)
+      )
+    }
 
     override Type getParameterType(DeclarationPosition dpos, TypePath path) {
       exists(Param p, int i, boolean inMethod |
         paramPos(this.getParamList(), p, i, inMethod) and
         dpos = TPositionalDeclarationPosition(i, inMethod) and
-        result = inferAnnotatedTypeInclSelf(p.getPat(), path)
+        result = inferAnnotatedType(p.getPat(), path)
       )
       or
       exists(SelfParam self |
         self = pragma[only_bind_into](this.getParamList().getSelfParam()) and
         dpos.isSelf()
       |
-        // `self` parameter with type annotation
-        result = inferAnnotatedTypeInclSelf(self, path)
+        result = inferAnnotatedType(self, path) // `self` parameter with type annotation
         or
-        // `self` parameter without type annotation
-        result = inferImplicitSelfType(self, path)
-        or
-        // `self` parameter without type annotation should also have the special `Self` type
-        result = getRefAdjustImplicitSelfType(self, TypePath::nil(), TSelfTypeParameter(), path)
+        result = inferImplicitSelfType(self, path) // `self` parameter without type annotation
       )
     }
 
     override Type getReturnType(TypePath path) {
-      result = this.getRetType().getTypeRepr().(TypeReprMention).resolveTypeAtInclSelf(path)
+      result = this.getRetType().getTypeRepr().(TypeReprMention).resolveTypeAt(path)
     }
   }
 

--- a/rust/ql/lib/codeql/rust/internal/TypeMention.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeMention.qll
@@ -29,27 +29,6 @@ abstract class TypeMention extends AstNode {
 
   /** Gets the type that the sub mention at `path` resolves to, if any. */
   Type resolveTypeAt(TypePath path) { result = this.getMentionAt(path).resolveType() }
-
-  /**
-   * Like `resolveTypeAt`, but also resolves `Self` mentions to the implicit
-   * `Self` type parameter.
-   *
-   * This is only needed when resolving types for calls to methods; inside the
-   * methods themselves, `Self` only resolves to the relevant trait or type
-   * being implemented.
-   */
-  final Type resolveTypeAtInclSelf(TypePath path) {
-    result = this.resolveTypeAt(path)
-    or
-    exists(TypeMention tm, ImplOrTraitItemNode node |
-      tm = this.getMentionAt(path) and
-      result = TSelfTypeParameter()
-    |
-      tm = node.getASelfPath()
-      or
-      tm.(PathTypeRepr).getPath() = node.getASelfPath()
-    )
-  }
 }
 
 class TypeReprMention extends TypeMention, TypeRepr {
@@ -80,11 +59,11 @@ class PathMention extends TypeMention, Path {
   override TypeMention getTypeArgument(int i) {
     result = this.getSegment().getGenericArgList().getTypeArg(i)
     or
-    // `Self` paths inside traits and `impl` blocks have implicit type arguments
-    // that are the type parameters of the trait or impl. For example, in
+    // `Self` paths inside `impl` blocks have implicit type arguments that are
+    // the type parameters of the `impl` block. For example, in
     //
     // ```rust
-    // impl Foo<T> {
+    // impl<T> Foo<T> {
     //   fn m(self) -> Self {
     //     self
     //   }
@@ -92,10 +71,9 @@ class PathMention extends TypeMention, Path {
     // ```
     //
     // the `Self` return type is shorthand for `Foo<T>`.
-    exists(ImplOrTraitItemNode node | this = node.getASelfPath() |
+    exists(ImplItemNode node |
+      this = node.getASelfPath() and
       result = node.(ImplItemNode).getSelfPath().getSegment().getGenericArgList().getTypeArg(i)
-      or
-      result = node.(Trait).getGenericParamList().getTypeParam(i)
     )
   }
 
@@ -105,7 +83,13 @@ class PathMention extends TypeMention, Path {
       or
       result = TEnum(i)
       or
-      result = TTrait(i)
+      exists(TraitItemNode trait | trait = i |
+        // If this is a `Self` path, then it resolves to the implicit `Self`
+        // type parameter, otherwise it is a trait bound.
+        if this = trait.getASelfPath()
+        then result = TSelfTypeParameter(trait)
+        else result = TTrait(trait)
+      )
       or
       result = TTypeParamTypeParameter(i)
       or
@@ -170,4 +154,10 @@ class ImplMention extends TypeMention, ImplItemNode {
       path = TypePath::singleton(tp)
     )
   }
+}
+
+class TraitMention extends TypeMention, TraitItemNode {
+  override TypeMention getTypeArgument(int i) { result = this.getTypeParam(i) }
+
+  override Type resolveType() { result = TTrait(this) }
 }

--- a/rust/ql/test/library-tests/type-inference/type-inference.expected
+++ b/rust/ql/test/library-tests/type-inference/type-inference.expected
@@ -1,42 +1,7 @@
 inferType
-| loop/main.rs:7:12:7:15 | SelfParam |  | loop/main.rs:6:1:8:1 | trait T1 |
-| loop/main.rs:7:12:7:15 | SelfParam | T | loop/main.rs:6:10:6:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam |  | loop/main.rs:6:1:8:1 | trait T1 |
-| loop/main.rs:11:12:11:15 | SelfParam |  | loop/main.rs:10:1:14:1 | trait T2 |
-| loop/main.rs:11:12:11:15 | SelfParam | T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:11:12:11:15 | SelfParam | T.T.T.T.T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self |  | loop/main.rs:6:1:8:1 | trait T1 |
-| loop/main.rs:12:9:12:12 | self |  | loop/main.rs:10:1:14:1 | trait T2 |
-| loop/main.rs:12:9:12:12 | self | T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self | T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self | T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T.T.T.T | loop/main.rs:4:1:4:15 | struct S |
-| loop/main.rs:12:9:12:12 | self | T.T.T.T.T.T.T.T.T.T | loop/main.rs:10:10:10:10 | T |
+| loop/main.rs:7:12:7:15 | SelfParam |  | loop/main.rs:6:1:8:1 | Self [trait T1] |
+| loop/main.rs:11:12:11:15 | SelfParam |  | loop/main.rs:10:1:14:1 | Self [trait T2] |
+| loop/main.rs:12:9:12:12 | self |  | loop/main.rs:10:1:14:1 | Self [trait T2] |
 | main.rs:26:13:26:13 | x |  | main.rs:5:5:8:5 | struct MyThing |
 | main.rs:26:17:26:32 | MyThing {...} |  | main.rs:5:5:8:5 | struct MyThing |
 | main.rs:26:30:26:30 | S |  | main.rs:2:5:3:13 | struct S |
@@ -171,21 +136,13 @@ inferType
 | main.rs:137:26:137:26 | y |  | main.rs:94:5:97:5 | struct MyThing |
 | main.rs:137:26:137:26 | y | A | main.rs:101:5:102:14 | struct S2 |
 | main.rs:137:26:137:31 | y.m2(...) |  | main.rs:101:5:102:14 | struct S2 |
-| main.rs:153:15:153:18 | SelfParam |  | main.rs:152:5:161:5 | trait MyTrait |
-| main.rs:153:15:153:18 | SelfParam | A | main.rs:152:19:152:19 | A |
-| main.rs:155:15:155:18 | SelfParam |  | main.rs:152:5:161:5 | trait MyTrait |
-| main.rs:155:15:155:18 | SelfParam | A | main.rs:152:19:152:19 | A |
-| main.rs:158:9:160:9 | { ... } |  | main.rs:152:5:161:5 | trait MyTrait |
-| main.rs:158:9:160:9 | { ... } | A | main.rs:152:19:152:19 | A |
-| main.rs:159:13:159:16 | self |  | main.rs:152:5:161:5 | trait MyTrait |
-| main.rs:159:13:159:16 | self | A | main.rs:152:19:152:19 | A |
-| main.rs:163:43:163:43 | x |  | main.rs:152:5:161:5 | trait MyTrait |
+| main.rs:153:15:153:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
+| main.rs:155:15:155:18 | SelfParam |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
+| main.rs:158:9:160:9 | { ... } |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
+| main.rs:159:13:159:16 | self |  | main.rs:152:5:161:5 | Self [trait MyTrait] |
 | main.rs:163:43:163:43 | x |  | main.rs:163:26:163:40 | T2 |
-| main.rs:163:43:163:43 | x | A | main.rs:163:22:163:23 | T1 |
 | main.rs:163:56:165:5 | { ... } |  | main.rs:163:22:163:23 | T1 |
-| main.rs:164:9:164:9 | x |  | main.rs:152:5:161:5 | trait MyTrait |
 | main.rs:164:9:164:9 | x |  | main.rs:163:26:163:40 | T2 |
-| main.rs:164:9:164:9 | x | A | main.rs:163:22:163:23 | T1 |
 | main.rs:164:9:164:14 | x.m1(...) |  | main.rs:163:22:163:23 | T1 |
 | main.rs:168:15:168:18 | SelfParam |  | main.rs:142:5:145:5 | struct MyThing |
 | main.rs:168:15:168:18 | SelfParam | A | main.rs:147:5:148:14 | struct S1 |
@@ -230,124 +187,65 @@ inferType
 | main.rs:189:40:189:40 | x | A | main.rs:147:5:148:14 | struct S1 |
 | main.rs:190:40:190:40 | y |  | main.rs:142:5:145:5 | struct MyThing |
 | main.rs:190:40:190:40 | y | A | main.rs:149:5:150:14 | struct S2 |
-| main.rs:206:19:206:22 | SelfParam |  | main.rs:205:5:207:5 | trait FirstTrait |
-| main.rs:206:19:206:22 | SelfParam | FT | main.rs:205:22:205:23 | FT |
-| main.rs:210:19:210:22 | SelfParam |  | main.rs:209:5:211:5 | trait SecondTrait |
-| main.rs:210:19:210:22 | SelfParam | ST | main.rs:209:23:209:24 | ST |
-| main.rs:213:64:213:64 | x |  | main.rs:209:5:211:5 | trait SecondTrait |
+| main.rs:206:19:206:22 | SelfParam |  | main.rs:205:5:207:5 | Self [trait FirstTrait] |
+| main.rs:210:19:210:22 | SelfParam |  | main.rs:209:5:211:5 | Self [trait SecondTrait] |
 | main.rs:213:64:213:64 | x |  | main.rs:213:45:213:61 | T |
-| main.rs:213:64:213:64 | x | ST | main.rs:213:35:213:42 | I |
 | main.rs:215:13:215:14 | s1 |  | main.rs:213:35:213:42 | I |
-| main.rs:215:18:215:18 | x |  | main.rs:209:5:211:5 | trait SecondTrait |
 | main.rs:215:18:215:18 | x |  | main.rs:213:45:213:61 | T |
-| main.rs:215:18:215:18 | x | ST | main.rs:213:35:213:42 | I |
 | main.rs:215:18:215:27 | x.method(...) |  | main.rs:213:35:213:42 | I |
 | main.rs:216:26:216:27 | s1 |  | main.rs:213:35:213:42 | I |
-| main.rs:219:65:219:65 | x |  | main.rs:209:5:211:5 | trait SecondTrait |
 | main.rs:219:65:219:65 | x |  | main.rs:219:46:219:62 | T |
-| main.rs:219:65:219:65 | x | ST | main.rs:219:36:219:43 | I |
 | main.rs:221:13:221:14 | s2 |  | main.rs:219:36:219:43 | I |
-| main.rs:221:18:221:18 | x |  | main.rs:209:5:211:5 | trait SecondTrait |
 | main.rs:221:18:221:18 | x |  | main.rs:219:46:219:62 | T |
-| main.rs:221:18:221:18 | x | ST | main.rs:219:36:219:43 | I |
 | main.rs:221:18:221:27 | x.method(...) |  | main.rs:219:36:219:43 | I |
 | main.rs:222:26:222:27 | s2 |  | main.rs:219:36:219:43 | I |
-| main.rs:225:49:225:49 | x |  | main.rs:205:5:207:5 | trait FirstTrait |
 | main.rs:225:49:225:49 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:225:49:225:49 | x | FT | main.rs:197:5:198:14 | struct S1 |
 | main.rs:226:13:226:13 | s |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:226:17:226:17 | x |  | main.rs:205:5:207:5 | trait FirstTrait |
 | main.rs:226:17:226:17 | x |  | main.rs:225:30:225:46 | T |
-| main.rs:226:17:226:17 | x | FT | main.rs:197:5:198:14 | struct S1 |
 | main.rs:226:17:226:26 | x.method(...) |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:227:26:227:26 | s |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:230:53:230:53 | x |  | main.rs:205:5:207:5 | trait FirstTrait |
 | main.rs:230:53:230:53 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:230:53:230:53 | x | FT | main.rs:197:5:198:14 | struct S1 |
 | main.rs:231:13:231:13 | s |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:231:17:231:17 | x |  | main.rs:205:5:207:5 | trait FirstTrait |
 | main.rs:231:17:231:17 | x |  | main.rs:230:34:230:50 | T |
-| main.rs:231:17:231:17 | x | FT | main.rs:197:5:198:14 | struct S1 |
 | main.rs:231:17:231:26 | x.method(...) |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:232:26:232:26 | s |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:236:16:236:19 | SelfParam |  | main.rs:235:5:239:5 | trait Pair |
-| main.rs:236:16:236:19 | SelfParam | P1 | main.rs:235:16:235:17 | P1 |
-| main.rs:236:16:236:19 | SelfParam | P2 | main.rs:235:20:235:21 | P2 |
-| main.rs:238:16:238:19 | SelfParam |  | main.rs:235:5:239:5 | trait Pair |
-| main.rs:238:16:238:19 | SelfParam | P1 | main.rs:235:16:235:17 | P1 |
-| main.rs:238:16:238:19 | SelfParam | P2 | main.rs:235:20:235:21 | P2 |
-| main.rs:241:58:241:58 | x |  | main.rs:235:5:239:5 | trait Pair |
+| main.rs:236:16:236:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
+| main.rs:238:16:238:19 | SelfParam |  | main.rs:235:5:239:5 | Self [trait Pair] |
 | main.rs:241:58:241:58 | x |  | main.rs:241:41:241:55 | T |
-| main.rs:241:58:241:58 | x | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:241:58:241:58 | x | P2 | main.rs:200:5:201:14 | struct S2 |
-| main.rs:241:64:241:64 | y |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:241:64:241:64 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:241:64:241:64 | y | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:241:64:241:64 | y | P2 | main.rs:200:5:201:14 | struct S2 |
 | main.rs:243:13:243:14 | s1 |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:243:18:243:18 | x |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:243:18:243:18 | x |  | main.rs:241:41:241:55 | T |
-| main.rs:243:18:243:18 | x | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:243:18:243:18 | x | P2 | main.rs:200:5:201:14 | struct S2 |
 | main.rs:243:18:243:24 | x.fst(...) |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:244:13:244:14 | s2 |  | main.rs:200:5:201:14 | struct S2 |
-| main.rs:244:18:244:18 | y |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:244:18:244:18 | y |  | main.rs:241:41:241:55 | T |
-| main.rs:244:18:244:18 | y | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:244:18:244:18 | y | P2 | main.rs:200:5:201:14 | struct S2 |
 | main.rs:244:18:244:24 | y.snd(...) |  | main.rs:200:5:201:14 | struct S2 |
 | main.rs:245:32:245:33 | s1 |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:245:36:245:37 | s2 |  | main.rs:200:5:201:14 | struct S2 |
-| main.rs:248:69:248:69 | x |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:248:69:248:69 | x |  | main.rs:248:52:248:66 | T |
-| main.rs:248:69:248:69 | x | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:248:69:248:69 | x | P2 | main.rs:248:41:248:49 | T2 |
-| main.rs:248:75:248:75 | y |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:248:75:248:75 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:248:75:248:75 | y | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:248:75:248:75 | y | P2 | main.rs:248:41:248:49 | T2 |
 | main.rs:250:13:250:14 | s1 |  | main.rs:197:5:198:14 | struct S1 |
-| main.rs:250:18:250:18 | x |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:250:18:250:18 | x |  | main.rs:248:52:248:66 | T |
-| main.rs:250:18:250:18 | x | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:250:18:250:18 | x | P2 | main.rs:248:41:248:49 | T2 |
 | main.rs:250:18:250:24 | x.fst(...) |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:251:13:251:14 | s2 |  | main.rs:248:41:248:49 | T2 |
-| main.rs:251:18:251:18 | y |  | main.rs:235:5:239:5 | trait Pair |
 | main.rs:251:18:251:18 | y |  | main.rs:248:52:248:66 | T |
-| main.rs:251:18:251:18 | y | P1 | main.rs:197:5:198:14 | struct S1 |
-| main.rs:251:18:251:18 | y | P2 | main.rs:248:41:248:49 | T2 |
 | main.rs:251:18:251:24 | y.snd(...) |  | main.rs:248:41:248:49 | T2 |
 | main.rs:252:32:252:33 | s1 |  | main.rs:197:5:198:14 | struct S1 |
 | main.rs:252:36:252:37 | s2 |  | main.rs:248:41:248:49 | T2 |
-| main.rs:268:15:268:18 | SelfParam |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:268:15:268:18 | SelfParam | A | main.rs:267:19:267:19 | A |
-| main.rs:270:15:270:18 | SelfParam |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:270:15:270:18 | SelfParam | A | main.rs:267:19:267:19 | A |
+| main.rs:268:15:268:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
+| main.rs:270:15:270:18 | SelfParam |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
 | main.rs:273:9:275:9 | { ... } |  | main.rs:267:19:267:19 | A |
-| main.rs:274:13:274:16 | self |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:274:13:274:16 | self | A | main.rs:267:19:267:19 | A |
+| main.rs:274:13:274:16 | self |  | main.rs:267:5:276:5 | Self [trait MyTrait] |
 | main.rs:274:13:274:21 | self.m1(...) |  | main.rs:267:19:267:19 | A |
-| main.rs:279:43:279:43 | x |  | main.rs:267:5:276:5 | trait MyTrait |
 | main.rs:279:43:279:43 | x |  | main.rs:279:26:279:40 | T2 |
-| main.rs:279:43:279:43 | x | A | main.rs:279:22:279:23 | T1 |
 | main.rs:279:56:281:5 | { ... } |  | main.rs:279:22:279:23 | T1 |
-| main.rs:280:9:280:9 | x |  | main.rs:267:5:276:5 | trait MyTrait |
 | main.rs:280:9:280:9 | x |  | main.rs:279:26:279:40 | T2 |
-| main.rs:280:9:280:9 | x | A | main.rs:279:22:279:23 | T1 |
 | main.rs:280:9:280:14 | x.m1(...) |  | main.rs:279:22:279:23 | T1 |
 | main.rs:284:49:284:49 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:284:49:284:49 | x | T | main.rs:267:5:276:5 | trait MyTrait |
 | main.rs:284:49:284:49 | x | T | main.rs:284:32:284:46 | T2 |
-| main.rs:284:49:284:49 | x | T.A | main.rs:284:28:284:29 | T1 |
 | main.rs:284:71:286:5 | { ... } |  | main.rs:284:28:284:29 | T1 |
 | main.rs:285:9:285:9 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:285:9:285:9 | x | T | main.rs:267:5:276:5 | trait MyTrait |
 | main.rs:285:9:285:9 | x | T | main.rs:284:32:284:46 | T2 |
-| main.rs:285:9:285:9 | x | T.A | main.rs:284:28:284:29 | T1 |
-| main.rs:285:9:285:11 | x.a |  | main.rs:267:5:276:5 | trait MyTrait |
 | main.rs:285:9:285:11 | x.a |  | main.rs:284:32:284:46 | T2 |
-| main.rs:285:9:285:11 | x.a | A | main.rs:284:28:284:29 | T1 |
 | main.rs:285:9:285:16 | ... .m1(...) |  | main.rs:284:28:284:29 | T1 |
 | main.rs:289:15:289:18 | SelfParam |  | main.rs:257:5:260:5 | struct MyThing |
 | main.rs:289:15:289:18 | SelfParam | T | main.rs:288:10:288:10 | T |
@@ -372,31 +270,19 @@ inferType
 | main.rs:299:26:299:26 | y | T | main.rs:264:5:265:14 | struct S2 |
 | main.rs:299:26:299:31 | y.m1(...) |  | main.rs:264:5:265:14 | struct S2 |
 | main.rs:301:13:301:13 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:301:13:301:13 | x |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:301:13:301:13 | x | A | main.rs:262:5:263:14 | struct S1 |
 | main.rs:301:13:301:13 | x | T | main.rs:262:5:263:14 | struct S1 |
 | main.rs:301:17:301:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:301:17:301:33 | MyThing {...} |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:301:17:301:33 | MyThing {...} | A | main.rs:262:5:263:14 | struct S1 |
 | main.rs:301:17:301:33 | MyThing {...} | T | main.rs:262:5:263:14 | struct S1 |
 | main.rs:301:30:301:31 | S1 |  | main.rs:262:5:263:14 | struct S1 |
 | main.rs:302:13:302:13 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:302:13:302:13 | y |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:302:13:302:13 | y | A | main.rs:264:5:265:14 | struct S2 |
 | main.rs:302:13:302:13 | y | T | main.rs:264:5:265:14 | struct S2 |
 | main.rs:302:17:302:33 | MyThing {...} |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:302:17:302:33 | MyThing {...} |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:302:17:302:33 | MyThing {...} | A | main.rs:264:5:265:14 | struct S2 |
 | main.rs:302:17:302:33 | MyThing {...} | T | main.rs:264:5:265:14 | struct S2 |
 | main.rs:302:30:302:31 | S2 |  | main.rs:264:5:265:14 | struct S2 |
 | main.rs:304:26:304:26 | x |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:304:26:304:26 | x |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:304:26:304:26 | x | A | main.rs:262:5:263:14 | struct S1 |
 | main.rs:304:26:304:26 | x | T | main.rs:262:5:263:14 | struct S1 |
 | main.rs:304:26:304:31 | x.m2(...) |  | main.rs:262:5:263:14 | struct S1 |
 | main.rs:305:26:305:26 | y |  | main.rs:257:5:260:5 | struct MyThing |
-| main.rs:305:26:305:26 | y |  | main.rs:267:5:276:5 | trait MyTrait |
-| main.rs:305:26:305:26 | y | A | main.rs:264:5:265:14 | struct S2 |
 | main.rs:305:26:305:26 | y | T | main.rs:264:5:265:14 | struct S2 |
 | main.rs:305:26:305:31 | y.m2(...) |  | main.rs:264:5:265:14 | struct S2 |
 | main.rs:307:13:307:14 | x2 |  | main.rs:257:5:260:5 | struct MyThing |
@@ -441,8 +327,8 @@ inferType
 | main.rs:321:46:321:47 | y3 |  | main.rs:257:5:260:5 | struct MyThing |
 | main.rs:321:46:321:47 | y3 | T | main.rs:257:5:260:5 | struct MyThing |
 | main.rs:321:46:321:47 | y3 | T.T | main.rs:264:5:265:14 | struct S2 |
-| main.rs:329:15:329:18 | SelfParam |  | main.rs:326:5:338:5 | trait MyTrait |
-| main.rs:331:15:331:18 | SelfParam |  | main.rs:326:5:338:5 | trait MyTrait |
+| main.rs:329:15:329:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
+| main.rs:331:15:331:18 | SelfParam |  | main.rs:326:5:338:5 | Self [trait MyTrait] |
 | main.rs:346:15:346:18 | SelfParam |  | main.rs:340:5:341:13 | struct S |
 | main.rs:346:45:348:9 | { ... } |  | main.rs:340:5:341:13 | struct S |
 | main.rs:347:13:347:13 | S |  | main.rs:340:5:341:13 | struct S |
@@ -450,11 +336,8 @@ inferType
 | main.rs:352:17:352:17 | S |  | main.rs:340:5:341:13 | struct S |
 | main.rs:353:26:353:26 | x |  | main.rs:340:5:341:13 | struct S |
 | main.rs:353:26:353:31 | x.m1(...) |  | main.rs:340:5:341:13 | struct S |
-| main.rs:355:13:355:13 | x |  | main.rs:326:5:338:5 | trait MyTrait |
 | main.rs:355:13:355:13 | x |  | main.rs:340:5:341:13 | struct S |
-| main.rs:355:17:355:17 | S |  | main.rs:326:5:338:5 | trait MyTrait |
 | main.rs:355:17:355:17 | S |  | main.rs:340:5:341:13 | struct S |
-| main.rs:356:26:356:26 | x |  | main.rs:326:5:338:5 | trait MyTrait |
 | main.rs:356:26:356:26 | x |  | main.rs:340:5:341:13 | struct S |
 | main.rs:373:15:373:18 | SelfParam |  | main.rs:361:5:365:5 | enum MyEnum |
 | main.rs:373:15:373:18 | SelfParam | A | main.rs:372:10:372:10 | T |
@@ -482,39 +365,21 @@ inferType
 | main.rs:386:26:386:26 | y |  | main.rs:361:5:365:5 | enum MyEnum |
 | main.rs:386:26:386:26 | y | A | main.rs:369:5:370:14 | struct S2 |
 | main.rs:386:26:386:31 | y.m1(...) |  | main.rs:369:5:370:14 | struct S2 |
-| main.rs:407:15:407:18 | SelfParam |  | main.rs:406:5:408:5 | trait MyTrait1 |
-| main.rs:407:15:407:18 | SelfParam | Tr1 | main.rs:406:20:406:22 | Tr1 |
-| main.rs:411:15:411:18 | SelfParam |  | main.rs:406:5:408:5 | trait MyTrait1 |
-| main.rs:411:15:411:18 | SelfParam |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:411:15:411:18 | SelfParam | Tr1 | main.rs:410:20:410:22 | Tr2 |
-| main.rs:411:15:411:18 | SelfParam | Tr2 | main.rs:410:20:410:22 | Tr2 |
+| main.rs:407:15:407:18 | SelfParam |  | main.rs:406:5:408:5 | Self [trait MyTrait1] |
+| main.rs:411:15:411:18 | SelfParam |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
 | main.rs:414:9:420:9 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:415:13:419:13 | if ... {...} else {...} |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:415:26:417:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:416:17:416:20 | self |  | main.rs:406:5:408:5 | trait MyTrait1 |
-| main.rs:416:17:416:20 | self |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:416:17:416:20 | self | Tr1 | main.rs:410:20:410:22 | Tr2 |
-| main.rs:416:17:416:20 | self | Tr2 | main.rs:410:20:410:22 | Tr2 |
+| main.rs:416:17:416:20 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
 | main.rs:416:17:416:25 | self.m1(...) |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:417:20:419:13 | { ... } |  | main.rs:410:20:410:22 | Tr2 |
 | main.rs:418:17:418:30 | ...::m1(...) |  | main.rs:410:20:410:22 | Tr2 |
-| main.rs:418:26:418:29 | self |  | main.rs:406:5:408:5 | trait MyTrait1 |
-| main.rs:418:26:418:29 | self |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:418:26:418:29 | self | Tr1 | main.rs:410:20:410:22 | Tr2 |
-| main.rs:418:26:418:29 | self | Tr2 | main.rs:410:20:410:22 | Tr2 |
-| main.rs:424:15:424:18 | SelfParam |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:424:15:424:18 | SelfParam |  | main.rs:423:5:434:5 | trait MyTrait3 |
-| main.rs:424:15:424:18 | SelfParam | Tr2 | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:424:15:424:18 | SelfParam | Tr2.A | main.rs:423:20:423:22 | Tr3 |
-| main.rs:424:15:424:18 | SelfParam | Tr3 | main.rs:423:20:423:22 | Tr3 |
+| main.rs:418:26:418:29 | self |  | main.rs:410:5:421:5 | Self [trait MyTrait2] |
+| main.rs:424:15:424:18 | SelfParam |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
 | main.rs:427:9:433:9 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:428:13:432:13 | if ... {...} else {...} |  | main.rs:423:20:423:22 | Tr3 |
 | main.rs:428:26:430:13 | { ... } |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:429:17:429:20 | self |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:429:17:429:20 | self |  | main.rs:423:5:434:5 | trait MyTrait3 |
-| main.rs:429:17:429:20 | self | Tr2 | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:429:17:429:20 | self | Tr2.A | main.rs:423:20:423:22 | Tr3 |
-| main.rs:429:17:429:20 | self | Tr3 | main.rs:423:20:423:22 | Tr3 |
+| main.rs:429:17:429:20 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
 | main.rs:429:17:429:25 | self.m2(...) |  | main.rs:391:5:394:5 | struct MyThing |
 | main.rs:429:17:429:25 | self.m2(...) | A | main.rs:423:20:423:22 | Tr3 |
 | main.rs:429:17:429:27 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
@@ -522,11 +387,7 @@ inferType
 | main.rs:431:17:431:30 | ...::m2(...) |  | main.rs:391:5:394:5 | struct MyThing |
 | main.rs:431:17:431:30 | ...::m2(...) | A | main.rs:423:20:423:22 | Tr3 |
 | main.rs:431:17:431:32 | ... .a |  | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:26:431:29 | self |  | main.rs:410:5:421:5 | trait MyTrait2 |
-| main.rs:431:26:431:29 | self |  | main.rs:423:5:434:5 | trait MyTrait3 |
-| main.rs:431:26:431:29 | self | Tr2 | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:431:26:431:29 | self | Tr2.A | main.rs:423:20:423:22 | Tr3 |
-| main.rs:431:26:431:29 | self | Tr3 | main.rs:423:20:423:22 | Tr3 |
+| main.rs:431:26:431:29 | self |  | main.rs:423:5:434:5 | Self [trait MyTrait3] |
 | main.rs:437:15:437:18 | SelfParam |  | main.rs:391:5:394:5 | struct MyThing |
 | main.rs:437:15:437:18 | SelfParam | A | main.rs:436:10:436:10 | T |
 | main.rs:437:26:439:9 | { ... } |  | main.rs:436:10:436:10 | T |
@@ -559,60 +420,36 @@ inferType
 | main.rs:459:26:459:26 | y | A | main.rs:403:5:404:14 | struct S2 |
 | main.rs:459:26:459:31 | y.m1(...) |  | main.rs:403:5:404:14 | struct S2 |
 | main.rs:461:13:461:13 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:461:13:461:13 | x |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:461:13:461:13 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:461:13:461:13 | x | Tr2 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:461:17:461:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:461:17:461:33 | MyThing {...} |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:461:17:461:33 | MyThing {...} | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:461:17:461:33 | MyThing {...} | Tr2 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:461:30:461:31 | S1 |  | main.rs:401:5:402:14 | struct S1 |
 | main.rs:462:13:462:13 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:462:13:462:13 | y |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:462:13:462:13 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:462:13:462:13 | y | Tr2 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:462:17:462:33 | MyThing {...} |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:462:17:462:33 | MyThing {...} |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:462:17:462:33 | MyThing {...} | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:462:17:462:33 | MyThing {...} | Tr2 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:462:30:462:31 | S2 |  | main.rs:403:5:404:14 | struct S2 |
 | main.rs:464:26:464:26 | x |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:464:26:464:26 | x |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:464:26:464:26 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:464:26:464:26 | x | Tr2 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:464:26:464:31 | x.m2(...) |  | main.rs:401:5:402:14 | struct S1 |
 | main.rs:465:26:465:26 | y |  | main.rs:391:5:394:5 | struct MyThing |
-| main.rs:465:26:465:26 | y |  | main.rs:410:5:421:5 | trait MyTrait2 |
 | main.rs:465:26:465:26 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:465:26:465:26 | y | Tr2 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:465:26:465:31 | y.m2(...) |  | main.rs:403:5:404:14 | struct S2 |
 | main.rs:467:13:467:13 | x |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:467:13:467:13 | x |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:467:13:467:13 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:467:13:467:13 | x | Tr3 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:467:17:467:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:467:17:467:34 | MyThing2 {...} |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:467:17:467:34 | MyThing2 {...} | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:467:17:467:34 | MyThing2 {...} | Tr3 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:467:31:467:32 | S1 |  | main.rs:401:5:402:14 | struct S1 |
 | main.rs:468:13:468:13 | y |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:468:13:468:13 | y |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:468:13:468:13 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:468:13:468:13 | y | Tr3 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:468:17:468:34 | MyThing2 {...} |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:468:17:468:34 | MyThing2 {...} |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:468:17:468:34 | MyThing2 {...} | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:468:17:468:34 | MyThing2 {...} | Tr3 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:468:31:468:32 | S2 |  | main.rs:403:5:404:14 | struct S2 |
 | main.rs:470:26:470:26 | x |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:470:26:470:26 | x |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:470:26:470:26 | x | A | main.rs:401:5:402:14 | struct S1 |
-| main.rs:470:26:470:26 | x | Tr3 | main.rs:401:5:402:14 | struct S1 |
 | main.rs:470:26:470:31 | x.m3(...) |  | main.rs:401:5:402:14 | struct S1 |
 | main.rs:471:26:471:26 | y |  | main.rs:396:5:399:5 | struct MyThing2 |
-| main.rs:471:26:471:26 | y |  | main.rs:423:5:434:5 | trait MyTrait3 |
 | main.rs:471:26:471:26 | y | A | main.rs:403:5:404:14 | struct S2 |
-| main.rs:471:26:471:26 | y | Tr3 | main.rs:403:5:404:14 | struct S2 |
 | main.rs:471:26:471:31 | y.m3(...) |  | main.rs:403:5:404:14 | struct S2 |
 | main.rs:489:22:489:22 | x |  | file://:0:0:0:0 | & |
 | main.rs:489:22:489:22 | x | &T | main.rs:489:11:489:19 | T |
@@ -685,16 +522,13 @@ inferType
 | main.rs:563:26:563:27 | p3 |  | main.rs:525:5:531:5 | enum PairOption |
 | main.rs:563:26:563:27 | p3 | Fst | main.rs:539:5:540:14 | struct S3 |
 | main.rs:575:16:575:24 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:575:16:575:24 | SelfParam | &T | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:575:16:575:24 | SelfParam | &T.S | main.rs:574:19:574:19 | S |
+| main.rs:575:16:575:24 | SelfParam | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
 | main.rs:575:27:575:31 | value |  | main.rs:574:19:574:19 | S |
 | main.rs:577:21:577:29 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:577:21:577:29 | SelfParam | &T | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:577:21:577:29 | SelfParam | &T.S | main.rs:574:19:574:19 | S |
+| main.rs:577:21:577:29 | SelfParam | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
 | main.rs:577:32:577:36 | value |  | main.rs:574:19:574:19 | S |
 | main.rs:578:13:578:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:578:13:578:16 | self | &T | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:578:13:578:16 | self | &T.S | main.rs:574:19:574:19 | S |
+| main.rs:578:13:578:16 | self | &T | main.rs:574:5:580:5 | Self [trait MyTrait] |
 | main.rs:578:22:578:26 | value |  | main.rs:574:19:574:19 | S |
 | main.rs:583:16:583:24 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:583:16:583:24 | SelfParam | &T | main.rs:568:5:572:5 | enum MyOption |
@@ -733,18 +567,10 @@ inferType
 | main.rs:610:26:610:27 | x2 |  | main.rs:568:5:572:5 | enum MyOption |
 | main.rs:610:26:610:27 | x2 | T | main.rs:601:5:602:13 | struct S |
 | main.rs:612:13:612:18 | mut x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:612:13:612:18 | mut x3 |  | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:612:13:612:18 | mut x3 | S | main.rs:601:5:602:13 | struct S |
 | main.rs:612:22:612:36 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:612:22:612:36 | ...::new(...) |  | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:612:22:612:36 | ...::new(...) | S | main.rs:601:5:602:13 | struct S |
 | main.rs:613:9:613:10 | x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:613:9:613:10 | x3 |  | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:613:9:613:10 | x3 | S | main.rs:601:5:602:13 | struct S |
 | main.rs:613:21:613:21 | S |  | main.rs:601:5:602:13 | struct S |
 | main.rs:614:26:614:27 | x3 |  | main.rs:568:5:572:5 | enum MyOption |
-| main.rs:614:26:614:27 | x3 |  | main.rs:574:5:580:5 | trait MyTrait |
-| main.rs:614:26:614:27 | x3 | S | main.rs:601:5:602:13 | struct S |
 | main.rs:616:13:616:18 | mut x4 |  | main.rs:568:5:572:5 | enum MyOption |
 | main.rs:616:13:616:18 | mut x4 | T | main.rs:601:5:602:13 | struct S |
 | main.rs:616:22:616:36 | ...::new(...) |  | main.rs:568:5:572:5 | enum MyOption |
@@ -940,29 +766,25 @@ inferType
 | main.rs:697:28:697:29 | x6 | &T | main.rs:651:5:652:19 | struct S |
 | main.rs:697:28:697:29 | x6 | &T.T | main.rs:654:5:655:14 | struct S2 |
 | main.rs:703:16:703:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:703:16:703:20 | SelfParam | &T | main.rs:702:5:708:5 | trait MyTrait |
+| main.rs:703:16:703:20 | SelfParam | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:705:16:705:20 | SelfParam |  | file://:0:0:0:0 | & |
-| main.rs:705:16:705:20 | SelfParam | &T | main.rs:702:5:708:5 | trait MyTrait |
+| main.rs:705:16:705:20 | SelfParam | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:705:32:707:9 | { ... } |  | file://:0:0:0:0 | & |
-| main.rs:705:32:707:9 | { ... } | &T | main.rs:702:5:708:5 | trait MyTrait |
+| main.rs:705:32:707:9 | { ... } | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:706:13:706:16 | self |  | file://:0:0:0:0 | & |
-| main.rs:706:13:706:16 | self | &T | main.rs:702:5:708:5 | trait MyTrait |
+| main.rs:706:13:706:16 | self | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:706:13:706:22 | self.foo(...) |  | file://:0:0:0:0 | & |
-| main.rs:706:13:706:22 | self.foo(...) | &T | main.rs:702:5:708:5 | trait MyTrait |
+| main.rs:706:13:706:22 | self.foo(...) | &T | main.rs:702:5:708:5 | Self [trait MyTrait] |
 | main.rs:713:16:713:20 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:713:16:713:20 | SelfParam | &T | main.rs:710:5:710:20 | struct MyStruct |
 | main.rs:713:36:715:9 | { ... } |  | file://:0:0:0:0 | & |
 | main.rs:713:36:715:9 | { ... } | &T | main.rs:710:5:710:20 | struct MyStruct |
 | main.rs:714:13:714:16 | self |  | file://:0:0:0:0 | & |
 | main.rs:714:13:714:16 | self | &T | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:719:13:719:13 | x |  | main.rs:702:5:708:5 | trait MyTrait |
 | main.rs:719:13:719:13 | x |  | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:719:17:719:24 | MyStruct |  | main.rs:702:5:708:5 | trait MyTrait |
 | main.rs:719:17:719:24 | MyStruct |  | main.rs:710:5:710:20 | struct MyStruct |
-| main.rs:720:9:720:9 | x |  | main.rs:702:5:708:5 | trait MyTrait |
 | main.rs:720:9:720:9 | x |  | main.rs:710:5:710:20 | struct MyStruct |
 | main.rs:720:9:720:15 | x.bar(...) |  | file://:0:0:0:0 | & |
-| main.rs:720:9:720:15 | x.bar(...) | &T | main.rs:702:5:708:5 | trait MyTrait |
 | main.rs:720:9:720:15 | x.bar(...) | &T | main.rs:710:5:710:20 | struct MyStruct |
 | main.rs:730:16:730:20 | SelfParam |  | file://:0:0:0:0 | & |
 | main.rs:730:16:730:20 | SelfParam | &T | main.rs:727:5:727:26 | struct MyStruct |


### PR DESCRIPTION
This PR changes how the `Self` parameter is handled in trait methods. Suppose some trait `Trait<A>`. Today a method on this trait is handled like this (where the `|` is some fictional syntax):
```rust
fn before<Self>(self: Self | Trait<A>) -> A;
```
The `self` parameter has the type of an implicit `Self` parameter and the trait type. On a call the passed `self` is then matched as a "subtype" of `Trait<A>` to infer `A`.

With this PR the situration is now like this:
```rust
fn after<A, Self : Trait<A>>(self: Self) -> A;
```
The `self` parameter only has the `Self` type and the `Self` type parameter now has the trait as a trait bound. This works since we can now handle trait bounds on type parameters, and `A` is inferred through that.

The biggest benefit of this is that we no longer infer superfluous types. For instance, we currently infer multiple return types for calls to trait methods that return `Self`: both the inferred `Self` type and the trait type itself. But the latter follows from the former. This reduction in type can be seen in the change to the `.expected` file where all the trait types and their type arguments are now gone.