### PR TITLE
Rust: Take prelude into account when resolving paths

### DIFF
--- a/rust/ql/integration-tests/hello-project/summary.expected
+++ b/rust/ql/integration-tests/hello-project/summary.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Taint edges - number of edges | 1674 |
+| Taint edges - number of edges | 1691 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.cargo.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Taint edges - number of edges | 1674 |
+| Taint edges - number of edges | 1691 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
+++ b/rust/ql/integration-tests/hello-workspace/summary.rust-project.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 2 |
 | Macro calls - total | 2 |
 | Macro calls - unresolved | 0 |
-| Taint edges - number of edges | 1674 |
+| Taint edges - number of edges | 1691 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |

--- a/rust/ql/lib/codeql/rust/dataflow/internal/Content.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/Content.qll
@@ -255,8 +255,6 @@ cached
 newtype TContent =
   TTupleFieldContent(TupleField field) { Stages::DataFlowStage::ref() } or
   TStructFieldContent(StructField field) or
-  // TODO: Remove once library types are extracted
-  TVariantInLibTupleFieldContent(VariantInLib::VariantInLib v, int pos) { pos = v.getAPosition() } or
   TElementContent() or
   TFutureContent() or
   TTuplePositionContent(int pos) {

--- a/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
+++ b/rust/ql/lib/codeql/rust/dataflow/internal/DataFlowImpl.qll
@@ -296,125 +296,6 @@ module LocalFlow {
   }
 }
 
-/**
- * Provides temporary modeling of built-in variants, for which no source code
- * `Item`s are available.
- *
- * TODO: Remove once library code is extracted.
- */
-module VariantInLib {
-  private import codeql.util.Option
-
-  private class CrateOrigin extends string {
-    CrateOrigin() { this = any(Resolvable r).getResolvedCrateOrigin() }
-  }
-
-  private class CrateOriginOption = Option<CrateOrigin>::Option;
-
-  private CrateOriginOption langCoreCrate() { result.asSome() = "lang:core" }
-
-  private newtype TVariantInLib =
-    MkVariantInLib(CrateOriginOption crate, string path, string name) {
-      crate = langCoreCrate() and
-      (
-        path = "crate::option::Option" and
-        name = "Some"
-        or
-        path = "crate::result::Result" and
-        name = ["Ok", "Err"]
-      )
-    }
-
-  /** An enum variant from library code, represented by the enum's canonical path and the variant's name. */
-  class VariantInLib extends MkVariantInLib {
-    CrateOriginOption crate;
-    string path;
-    string name;
-
-    VariantInLib() { this = MkVariantInLib(crate, path, name) }
-
-    int getAPosition() {
-      this = MkVariantInLib(langCoreCrate(), "crate::option::Option", "Some") and
-      result = 0
-      or
-      this = MkVariantInLib(langCoreCrate(), "crate::result::Result", ["Ok", "Err"]) and
-      result = 0
-    }
-
-    string getExtendedCanonicalPath() { result = path + "::" + name }
-
-    string toString() { result = name }
-  }
-
-  /** A tuple variant from library code. */
-  class VariantInLibTupleFieldContent extends Content, TVariantInLibTupleFieldContent {
-    private VariantInLib::VariantInLib v;
-    private int pos_;
-
-    VariantInLibTupleFieldContent() { this = TVariantInLibTupleFieldContent(v, pos_) }
-
-    VariantInLib::VariantInLib getVariantInLib(int pos) { result = v and pos = pos_ }
-
-    string getExtendedCanonicalPath() { result = v.getExtendedCanonicalPath() }
-
-    int getPosition() { result = pos_ }
-
-    final override string toString() {
-      // only print indices when the arity is > 1
-      if exists(TVariantInLibTupleFieldContent(v, 1))
-      then result = v.toString() + "(" + pos_ + ")"
-      else result = v.toString()
-    }
-
-    final override Location getLocation() { result instanceof EmptyLocation }
-  }
-
-  pragma[nomagic]
-  private predicate resolveExtendedCanonicalPath(Resolvable r, CrateOriginOption crate, string path) {
-    path = r.getResolvedPath() and
-    (
-      crate.asSome() = r.getResolvedCrateOrigin()
-      or
-      crate.isNone() and
-      not r.hasResolvedCrateOrigin()
-    )
-  }
-
-  /** Holds if path `p` resolves to variant `v`. */
-  private predicate pathResolveToVariantInLib(PathAstNode p, VariantInLib v) {
-    exists(CrateOriginOption crate, string path, string name |
-      resolveExtendedCanonicalPath(p, pragma[only_bind_into](crate), path + "::" + name) and
-      v = MkVariantInLib(pragma[only_bind_into](crate), path, name)
-    )
-  }
-
-  /** Holds if `p` destructs an enum variant `v`. */
-  pragma[nomagic]
-  private predicate tupleVariantCanonicalDestruction(TupleStructPat p, VariantInLib v) {
-    pathResolveToVariantInLib(p, v)
-  }
-
-  bindingset[pos]
-  predicate tupleVariantCanonicalDestruction(
-    TupleStructPat pat, VariantInLibTupleFieldContent c, int pos
-  ) {
-    tupleVariantCanonicalDestruction(pat, c.getVariantInLib(pos))
-  }
-
-  /** Holds if `ce` constructs an enum value of type `v`. */
-  pragma[nomagic]
-  private predicate tupleVariantCanonicalConstruction(CallExpr ce, VariantInLib v) {
-    pathResolveToVariantInLib(ce.getFunction().(PathExpr), v)
-  }
-
-  bindingset[pos]
-  predicate tupleVariantCanonicalConstruction(CallExpr ce, VariantInLibTupleFieldContent c, int pos) {
-    tupleVariantCanonicalConstruction(ce, c.getVariantInLib(pos))
-  }
-}
-
-class VariantInLibTupleFieldContent = VariantInLib::VariantInLibTupleFieldContent;
-
 class LambdaCallKind = Unit;
 
 /** Holds if `creation` is an expression that creates a lambda of kind `kind`. */
