### PR TITLE
Ssa: Replace phi-read references in VariableCapture with default use-use flow

### DIFF
--- a/java/ql/test/library-tests/dataflow/capture/test.expected
+++ b/java/ql/test/library-tests/dataflow/capture/test.expected
@@ -18,7 +18,6 @@
 | A.java:21:11:21:13 | "B" : String | A.java:15:16:15:22 | get(...) : String |
 | A.java:21:11:21:13 | "B" : String | A.java:21:7:21:13 | ...=... : String |
 | A.java:21:11:21:13 | "B" : String | A.java:25:5:25:26 | SSA phi(s) : String |
-| A.java:21:11:21:13 | "B" : String | A.java:25:5:25:26 | phi(String s) : String |
 | A.java:21:11:21:13 | "B" : String | A.java:28:11:38:5 | String s : String |
 | A.java:21:11:21:13 | "B" : String | A.java:28:11:38:5 | new (...) : new A(...) { ... } [String s] |
 | A.java:21:11:21:13 | "B" : String | A.java:30:14:30:16 | parameter this : new A(...) { ... } [String s] |
@@ -35,7 +34,6 @@
 | A.java:23:11:23:13 | "C" : String | A.java:15:16:15:22 | get(...) : String |
 | A.java:23:11:23:13 | "C" : String | A.java:23:7:23:13 | ...=... : String |
 | A.java:23:11:23:13 | "C" : String | A.java:25:5:25:26 | SSA phi(s) : String |
-| A.java:23:11:23:13 | "C" : String | A.java:25:5:25:26 | phi(String s) : String |
 | A.java:23:11:23:13 | "C" : String | A.java:28:11:38:5 | String s : String |
 | A.java:23:11:23:13 | "C" : String | A.java:28:11:38:5 | new (...) : new A(...) { ... } [String s] |
 | A.java:23:11:23:13 | "C" : String | A.java:30:14:30:16 | parameter this : new A(...) { ... } [String s] |

--- a/rust/ql/test/library-tests/dataflow/local/CONSISTENCY/DataFlowConsistency.expected
+++ b/rust/ql/test/library-tests/dataflow/local/CONSISTENCY/DataFlowConsistency.expected
@@ -1,2 +1,0 @@
-identityLocalStep
-| main.rs:442:9:442:20 | phi(default_name) | Node steps to itself |

--- a/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
+++ b/rust/ql/test/library-tests/dataflow/local/DataFlowStep.expected
@@ -647,10 +647,9 @@ localStep
 | main.rs:441:24:441:33 | [post] receiver for source(...) | main.rs:441:24:441:33 | [post] source(...) |
 | main.rs:441:24:441:33 | source(...) | main.rs:441:24:441:33 | receiver for source(...) |
 | main.rs:441:24:441:45 | ... .to_string(...) | main.rs:441:9:441:20 | default_name |
-| main.rs:441:24:441:45 | ... .to_string(...) | main.rs:442:9:442:20 | phi(default_name) |
+| main.rs:441:24:441:45 | ... .to_string(...) | main.rs:442:9:442:20 | SSA phi read(default_name) |
 | main.rs:442:5:448:5 | for ... in ... { ... } | main.rs:440:75:449:1 | { ... } |
-| main.rs:442:9:442:20 | phi(default_name) | main.rs:442:9:442:20 | phi(default_name) |
-| main.rs:442:9:442:20 | phi(default_name) | main.rs:444:41:444:67 | default_name |
+| main.rs:442:9:442:20 | SSA phi read(default_name) | main.rs:444:41:444:67 | default_name |
 | main.rs:442:10:442:13 | [SSA] cond | main.rs:443:12:443:15 | cond |
 | main.rs:442:10:442:13 | cond | main.rs:442:10:442:13 | [SSA] cond |
 | main.rs:442:10:442:13 | cond | main.rs:442:10:442:13 | cond |
@@ -664,9 +663,9 @@ localStep
 | main.rs:444:21:444:24 | [post] receiver for name | main.rs:444:21:444:24 | [post] name |
 | main.rs:444:21:444:24 | name | main.rs:444:21:444:24 | receiver for name |
 | main.rs:444:21:444:68 | name.unwrap_or_else(...) | main.rs:444:17:444:17 | n |
-| main.rs:444:41:444:67 | [post] default_name | main.rs:442:9:442:20 | phi(default_name) |
+| main.rs:444:41:444:67 | [post] default_name | main.rs:442:9:442:20 | SSA phi read(default_name) |
 | main.rs:444:41:444:67 | closure self in \|...\| ... | main.rs:444:44:444:55 | this |
