### PR TITLE
C++: Add class representing calling conventions

### DIFF
--- a/cpp/ql/lib/change-notes/2025-03-31-calling-convention.md
+++ b/cpp/ql/lib/change-notes/2025-03-31-calling-convention.md
@@ -1,0 +1,5 @@
+---
+category: feature
+---
+* Calling conventions explicitly specified on function declarations (`__cdecl`, `__stdcall`, `__fastcall`, etc.)  are now represented as specifiers of those declarations.
+* A new class `CallingConventionSpecifier` extending the `Specifier` class was introduced, which represents explicitly specified calling conventions.

--- a/cpp/ql/lib/semmle/code/cpp/Specifier.qll
+++ b/cpp/ql/lib/semmle/code/cpp/Specifier.qll
@@ -98,6 +98,18 @@ class AccessSpecifier extends Specifier {
 }
 
 /**
+ * A C/C++ calling convention specifier: `cdecl`, `fastcall`, `stdcall`, `thiscall`,
+ * `vectorcall`, or `clrcall`.
+ */
+class CallingConventionSpecifier extends Specifier {
+  CallingConventionSpecifier() {
+    this.hasName(["cdecl", "fastcall", "stdcall", "thiscall", "vectorcall", "clrcall"])
+  }
+
+  override string getAPrimaryQlClass() { result = "CallingConventionSpecifier" }
+}
+
+/**
  * An attribute introduced by GNU's `__attribute__((name))` syntax,
  * Microsoft's `__declspec(name)` syntax, Microsoft's `[name]` syntax, the
  * C++11 standard `[[name]]` syntax, or the C++11 `alignas` syntax.

--- a/cpp/ql/test/library-tests/calling-convention/calling-convention.expected
+++ b/cpp/ql/test/library-tests/calling-convention/calling-convention.expected
@@ -1,0 +1,7 @@
+| test.cpp:4:21:4:35 | definition of thiscall_method | thiscall |
+| test.cpp:7:14:7:23 | definition of func_cdecl | cdecl |
+| test.cpp:9:16:9:27 | definition of func_stdcall | stdcall |
+| test.cpp:11:17:11:29 | definition of func_fastcall | fastcall |
+| test.cpp:13:20:13:34 | definition of func_vectorcall | vectorcall |
+| test.cpp:15:13:15:25 | definition of func_overload | cdecl |
+| test.cpp:16:15:16:27 | definition of func_overload | stdcall |

--- a/cpp/ql/test/library-tests/calling-convention/calling-convention.ql
+++ b/cpp/ql/test/library-tests/calling-convention/calling-convention.ql
@@ -1,0 +1,5 @@
+import cpp
+
+from FunctionDeclarationEntry func, CallingConventionSpecifier ccs
+where ccs.hasName(func.getASpecifier())
+select func, func.getASpecifier()

--- a/cpp/ql/test/library-tests/calling-convention/test.cpp
+++ b/cpp/ql/test/library-tests/calling-convention/test.cpp
@@ -1,0 +1,16 @@
+// semmle-extractor-options: --microsoft
+
+struct call_conventions {
+    void __thiscall thiscall_method() {}
+};
+
+void __cdecl func_cdecl() {}
+
+void __stdcall func_stdcall() {}
+
+void __fastcall func_fastcall() {}
+
+void __vectorcall  func_vectorcall() {}
+
+int __cdecl func_overload() {}
+int __stdcall func_overload(int x) {}


### PR DESCRIPTION
- Introduced the class `CallingConventionSpecifier` to represent calling conventions in C++ functions.
- Added tests for calling conventions in C++ functions.
- Added a change note for calling convention support.