@@ -480,6 +361,7 @@ module RustDataFlow implements InputSig<Location> {
   private import Aliases
   private import codeql.rust.dataflow.DataFlow
   private import Node as Node
+  private import codeql.rust.frameworks.stdlib.Stdlib
 
   /**
    * An element, viewed as a node in a data flow graph. Either an expression
@@ -665,11 +547,8 @@ module RustDataFlow implements InputSig<Location> {
     exists(Content c | c = cs.(SingletonContentSet).getContent() |
       exists(TupleStructPatCfgNode pat, int pos |
         pat = node1.asPat() and
-        node2.asPat() = pat.getField(pos)
-      |
+        node2.asPat() = pat.getField(pos) and
         c = TTupleFieldContent(pat.getTupleStructPat().getTupleField(pos))
-        or
-        VariantInLib::tupleVariantCanonicalDestruction(pat.getPat(), c, pos)
       )
       or
       exists(TuplePatCfgNode pat, int pos |
@@ -714,8 +593,8 @@ module RustDataFlow implements InputSig<Location> {
       exists(TryExprCfgNode try |
         node1.asExpr() = try.getExpr() and
         node2.asExpr() = try and
-        c.(VariantInLibTupleFieldContent).getVariantInLib(0).getExtendedCanonicalPath() =
-          ["crate::option::Option::Some", "crate::result::Result::Ok"]
+        c.(TupleFieldContent)
+            .isVariantField([any(OptionEnum o).getSome(), any(ResultEnum r).getOk()], 0)
       )
       or
       exists(PrefixExprCfgNode deref |
@@ -791,11 +670,8 @@ module RustDataFlow implements InputSig<Location> {
   private predicate storeContentStep(Node node1, Content c, Node node2) {
     exists(CallExprCfgNode call, int pos |
       node1.asExpr() = call.getArgument(pragma[only_bind_into](pos)) and
-      node2.asExpr() = call
-    |
+      node2.asExpr() = call and
       c = TTupleFieldContent(call.getCallExpr().getTupleField(pragma[only_bind_into](pos)))
-      or
-      VariantInLib::tupleVariantCanonicalConstruction(call.getCallExpr(), c, pos)
     )
     or
     exists(StructExprCfgNode re, string field |

--- a/rust/ql/lib/codeql/rust/elements/internal/EnumImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/EnumImpl.qll
@@ -11,6 +11,8 @@ private import codeql.rust.elements.internal.generated.Enum
  * be referenced directly.
  */
 module Impl {
+  private import rust
+
   // the following QLdoc is generated: if you need to edit it, do it in the schema file
   /**
    * A Enum. For example:
@@ -20,5 +22,12 @@ module Impl {
    */
   class Enum extends Generated::Enum {
     override string toStringImpl() { result = "enum " + this.getName().getText() }
+
+    /** Gets the variant named `name`, if any. */
+    pragma[nomagic]
+    Variant getVariant(string name) {
+      result = this.getVariantList().getAVariant() and
+      result.getName().getText() = name
+    }
   }
 }

--- a/rust/ql/lib/codeql/rust/elements/internal/PathImpl.qll
+++ b/rust/ql/lib/codeql/rust/elements/internal/PathImpl.qll
@@ -40,6 +40,18 @@ module Impl {
      */
     pragma[nomagic]
     string getText() { result = this.getSegment().getIdentifier().getText() }
+
+    /**
+     * Gets the full text of this path, including the qualifier.
+     *
+     * Should only be used for debugging purposes.
+     */
+    string toStringDebug() {
+      not this.hasQualifier() and
+      result = this.getText()
+      or
+      result = this.getQualifier().toStringDebug() + "::" + this.getText()
+    }
   }
 
   /** A simple identifier path. */

--- a/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
+++ b/rust/ql/lib/codeql/rust/frameworks/stdlib/Stdlib.qll
@@ -21,3 +21,48 @@ private class StartswithCall extends Path::SafeAccessCheck::Range, CfgNodes::Met
     branch = true
   }
 }
+
+/**
+ * The [`Option` enum][1].
+ *
+ * [1]: https://doc.rust-lang.org/std/option/enum.Option.html
+ */
+class OptionEnum extends Enum {
+  OptionEnum() {
+    // todo: replace with canonical path, once calculated in QL
+    exists(Crate core, Module m |
+      core.getName() = "core" and
+      m = core.getModule().getItemList().getAnItem() and
+      m.getName().getText() = "option" and
+      this = m.getItemList().getAnItem() and
+      this.getName().getText() = "Option"
+    )
+  }
+
+  /** Gets the `Some` variant. */
+  Variant getSome() { result = this.getVariant("Some") }
+}
+
+/**
+ * The [`Result` enum][1].
+ *
+ * [1]: https://doc.rust-lang.org/stable/std/result/enum.Result.html
+ */
+class ResultEnum extends Enum {
+  ResultEnum() {
+    // todo: replace with canonical path, once calculated in QL
+    exists(Crate core, Module m |
+      core.getName() = "core" and
+      m = core.getModule().getItemList().getAnItem() and
+      m.getName().getText() = "result" and
+      this = m.getItemList().getAnItem() and
+      this.getName().getText() = "Result"
+    )
+  }
+
+  /** Gets the `Ok` variant. */
+  Variant getOk() { result = this.getVariant("Ok") }
+
+  /** Gets the `Err` variant. */
+  Variant getErr() { result = this.getVariant("Err") }
+}

--- a/rust/ql/lib/codeql/rust/internal/CachedStages.qll
+++ b/rust/ql/lib/codeql/rust/internal/CachedStages.qll
@@ -96,16 +96,47 @@ module Stages {
   }
 
   /**
+   * The path resolution stage.
+   */
+  cached
+  module PathResolutionStage {
+    private import codeql.rust.internal.PathResolution
+
+    /**
+     * Always holds.
+     * Ensures that a predicate is evaluated as part of the path resolution stage.
+     */
+    cached
+    predicate ref() { 1 = 1 }
+
+    /**
+     * DO NOT USE!
+     *
+     * Contains references to each predicate that use the above `ref` predicate.
+     */
+    cached
+    predicate backref() {
+      1 = 1
+      or
+      exists(resolvePath(_))
+      or
+      exists(any(ItemNode i).getASuccessor(_))
+      or
+      exists(any(ItemNode i).getASuccessorRec(_))
+    }
+  }
+
+  /**
    * The type inference stage.
    */
   cached