-| main.rs:444:41:444:67 | default_name | main.rs:442:9:442:20 | phi(default_name) |
+| main.rs:444:41:444:67 | default_name | main.rs:442:9:442:20 | SSA phi read(default_name) |
 | main.rs:444:44:444:55 | [post] receiver for default_name | main.rs:444:44:444:55 | [post] default_name |
 | main.rs:444:44:444:55 | default_name | main.rs:444:44:444:55 | receiver for default_name |
 | main.rs:445:18:445:18 | [post] receiver for n | main.rs:445:18:445:18 | [post] n |

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1661,7 +1661,16 @@ module Make<LocationSig Location, InputSig<Location> Input> {
     private newtype TNode =
       TWriteDefSource(WriteDefinition def) { DfInput::ssaDefHasSource(def) } or
       TExprNode(DfInput::Expr e, Boolean isPost) { e = DfInput::getARead(_) } or
-      TSsaDefinitionNode(DefinitionExt def) { not phiHasUniqNextNode(def) } or
+      TSsaDefinitionNode(DefinitionExt def) {
+        not phiHasUniqNextNode(def) and
+        if DfInput::includeWriteDefsInFlowStep()
+        then any()
+        else (
+          def instanceof PhiNode or
+          def instanceof PhiReadNode or
+          DfInput::allowFlowIntoUncertainDef(def)
+        )
+      } or
       TSsaInputNode(SsaPhiExt phi, BasicBlock input) { relevantPhiInputNode(phi, input) }
 
     /**
@@ -1904,14 +1913,7 @@ module Make<LocationSig Location, InputSig<Location> Input> {
       exists(DefinitionExt def |
         nodeFrom.(SsaDefinitionExtNodeImpl).getDefExt() = def and
         def.definesAt(v, bb, i, _) and
-        isUseStep = false and
-        if DfInput::includeWriteDefsInFlowStep()
-        then any()
-        else (
-          def instanceof PhiNode or
-          def instanceof PhiReadNode or
-          DfInput::allowFlowIntoUncertainDef(def)
-        )
+        isUseStep = false
       )
       or
       [nodeFrom, nodeFrom.(ExprPostUpdateNode).getPreUpdateNode()].(ReadNode).readsAt(bb, i, v) and

--- a/shared/ssa/codeql/ssa/Ssa.qll
+++ b/shared/ssa/codeql/ssa/Ssa.qll
@@ -1757,8 +1757,6 @@ module Make<LocationSig Location, InputSig<Location> Input> {
         this.getExpr().hasCfgNode(bb_, i_)
       }
 
-      SourceVariable getVariable() { result = v_ }
-
       pragma[nomagic]
       predicate readsAt(BasicBlock bb, int i, SourceVariable v) {
         bb = bb_ and

--- a/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
+++ b/swift/ql/test/library-tests/dataflow/dataflow/LocalFlow.expected
@@ -1378,17 +1378,17 @@
 | test.swift:888:9:888:9 | stream | test.swift:888:9:888:9 | SSA def(stream) |
 | test.swift:888:18:896:6 | call to AsyncStream<Element>.init(_:bufferingPolicy:_:) | test.swift:888:9:888:9 | stream |
 | test.swift:889:9:889:9 | continuation | test.swift:890:27:895:13 | continuation |
-| test.swift:890:27:895:13 | closure self parameter | test.swift:891:17:891:17 | phi(this) |
+| test.swift:890:27:895:13 | closure self parameter | test.swift:891:17:891:17 | SSA phi read(this) |
 | test.swift:891:17:891:17 | $generator | test.swift:891:17:891:17 | &... |
 | test.swift:891:17:891:17 | &... | test.swift:891:17:891:17 | $generator |
+| test.swift:891:17:891:17 | SSA phi read(this) | test.swift:892:21:892:21 | this |
+| test.swift:891:17:891:17 | SSA phi read(this) | test.swift:894:17:894:17 | this |
 | test.swift:891:17:891:17 | [post] $generator | test.swift:891:17:891:17 | &... |
-| test.swift:891:17:891:17 | phi(this) | test.swift:892:21:892:21 | this |
-| test.swift:891:17:891:17 | phi(this) | test.swift:894:17:894:17 | this |
 | test.swift:891:26:891:26 | $generator | test.swift:891:26:891:26 | SSA def($generator) |
 | test.swift:891:26:891:26 | SSA def($generator) | test.swift:891:17:891:17 | $generator |
 | test.swift:891:26:891:30 | call to makeIterator() | test.swift:891:26:891:26 | $generator |
-| test.swift:892:21:892:21 | this | test.swift:891:17:891:17 | phi(this) |
-| test.swift:892:21:892:21 | this | test.swift:891:17:891:17 | phi(this) |
+| test.swift:892:21:892:21 | this | test.swift:891:17:891:17 | SSA phi read(this) |
+| test.swift:892:21:892:21 | this | test.swift:891:17:891:17 | SSA phi read(this) |
 | test.swift:898:5:898:5 | $i$generator | test.swift:898:5:898:5 | &... |
 | test.swift:898:5:898:5 | &... | test.swift:898:5:898:5 | $i$generator |
 | test.swift:898:5:898:5 | [post] $i$generator | test.swift:898:5:898:5 | &... |


### PR DESCRIPTION
The first commit contains the primary change: The VariableCapture library is updated to use the DataFlowIntegration module instead of direct references to phi-read nodes. The nested SSA instantiation causes a little bit of caching, so I make sure to collapse those stages with parts of VariableCapture that would otherwise be duplicated across several stages. This ensures that we maintain the same number of cached stages (as the nested SSA already introduces a stage), and I think it also ought to be a mostly strict reduction of cross-stage DIL duplication.

The subsequent 2 commits are simple SSA cleanups.