### PR TITLE
ruby: remove some FPs from `rb/useless-assignment-to-local`

### DIFF
--- a/ruby/ql/src/change-notes/2025-04-04-refine-deadstore.md
+++ b/ruby/ql/src/change-notes/2025-04-04-refine-deadstore.md
@@ -1,0 +1,4 @@
+---
+category: majorAnalysis
+---
+* The query `rb/useless-assignment-to-local` now comes with query help and has been tweaked to produce fewer false positives.

--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.qhelp
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.qhelp
@@ -1,0 +1,49 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>
+A value is assigned to a local variable, but either that variable is never read
+later on, or its value is always overwritten before being read. This means
+that the original assignment has no effect, and could indicate a logic error or
+incomplete code.
+</p>
+
+</overview>
+<recommendation>
+
+<p>
+Ensure that you check the control and data flow in the method carefully.
+If a value is really not needed, consider omitting the assignment. Be careful,
+though: if the right-hand side has a side-effect (like performing a method call),
+it is important to keep this to preserve the overall behavior.
+</p>
+
+</recommendation>
+<example>
+
+<p>
+In the following example, the return value of the call to <code>send</code> on line 2
+is assigned to the local variable <code>result</code>, but then never used.
+</p>
+
+<sample src="examples/DeadStoreOfLocal.rb" />
+
+<p>
+Assuming that <code>send</code> returns a status code indicating whether the operation
+succeeded or not, the value of <code>result</code> should be checked, perhaps like this:
+</p>
+
+<sample src="examples/DeadStoreOfLocalGood.rb" />
+
+</example>
+<references>
+
+
+<li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Dead_store">Dead store</a>.</li>
+
+
+
+</references>
+</qhelp>

--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
@@ -7,7 +7,7 @@
  * @id rb/useless-assignment-to-local
  * @tags maintainability
  *       external/cwe/cwe-563
- * @precision low
+ * @precision medium
  */
 
 import codeql.ruby.AST

--- a/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
+++ b/ruby/ql/src/queries/variables/DeadStoreOfLocal.ql
@@ -12,11 +12,20 @@
 
 import codeql.ruby.AST
 import codeql.ruby.dataflow.SSA
+import codeql.ruby.ApiGraphs
 
 class RelevantLocalVariableWriteAccess extends LocalVariableWriteAccess {
   RelevantLocalVariableWriteAccess() {
     not this.getVariable().getName().charAt(0) = "_" and
-    not this = any(Parameter p).getAVariable().getDefiningAccess()
+    not this = any(Parameter p).getAVariable().getDefiningAccess() and
+    not API::getTopLevelMember("ERB").getInstance().getAMethodCall("result").asExpr().getScope() =
+      this.getCfgScope() and
+    not exists(RetryStmt r | r.getCfgScope() = this.getCfgScope()) and
+    not exists(MethodCall c |
+      c.getReceiver() instanceof SelfVariableAccess and
+      c.getMethodName() = "binding" and
+      c.getCfgScope() = this.getCfgScope()
+    )
   }
 }
 

--- a/ruby/ql/src/queries/variables/examples/DeadStoreOfLocal.rb
+++ b/ruby/ql/src/queries/variables/examples/DeadStoreOfLocal.rb
@@ -1,0 +1,5 @@
+def f(x)
+  result = send(x)
+  waitForResponse
+  return getResponse
+end

--- a/ruby/ql/src/queries/variables/examples/DeadStoreOfLocalGood.rb
+++ b/ruby/ql/src/queries/variables/examples/DeadStoreOfLocalGood.rb
@@ -1,0 +1,9 @@
+def f(x)
+  result = send(x)
+	# check for error
+  if (result == -1)
+    raise "Unable to send, check network."
+  end
+  waitForResponse
+  return getResponse
+end

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,4 +1,1 @@
 | DeadStoreOfLocal.rb:2:5:2:5 | y | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:2:5:2:5 | y | y |