-  module TypeInference {
+  module TypeInferenceStage {
     private import codeql.rust.internal.Type
     private import codeql.rust.internal.TypeInference
 
     /**
      * Always holds.
-     * Ensures that a predicate is evaluated as part of the CFG stage.
+     * Ensures that a predicate is evaluated as part of the type inference stage.
      */
     cached
     predicate ref() { 1 = 1 }

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -181,7 +181,9 @@ abstract class ItemNode extends Locatable {
     else result = this.getImmediateParentModule().getImmediateParentModule()
     or
     name = "self" and
-    if this instanceof Module then result = this else result = this.getImmediateParentModule()
+    if this instanceof Module or this instanceof Enum or this instanceof Struct
+    then result = this
+    else result = this.getImmediateParentModule()
     or
     name = "Self" and
     this = result.(ImplOrTraitItemNode).getAnItemInSelfScope()

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -4,6 +4,7 @@
 
 private import rust
 private import codeql.rust.elements.internal.generated.ParentChild
+private import codeql.rust.internal.CachedStages
 
 private newtype TNamespace =
   TTypeNamespace() or
@@ -115,8 +116,9 @@ abstract class ItemNode extends Locatable {
     result = this.(SourceFileItemNode).getSuper()
   }
 
-  pragma[nomagic]
+  cached
   ItemNode getASuccessorRec(string name) {
+    Stages::PathResolutionStage::ref() and
     sourceFileEdge(this, name, result)
     or
     this = result.getImmediateParent() and
@@ -171,9 +173,12 @@ abstract class ItemNode extends Locatable {
   }
 
   /** Gets a successor named `name` of this item, if any. */
-  pragma[nomagic]
+  cached
   ItemNode getASuccessor(string name) {
+    Stages::PathResolutionStage::ref() and
     result = this.getASuccessorRec(name)
+    or
+    preludeEdge(this, name, result)
     or
     name = "super" and
     if this instanceof Module or this instanceof SourceFile
@@ -195,6 +200,16 @@ abstract class ItemNode extends Locatable {
         or
         this = crate.getModuleNode()
       )
+    or
+    // todo: implement properly
+    name = "$crate" and
+    result =
+      any(CrateItemNode crate |
+        this = crate.getASourceFile()
+        or
+        this = crate.getModuleNode()
+      ).(Crate).getADependency*() and
+    result.(CrateItemNode).isPotentialDollarCrateTarget()
   }
 
   /** Gets the location of this item. */
@@ -213,6 +228,16 @@ abstract private class ModuleLikeNode extends ItemNode {
       result.getImmediateParent() = mid and
       not mid instanceof ModuleLikeNode
     )
+  }
+
+  /**
+   * Holds if this is a root module, meaning either a source file or
+   * the entry module of a crate.
+   */
+  predicate isRoot() {
+    this instanceof SourceFileItemNode
+    or
+    this = any(CrateItemNode c).getModuleNode()
   }
 }
 
@@ -266,6 +291,14 @@ class CrateItemNode extends ItemNode instanceof Crate {
       mod.getFile() = mid.getFile() and
       fileImport(mod, result) and
       not result = any(Crate other).getSourceFile()
+    )
+  }
+
+  pragma[nomagic]
+  predicate isPotentialDollarCrateTarget() {
+    exists(string name, RelevantPath p |
+      p.isDollarCrateQualifiedPath(name) and
+      exists(this.getASuccessor(name))
     )
   }
 
@@ -488,6 +521,7 @@ class TraitItemNode extends ImplOrTraitItemNode instanceof Trait {
     result = super.getTypeBoundList().getABound().getTypeRepr().(PathTypeRepr).getPath()
   }
 
+  pragma[nomagic]
   ItemNode resolveABound() { result = resolvePath(this.getABoundPath()) }
 
   override AssocItemNode getAnAssocItem() { result = super.getAssocItemList().getAnAssocItem() }
@@ -549,6 +583,7 @@ private class TypeParamItemNode extends ItemNode instanceof TypeParam {
     result = super.getTypeBoundList().getABound().getTypeRepr().(PathTypeRepr).getPath()
   }
 
+  pragma[nomagic]
   ItemNode resolveABound() { result = resolvePath(this.getABoundPath()) }
 
   /**
@@ -769,7 +804,7 @@ private predicate declares(ItemNode item, Namespace ns, string name) {
 }
 
 /** A path that does not access a local variable. */
-private class RelevantPath extends Path {
+class RelevantPath extends Path {
   RelevantPath() { not this = any(VariableAccess va).(PathExpr).getPath() }
 
   pragma[nomagic]
@@ -777,6 +812,19 @@ private class RelevantPath extends Path {
     not exists(this.getQualifier()) and
     not this = any(UseTreeList list).getAUseTree().getPath() and
     name = this.getText()
+  }
+
+  pragma[nomagic]
+  predicate isCratePath(string name, ItemNode encl) {
+    name = ["crate", "$crate"] and
+    this.isUnqualified(name) and
+    encl.getADescendant() = this
+  }
+
+  pragma[nomagic]
+  predicate isDollarCrateQualifiedPath(string name) {
+    this.getQualifier().(RelevantPath).isCratePath("$crate", _) and
+    this.getText() = name
   }
 }
 
@@ -790,7 +838,8 @@ private predicate unqualifiedPathLookup(RelevantPath p, string name, Namespace n
     // lookup in the immediately enclosing item
     p.isUnqualified(name) and
     encl0.getADescendant() = p and
-    exists(ns)
+    exists(ns) and
+    not name = ["crate", "$crate"]
     or
     // lookup in an outer scope, but only if the item is not declared in inner scope
     exists(ItemNode mid |
@@ -800,16 +849,12 @@ private predicate unqualifiedPathLookup(RelevantPath p, string name, Namespace n
       not (
         name = "Self" and
         mid = any(ImplOrTraitItemNode i).getAnItemInSelfScope()
-      ) and
-      not (
-        name = "crate" and
-        mid = any(CrateItemNode i).getASourceFile()
       )
     |
       // nested modules do not have unqualified access to items from outer modules,
-      // except for items declared at top-level in the source file
+      // except for items declared at top-level in the root module
       if mid instanceof Module
-      then encl0.(SourceFileItemNode) = mid.getImmediateParent+()
+      then encl0 = mid.getImmediateParent+() and encl0.(ModuleLikeNode).isRoot()
       else encl0 = mid.getImmediateParent()
     )
   |
@@ -827,11 +872,29 @@ private ItemNode getASuccessor(ItemNode pred, string name, Namespace ns) {
   ns = result.getNamespace()
 }
 
+private predicate isRoot(ItemNode root) { root.(ModuleLikeNode).isRoot() }
+
+private predicate hasCratePath(ItemNode i) { any(RelevantPath path).isCratePath(_, i) }
+
+private predicate hasChild(ItemNode parent, ItemNode child) { child.getImmediateParent() = parent }
+
+private predicate rootHasCratePathTc(ItemNode i1, ItemNode i2) =
+  doublyBoundedFastTC(hasChild/2, isRoot/1, hasCratePath/1)(i1, i2)
+
 pragma[nomagic]
 private ItemNode unqualifiedPathLookup(RelevantPath path, Namespace ns) {
   exists(ItemNode encl, string name |
-    unqualifiedPathLookup(path, name, ns, encl) and
-    result = getASuccessor(encl, name, ns)
+    result = getASuccessor(encl, pragma[only_bind_into](name), ns)
+  |
+    unqualifiedPathLookup(path, name, ns, encl)
+    or
+    // For `($)crate`, jump directly to the root module
+    exists(ItemNode i | path.isCratePath(pragma[only_bind_into](name), i) |
+      encl.(ModuleLikeNode).isRoot() and
+      encl = i
+      or
+      rootHasCratePathTc(encl, i)
+    )
   )
 }
 
@@ -1006,7 +1069,7 @@ private predicate useImportEdge(Use use, string name, ItemNode item) {
         item = getASuccessor(used, name, ns) and
         // glob imports can be shadowed
         not declares(encl, ns, name) and
-        not name = ["super", "self", "Self", "crate"]
+        not name = ["super", "self", "Self", "$crate", "crate"]
       )
     else (
       item = used and
@@ -1021,19 +1084,42 @@ private predicate useImportEdge(Use use, string name, ItemNode item) {
   )
 }
 
+/**
+ * Holds if `i` is available inside `f` because it is reexported in [the prelude][1].
+ *
+ * We don't yet have access to prelude information from the extractor, so for now
+ * we include all the preludes for Rust 2015, 2018, 2021, and 2024.
+ *
+ * [1]: https://doc.rust-lang.org/core/prelude/index.html
+ */
+private predicate preludeEdge(SourceFile f, string name, ItemNode i) {
+  exists(Crate core, ModuleItemNode mod, ModuleItemNode prelude, ModuleItemNode rust |
+    f = any(Crate c0 | core = c0.getDependency(_)).getASourceFile() and
+    core.getName() = "core" and
+    mod = core.getModule() and
+    prelude = mod.getASuccessorRec("prelude") and
+    rust = prelude.getASuccessorRec(["rust_2015", "rust_2018", "rust_2021", "rust_2024"]) and
+    i = rust.getASuccessorRec(name) and
+    not i instanceof Use
+  )
+}
+
 /** Provides predicates for debugging the path resolution implementation. */
 private module Debug {
   private Locatable getRelevantLocatable() {
     exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
       result.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn) and
-      filepath.matches("%/main.rs") and
-      startline = [1, 3]
+      filepath.matches("%/test_logging.rs") and
+      startline = 163
     )
   }
 
-  predicate debugUnqualifiedPathLookup(RelevantPath p, string name, Namespace ns, ItemNode encl) {
+  predicate debugUnqualifiedPathLookup(
+    RelevantPath p, string name, Namespace ns, ItemNode encl, string path
+  ) {
     p = getRelevantLocatable() and
-    unqualifiedPathLookup(p, name, ns, encl)
+    unqualifiedPathLookup(p, name, ns, encl) and
+    path = p.toStringDebug()
   }
 
   ItemNode debugResolvePath(RelevantPath path) {

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -1088,7 +1088,7 @@ private predicate useImportEdge(Use use, string name, ItemNode item) {
  * Holds if `i` is available inside `f` because it is reexported in [the prelude][1].
  *
  * We don't yet have access to prelude information from the extractor, so for now
- * we include all the preludes for Rust 2015, 2018, 2021, and 2024.
+ * we include all the preludes for Rust: 2015, 2018, 2021, and 2024.
  *
  * [1]: https://doc.rust-lang.org/core/prelude/index.html
  */

--- a/rust/ql/lib/codeql/rust/internal/PathResolution.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolution.qll
@@ -321,7 +321,7 @@ private class VariantItemNode extends ItemNode instanceof Variant {
     result = super.getEnum().getGenericParamList().getTypeParam(i)
   }
 
-  override Visibility getVisibility() { result = Variant.super.getVisibility() }
+  override Visibility getVisibility() { result = super.getEnum().getVisibility() }
 }
 
 class FunctionItemNode extends AssocItemNode instanceof Function {

--- a/rust/ql/lib/codeql/rust/internal/PathResolutionConsistency.qll
+++ b/rust/ql/lib/codeql/rust/internal/PathResolutionConsistency.qll
@@ -9,6 +9,8 @@ private import PathResolution
 query predicate multiplePathResolutions(Path p, ItemNode i) {
   p.fromSource() and
   i = resolvePath(p) and
+  // known limitation for `$crate`
+  not p.getQualifier*().(RelevantPath).isUnqualified("$crate") and
   // `use foo::bar` may use both a type `bar` and a value `bar`
   not p =
     any(UseTree use |
@@ -19,7 +21,7 @@ query predicate multiplePathResolutions(Path p, ItemNode i) {
 }
 
 /** Holds if `call` has multiple static call targets including `target`. */
-query predicate multipleStaticCallTargets(CallExprBase call, Callable target) {
+query predicate multipleMethodCallTargets(MethodCallExpr call, Callable target) {
   target = call.getStaticTarget() and
   strictcount(call.getStaticTarget()) > 1
 }
@@ -43,8 +45,8 @@ int getPathResolutionInconsistencyCounts(string type) {
   type = "Multiple path resolutions" and
   result = count(Path p | multiplePathResolutions(p, _) | p)
   or
-  type = "Multiple static call targets" and
-  result = count(CallExprBase call | multipleStaticCallTargets(call, _) | call)
+  type = "Multiple static method call targets" and
+  result = count(CallExprBase call | multipleMethodCallTargets(call, _) | call)
   or
   type = "Multiple record fields" and
   result = count(FieldExpr fe | multipleStructFields(fe, _) | fe)

--- a/rust/ql/lib/codeql/rust/internal/Type.qll
+++ b/rust/ql/lib/codeql/rust/internal/Type.qll
@@ -8,7 +8,7 @@ private import codeql.rust.internal.CachedStages
 
 cached
 newtype TType =
-  TStruct(Struct s) { Stages::TypeInference::ref() } or
+  TStruct(Struct s) { Stages::TypeInferenceStage::ref() } or
   TEnum(Enum e) or
   TTrait(Trait t) or
   TImpl(Impl i) or

--- a/rust/ql/lib/codeql/rust/internal/TypeInference.qll
+++ b/rust/ql/lib/codeql/rust/internal/TypeInference.qll
@@ -993,7 +993,7 @@ private module Cached {
    */
   cached
   Type inferType(AstNode n, TypePath path) {
-    Stages::TypeInference::backref() and
+    Stages::TypeInferenceStage::ref() and
     result = inferAnnotatedType(n, path)
     or
     result = inferTypeEquality(n, path)

--- a/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/extractor-tests/canonical_path/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
-multipleStaticCallTargets
+multipleMethodCallTargets
 | regular.rs:29:5:29:9 | s.g() | anonymous.rs:15:9:15:22 | fn g |
 | regular.rs:29:5:29:9 | s.g() | regular.rs:13:5:13:18 | fn g |

--- a/rust/ql/test/extractor-tests/canonical_path_disabled/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/extractor-tests/canonical_path_disabled/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,3 +1,3 @@
-multipleStaticCallTargets
+multipleMethodCallTargets
 | regular.rs:32:5:32:9 | s.g() | anonymous.rs:18:9:18:22 | fn g |
 | regular.rs:32:5:32:9 | s.g() | regular.rs:16:5:16:18 | fn g |

--- a/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
+++ b/rust/ql/test/library-tests/path-resolution/CONSISTENCY/PathResolutionConsistency.expected
@@ -1,6 +1,3 @@
 multiplePathResolutions
 | main.rs:118:9:118:9 | f | main.rs:104:5:106:5 | fn f |
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
-multipleStaticCallTargets
-| main.rs:118:9:118:11 | f(...) | main.rs:104:5:106:5 | fn f |
-| main.rs:118:9:118:11 | f(...) | main.rs:110:5:112:5 | fn f |

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -505,17 +505,17 @@ mod m21 {
     mod m33 {
         #[rustfmt::skip]
         use super::m22::MyEnum::{ // $ item=I105
-            self // $ MISSING: item=I105 $ SPURIOUS: item=I107
+            self // $ item=I105
         };
 
         #[rustfmt::skip]
         use super::m22::MyStruct::{ // $ item=I106
-            self // $ MISSING: item=I106 $ SPURIOUS: item=I107
+            self // $ item=I106
         };
 
         fn f() {
             let _ = MyEnum::A; // $ MISSING: item=I104
-            let _ = MyStruct {}; // $ MISSING: item=I106
+            let _ = MyStruct {}; // $ item=I106
         }
     }
 }

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -493,6 +493,33 @@ mod m18 {
     }
 }
 
+mod m21 {
+    mod m22 {
+        pub enum MyEnum {
+            A, // I104
+        } // I105
+
+        pub struct MyStruct; // I106
+    } // I107
+
+    mod m33 {
+        #[rustfmt::skip]
+        use super::m22::MyEnum::{ // $ item=I105
+            self // $ MISSING: item=I105 $ SPURIOUS: item=I107
+        };
+
+        #[rustfmt::skip]
+        use super::m22::MyStruct::{ // $ item=I106
+            self // $ MISSING: item=I106 $ SPURIOUS: item=I107
+        };
+
+        fn f() {
+            let _ = MyEnum::A; // $ MISSING: item=I104
+            let _ = MyStruct {}; // $ MISSING: item=I106
+        }
+    }
+}
+
 fn main() {
     my::nested::nested1::nested2::f(); // $ item=I4
     my::f(); // $ item=I38

--- a/rust/ql/test/library-tests/path-resolution/main.rs
+++ b/rust/ql/test/library-tests/path-resolution/main.rs
@@ -514,7 +514,7 @@ mod m21 {
         };
 
         fn f() {
-            let _ = MyEnum::A; // $ MISSING: item=I104
+            let _ = MyEnum::A; // $ item=I104
             let _ = MyStruct {}; // $ item=I106
         }
     }

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -226,11 +226,13 @@ resolvePath
 | main.rs:507:13:507:17 | super | main.rs:496:1:521:1 | mod m21 |
 | main.rs:507:13:507:22 | ...::m22 | main.rs:497:5:503:5 | mod m22 |
 | main.rs:507:13:507:30 | ...::MyEnum | main.rs:498:9:500:9 | enum MyEnum |
-| main.rs:508:13:508:16 | self | main.rs:497:5:503:5 | mod m22 |
+| main.rs:508:13:508:16 | self | main.rs:498:9:500:9 | enum MyEnum |
 | main.rs:512:13:512:17 | super | main.rs:496:1:521:1 | mod m21 |
 | main.rs:512:13:512:22 | ...::m22 | main.rs:497:5:503:5 | mod m22 |
 | main.rs:512:13:512:32 | ...::MyStruct | main.rs:502:9:502:28 | struct MyStruct |
-| main.rs:513:13:513:16 | self | main.rs:497:5:503:5 | mod m22 |
+| main.rs:513:13:513:16 | self | main.rs:502:9:502:28 | struct MyStruct |
+| main.rs:517:21:517:26 | MyEnum | main.rs:498:9:500:9 | enum MyEnum |
+| main.rs:518:21:518:28 | MyStruct | main.rs:502:9:502:28 | struct MyStruct |
 | main.rs:524:5:524:6 | my | main.rs:1:1:1:7 | mod my |
 | main.rs:524:5:524:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
 | main.rs:524:5:524:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -232,6 +232,7 @@ resolvePath
 | main.rs:512:13:512:32 | ...::MyStruct | main.rs:502:9:502:28 | struct MyStruct |
 | main.rs:513:13:513:16 | self | main.rs:502:9:502:28 | struct MyStruct |
 | main.rs:517:21:517:26 | MyEnum | main.rs:498:9:500:9 | enum MyEnum |
+| main.rs:517:21:517:29 | ...::A | main.rs:499:13:499:13 | A |
 | main.rs:518:21:518:28 | MyStruct | main.rs:502:9:502:28 | struct MyStruct |
 | main.rs:524:5:524:6 | my | main.rs:1:1:1:7 | mod my |
 | main.rs:524:5:524:14 | ...::nested | my.rs:1:1:1:15 | mod nested |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.expected
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.expected
@@ -24,6 +24,9 @@ mod
 | main.rs:476:1:494:1 | mod m18 |
 | main.rs:481:5:493:5 | mod m19 |
 | main.rs:486:9:492:9 | mod m20 |
+| main.rs:496:1:521:1 | mod m21 |
+| main.rs:497:5:503:5 | mod m22 |
+| main.rs:505:5:520:5 | mod m33 |
 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/mod.rs:12:1:12:12 | mod my3 |
 | my2/nested2.rs:1:1:11:1 | mod nested3 |
@@ -56,7 +59,7 @@ resolvePath
 | main.rs:30:17:30:21 | super | main.rs:18:5:36:5 | mod m2 |
 | main.rs:30:17:30:24 | ...::f | main.rs:19:9:21:9 | fn f |
 | main.rs:33:17:33:17 | f | main.rs:19:9:21:9 | fn f |
-| main.rs:40:9:40:13 | super | main.rs:1:1:523:2 | SourceFile |
+| main.rs:40:9:40:13 | super | main.rs:1:1:550:2 | SourceFile |
 | main.rs:40:9:40:17 | ...::m1 | main.rs:13:1:37:1 | mod m1 |
 | main.rs:40:9:40:21 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
 | main.rs:40:9:40:24 | ...::g | main.rs:23:9:27:9 | fn g |
@@ -68,7 +71,7 @@ resolvePath
 | main.rs:61:17:61:19 | Foo | main.rs:59:9:59:21 | struct Foo |
 | main.rs:64:13:64:15 | Foo | main.rs:53:5:53:17 | struct Foo |
 | main.rs:66:5:66:5 | f | main.rs:55:5:62:5 | fn f |
-| main.rs:68:5:68:8 | self | main.rs:1:1:523:2 | SourceFile |
+| main.rs:68:5:68:8 | self | main.rs:1:1:550:2 | SourceFile |
 | main.rs:68:5:68:11 | ...::i | main.rs:71:1:83:1 | fn i |
 | main.rs:74:13:74:15 | Foo | main.rs:48:1:48:13 | struct Foo |
 | main.rs:81:17:81:19 | Foo | main.rs:77:9:79:9 | struct Foo |
@@ -82,7 +85,7 @@ resolvePath
 | main.rs:87:57:87:66 | ...::g | my2/nested2.rs:7:9:9:9 | fn g |
 | main.rs:87:80:87:86 | nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
 | main.rs:100:5:100:22 | f_defined_in_macro | main.rs:99:18:99:42 | fn f_defined_in_macro |
-| main.rs:117:13:117:17 | super | main.rs:1:1:523:2 | SourceFile |
+| main.rs:117:13:117:17 | super | main.rs:1:1:550:2 | SourceFile |
 | main.rs:117:13:117:21 | ...::m5 | main.rs:103:1:107:1 | mod m5 |
 | main.rs:118:9:118:9 | f | main.rs:104:5:106:5 | fn f |
 | main.rs:118:9:118:9 | f | main.rs:110:5:112:5 | fn f |
@@ -220,61 +223,69 @@ resolvePath
 | main.rs:490:17:490:21 | super | main.rs:481:5:493:5 | mod m19 |
 | main.rs:490:17:490:28 | ...::super | main.rs:476:1:494:1 | mod m18 |
 | main.rs:490:17:490:31 | ...::f | main.rs:477:5:479:5 | fn f |
-| main.rs:497:5:497:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:497:5:497:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
-| main.rs:497:5:497:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
-| main.rs:497:5:497:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
-| main.rs:497:5:497:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
-| main.rs:498:5:498:6 | my | main.rs:1:1:1:7 | mod my |
-| main.rs:498:5:498:9 | ...::f | my.rs:5:1:7:1 | fn f |
-| main.rs:499:5:499:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
-| main.rs:499:5:499:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
-| main.rs:499:5:499:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
-| main.rs:499:5:499:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:500:5:500:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:501:5:501:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:502:5:502:9 | crate | main.rs:0:0:0:0 | Crate(main@0.0.1) |
-| main.rs:502:5:502:12 | ...::h | main.rs:50:1:69:1 | fn h |
-| main.rs:503:5:503:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:503:5:503:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:503:5:503:13 | ...::g | main.rs:23:9:27:9 | fn g |
-| main.rs:504:5:504:6 | m1 | main.rs:13:1:37:1 | mod m1 |
-| main.rs:504:5:504:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
-| main.rs:504:5:504:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
-| main.rs:504:5:504:17 | ...::h | main.rs:30:27:34:13 | fn h |
-| main.rs:505:5:505:6 | m4 | main.rs:39:1:46:1 | mod m4 |
-| main.rs:505:5:505:9 | ...::i | main.rs:42:5:45:5 | fn i |
-| main.rs:506:5:506:5 | h | main.rs:50:1:69:1 | fn h |
-| main.rs:507:5:507:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
-| main.rs:508:5:508:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
-| main.rs:509:5:509:5 | j | main.rs:97:1:101:1 | fn j |
-| main.rs:510:5:510:6 | m6 | main.rs:109:1:120:1 | mod m6 |
-| main.rs:510:5:510:9 | ...::g | main.rs:114:5:119:5 | fn g |
-| main.rs:511:5:511:6 | m7 | main.rs:122:1:137:1 | mod m7 |
-| main.rs:511:5:511:9 | ...::f | main.rs:129:5:136:5 | fn f |
-| main.rs:512:5:512:6 | m8 | main.rs:139:1:193:1 | mod m8 |
-| main.rs:512:5:512:9 | ...::g | main.rs:177:5:192:5 | fn g |
-| main.rs:513:5:513:6 | m9 | main.rs:195:1:203:1 | mod m9 |
-| main.rs:513:5:513:9 | ...::f | main.rs:198:5:202:5 | fn f |
-| main.rs:514:5:514:7 | m11 | main.rs:226:1:263:1 | mod m11 |
-| main.rs:514:5:514:10 | ...::f | main.rs:231:5:234:5 | fn f |
-| main.rs:515:5:515:7 | m15 | main.rs:294:1:348:1 | mod m15 |
-| main.rs:515:5:515:10 | ...::f | main.rs:335:5:347:5 | fn f |
-| main.rs:516:5:516:7 | m16 | main.rs:350:1:442:1 | mod m16 |
-| main.rs:516:5:516:10 | ...::f | main.rs:417:5:441:5 | fn f |
-| main.rs:517:5:517:7 | m17 | main.rs:444:1:474:1 | mod m17 |
-| main.rs:517:5:517:10 | ...::f | main.rs:468:5:473:5 | fn f |
-| main.rs:518:5:518:11 | nested6 | my2/nested2.rs:14:5:18:5 | mod nested6 |
-| main.rs:518:5:518:14 | ...::f | my2/nested2.rs:15:9:17:9 | fn f |
-| main.rs:519:5:519:11 | nested8 | my2/nested2.rs:22:5:26:5 | mod nested8 |
-| main.rs:519:5:519:14 | ...::f | my2/nested2.rs:23:9:25:9 | fn f |
-| main.rs:520:5:520:7 | my3 | my2/mod.rs:12:1:12:12 | mod my3 |
-| main.rs:520:5:520:10 | ...::f | my2/my3/mod.rs:1:1:5:1 | fn f |
-| main.rs:521:5:521:12 | nested_f | my/my4/my5/mod.rs:1:1:3:1 | fn f |
-| main.rs:522:5:522:7 | m18 | main.rs:476:1:494:1 | mod m18 |
-| main.rs:522:5:522:12 | ...::m19 | main.rs:481:5:493:5 | mod m19 |
-| main.rs:522:5:522:17 | ...::m20 | main.rs:486:9:492:9 | mod m20 |
-| main.rs:522:5:522:20 | ...::g | main.rs:487:13:491:13 | fn g |
+| main.rs:507:13:507:17 | super | main.rs:496:1:521:1 | mod m21 |
+| main.rs:507:13:507:22 | ...::m22 | main.rs:497:5:503:5 | mod m22 |
+| main.rs:507:13:507:30 | ...::MyEnum | main.rs:498:9:500:9 | enum MyEnum |
+| main.rs:508:13:508:16 | self | main.rs:497:5:503:5 | mod m22 |
+| main.rs:512:13:512:17 | super | main.rs:496:1:521:1 | mod m21 |
+| main.rs:512:13:512:22 | ...::m22 | main.rs:497:5:503:5 | mod m22 |
+| main.rs:512:13:512:32 | ...::MyStruct | main.rs:502:9:502:28 | struct MyStruct |
+| main.rs:513:13:513:16 | self | main.rs:497:5:503:5 | mod m22 |
+| main.rs:524:5:524:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:524:5:524:14 | ...::nested | my.rs:1:1:1:15 | mod nested |
+| main.rs:524:5:524:23 | ...::nested1 | my/nested.rs:1:1:17:1 | mod nested1 |
+| main.rs:524:5:524:32 | ...::nested2 | my/nested.rs:2:5:11:5 | mod nested2 |
+| main.rs:524:5:524:35 | ...::f | my/nested.rs:3:9:5:9 | fn f |
+| main.rs:525:5:525:6 | my | main.rs:1:1:1:7 | mod my |
+| main.rs:525:5:525:9 | ...::f | my.rs:5:1:7:1 | fn f |
+| main.rs:526:5:526:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
+| main.rs:526:5:526:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
+| main.rs:526:5:526:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
+| main.rs:526:5:526:32 | ...::f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:527:5:527:5 | f | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:528:5:528:5 | g | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:529:5:529:9 | crate | main.rs:0:0:0:0 | Crate(main@0.0.1) |
+| main.rs:529:5:529:12 | ...::h | main.rs:50:1:69:1 | fn h |
+| main.rs:530:5:530:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:530:5:530:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:530:5:530:13 | ...::g | main.rs:23:9:27:9 | fn g |
+| main.rs:531:5:531:6 | m1 | main.rs:13:1:37:1 | mod m1 |
+| main.rs:531:5:531:10 | ...::m2 | main.rs:18:5:36:5 | mod m2 |
+| main.rs:531:5:531:14 | ...::m3 | main.rs:29:9:35:9 | mod m3 |
+| main.rs:531:5:531:17 | ...::h | main.rs:30:27:34:13 | fn h |
+| main.rs:532:5:532:6 | m4 | main.rs:39:1:46:1 | mod m4 |
+| main.rs:532:5:532:9 | ...::i | main.rs:42:5:45:5 | fn i |
+| main.rs:533:5:533:5 | h | main.rs:50:1:69:1 | fn h |
+| main.rs:534:5:534:11 | f_alias | my2/nested2.rs:3:9:5:9 | fn f |
+| main.rs:535:5:535:11 | g_alias | my2/nested2.rs:7:9:9:9 | fn g |
+| main.rs:536:5:536:5 | j | main.rs:97:1:101:1 | fn j |
+| main.rs:537:5:537:6 | m6 | main.rs:109:1:120:1 | mod m6 |
+| main.rs:537:5:537:9 | ...::g | main.rs:114:5:119:5 | fn g |
+| main.rs:538:5:538:6 | m7 | main.rs:122:1:137:1 | mod m7 |
+| main.rs:538:5:538:9 | ...::f | main.rs:129:5:136:5 | fn f |
+| main.rs:539:5:539:6 | m8 | main.rs:139:1:193:1 | mod m8 |
+| main.rs:539:5:539:9 | ...::g | main.rs:177:5:192:5 | fn g |
+| main.rs:540:5:540:6 | m9 | main.rs:195:1:203:1 | mod m9 |
+| main.rs:540:5:540:9 | ...::f | main.rs:198:5:202:5 | fn f |
+| main.rs:541:5:541:7 | m11 | main.rs:226:1:263:1 | mod m11 |
+| main.rs:541:5:541:10 | ...::f | main.rs:231:5:234:5 | fn f |
+| main.rs:542:5:542:7 | m15 | main.rs:294:1:348:1 | mod m15 |
+| main.rs:542:5:542:10 | ...::f | main.rs:335:5:347:5 | fn f |
+| main.rs:543:5:543:7 | m16 | main.rs:350:1:442:1 | mod m16 |
+| main.rs:543:5:543:10 | ...::f | main.rs:417:5:441:5 | fn f |
+| main.rs:544:5:544:7 | m17 | main.rs:444:1:474:1 | mod m17 |
+| main.rs:544:5:544:10 | ...::f | main.rs:468:5:473:5 | fn f |
+| main.rs:545:5:545:11 | nested6 | my2/nested2.rs:14:5:18:5 | mod nested6 |
+| main.rs:545:5:545:14 | ...::f | my2/nested2.rs:15:9:17:9 | fn f |
+| main.rs:546:5:546:11 | nested8 | my2/nested2.rs:22:5:26:5 | mod nested8 |
+| main.rs:546:5:546:14 | ...::f | my2/nested2.rs:23:9:25:9 | fn f |
+| main.rs:547:5:547:7 | my3 | my2/mod.rs:12:1:12:12 | mod my3 |
+| main.rs:547:5:547:10 | ...::f | my2/my3/mod.rs:1:1:5:1 | fn f |
+| main.rs:548:5:548:12 | nested_f | my/my4/my5/mod.rs:1:1:3:1 | fn f |
+| main.rs:549:5:549:7 | m18 | main.rs:476:1:494:1 | mod m18 |
+| main.rs:549:5:549:12 | ...::m19 | main.rs:481:5:493:5 | mod m19 |
+| main.rs:549:5:549:17 | ...::m20 | main.rs:486:9:492:9 | mod m20 |
+| main.rs:549:5:549:20 | ...::g | main.rs:487:13:491:13 | fn g |
 | my2/mod.rs:5:5:5:11 | nested2 | my2/mod.rs:1:1:1:16 | mod nested2 |
 | my2/mod.rs:5:5:5:20 | ...::nested3 | my2/nested2.rs:1:1:11:1 | mod nested3 |
 | my2/mod.rs:5:5:5:29 | ...::nested4 | my2/nested2.rs:2:5:10:5 | mod nested4 |
@@ -288,7 +299,7 @@ resolvePath
 | my2/my3/mod.rs:3:5:3:5 | g | my2/mod.rs:3:1:6:1 | fn g |
 | my2/my3/mod.rs:4:5:4:5 | h | main.rs:50:1:69:1 | fn h |
 | my2/my3/mod.rs:7:5:7:9 | super | my2/mod.rs:1:1:12:13 | SourceFile |
-| my2/my3/mod.rs:7:5:7:16 | ...::super | main.rs:1:1:523:2 | SourceFile |
+| my2/my3/mod.rs:7:5:7:16 | ...::super | main.rs:1:1:550:2 | SourceFile |
 | my2/my3/mod.rs:7:5:7:19 | ...::h | main.rs:50:1:69:1 | fn h |
 | my2/my3/mod.rs:8:5:8:9 | super | my2/mod.rs:1:1:12:13 | SourceFile |
 | my2/my3/mod.rs:8:5:8:12 | ...::g | my2/mod.rs:3:1:6:1 | fn g |

--- a/rust/ql/test/library-tests/path-resolution/path-resolution.ql
+++ b/rust/ql/test/library-tests/path-resolution/path-resolution.ql
@@ -5,4 +5,6 @@ import TestUtils
 
 query predicate mod(Module m) { toBeTested(m) }
 
-query predicate resolvePath(Path p, ItemNode i) { toBeTested(p) and i = resolvePath(p) }
+query predicate resolvePath(Path p, ItemNode i) {
+  toBeTested(p) and not p.isInMacroExpansion() and i = resolvePath(p)
+}

--- a/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
+++ b/rust/ql/test/query-tests/diagnostics/SummaryStats.expected
@@ -15,7 +15,7 @@
 | Macro calls - resolved | 8 |
 | Macro calls - total | 9 |
 | Macro calls - unresolved | 1 |
-| Taint edges - number of edges | 1674 |
+| Taint edges - number of edges | 1691 |
 | Taint reach - nodes tainted | 0 |
 | Taint reach - per million nodes | 0 |
 | Taint sinks - cryptographic operations | 0 |


### PR DESCRIPTION
This PR started out with me wanting to get rid of the `VariantInLib` workaround, which was needed prior to [extracting the crate graph](https://github.com/github/codeql/pull/18228).

Removing `VariantLib` means we will be using our QL logic for resolving `option::Option` and `result::Result` paths, instead of relying on `getExtendedCanonicalPath` provided by the extractor. However, in order to resolve those paths, we need to take [the standard library prelude](https://doc.rust-lang.org/reference/names/preludes.html#standard-library-prelude) into account, which is exactly what this PR does.

Since we don't know which edition of Rust is being used, we simply include all the editions; 2015, 2018, 2021, and 2024.

Removing `VariantLib` also revealed that we need to handle `$crate` paths inside expanded macros. For now, we over-approximate resolution of `$crate` paths by considering _all_ transitive dependencies.

[DCA shows]() that, while we mostly maintain performance, we gain an additional 10% true positive call edges (up 475,373 from 430,130) and an additional 14% true positive resolved paths (up 368,369 from 324,251), all numbers computed across the entire DCA suite.