-| DeadStoreOfLocal.rb:14:9:14:9 | x | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:8:5:8:5 | x | x |
-| DeadStoreOfLocal.rb:21:5:21:5 | x | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:21:5:21:5 | x | x |
-| TestTemplate.rb:9:1:9:1 | x | This assignment to $@ is useless, since its value is never read. | TestTemplate.rb:9:1:9:1 | x | x |

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,0 +1,4 @@
+| DeadStoreOfLocal.rb:2:5:2:5 | y | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:2:5:2:5 | y | y |
+| DeadStoreOfLocal.rb:14:9:14:9 | x | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:8:5:8:5 | x | x |
+| DeadStoreOfLocal.rb:21:5:21:5 | x | This assignment to $@ is useless, since its value is never read. | DeadStoreOfLocal.rb:21:5:21:5 | x | x |
+| TestTemplate.rb:9:1:9:1 | x | This assignment to $@ is useless, since its value is never read. | TestTemplate.rb:9:1:9:1 | x | x |

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.qlref
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.qlref
@@ -1,0 +1,2 @@
+query: queries/variables/DeadStoreOfLocal.ql
+postprocess: utils/test/InlineExpectationsTestQuery.ql

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.rb
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.rb
@@ -1,0 +1,36 @@
+def test_basic(x)
+    y = x  #$ Alert
+    y = x + 2
+    return y
+end
+
+def test_retry
+    x = 0
+    begin
+        if x == 0
+            raise "error"
+        end
+    rescue
+        x = 2  #$ SPURIOUS: Alert
+        retry
+    end
+    return 42
+end
+
+def test_binding
+    x = 4  #$ SPURIOUS: Alert
+    return binding
+end
+
+class Sup
+    def m(x)
+        print(x + 1)
+    end
+end
+  
+class Sub < Sup
+    def m(y)
+        y = 3  # OK - the call to `super` sees the value of y
+        super
+    end
+end

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.rb
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/DeadStoreOfLocal.rb
@@ -11,14 +11,14 @@ def test_retry
             raise "error"
         end
     rescue
-        x = 2  #$ SPURIOUS: Alert
+        x = 2  # OK - the retry will allow a later read
         retry
     end
     return 42
 end
 
 def test_binding
-    x = 4  #$ SPURIOUS: Alert
+    x = 4  # OK - the binding collects the value of x
     return binding
 end
 
@@ -30,7 +30,7 @@ end
   
 class Sub < Sup
     def m(y)
-        y = 3  # OK - the call to `super` sees the value of y
+        y = 3  # OK - the call to `super` sees the value of `y``
         super
     end
 end

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/TestTemplate.rb
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/TestTemplate.rb
@@ -6,5 +6,5 @@ template = ERB.new <<EOF
   \_\_ENCODING\_\_ is <%= \_\_ENCODING\_\_ %>.
   x is <%= x %>.
 EOF
-x = 5  #$ SPURIOUS: Alert
+x = 5  # OK - the template can see the value of x
 puts template.result

--- a/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/TestTemplate.rb
+++ b/ruby/ql/test/query-tests/variables/DeadStoreOfLocal/TestTemplate.rb
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+require 'erb'
+
+template = ERB.new <<EOF
+<%#-*- coding: Big5 -*-%>
+  \_\_ENCODING\_\_ is <%= \_\_ENCODING\_\_ %>.
+  x is <%= x %>.
+EOF
+x = 5  #$ SPURIOUS: Alert
+puts template.result


### PR DESCRIPTION
In preparation for shipping `rb/useless-assignment-to-local` as a quality query, this PR removes three classes of FPs:
- a call to `result` on an ERB template will grab all the local variables referenced in the template (example [here](https://github.com/rails/rails/blob/951ea8f75d9bf6d2999df2f0497347976dce9476/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb#L159C11-L159C21)). As an approximation, we do not report useless assignments in the vicinity of such calls.
- a reference to `binding` (as seen in the above example, but templates can also work without such a reference) will capture all the local variables in the scope. This means such assignments are useful even if not explicitly read. Our SSA analysis currently do not see these implicit reads. As an approximation, we do not report useless assignments in the vicinity of references to `binding`.
- if there is a `retry` statement, the assigned variable may be read when control is transferred to the block being rescued. Currently, the control flow graph is missing this edge, so the uses are not seen. As an approximation, we do not report useless assignments in the vicinity of `retry` statements. (I did implement this missing edge, but it had some performance implications, so I will postpone that solution.)

It may be interesting to make proper improvements to the SSA analysis and the CFG to handle these cases more accurately in the future.